### PR TITLE
[SPARK-24666][ML] Fix infinity vectors produced by Word2Vec when numIterations are large

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/Word2Vec.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/Word2Vec.scala
@@ -440,16 +440,10 @@ class Word2Vec extends Serializable with Logging {
         }.flatten
       }
       val synAgg = partial.reduceByKey { case (v1, v2) =>
-          blas.saxpy(vectorSize, 1.0f, v2, 1, v1, 1)
+          // SPARK-24666: Divide word vector to avoid Inf value.
+          blas.saxpy(vectorSize, 1.0f / numPartitions, v2, 1, v1, 1)
           v1
-      }.collect().map { case (idx, fVector) =>
-        // SPARK-24666: Normalize word vector to avoid Inf value.
-        val vecNorm = blas.snrm2(vectorSize, fVector, 1)
-        if (vecNorm != 0.0f) {
-          blas.sscal(vectorSize, 1 / vecNorm, fVector, 0, 1)
-        }
-        (idx, fVector)
-      }
+      }.collect()
       var i = 0
       while (i < synAgg.length) {
         val index = synAgg(i)._1

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/Word2Vec.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/Word2Vec.scala
@@ -451,9 +451,8 @@ class Word2Vec extends Serializable with Logging {
         blas.saxpy(vectorSize, 1.0f, v2, 1, v1, 1)
         (v1, count1 + count2)
       }.map { case (id, (vec, count)) =>
-        val averagedVec = Array.fill[Float](vectorSize)(0.0f)
-        blas.saxpy(vectorSize, 1.0f / count, vec, 1, averagedVec, 1)
-        (id, averagedVec)
+        blas.sscal(vectorSize, 1.0f / count, vec, 1)
+        (id, vec)
       }.collect()
       var i = 0
       while (i < synAgg.length) {

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/Word2Vec.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/Word2Vec.scala
@@ -438,12 +438,23 @@ class Word2Vec extends Serializable with Logging {
             None
           }
         }.flatten
-      }
-      val synAgg = partial.reduceByKey { case (v1, v2) =>
-          // SPARK-24666: Divide word vector to avoid Inf value.
-          blas.saxpy(vectorSize, 1.0f / numPartitions, v2, 1, v1, 1)
-          v1
+      }.persist()
+      // SPARK-24666: do normalization for aggregating weights from partitions.
+      // Original Word2Vec either single-thread or multi-thread which do Hogwild-style aggregation.
+      // Our approach needs to do extra normalization, otherwise adding weights continuously may
+      // cause overflow on float and lead to infinity/-infinity weights.
+      val keyCounts = partial.countByKey()
+      val synAgg = partial.mapPartitions { iter =>
+        iter.map { case (id, vec) =>
+          val v1 = Array.fill[Float](vectorSize)(0.0f)
+          blas.saxpy(vectorSize, 1.0f / keyCounts(id), vec, 1, v1, 1)
+          (id, v1)
+        }
+      }.reduceByKey { case (v1, v2) =>
+        blas.saxpy(vectorSize, 1.0f, v2, 1, v1, 1)
+        v1
       }.collect()
+      partial.unpersist()
       var i = 0
       while (i < synAgg.length) {
         val index = synAgg(i)._1

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/Word2VecSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/Word2VecSuite.scala
@@ -65,7 +65,7 @@ class Word2VecSuite extends MLTest with DefaultReadWriteTest {
 
     // These expectations are just magic values, characterizing the current
     // behavior.  The test needs to be updated to be more general, see SPARK-11502
-    val magicExp = Vectors.dense(-0.11654884266582402, 0.3115301721475341, -0.6879349987615239)
+    val magicExp = Vectors.dense(-0.013768484646623785, 0.48893146767196327, -0.4022105142304843)
     testTransformer[(Seq[String], Vector)](docDF, model, "result", "expected") {
       case Row(vector1: Vector, vector2: Vector) =>
         assert(vector1 ~== magicExp absTol 1E-5, "Transformed vector is different with expected.")
@@ -75,14 +75,6 @@ class Word2VecSuite extends MLTest with DefaultReadWriteTest {
   test("getVectors") {
     val sentence = "a b " * 100 + "a c " * 10
     val doc = sc.parallelize(Seq(sentence, sentence)).map(line => line.split(" "))
-
-    val codes = Map(
-      "a" -> Array(-0.2811822295188904, -0.6356269121170044, -0.3020961284637451),
-      "b" -> Array(1.0309048891067505, -1.29472815990448, 0.22276712954044342),
-      "c" -> Array(-0.08456747233867645, 0.5137411952018738, 0.11731560528278351)
-    )
-    val expectedVectors = codes.toSeq.sortBy(_._1).map { case (w, v) => Vectors.dense(v) }
-
     val docDF = doc.zip(doc).toDF("text", "alsotext")
 
     val model = new Word2Vec()
@@ -98,9 +90,9 @@ class Word2VecSuite extends MLTest with DefaultReadWriteTest {
     // These expectations are just magic values, characterizing the current
     // behavior.  The test needs to be updated to be more general, see SPARK-11502
     val magicExpected = Seq(
-      Vectors.dense(0.12662248313426971, 0.6108677387237549, -0.006755620241165161),
-      Vectors.dense(-0.3870747685432434, 0.023309476673603058, -1.567158818244934),
-      Vectors.dense(-0.08617416769266129, -0.09897610545158386, 0.6113300323486328)
+      Vectors.dense(0.20295652747154236, 0.979127824306488, -0.010828228667378426),
+      Vectors.dense(-0.2397606521844864, 0.014438283629715443, -0.9707246422767639),
+      Vectors.dense(-0.13782194256782532, -0.1582966148853302, 0.977725625038147)
     )
 
     realVectors.zip(magicExpected).foreach {

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/Word2VecSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/Word2VecSuite.scala
@@ -65,7 +65,7 @@ class Word2VecSuite extends MLTest with DefaultReadWriteTest {
 
     // These expectations are just magic values, characterizing the current
     // behavior.  The test needs to be updated to be more general, see SPARK-11502
-    val magicExp = Vectors.dense(-0.013768484646623785, 0.48893146767196327, -0.4022105142304843)
+    val magicExp = Vectors.dense(-0.11654884266582402, 0.3115301721475341, -0.6879349987615239)
     testTransformer[(Seq[String], Vector)](docDF, model, "result", "expected") {
       case Row(vector1: Vector, vector2: Vector) =>
         assert(vector1 ~== magicExp absTol 1E-5, "Transformed vector is different with expected.")
@@ -90,9 +90,9 @@ class Word2VecSuite extends MLTest with DefaultReadWriteTest {
     // These expectations are just magic values, characterizing the current
     // behavior.  The test needs to be updated to be more general, see SPARK-11502
     val magicExpected = Seq(
-      Vectors.dense(0.20295652747154236, 0.979127824306488, -0.010828228667378426),
-      Vectors.dense(-0.2397606521844864, 0.014438283629715443, -0.9707246422767639),
-      Vectors.dense(-0.13782194256782532, -0.1582966148853302, 0.977725625038147)
+      Vectors.dense(0.12662248313426971, 0.6108677387237549, -0.006755620241165161),
+      Vectors.dense(-0.3870747685432434, 0.023309476673603058, -1.567158818244934),
+      Vectors.dense(-0.08617416769266129, -0.09897610545158386, 0.6113300323486328)
     )
 
     realVectors.zip(magicExpected).foreach {

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -4507,13 +4507,13 @@ class Word2Vec(JavaEstimator, _Word2VecParams, JavaMLReadable, JavaMLWritable):
     +----+--------------------+
     |word|              vector|
     +----+--------------------+
-    |   a|[0.09511678665876...|
-    |   b|[-1.2028766870498...|
-    |   c|[0.30153277516365...|
+    |   a|[0.15613564848899...|
+    |   b|[-0.7599201798439...|
+    |   c|[0.51226902008056...|
     +----+--------------------+
     ...
     >>> model.findSynonymsArray("a", 2)
-    [(u'b', 0.015859870240092278), (u'c', -0.5680795907974243)]
+    [(u'b', 0.015859881415963173), (u'c', -0.5680797100067139)]
     >>> from pyspark.sql.functions import format_number as fmt
     >>> model.findSynonyms("a", 2).select("word", fmt("similarity", 5).alias("similarity")).show()
     +----+----------+
@@ -4524,7 +4524,7 @@ class Word2Vec(JavaEstimator, _Word2VecParams, JavaMLReadable, JavaMLWritable):
     +----+----------+
     ...
     >>> model.transform(doc).head().model
-    DenseVector([-0.4833, 0.1855, -0.273, -0.0509, -0.4769])
+    DenseVector([-0.243, 0.3073, -0.373, -0.0963, -0.3179])
     >>> word2vecPath = temp_path + "/word2vec"
     >>> word2Vec.save(word2vecPath)
     >>> loadedWord2Vec = Word2Vec.load(word2vecPath)

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -4507,13 +4507,13 @@ class Word2Vec(JavaEstimator, _Word2VecParams, JavaMLReadable, JavaMLWritable):
     +----+--------------------+
     |word|              vector|
     +----+--------------------+
-    |   a|[0.15613564848899...|
-    |   b|[-0.7599201798439...|
-    |   c|[0.51226902008056...|
+    |   a|[0.09511678665876...|
+    |   b|[-1.2028766870498...|
+    |   c|[0.30153277516365...|
     +----+--------------------+
     ...
     >>> model.findSynonymsArray("a", 2)
-    [(u'b', 0.015859881415963173), (u'c', -0.5680797100067139)]
+    [(u'b', 0.015859870240092278), (u'c', -0.5680795907974243)]
     >>> from pyspark.sql.functions import format_number as fmt
     >>> model.findSynonyms("a", 2).select("word", fmt("similarity", 5).alias("similarity")).show()
     +----+----------+
@@ -4524,7 +4524,7 @@ class Word2Vec(JavaEstimator, _Word2VecParams, JavaMLReadable, JavaMLWritable):
     +----+----------+
     ...
     >>> model.transform(doc).head().model
-    DenseVector([-0.243, 0.3073, -0.373, -0.0963, -0.3179])
+    DenseVector([-0.4833, 0.1855, -0.273, -0.0509, -0.4769])
     >>> word2vecPath = temp_path + "/word2vec"
     >>> word2Vec.save(word2vecPath)
     >>> loadedWord2Vec = Word2Vec.load(word2vecPath)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This patch adds normalization to word vectors when fitting dataset in Word2Vec.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Running Word2Vec on some datasets, when numIterations is large, can produce infinity word vectors.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

Yes. After this patch, Word2Vec won't produce infinity word vectors.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Manually. This issue is not always reproducible on any dataset. The dataset known to reproduce it is too large (925M) to upload.

```scala
case class Sentences(name: String, words: Array[String])
val dataset = spark.read
  .option("header", "true").option("sep", "\t")
  .option("quote", "").option("nullValue", "\\N")
  .csv("/tmp/title.akas.tsv")
  .filter("region = 'US' or language = 'en'")
  .select("title")
  .as[String]
  .map(s => Sentences(s, s.split(' ')))
  .persist()

println("Training model...")
val word2Vec = new Word2Vec()
  .setInputCol("words")
  .setOutputCol("vector")
  .setVectorSize(64)
  .setWindowSize(4)
  .setNumPartitions(50)
  .setMinCount(5)
  .setMaxIter(30)
val model = word2Vec.fit(dataset)
model.getVectors.show()
```

Before:
```
Training model...                    
+-------------+--------------------+                                                                                                                                         
|         word|              vector|                                                                                                                                         
+-------------+--------------------+                                                                                                                                         
|     Unspoken|[-Infinity,-Infin...|                                                                                                                                         
|       Talent|[-Infinity,Infini...|                                                                                                                                         
|    Hourglass|[2.02805806500023...|                                                                                                                                         
|Nickelodeon's|[-4.2918617120906...|                                                                                                                                         
|      Priests|[-1.3570403355926...|                                                                                                                                         
|    Religion:|[-6.7049072282803...|                                                                                                                                         
|           Bu|[5.05591774315586...|                                                                                                                                         
|      Totoro:|[-1.0539840178632...|                                                                                                                                         
|     Trouble,|[-3.5363592836003...|                                                                                                                                         
|       Hatter|[4.90413981352826...|                                                                                                                                         
|          '79|[7.50436471285412...|                                                                                                                                         
|         Vile|[-2.9147142985312...|                                                                                                                                         
|         9/11|[-Infinity,Infini...|                                                                                                                                         
|      Santino|[1.30005911270850...|                                                                                                                                         
|      Motives|[-1.2538958306253...|                                                                                                                                         
|          '13|[-4.5040152427657...|                                                                                                                                         
|       Fierce|[Infinity,Infinit...|                                                                                                                                         
|       Stover|[-2.6326895394029...|                                                                                                                                         
|          'It|[1.66574533864436...|                                                                                                                                         
|        Butts|[Infinity,Infinit...|                                                                      
+-------------+--------------------+                                                                                                                                         
only showing top 20 rows              
```

After:
```
Training model...                    
+-------------+--------------------+                                  
|         word|              vector|
+-------------+--------------------+                  
|     Unspoken|[-0.0454501919448...|                           
|       Talent|[-0.2657704949378...|
|    Hourglass|[-0.1399687677621...|
|Nickelodeon's|[-0.1767119318246...|
|      Priests|[-0.0047509293071...|
|    Religion:|[-0.0411605164408...|
|           Bu|[0.11837736517190...|
|      Totoro:|[0.05258282646536...|
|     Trouble,|[0.09482011198997...|
|       Hatter|[0.06040831282734...|
|          '79|[0.04783720895648...|
|         Vile|[-0.0017210749210...|
|         9/11|[-0.0713915303349...|
|      Santino|[-0.0412711687386...|
|      Motives|[-0.0492418706417...|
|          '13|[-0.0073119504377...|
|       Fierce|[-0.0565455369651...|
|       Stover|[0.06938160210847...|
|          'It|[0.01117012929171...|
|        Butts|[0.05374567210674...|
+-------------+--------------------+
only showing top 20 rows
```
