### PR TITLE
[SPARK-27523][CORE] - Resolve scheme-less event log directory relative to default filesystem

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -507,7 +507,10 @@ class SparkContext(config: SparkConf) extends Logging {
         val defaultFS = if (defaultFSProperty == null) "" else defaultFSProperty
 
         val unresolvedDir = s"$defaultFS${conf.get(EVENT_LOG_DIR).stripSuffix("/")}"
-        Some(Utils.resolveURI(unresolvedDir))
+
+        val fs = new Path(unresolvedDir).getFileSystem(_hadoopConfiguration)
+        val qualifiedPath = fs.makeQualified(new Path(unresolvedDir))
+        Some(qualifiedPath.toUri)
       } else {
         None
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
`evenlog.dir` is resolved with respect to the default filesystem.


### Why are the changes needed?
These changes needed for resolved `evelog.dir` when `defaultFS` is specified. 


### Does this PR introduce any user-facing change?
no


### How was this patch tested?
this patch was tested manually and covered by the unit test. 
