### PR TITLE
[SPARK-30088][SQL]Adaptive execution should convert SortMergeJoin to BroadcastJoin when plan generates empty result

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageExec.scala
@@ -79,7 +79,9 @@ abstract class QueryStageExec extends LeafExecNode {
    */
   def computeStats(): Option[Statistics] = resultOption.map { _ =>
     // Metrics `dataSize` are available in both `ShuffleExchangeExec` and `BroadcastExchangeExec`.
-    Statistics(sizeInBytes = plan.metrics("dataSize").value)
+    // The `dataSize` metric may be a negative number when this spark plan generates empty result,
+    // since SQLMetric use -1 as initial value.
+    Statistics(sizeInBytes = Math.max(plan.metrics("dataSize").value, 0))
   }
 
   @transient


### PR DESCRIPTION
### What changes were proposed in this pull request?
Adaptive execution should convert `SortMergeJoin` to `BroadcastJoin` if the subquery generates empty result. 

### Why are the changes needed?
Adaptive execution try to  convert `SortMergeJoin` to `BroadcastJoin` by checking the `dataSize` metrics of spark plan. However, if the spark plan generates empty result, the `dataSize` metrics is empty due to `org.apache.spark.sql.execution.metric.SQLMetrics`'s initial value is -1, which could lead to the following check return `false`

```
private def canBroadcast(plan: LogicalPlan): Boolean = {
  plan.stats.sizeInBytes >= 0 && plan.stats.sizeInBytes <= conf.autoBroadcastJoinThreshold
}
```

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Adding a test case in `AdaptiveQueryExecSuite`
