### PR TITLE
[SPARK-30097][SS][SQL] - Add suport for core sinks in writeStream

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
@@ -132,6 +132,30 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) {
     this
   }
 
+  def parquet(path: String): StreamingQuery = {
+    format("parquet")
+      .option("path", path)
+      .start()
+  }
+
+  def json(path: String): StreamingQuery = {
+    format("json")
+      .option("path", path)
+      .start()
+  }
+
+  def csv(path: String): StreamingQuery = {
+    format("csv")
+      .option("path", path)
+      .start()
+  }
+
+  def text(path: String): StreamingQuery = {
+    format("text")
+      .option("path", path)
+      .start()
+  }
+
   /**
    * Partitions the output by the given columns on the file system. If specified, the output is
    * laid out on the file system similar to Hive's partitioning scheme. As an example, when we

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamReaderWriterSuite.scala
@@ -569,6 +569,84 @@ test("prevent all column partitioning parquet second signature") {
     }
   }
 
+  test("read from memory stream and write in streaming to parquet") {
+    import testImplicits._
+    val expectedDF = Seq(1, 2, 3).toDF
+    withTempDir { src =>
+      val ds = MemoryStream[Int]
+      ds.addData(1 to 3)
+
+      val query =
+        ds.toDF()
+          .writeStream
+          .option("checkpointLocation", newMetadataDir)
+          .parquet(src.toString)
+
+      query.processAllAvailable()
+      val dfr = spark.read.parquet(src.toString)
+      checkAnswer(dfr, expectedDF)
+    }
+  }
+
+  test("read from memory stream and write in streaming to json") {
+    import testImplicits._
+    val expectedDF = Seq(1, 2, 3).toDF
+    withTempDir { src =>
+      val ds = MemoryStream[Int]
+      ds.addData(1 to 3)
+
+      val query =
+        ds.toDF()
+          .writeStream
+          .option("checkpointLocation", newMetadataDir)
+          .json(src.toString)
+
+      query.processAllAvailable()
+      val dfr = spark.read.json(src.toString)
+      checkAnswer(dfr, expectedDF)
+    }
+  }
+
+  test("read from memory stream and write in streaming to csv") {
+    import testImplicits._
+    val expectedDF = Seq(1, 2, 3).toDF
+    withTempDir { src =>
+      val ds = MemoryStream[Int]
+      ds.addData(1 to 3)
+
+      val query =
+        ds.toDF()
+          .writeStream
+          .option("checkpointLocation", newMetadataDir)
+          .csv(src.toString)
+
+      query.processAllAvailable()
+      val dfr = spark.read.schema("value INT").csv(src.toString)
+      checkAnswer(dfr, expectedDF)
+    }
+  }
+
+  test("read from memory stream and write in streaming to text") {
+    import testImplicits._
+    val expectedDF = Seq("a", "b", "c").toDF
+    withTempDir { src =>
+      val ds = MemoryStream[String]
+      ds.addData("a")
+      ds.addData("b")
+      ds.addData("c")
+
+      val query =
+        ds.toDF()
+          .writeStream
+          .option("checkpointLocation", newMetadataDir)
+          .text(src.toString)
+
+      query.processAllAvailable()
+      val dfr = spark.read.text(src.toString)
+      checkAnswer(dfr, expectedDF)
+    }
+  }
+
   test("user specified checkpointLocation precedes SQLConf") {
     import testImplicits._
     withTempDir { checkpointPath =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamReaderWriterSuite.scala
@@ -434,6 +434,18 @@ class DataStreamReaderWriterSuite extends StreamTest with BeforeAndAfter {
     }
   }
 
+test("prevent all column partitioning parquet second signature") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      intercept[AnalysisException] {
+        spark.range(10).writeStream
+          .outputMode("append")
+          .partitionBy("id")
+          .parquet(path)
+      }
+    }
+  }
+
   private def testMemorySinkCheckpointRecovery(chkLoc: String, provideInWriter: Boolean): Unit = {
     import testImplicits._
     val ms = new MemoryStream[Int](0, sqlContext)


### PR DESCRIPTION
### What changes were proposed in this pull request?

When using `writeStream` we always have to use `format("xxx")` in order to target the selected sink while in `readStream` you can use directly e.g `.parquet` 

Basically this is to add the support to the core writers for writeStream

Example:
 
```
writeStream
.outputMode("append")
.partitionBy("id")
.options(options)
.parquet(path)
 ```


### Why are the changes needed?
The changes are needed to maintain same syntax between `write` and `writeStream` just like `read` and `readStream` 

### Does this PR introduce any user-facing change?

It adds a new way of calling the sinks when using `writeStream`


### How was this patch tested?
For now I just added a test for the `parquet` sink
