### PR TITLE
[SPARK-30082][SQL] Depend on Scala type coercion when building replace query

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -492,9 +492,9 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
     case TimestampType =>
       buildCast[Long](_, t => timestampToLong(t))
     case x: NumericType if ansiEnabled =>
-      b => x.exactNumeric.asInstanceOf[Numeric[Any]].toLong(b)
+      b => if (checkIfNaN(b)) null else x.exactNumeric.asInstanceOf[Numeric[Any]].toLong(b)
     case x: NumericType =>
-      b => x.numeric.asInstanceOf[Numeric[Any]].toLong(b)
+      b => if (checkIfNaN(b)) null else x.numeric.asInstanceOf[Numeric[Any]].toLong(b)
   }
 
   // IntConverter
@@ -511,9 +511,9 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
     case TimestampType =>
       buildCast[Long](_, t => timestampToLong(t).toInt)
     case x: NumericType if ansiEnabled =>
-      b => x.exactNumeric.asInstanceOf[Numeric[Any]].toInt(b)
+      b => if (checkIfNaN(b)) null else x.exactNumeric.asInstanceOf[Numeric[Any]].toInt(b)
     case x: NumericType =>
-      b => x.numeric.asInstanceOf[Numeric[Any]].toInt(b)
+      b => if (checkIfNaN(b)) null else x.numeric.asInstanceOf[Numeric[Any]].toInt(b)
   }
 
   // ShortConverter
@@ -549,12 +549,12 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
             throw new ArithmeticException(s"Casting $b to short causes overflow")
         }
         if (intValue == intValue.toShort) {
-          intValue.toShort
+          if (checkIfNaN(b)) null else intValue.toShort
         } else {
           throw new ArithmeticException(s"Casting $b to short causes overflow")
         }
     case x: NumericType =>
-      b => x.numeric.asInstanceOf[Numeric[Any]].toInt(b).toShort
+      b => if (checkIfNaN(b)) null else x.numeric.asInstanceOf[Numeric[Any]].toInt(b).toShort
   }
 
   // ByteConverter
@@ -590,12 +590,12 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
             throw new ArithmeticException(s"Casting $b to byte causes overflow")
         }
         if (intValue == intValue.toByte) {
-          intValue.toByte
+          if (checkIfNaN(b)) null else intValue.toByte
         } else {
           throw new ArithmeticException(s"Casting $b to byte causes overflow")
         }
     case x: NumericType =>
-      b => x.numeric.asInstanceOf[Numeric[Any]].toInt(b).toByte
+      b => if (checkIfNaN(b)) null else x.numeric.asInstanceOf[Numeric[Any]].toInt(b).toByte
   }
 
   /**
@@ -779,6 +779,11 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
       }
     }
   }
+
+  // Check if NaN
+  private[this] def checkIfNaN(value: Any): Boolean =
+    (value.isInstanceOf[Double] && value.asInstanceOf[Double].isNaN) ||
+      (value.isInstanceOf[Float] && value.asInstanceOf[Float].isNaN)
 
   private[this] lazy val cast: Any => Any = cast(child.dataType, dataType)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -492,9 +492,9 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
     case TimestampType =>
       buildCast[Long](_, t => timestampToLong(t))
     case x: NumericType if ansiEnabled =>
-      b => if (checkIfNaN(b)) null else x.exactNumeric.asInstanceOf[Numeric[Any]].toLong(b)
+      b => x.exactNumeric.asInstanceOf[Numeric[Any]].toLong(b)
     case x: NumericType =>
-      b => if (checkIfNaN(b)) null else x.numeric.asInstanceOf[Numeric[Any]].toLong(b)
+      b => x.numeric.asInstanceOf[Numeric[Any]].toLong(b)
   }
 
   // IntConverter
@@ -511,9 +511,9 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
     case TimestampType =>
       buildCast[Long](_, t => timestampToLong(t).toInt)
     case x: NumericType if ansiEnabled =>
-      b => if (checkIfNaN(b)) null else x.exactNumeric.asInstanceOf[Numeric[Any]].toInt(b)
+      b => x.exactNumeric.asInstanceOf[Numeric[Any]].toInt(b)
     case x: NumericType =>
-      b => if (checkIfNaN(b)) null else x.numeric.asInstanceOf[Numeric[Any]].toInt(b)
+      b => x.numeric.asInstanceOf[Numeric[Any]].toInt(b)
   }
 
   // ShortConverter
@@ -549,12 +549,12 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
             throw new ArithmeticException(s"Casting $b to short causes overflow")
         }
         if (intValue == intValue.toShort) {
-          if (checkIfNaN(b)) null else intValue.toShort
+          intValue.toShort
         } else {
           throw new ArithmeticException(s"Casting $b to short causes overflow")
         }
     case x: NumericType =>
-      b => if (checkIfNaN(b)) null else x.numeric.asInstanceOf[Numeric[Any]].toInt(b).toShort
+      b => x.numeric.asInstanceOf[Numeric[Any]].toInt(b).toShort
   }
 
   // ByteConverter
@@ -590,12 +590,12 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
             throw new ArithmeticException(s"Casting $b to byte causes overflow")
         }
         if (intValue == intValue.toByte) {
-          if (checkIfNaN(b)) null else intValue.toByte
+          intValue.toByte
         } else {
           throw new ArithmeticException(s"Casting $b to byte causes overflow")
         }
     case x: NumericType =>
-      b => if (checkIfNaN(b)) null else x.numeric.asInstanceOf[Numeric[Any]].toInt(b).toByte
+      b => x.numeric.asInstanceOf[Numeric[Any]].toInt(b).toByte
   }
 
   /**
@@ -779,11 +779,6 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
       }
     }
   }
-
-  // Check if NaN
-  private[this] def checkIfNaN(value: Any): Boolean =
-    (value.isInstanceOf[Double] && value.asInstanceOf[Double].isNaN) ||
-      (value.isInstanceOf[Float] && value.asInstanceOf[Float].isNaN)
 
   private[this] lazy val cast: Any => Any = cast(child.dataType, dataType)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
@@ -456,7 +456,7 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
     val keyExpr = df.col(col.name).expr
     def buildExpr(v: Any) = Cast(Literal(v), keyExpr.dataType)
     val branches = replacementMap.flatMap { case (src, target) =>
-        Seq(Literal(src), buildExpr(target))
+      Seq(Literal(src), buildExpr(target))
     }.toSeq
     new Column(CaseKeyWhen(keyExpr, branches :+ keyExpr)).as(col.name)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
@@ -455,8 +455,8 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
   private def replaceCol(col: StructField, replacementMap: Map[_, _]): Column = {
     val keyExpr = df.col(col.name).expr
     def buildExpr(v: Any) = Cast(Literal(v), keyExpr.dataType)
-    val branches = replacementMap.flatMap { case (src, target) =>
-      Seq(Literal(src), buildExpr(target))
+    val branches = replacementMap.flatMap { case (source, target) =>
+      Seq(Literal(source), buildExpr(target))
     }.toSeq
     new Column(CaseKeyWhen(keyExpr, branches :+ keyExpr)).as(col.name)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
@@ -442,8 +442,8 @@ class DataFrameNaFunctionsSuite extends QueryTest with SharedSparkSession {
       createNaNDF().na.replace("*", Map(
         1.0f -> Float.NaN
       )),
-      Row(1, new java.lang.Long(1), new java.lang.Short("1"),
-        new java.lang.Byte("1"), java.lang.Float.NaN, java.lang.Double.NaN) ::
+      Row(0, new java.lang.Long(0), new java.lang.Short("0"),
+        new java.lang.Byte("0"), java.lang.Float.NaN, java.lang.Double.NaN) ::
       Row(0, new java.lang.Long(0), new java.lang.Short("0"),
         new java.lang.Byte("0"), java.lang.Float.NaN, java.lang.Double.NaN) :: Nil)
   }
@@ -453,8 +453,8 @@ class DataFrameNaFunctionsSuite extends QueryTest with SharedSparkSession {
       createNaNDF().na.replace("*", Map(
         1.toDouble -> Double.NaN
       )),
-      Row(1, new java.lang.Long(1), new java.lang.Short("1"),
-        new java.lang.Byte("1"), java.lang.Float.NaN, java.lang.Double.NaN) ::
+      Row(0, new java.lang.Long(0), new java.lang.Short("0"),
+        new java.lang.Byte("0"), java.lang.Float.NaN, java.lang.Double.NaN) ::
       Row(0, new java.lang.Long(0), new java.lang.Short("0"),
         new java.lang.Byte("0"), java.lang.Float.NaN, java.lang.Double.NaN) :: Nil)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
@@ -404,4 +404,81 @@ class DataFrameNaFunctionsSuite extends QueryTest with SharedSparkSession {
       df.na.drop("any"),
       Row("5", "6", "6") :: Nil)
   }
+
+  test("replace nan with float") {
+    val input = Seq[(java.lang.Integer, java.lang.Long, java.lang.Short,
+      java.lang.Byte, java.lang.Float, java.lang.Double)](
+      (1, new java.lang.Long(1), new java.lang.Short("1"),
+        new java.lang.Byte("1"), new java.lang.Float(1.0), 1.0),
+      (0, new java.lang.Long(0), new java.lang.Short("0"),
+        new java.lang.Byte("0"), java.lang.Float.NaN, java.lang.Double.NaN)
+    ).toDF("int", "long", "short", "byte", "float", "double")
+
+    checkAnswer(
+      input.na.replace("*", Map(
+        Float.NaN -> 10f
+      )),
+      Row(1, new java.lang.Long(1), new java.lang.Short("1"),
+        new java.lang.Byte("1"), new java.lang.Float(1.0), 1.0) ::
+        Row(0, new java.lang.Long(0), new java.lang.Short("0"),
+          new java.lang.Byte("0"), new java.lang.Float(10), new java.lang.Double(10)) :: Nil)
+  }
+
+  test("replace nan with double") {
+    val input = Seq[(java.lang.Integer, java.lang.Long, java.lang.Short,
+      java.lang.Byte, java.lang.Float, java.lang.Double)](
+      (1, new java.lang.Long(1), new java.lang.Short("1"),
+        new java.lang.Byte("1"), new java.lang.Float(1.0), 1.0),
+      (0, new java.lang.Long(0), new java.lang.Short("0"),
+        new java.lang.Byte("0"), java.lang.Float.NaN, java.lang.Double.NaN)
+    ).toDF("int", "long", "short", "byte", "float", "double")
+
+    checkAnswer(
+      input.na.replace("*", Map(
+        Double.NaN -> 10.toDouble
+      )),
+      Row(1, new java.lang.Long(1), new java.lang.Short("1"),
+        new java.lang.Byte("1"), new java.lang.Float(1.0), 1.0) ::
+      Row(0, new java.lang.Long(0), new java.lang.Short("0"),
+        new java.lang.Byte("0"), new java.lang.Float(10), new java.lang.Double(10)) :: Nil)
+  }
+
+  test("replace float with nan") {
+    val input = Seq[(java.lang.Integer, java.lang.Long, java.lang.Short,
+      java.lang.Byte, java.lang.Float, java.lang.Double)](
+      (1, new java.lang.Long(1), new java.lang.Short("1"),
+        new java.lang.Byte("1"), new java.lang.Float(1.0), 1.0),
+      (0, new java.lang.Long(0), new java.lang.Short("0"),
+        new java.lang.Byte("0"), java.lang.Float.NaN, java.lang.Double.NaN)
+    ).toDF("int", "long", "short", "byte", "float", "double")
+
+    checkAnswer(
+      input.na.replace("*", Map(
+        1.0f -> Float.NaN
+      )),
+      Row(1, new java.lang.Long(1), new java.lang.Short("1"),
+        new java.lang.Byte("1"), java.lang.Float.NaN, java.lang.Double.NaN) ::
+      Row(0, new java.lang.Long(0), new java.lang.Short("0"),
+        new java.lang.Byte("0"), java.lang.Float.NaN, java.lang.Double.NaN) :: Nil)
+  }
+
+  test("replace double with nan") {
+    val input = Seq[(java.lang.Integer, java.lang.Long, java.lang.Short,
+      java.lang.Byte, java.lang.Float, java.lang.Double)](
+      (1, new java.lang.Long(1), new java.lang.Short("1"),
+        new java.lang.Byte("1"), new java.lang.Float(1.0), 1.0),
+      (0, new java.lang.Long(0), new java.lang.Short("0"),
+        new java.lang.Byte("0"), java.lang.Float.NaN, java.lang.Double.NaN)
+    ).toDF("int", "long", "short", "byte", "float", "double")
+
+    checkAnswer(
+      input.na.replace("*", Map(
+        1.toDouble -> Double.NaN
+      )),
+      Row(1, new java.lang.Long(1), new java.lang.Short("1"),
+        new java.lang.Byte("1"), java.lang.Float.NaN, java.lang.Double.NaN) ::
+      Row(0, new java.lang.Long(0), new java.lang.Short("0"),
+        new java.lang.Byte("0"), java.lang.Float.NaN, java.lang.Double.NaN) :: Nil)
+
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
@@ -37,6 +37,16 @@ class DataFrameNaFunctionsSuite extends QueryTest with SharedSparkSession {
       ).toDF("name", "age", "height")
   }
 
+  def createNaNDF(): DataFrame = {
+    Seq[(java.lang.Integer, java.lang.Long, java.lang.Short,
+      java.lang.Byte, java.lang.Float, java.lang.Double)](
+      (1, new java.lang.Long(1), new java.lang.Short("1"),
+        new java.lang.Byte("1"), new java.lang.Float(1.0), 1.0),
+      (0, new java.lang.Long(0), new java.lang.Short("0"),
+        new java.lang.Byte("0"), java.lang.Float.NaN, java.lang.Double.NaN)
+    ).toDF("int", "long", "short", "byte", "float", "double")
+  }
+
   test("drop") {
     val input = createDF()
     val rows = input.collect()
@@ -406,35 +416,19 @@ class DataFrameNaFunctionsSuite extends QueryTest with SharedSparkSession {
   }
 
   test("replace nan with float") {
-    val input = Seq[(java.lang.Integer, java.lang.Long, java.lang.Short,
-      java.lang.Byte, java.lang.Float, java.lang.Double)](
-      (1, new java.lang.Long(1), new java.lang.Short("1"),
-        new java.lang.Byte("1"), new java.lang.Float(1.0), 1.0),
-      (0, new java.lang.Long(0), new java.lang.Short("0"),
-        new java.lang.Byte("0"), java.lang.Float.NaN, java.lang.Double.NaN)
-    ).toDF("int", "long", "short", "byte", "float", "double")
-
     checkAnswer(
-      input.na.replace("*", Map(
+      createNaNDF().na.replace("*", Map(
         Float.NaN -> 10f
       )),
       Row(1, new java.lang.Long(1), new java.lang.Short("1"),
         new java.lang.Byte("1"), new java.lang.Float(1.0), 1.0) ::
-        Row(0, new java.lang.Long(0), new java.lang.Short("0"),
-          new java.lang.Byte("0"), new java.lang.Float(10), new java.lang.Double(10)) :: Nil)
+      Row(0, new java.lang.Long(0), new java.lang.Short("0"),
+        new java.lang.Byte("0"), new java.lang.Float(10), new java.lang.Double(10)) :: Nil)
   }
 
   test("replace nan with double") {
-    val input = Seq[(java.lang.Integer, java.lang.Long, java.lang.Short,
-      java.lang.Byte, java.lang.Float, java.lang.Double)](
-      (1, new java.lang.Long(1), new java.lang.Short("1"),
-        new java.lang.Byte("1"), new java.lang.Float(1.0), 1.0),
-      (0, new java.lang.Long(0), new java.lang.Short("0"),
-        new java.lang.Byte("0"), java.lang.Float.NaN, java.lang.Double.NaN)
-    ).toDF("int", "long", "short", "byte", "float", "double")
-
     checkAnswer(
-      input.na.replace("*", Map(
+      createNaNDF().na.replace("*", Map(
         Double.NaN -> 10.toDouble
       )),
       Row(1, new java.lang.Long(1), new java.lang.Short("1"),
@@ -444,16 +438,8 @@ class DataFrameNaFunctionsSuite extends QueryTest with SharedSparkSession {
   }
 
   test("replace float with nan") {
-    val input = Seq[(java.lang.Integer, java.lang.Long, java.lang.Short,
-      java.lang.Byte, java.lang.Float, java.lang.Double)](
-      (1, new java.lang.Long(1), new java.lang.Short("1"),
-        new java.lang.Byte("1"), new java.lang.Float(1.0), 1.0),
-      (0, new java.lang.Long(0), new java.lang.Short("0"),
-        new java.lang.Byte("0"), java.lang.Float.NaN, java.lang.Double.NaN)
-    ).toDF("int", "long", "short", "byte", "float", "double")
-
     checkAnswer(
-      input.na.replace("*", Map(
+      createNaNDF().na.replace("*", Map(
         1.0f -> Float.NaN
       )),
       Row(1, new java.lang.Long(1), new java.lang.Short("1"),
@@ -463,22 +449,13 @@ class DataFrameNaFunctionsSuite extends QueryTest with SharedSparkSession {
   }
 
   test("replace double with nan") {
-    val input = Seq[(java.lang.Integer, java.lang.Long, java.lang.Short,
-      java.lang.Byte, java.lang.Float, java.lang.Double)](
-      (1, new java.lang.Long(1), new java.lang.Short("1"),
-        new java.lang.Byte("1"), new java.lang.Float(1.0), 1.0),
-      (0, new java.lang.Long(0), new java.lang.Short("0"),
-        new java.lang.Byte("0"), java.lang.Float.NaN, java.lang.Double.NaN)
-    ).toDF("int", "long", "short", "byte", "float", "double")
-
     checkAnswer(
-      input.na.replace("*", Map(
+      createNaNDF().na.replace("*", Map(
         1.toDouble -> Double.NaN
       )),
       Row(1, new java.lang.Long(1), new java.lang.Short("1"),
         new java.lang.Byte("1"), java.lang.Float.NaN, java.lang.Double.NaN) ::
       Row(0, new java.lang.Long(0), new java.lang.Short("0"),
         new java.lang.Byte("0"), java.lang.Float.NaN, java.lang.Double.NaN) :: Nil)
-
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
@@ -40,10 +40,8 @@ class DataFrameNaFunctionsSuite extends QueryTest with SharedSparkSession {
   def createNaNDF(): DataFrame = {
     Seq[(java.lang.Integer, java.lang.Long, java.lang.Short,
       java.lang.Byte, java.lang.Float, java.lang.Double)](
-      (1, new java.lang.Long(1), new java.lang.Short("1"),
-        new java.lang.Byte("1"), new java.lang.Float(1.0), 1.0),
-      (0, new java.lang.Long(0), new java.lang.Short("0"),
-        new java.lang.Byte("0"), java.lang.Float.NaN, java.lang.Double.NaN)
+      (1, 1L, 1.toShort, 1.toByte, 1.0f, 1.0),
+      (0, 0L, 0.toShort, 0.toByte, Float.NaN, Double.NaN)
     ).toDF("int", "long", "short", "byte", "float", "double")
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
@@ -416,23 +416,19 @@ class DataFrameNaFunctionsSuite extends QueryTest with SharedSparkSession {
   test("replace nan with float") {
     checkAnswer(
       createNaNDF().na.replace("*", Map(
-        Float.NaN -> 10f
+        Float.NaN -> 10.0f
       )),
-      Row(1, new java.lang.Long(1), new java.lang.Short("1"),
-        new java.lang.Byte("1"), new java.lang.Float(1.0), 1.0) ::
-      Row(0, new java.lang.Long(0), new java.lang.Short("0"),
-        new java.lang.Byte("0"), new java.lang.Float(10), new java.lang.Double(10)) :: Nil)
+      Row(1, 1L, 1.toShort, 1.toByte, 1.0f, 1.0) ::
+      Row(0, 0L, 0.toShort, 0.toByte, 10.0f, 10.0) :: Nil)
   }
 
   test("replace nan with double") {
     checkAnswer(
       createNaNDF().na.replace("*", Map(
-        Double.NaN -> 10.toDouble
+        Double.NaN -> 10.0
       )),
-      Row(1, new java.lang.Long(1), new java.lang.Short("1"),
-        new java.lang.Byte("1"), new java.lang.Float(1.0), 1.0) ::
-      Row(0, new java.lang.Long(0), new java.lang.Short("0"),
-        new java.lang.Byte("0"), new java.lang.Float(10), new java.lang.Double(10)) :: Nil)
+      Row(1, 1L, 1.toShort, 1.toByte, 1.0f, 1.0) ::
+      Row(0, 0L, 0.toShort, 0.toByte, 10.0f, 10.0) :: Nil)
   }
 
   test("replace float with nan") {
@@ -440,20 +436,16 @@ class DataFrameNaFunctionsSuite extends QueryTest with SharedSparkSession {
       createNaNDF().na.replace("*", Map(
         1.0f -> Float.NaN
       )),
-      Row(0, new java.lang.Long(0), new java.lang.Short("0"),
-        new java.lang.Byte("0"), java.lang.Float.NaN, java.lang.Double.NaN) ::
-      Row(0, new java.lang.Long(0), new java.lang.Short("0"),
-        new java.lang.Byte("0"), java.lang.Float.NaN, java.lang.Double.NaN) :: Nil)
+      Row(0, 0L, 0.toShort, 0.toByte, Float.NaN, Double.NaN) ::
+      Row(0, 0L, 0.toShort, 0.toByte, Float.NaN, Double.NaN) :: Nil)
   }
 
   test("replace double with nan") {
     checkAnswer(
       createNaNDF().na.replace("*", Map(
-        1.toDouble -> Double.NaN
+        1.0 -> Double.NaN
       )),
-      Row(0, new java.lang.Long(0), new java.lang.Short("0"),
-        new java.lang.Byte("0"), java.lang.Float.NaN, java.lang.Double.NaN) ::
-      Row(0, new java.lang.Long(0), new java.lang.Short("0"),
-        new java.lang.Byte("0"), java.lang.Float.NaN, java.lang.Double.NaN) :: Nil)
+      Row(0, 0L, 0.toShort, 0.toByte, Float.NaN, Double.NaN) ::
+      Row(0, 0L, 0.toShort, 0.toByte, Float.NaN, Double.NaN) :: Nil)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Depend on type coercion when building the replace query. This would solve an edge case where when trying to replace `NaN`s, `0`s would get replace too.

### Why are the changes needed?
This Scala code snippet:
```
import scala.math;

println(Double.NaN.toLong)
```
returns `0` which is problematic as if you run the following Spark code, `0`s get replaced as well:
```
>>> df = spark.createDataFrame([(1.0, 0), (0.0, 3), (float('nan'), 0)], ("index", "value"))
>>> df.show()
+-----+-----+
|index|value|
+-----+-----+
|  1.0|    0|
|  0.0|    3|
|  NaN|    0|
+-----+-----+
>>> df.replace(float('nan'), 2).show()
+-----+-----+
|index|value|
+-----+-----+
|  1.0|    2|
|  0.0|    3|
|  2.0|    2|
+-----+-----+ 
```

### Does this PR introduce any user-facing change?
Yes, after the PR, running the same above code snippet returns the correct expected results:
```
>>> df = spark.createDataFrame([(1.0, 0), (0.0, 3), (float('nan'), 0)], ("index", "value"))
>>> df.show()
+-----+-----+
|index|value|
+-----+-----+
|  1.0|    0|
|  0.0|    3|
|  NaN|    0|
+-----+-----+

>>> df.replace(float('nan'), 2).show()
+-----+-----+
|index|value|
+-----+-----+
|  1.0|    0|
|  0.0|    3|
|  2.0|    0|
+-----+-----+
```
And additionally, query results are changed as a result of the change in depending on scala's type coercion rules.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added unit tests to verify replacing `NaN` only affects columns of type `Float` and `Double`.
