### PR TITLE
[SPARK-30053][SQL] Add the ability for v2 datasource so specify a vacuum action on the table

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -391,6 +391,7 @@ dmlStatementNoWith
     : insertInto queryTerm queryOrganization                                       #singleInsertQuery
     | fromClause multiInsertQueryBody+                                             #multiInsertQuery
     | DELETE FROM multipartIdentifier tableAlias whereClause?                      #deleteFromTable
+    | VACUUM multipartIdentifier tableAlias                                        #vacuumFromTable
     | UPDATE multipartIdentifier tableAlias setClause whereClause?                 #updateTable
     | MERGE INTO target=multipartIdentifier targetAlias=tableAlias
         USING (source=multipartIdentifier |
@@ -1149,6 +1150,7 @@ ansiNonReserved
     | UNSET
     | UPDATE
     | USE
+    | VACUUM
     | VALUES
     | VIEW
     | WEEK
@@ -1425,6 +1427,7 @@ nonReserved
     | UPDATE
     | USE
     | USER
+    | VACUUM
     | VALUES
     | VIEW
     | WEEK
@@ -1698,6 +1701,7 @@ UPDATE: 'UPDATE';
 USE: 'USE';
 USER: 'USER';
 USING: 'USING';
+VACUUM: 'VACUUM';
 VALUES: 'VALUES';
 VIEW: 'VIEW';
 WEEK: 'WEEK';

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsVacuum.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsVacuum.java
@@ -1,0 +1,18 @@
+package org.apache.spark.sql.connector.catalog;
+
+import org.apache.spark.annotation.Experimental;
+/**
+ * A mix-in interface for {@link Table} vacuum support. Data sources can implement this
+ * interface to provide the ability to perform table maintenance on request of the user.
+ */
+@Experimental
+public interface SupportsVacuum {
+
+  /**
+   * Performs maintenance on the table.  This often includes removing unneeded data and
+   * deleting stale records.
+   *
+   * @throws IllegalArgumentException If the vacuum is rejected due to required effort.
+   */
+  void vacuum();
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -365,6 +365,14 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
     DeleteFromTable(aliasedTable, predicate)
   }
 
+  override def visitVacuumFromTable(ctx: VacuumFromTableContext): LogicalPlan = withOrigin(ctx) {
+    val table = UnresolvedRelation(visitMultipartIdentifier(ctx.multipartIdentifier()))
+    val tableAlias = getTableAliasWithoutColumnAlias(ctx.tableAlias(), "VACUUM")
+    val aliasedTable = tableAlias.map(SubqueryAlias(_, table)).getOrElse(table)
+
+    VacuumTable(aliasedTable)
+  }
+
   override def visitUpdateTable(ctx: UpdateTableContext): LogicalPlan = withOrigin(ctx) {
     val table = UnresolvedRelation(visitMultipartIdentifier(ctx.multipartIdentifier()))
     val tableAlias = getTableAliasWithoutColumnAlias(ctx.tableAlias(), "UPDATE")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -304,8 +304,15 @@ case class DescribeTable(table: NamedRelation, isExtended: Boolean) extends Comm
  * The logical plan of the DELETE FROM command that works for v2 tables.
  */
 case class DeleteFromTable(
-    table: LogicalPlan,
-    condition: Option[Expression]) extends Command with SupportsSubquery {
+                            table: LogicalPlan,
+                            condition: Option[Expression]) extends Command with SupportsSubquery {
+  override def children: Seq[LogicalPlan] = table :: Nil
+}
+
+/**
+ * The logical plan of the DELETE FROM command that works for v2 tables.
+ */
+case class VacuumTable(table: LogicalPlan) extends Command with SupportsSubquery {
   override def children: Seq[LogicalPlan] = table :: Nil
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Implicits.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Implicits.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.datasources.v2
 import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.connector.catalog.{SupportsDelete, SupportsRead, SupportsWrite, Table, TableCapability}
+import org.apache.spark.sql.connector.catalog.{SupportsDelete, SupportsRead, SupportsVacuum, SupportsWrite, Table, TableCapability}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 object DataSourceV2Implicits {
@@ -49,6 +49,15 @@ object DataSourceV2Implicits {
           support
         case _ =>
           throw new AnalysisException(s"Table does not support deletes: ${table.name}")
+      }
+    }
+
+    def asVacuumable: SupportsVacuum = {
+      table match {
+        case support: SupportsVacuum =>
+          support
+        case _ =>
+          throw new AnalysisException(s"Table does not support vacuum: ${table.name}")
       }
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DeleteFromTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DeleteFromTableExec.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.datasources.v2
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.connector.catalog.SupportsDelete
+import org.apache.spark.sql.connector.catalog.{SupportsDelete, SupportsVacuum}
 import org.apache.spark.sql.sources.Filter
 
 case class DeleteFromTableExec(
@@ -28,6 +28,16 @@ case class DeleteFromTableExec(
 
   override protected def run(): Seq[InternalRow] = {
     table.deleteWhere(condition)
+    Seq.empty
+  }
+
+  override def output: Seq[Attribute] = Nil
+}
+
+case class VacuumTableExec(table: SupportsVacuum) extends V2CommandExec {
+
+  override protected def run(): Seq[InternalRow] = {
+    table.vacuum
     Seq.empty
   }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-30053?page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel&focusedCommentId=16985760


### What changes were proposed in this pull request?

This cr includes a new api so that users of the V2 Datasource api can specify an action to take when a user types in the 'Vacuum {table}' command.  This is commonly used to remove deleted records and optimize the table.


### Why are the changes needed?

There is currently no way for users to create this type of behavior in SQL

> vacuum is a very common command. for example .
>
> - https://www.sqlite.org/lang_vacuum.html
> - https://www.postgresql.org/docs/9.1/sql-vacuum.html
> - https://docs.aws.amazon.com/redshift/latest/dg/r_VACUUM_command.html
> - https://docs.databricks.com/spark/latest/spark-sql/language-manual/vacuum.html
> 
> Another option would the optimize key word which databricks uses for delta.
> - https://docs.databricks.com/spark/latest/spark-sql/language-manual/optimize.html

### Does this PR introduce any user-facing change?

Yes this includes a new public but experimental API

### How was this patch tested?
 Unit tests.
