### PR TITLE
[SPARK-30051][BUILD] Clean up hadoop-3.2 dependency

### DIFF
--- a/dev/deps/spark-deps-hadoop-3.2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3.2-hive-2.3
@@ -135,8 +135,6 @@ jersey-container-servlet-core-2.29.jar
 jersey-hk2-2.29.jar
 jersey-media-jaxb-2.29.jar
 jersey-server-2.29.jar
-jetty-webapp-9.4.18.v20190429.jar
-jetty-xml-9.4.18.v20190429.jar
 jline-2.14.6.jar
 joda-time-2.10.5.jar
 jodd-core-3.5.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -407,6 +407,12 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-webapp</artifactId>
+        <version>${jetty.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>14.0.1</version>
@@ -1029,6 +1035,10 @@
           <exclusion>
             <groupId>javax.ws.rs</groupId>
             <artifactId>jsr311-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-webapp</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to cut `org.eclipse.jetty:jetty-webapp`and `org.eclipse.jetty:jetty-xml` transitive dependency from `hadoop-common`.

### Why are the changes needed?

This will simplify our dependency management by the removal of unused dependencies.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Pass the GitHub Action with all combinations and the Jenkins UT with (Hadoop-3.2).