### PR TITLE
[SPARK-29188][PYTHON] toPandas (without Arrow) gets wrong dtypes when applied on empty DF

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2191,6 +2191,7 @@ class DataFrame(object):
                 not(isinstance(field.dataType, IntegralType) and field.nullable and
                     pdf[field.name].isnull().any()):
                 dtype[field.name] = pandas_type
+            # Ensure we fall back to nullable numpy types, even when whole column is null:
             if isinstance(field.dataType, IntegralType) and pdf[field.name].isnull().any():
                 dtype[field.name] = np.float64
             if isinstance(field.dataType, BooleanType) and pdf[field.name].isnull().any():

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2110,6 +2110,7 @@ class DataFrame(object):
         from pyspark.sql.utils import require_minimum_pandas_version
         require_minimum_pandas_version()
 
+        import numpy as np
         import pandas as pd
 
         if self.sql_ctx._conf.pandasRespectSessionTimeZone():
@@ -2190,6 +2191,10 @@ class DataFrame(object):
                 not(isinstance(field.dataType, IntegralType) and field.nullable and
                     pdf[field.name].isnull().any()):
                 dtype[field.name] = pandas_type
+            if isinstance(field.dataType, IntegralType) and pdf[field.name].isnull().any():
+                dtype[field.name] = np.float64
+            if isinstance(field.dataType, BooleanType) and pdf[field.name].isnull().any():
+                dtype[field.name] = np.object
 
         for f, t in dtype.items():
             pdf[f] = pdf[f].astype(t, copy=False)
@@ -2317,6 +2322,10 @@ def _to_corrected_pandas_type(dt):
         return np.float32
     elif type(dt) == DoubleType:
         return np.float64
+    elif type(dt) == BooleanType:
+        return np.bool
+    elif type(dt) == TimestampType:
+        return np.datetime64
     else:
         return None
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2311,8 +2311,12 @@ def _to_corrected_pandas_type(dt):
         return np.int16
     elif type(dt) == IntegerType:
         return np.int32
+    elif type(dt) == LongType:
+        return np.int64
     elif type(dt) == FloatType:
         return np.float32
+    elif type(dt) == DoubleType:
+        return np.float64
     else:
         return None
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2305,20 +2305,15 @@ def _to_corrected_pandas_type(dt):
     uncorrectly.
     """
     import numpy as np
-    if type(dt) == ByteType:
-        return np.int8
-    elif type(dt) == ShortType:
-        return np.int16
-    elif type(dt) == IntegerType:
-        return np.int32
-    elif type(dt) == LongType:
-        return np.int64
-    elif type(dt) == FloatType:
-        return np.float32
-    elif type(dt) == DoubleType:
-        return np.float64
-    else:
-        return None
+    mappings = {
+        ByteType: np.int8,
+        ShortType: np.int16,
+        IntegerType: np.int32,
+        LongType: np.int64,
+        FloatType: np.float32,
+        DoubleType: np.float64
+    }
+    return mappings.get(type(dt), None)
 
 
 class DataFrameNaFunctions(object):

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2305,15 +2305,20 @@ def _to_corrected_pandas_type(dt):
     uncorrectly.
     """
     import numpy as np
-    mappings = {
-        ByteType: np.int8,
-        ShortType: np.int16,
-        IntegerType: np.int32,
-        LongType: np.int64,
-        FloatType: np.float32,
-        DoubleType: np.float64
-    }
-    return mappings.get(type(dt), None)
+    if type(dt) == ByteType:
+        return np.int8
+    elif type(dt) == ShortType:
+        return np.int16
+    elif type(dt) == IntegerType:
+        return np.int32
+    elif type(dt) == LongType:
+        return np.int64
+    elif type(dt) == FloatType:
+        return np.float32
+    elif type(dt) == DoubleType:
+        return np.float64
+    else:
+        return None
 
 
 class DataFrameNaFunctions(object):

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -595,7 +595,7 @@ class DataFrameTests(ReusedSQLTestCase):
 
     @unittest.skipIf(not have_pandas, pandas_requirement_message)
     def test_to_pandas_from_mixed_dataframe(self):
-        # SPARK-29188 test that toPandas() on a dataframe with mixed nulls and non-nulls has correct dtypes
+        # SPARK-29188 test that toPandas() on a dataframe with some nulls has correct dtypes
         import numpy as np
         sql = """
         SELECT CAST(col1 AS TINYINT) AS tinyint,
@@ -607,7 +607,8 @@ class DataFrameTests(ReusedSQLTestCase):
         CAST(col7 AS BOOLEAN) AS boolean,
         CAST(col8 AS STRING) AS string,
         CAST(col9 AS TIMESTAMP) AS timestamp
-        FROM VALUES (1, 1, 1, 1, 1, 1, 1, 1, 1), (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL) 
+        FROM VALUES (1, 1, 1, 1, 1, 1, 1, 1, 1),
+                    (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
         """
         pdf_with_some_nulls = self.spark.sql(sql).toPandas()
         pdf_with_only_nulls = self.spark.sql(sql).filter('tinyint is null').toPandas()

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -549,7 +549,7 @@ class DataFrameTests(ReusedSQLTestCase):
 
     @unittest.skipIf(not have_pandas, pandas_requirement_message)
     def test_to_pandas_from_empty_dataframe(self):
-        # SPARK-29188 test that toPandas() on an empty dataframe had the correct dtypes
+        # SPARK-29188 test that toPandas() on an empty dataframe has the correct dtypes
         import numpy as np
         sql = """
         SELECT CAST(1 AS TINYINT) AS tinyint,
@@ -568,7 +568,7 @@ class DataFrameTests(ReusedSQLTestCase):
 
     @unittest.skipIf(not have_pandas, pandas_requirement_message)
     def test_to_pandas_from_null_dataframe(self):
-        # SPARK-29188 test that toPandas() on an empty dataframe had the correct dtypes
+        # SPARK-29188 test that toPandas() on a dataframe with only nulls has correct dtypes
         import numpy as np
         sql = """
         SELECT CAST(NULL AS TINYINT) AS tinyint,
@@ -592,6 +592,26 @@ class DataFrameTests(ReusedSQLTestCase):
         self.assertEqual(types[6], np.object)
         self.assertEqual(types[7], np.object)
         self.assertTrue(np.can_cast(np.datetime64, types[8]))
+
+    @unittest.skipIf(not have_pandas, pandas_requirement_message)
+    def test_to_pandas_from_mixed_dataframe(self):
+        # SPARK-29188 test that toPandas() on a dataframe with mixed nulls and non-nulls has correct dtypes
+        import numpy as np
+        sql = """
+        SELECT CAST(col1 AS TINYINT) AS tinyint,
+        CAST(col2 AS SMALLINT) AS smallint,
+        CAST(col3 AS INT) AS int,
+        CAST(col4 AS BIGINT) AS bigint,
+        CAST(col5 AS FLOAT) AS float,
+        CAST(col6 AS DOUBLE) AS double,
+        CAST(col7 AS BOOLEAN) AS boolean,
+        CAST(col8 AS STRING) AS string,
+        CAST(col9 AS TIMESTAMP) AS timestamp
+        FROM VALUES (1, 1, 1, 1, 1, 1, 1, 1, 1), (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL) 
+        """
+        pdf_with_some_nulls = self.spark.sql(sql).toPandas()
+        pdf_with_only_nulls = self.spark.sql(sql).filter('tinyint is null').toPandas()
+        self.assertTrue(np.all(pdf_with_only_nulls.dtypes == pdf_with_some_nulls.dtypes))
 
     def test_create_dataframe_from_array_of_long(self):
         import array

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -547,6 +547,27 @@ class DataFrameTests(ReusedSQLTestCase):
         self.assertEquals(types[1], np.object)
         self.assertEquals(types[2], np.float64)
 
+    @unittest.skipIf(not have_pandas, pandas_requirement_message)
+    def test_to_pandas_from_empty_dataframe(self):
+        # SPARK-29188 test that toPandas() on an empty dataframe had the correct dtypes
+        import numpy as np
+        schema = StructType([
+            StructField('double', DoubleType(), True),
+            StructField('float', FloatType(), True),
+            StructField('byte', ByteType(), True),
+            StructField('integer', IntegerType(), True),
+            StructField('long', LongType(), True),
+            StructField('short', ShortType(), True),
+        ])
+        df = self.spark.createDataFrame([], schema=schema)
+        types = df.toPandas().dtypes
+        self.assertEqual(types[0], np.float64)
+        self.assertEqual(types[1], np.float32)
+        self.assertEqual(types[2], np.int8)
+        self.assertEqual(types[3], np.int32)
+        self.assertEqual(types[4], np.int64)
+        self.assertEqual(types[5], np.int16)
+
     def test_create_dataframe_from_array_of_long(self):
         import array
         data = [Row(longarray=array.array('l', [-9223372036854775808, 0, 9223372036854775807]))]


### PR DESCRIPTION
### What changes were proposed in this pull request?

An empty Spark DataFrame converted to a Pandas DataFrame wouldn't have the right column types. Several type mappings were missing.

### Why are the changes needed?

Empty Spark DataFrames can be used to write unit tests, and verified by converting them to Pandas first. But this can fail when the column types are wrong.

### Does this PR introduce any user-facing change?

Yes; the error reported in the JIRA issue should not happen anymore.

### How was this patch tested?

Through unit tests in `pyspark.sql.tests.test_dataframe.DataFrameTests#test_to_pandas_from_empty_dataframe`