### PR TITLE
[SPARK-30115][SQL] Improve limit only query on datasource table

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2072,6 +2072,21 @@ object SQLConf {
       .stringConf
       .createWithDefault(
         "https://maven-central.storage-download.googleapis.com/repos/central/data/")
+
+  val PARTIAL_LISTING_ENABLED =
+    buildConf("spark.sql.sources.partialListing.enabled")
+      .doc("The configuration property enables the partial listing for limit only query. " +
+        "When set to true, same queries with limit won't scan all files.")
+      .booleanConf
+      .createWithDefault(true)
+
+  val PARTIAL_LISTING_MAX_FILES =
+    buildConf("spark.sql.sources.partialListing.maxFiles")
+      .doc("The max number of listing files for limit only query at driver side.")
+      .intConf
+      .checkValue(files => files >= 0, "The max number of listing files for " +
+        "limit only query must not be negative")
+      .createWithDefault(5)
 }
 
 /**
@@ -2572,6 +2587,10 @@ class SQLConf extends Serializable with Logging {
   def castDatetimeToString: Boolean = getConf(SQLConf.LEGACY_CAST_DATETIME_TO_STRING)
 
   def ignoreDataLocality: Boolean = getConf(SQLConf.IGNORE_DATA_LOCALITY)
+
+  def partialListingEnabled: Boolean = getConf(SQLConf.PARTIAL_LISTING_ENABLED)
+
+  def partialListingMaxFiles: Int = getConf(SQLConf.PARTIAL_LISTING_MAX_FILES)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FilePartition.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FilePartition.scala
@@ -94,4 +94,10 @@ object FilePartition extends Logging {
 
     Math.min(defaultMaxSplitBytes, Math.max(openCostInBytes, bytesPerCore))
   }
+
+  def getSingleFilePartitions(partitionedFiles: Seq[PartitionedFile]): Seq[FilePartition] = {
+    // Assign all files to a single partition
+    val newPartition = FilePartition(0, partitionedFiles.toArray)
+    Seq(newPartition)
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
@@ -23,7 +23,8 @@ import java.net.URI
 import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.hadoop.mapred.{FileInputFormat, JobConf}
 import org.apache.parquet.io.ParquetDecodingException
-import org.apache.spark.{TaskContext, Partition => RDDPartition}
+
+import org.apache.spark.{Partition => RDDPartition, TaskContext}
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.rdd.{InputFileBlockHolder, RDD}
 import org.apache.spark.sql.SparkSession

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
@@ -18,17 +18,19 @@
 package org.apache.spark.sql.execution.datasources
 
 import java.io.{FileNotFoundException, IOException}
+import java.net.URI
 
+import org.apache.hadoop.fs.{FileStatus, Path}
+import org.apache.hadoop.mapred.{FileInputFormat, JobConf}
 import org.apache.parquet.io.ParquetDecodingException
-
-import org.apache.spark.{Partition => RDDPartition, TaskContext}
+import org.apache.spark.{TaskContext, Partition => RDDPartition}
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.rdd.{InputFileBlockHolder, RDD}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.QueryExecutionException
 import org.apache.spark.sql.vectorized.ColumnarBatch
-import org.apache.spark.util.NextIterator
+import org.apache.spark.util.{NextIterator, SerializableConfiguration}
 
 /**
  * A part (i.e. "block") of a single file that should be read, along with partition column values
@@ -64,141 +66,7 @@ class FileScanRDD(
   private val ignoreMissingFiles = sparkSession.sessionState.conf.ignoreMissingFiles
 
   override def compute(split: RDDPartition, context: TaskContext): Iterator[InternalRow] = {
-    val iterator = new Iterator[Object] with AutoCloseable {
-      private val inputMetrics = context.taskMetrics().inputMetrics
-      private val existingBytesRead = inputMetrics.bytesRead
-
-      // Find a function that will return the FileSystem bytes read by this thread. Do this before
-      // apply readFunction, because it might read some bytes.
-      private val getBytesReadCallback =
-        SparkHadoopUtil.get.getFSBytesReadOnThreadCallback()
-
-      // We get our input bytes from thread-local Hadoop FileSystem statistics.
-      // If we do a coalesce, however, we are likely to compute multiple partitions in the same
-      // task and in the same thread, in which case we need to avoid override values written by
-      // previous partitions (SPARK-13071).
-      private def incTaskInputMetricsBytesRead(): Unit = {
-        inputMetrics.setBytesRead(existingBytesRead + getBytesReadCallback())
-      }
-
-      private[this] val files = split.asInstanceOf[FilePartition].files.toIterator
-      private[this] var currentFile: PartitionedFile = null
-      private[this] var currentIterator: Iterator[Object] = null
-
-      def hasNext: Boolean = {
-        // Kill the task in case it has been marked as killed. This logic is from
-        // InterruptibleIterator, but we inline it here instead of wrapping the iterator in order
-        // to avoid performance overhead.
-        context.killTaskIfInterrupted()
-        (currentIterator != null && currentIterator.hasNext) || nextIterator()
-      }
-      def next(): Object = {
-        val nextElement = currentIterator.next()
-        // TODO: we should have a better separation of row based and batch based scan, so that we
-        // don't need to run this `if` for every record.
-        val preNumRecordsRead = inputMetrics.recordsRead
-        if (nextElement.isInstanceOf[ColumnarBatch]) {
-          incTaskInputMetricsBytesRead()
-          inputMetrics.incRecordsRead(nextElement.asInstanceOf[ColumnarBatch].numRows())
-        } else {
-          // too costly to update every record
-          if (inputMetrics.recordsRead %
-              SparkHadoopUtil.UPDATE_INPUT_METRICS_INTERVAL_RECORDS == 0) {
-            incTaskInputMetricsBytesRead()
-          }
-          inputMetrics.incRecordsRead(1)
-        }
-        nextElement
-      }
-
-      private def readCurrentFile(): Iterator[InternalRow] = {
-        try {
-          readFunction(currentFile)
-        } catch {
-          case e: FileNotFoundException =>
-            throw new FileNotFoundException(
-              e.getMessage + "\n" +
-                "It is possible the underlying files have been updated. " +
-                "You can explicitly invalidate the cache in Spark by " +
-                "running 'REFRESH TABLE tableName' command in SQL or " +
-                "by recreating the Dataset/DataFrame involved.")
-        }
-      }
-
-      /** Advances to the next file. Returns true if a new non-empty iterator is available. */
-      private def nextIterator(): Boolean = {
-        if (files.hasNext) {
-          currentFile = files.next()
-          logInfo(s"Reading File $currentFile")
-          // Sets InputFileBlockHolder for the file block's information
-          InputFileBlockHolder.set(currentFile.filePath, currentFile.start, currentFile.length)
-
-          if (ignoreMissingFiles || ignoreCorruptFiles) {
-            currentIterator = new NextIterator[Object] {
-              // The readFunction may read some bytes before consuming the iterator, e.g.,
-              // vectorized Parquet reader. Here we use lazy val to delay the creation of
-              // iterator so that we will throw exception in `getNext`.
-              private lazy val internalIter = readCurrentFile()
-
-              override def getNext(): AnyRef = {
-                try {
-                  if (internalIter.hasNext) {
-                    internalIter.next()
-                  } else {
-                    finished = true
-                    null
-                  }
-                } catch {
-                  case e: FileNotFoundException if ignoreMissingFiles =>
-                    logWarning(s"Skipped missing file: $currentFile", e)
-                    finished = true
-                    null
-                  // Throw FileNotFoundException even if `ignoreCorruptFiles` is true
-                  case e: FileNotFoundException if !ignoreMissingFiles => throw e
-                  case e @ (_: RuntimeException | _: IOException) if ignoreCorruptFiles =>
-                    logWarning(
-                      s"Skipped the rest of the content in the corrupted file: $currentFile", e)
-                    finished = true
-                    null
-                }
-              }
-
-              override def close(): Unit = {}
-            }
-          } else {
-            currentIterator = readCurrentFile()
-          }
-
-          try {
-            hasNext
-          } catch {
-            case e: SchemaColumnConvertNotSupportedException =>
-              val message = "Parquet column cannot be converted in " +
-                s"file ${currentFile.filePath}. Column: ${e.getColumn}, " +
-                s"Expected: ${e.getLogicalType}, Found: ${e.getPhysicalType}"
-              throw new QueryExecutionException(message, e)
-            case e: ParquetDecodingException =>
-              if (e.getMessage.contains("Can not read value at")) {
-                val message = "Encounter error while reading parquet files. " +
-                  "One possible cause: Parquet column cannot be converted in the " +
-                  "corresponding files. Details: "
-                throw new QueryExecutionException(message, e)
-              }
-              throw e
-          }
-        } else {
-          currentFile = null
-          InputFileBlockHolder.unset()
-          false
-        }
-      }
-
-      override def close(): Unit = {
-        incTaskInputMetricsBytesRead()
-        InputFileBlockHolder.unset()
-      }
-    }
-
+    val iterator = new PartitionScanIterator(split, context)
     // Register an on-task-completion callback to close the input stream.
     context.addTaskCompletionListener[Unit](_ => iterator.close())
 
@@ -209,5 +77,240 @@ class FileScanRDD(
 
   override protected def getPreferredLocations(split: RDDPartition): Seq[String] = {
     split.asInstanceOf[FilePartition].preferredLocations()
+  }
+
+  class PartitionScanIterator(
+      split: RDDPartition,
+      context: TaskContext) extends Iterator[Object] with AutoCloseable {
+    private val inputMetrics = context.taskMetrics().inputMetrics
+    private val existingBytesRead = inputMetrics.bytesRead
+
+    // Find a function that will return the FileSystem bytes read by this thread. Do this before
+    // apply readFunction, because it might read some bytes.
+    private val getBytesReadCallback =
+    SparkHadoopUtil.get.getFSBytesReadOnThreadCallback()
+
+    // We get our input bytes from thread-local Hadoop FileSystem statistics.
+    // If we do a coalesce, however, we are likely to compute multiple partitions in the same
+    // task and in the same thread, in which case we need to avoid override values written by
+    // previous partitions (SPARK-13071).
+    private def incTaskInputMetricsBytesRead(): Unit = {
+      inputMetrics.setBytesRead(existingBytesRead + getBytesReadCallback())
+    }
+
+    protected var files = split.asInstanceOf[FilePartition].files.toIterator
+    protected var currentFile: PartitionedFile = null
+    private var currentIterator: Iterator[Object] = null
+
+    def hasNext: Boolean = {
+      // Kill the task in case it has been marked as killed. This logic is from
+      // InterruptibleIterator, but we inline it here instead of wrapping the iterator in order
+      // to avoid performance overhead.
+      context.killTaskIfInterrupted()
+      (currentIterator != null && currentIterator.hasNext) || nextIterator()
+    }
+    def next(): Object = {
+      val nextElement = currentIterator.next()
+      // TODO: we should have a better separation of row based and batch based scan, so that we
+      // don't need to run this `if` for every record.
+      val preNumRecordsRead = inputMetrics.recordsRead
+      if (nextElement.isInstanceOf[ColumnarBatch]) {
+        incTaskInputMetricsBytesRead()
+        inputMetrics.incRecordsRead(nextElement.asInstanceOf[ColumnarBatch].numRows())
+      } else {
+        // too costly to update every record
+        if (inputMetrics.recordsRead %
+          SparkHadoopUtil.UPDATE_INPUT_METRICS_INTERVAL_RECORDS == 0) {
+          incTaskInputMetricsBytesRead()
+        }
+        inputMetrics.incRecordsRead(1)
+      }
+      nextElement
+    }
+
+    private def readCurrentFile(): Iterator[InternalRow] = {
+      try {
+        readFunction(currentFile)
+      } catch {
+        case e: FileNotFoundException =>
+          throw new FileNotFoundException(
+            e.getMessage + "\n" +
+              "It is possible the underlying files have been updated. " +
+              "You can explicitly invalidate the cache in Spark by " +
+              "running 'REFRESH TABLE tableName' command in SQL or " +
+              "by recreating the Dataset/DataFrame involved.")
+      }
+    }
+
+    /** Advances to the next file. Returns true if a new non-empty iterator is available. */
+    protected def nextIterator(): Boolean = {
+      if (files.hasNext) {
+        currentFile = files.next()
+        logInfo(s"Reading File $currentFile")
+        // Sets InputFileBlockHolder for the file block's information
+        InputFileBlockHolder.set(currentFile.filePath, currentFile.start, currentFile.length)
+
+        if (ignoreMissingFiles || ignoreCorruptFiles) {
+          currentIterator = new NextIterator[Object] {
+            // The readFunction may read some bytes before consuming the iterator, e.g.,
+            // vectorized Parquet reader. Here we use lazy val to delay the creation of
+            // iterator so that we will throw exception in `getNext`.
+            private lazy val internalIter = readCurrentFile()
+
+            override def getNext(): AnyRef = {
+              try {
+                if (internalIter.hasNext) {
+                  internalIter.next()
+                } else {
+                  finished = true
+                  null
+                }
+              } catch {
+                case e: FileNotFoundException if ignoreMissingFiles =>
+                  logWarning(s"Skipped missing file: $currentFile", e)
+                  finished = true
+                  null
+                // Throw FileNotFoundException even if `ignoreCorruptFiles` is true
+                case e: FileNotFoundException if !ignoreMissingFiles => throw e
+                case e @ (_: RuntimeException | _: IOException) if ignoreCorruptFiles =>
+                  logWarning(
+                    s"Skipped the rest of the content in the corrupted file: $currentFile", e)
+                  finished = true
+                  null
+              }
+            }
+
+            override def close(): Unit = {}
+          }
+        } else {
+          currentIterator = readCurrentFile()
+        }
+
+        try {
+          hasNext
+        } catch {
+          case e: SchemaColumnConvertNotSupportedException =>
+            val message = "Parquet column cannot be converted in " +
+              s"file ${currentFile.filePath}. Column: ${e.getColumn}, " +
+              s"Expected: ${e.getLogicalType}, Found: ${e.getPhysicalType}"
+            throw new QueryExecutionException(message, e)
+          case e: ParquetDecodingException =>
+            if (e.getMessage.contains("Can not read value at")) {
+              val message = "Encounter error while reading parquet files. " +
+                "One possible cause: Parquet column cannot be converted in the " +
+                "corresponding files. Details: "
+              throw new QueryExecutionException(message, e)
+            }
+            throw e
+        }
+      } else {
+        currentFile = null
+        InputFileBlockHolder.unset()
+        false
+      }
+    }
+
+    override def close(): Unit = {
+      incTaskInputMetricsBytesRead()
+      InputFileBlockHolder.unset()
+    }
+  }
+}
+
+class SinglePartitionFileScanRDD(
+    sparkSession: SparkSession,
+    readFunction: (PartitionedFile) => Iterator[InternalRow],
+    filePartitions: Seq[FilePartition],
+    rootPaths: Map[String, InternalRow])
+  extends FileScanRDD(sparkSession, readFunction, filePartitions) {
+
+  val broadcastedHadoopConf = sparkSession.sparkContext.broadcast(
+    new SerializableConfiguration(sparkSession.sessionState.newHadoopConf()))
+
+  override def compute(split: RDDPartition, context: TaskContext): Iterator[InternalRow] = {
+    val iterator = new PartitionAndRootFilesScanIterator(split, context, rootPaths)
+    // Register an on-task-completion callback to close the input stream.
+    context.addTaskCompletionListener[Unit](_ => iterator.close())
+    iterator.asInstanceOf[Iterator[InternalRow]]
+  }
+
+  class PartitionAndRootFilesScanIterator(
+      split: RDDPartition,
+      context: TaskContext,
+      rootPaths: Map[String, InternalRow]) extends PartitionScanIterator(split, context) {
+
+    private val rootDirs = rootPaths.toIterator
+    private val fileSet = split.asInstanceOf[FilePartition].files.map(_.filePath).toSet
+
+    override def nextIterator(): Boolean = {
+      if (super.nextIterator()) {
+        true
+      } else {
+        if (rootDirs.hasNext) {
+          val nextPath = rootDirs.next()
+          val parentPath = nextPath._1
+          logInfo(s"list root path ${parentPath} to future out more files to scan.")
+          val leafFiles = listLeafFiles(new Path(new URI(parentPath)), fileSet)
+          files = leafFiles.map { file =>
+            PartitionedFile(nextPath._2, file.getPath.toUri.toString, 0, file.getLen)}.toIterator
+
+          nextIterator
+        } else {
+          currentFile = null
+          InputFileBlockHolder.unset()
+          false
+        }
+      }
+    }
+
+    /**
+     * Lists a single filesystem path recursively.
+     * @return all children of path that match the specified filter.
+     */
+    private def listLeafFiles(path: Path, excludedFileSet: Set[String]): Seq[FileStatus] = {
+      val hadoopConf = broadcastedHadoopConf.value.value
+      val fs = path.getFileSystem(hadoopConf)
+      val filter = FileInputFormat.getInputPathFilter(new JobConf(hadoopConf, this.getClass))
+
+      val statuses: Array[FileStatus] =
+        try {
+          fs.listStatus(path)
+        } catch {
+          case _: FileNotFoundException =>
+            logWarning(s"The directory $path was not found. Was it deleted very recently?")
+            Array.empty[FileStatus]
+        }
+      val filteredStatuses = statuses.filterNot(status =>
+        shouldFilterOut(status.getPath, excludedFileSet))
+      val allLeafStatuses = {
+        val (dirs, topLevelFiles) = filteredStatuses.partition(_.isDirectory)
+        val nestedFiles: Seq[FileStatus] = dirs.flatMap(dir =>
+          listLeafFiles(dir.getPath, excludedFileSet))
+
+        val allFiles = topLevelFiles ++ nestedFiles
+        if (filter != null) allFiles.filter(f => filter.accept(f.getPath)) else allFiles
+      }
+      allLeafStatuses.filterNot(status => shouldFilterOut(status.getPath, excludedFileSet))
+    }
+
+    /** Checks if we should filter out this path. */
+    def shouldFilterOut(path: Path, excludedFileSet: Set[String]): Boolean = {
+      if (excludedFileSet.contains(path.toUri.toString)) {
+        true
+      } else {
+        val pathName = path.getName
+        // We filter follow paths:
+        // 1. everything that starts with _ and ., except _common_metadata and _metadata
+        // because Parquet needs to find those metadata files from leaf files returned
+        // by this method.
+        // We should refactor this logic to not mix metadata files with data files.
+        // 2. everything that ends with `._COPYING_`, because this is a intermediate
+        // state of file. we should skip this file in case of double reading.
+        val exclude = (pathName.startsWith("_") && !pathName.contains("=")) ||
+          pathName.startsWith(".") || pathName.endsWith("._COPYING_")
+        val include = pathName.startsWith("_common_metadata") || pathName.startsWith("_metadata")
+        exclude && !include
+      }
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/LimitOnlyQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/LimitOnlyQuerySuite.scala
@@ -228,7 +228,7 @@ class LimitOnlyQuerySuite extends SparkFunSuite with SQLMetricsTestUtils with Sh
   test("Join with limit only scan on partition + bucketed table") {
     withTable("testDataForScan") {
       spark.range(1000).selectExpr("id", "id % 5 as p")
-        .write.partitionBy("p").saveAsTable("testDataForScan")
+        .write.partitionBy("p").bucketBy(3, "id").saveAsTable("testDataForScan")
       // The execution plan has 2 FileScan nodes.
       val df = spark.sql(
         " SELECT * FROM testDataForScan JOIN" +
@@ -249,7 +249,7 @@ class LimitOnlyQuerySuite extends SparkFunSuite with SQLMetricsTestUtils with Sh
       val firstScanRDD = fileScanRDDs.head
       val secondScanRDD = fileScanRDDs.tail.head.asInstanceOf[SinglePartitionFileScanRDD]
 
-      assert(firstScanRDD.partitions.length == 2)
+      assert(firstScanRDD.partitions.length == 3)
       assert(secondScanRDD.partitions.length == 1)
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/LimitOnlyQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/LimitOnlyQuerySuite.scala
@@ -1,0 +1,256 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.execution.{DataSourceScanExec, FileSourceScanExec}
+import org.apache.spark.sql.execution.datasources.{FileScanRDD, SinglePartitionFileScanRDD}
+import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetricsTestUtils}
+import org.apache.spark.sql.test.SharedSparkSession
+
+class LimitOnlyQuerySuite extends SparkFunSuite with SQLMetricsTestUtils with SharedSparkSession {
+
+  private def getScanNodeMetrics(df: DataFrame): Map[String, SQLMetric] = {
+    val scanNode =
+      df.queryExecution.executedPlan.collectLeaves().head.asInstanceOf[FileSourceScanExec]
+    scanNode.metrics
+  }
+
+  test("Limit only query on normal table") {
+    withTable("testDataForScan") {
+      spark.range(0, 1000, 1, 10).selectExpr("id")
+        .write.saveAsTable("testDataForScan")
+      val df = spark.sql("SELECT * FROM testDataForScan limit 600")
+      df.collect()
+      val fileScanRDD = df.queryExecution.executedPlan.collect {
+        case scan: DataSourceScanExec
+          if scan.inputRDDs().head.isInstanceOf[SinglePartitionFileScanRDD] =>
+          scan.inputRDDs().head.asInstanceOf[SinglePartitionFileScanRDD]
+      }.headOption.getOrElse {
+        fail(s"No SinglePartitionFileScanRDD in query\n${df.queryExecution}")
+      }
+      assert(fileScanRDD.partitions.length == 1)
+
+      val metrics = getScanNodeMetrics(df)
+      // Check deterministic metrics.
+      assert(metrics("numFiles").value == 5)
+      assert(metrics("numOutputRows").value == 600)
+    }
+  }
+
+  test("Limit with filter on normal table") {
+    withTable("testDataForScan") {
+      spark.range(0, 1000, 1, 10).selectExpr("id")
+        .write.saveAsTable("testDataForScan")
+      val df = spark.sql(
+        "SELECT * FROM testDataForScan where id > 0 limit 600")
+      df.collect()
+      val fileScanRDD = df.queryExecution.executedPlan.collect {
+        case scan: DataSourceScanExec
+          if scan.inputRDDs().head.isInstanceOf[FileScanRDD] =>
+          scan.inputRDDs().head.asInstanceOf[FileScanRDD]
+      }.headOption.getOrElse {
+        fail(s"No FileScanRDD in query\n${df.queryExecution}")
+      }
+      assert(fileScanRDD.partitions.length == 2)
+      val metrics = getScanNodeMetrics(df)
+      // Check deterministic metrics.
+      assert(metrics("numFiles").value == 10)
+      assert(metrics("numOutputRows").value == 1000)
+    }
+  }
+
+  test("Limit with order by on normal table") {
+    withTable("testDataForScan") {
+      spark.range(0, 1000, 1, 10).selectExpr("id")
+        .write.saveAsTable("testDataForScan")
+      val df = spark.sql(
+        "SELECT * FROM testDataForScan order by id limit 600")
+      df.collect()
+      val fileScanRDD = df.queryExecution.executedPlan.collect {
+        case scan: DataSourceScanExec
+          if scan.inputRDDs().head.isInstanceOf[FileScanRDD] =>
+          scan.inputRDDs().head.asInstanceOf[FileScanRDD]
+      }.headOption.getOrElse {
+        fail(s"No FileScanRDD in query\n${df.queryExecution}")
+      }
+      assert(fileScanRDD.partitions.length == 2)
+      val metrics = getScanNodeMetrics(df)
+      // Check deterministic metrics.
+      assert(metrics("numFiles").value == 10)
+      assert(metrics("numOutputRows").value == 1000)
+    }
+  }
+
+  test("Limit only query on partition table") {
+    withTable("testDataForScan") {
+      spark.range(1000).selectExpr("id", "id % 5 as p")
+        .write.partitionBy("p").saveAsTable("testDataForScan")
+      val df = spark.sql("SELECT * FROM testDataForScan limit 600")
+      df.collect()
+      val fileScanRDD = df.queryExecution.executedPlan.collect {
+        case scan: DataSourceScanExec
+          if scan.inputRDDs().head.isInstanceOf[SinglePartitionFileScanRDD] =>
+          scan.inputRDDs().head.asInstanceOf[SinglePartitionFileScanRDD]
+      }.headOption.getOrElse {
+        fail(s"No SinglePartitionFileScanRDD in query\n${df.queryExecution}")
+      }
+      assert(fileScanRDD.partitions.length == 1)
+      val metrics = getScanNodeMetrics(df)
+      // Check deterministic metrics.
+      assert(metrics("numFiles").value == 5)
+      assert(metrics("numOutputRows").value == 600)
+    }
+  }
+
+  test("Limit with filter on partition table") {
+    withTable("testDataForScan") {
+      spark.range(1000).selectExpr("id", "id % 5 as p")
+        .write.partitionBy("p").saveAsTable("testDataForScan")
+      val df = spark.sql(
+        "SELECT * FROM testDataForScan where id > 0 limit 600")
+      df.collect()
+      val fileScanRDD = df.queryExecution.executedPlan.collect {
+        case scan: DataSourceScanExec
+          if scan.inputRDDs().head.isInstanceOf[FileScanRDD] =>
+          scan.inputRDDs().head.asInstanceOf[FileScanRDD]
+      }.headOption.getOrElse {
+        fail(s"No FileScanRDD in query\n${df.queryExecution}")
+      }
+      assert(fileScanRDD.partitions.length == 2)
+      val metrics = getScanNodeMetrics(df)
+      // Check deterministic metrics.
+      assert(metrics("numFiles").value == 10)
+      assert(metrics("numOutputRows").value == 1000)
+    }
+  }
+
+  test("Limit with partition filter on partition table") {
+    withTable("testDataForScan") {
+      spark.range(1000).selectExpr("id", "id % 5 as p")
+        .write.partitionBy("p").saveAsTable("testDataForScan")
+      val df = spark.sql(
+        "SELECT * FROM testDataForScan where p = 0 limit 600")
+      df.collect()
+      val fileScanRDD = df.queryExecution.executedPlan.collect {
+        case scan: DataSourceScanExec
+          if scan.inputRDDs().head.isInstanceOf[FileScanRDD] =>
+          scan.inputRDDs().head.asInstanceOf[FileScanRDD]
+      }.headOption.getOrElse {
+        fail(s"No FileScanRDD in query\n${df.queryExecution}")
+      }
+      assert(fileScanRDD.partitions.length == 2)
+      val metrics = getScanNodeMetrics(df)
+      // Check deterministic metrics.
+      assert(metrics("numFiles").value == 2)
+      assert(metrics("numOutputRows").value == 200)
+    }
+  }
+
+  test("Limit only query on bucketed table") {
+    withTable("testDataForScan") {
+      spark.range(1000).selectExpr("id", "id % 5 as p")
+        .write.bucketBy(20, "id").saveAsTable("testDataForScan")
+      val df = spark.sql(
+        "SELECT * FROM testDataForScan limit 600")
+      df.collect()
+      val fileScanRDD = df.queryExecution.executedPlan.collect {
+        case scan: DataSourceScanExec
+          if scan.inputRDDs().head.isInstanceOf[SinglePartitionFileScanRDD] =>
+          scan.inputRDDs().head.asInstanceOf[SinglePartitionFileScanRDD]
+      }.headOption.getOrElse {
+        fail(s"No SinglePartitionFileScanRDD in query\n${df.queryExecution}")
+      }
+      assert(fileScanRDD.partitions.length == 1)
+      val metrics = getScanNodeMetrics(df)
+      // Check deterministic metrics.
+      assert(metrics("numFiles").value == 5)
+    }
+  }
+
+  test("Limit with filter on bucketed table") {
+    withTable("testDataForScan") {
+      spark.range(1000).selectExpr("id", "id % 5 as p")
+        .write.bucketBy(20, "id").saveAsTable("testDataForScan")
+      val df = spark.sql(
+        "SELECT * FROM testDataForScan where p >= 0 limit 600")
+      df.collect()
+      val fileScanRDD = df.queryExecution.executedPlan.collect {
+        case scan: DataSourceScanExec
+          if scan.inputRDDs().head.isInstanceOf[FileScanRDD] =>
+          scan.inputRDDs().head.asInstanceOf[FileScanRDD]
+      }.headOption.getOrElse {
+        fail(s"No FileScanRDD in query\n${df.queryExecution}")
+      }
+      assert(fileScanRDD.partitions.length == 20)
+      val metrics = getScanNodeMetrics(df)
+      // Check deterministic metrics.
+      assert(metrics("numFiles").value == 40)
+    }
+  }
+
+  test("Limit only query on partition + bucketed table") {
+    withTable("testDataForScan") {
+      spark.range(1000).selectExpr("id", "id % 5 as p")
+        .write.partitionBy("p").bucketBy(3, "id").saveAsTable("testDataForScan")
+      val df = spark.sql(
+        "SELECT id FROM testDataForScan limit 600")
+      df.collect()
+      val fileScanRDD = df.queryExecution.executedPlan.collect {
+        case scan: DataSourceScanExec
+          if scan.inputRDDs().head.isInstanceOf[SinglePartitionFileScanRDD] =>
+          scan.inputRDDs().head.asInstanceOf[SinglePartitionFileScanRDD]
+      }.headOption.getOrElse {
+        fail(s"No SinglePartitionFileScanRDD in query\n${df.queryExecution}")
+      }
+      assert(fileScanRDD.partitions.length == 1)
+      val metrics = getScanNodeMetrics(df)
+      // Check deterministic metrics.
+      assert(metrics("numFiles").value == 5)
+    }
+  }
+
+  test("Join with limit only scan on partition + bucketed table") {
+    withTable("testDataForScan") {
+      spark.range(1000).selectExpr("id", "id % 5 as p")
+        .write.partitionBy("p").saveAsTable("testDataForScan")
+      // The execution plan has 2 FileScan nodes.
+      val df = spark.sql(
+        " SELECT * FROM testDataForScan JOIN" +
+          " (SELECT id as id2 FROM testDataForScan limit 600)" +
+          " ON id = id2")
+      assert(df.count() == 600)
+
+      val fileScanRDDs = df.queryExecution.executedPlan.collect {
+        case scan: DataSourceScanExec
+          if scan.inputRDDs().head.isInstanceOf[FileScanRDD] =>
+          scan.inputRDDs().head.asInstanceOf[FileScanRDD]
+        case scan: DataSourceScanExec
+          if scan.inputRDDs().head.isInstanceOf[SinglePartitionFileScanRDD] =>
+          scan.inputRDDs().head.asInstanceOf[SinglePartitionFileScanRDD]
+      }
+      assert(fileScanRDDs.length == 2)
+
+      val firstScanRDD = fileScanRDDs.head
+      val secondScanRDD = fileScanRDDs.tail.head.asInstanceOf[SinglePartitionFileScanRDD]
+
+      assert(firstScanRDD.partitions.length == 2)
+      assert(secondScanRDD.partitions.length == 1)
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

We use Spark as ad-hoc query engine. Most of users' SELECT queries with LIMIT operation like
1) SELECT * FROM TABLE_A LIMIT N
2) SELECT colA FROM TABLE_A LIMIT N
3) CREATE TAB_B as SELECT * FROM TABLE_A LIMIT N
If the TABLE_A is a large table (a RDD with thousands and thousands of partitions), the execution time would be very big since it has to list all files to build a RDD before execution. But almost time, the N is just like 10, 100, 1000, not very big. We don't need to scan all files. This optimization will create a **SinglePartitionReadRDD** to address it.

In our production result, this optimization benefits a lot. The duration time of simple query with LIMIT could reduce 5~10 times. For example, before this optimization, a query on a table which has about one hundred thousands files would run over 30 seconds, after applying this optimization, the time decreased to 5 seconds.

Should support both Spark DataSource Table and Hive Table which can be converted to DataSource table.
Should support bucket table, partition table, normal table.
Should support different file formats like parquet, orc.
This PR only addresses Spark datasource table.
Hive table and view will be filed after this merged.

### How to implement?
1. Add two configurations, `PARTIAL_LISTING_ENABLED` and `PARTIAL_LISTING_MAX_FILES`
2. In `FindDataSourceTable.apply()`, we resolve `GlobalLimit` to add a flag `partialListing` to `FileIndex`
3. In `DataSourceScanExec.inputRDD`, by checking the flag `partialListing` in `relation.location`, we create a `SinglePartitionReadRDD`. This RDD will assign less than `PARTIAL_LISTING_MAX_FILES` files to a single partition.

### Does this PR introduce any user-facing change?
No


### How was this patch tested?
Add LimitOnlyQuerySuite