### PR TITLE
[SPARK-30131] add array_median function 

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -1832,6 +1832,87 @@ case class ArrayMax(child: Expression) extends UnaryExpression with ImplicitCast
   override def prettyName: String = "array_max"
 }
 
+/**
+ * Returns the median value as double of an array of numeric values.
+ */
+@ExpressionDescription(
+  usage = """
+_FUNC_(array) - Returns the median value in the array, but only accepts arrays with numeric values.
+  NULL elements are skipped and returns NULL if array is empty.""",
+  examples = """
+    Examples:
+      > SELECT _FUNC_(array(1, 2, null, 3));
+       2
+  """, since = "3.0.0")
+case class ArrayMedian(child: Expression) extends UnaryExpression with ImplicitCastInputTypes {
+
+  override def checkInputDataTypes(): TypeCheckResult = child.dataType match {
+    case ArrayType(dt, _) => dt match {
+      case _: NumericType => TypeCheckResult.TypeCheckSuccess
+      case _ => TypeCheckResult.TypeCheckFailure(
+        s"$prettyName does not support arrays of type ${dt.catalogString} which is not numeric.")
+    }
+    case _ =>
+      TypeCheckResult.TypeCheckFailure(s"$prettyName only supports array input.")
+  }
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(ArrayType)
+
+  private def containsNulls: Boolean = child.dataType.asInstanceOf[ArrayType].containsNull
+
+  private def assignArrayCodeGen(array: String, ctx: CodegenContext, c: String): String = {
+    val javaType = CodeGenerator.javaType(arrayType)
+    val primitiveTypeName = CodeGenerator.primitiveTypeName(arrayType)
+
+    if(containsNulls) {
+      val numElements = ctx.freshName("numElements")
+      val tempArray = ctx.freshName("tempArray")
+      val count = ctx.freshName("count")
+      val i = ctx.freshName("i")
+
+      s"""
+         |int $numElements = $c.numElements();
+         |$javaType[] $tempArray = new $javaType[$numElements];
+         |int $count = -1;
+         |for (int $i = 0; $i < $numElements; $i++) {
+         |  if(!$c.isNullAt($i)) {
+         |    $tempArray[++$count] = $c.get$primitiveTypeName($i);
+         |  }
+         |}
+         |$javaType[] $array = java.util.Arrays.copyOf($tempArray, $count + 1);
+       """.stripMargin
+    } else {
+      s"""
+         |$javaType[] $array = $c.to${primitiveTypeName}Array();
+         """.stripMargin
+    }
+  }
+
+  override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    val size = ctx.freshName("size")
+    val array = ctx.freshName("array")
+
+    nullSafeCodeGen(ctx, ev, c =>
+      s"""
+         |${assignArrayCodeGen(array, ctx, c)}
+         |java.util.Arrays.sort($array);
+         |final int $size = $array.length;
+         |if ($size == 0) {
+         |  ${ev.isNull} = true;
+         |} else if ($size % 2 == 0) {
+         |  ${ev.value} = ($array[$size / 2] + $array[$size / 2 - 1]) / 2d;
+         |} else {
+         |   ${ev.value} = $array[$size / 2] / 1d;
+         |}
+       """.stripMargin)
+  }
+
+  @transient override val dataType: DataType = DoubleType
+
+  private val arrayType: DataType = child.dataType.asInstanceOf[ArrayType].elementType
+
+  override def prettyName: String = "array_median"
+}
 
 /**
  * Returns the position of the first occurrence of element in the given array as long.

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3911,6 +3911,14 @@ object functions {
   def array_max(e: Column): Column = withExpr { ArrayMax(e.expr) }
 
   /**
+   * Returns the median value as double of an array of numeric values.
+   *
+   * @group collection_funcs
+   * @since 3.0.0
+   */
+  def array_median(e: Column): Column = withExpr { ArrayMedian(e.expr) }
+
+  /**
    * Returns a random permutation of the given array.
    *
    * @note The function is non-deterministic.

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -898,6 +898,36 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
     checkAnswer(df.selectExpr("array_max(a)"), answer)
   }
 
+  test("array_median function") {
+    val doubles = Seq(
+      Seq(1.0, 3.0, 2.0).map(Option.apply),
+      Seq(Some(1.2), Some(-100.0), Some(2.5), Option.empty[Double]),
+      Seq(6.0, 2.0, 3.0, 5.0, 4.0, 1.0).map(Option.apply),
+      Seq.empty[Option[Double]]
+    ).toDF("a")
+
+    val answerDoubles = Seq(Row(2.0), Row(1.2), Row(3.5), Row(null))
+
+    val ints = Seq(
+      Seq(1, 3, 2),
+      Seq(1, -100, 2)
+    ).toDF("a")
+
+    val longs = Seq(
+      Seq(1L, 3L, 2L),
+      Seq(1L, -100L, 2L)
+    ).toDF("a")
+
+    val answerLongAndInt = Seq(Row(2.0), Row(1.0))
+
+    checkAnswer(doubles.select(array_median(doubles("a"))), answerDoubles)
+    checkAnswer(doubles.selectExpr("array_median(a)"), answerDoubles)
+    checkAnswer(ints.select(array_median(ints("a"))), answerLongAndInt)
+    checkAnswer(ints.selectExpr("array_median(a)"), answerLongAndInt)
+    checkAnswer(longs.select(array_median(longs("a"))), answerLongAndInt)
+    checkAnswer(longs.selectExpr("array_median(a)"), answerLongAndInt)
+  }
+
   test("sequence") {
     checkAnswer(Seq((-2, 2)).toDF().select(sequence('_1, '_2)), Seq(Row(Array(-2, -1, 0, 1, 2))))
     checkAnswer(Seq((7, 2, -2)).toDF().select(sequence('_1, '_2, '_3)), Seq(Row(Array(7, 5, 3))))


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this PR I have added a dataframe function `array_median` that takes in one argument i.e. the array, checks that it only contains numeric values and returns the median value as a double.


### Why are the changes needed?
It is known that there isn't any exact median function in Spark SQL, and this might be a difficult problem to solve efficiently. However, to find the median for an array should be a simple task, and something that users can utilize when collecting numeric values to a list or set.

There is a ticket requesting exact median: https://issues.apache.org/jira/browse/SPARK-26589

And some online questions regarding medians and exact medians:
https://stackoverflow.com/questions/41431270/how-to-find-exact-median-for-grouped-data-in-spark?rq=1
https://www.edureka.co/community/24516/how-can-i-calculate-exact-median-with-apache-spark
https://stackoverflow.com/questions/47988133/to-find-median-value-of-a-data-frame-in-apache-spark
https://stackoverflow.com/questions/31432843/how-to-find-median-and-quantiles-using-spark)
https://stackoverflow.com/questions/28158729/how-can-i-calculate-exact-median-with-apache-spark

This is not an aggregate function per se, but in other DBs you can find exact median functions:
https://www.ibm.com/support/knowledgecenter/en/SSCJDQ/com.ibm.swg.im.dashdb.sql.ref.doc/doc/r0061839.html
https://docs.aws.amazon.com/redshift/latest/dg/r_MEDIAN.html
https://docs.oracle.com/cd/B19306_01/server.102/b14200/functions086.htm
http://www.h2database.com/html/functions-aggregate.html#median

or have extensions implementing it:
https://pgxn.org/dist/quantile/ 

### Does this PR introduce any user-facing change?
Yes, a new function will be available for users, `array_median`.


### How was this patch tested?
unit tests
