### PR TITLE
[SPARK-30141][SQL][TESTS] Fix QueryTest.checkAnswer usage

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -2030,7 +2030,10 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession {
       def verifyCallCount(df: DataFrame, expectedResult: Row, expectedCount: Int): Unit = {
         countAcc.setValue(0)
         QueryTest.checkAnswer(
-          df, Seq(expectedResult), checkToRDD = false /* avoid duplicate exec */)
+          df, Seq(expectedResult), checkToRDD = false /* avoid duplicate exec */) match {
+          case Some(errorMessage) => fail(errorMessage)
+          case None =>
+        }
         assert(countAcc.value == expectedCount)
       }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SessionStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SessionStateSuite.scala
@@ -193,7 +193,10 @@ class SessionStateSuite extends SparkFunSuite {
           |FROM df x JOIN df y ON x.str = y.str
           |GROUP BY x.str
         """.stripMargin),
-        Row("1", 1) :: Row("2", 1) :: Row("3", 1) :: Nil)
+        Row("1", 1) :: Row("2", 1) :: Row("3", 1) :: Nil) match {
+        case Some(errorMessage) => fail(errorMessage)
+        case None =>
+      }
     }
 
     val spark = activeSession

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
@@ -352,15 +352,24 @@ class BinaryFileFormatSuite extends QueryTest with SharedSparkSession {
           .select(CONTENT)
       }
       val expected = Seq(Row(content))
-      QueryTest.checkAnswer(readContent(), expected)
+      QueryTest.checkAnswer(readContent(), expected) match {
+        case Some(errorMessage) => fail(errorMessage)
+        case None =>
+      }
       withSQLConf(SOURCES_BINARY_FILE_MAX_LENGTH.key -> content.length.toString) {
-        QueryTest.checkAnswer(readContent(), expected)
+        QueryTest.checkAnswer(readContent(), expected) match {
+          case Some(errorMessage) => fail(errorMessage)
+          case None =>
+        }
       }
       // Disable read. If the implementation attempts to read, the exception would be different.
       file.setReadable(false)
       val caught = intercept[SparkException] {
         withSQLConf(SOURCES_BINARY_FILE_MAX_LENGTH.key -> (content.length - 1).toString) {
-          QueryTest.checkAnswer(readContent(), expected)
+          QueryTest.checkAnswer(readContent(), expected) match {
+            case Some(errorMessage) => fail(errorMessage)
+            case None =>
+          }
         }
       }
       assert(caught.getMessage.contains("exceeds the max length allowed"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -756,8 +756,8 @@ class StreamSuite extends StreamTest {
         streamingQuery.processAllAvailable()
 
         QueryTest.checkAnswer(spark.table("counts").toDF(),
-          Row("1", 1) :: Row("2", 1) :: Row("3", 2) :: Row("4", 2) ::
-          Row("5", 2) :: Row("6", 2) :: Row("7", 1) :: Row("8", 1) :: Row("9", 1) :: Nil) match {
+          Row(1, 1L) :: Row(2, 1L) :: Row(3, 2L) :: Row(4, 2L) ::
+          Row(5, 2L) :: Row(6, 2L) :: Row(7, 1L) :: Row(8, 1L) :: Row(9, 1L) :: Nil) match {
           case Some(errorMessage) => fail(errorMessage)
           case None =>
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -757,7 +757,10 @@ class StreamSuite extends StreamTest {
 
         QueryTest.checkAnswer(spark.table("counts").toDF(),
           Row("1", 1) :: Row("2", 1) :: Row("3", 2) :: Row("4", 2) ::
-          Row("5", 2) :: Row("6", 2) :: Row("7", 1) :: Row("8", 1) :: Row("9", 1) :: Nil)
+          Row("5", 2) :: Row("6", 2) :: Row("7", 1) :: Row("8", 1) :: Row("9", 1) :: Nil) match {
+          case Some(errorMessage) => fail(errorMessage)
+          case None =>
+        }
       } finally {
         if (streamingQuery ne null) {
           streamingQuery.stop()


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR fixes the usage of `QueryTest.checkAnswer`. It should fail if the results do not match.


### Why are the changes needed?
Fix test bug.


### Does this PR introduce any user-facing change?
No.


### How was this patch tested?
N/A
