### PR TITLE
[SPARK-27506][SQL] Allow deserialization of Avro data using compatible schemas 

### DIFF
--- a/docs/sql-data-sources-avro.md
+++ b/docs/sql-data-sources-avro.md
@@ -241,10 +241,11 @@ Data source options of Avro can be set via:
     <td>function <code>from_avro</code></td>
   </tr>
   <tr>
-    <td><code>writerSchema</code></td>
+    <td><code>actualSchema</code></td>
     <td>None</td>
     <td>Optional Avro schema (in JSON format) that was used to serialize the data. This should be set if the schema provided
       for deserialization is compatible with - but not the same as - the one used to originally convert the data to Avro.
+      For more information on Avro's schema evolution and compatability, please refer to the [documentation of Confluent](https://docs.confluent.io/current/schema-registry/avro.html).
     </td>
     <td>function <code>from_avro</code></td>
   </tr>

--- a/docs/sql-data-sources-avro.md
+++ b/docs/sql-data-sources-avro.md
@@ -240,6 +240,14 @@ Data source options of Avro can be set via:
     </td>
     <td>function <code>from_avro</code></td>
   </tr>
+  <tr>
+    <td><code>writerSchema</code></td>
+    <td>None</td>
+    <td>Optional Avro schema (in JSON format) that was used to serialize the data. This should be set if the schema provided
+      for deserialization is compatible with - but not the same as - the one used to originally convert the data to Avro.
+    </td>
+    <td>function <code>from_avro</code></td>
+  </tr>
 </table>
 
 ## Configuration

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDataToCatalyst.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDataToCatalyst.scala
@@ -56,7 +56,8 @@ case class AvroDataToCatalyst(
   @transient private lazy val avroSchema = new Schema.Parser().parse(jsonFormatSchema)
 
   @transient private lazy val reader = avroOptions.actualSchema
-    .map(actualSchema => new GenericDatumReader[Any](new Schema.Parser().parse(actualSchema), avroSchema))
+    .map(actualSchema =>
+      new GenericDatumReader[Any](new Schema.Parser().parse(actualSchema), avroSchema))
     .getOrElse(new GenericDatumReader[Any](avroSchema))
 
   @transient private lazy val deserializer = new AvroDeserializer(avroSchema, dataType)

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDataToCatalyst.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDataToCatalyst.scala
@@ -56,7 +56,7 @@ case class AvroDataToCatalyst(
   @transient private lazy val avroSchema = new Schema.Parser().parse(jsonFormatSchema)
 
   @transient private lazy val reader = avroOptions.actualSchema
-    .map(writer => new GenericDatumReader[Any](new Schema.Parser().parse(writer), avroSchema))
+    .map(actualSchema => new GenericDatumReader[Any](new Schema.Parser().parse(actualSchema), avroSchema))
     .getOrElse(new GenericDatumReader[Any](avroSchema))
 
   @transient private lazy val deserializer = new AvroDeserializer(avroSchema, dataType)

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDataToCatalyst.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDataToCatalyst.scala
@@ -55,7 +55,7 @@ case class AvroDataToCatalyst(
 
   @transient private lazy val avroSchema = new Schema.Parser().parse(jsonFormatSchema)
 
-  @transient private lazy val reader = avroOptions.writerSchema
+  @transient private lazy val reader = avroOptions.actualSchema
     .map(writer => new GenericDatumReader[Any](new Schema.Parser().parse(writer), avroSchema))
     .getOrElse(new GenericDatumReader[Any](avroSchema))
 

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
@@ -44,7 +44,7 @@ class AvroOptions(
    * Optional Avro schema (in JSON format) that was used to serialize the data.
    * This should be set if the schema provided for deserialization is compatible
    * with - but not the same as - the one used to originally convert the data to Avro.
-   * See https://github.com/apache/spark/pull/24405 for more details.
+   * See SPARK-27506 for more details.
    */
   val writerSchema: Option[String] = parameters.get("writerSchema")
 

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
@@ -46,7 +46,7 @@ class AvroOptions(
    * with - but not the same as - the one used to originally convert the data to Avro.
    * See SPARK-27506 for more details.
    */
-  val writerSchema: Option[String] = parameters.get("writerSchema")
+  val actualSchema: Option[String] = parameters.get("actualSchema")
 
   /**
    * Top level record name in write result, which is required in Avro spec.

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
@@ -41,6 +41,14 @@ class AvroOptions(
   val schema: Option[String] = parameters.get("avroSchema")
 
   /**
+   * Optional Avro schema (in JSON format) that was used to serialize the data.
+   * This should be set if the schema provided for deserialization is compatible
+   * with - but not the same as - the one used to originally convert the data to Avro.
+   * See https://github.com/apache/spark/pull/24405 for more details.
+   */
+  val writerSchema: Option[String] = parameters.get("writerSchema")
+
+  /**
    * Top level record name in write result, which is required in Avro spec.
    * See https://avro.apache.org/docs/1.8.2/spec.html#schema_record .
    * Default value is "topLevelRecord"

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/functions.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/functions.scala
@@ -45,9 +45,10 @@ object functions {
   }
 
   /**
-   * Converts a binary column of avro format into its corresponding catalyst value. The specified
-   * schema must match the read data, otherwise the behavior is undefined: it may fail or return
-   * arbitrary result.
+   * Converts a binary column of avro format into its corresponding catalyst value. If a writer's
+   * schema is provided in the options, a different (but compatible) schema can be used for reading.
+   * If no writer's schema is provided, the specified schema must match the read data, otherwise the
+   * behavior is undefined: it may fail or return arbitrary result.
    *
    * @param data the binary column.
    * @param jsonFormatSchema the avro schema in JSON string format.

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/functions.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/functions.scala
@@ -45,10 +45,10 @@ object functions {
   }
 
   /**
-   * Converts a binary column of avro format into its corresponding catalyst value. If a writer's
-   * schema is provided in the options, a different (but compatible) schema can be used for reading.
-   * If no writer's schema is provided, the specified schema must match the read data, otherwise the
-   * behavior is undefined: it may fail or return arbitrary result.
+   * Converts a binary column of Avro format into its corresponding catalyst value. If a schema is
+   * provided via the option actualSchema, a different (but compatible) schema can be used for
+   * reading. If no actualSchema option is provided, the specified schema must match the read data,
+   * otherwise the behavior is undefined: it may fail or return arbitrary result.
    *
    * @param data the binary column.
    * @param jsonFormatSchema the avro schema in JSON string format.

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroFunctionsSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroFunctionsSuite.scala
@@ -159,28 +159,30 @@ class AvroFunctionsSuite extends QueryTest with SharedSparkSession {
       struct('id.as("col1"), 'id.cast("string").as("col2")).as("struct")
     )
     val avroStructDF = df.select(functions.to_avro('struct).as("avro"))
-    val actualAvroSchema = s"""
-                             |{
-                             |  "type": "record",
-                             |  "name": "struct",
-                             |  "fields": [
-                             |    {"name": "col1", "type": "int"},
-                             |    {"name": "col2", "type": "string"}
-                             |  ]
-                             |}
-    """.stripMargin
+    val actualAvroSchema =
+      s"""
+         |{
+         |  "type": "record",
+         |  "name": "struct",
+         |  "fields": [
+         |    {"name": "col1", "type": "int"},
+         |    {"name": "col2", "type": "string"}
+         |  ]
+         |}
+         |""".stripMargin
 
-    val evolvedAvroSchema = s"""
-                              |{
-                              |  "type": "record",
-                              |  "name": "struct",
-                              |  "fields": [
-                              |    {"name": "col1", "type": "int"},
-                              |    {"name": "col2", "type": "string"},
-                              |    {"name": "col3", "type": "string", "default": ""}
-                              |  ]
-                              |}
-    """.stripMargin
+    val evolvedAvroSchema =
+      s"""
+         |{
+         |  "type": "record",
+         |  "name": "struct",
+         |  "fields": [
+         |    {"name": "col1", "type": "int"},
+         |    {"name": "col2", "type": "string"},
+         |    {"name": "col3", "type": "string", "default": ""}
+         |  ]
+         |}
+         |""".stripMargin
 
     val expected = spark.range(10).select(
       struct('id.as("col1"), 'id.cast("string").as("col2"), lit("").as("col3")).as("struct")

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroFunctionsSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroFunctionsSuite.scala
@@ -159,27 +159,27 @@ class AvroFunctionsSuite extends QueryTest with SharedSparkSession {
       struct('id.as("col1"), 'id.cast("string").as("col2")).as("struct")
     )
     val avroStructDF = df.select(functions.to_avro('struct).as("avro"))
-    val writerAvroSchema = s"""
-      |{
-      |  "type": "record",
-      |  "name": "struct",
-      |  "fields": [
-      |    {"name": "col1", "type": "int"},
-      |    {"name": "col2", "type": "string"}
-      |  ]
-      |}
+    val actualAvroSchema = s"""
+                             |{
+                             |  "type": "record",
+                             |  "name": "struct",
+                             |  "fields": [
+                             |    {"name": "col1", "type": "int"},
+                             |    {"name": "col2", "type": "string"}
+                             |  ]
+                             |}
     """.stripMargin
 
     val evolvedAvroSchema = s"""
-      |{
-      |  "type": "record",
-      |  "name": "struct",
-      |  "fields": [
-      |    {"name": "col1", "type": "int"},
-      |    {"name": "col2", "type": "string"},
-      |    {"name": "col3", "type": "string", "default": ""}
-      |  ]
-      |}
+                              |{
+                              |  "type": "record",
+                              |  "name": "struct",
+                              |  "fields": [
+                              |    {"name": "col1", "type": "int"},
+                              |    {"name": "col2", "type": "string"},
+                              |    {"name": "col3", "type": "string", "default": ""}
+                              |  ]
+                              |}
     """.stripMargin
 
     val expected = spark.range(10).select(
@@ -191,7 +191,7 @@ class AvroFunctionsSuite extends QueryTest with SharedSparkSession {
         functions.from_avro(
           'avro,
           evolvedAvroSchema,
-          Map("writerSchema" -> writerAvroSchema).asJava)),
+          Map("actualSchema" -> actualAvroSchema).asJava)),
       expected)
   }
 }

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroFunctionsSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroFunctionsSuite.scala
@@ -28,7 +28,7 @@ import org.apache.avro.io.EncoderFactory
 import org.apache.spark.SparkException
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.execution.LocalTableScanExec
-import org.apache.spark.sql.functions.{col, struct}
+import org.apache.spark.sql.functions.{col, lit, struct}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
@@ -152,5 +152,46 @@ class AvroFunctionsSuite extends QueryTest with SharedSparkSession {
       assert(df.queryExecution.executedPlan.isInstanceOf[LocalTableScanExec])
       assert(df.collect().map(_.get(0)) === Seq(Row("one"), Row("two"), Row("three"), Row("four")))
     }
+  }
+
+  test("SPARK-27506: roundtrip in to_avro and from_avro with different compatible schemas") {
+    val df = spark.range(10).select(
+      struct('id.as("col1"), 'id.cast("string").as("col2")).as("struct")
+    )
+    val avroStructDF = df.select(functions.to_avro('struct).as("avro"))
+    val writerAvroSchema = s"""
+      |{
+      |  "type": "record",
+      |  "name": "struct",
+      |  "fields": [
+      |    {"name": "col1", "type": "int"},
+      |    {"name": "col2", "type": "string"}
+      |  ]
+      |}
+    """.stripMargin
+
+    val evolvedAvroSchema = s"""
+      |{
+      |  "type": "record",
+      |  "name": "struct",
+      |  "fields": [
+      |    {"name": "col1", "type": "int"},
+      |    {"name": "col2", "type": "string"},
+      |    {"name": "col3", "type": "string", "default": ""}
+      |  ]
+      |}
+    """.stripMargin
+
+    val expected = spark.range(10).select(
+      struct('id.as("col1"), 'id.cast("string").as("col2"), lit("").as("col3")).as("struct")
+    )
+
+    checkAnswer(
+      avroStructDF.select(
+        functions.from_avro(
+          'avro,
+          evolvedAvroSchema,
+          Map("writerSchema" -> writerAvroSchema).asJava)),
+      expected)
   }
 }

--- a/python/pyspark/sql/avro/functions.py
+++ b/python/pyspark/sql/avro/functions.py
@@ -30,9 +30,10 @@ from pyspark.util import _print_missing_jar
 @since(3.0)
 def from_avro(data, jsonFormatSchema, options={}):
     """
-    Converts a binary column of avro format into its corresponding catalyst value. The specified
-    schema must match the read data, otherwise the behavior is undefined: it may fail or return
-    arbitrary result.
+    Converts a binary column of avro format into its corresponding catalyst value. If a writer's
+    schema is provided in the options, a different (but compatible) schema can be used for reading.
+    If no writer's schema is provided, the specified schema must match the read data, otherwise the
+    behavior is undefined: it may fail or return arbitrary result.
 
     Note: Avro is built-in but external data source module since Spark 2.4. Please deploy the
     application as per the deployment section of "Apache Avro Data Source Guide".

--- a/python/pyspark/sql/avro/functions.py
+++ b/python/pyspark/sql/avro/functions.py
@@ -30,10 +30,10 @@ from pyspark.util import _print_missing_jar
 @since(3.0)
 def from_avro(data, jsonFormatSchema, options={}):
     """
-    Converts a binary column of avro format into its corresponding catalyst value. If a writer's
-    schema is provided in the options, a different (but compatible) schema can be used for reading.
-    If no writer's schema is provided, the specified schema must match the read data, otherwise the
-    behavior is undefined: it may fail or return arbitrary result.
+    Converts a binary column of Avro format into its corresponding catalyst value. If a schema is
+    provided via the option actualSchema, a different (but compatible) schema can be used for
+    reading. If no actualSchema option is provided, the specified schema must match the read data,
+    otherwise the behavior is undefined: it may fail or return arbitrary result.
 
     Note: Avro is built-in but external data source module since Spark 2.4. Please deploy the
     application as per the deployment section of "Apache Avro Data Source Guide".


### PR DESCRIPTION
Follow up of https://github.com/apache/spark/pull/24405

### What changes were proposed in this pull request?
The current implementation of _from_avro_ and _AvroDataToCatalyst_ doesn't allow doing schema evolution since it requires the deserialization of an Avro record with the exact same schema with which it was serialized.

The proposed change is to add a new option `actualSchema` to allow passing the schema used to serialize the records. This allows using a different compatible schema for reading by passing both schemas to _GenericDatumReader_. If no writer's schema is provided, nothing changes from before.

### Why are the changes needed?
Consider the following example.

```
// schema ID: 1
val schema1 = """
{
    "type": "record",
    "name": "MySchema",
    "fields": [
        {"name": "col1", "type": "int"},
        {"name": "col2", "type": "string"}
     ]
}
"""

// schema ID: 2
val schema2 = """
{
    "type": "record",
    "name": "MySchema",
    "fields": [
        {"name": "col1", "type": "int"},
        {"name": "col2", "type": "string"},
        {"name": "col3", "type": "string", "default": ""}
     ]
}
"""
```

The two schemas are compatible - i.e. you can use `schema2` to deserialize events serialized with `schema1`, in which case there will be the field `col3` with the default value.

Now imagine that you have two dataframes (read from batch or streaming), one with Avro events from schema1 and the other with events from schema2. **We want to combine them into one dataframe** for storing or further processing.

With the current `from_avro` function we can only decode each of them with the corresponding schema:

```
scalaval df1 = ... // Avro events created with schema1
df1: org.apache.spark.sql.DataFrame = [eventBytes: binary]
scalaval decodedDf1 = df1.select(from_avro('eventBytes, schema1) as "decoded")
decodedDf1: org.apache.spark.sql.DataFrame = [decoded: struct<col1: int, col2: string>]

scalaval df2= ... // Avro events created with schema2
df2: org.apache.spark.sql.DataFrame = [eventBytes: binary]
scalaval decodedDf2 = df2.select(from_avro('eventBytes, schema2) as "decoded")
decodedDf2: org.apache.spark.sql.DataFrame = [decoded: struct<col1: int, col2: string, col3: string>]
```

but then `decodedDf1` and `decodedDf2` have different Spark schemas and we can't union them. Instead, with the proposed change we can decode `df1` in the following way:

```
scalaimport scala.collection.JavaConverters._
scalaval decodedDf1 = df1.select(from_avro(data = 'eventBytes, jsonFormatSchema = schema2, options = Map("actualSchema" -> schema1).asJava) as "decoded")
decodedDf1: org.apache.spark.sql.DataFrame = [decoded: struct<col1: int, col2: string, col3: string>]
```

so that both dataframes have the same schemas and can be merged.

### Does this PR introduce any user-facing change?
This PR allows users to pass a new configuration but it doesn't affect current code.

### How was this patch tested?
A new unit test was added.

