### PR TITLE
[SPARK-30152][INFRA] Enable Hadoop-2.7/JDK11 build at GitHub Action

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -19,8 +19,6 @@ jobs:
         hive: [ 'hive-1.2', 'hive-2.3' ]
         exclude:
         - java: '11'
-          hadoop: 'hadoop-2.7'
-        - java: '11'
           hive: 'hive-1.2'
         - hadoop: 'hadoop-3.2'
           hive: 'hive-1.2'


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR enables JDK11 build with `hadoop-2.7` profile at `GitHub Action`.

**BEFORE (6 jobs including one JDK11 job)**
![before](https://user-images.githubusercontent.com/9700541/70342731-7763f300-180a-11ea-859f-69038b88451f.png)

**AFTER (7 jobs including two JDK11 jobs)**
![after](https://user-images.githubusercontent.com/9700541/70342658-54d1da00-180a-11ea-9fba-507fc087dc62.png)

### Why are the changes needed?

SPARK-29957 makes JDK11 test work with `hadoop-2.7` profile. We need to protect it.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

This is `GitHub Action` only PR. See the result of `GitHub Action` on this PR.
