### PR TITLE
[SPARK-30153][PYTHON][WIP] Extend data exchange options for vectorized UDF functions with vanilla Arrow serialization

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
@@ -49,6 +49,7 @@ private[spark] object PythonEvalType {
   val SQL_SCALAR_PANDAS_ITER_UDF = 204
   val SQL_MAP_PANDAS_ITER_UDF = 205
   val SQL_COGROUPED_MAP_PANDAS_UDF = 206
+  val SQL_SCALAR_ARROW_UDF = 207
 
   def toString(pythonEvalType: Int): String = pythonEvalType match {
     case NON_UDF => "NON_UDF"
@@ -60,6 +61,7 @@ private[spark] object PythonEvalType {
     case SQL_SCALAR_PANDAS_ITER_UDF => "SQL_SCALAR_PANDAS_ITER_UDF"
     case SQL_MAP_PANDAS_ITER_UDF => "SQL_MAP_PANDAS_ITER_UDF"
     case SQL_COGROUPED_MAP_PANDAS_UDF => "SQL_COGROUPED_MAP_PANDAS_UDF"
+    case SQL_SCALAR_ARROW_UDF => "SQL_SCALAR_ARROW_UDF"
   }
 }
 

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -76,6 +76,7 @@ class PythonEvalType(object):
     SQL_SCALAR_PANDAS_ITER_UDF = 204
     SQL_MAP_PANDAS_ITER_UDF = 205
     SQL_COGROUPED_MAP_PANDAS_UDF = 206
+    SQL_SCALAR_ARROW_UDF = 207
 
 
 def portable_hash(x):

--- a/python/pyspark/sql/pandas/functions.py
+++ b/python/pyspark/sql/pandas/functions.py
@@ -39,6 +39,8 @@ class PandasUDFType(object):
 
     GROUPED_AGG = PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF
 
+    SCALAR_ARROW = PythonEvalType.SQL_SCALAR_ARROW_UDF
+
 
 @since(2.3)
 def pandas_udf(f=None, returnType=None, functionType=None):
@@ -420,6 +422,7 @@ def pandas_udf(f=None, returnType=None, functionType=None):
     if eval_type not in [PythonEvalType.SQL_SCALAR_PANDAS_UDF,
                          PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF,
                          PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF,
+                         PythonEvalType.SQL_SCALAR_ARROW_UDF,
                          PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF,
                          PythonEvalType.SQL_MAP_PANDAS_ITER_UDF,
                          PythonEvalType.SQL_COGROUPED_MAP_PANDAS_UDF,
@@ -457,7 +460,8 @@ def _create_pandas_udf(f, returnType, evalType):
         evalType = PythonEvalType.SQL_SCALAR_PANDAS_UDF
 
     if (evalType == PythonEvalType.SQL_SCALAR_PANDAS_UDF or
-            evalType == PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF) and \
+            evalType == PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF or
+            evalType == PythonEvalType.SQL_SCALAR_ARROW_UDF) and \
             len(argspec.args) == 0 and \
             argspec.varargs is None:
         raise ValueError(

--- a/python/pyspark/sql/pandas/functions.py
+++ b/python/pyspark/sql/pandas/functions.py
@@ -446,7 +446,8 @@ def _create_pandas_udf(f, returnType, evalType):
 
         if evalType in [PythonEvalType.SQL_SCALAR_PANDAS_UDF,
                         PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF,
-                        PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF]:
+                        PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF,
+                        PythonEvalType.SQL_SCALAR_ARROW_UDF]:
             warnings.warn(
                 "In Python 3.6+ and Spark 3.0+, it is preferred to specify type hints for "
                 "pandas UDF instead of specifying pandas UDF type which will be deprecated "

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -101,6 +101,13 @@ class UserDefinedFunction(object):
                 raise NotImplementedError(
                     "Invalid return type with scalar Pandas UDFs: %s is "
                     "not supported" % str(self._returnType_placeholder))
+        elif self.evalType == PythonEvalType.SQL_SCALAR_ARROW_UDF:
+            try:
+                to_arrow_type(self._returnType_placeholder)
+            except TypeError:
+                raise NotImplementedError(
+                    "Invalid return type with scalar Arrow UDFs: %s is "
+                    "not supported" % str(self._returnType_placeholder))
         elif self.evalType == PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF:
             if isinstance(self._returnType_placeholder, StructType):
                 try:
@@ -329,12 +336,13 @@ class UDFRegistration(object):
             if f.evalType not in [PythonEvalType.SQL_BATCHED_UDF,
                                   PythonEvalType.SQL_SCALAR_PANDAS_UDF,
                                   PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF,
+                                  PythonEvalType.SQL_SCALAR_ARROW_UDF,
                                   PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF,
                                   PythonEvalType.SQL_MAP_PANDAS_ITER_UDF]:
                 raise ValueError(
                     "Invalid f: f must be SQL_BATCHED_UDF, SQL_SCALAR_PANDAS_UDF, "
-                    "SQL_SCALAR_PANDAS_ITER_UDF, SQL_GROUPED_AGG_PANDAS_UDF or "
-                    "SQL_MAP_PANDAS_ITER_UDF.")
+                    "SQL_SCALAR_PANDAS_ITER_UDF, SQL_SCALAR_ARROW_UDF, "
+                    "SQL_GROUPED_AGG_PANDAS_UDF or SQL_MAP_PANDAS_ITER_UDF.")
             register_udf = UserDefinedFunction(f.func, returnType=f.returnType, name=name,
                                                evalType=f.evalType,
                                                deterministic=f.deterministic)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
@@ -28,7 +28,8 @@ object PythonUDF {
   private[this] val SCALAR_TYPES = Set(
     PythonEvalType.SQL_BATCHED_UDF,
     PythonEvalType.SQL_SCALAR_PANDAS_UDF,
-    PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF
+    PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF,
+    PythonEvalType.SQL_SCALAR_ARROW_UDF
   )
 
   def isScalarPythonUDF(e: Expression): Boolean = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
@@ -256,7 +256,8 @@ object ExtractPythonUDFs extends Rule[LogicalPlan] with PredicateHelper {
           val evaluation = evalType match {
             case PythonEvalType.SQL_BATCHED_UDF =>
               BatchEvalPython(validUdfs, resultAttrs, child)
-            case PythonEvalType.SQL_SCALAR_PANDAS_UDF | PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF =>
+            case PythonEvalType.SQL_SCALAR_PANDAS_UDF | PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF
+                 | PythonEvalType.SQL_SCALAR_ARROW_UDF =>
               ArrowEvalPython(validUdfs, resultAttrs, child, evalType)
             case _ =>
               throw new AnalysisException("Unexcepted UDF evalType")


### PR DESCRIPTION
### What changes were proposed in this pull request?
This proposes to extend data exchange options for vectorized UDF functions, by introducing the possibility to have plain Arrow serialization without conversions to Pandas. 
This PR proposes to introduce SCALAR_ARROW pandas_udf type as a step in that direction. As detailed in the test case below, the performance results are quite promising, in particular when processing data sets with numerical arrays, showing a speedup of 3x in the test case.

### Why are the changes needed?
Having the possibility to deploy vectorized Python UDFs that bypass the conversion to_pandas, can provide performance improvements (see test below) and extended flexibility (as the Arrow type system is broader than Pandas's) for operating data manipulation, in particular this is relevant for data sets including numerical arrays, possibly of variable length. While conversion to Pandas covers many cases already for vectorized Python UDF in a satisfying manner, the proposed improvement applies to certain special cases, notably of interested for scientific computing (such as in high energy physics), where performant processing of arrays of variable length is of paramount importance.

A test case shows a measured increase of performance of about 3x using the proposed approach, compared to the equivalent processing with pandas_udf (details below in the test section).  Processing of Arrow data in the test case was done via the "awkward arrays" library (https://github.com/scikit-hep/awkward-array).
In general, we can imagine that more specialized libraries using Arrow for data exchange can appear in the future to address computational needs in specific domains, possibly covering also cases of ML and DL libraries. It can be advantageous for Apache Spark to add the possibility to hook to such libraries, as proposed in the PR or with similar methods, for gains in performance and extra flexibility.

### Does this PR introduce any user-facing change?
This PR introduces an extension of pandas_udf types with a new SCALAR_ARROW type.

### How was this patch tested?
1. Manually tested:  a proposed "SCALAR_ARROW" pandas_udf test, detailed below, runs in 21 seconds vs. 62 seconds of the corresponding version with standard "pandas_udf SCALAR" code. This is close to a 3x speedup. The test is implemented using the awkward array library https://pypi.org/project/awkward/ for data processing, in alternative to Pandas:
```
bin/pyspark --master local[2]

df = sql("select cast(1.0 as double) col1, rand(42) col2, Array(rand(),rand(),rand()) col3 from range(1e8)")
df.printSchema()

root
 |-- col1: double (nullable = false)
 |-- col2: double (nullable = false)
 |-- col3: array (nullable = false)
 |    |-- element: double (containsNull = false)


from pyspark.sql.functions import pandas_udf, PandasUDFType
from pyspark.sql.types import *
import awkward

@pandas_udf(ArrayType(DoubleType()), PandasUDFType.SCALAR_ARROW)
def test_arrow(col1):
    b = awkward.fromarrow(col1.chunk(0))
    c = awkward.toarrow(b * b)
    return c 

// Note: following SPARK-28264 this can also be written as:
import pyarrow as pa
@pandas_udf(ArrayType(DoubleType()))
def test_arrow(col1: pa.ChunkedArray) -> pa.Array:
    b = awkward.fromarrow(col1.chunk(0))
    c = awkward.toarrow(b * b)
    return c 

import time
start = time.time()
df.withColumn('test', test_arrow(df.col3)).write.format("noop").mode("overwrite").save()
end = time.time()
print(end - start)
```

2. This is the reference code with pandas_udf SCALAR (this runs in 62 seconds vs. 21 seconds of the code above with SCALAR_ARROW implementation):
```
@pandas_udf(ArrayType(DoubleType()), PandasUDFType.SCALAR)
def test_pandas(col1):
  return col1*col1

import time
start = time.time()
df.withColumn('test', test_pandas(df.col3)).write.format("noop").mode("overwrite").save()
end = time.time()
print(end - start)
```

3. This is how the test workload can be implemented using Spark SQL (with higher order SQL functions). This test rund in 11 seconds
```
import time
start = time.time()
df.selectExpr("col1", "col2", "col3", "transform(col3, x -> x * x) as test").write.format("noop").mode("overwrite").save()
end = time.time()
print(end - start)
```

In conclusion the test workload runs 6x slower than Spark SQL with pandas_udf of type SCALAR, and 2x slower than Spark SQL with the proposed arrow-only serialization with SCALAR_PYARROW pandas_udf.

----
In addition, we collected and compared Flamegraph profiling of the Python code execution on the Python daemons, in the 2 Python UDF cases tested (SCALAR UDF and nthe proposed SCALAR_ARROW type). Results show that in the SCALAR case **an important amount of time is spent in the to_pandas conversion** operations and in array processing, the SCALAR_ARROW case optimizes processing of array data and avoid conversion to Pandas for array data, thus saving considerable time. 

This is a Flamegraph of workload on the Python daemon when running the pandas_udf SCALAR_ARROW:
![](https://issues.apache.org/jira/secure/attachment/12987761/Flamegraph_test_pandas_udf_SCALAR_ARROW.png)

This is a Flamegraph of workload on the Python daemon when running the pandas_udf SCALAR:
![](https://issues.apache.org/jira/secure/attachment/12987760/Flamegraph_test_pandas_udf_SCALAR.png)

Co-authors of this work:
Luca Canali @LucaCanali 
Lindsey Gray @lgray
Jim Pivarski @jpivarski
