### PR TITLE
[SPARK-30157][BUILD][test-hadoop3.2][test-java11] Upgrade Apache HttpCore from 4.4.10 to 4.4.12

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.7-hive-1.2
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-1.2
@@ -85,7 +85,7 @@ hk2-locator-2.5.0.jar
 hk2-utils-2.5.0.jar
 htrace-core-3.1.0-incubating.jar
 httpclient-4.5.6.jar
-httpcore-4.4.10.jar
+httpcore-4.4.12.jar
 istack-commons-runtime-3.0.8.jar
 ivy-2.4.0.jar
 jackson-annotations-2.10.0.jar

--- a/dev/deps/spark-deps-hadoop-2.7-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-2.3
@@ -99,7 +99,7 @@ hk2-locator-2.5.0.jar
 hk2-utils-2.5.0.jar
 htrace-core-3.1.0-incubating.jar
 httpclient-4.5.6.jar
-httpcore-4.4.10.jar
+httpcore-4.4.12.jar
 istack-commons-runtime-3.0.8.jar
 ivy-2.4.0.jar
 jackson-annotations-2.10.0.jar

--- a/dev/deps/spark-deps-hadoop-3.2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3.2-hive-2.3
@@ -98,7 +98,7 @@ hk2-locator-2.5.0.jar
 hk2-utils-2.5.0.jar
 htrace-core4-4.1.0-incubating.jar
 httpclient-4.5.6.jar
-httpcore-4.4.10.jar
+httpcore-4.4.12.jar
 istack-commons-runtime-3.0.8.jar
 ivy-2.4.0.jar
 jackson-annotations-2.10.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
     <aws.kinesis.producer.version>0.12.8</aws.kinesis.producer.version>
     <!--  org.apache.httpcomponents/httpclient-->
     <commons.httpclient.version>4.5.6</commons.httpclient.version>
-    <commons.httpcore.version>4.4.10</commons.httpcore.version>
+    <commons.httpcore.version>4.4.12</commons.httpcore.version>
     <!--  commons-httpclient/commons-httpclient-->
     <httpclient.classic.version>3.1</httpclient.classic.version>
     <commons.math3.version>3.4.1</commons.math3.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `Apache HttpCore` from 4.4.10 to 4.4.12.

### Why are the changes needed?

`Apache HttpCore v4.4.11` is the first official release for JDK11.
> This is a maintenance release that corrects a number of defects in non-blocking SSL session code that caused compatibility issues with TLSv1.3 protocol implementation shipped with Java 11.

For the full release note, please see the following.
- https://www.apache.org/dist/httpcomponents/httpcore/RELEASE_NOTES-4.4.x.txt

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Pass the Jenkins.