### PR TITLE
[SPARK-30160][K8S] Introduce the ExecutorPodController API 

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -324,6 +324,13 @@ private[spark] object Config extends Logging {
       .stringConf
       .createOptional
 
+  val EXECUTOR_POD_CONTROLLER_CLASS =
+    ConfigBuilder("spark.kubernetes.executor.podController.class")
+      .doc("Experimental. Specify a class that can handle the creation " +
+        "and deletion of pods")
+      .stringConf
+      .createOptional
+
   val KUBERNETES_AUTH_SUBMISSION_CONF_PREFIX =
     "spark.kubernetes.authenticate.submission"
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodController.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodController.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.scheduler.cluster.k8s
+
+import io.fabric8.kubernetes.api.model.Pod
+import io.fabric8.kubernetes.client.KubernetesClient
+
+
+/**
+ * Responsible for the creation and deletion of Pods as per the
+ * request of the ExecutorPodAllocator, ExecutorPodLifecycleManager, and the
+ * KubernetesClusterSchedulerBackend. The default implementation:
+ * ExecutorPodControllerImpl communicates directly
+ * with the KubernetesClient to create Pods. This class can be extended
+ * to have your communication be done with a unique CRD that satisfies
+ * your specific SLA and security concerns.
+ */
+private[spark] trait ExecutorPodController {
+
+  def initialize(kubernetesClient: KubernetesClient, appId: String): Unit
+
+  def addPod(pod: Pod): Unit
+
+  def commitAndGetTotalAllocated(): Int
+
+  def removePodById(execId: String): Unit
+
+  def removePod(pod: Pod): Unit
+
+  def commitAndGetTotalDeleted(): Int
+
+  def removePods(execIds: Seq[Long], state: Option[String] = None): Iterable[Long]
+
+  def removeAllPods(): Boolean
+
+  def stop(): Boolean
+}

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodControllerImpl.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodControllerImpl.scala
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.scheduler.cluster.k8s
+
+import java.util.concurrent.LinkedBlockingQueue
+
+import io.fabric8.kubernetes.api.model.Pod
+import io.fabric8.kubernetes.client.KubernetesClient
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+import org.apache.spark.SparkConf
+import org.apache.spark.deploy.k8s.Constants._
+
+
+private[spark] class ExecutorPodControllerImpl(
+    val conf: SparkConf)
+  extends ExecutorPodController {
+
+  private var kubernetesClient: KubernetesClient = _
+  private var removePodList: LinkedBlockingQueue[String] = _
+  private var addPodList: LinkedBlockingQueue[Pod] = _
+
+  private var appId: String = _
+
+  override def initialize(kClient: KubernetesClient, _appId: String) : Unit = {
+    kubernetesClient = kClient
+    appId = _appId
+    removePodList = new LinkedBlockingQueue[String]()
+    addPodList = new LinkedBlockingQueue[Pod]()
+  }
+  override def addPod(pod: Pod): Unit = {
+    addPodList.add(pod)
+  }
+
+  override def commitAndGetTotalAllocated(): Int = {
+    val finalAddList = mutable.Buffer.empty[Pod].asJava
+    addPodList.drainTo(finalAddList)
+    val finalList = finalAddList.asScala.map{
+      kubernetesClient.pods().create(_)
+    }
+    finalList.size
+  }
+
+  override def removePodById(execId: String): Unit = {
+    removePodList.add(execId)
+  }
+
+  override def removePod(pod: Pod): Unit = {
+    kubernetesClient.pods().delete(pod)
+  }
+
+  override def commitAndGetTotalDeleted(): Int = {
+    val finalRemoveList = mutable.Buffer.empty[String].asJava
+    removePodList.drainTo(finalRemoveList)
+    val finalList = finalRemoveList.asScala
+    kubernetesClient
+      .pods()
+      .withLabel(SPARK_APP_ID_LABEL, appId)
+      .withLabel(SPARK_ROLE_LABEL, SPARK_POD_EXECUTOR_ROLE)
+      .withLabelIn(SPARK_EXECUTOR_ID_LABEL, finalList: _*)
+      .delete()
+    finalRemoveList.size()
+  }
+
+  override def removePods(execIds: Seq[Long], status: Option[String]): Iterable[Long] = {
+    var shouldSearch = false
+    var ids = execIds
+    val execStringIds = execIds.map(_.toString)
+    val filterable = status match {
+      case Some(phase) =>
+        shouldSearch = true
+        kubernetesClient
+          .pods()
+          .withField("status.phase", phase)
+          .withLabel(SPARK_APP_ID_LABEL, appId)
+          .withLabel(SPARK_ROLE_LABEL, SPARK_POD_EXECUTOR_ROLE)
+          .withLabelIn(SPARK_EXECUTOR_ID_LABEL, execStringIds: _*)
+      case None =>
+        kubernetesClient
+          .pods()
+          .withLabel(SPARK_APP_ID_LABEL, appId)
+          .withLabel(SPARK_ROLE_LABEL, SPARK_POD_EXECUTOR_ROLE)
+          .withLabelIn(SPARK_EXECUTOR_ID_LABEL, execStringIds: _*)
+    }
+    if (shouldSearch) {
+      ids = filterable.list().getItems().asScala.map {
+        _.getMetadata().getLabels().get(SPARK_EXECUTOR_ID_LABEL).toLong }
+    }
+    filterable.delete()
+    ids
+  }
+
+  override def removeAllPods(): Boolean = {
+    kubernetesClient
+      .pods()
+      .withLabel(SPARK_APP_ID_LABEL, appId)
+      .withLabel(SPARK_ROLE_LABEL, SPARK_POD_EXECUTOR_ROLE)
+      .delete()
+  }
+
+  override def stop(): Boolean = {
+    removeAllPods()
+  }
+}

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodControllerSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodControllerSuite.scala
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.scheduler.cluster.k8s
+
+import io.fabric8.kubernetes.api.model.{DoneablePod, Pod, PodBuilder, PodList}
+import io.fabric8.kubernetes.client.{KubernetesClient, Watch, Watcher}
+import io.fabric8.kubernetes.client.dsl.{FilterWatchListDeletable, PodResource}
+import org.mockito.{Mock, MockitoAnnotations}
+import org.mockito.Mockito.{never, times, verify, when}
+import org.scalatest.BeforeAndAfter
+
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.deploy.k8s.Constants.{SPARK_APP_ID_LABEL, SPARK_EXECUTOR_ID_LABEL, SPARK_POD_EXECUTOR_ROLE, SPARK_ROLE_LABEL}
+import org.apache.spark.deploy.k8s.Fabric8Aliases.PODS
+import org.apache.spark.scheduler.cluster.k8s.ExecutorLifecycleTestUtils.TEST_SPARK_APP_ID
+
+class ExecutorPodControllerSuite extends SparkFunSuite with BeforeAndAfter {
+
+  private var executorPodController: ExecutorPodController = _
+
+  private val sparkConf = new SparkConf(false)
+
+  private val execExampleId = "exec-id"
+  private val numPods = 5
+  private val execPodList = (1 to numPods).map(_.toLong)
+  private val execPodString = execPodList.map(_.toString)
+
+  private def buildPod(execId: String ): Pod = {
+    new PodBuilder()
+      .withNewMetadata()
+      .withName(execId)
+      .endMetadata()
+      .build()
+  }
+
+  private val execPod = buildPod(execExampleId)
+
+  @Mock
+  private var kubernetesClient: KubernetesClient = _
+
+  @Mock
+  private var podOperations: PODS = _
+
+  @Mock
+  private var execPodOperations: PodResource[Pod, DoneablePod] = _
+
+  @Mock
+  private var ePodOperations:
+    FilterWatchListDeletable[Pod, PodList, java.lang.Boolean, Watch, Watcher[Pod]] = _
+
+  @Mock
+  private var fPodOperations:
+    FilterWatchListDeletable[Pod, PodList, java.lang.Boolean, Watch, Watcher[Pod]] = _
+
+
+  before {
+    MockitoAnnotations.initMocks(this)
+    when(kubernetesClient.pods()).thenReturn(podOperations)
+    when(podOperations.withName(execExampleId))
+      .thenReturn(execPodOperations)
+    when(podOperations
+      .withLabel(SPARK_APP_ID_LABEL, TEST_SPARK_APP_ID)).thenReturn(podOperations)
+    when(podOperations
+      .withLabel(SPARK_ROLE_LABEL, SPARK_POD_EXECUTOR_ROLE)).thenReturn(ePodOperations)
+    when(ePodOperations.delete()).thenReturn(true)
+    when(ePodOperations
+      .withLabelIn(SPARK_EXECUTOR_ID_LABEL, execPodString: _*)).thenReturn(fPodOperations)
+    when(fPodOperations.delete()).thenReturn(true)
+    executorPodController = new ExecutorPodControllerImpl(sparkConf)
+    executorPodController.initialize(kubernetesClient, TEST_SPARK_APP_ID)
+  }
+
+  test("Adding a pod and watching counter go up correctly") {
+    val numAllocated = 5
+    for ( _ <- 0 until numAllocated) {
+      executorPodController.addPod(execPod)
+    }
+    verify(podOperations, never()).create(execPod)
+    assert(executorPodController.commitAndGetTotalAllocated() == numAllocated)
+    verify(podOperations, times(numAllocated)).create(execPod)
+    assert(executorPodController.commitAndGetTotalAllocated() == 0)
+    executorPodController.addPod(execPod)
+    assert(executorPodController.commitAndGetTotalAllocated() == 1)
+  }
+
+  test("Remove a single pod") {
+    executorPodController.removePod(execPod)
+    verify(podOperations).delete(execPod)
+  }
+
+  test("Remove a pod list") {
+    executorPodController.removePods(execPodList)
+    verify(fPodOperations, times(1)).delete()
+  }
+
+  test("Remove a pod and watching counter go up correctly") {
+    execPodString.foreach{
+      executorPodController.removePodById(_)
+    }
+    verify(fPodOperations, never()).delete()
+    assert(executorPodController.commitAndGetTotalDeleted() == numPods)
+    verify(fPodOperations, times(1)).delete()
+  }
+
+  test("Remove all pods") {
+    executorPodController.removeAllPods()
+    verify(ePodOperations).delete()
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
I am putting existing functionality behind an API that allows for developers to customize how executors are brought up and down. 

### Why are the changes needed?
 Companies may require that executor creation be done by privileged resources (like admin controllers / operators who would receive events or updates) that would create the Kubernetes Executor pods on-behalf of the user. In essence, the assumption that the driver has the appropriate service-account to create pods is not a guarantee in various organizations.



### Does this PR introduce any user-facing change?
No


### How was this patch tested?
- [x] Unit tests
- [x] integration tests
- [x] Ran an implementation of the API against dev and prod, extending a custom Kubernetes CRD
