### PR TITLE
[WIP][MINOR][INFRA] Increase GitHub Action Maven connectionTimeout

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -65,7 +65,7 @@ jobs:
       run: |
         export MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=1g -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
         export MAVEN_CLI_OPTS="--no-transfer-progress"
-        echo "<settings><servers><server><id>central</id><configuration><httpConfiguration><all><connectionTimeout>120000</connectionTimeout></all></httpConfiguration></configuration></server></servers></settings>" > ~/.m2/settings.xml
+        echo "<settings><servers><server><id>central</id><configuration><httpConfiguration><all><connectionTimeout>180000</connectionTimeout></all></httpConfiguration></configuration></server></servers></settings>" > ~/.m2/settings.xml
         ./build/mvn $MAVEN_CLI_OPTS -DskipTests -Pyarn -Pmesos -Pkubernetes -Phive -P${{ matrix.hive }} -Phive-thriftserver -P${{ matrix.hadoop }} -Phadoop-cloud -Djava.version=${{ matrix.java }} install
         rm -rf ~/.m2/repository/org/apache/spark
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -64,7 +64,8 @@ jobs:
     - name: Build with Maven
       run: |
         export MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=1g -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
-        export MAVEN_CLI_OPTS="--no-transfer-progress -Dmaven.wagon.rto=3600000"
+        export MAVEN_CLI_OPTS="--no-transfer-progress"
+        echo "<settings><servers><server><id>central</id><configuration><httpConfiguration><all><connectionTimeout>120000</connectionTimeout></all></httpConfiguration></configuration></server></servers></settings>" > ~/.m2/settings.xml
         ./build/mvn $MAVEN_CLI_OPTS -DskipTests -Pyarn -Pmesos -Pkubernetes -Phive -P${{ matrix.hive }} -Phive-thriftserver -P${{ matrix.hadoop }} -Phadoop-cloud -Djava.version=${{ matrix.java }} install
         rm -rf ~/.m2/repository/org/apache/spark
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Build with Maven
       run: |
         export MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=1g -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
-        export MAVEN_CLI_OPTS="--no-transfer-progress"
+        export MAVEN_CLI_OPTS="--no-transfer-progress -Dmaven.wagon.rto=3600000"
         ./build/mvn $MAVEN_CLI_OPTS -DskipTests -Pyarn -Pmesos -Pkubernetes -Phive -P${{ matrix.hive }} -Phive-thriftserver -P${{ matrix.hadoop }} -Phadoop-cloud -Djava.version=${{ matrix.java }} install
         rm -rf ~/.m2/repository/org/apache/spark
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR increases Maven's `connectionTimeout ` from 1 minute (default) to 3 minutes.

- https://maven.apache.org/guides/mini/guide-http-settings.html#Connection_Timeouts

```xml
<settings>
  <servers>
    <server>
      <id>central</id>
      <configuration>
        <httpConfiguration>
          <all>
            <connectionTimeout>180000</connectionTimeout>
          </all>
        </httpConfiguration>
      </configuration>
    </server>
  </servers>
</settings>
```

### Why are the changes needed?

Although we added Maven cache inside `GitHub Action`, the timeouts happen too frequently.

```
[ERROR] Failed to execute goal on project spark-mllib_2.12:
...
Connection timed out (Read failed) -> [Help 1]
```

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

This PR is irrelevant to Jenkins result. This should succeed in GitHub Action.