### PR TITLE
[SPARK-30145][CORE]sparkContext.addJar fails when file path contains …

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1848,7 +1848,7 @@ class SparkContext(config: SparkConf) extends Logging {
 
     def checkRemoteJarFile(path: String): String = {
       val hadoopPath = new Path(path)
-      val scheme = new URI(path).getScheme
+      val scheme = hadoopPath.toUri.getScheme
       if (!Array("http", "https", "ftp").contains(scheme)) {
         try {
           val fs = hadoopPath.getFileSystem(hadoopConfiguration)
@@ -1877,14 +1877,14 @@ class SparkContext(config: SparkConf) extends Logging {
         // For local paths with backslashes on Windows, URI throws an exception
         addLocalJarFile(new File(path))
       } else {
-        val uri = new URI(path)
+        val uri = new Path(path).toUri
         // SPARK-17650: Make sure this is a valid URL before adding it to the list of dependencies
         Utils.validateURL(uri)
         uri.getScheme match {
           // A JAR file which exists only on the driver node
           case null =>
             // SPARK-22585 path without schema is not url encoded
-            addLocalJarFile(new File(uri.getRawPath))
+            addLocalJarFile(new File(uri.getPath))
           // A JAR file which exists only on the driver node
           case "file" => addLocalJarFile(new File(uri.getPath))
           // A JAR file which exists locally on every worker node

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -303,8 +303,21 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
 
       // Invalid jar path will only print the error log, will not add to file server.
       sc.addJar("dummy.jar")
-      sc.addJar("")
       sc.addJar(tmpDir.getAbsolutePath)
+
+      assert(sc.listJars().size == 1)
+      assert(sc.listJars().head.contains(tmpJar.getName))
+    }
+  }
+
+  test("add jar when path contains spaces") {
+    withTempDir { dir =>
+      val sep = File.separator
+      val tmpDir = Utils.createTempDir(dir.getAbsolutePath + sep + "test space")
+      val tmpJar = File.createTempFile("test", ".jar", tmpDir)
+
+      sc = new SparkContext(new SparkConf().setAppName("test").setMaster("local"))
+      sc.addJar(tmpJar.getAbsolutePath)
 
       assert(sc.listJars().size == 1)
       assert(sc.listJars().head.contains(tmpJar.getName))


### PR DESCRIPTION
### What changes were proposed in this pull request?
sparkContext.addJar fails when file path contains spaces

### Why are the changes needed?
When uploading a jar file to the spark context via the addJar function, an exception is thrown when file path contains a space character. Escaping the space with %20 or
or + doesn't change the result.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Added New Test cases.
