### PR TITLE
[SPARK-30186][SQL] support Dynamic Partition Pruning in Adaptive Execution

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -34,6 +34,7 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, ReturnAnswer}
 import org.apache.spark.sql.catalyst.rules.{Rule, RuleExecutor}
 import org.apache.spark.sql.catalyst.trees.TreeNodeTag
+import org.apache.spark.sql.dynamicpruning.PlanDynamicPruningFilters
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec._
 import org.apache.spark.sql.execution.exchange._
@@ -82,6 +83,8 @@ case class AdaptiveSparkPlanExec(
   // plan should reach a final status of query stages (i.e., no more addition or removal of
   // Exchange nodes) after running these rules.
   private def queryStagePreparationRules: Seq[Rule[SparkPlan]] = Seq(
+    PlanDynamicPruningFilters(session),
+    PlanSubqueries(session),
     ensureRequirements
   )
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -787,8 +787,11 @@ case class SubqueryExec(name: String, child: SparkPlan)
 }
 
 object SubqueryExec {
+
+  val poolName = "subquery"
+
   private[execution] val executionContext = ExecutionContext.fromExecutorService(
-    ThreadUtils.newDaemonCachedThreadPool("subquery", 16))
+    ThreadUtils.newDaemonCachedThreadPool(poolName, 16))
 }
 
 /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
To support queries with dynamic partition pruning subqueries work in adaptive query execution.


### Why are the changes needed?
Queries' performance can benefit from AE and DPP at the same time.


### Does this PR introduce any user-facing change?
NO


### How was this patch tested?
Test cases are added.
