### PR TITLE
[SPARK-30197][PYSPARK] Add minimum `requirements-dev.txt` file to `python` directory

### DIFF
--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -1,0 +1,6 @@
+# ML/MLlib
+numpy==1.14.6
+scipy==1.0.1
+# SQL
+pandas==0.23.2
+pyarrow==0.15.1

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,4 @@
+numpy==1.16.4
+scipy==1.2.2
+pandas==0.23.2
+pyarrow==0.12.1

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,4 @@
 numpy==1.16.4
 scipy==1.2.2
 pandas==0.23.2
-pyarrow==0.12.1
+pyarrow==0.15.1

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,0 @@
-numpy==1.16.4
-scipy==1.2.2
-pandas==0.23.2
-pyarrow==0.15.1


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add the minimum `requirements-dev.txt` file into `python` directory.
Note that this is not an installation requirement.

### Why are the changes needed?

This helps the users identify/install/test the `minimum` requirements for the full features.
This PR is tested with `Python 3.7.5` on `Mac`.

- NumPy 1.14.6 is the first version to support Python 3.7
  * https://docs.scipy.org/doc/numpy/release.html#numpy-1-14-6-release-notes
- SciPi 1.0.1 is the first version which is installable with Python 3.7.5.
  * Tested on Mac.
- Pandas 0.23.2 and PyArrow 0.15.1 are defined in our `setup.py`.


### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Manually test with the following.
```
$ pip install -r python/requirements-dev.txt
$ python/run-tests.py --python-executables python3
```

```
$ dev/make-distribution.sh --pip --tgz
$ tar tvfz spark-3.0.0-SNAPSHOT-bin-2.7.4.tgz | grep requirements-dev.txt
-rw-r--r--  0 dongjoon staff      75 Dec  9 20:55 spark-3.0.0-SNAPSHOT-bin-2.7.4/python/requirements-dev.txt
```