### PR TITLE
[SPARK-30193]Wrong 2nd argument type. Found: 'org.apache.spark.sql.Column', required: 'scala.collection.Seq<org.apache.spark.sql.Column>'

### DIFF
--- a/examples/src/main/java/org/apache/spark/examples/ml/JavaTokenizerExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/ml/JavaTokenizerExample.java
@@ -30,13 +30,12 @@ import org.apache.spark.ml.feature.Tokenizer;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.*;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 
-// col("...") is preferable to df.col("...")
-import static org.apache.spark.sql.functions.callUDF;
 import static org.apache.spark.sql.functions.col;
 // $example off$
 
@@ -73,12 +72,12 @@ public class JavaTokenizerExample {
 
     Dataset<Row> tokenized = tokenizer.transform(sentenceDataFrame);
     tokenized.select("sentence", "words")
-        .withColumn("tokens", callUDF("countTokens", col("words")))
+        .withColumn("tokens", functions.callUDF("countTokens", col("words")))
         .show(false);
 
     Dataset<Row> regexTokenized = regexTokenizer.transform(sentenceDataFrame);
     regexTokenized.select("sentence", "words")
-        .withColumn("tokens", callUDF("countTokens", col("words")))
+        .withColumn("tokens", functions.callUDF("countTokens", col("words")))
         .show(false);
     // $example off$
 

--- a/sql/hive/src/test/java/org/apache/spark/sql/hive/JavaDataFrameSuite.java
+++ b/sql/hive/src/test/java/org/apache/spark/sql/hive/JavaDataFrameSuite.java
@@ -85,7 +85,7 @@ public class JavaDataFrameSuite {
           udaf.distinct(col("value")),
           udaf.apply(col("value")),
           registeredUDAF.apply(col("value")),
-          callUDF("mydoublesum", col("value")));
+          functions.callUDF("mydoublesum", col("value")));
 
     List<Row> expectedResult = new ArrayList<>();
     expectedResult.add(RowFactory.create(4950.0, 9900.0, 9900.0, 9900.0));


### PR DESCRIPTION
### What changes were proposed in this pull request?
Wrong 2nd argument type. Found: 'org.apache.spark.sql.Column', required: 'scala.collection.Seq<org.apache.spark.sql.Column>'

### Why are the changes needed?
Fixed java file compilation error problem.
Wrong 2nd argument type. Found: 'org.apache.spark.sql.Column', required: 'scala.collection.Seq<org.apache.spark.sql.Column>'

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
build examples module locally
