### PR TITLE
[SPARK-30204][K8S] Support for configure Pod DNS for Kubernetes

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -75,6 +75,22 @@ private[spark] object Config extends Logging {
       .toSequence
       .createWithDefault(Nil)
 
+  var KUBERNETES_DNS_CONFIG_NAMESERVERS =
+    ConfigBuilder("spark.kubernetes.dnsConfig.nameservers")
+      .doc("Comma separated list of the Kubernetes dns nameservers.")
+      .stringConf
+      .toSequence
+      .createWithDefault(Nil)
+
+  var KUBERNETES_DNS_CONFIG_SEARCHES =
+    ConfigBuilder("spark.kubernetes.dnsConfig.searches")
+      .doc("Comma separated list of the Kubernetes dns searches.")
+      .stringConf
+      .toSequence
+      .createWithDefault(Nil)
+
+  var KUBERNETES_DNS_CONFIG_OPTIONS_PREFIX = "spark.kubernetes.dnsConfig.options."
+
   val KUBERNETES_AUTH_DRIVER_CONF_PREFIX = "spark.kubernetes.authenticate.driver"
   val KUBERNETES_AUTH_EXECUTOR_CONF_PREFIX = "spark.kubernetes.authenticate.executor"
   val KUBERNETES_AUTH_DRIVER_MOUNTED_CONF_PREFIX = "spark.kubernetes.authenticate.driver.mounted"

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
@@ -55,6 +55,10 @@ private[spark] abstract class KubernetesConf(val sparkConf: SparkConf) {
       }
   }
 
+  def dnsConfigNameservers: Seq[String] = get(KUBERNETES_DNS_CONFIG_NAMESERVERS)
+  def dnsConfigSearches: Seq[String] = get(KUBERNETES_DNS_CONFIG_SEARCHES)
+  def dnsConfigOptions: Map[String, String]
+
   def nodeSelector: Map[String, String] =
     KubernetesUtils.parsePrefixedKeyValuePairs(sparkConf, KUBERNETES_NODE_SELECTOR_PREFIX)
 
@@ -96,6 +100,10 @@ private[spark] class KubernetesDriverConf(
     }
 
     driverCustomLabels ++ presetLabels
+  }
+
+  override def dnsConfigOptions: Map[String, String] = {
+    KubernetesUtils.parsePrefixedKeyValuePairs(sparkConf, KUBERNETES_DNS_CONFIG_OPTIONS_PREFIX)
   }
 
   override def environment: Map[String, String] = {
@@ -147,6 +155,10 @@ private[spark] class KubernetesExecutorConf(
     }
 
     executorCustomLabels ++ presetLabels
+  }
+
+  override def dnsConfigOptions: Map[String, String] = {
+    KubernetesUtils.parsePrefixedKeyValuePairs(sparkConf, KUBERNETES_DNS_CONFIG_OPTIONS_PREFIX)
   }
 
   override def environment: Map[String, String] = sparkConf.getExecutorEnv.filter(

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStep.scala
@@ -78,6 +78,14 @@ private[spark] class BasicDriverFeatureStep(conf: KubernetesDriverConf)
           .build()
       }
 
+    val driverDnsConfigOptions = conf.dnsConfigOptions.toSeq
+      .map { option =>
+        new PodDNSConfigOptionBuilder()
+          .withName(option._1)
+          .withValue(option._2)
+          .build()
+    }
+
     val driverCpuQuantity = new QuantityBuilder(false)
       .withAmount(driverCoresRequest)
       .build()
@@ -146,6 +154,11 @@ private[spark] class BasicDriverFeatureStep(conf: KubernetesDriverConf)
         .withRestartPolicy("Never")
         .addToNodeSelector(conf.nodeSelector.asJava)
         .addToImagePullSecrets(conf.imagePullSecrets: _*)
+        .editOrNewDnsConfig()
+          .addToNameservers(conf.dnsConfigNameservers: _*)
+          .addToSearches(conf.dnsConfigSearches: _*)
+          .addAllToOptions(driverDnsConfigOptions.asJava)
+          .endDnsConfig()
         .endSpec()
       .build()
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
@@ -155,6 +155,14 @@ private[spark] class BasicExecutorFeatureStep(
         }
       }
 
+    val executorDnsConfigOptions = kubernetesConf.dnsConfigOptions.toSeq
+      .map { option =>
+        new PodDNSConfigOptionBuilder()
+          .withName(option._1)
+          .withValue(option._2)
+          .build()
+    }
+
     val requiredPorts = Seq(
       (BLOCK_MANAGER_PORT_NAME, blockManagerPort))
       .map { case (name, port) =>
@@ -213,6 +221,11 @@ private[spark] class BasicExecutorFeatureStep(
         .withRestartPolicy("Never")
         .addToNodeSelector(kubernetesConf.nodeSelector.asJava)
         .addToImagePullSecrets(kubernetesConf.imagePullSecrets: _*)
+        .editOrNewDnsConfig()
+          .addToNameservers(kubernetesConf.dnsConfigNameservers: _*)
+          .addToSearches(kubernetesConf.dnsConfigSearches: _*)
+          .addAllToOptions(executorDnsConfigOptions.asJava)
+          .endDnsConfig()
         .endSpec()
       .build()
 

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesTestConf.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesTestConf.scala
@@ -50,7 +50,8 @@ object KubernetesTestConf {
       annotations: Map[String, String] = Map.empty,
       secretEnvNamesToKeyRefs: Map[String, String] = Map.empty,
       secretNamesToMountPaths: Map[String, String] = Map.empty,
-      volumes: Seq[KubernetesVolumeSpec] = Seq.empty): KubernetesDriverConf = {
+      volumes: Seq[KubernetesVolumeSpec] = Seq.empty,
+      dnsConfigOptions: Map[String, String] = Map.empty): KubernetesDriverConf = {
     val conf = sparkConf.clone()
 
     resourceNamePrefix.foreach { prefix =>
@@ -61,6 +62,7 @@ object KubernetesTestConf {
     setPrefixedConfigs(conf, KUBERNETES_DRIVER_ANNOTATION_PREFIX, annotations)
     setPrefixedConfigs(conf, KUBERNETES_DRIVER_SECRETS_PREFIX, secretNamesToMountPaths)
     setPrefixedConfigs(conf, KUBERNETES_DRIVER_SECRET_KEY_REF_PREFIX, secretEnvNamesToKeyRefs)
+    setPrefixedConfigs(conf, KUBERNETES_DNS_CONFIG_OPTIONS_PREFIX, dnsConfigOptions)
     setVolumeSpecs(conf, KUBERNETES_DRIVER_VOLUMES_PREFIX, volumes)
 
     new KubernetesDriverConf(conf, appId, mainAppResource, mainClass, appArgs)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add support for configure pod dns for Kubernetes when submit a job. So that user can specify the dns nameservers, dns searches and dns options.

### Why are the changes needed?
This's a common scenarios for hybricloud where we use public cloud compute resourses while with specified private dns.

### Does this PR introduce any user-facing change?
Yes. User can specify the dns options when submit a job.
As a result, we can use the following property to specify the pod dns config.

- spark.kubernetes.dnsConfig.nameservers, Comma separated list of the Kubernetes dns nameservers for driver and executor.
- spark.kubernetes.dnsConfig.searches, Comma separated list of the Kubernetes dns searches for driver and executor.
- spark.kubernetes.dnsConfig.options.[OptionVariableName], Add the dns option variable specified by OptionVariableName to the Driver And Executor process. The user can specify multiple of these to set multiple options variables.


### How was this patch tested?
Add test.

Closes #26834 from vanderliang/spark-30204.

Lead-authored-by: Deliang Fan <vanderliang@gmail.com>
Co-authored-by: Lu Zi <zilu@mogu.com>
Signed-off-by: vanderliang <vanderliang@gmail.com>