### PR TITLE
[SPARK-30215][SQL] Remove PrunedInMemoryFileIndex and merge its functionality into InMemoryFileIndex

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/CatalogFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/CatalogFileIndex.scala
@@ -81,8 +81,9 @@ class CatalogFileIndex(
       }
       val partitionSpec = PartitionSpec(partitionSchema, partitions)
       val timeNs = System.nanoTime() - startTime
-      new InMemoryFileIndex(sparkSession, partitionSpec,
-        Map.empty, Some(partitionSpec.partitionColumns), fileStatusCache, Option(timeNs))
+      new InMemoryFileIndex(sparkSession, partitionSpec.partitions.map(_.path), Map.empty,
+        Some(partitionSpec.partitionColumns), fileStatusCache,
+        Some(partitionSpec), Some(timeNs))
     } else {
       new InMemoryFileIndex(sparkSession, rootPaths, table.storage.properties,
         userSpecifiedSchema = None, fileStatusCache = fileStatusCache)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/CatalogFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/CatalogFileIndex.scala
@@ -81,11 +81,15 @@ class CatalogFileIndex(
       }
       val partitionSpec = PartitionSpec(partitionSchema, partitions)
       val timeNs = System.nanoTime() - startTime
-      new InMemoryFileIndex(sparkSession, partitionSpec.partitions.map(_.path), Map.empty,
-        Some(partitionSpec.partitionColumns), fileStatusCache,
-        Some(partitionSpec), Some(timeNs))
+      new InMemoryFileIndex(sparkSession,
+        rootPathsSpecified = partitionSpec.partitions.map(_.path),
+        parameters = Map.empty,
+        userSpecifiedSchema = Some(partitionSpec.partitionColumns),
+        fileStatusCache = fileStatusCache,
+        userSpecifiedPartitionSpec = Some(partitionSpec),
+        metadataOpsTimeNs = Some(timeNs))
     } else {
-      new InMemoryFileIndex(sparkSession, rootPaths, table.storage.properties,
+      new InMemoryFileIndex(sparkSession, rootPaths, parameters = table.storage.properties,
         userSpecifiedSchema = None, fileStatusCache = fileStatusCache)
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/CatalogFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/CatalogFileIndex.scala
@@ -81,8 +81,8 @@ class CatalogFileIndex(
       }
       val partitionSpec = PartitionSpec(partitionSchema, partitions)
       val timeNs = System.nanoTime() - startTime
-      new PrunedInMemoryFileIndex(
-        sparkSession, new Path(baseLocation.get), fileStatusCache, partitionSpec, Option(timeNs))
+      new InMemoryFileIndex(sparkSession, partitionSpec,
+        Map.empty, Some(partitionSpec.partitionColumns), fileStatusCache, Option(timeNs))
     } else {
       new InMemoryFileIndex(sparkSession, rootPaths, table.storage.properties,
         userSpecifiedSchema = None, fileStatusCache = fileStatusCache)
@@ -101,23 +101,3 @@ class CatalogFileIndex(
 
   override def hashCode(): Int = table.identifier.hashCode()
 }
-
-/**
- * An override of the standard HDFS listing based catalog, that overrides the partition spec with
- * the information from the metastore.
- *
- * @param tableBasePath The default base path of the Hive metastore table
- * @param partitionSpec The partition specifications from Hive metastore
- */
-private class PrunedInMemoryFileIndex(
-    sparkSession: SparkSession,
-    tableBasePath: Path,
-    fileStatusCache: FileStatusCache,
-    override val partitionSpec: PartitionSpec,
-    override val metadataOpsTimeNs: Option[Long])
-  extends InMemoryFileIndex(
-    sparkSession,
-    partitionSpec.partitions.map(_.path),
-    Map.empty,
-    Some(partitionSpec.partitionColumns),
-    fileStatusCache)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
@@ -70,11 +70,12 @@ class InMemoryFileIndex(
   refresh0()
 
   override def partitionSpec(): PartitionSpec = {
-    if (userSpecifiedPartitionSpec.isDefined) {
-      return userSpecifiedPartitionSpec.get
-    }
     if (cachedPartitionSpec == null) {
-      cachedPartitionSpec = inferPartitioning()
+      if (userSpecifiedPartitionSpec.isDefined) {
+        cachedPartitionSpec = userSpecifiedPartitionSpec.get
+      } else {
+        cachedPartitionSpec = inferPartitioning()
+      }
     }
     logTrace(s"Partition spec: $cachedPartitionSpec")
     cachedPartitionSpec

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
@@ -69,7 +69,13 @@ class InMemoryFileIndex(
 
   refresh0()
 
-  override def metadataOpsTimeNs: Option[Long] = _metadataOpsTimeNs
+  override def metadataOpsTimeNs: Option[Long] = {
+    if (_metadataOpsTimeNs.isDefined) {
+      _metadataOpsTimeNs
+    } else {
+      super.metadataOpsTimeNs
+    }
+  }
 
   override def partitionSpec(): PartitionSpec = {
     if (userSpecifiedPartitionSpec.isDefined) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
@@ -61,7 +61,7 @@ class InMemoryFileIndex(
   override val rootPaths =
     rootPathsSpecified.filterNot(FileStreamSink.ancestorIsMetadataDirectory(_, hadoopConf))
 
-  var _metadataOpsTimeNs: Option[Long] = None
+  private var _metadataOpsTimeNs: Option[Long] = None
   @volatile private var cachedLeafFiles: mutable.LinkedHashMap[Path, FileStatus] = _
   @volatile private var cachedLeafDirToChildrenFiles: Map[Path, Array[FileStatus]] = _
   @volatile private var cachedPartitionSpec: PartitionSpec = _

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
@@ -52,7 +52,7 @@ class InMemoryFileIndex(
     userSpecifiedSchema: Option[StructType],
     fileStatusCache: FileStatusCache = NoopCache,
     userSpecifiedPartitionSpec: Option[PartitionSpec] = None,
-    override val metadataOpsTimeNs: Option[Long] = super.metadataOpsTimeNs)
+    override val metadataOpsTimeNs: Option[Long] = None)
   extends PartitioningAwareFileIndex(
     sparkSession, parameters, userSpecifiedSchema, fileStatusCache) {
 
@@ -68,6 +68,14 @@ class InMemoryFileIndex(
   @volatile private var cachedPartitionSpec: PartitionSpec = _
 
   refresh0()
+
+//  override def metadataOpsTimeNs: Option[Long] = {
+//    if (_metadataOpsTimeNs.isDefined) {
+//      _metadataOpsTimeNs
+//    } else {
+//      super.metadataOpsTimeNs
+//    }
+//  }
 
   override def partitionSpec(): PartitionSpec = {
     if (userSpecifiedPartitionSpec.isDefined) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
@@ -52,7 +52,7 @@ class InMemoryFileIndex(
     userSpecifiedSchema: Option[StructType],
     fileStatusCache: FileStatusCache = NoopCache,
     userSpecifiedPartitionSpec: Option[PartitionSpec] = None,
-    _metadataOpsTimeNs: Option[Long] = None)
+    override val metadataOpsTimeNs: Option[Long] = super.metadataOpsTimeNs)
   extends PartitioningAwareFileIndex(
     sparkSession, parameters, userSpecifiedSchema, fileStatusCache) {
 
@@ -68,14 +68,6 @@ class InMemoryFileIndex(
   @volatile private var cachedPartitionSpec: PartitionSpec = _
 
   refresh0()
-
-  override def metadataOpsTimeNs: Option[Long] = {
-    if (_metadataOpsTimeNs.isDefined) {
-      _metadataOpsTimeNs
-    } else {
-      super.metadataOpsTimeNs
-    }
-  }
 
   override def partitionSpec(): PartitionSpec = {
     if (userSpecifiedPartitionSpec.isDefined) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
@@ -69,14 +69,6 @@ class InMemoryFileIndex(
 
   refresh0()
 
-//  override def metadataOpsTimeNs: Option[Long] = {
-//    if (_metadataOpsTimeNs.isDefined) {
-//      _metadataOpsTimeNs
-//    } else {
-//      super.metadataOpsTimeNs
-//    }
-//  }
-
   override def partitionSpec(): PartitionSpec = {
     if (userSpecifiedPartitionSpec.isDefined) {
       return userSpecifiedPartitionSpec.get

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
@@ -255,10 +255,10 @@ class ExplainSuite extends QueryTest with SharedSparkSession {
             "PartitionFilters: \\[isnotnull\\(k#xL\\), dynamicpruningexpression\\(k#xL " +
               "IN subquery#x\\)\\]"
           val expected_pattern3 =
-            "Location: PrunedInMemoryFileIndex \\[.*org.apache.spark.sql.ExplainSuite" +
+            "Location: InMemoryFileIndex \\[.*org.apache.spark.sql.ExplainSuite" +
               "/df2/.*, ... 99 entries\\]"
           val expected_pattern4 =
-            "Location: PrunedInMemoryFileIndex \\[.*org.apache.spark.sql.ExplainSuite" +
+            "Location: InMemoryFileIndex \\[.*org.apache.spark.sql.ExplainSuite" +
               "/df1/.*, ... 999 entries\\]"
           withNormalizedExplain(sqlText) { normalizedOutput =>
             assert(expected_pattern1.r.findAllMatchIn(normalizedOutput).length == 1)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove PrunedInMemoryFileIndex and merge its functionality into InMemoryFileIndex.


### Why are the changes needed?
PrunedInMemoryFileIndex is only used in CatalogFileIndex.filterPartitions, and its name is kind of confusing, we can completely merge its functionality into InMemoryFileIndex and remove the class.


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
Existing unit tests.
