### PR TITLE
[SPARK-30236][SQL][DOCS] Clarify date and time patterns supported in docs

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -1432,8 +1432,8 @@ case class ToUTCTimestamp(left: Expression, right: Expression)
 @ExpressionDescription(
   usage = """
     _FUNC_(date_str[, fmt]) - Parses the `date_str` expression with the `fmt` expression to
-    a date. Returns null with invalid input. By default, it follows casting rules to a date if
-    the `fmt` is omitted.
+      a date. Returns null with invalid input. By default, it follows casting rules to a date if
+      the `fmt` is omitted.
   """,
   arguments = """
     Arguments:
@@ -1480,8 +1480,8 @@ case class ParseToDate(left: Expression, format: Option[Expression], child: Expr
 @ExpressionDescription(
   usage = """
     _FUNC_(timestamp_str[, fmt]) - Parses the `timestamp` expression with the `fmt` expression to
-    a timestamp. Returns null with invalid input. By default, it follows casting rules to
-    a timestamp if the `fmt` is omitted.
+      a timestamp. Returns null with invalid input. By default, it follows casting rules to
+      a timestamp if the `fmt` is omitted.
   """,
   arguments = """
     Arguments:

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -657,7 +657,10 @@ case class DateFormatClass(left: Expression, right: Expression, timeZoneId: Opti
  * Deterministic version of [[UnixTimestamp]], must have at least one parameter.
  */
 @ExpressionDescription(
-  usage = "_FUNC_(expr[, pattern]) - Returns the UNIX timestamp of the given time.",
+  usage = """
+    _FUNC_(expr[, pattern]) - Returns the UNIX timestamp of the given time.
+    See `java.time.format.DateTimeFormatter` for valid date and time format patterns.
+  """,
   examples = """
     Examples:
       > SELECT _FUNC_('2016-04-08', 'yyyy-MM-dd');
@@ -695,7 +698,10 @@ case class ToUnixTimestamp(
  * second parameter.
  */
 @ExpressionDescription(
-  usage = "_FUNC_([expr[, pattern]]) - Returns the UNIX timestamp of current or specified time.",
+  usage = """
+    _FUNC_([expr[, pattern]]) - Returns the UNIX timestamp of current or specified time.
+    See `java.time.format.DateTimeFormatter` for valid date and time format patterns.
+  """,
   examples = """
     Examples:
       > SELECT _FUNC_();
@@ -868,7 +874,10 @@ abstract class UnixTime extends ToTimestamp {
  * Note that hive Language Manual says it returns 0 if fail, but in fact it returns null.
  */
 @ExpressionDescription(
-  usage = "_FUNC_(unix_time, format) - Returns `unix_time` in the specified `format`.",
+  usage = """
+     _FUNC_(unix_time, format) - Returns `unix_time` in the specified `format`.
+     See `java.time.format.DateTimeFormatter` for valid date and time format patterns.
+  """,
   examples = """
     Examples:
       > SELECT _FUNC_(0, 'yyyy-MM-dd HH:mm:ss');
@@ -1409,7 +1418,7 @@ case class ToUTCTimestamp(left: Expression, right: Expression)
   usage = """
     _FUNC_(date_str[, fmt]) - Parses the `date_str` expression with the `fmt` expression to
       a date. Returns null with invalid input. By default, it follows casting rules to a date if
-      the `fmt` is omitted.
+      the `fmt` is omitted. See `java.time.format.DateTimeFormatter` for valid date and time format patterns.
   """,
   examples = """
     Examples:
@@ -1451,7 +1460,7 @@ case class ParseToDate(left: Expression, format: Option[Expression], child: Expr
   usage = """
     _FUNC_(timestamp[, fmt]) - Parses the `timestamp` expression with the `fmt` expression to
       a timestamp. Returns null with invalid input. By default, it follows casting rules to
-      a timestamp if the `fmt` is omitted.
+      a timestamp if the `fmt` is omitted. See `java.time.format.DateTimeFormatter` for valid date and time format patterns.
   """,
   examples = """
     Examples:

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -599,6 +599,11 @@ case class WeekOfYear(child: Expression) extends UnaryExpression with ImplicitCa
     _FUNC_(timestamp, fmt) - Converts `timestamp` to a value of string in the format specified by the date format `fmt`.
     See `java.time.format.DateTimeFormatter` for valid date and time format patterns.
   """,
+  arguments = """
+    Arguments:
+      * timestamp - Date/timestamp or String to be converted to the given format. Default value is current time
+      * fmt - Date/time format pattern to follow
+  """,
   examples = """
     Examples:
       > SELECT _FUNC_('2016-04-08', 'y');
@@ -661,6 +666,13 @@ case class DateFormatClass(left: Expression, right: Expression, timeZoneId: Opti
     _FUNC_(expr[, pattern]) - Returns the UNIX timestamp of the given time.
     See `java.time.format.DateTimeFormatter` for valid date and time format patterns.
   """,
+  arguments = """
+    Arguments:
+      * expr - A date/timestamp or String which is returned as a UNIX timestamp.
+               Default value is current time
+      * pattern - Date/time format pattern to follow. Ignored if `expr` is not a String.
+                 Default value is "uuuu-MM-dd HH:mm:ss"
+  """,
   examples = """
     Examples:
       > SELECT _FUNC_('2016-04-08', 'yyyy-MM-dd');
@@ -701,6 +713,12 @@ case class ToUnixTimestamp(
   usage = """
     _FUNC_([expr[, pattern]]) - Returns the UNIX timestamp of current or specified time.
     See `java.time.format.DateTimeFormatter` for valid date and time format patterns.
+  """,
+  arguments = """
+    Arguments:
+      * expr - A date/timestamp or String. Default value is current time
+      * pattern - Date/time format pattern to follow. Ignored if `expr` is not a String.
+                 Default value is "uuuu-MM-dd HH:mm:ss"
   """,
   examples = """
     Examples:
@@ -877,6 +895,11 @@ abstract class UnixTime extends ToTimestamp {
   usage = """
      _FUNC_(unix_time, format) - Returns `unix_time` in the specified `format`.
      See `java.time.format.DateTimeFormatter` for valid date and time format patterns.
+  """,
+  arguments = """
+    Arguments:
+      * unix_time - UNIX Timestamp to be converted to the provided format
+      * format - Date/time format pattern to follow.
   """,
   examples = """
     Examples:
@@ -1421,6 +1444,11 @@ case class ToUTCTimestamp(left: Expression, right: Expression)
     the `fmt` is omitted. See `java.time.format.DateTimeFormatter` for valid date and time
     format patterns.
   """,
+  arguments = """
+    Arguments:
+      * dateStr - String to be parsed to date
+      * fmt - Date format pattern to follow
+  """,
   examples = """
     Examples:
       > SELECT _FUNC_('2009-07-30 04:17:52');
@@ -1459,10 +1487,15 @@ case class ParseToDate(left: Expression, format: Option[Expression], child: Expr
  */
 @ExpressionDescription(
   usage = """
-    _FUNC_(timestamp[, fmt]) - Parses the `timestamp` expression with the `fmt` expression to
+    _FUNC_(timestamp_str[, fmt]) - Parses the `timestamp` expression with the `fmt` expression to
     a timestamp. Returns null with invalid input. By default, it follows casting rules to
     a timestamp if the `fmt` is omitted. See `java.time.format.DateTimeFormatter` for valid
     date and time format patterns.
+  """,
+  arguments = """
+    Arguments:
+      * timestamp_str - String to be parsed to timestamp
+      * fmt - Time format pattern to follow
   """,
   examples = """
     Examples:

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -544,7 +544,7 @@ case class WeekDay(child: Expression) extends DayWeek {
   override protected def nullSafeEval(date: Any): Any = {
     val localDate = LocalDate.ofEpochDay(date.asInstanceOf[Int])
     localDate.getDayOfWeek.ordinal()
-  }
+  }`
 
   override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     nullSafeCodeGen(ctx, ev, days => {
@@ -598,7 +598,7 @@ case class WeekOfYear(child: Expression) extends UnaryExpression with ImplicitCa
   usage = "_FUNC_(timestamp, fmt) - Converts `timestamp` to a value of string in the format specified by the date format `fmt`.",
   arguments = """
     Arguments:
-      * timestamp - A date/timestamp or string to be converted to the given format. Default value is current time
+      * timestamp - A date/timestamp or string to be converted to the given format.
       * fmt - Date/time format pattern to follow. See `java.time.format.DateTimeFormatter` for valid date
               and time format patterns.
   """,
@@ -664,8 +664,7 @@ case class DateFormatClass(left: Expression, right: Expression, timeZoneId: Opti
   arguments = """
     Arguments:
       * timeExp - A date/timestamp or string which is returned as a UNIX timestamp.
-               Default value is current time
-      * format - Date/time format pattern to follow. Ignored if `timeExp` is not a String.
+      * format - Date/time format pattern to follow. Ignored if `timeExp` is not a string.
                  Default value is "uuuu-MM-dd HH:mm:ss". See `java.time.format.DateTimeFormatter`
                  for valid date and time format patterns.
   """,
@@ -709,8 +708,8 @@ case class ToUnixTimestamp(
   usage = "_FUNC_([timeExp[, format]]) - Returns the UNIX timestamp of current or specified time.",
   arguments = """
     Arguments:
-      * timeExp - A date/timestamp or String. Default value is current time
-      * format - Date/time format pattern to follow. Ignored if `timeExp` is not a String.
+      * timeExp - A date/timestamp or String. If not provided, this defaults to current time.
+      * format - Date/time format pattern to follow. Ignored if `timeExp` is not a string.
                  Default value is "uuuu-MM-dd HH:mm:ss". See `java.time.format.DateTimeFormatter`
                  for valid date and time format patterns.
   """,
@@ -889,7 +888,7 @@ abstract class UnixTime extends ToTimestamp {
   usage = "_FUNC_(unix_time, format) - Returns `unix_time` in the specified `format`.",
   arguments = """
     Arguments:
-      * unix_time - UNIX Timestamp to be converted to the provided format
+      * unix_time - UNIX Timestamp to be converted to the provided format.
       * format - Date/time format pattern to follow. See `java.time.format.DateTimeFormatter`
                  for valid date and time format patterns.
   """,
@@ -1437,7 +1436,7 @@ case class ToUTCTimestamp(left: Expression, right: Expression)
   """,
   arguments = """
     Arguments:
-      * date_str - String to be parsed to date
+      * date_str - String to be parsed to date.
       * fmt - Date format pattern to follow. See `java.time.format.DateTimeFormatter` for valid
               date and time format patterns.
   """,
@@ -1485,7 +1484,7 @@ case class ParseToDate(left: Expression, format: Option[Expression], child: Expr
   """,
   arguments = """
     Arguments:
-      * timestamp_str - String to be parsed to timestamp
+      * timestamp_str - A string to be parsed to timestamp.
       * fmt - Timestamp format pattern to follow. See `java.time.format.DateTimeFormatter` for valid
               date and time format patterns.
   """,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -595,7 +595,7 @@ case class WeekOfYear(child: Expression) extends UnaryExpression with ImplicitCa
 
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = "_FUNC_(timestamp, fmt) - Converts `timestamp` to a value of string in the format specified by the date format `fmt`.",
+  usage = "_FUNC_(timestamp, fmt) - Converts `timestamp` to a value of string in the format specified by the date format `fmt`. See [[java.text.SimpleDateFormat]] for valid date and time format patterns.",
   examples = """
     Examples:
       > SELECT _FUNC_('2016-04-08', 'y');

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -544,7 +544,7 @@ case class WeekDay(child: Expression) extends DayWeek {
   override protected def nullSafeEval(date: Any): Any = {
     val localDate = LocalDate.ofEpochDay(date.asInstanceOf[Int])
     localDate.getDayOfWeek.ordinal()
-  }`
+  }
 
   override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     nullSafeCodeGen(ctx, ev, days => {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -1436,7 +1436,7 @@ case class ToUTCTimestamp(left: Expression, right: Expression)
   """,
   arguments = """
     Arguments:
-      * date_str - String to be parsed to date.
+      * date_str - A string to be parsed to date.
       * fmt - Date format pattern to follow. See `java.time.format.DateTimeFormatter` for valid
               date and time format patterns.
   """,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -596,8 +596,8 @@ case class WeekOfYear(child: Expression) extends UnaryExpression with ImplicitCa
 // scalastyle:off line.size.limit
 @ExpressionDescription(
   usage = """
-  _FUNC_(timestamp, fmt) - Converts `timestamp` to a value of string in the format specified by the date format `fmt`.
-  See `java.text.SimpleDateFormat` for valid date and time format patterns.
+    _FUNC_(timestamp, fmt) - Converts `timestamp` to a value of string in the format specified by the date format `fmt`.
+    See `java.text.SimpleDateFormat` for valid date and time format patterns.
   """,
   examples = """
     Examples:

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -1446,7 +1446,7 @@ case class ToUTCTimestamp(left: Expression, right: Expression)
   """,
   arguments = """
     Arguments:
-      * dateStr - String to be parsed to date
+      * date_str - String to be parsed to date
       * fmt - Date format pattern to follow
   """,
   examples = """

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -706,11 +706,11 @@ case class ToUnixTimestamp(
  * second parameter.
  */
 @ExpressionDescription(
-  usage = "_FUNC_([expr[, pattern]]) - Returns the UNIX timestamp of current or specified time.",
+  usage = "_FUNC_([timeExp[, format]]) - Returns the UNIX timestamp of current or specified time.",
   arguments = """
     Arguments:
-      * expr - A date/timestamp or String. Default value is current time
-      * pattern - Date/time format pattern to follow. Ignored if `expr` is not a String.
+      * timeExp - A date/timestamp or String. Default value is current time
+      * format - Date/time format pattern to follow. Ignored if `timeExp` is not a String.
                  Default value is "uuuu-MM-dd HH:mm:ss". See `java.time.format.DateTimeFormatter`
                  for valid date and time format patterns.
   """,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -595,7 +595,7 @@ case class WeekOfYear(child: Expression) extends UnaryExpression with ImplicitCa
 
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = "_FUNC_(timestamp, fmt) - Converts `timestamp` to a value of string in the format specified by the date format `fmt`. See [[java.text.SimpleDateFormat]] for valid date and time format patterns.",
+  usage = "_FUNC_(timestamp, fmt) - Converts `timestamp` to a value of string in the format specified by the date format `fmt`. See `java.text.SimpleDateFormat` for valid date and time format patterns.",
   examples = """
     Examples:
       > SELECT _FUNC_('2016-04-08', 'y');

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -708,7 +708,7 @@ case class ToUnixTimestamp(
   usage = "_FUNC_([timeExp[, format]]) - Returns the UNIX timestamp of current or specified time.",
   arguments = """
     Arguments:
-      * timeExp - A date/timestamp or String. If not provided, this defaults to current time.
+      * timeExp - A date/timestamp or string. If not provided, this defaults to current time.
       * format - Date/time format pattern to follow. Ignored if `timeExp` is not a string.
                  Default value is "uuuu-MM-dd HH:mm:ss". See `java.time.format.DateTimeFormatter`
                  for valid date and time format patterns.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -1479,8 +1479,8 @@ case class ParseToDate(left: Expression, format: Option[Expression], child: Expr
  */
 @ExpressionDescription(
   usage = """
-    _FUNC_(timestamp_str[, fmt]) - Parses the `timestamp` expression with the `fmt` expression to
-      a timestamp. Returns null with invalid input. By default, it follows casting rules to
+    _FUNC_(timestamp_str[, fmt]) - Parses the `timestamp_str` expression with the `fmt` expression
+      to a timestamp. Returns null with invalid input. By default, it follows casting rules to
       a timestamp if the `fmt` is omitted.
   """,
   arguments = """

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -597,7 +597,7 @@ case class WeekOfYear(child: Expression) extends UnaryExpression with ImplicitCa
 @ExpressionDescription(
   usage = """
     _FUNC_(timestamp, fmt) - Converts `timestamp` to a value of string in the format specified by the date format `fmt`.
-    See `java.text.SimpleDateFormat` for valid date and time format patterns.
+    See `java.time.format.DateTimeFormatter` for valid date and time format patterns.
   """,
   examples = """
     Examples:

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -595,7 +595,10 @@ case class WeekOfYear(child: Expression) extends UnaryExpression with ImplicitCa
 
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = "_FUNC_(timestamp, fmt) - Converts `timestamp` to a value of string in the format specified by the date format `fmt`. See `java.text.SimpleDateFormat` for valid date and time format patterns.",
+  usage = """
+  _FUNC_(timestamp, fmt) - Converts `timestamp` to a value of string in the format specified by the date format `fmt`.
+  See `java.text.SimpleDateFormat` for valid date and time format patterns.
+  """,
   examples = """
     Examples:
       > SELECT _FUNC_('2016-04-08', 'y');

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -595,14 +595,12 @@ case class WeekOfYear(child: Expression) extends UnaryExpression with ImplicitCa
 
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = """
-    _FUNC_(timestamp, fmt) - Converts `timestamp` to a value of string in the format specified by the date format `fmt`.
-    See `java.time.format.DateTimeFormatter` for valid date and time format patterns.
-  """,
+  usage = "_FUNC_(timestamp, fmt) - Converts `timestamp` to a value of string in the format specified by the date format `fmt`.",
   arguments = """
     Arguments:
       * timestamp - Date/timestamp or String to be converted to the given format. Default value is current time
-      * fmt - Date/time format pattern to follow
+      * fmt - Date/time format pattern to follow. See `java.time.format.DateTimeFormatter` for valid date
+              and time format patterns.
   """,
   examples = """
     Examples:
@@ -662,16 +660,14 @@ case class DateFormatClass(left: Expression, right: Expression, timeZoneId: Opti
  * Deterministic version of [[UnixTimestamp]], must have at least one parameter.
  */
 @ExpressionDescription(
-  usage = """
-    _FUNC_(expr[, pattern]) - Returns the UNIX timestamp of the given time.
-    See `java.time.format.DateTimeFormatter` for valid date and time format patterns.
-  """,
+  usage = "_FUNC_(expr[, pattern]) - Returns the UNIX timestamp of the given time.",
   arguments = """
     Arguments:
       * expr - A date/timestamp or String which is returned as a UNIX timestamp.
                Default value is current time
       * pattern - Date/time format pattern to follow. Ignored if `expr` is not a String.
-                 Default value is "uuuu-MM-dd HH:mm:ss"
+                  Default value is "uuuu-MM-dd HH:mm:ss". See `java.time.format.DateTimeFormatter`
+                  for valid date and time format patterns.
   """,
   examples = """
     Examples:
@@ -710,15 +706,13 @@ case class ToUnixTimestamp(
  * second parameter.
  */
 @ExpressionDescription(
-  usage = """
-    _FUNC_([expr[, pattern]]) - Returns the UNIX timestamp of current or specified time.
-    See `java.time.format.DateTimeFormatter` for valid date and time format patterns.
-  """,
+  usage = "_FUNC_([expr[, pattern]]) - Returns the UNIX timestamp of current or specified time.",
   arguments = """
     Arguments:
       * expr - A date/timestamp or String. Default value is current time
       * pattern - Date/time format pattern to follow. Ignored if `expr` is not a String.
-                 Default value is "uuuu-MM-dd HH:mm:ss"
+                 Default value is "uuuu-MM-dd HH:mm:ss". See `java.time.format.DateTimeFormatter`
+                 for valid date and time format patterns.
   """,
   examples = """
     Examples:
@@ -892,14 +886,12 @@ abstract class UnixTime extends ToTimestamp {
  * Note that hive Language Manual says it returns 0 if fail, but in fact it returns null.
  */
 @ExpressionDescription(
-  usage = """
-     _FUNC_(unix_time, format) - Returns `unix_time` in the specified `format`.
-     See `java.time.format.DateTimeFormatter` for valid date and time format patterns.
-  """,
+  usage = "_FUNC_(unix_time, format) - Returns `unix_time` in the specified `format`.",
   arguments = """
     Arguments:
       * unix_time - UNIX Timestamp to be converted to the provided format
-      * format - Date/time format pattern to follow.
+      * format - Date/time format pattern to follow. See `java.time.format.DateTimeFormatter`
+                 for valid date and time format patterns.
   """,
   examples = """
     Examples:
@@ -1441,13 +1433,13 @@ case class ToUTCTimestamp(left: Expression, right: Expression)
   usage = """
     _FUNC_(date_str[, fmt]) - Parses the `date_str` expression with the `fmt` expression to
     a date. Returns null with invalid input. By default, it follows casting rules to a date if
-    the `fmt` is omitted. See `java.time.format.DateTimeFormatter` for valid date and time
-    format patterns.
+    the `fmt` is omitted.
   """,
   arguments = """
     Arguments:
       * date_str - String to be parsed to date
-      * fmt - Date format pattern to follow
+      * fmt - Date format pattern to follow. See `java.time.format.DateTimeFormatter` for valid
+              date and time format patterns.
   """,
   examples = """
     Examples:
@@ -1489,13 +1481,13 @@ case class ParseToDate(left: Expression, format: Option[Expression], child: Expr
   usage = """
     _FUNC_(timestamp_str[, fmt]) - Parses the `timestamp` expression with the `fmt` expression to
     a timestamp. Returns null with invalid input. By default, it follows casting rules to
-    a timestamp if the `fmt` is omitted. See `java.time.format.DateTimeFormatter` for valid
-    date and time format patterns.
+    a timestamp if the `fmt` is omitted.
   """,
   arguments = """
     Arguments:
       * timestamp_str - String to be parsed to timestamp
-      * fmt - Time format pattern to follow
+      * fmt - Time format pattern to follow. See `java.time.format.DateTimeFormatter` for valid
+              date and time format patterns.
   """,
   examples = """
     Examples:

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -1417,8 +1417,9 @@ case class ToUTCTimestamp(left: Expression, right: Expression)
 @ExpressionDescription(
   usage = """
     _FUNC_(date_str[, fmt]) - Parses the `date_str` expression with the `fmt` expression to
-      a date. Returns null with invalid input. By default, it follows casting rules to a date if
-      the `fmt` is omitted. See `java.time.format.DateTimeFormatter` for valid date and time format patterns.
+    a date. Returns null with invalid input. By default, it follows casting rules to a date if
+    the `fmt` is omitted. See `java.time.format.DateTimeFormatter` for valid date and time
+    format patterns.
   """,
   examples = """
     Examples:
@@ -1459,8 +1460,9 @@ case class ParseToDate(left: Expression, format: Option[Expression], child: Expr
 @ExpressionDescription(
   usage = """
     _FUNC_(timestamp[, fmt]) - Parses the `timestamp` expression with the `fmt` expression to
-      a timestamp. Returns null with invalid input. By default, it follows casting rules to
-      a timestamp if the `fmt` is omitted. See `java.time.format.DateTimeFormatter` for valid date and time format patterns.
+    a timestamp. Returns null with invalid input. By default, it follows casting rules to
+    a timestamp if the `fmt` is omitted. See `java.time.format.DateTimeFormatter` for valid
+    date and time format patterns.
   """,
   examples = """
     Examples:

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -598,7 +598,7 @@ case class WeekOfYear(child: Expression) extends UnaryExpression with ImplicitCa
   usage = "_FUNC_(timestamp, fmt) - Converts `timestamp` to a value of string in the format specified by the date format `fmt`.",
   arguments = """
     Arguments:
-      * timestamp - Date/timestamp or String to be converted to the given format. Default value is current time
+      * timestamp - A date/timestamp or string to be converted to the given format. Default value is current time
       * fmt - Date/time format pattern to follow. See `java.time.format.DateTimeFormatter` for valid date
               and time format patterns.
   """,
@@ -660,14 +660,14 @@ case class DateFormatClass(left: Expression, right: Expression, timeZoneId: Opti
  * Deterministic version of [[UnixTimestamp]], must have at least one parameter.
  */
 @ExpressionDescription(
-  usage = "_FUNC_(expr[, pattern]) - Returns the UNIX timestamp of the given time.",
+  usage = "_FUNC_(timeExp[, format]) - Returns the UNIX timestamp of the given time.",
   arguments = """
     Arguments:
-      * expr - A date/timestamp or String which is returned as a UNIX timestamp.
+      * timeExp - A date/timestamp or string which is returned as a UNIX timestamp.
                Default value is current time
-      * pattern - Date/time format pattern to follow. Ignored if `expr` is not a String.
-                  Default value is "uuuu-MM-dd HH:mm:ss". See `java.time.format.DateTimeFormatter`
-                  for valid date and time format patterns.
+      * format - Date/time format pattern to follow. Ignored if `timeExp` is not a String.
+                 Default value is "uuuu-MM-dd HH:mm:ss". See `java.time.format.DateTimeFormatter`
+                 for valid date and time format patterns.
   """,
   examples = """
     Examples:
@@ -1486,7 +1486,7 @@ case class ParseToDate(left: Expression, format: Option[Expression], child: Expr
   arguments = """
     Arguments:
       * timestamp_str - String to be parsed to timestamp
-      * fmt - Time format pattern to follow. See `java.time.format.DateTimeFormatter` for valid
+      * fmt - Timestamp format pattern to follow. See `java.time.format.DateTimeFormatter` for valid
               date and time format patterns.
   """,
   examples = """


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Link to appropriate Java Class with list of date/time patterns supported

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Avoid confusion on the end-user's side of things, as seen in questions like [this](https://stackoverflow.com/questions/54496878/date-format-conversion-is-adding-1-year-to-the-border-dates) on StackOverflow

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
Yes, Docs are updated.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
`date_format`:
![image](https://user-images.githubusercontent.com/2394761/70796647-b5c55900-1d9a-11ea-89f9-7a8661641c09.png)

`to_unix_timestamp`:
![image](https://user-images.githubusercontent.com/2394761/70796664-c07fee00-1d9a-11ea-9029-e82d899e3f59.png)

`unix_timestamp`:
![image](https://user-images.githubusercontent.com/2394761/70796688-caa1ec80-1d9a-11ea-8868-a18c437a5d49.png)

`from_unixtime`:
![image](https://user-images.githubusercontent.com/2394761/70796703-d4c3eb00-1d9a-11ea-85fe-3c672e0cda28.png)

`to_date`:
![image](https://user-images.githubusercontent.com/2394761/70796718-dd1c2600-1d9a-11ea-81f4-a0966eeb0f1d.png)

`to_timestamp`:
![image](https://user-images.githubusercontent.com/2394761/70796735-e6a58e00-1d9a-11ea-8ef7-d3e1d9b5370f.png)

