### PR TITLE
[MINOR] Fix google style guide address

### DIFF
--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -24,7 +24,7 @@
     Checkstyle configuration based on the Google coding conventions from:
 
     -  Google Java Style
-       https://google-styleguide.googlecode.com/svn-history/r130/trunk/javaguide.html
+       https://google.github.io/styleguide/javaguide.html
 
     with Spark-specific changes from:
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR update  google style guide address to `https://google.github.io/styleguide/javaguide.html`.


### Why are the changes needed?

`https://google-styleguide.googlecode.com/svn-history/r130/trunk/javaguide.html` **404**:

![image](https://user-images.githubusercontent.com/5399861/70717915-431c9500-1d2a-11ea-895b-024be953a116.png)


### Does this PR introduce any user-facing change?
No


### How was this patch tested?

