### PR TITLE
[WIP][SPARK-30237][SQL] Move `sql()` method from DataType to AbstractTypemv sql method

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/AbstractDataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/AbstractDataType.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.types
 
+import java.util.Locale
+
 import scala.reflect.runtime.universe.TypeTag
 
 import org.apache.spark.annotation.Stable
@@ -47,6 +49,8 @@ private[sql] abstract class AbstractDataType {
 
   /** Readable string representation for the type. */
   private[sql] def simpleString: String
+
+  def sql: String = simpleString.toUpperCase(Locale.ROOT)
 }
 
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -88,8 +88,6 @@ abstract class DataType extends AbstractDataType {
   /** Readable string representation for the type with truncation */
   private[sql] def simpleString(maxNumberFields: Int): String = simpleString
 
-  def sql: String = simpleString.toUpperCase(Locale.ROOT)
-
   /**
    * Check if `this` and `other` are the same data type when ignoring nullability
    * (`StructField.nullable`, `ArrayType.containsNull`, and `MapType.valueContainsNull`).

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/ColumnTypeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/ColumnTypeSuite.scala
@@ -158,4 +158,19 @@ class ColumnTypeSuite extends SparkFunSuite with Logging {
 
     assert(message.contains("Unsupported type: invalid type name"))
   }
+
+  test("sql method of each data type") {
+    assert(NullType.sql == "NULL")
+    assert(IntegerType.sql == "INT")
+    assert(ShortType.sql == "SMALLINT")
+    assert(LongType.sql == "BIGINT")
+    assert(DoubleType.sql == "DOUBLE")
+    assert(FloatType.sql == "FLOAT")
+    assert(StructType(StructField("operation_log", StringType) :: Nil).sql ==
+      "STRUCT<`operation_log`: STRING>")
+    assert(DecimalType(38, 5).sql == "DECIMAL(38,5)")
+    assert(ArrayType(StringType).sql == "ARRAY<STRING>")
+    assert(MapType(StringType, DecimalType(5, 5)).sql == "MAP<STRING, DECIMAL(5,5)>")
+    assert(CalendarIntervalType.sql == "INTERVAL")
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Move `sql()` method from DataType to AbstractTypemv sql method

### Why are the changes needed?
Make all Spark Data type (such as `StructType`) can call method of `sql`


### Does this PR introduce any user-facing change?
NO


### How was this patch tested?
NO