### PR TITLE
[SPARK-30241][SQL] Make the target table relations not children of DELETE/UPDATE/MERGE

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -773,6 +773,21 @@ class Analyzer(
           .map(rel => show.copy(table = rel))
           .getOrElse(show)
 
+      case delete @ DeleteFromTable(u: UnresolvedV2Relation, _) =>
+        CatalogV2Util.loadRelation(u.catalog, u.tableName)
+          .map(rel => delete.copy(table = rel))
+          .getOrElse(delete)
+
+      case update @ UpdateTable(u: UnresolvedV2Relation, _, _) =>
+        CatalogV2Util.loadRelation(u.catalog, u.tableName)
+          .map(rel => update.copy(table = rel))
+          .getOrElse(update)
+
+      case merge @ MergeIntoTable(u: UnresolvedV2Relation, _, _, _, _) =>
+        CatalogV2Util.loadRelation(u.catalog, u.tableName)
+          .map(rel => merge.copy(targetTable = rel))
+          .getOrElse(merge)
+
       case u: UnresolvedV2Relation =>
         CatalogV2Util.loadRelation(u.catalog, u.tableName).getOrElse(u)
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -304,31 +304,27 @@ case class DescribeTable(table: NamedRelation, isExtended: Boolean) extends Comm
  * The logical plan of the DELETE FROM command that works for v2 tables.
  */
 case class DeleteFromTable(
-    table: LogicalPlan,
-    condition: Option[Expression]) extends Command with SupportsSubquery {
-  override def children: Seq[LogicalPlan] = table :: Nil
-}
+    table: NamedRelation,
+    condition: Option[Expression]) extends Command with SupportsSubquery
 
 /**
  * The logical plan of the UPDATE TABLE command that works for v2 tables.
  */
 case class UpdateTable(
-    table: LogicalPlan,
+    table: NamedRelation,
     assignments: Seq[Assignment],
-    condition: Option[Expression]) extends Command with SupportsSubquery {
-  override def children: Seq[LogicalPlan] = table :: Nil
-}
+    condition: Option[Expression]) extends Command with SupportsSubquery
 
 /**
  * The logical plan of the MERGE INTO command that works for v2 tables.
  */
 case class MergeIntoTable(
-    targetTable: LogicalPlan,
+    targetTable: NamedRelation,
     sourceTable: LogicalPlan,
     mergeCondition: Expression,
     matchedActions: Seq[MergeAction],
     notMatchedActions: Seq[MergeAction]) extends Command with SupportsSubquery {
-  override def children: Seq[LogicalPlan] = Seq(targetTable, sourceTable)
+  override def children: Seq[LogicalPlan] = Seq(sourceTable)
 }
 
 sealed abstract class MergeAction(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -876,6 +876,7 @@ class PlanResolutionSuite extends AnalysisTest {
         case DeleteFromTable(_: DataSourceV2Relation, None) =>
         case _ => fail("Expect DeleteFromTable, bug got:\n" + parsed1.treeString)
       }
+      assert(parsed1.children.isEmpty, "The target table should not be a child")
 
       parsed2 match {
         case DeleteFromTable(
@@ -941,6 +942,7 @@ class PlanResolutionSuite extends AnalysisTest {
 
         case _ => fail("Expect UpdateTable, but got:\n" + parsed1.treeString)
       }
+      assert(parsed1.children.isEmpty, "The target table should not be a child")
 
       parsed2 match {
         case UpdateTable(
@@ -1157,6 +1159,8 @@ class PlanResolutionSuite extends AnalysisTest {
 
           case _ => fail("Expect MergeIntoTable, but got:\n" + parsed1.treeString)
         }
+        val childName = parsed1.children.map(_.asInstanceOf[SubqueryAlias].name.identifier)
+        assert(childName === Seq("source"), "The source relation should be a child of the node")
 
         parsed2 match {
           case MergeIntoTable(


### PR DESCRIPTION
### What changes were proposed in this pull request?

The target tables of DELETE/UPDATE/MERGE should not be children of the nodes. They should simply be variables of the node.

### Why are the changes needed?

Having the targets as children can cause bad interactions with other catalyst rules that may want to perform actions assuming a child is a "read-only" relation. This change also makes these commands more consistent with AlterTable and DescribeTable.


### Does this PR introduce any user-facing change?

No


### How was this patch tested?

Existing tests