### PR TITLE
[SPARK-30243][BUILD][K8S] Upgrade K8s client dependency to 4.6.4

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.7-hive-1.2
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-1.2
@@ -137,14 +137,14 @@ jsr305-3.0.0.jar
 jta-1.1.jar
 jul-to-slf4j-1.7.16.jar
 kryo-shaded-4.0.2.jar
-kubernetes-client-4.6.1.jar
-kubernetes-model-4.6.1.jar
-kubernetes-model-common-4.6.1.jar
+kubernetes-client-4.6.4.jar
+kubernetes-model-4.6.4.jar
+kubernetes-model-common-4.6.4.jar
 leveldbjni-all-1.8.jar
 libfb303-0.9.3.jar
 libthrift-0.12.0.jar
 log4j-1.2.17.jar
-logging-interceptor-3.12.0.jar
+logging-interceptor-3.12.6.jar
 lz4-java-1.7.0.jar
 machinist_2.12-0.6.8.jar
 macro-compat_2.12-1.1.1.jar
@@ -158,7 +158,7 @@ minlog-1.3.0.jar
 netty-all-4.1.42.Final.jar
 objenesis-2.5.1.jar
 okapi-shade-0.4.2.jar
-okhttp-3.12.0.jar
+okhttp-3.12.6.jar
 okio-1.15.0.jar
 opencsv-2.3.jar
 orc-core-1.5.8-nohive.jar

--- a/dev/deps/spark-deps-hadoop-2.7-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-2.3
@@ -153,14 +153,14 @@ jsr305-3.0.0.jar
 jta-1.1.jar
 jul-to-slf4j-1.7.16.jar
 kryo-shaded-4.0.2.jar
-kubernetes-client-4.6.1.jar
-kubernetes-model-4.6.1.jar
-kubernetes-model-common-4.6.1.jar
+kubernetes-client-4.6.4.jar
+kubernetes-model-4.6.4.jar
+kubernetes-model-common-4.6.4.jar
 leveldbjni-all-1.8.jar
 libfb303-0.9.3.jar
 libthrift-0.12.0.jar
 log4j-1.2.17.jar
-logging-interceptor-3.12.0.jar
+logging-interceptor-3.12.6.jar
 lz4-java-1.7.0.jar
 machinist_2.12-0.6.8.jar
 macro-compat_2.12-1.1.1.jar
@@ -174,7 +174,7 @@ minlog-1.3.0.jar
 netty-all-4.1.42.Final.jar
 objenesis-2.5.1.jar
 okapi-shade-0.4.2.jar
-okhttp-3.12.0.jar
+okhttp-3.12.6.jar
 okio-1.15.0.jar
 opencsv-2.3.jar
 orc-core-1.5.8.jar

--- a/dev/deps/spark-deps-hadoop-3.2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3.2-hive-2.3
@@ -165,14 +165,14 @@ kerby-pkix-1.0.1.jar
 kerby-util-1.0.1.jar
 kerby-xdr-1.0.1.jar
 kryo-shaded-4.0.2.jar
-kubernetes-client-4.6.1.jar
-kubernetes-model-4.6.1.jar
-kubernetes-model-common-4.6.1.jar
+kubernetes-client-4.6.4.jar
+kubernetes-model-4.6.4.jar
+kubernetes-model-common-4.6.4.jar
 leveldbjni-all-1.8.jar
 libfb303-0.9.3.jar
 libthrift-0.12.0.jar
 log4j-1.2.17.jar
-logging-interceptor-3.12.0.jar
+logging-interceptor-3.12.6.jar
 lz4-java-1.7.0.jar
 machinist_2.12-0.6.8.jar
 macro-compat_2.12-1.1.1.jar
@@ -189,7 +189,7 @@ nimbus-jose-jwt-4.41.1.jar
 objenesis-2.5.1.jar
 okapi-shade-0.4.2.jar
 okhttp-2.7.5.jar
-okhttp-3.12.0.jar
+okhttp-3.12.6.jar
 okio-1.15.0.jar
 opencsv-2.3.jar
 orc-core-1.5.8.jar

--- a/resource-managers/kubernetes/core/pom.xml
+++ b/resource-managers/kubernetes/core/pom.xml
@@ -29,7 +29,7 @@
   <name>Spark Project Kubernetes</name>
   <properties>
     <sbt.project.name>kubernetes</sbt.project.name>
-    <kubernetes.client.version>4.6.1</kubernetes.client.version>
+    <kubernetes.client.version>4.6.4</kubernetes.client.version>
   </properties>
 
   <dependencies>

--- a/resource-managers/kubernetes/integration-tests/pom.xml
+++ b/resource-managers/kubernetes/integration-tests/pom.xml
@@ -29,7 +29,7 @@
     <download-maven-plugin.version>1.3.0</download-maven-plugin.version>
     <exec-maven-plugin.version>1.4.0</exec-maven-plugin.version>
     <extraScalaTestArgs></extraScalaTestArgs>
-    <kubernetes-client.version>4.6.1</kubernetes-client.version>
+    <kubernetes-client.version>4.6.4</kubernetes-client.version>
     <scala-maven-plugin.version>3.2.2</scala-maven-plugin.version>
     <scalatest-maven-plugin.version>1.0</scalatest-maven-plugin.version>
     <sbt.project.name>kubernetes-integration-tests</sbt.project.name>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade K8s client library from 4.6.1 to 4.6.4 for `3.0.0-preview2`.

### Why are the changes needed?

This will bring the latest bug fixes.
- https://github.com/fabric8io/kubernetes-client/releases/tag/v4.6.4
- https://github.com/fabric8io/kubernetes-client/releases/tag/v4.6.3
- https://github.com/fabric8io/kubernetes-client/releases/tag/v4.6.2

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Pass the Jenkins with K8s integration test.
