### PR TITLE
[SPARK-30173][INFRA] Automatically close stale PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: Close stale PRs
+
+on:
+  schedule:
+  - cron: "0 * * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v1.1.0
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-pr-message: |
+          We're closing this PR because it hasn't been updated in a while.
+          This isn't a judgement on the merit of the PR in any way. It's just
+          a way of keeping the PR queue manageable.
+
+          If you'd like to revive this PR, please reopen it!
+        days-before-stale: 3650
+        days-before-close: 3

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,7 +17,7 @@ jobs:
           a way of keeping the PR queue manageable.
 
           If you'd like to revive this PR, please reopen it!
-        days-before-stale: 180
+        days-before-stale: 100
         # Setting this to 0 is the same as setting it to 1.
         # See: https://github.com/actions/stale/issues/28
         days-before-close: 0

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,7 @@ name: Close stale PRs
 
 on:
   schedule:
-  - cron: "0 * * * *"
+  - cron: "0 0 * * *"
 
 jobs:
   stale:
@@ -17,5 +17,7 @@ jobs:
           a way of keeping the PR queue manageable.
 
           If you'd like to revive this PR, please reopen it!
-        days-before-stale: 3650
-        days-before-close: 3
+        days-before-stale: 180
+        # Setting this to 0 is the same as setting it to 1.
+        # See: https://github.com/actions/stale/issues/28
+        days-before-close: 0


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds [a GitHub workflow to automatically close stale PRs](https://github.com/marketplace/actions/close-stale-issues).

### Why are the changes needed?

This will help cut down the number of open but stale PRs and keep the PR queue manageable.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

I'm not sure how to test this PR without impacting real PRs on the repo.

See: https://github.com/actions/stale/issues/32