### PR TITLE
Revert "[SPARK-30230][SQL] Like ESCAPE syntax can not use '_' and '%'"

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -1393,10 +1393,6 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
           }
           str.charAt(0)
         }.getOrElse('\\')
-        if ('%' == escapeChar || '_' == escapeChar) {
-            throw new ParseException("Invalid escape string." +
-              "Escape string can not be '%', '_'.", ctx)
-        }
         invertIfNotDefined(Like(e, expression(ctx.pattern), escapeChar))
       case SqlBaseParser.RLIKE =>
         invertIfNotDefined(RLike(e, expression(ctx.pattern)))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
@@ -198,10 +198,6 @@ class ExpressionParserSuite extends AnalysisTest {
     assertEqual("a not like 'pattern%' escape '\"'", !('a.like("pattern%", '\"')))
     intercept("a not like 'pattern%' escape '\"/'", message)
     intercept("a not like 'pattern%' escape ''", message)
-
-    val message2 = "Escape string can not be '%', '_'."
-    intercept("a like 'pattern%' escape '_'", message2)
-    intercept("a like 'pattern%' escape '%'", message2)
   }
 
   test("like expressions with ESCAPED_STRING_LITERALS = true") {


### PR DESCRIPTION
This reverts commit cada5beef72530fa699b5ec13d67261be37730e4.