### PR TITLE
[SPARK-30261][SQL] Should not change owner of hive table for some commands like 'alter' operation

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -937,7 +937,12 @@ private[hive] object HiveClientImpl {
     }
     hiveTable.setFields(schema.asJava)
     hiveTable.setPartCols(partCols.asJava)
-    userName.foreach(hiveTable.setOwner)
+    // Here when the table owner exists, we should not reset the owner with current userName
+    if (table.owner != null && table.owner.nonEmpty) {
+      hiveTable.setOwner(table.owner)
+    } else {
+      userName.foreach(hiveTable.setOwner)
+    }
     hiveTable.setCreateTime((table.createTime / 1000).toInt)
     hiveTable.setLastAccessTime((table.lastAccessTime / 1000).toInt)
     table.storage.locationUri.map(CatalogUtils.URIToString).foreach { loc =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
For SparkSQL,When we do some alter operations on hive table, the owner of hive table would be changed to someone who invoked the operation, it's unresonable. And in fact, the owner should not changed for the real prodcution environment, otherwise the  authority check is out of order.

The problem can be reproduced as described in the below:
1. First I create a table with username='xie' and then `desc formatted table `,the owner is 'xiepengjie'
```
spark-sql> desc formatted bigdata_test.tt1;
col_name data_type comment
c int NULL
# Detailed Table Information
Database bigdata_test
Table tt1
Owner xie
Created Time Wed Sep 11 11:30:49 CST 2019
Last Access Thu Jan 01 08:00:00 CST 1970
Created By Spark 2.2 or prior
Type MANAGED
Provider hive
Table Properties [PART_LIMIT=10000, transient_lastDdlTime=1568172649, LEVEL=1, TTL=60]
Location hdfs://NS1/user/hive_admin/warehouse/bigdata_test.db/tt1
Serde Library org.apache.hadoop.hive.ql.io.orc.OrcSerde
InputFormat org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
OutputFormat org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
Storage Properties [serialization.format=1]
Partition Provider Catalog
Time taken: 0.371 seconds, Fetched 18 row(s)

```
2. Then I use another username='johnchen' and execute `alter table bigdata_test.tt1 set location 'hdfs://NS1/user/hive_admin/warehouse/bigdata_test.db/tt1'`, check the owner of hive table  is 'johnchen', it's unresonable
```
spark-sql> desc formatted bigdata_test.tt1;
col_name        data_type       comment
c       int     NULL
 
# Detailed Table Information
Database        bigdata_test
Table   tt1
Owner   johnchen
Created Time    Wed Sep 11 11:30:49 CST 2019
Last Access     Thu Jan 01 08:00:00 CST 1970
Created By      Spark 2.2 or prior
Type    MANAGED
Provider        hive
Table Properties        [transient_lastDdlTime=1568871017, PART_LIMIT=10000, LEVEL=1, TTL=60]
Location        hdfs://NS1/user/hive_admin/warehouse/bigdata_test.db/tt1
Serde Library   org.apache.hadoop.hive.ql.io.orc.OrcSerde
InputFormat     org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
OutputFormat    org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
Storage Properties      [serialization.format=1]
Partition Provider      Catalog
Time taken: 0.041 seconds, Fetched 18 row(s)

```





### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
In fact, the owner should not changed for the real prodcution environment, otherwise the  authority check is out of order.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Manual