### PR TITLE
Fix issue where `newFilesOnly` does nothing

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
@@ -185,7 +185,7 @@ class FileInputDStream[K, V, F <: NewInputFormat[K, V]](
       lastNewFileFindingTime = clock.getTimeMillis()
 
       // Calculate ignore threshold
-      val modTimeIgnoreThreshold = math.max(
+      val modTimeIgnoreThreshold = math.min(
         initialModTimeIgnoreThreshold,   // initial threshold based on newFilesOnly setting
         currentTime - durationToRemember.milliseconds  // trailing end of the remember window
       )


### PR DESCRIPTION
this 
```scala
// Calculate ignore threshold
val modTimeIgnoreThreshold = math.max(
    initialModTimeIgnoreThreshold,   // initial threshold based on newFilesOnly setting
    currentTime - durationToRemember.milliseconds  // trailing end of the remember window
)
```
is equivalent to simply

```scala
// Calculate ignore threshold
val modTimeIgnoreThreshold = currentTime - durationToRemember.milliseconds
```
whenever `initialModTimeIgnoreThreshold == 0`.