### PR TITLE
[SPARK-30066][SQL][FOLLOWUP] Remove size field for interval column cache

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnType.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnType.scala
@@ -705,14 +705,11 @@ private[columnar] case class MAP(dataType: MapType)
   override def clone(v: UnsafeMapData): UnsafeMapData = v.copy()
 }
 
-private[columnar] object CALENDAR_INTERVAL extends ColumnType[CalendarInterval]
-  with DirectCopyColumnType[CalendarInterval] {
+private[columnar] object CALENDAR_INTERVAL extends ColumnType[CalendarInterval] {
 
   override def dataType: DataType = CalendarIntervalType
 
-  override def defaultSize: Int = 16
-
-  override def actualSize(row: InternalRow, ordinal: Int): Int = 20
+  override val defaultSize: Int = 16
 
   override def getField(row: InternalRow, ordinal: Int): CalendarInterval = row.getInterval(ordinal)
 
@@ -721,15 +718,22 @@ private[columnar] object CALENDAR_INTERVAL extends ColumnType[CalendarInterval]
   }
 
   override def extract(buffer: ByteBuffer): CalendarInterval = {
-    ByteBufferHelper.getInt(buffer)
     val months = ByteBufferHelper.getInt(buffer)
     val days = ByteBufferHelper.getInt(buffer)
     val microseconds = ByteBufferHelper.getLong(buffer)
     new CalendarInterval(months, days, microseconds)
   }
 
+  // copy the bytes from ByteBuffer to UnsafeRow
+  override def extract(buffer: ByteBuffer, row: InternalRow, ordinal: Int): Unit = row match {
+    case r: MutableUnsafeRow =>
+      val cursor = buffer.position()
+      buffer.position(cursor + defaultSize)
+      r.writer.write(ordinal, buffer.array(), buffer.arrayOffset() + cursor, defaultSize)
+    case _ => setField(row, ordinal, extract(buffer))
+  }
+
   override def append(v: CalendarInterval, buffer: ByteBuffer): Unit = {
-    ByteBufferHelper.putInt(buffer, 16)
     ByteBufferHelper.putInt(buffer, v.months)
     ByteBufferHelper.putInt(buffer, v.days)
     ByteBufferHelper.putLong(buffer, v.microseconds)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnType.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnType.scala
@@ -725,12 +725,15 @@ private[columnar] object CALENDAR_INTERVAL extends ColumnType[CalendarInterval] 
   }
 
   // copy the bytes from ByteBuffer to UnsafeRow
-  override def extract(buffer: ByteBuffer, row: InternalRow, ordinal: Int): Unit = row match {
-    case r: MutableUnsafeRow =>
+  override def extract(buffer: ByteBuffer, row: InternalRow, ordinal: Int): Unit = {
+    if (row.isInstanceOf[MutableUnsafeRow]) {
       val cursor = buffer.position()
       buffer.position(cursor + defaultSize)
-      r.writer.write(ordinal, buffer.array(), buffer.arrayOffset() + cursor, defaultSize)
-    case _ => setField(row, ordinal, extract(buffer))
+      row.asInstanceOf[MutableUnsafeRow].writer.write(ordinal, buffer.array(),
+        buffer.arrayOffset() + cursor, defaultSize)
+    } else {
+      setField(row, ordinal, extract(buffer))
+    }
   }
 
   override def append(v: CalendarInterval, buffer: ByteBuffer): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnType.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnType.scala
@@ -709,7 +709,7 @@ private[columnar] object CALENDAR_INTERVAL extends ColumnType[CalendarInterval] 
 
   override def dataType: DataType = CalendarIntervalType
 
-  override val defaultSize: Int = 16
+  override def defaultSize: Int = 16
 
   override def getField(row: InternalRow, ordinal: Int): CalendarInterval = row.getInterval(ordinal)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/ColumnTypeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/ColumnTypeSuite.scala
@@ -78,7 +78,7 @@ class ColumnTypeSuite extends SparkFunSuite with Logging {
     checkActualSize(ARRAY_TYPE, Array[Any](1), 4 + 8 + 8 + 8)
     checkActualSize(MAP_TYPE, Map(1 -> "a"), 4 + (8 + 8 + 8 + 8) + (8 + 8 + 8 + 8))
     checkActualSize(STRUCT_TYPE, Row("hello"), 28)
-    checkActualSize(CALENDAR_INTERVAL, CalendarInterval.MAX_VALUE, 4 + 4 + 4 + 8)
+    checkActualSize(CALENDAR_INTERVAL, CalendarInterval.MAX_VALUE, 4 + 4 + 8)
   }
 
   testNativeColumnType(BOOLEAN)


### PR DESCRIPTION
### What changes were proposed in this pull request?

A followup for #26699, clear the size field for interval column cache, which is needless and can reduce the memory cost.


### Why are the changes needed?
followup


### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
existing ut.