### PR TITLE
[SPARK-30154][ML] PySpark UDF to convert MLlib vectors to dense arrays

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -460,6 +460,7 @@ pyspark_ml = Module(
         "pyspark.ml.evaluation",
         "pyspark.ml.feature",
         "pyspark.ml.fpm",
+        "pyspark.ml.functions",
         "pyspark.ml.image",
         "pyspark.ml.linalg.__init__",
         "pyspark.ml.recommendation",

--- a/mllib/src/main/scala/org/apache/spark/ml/functions.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/functions.scala
@@ -19,6 +19,7 @@ package org.apache.spark.ml
 
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml.linalg.Vector
+import org.apache.spark.mllib.linalg.{Vector => OldVector}
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.functions.udf
 
@@ -27,12 +28,20 @@ import org.apache.spark.sql.functions.udf
 object functions {
 // scalastyle:on
 
-  private[ml] val vector_to_dense_array_udf = udf { v: Vector => v.toArray }
+  private[ml] val vector_to_array_udf = udf { vec: Any =>
+    vec match {
+      case v: Vector => v.toArray
+      case v: OldVector => v.toArray
+      case _ => throw new IllegalArgumentException(
+        "function vector_to_array require an argument of type " +
+        "`org.apache.spark.ml.linalg.Vector` or `org.apache.spark.mllib.linalg.Vector`.")
+    }
+  }
 
   /**
    * Convert MLlib sparse/dense vectors in a DataFrame into dense arrays.
    *
    * @since 3.0.0
    */
-  def vector_to_dense_array(v: Column): Column = vector_to_dense_array_udf(v)
+  def vector_to_array(v: Column): Column = vector_to_array_udf(v)
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/functions.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/functions.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml
+
+import org.apache.spark.annotation.Since
+import org.apache.spark.ml.linalg.Vector
+import org.apache.spark.sql.functions.udf
+import org.apache.spark.sql.Column
+
+// scalastyle:off
+@Since("3.0.0")
+object functions {
+// scalastyle:on
+
+  private[ml] val vector_to_dense_array_udf = udf { v: Vector => v.toArray }
+
+  /**
+   * Convert MLlib sparse/dense vectors in a DataFrame into dense arrays.
+   *
+   * @since 3.0.0
+   */
+  def vector_to_dense_array(v: Column): Column = vector_to_dense_array_udf(v)
+}

--- a/mllib/src/main/scala/org/apache/spark/ml/functions.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/functions.scala
@@ -32,9 +32,10 @@ object functions {
     vec match {
       case v: Vector => v.toArray
       case v: OldVector => v.toArray
-      case _ => throw new IllegalArgumentException(
+      case v => throw new IllegalArgumentException(
         "function vector_to_array requires a non-null input argument and input type must be " +
-        "`org.apache.spark.ml.linalg.Vector` or `org.apache.spark.mllib.linalg.Vector`.")
+        "`org.apache.spark.ml.linalg.Vector` or `org.apache.spark.mllib.linalg.Vector`, " +
+        s"but got ${ if (v == null) "null" else v.getClass.getName }.")
     }
   }.asNonNullable()
 

--- a/mllib/src/main/scala/org/apache/spark/ml/functions.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/functions.scala
@@ -19,8 +19,8 @@ package org.apache.spark.ml
 
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml.linalg.Vector
-import org.apache.spark.sql.functions.udf
 import org.apache.spark.sql.Column
+import org.apache.spark.sql.functions.udf
 
 // scalastyle:off
 @Since("3.0.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/functions.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/functions.scala
@@ -28,20 +28,20 @@ import org.apache.spark.sql.functions.udf
 object functions {
 // scalastyle:on
 
-  private[ml] val vector_to_array_udf = udf { vec: Any =>
+  private val vectorToArrayUdf = udf { vec: Any =>
     vec match {
       case v: Vector => v.toArray
       case v: OldVector => v.toArray
       case _ => throw new IllegalArgumentException(
-        "function vector_to_array require an argument of type " +
+        "function vector_to_array requires a non-null input argument and input type must be " +
         "`org.apache.spark.ml.linalg.Vector` or `org.apache.spark.mllib.linalg.Vector`.")
     }
-  }
+  }.asNonNullable()
 
   /**
-   * Convert MLlib sparse/dense vectors in a DataFrame into dense arrays.
+   * Converts a column of MLlib sparse/dense vectors into a column of dense arrays.
    *
    * @since 3.0.0
    */
-  def vector_to_array(v: Column): Column = vector_to_array_udf(v)
+  def vector_to_array(v: Column): Column = vectorToArrayUdf(v)
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/FunctionsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/FunctionsSuite.scala
@@ -17,27 +17,29 @@
 
 package org.apache.spark.ml
 
-import org.apache.spark.ml.functions.vector_to_dense_array
+import org.apache.spark.ml.functions.vector_to_array
 import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.ml.util.MLTest
+import org.apache.spark.mllib.linalg.{Vectors => OldVectors}
 
 class FunctionsSuite extends MLTest {
 
   import testImplicits._
 
-  test("test vector_to_dense_array") {
+  test("test vector_to_array") {
     val df1 = Seq(
-      Tuple1(Vectors.dense(1.0, 2.0, 3.0)),
-      Tuple1(Vectors.sparse(3, Seq((0, 2.0), (2, 3.0))))
-    ).toDF("vec")
+      (Vectors.dense(1.0, 2.0, 3.0), OldVectors.dense(10.0, 20.0, 30.0)),
+      (Vectors.sparse(3, Seq((0, 2.0), (2, 3.0))), OldVectors.sparse(3, Seq((0, 20.0), (2, 30.0))))
+    ).toDF("vec", "oldVec")
 
-    val result = df1.select(vector_to_dense_array('vec))
-      .as[Array[Double]].collect()
+    val result = df1.select(vector_to_array('vec), vector_to_array('oldVec))
+      .as[(List[Double], List[Double])]
+      .collect()
+
     val expected = Array(
-      Array(1.0, 2.0, 3.0),
-      Array(2.0, 0.0, 3.0)
+      (List(1.0, 2.0, 3.0), List(10.0, 20.0, 30.0)),
+      (List(2.0, 0.0, 3.0), List(20.0, 0.0, 30.0))
     )
-
     assert(result === expected)
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/FunctionsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/FunctionsSuite.scala
@@ -27,18 +27,18 @@ class FunctionsSuite extends MLTest {
   import testImplicits._
 
   test("test vector_to_array") {
-    val df1 = Seq(
+    val df = Seq(
       (Vectors.dense(1.0, 2.0, 3.0), OldVectors.dense(10.0, 20.0, 30.0)),
       (Vectors.sparse(3, Seq((0, 2.0), (2, 3.0))), OldVectors.sparse(3, Seq((0, 20.0), (2, 30.0))))
     ).toDF("vec", "oldVec")
 
-    val result = df1.select(vector_to_array('vec), vector_to_array('oldVec))
-      .as[(List[Double], List[Double])]
-      .collect()
+    val result = df.select(vector_to_array('vec), vector_to_array('oldVec))
+      .as[(Seq[Double], Seq[Double])]
+      .collect().toSeq
 
-    val expected = Array(
-      (List(1.0, 2.0, 3.0), List(10.0, 20.0, 30.0)),
-      (List(2.0, 0.0, 3.0), List(20.0, 0.0, 30.0))
+    val expected = Seq(
+      (Seq(1.0, 2.0, 3.0), Seq(10.0, 20.0, 30.0)),
+      (Seq(2.0, 0.0, 3.0), Seq(20.0, 0.0, 30.0))
     )
     assert(result === expected)
   }

--- a/mllib/src/test/scala/org/apache/spark/ml/FunctionsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/FunctionsSuite.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml
+
+import org.apache.spark.ml.functions.vector_to_dense_array
+import org.apache.spark.ml.linalg.Vectors
+import org.apache.spark.ml.util.MLTest
+
+class FunctionsSuite extends MLTest {
+
+  import testImplicits._
+
+  test("test vector_to_dense_array") {
+    val df1 = Seq(
+      Tuple1(Vectors.dense(1.0, 2.0, 3.0)),
+      Tuple1(Vectors.sparse(3, Seq((0, 2.0), (2, 3.0))))
+    ).toDF("vec")
+
+    val result = df1.select(vector_to_dense_array('vec))
+      .as[Array[Double]].collect()
+    val expected = Array(
+      Array(1.0, 2.0, 3.0),
+      Array(2.0, 0.0, 3.0)
+    )
+
+    assert(result === expected)
+  }
+}

--- a/mllib/src/test/scala/org/apache/spark/ml/FunctionsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/FunctionsSuite.scala
@@ -58,9 +58,8 @@ class FunctionsSuite extends MLTest {
       }
       assert(thrown1.getCause.getMessage.contains(
         "function vector_to_array requires a non-null input argument and input type must be " +
-          "`org.apache.spark.ml.linalg.Vector` or `org.apache.spark.mllib.linalg.Vector`, " +
-          s"but got ${valType}"))
-
+        "`org.apache.spark.ml.linalg.Vector` or `org.apache.spark.mllib.linalg.Vector`, " +
+        s"but got ${valType}"))
     }
   }
 }

--- a/python/docs/pyspark.ml.rst
+++ b/python/docs/pyspark.ml.rst
@@ -41,6 +41,14 @@ pyspark.ml.clustering module
     :undoc-members:
     :inherited-members:
 
+pyspark.ml.functions module
+----------------------------
+
+.. automodule:: pyspark.ml.functions
+    :members:
+    :undoc-members:
+    :inherited-members:
+
 pyspark.ml.linalg module
 ----------------------------
 

--- a/python/pyspark/ml/functions.py
+++ b/python/pyspark/ml/functions.py
@@ -40,3 +40,25 @@ def vector_to_array(col):
     sc = SparkContext._active_spark_context
     return Column(
         sc._jvm.org.apache.spark.ml.functions.vector_to_array(_to_java_column(col)))
+
+
+def _test():
+    import doctest
+    import pyspark.ml.functions
+    globs = pyspark.ml.functions.__dict__.copy()
+    spark = SparkSession.builder \
+        .master("local[2]") \
+        .appName("ml.functions tests") \
+        .getOrCreate()
+    sc = spark.sparkContext
+    globs['sc'] = sc
+    globs['spark'] = spark
+
+    (failure_count, test_count) = doctest.testmod(pyspark.ml.functions, globs=globs)
+    spark.stop()
+    if failure_count:
+        sys.exit(-1)
+
+
+if __name__ == "__main__":
+    _test()

--- a/python/pyspark/ml/functions.py
+++ b/python/pyspark/ml/functions.py
@@ -44,6 +44,7 @@ def vector_to_array(col):
 
 def _test():
     import doctest
+    from pyspark.sql import SparkSession
     import pyspark.ml.functions
     globs = pyspark.ml.functions.__dict__.copy()
     spark = SparkSession.builder \

--- a/python/pyspark/ml/functions.py
+++ b/python/pyspark/ml/functions.py
@@ -46,6 +46,7 @@ def _test():
     import doctest
     from pyspark.sql import SparkSession
     import pyspark.ml.functions
+    import sys
     globs = pyspark.ml.functions.__dict__.copy()
     spark = SparkSession.builder \
         .master("local[2]") \
@@ -55,7 +56,9 @@ def _test():
     globs['sc'] = sc
     globs['spark'] = spark
 
-    (failure_count, test_count) = doctest.testmod(pyspark.ml.functions, globs=globs)
+    (failure_count, test_count) = doctest.testmod(
+        pyspark.ml.functions, globs=globs,
+        optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE)
     spark.stop()
     if failure_count:
         sys.exit(-1)

--- a/python/pyspark/ml/functions.py
+++ b/python/pyspark/ml/functions.py
@@ -1,0 +1,36 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pyspark import since, SparkContext
+from pyspark.sql.column import Column, _to_java_column
+
+@since(3.0)
+def vector_to_dense_array(col):
+    """
+    Convert MLlib sparse/dense vectors in a DataFrame into dense arrays.
+
+    >>> from pyspark.ml.linalg import Vectors
+    >>> from pyspark.ml.functions import vector_to_dense_array
+    >>> df = spark.createDataFrame([
+    ...     (Vectors.dense(1.0, 2.0, 3.0),),
+    ...     (Vectors.sparse(3, [(0, 2.0), (2, 3.0)]),)], ["vec"])
+    >>> df.select(vector_to_dense_array("vec").alias("arr")).collect()
+    [Row(arr=[1.0, 2.0, 3.0]), Row(arr=[2.0, 0.0, 3.0])]
+    """
+    sc = SparkContext._active_spark_context
+    return Column(
+        sc._jvm.org.apache.spark.ml.functions.vector_to_dense_array(_to_java_column(col)))

--- a/python/pyspark/ml/functions.py
+++ b/python/pyspark/ml/functions.py
@@ -18,19 +18,25 @@
 from pyspark import since, SparkContext
 from pyspark.sql.column import Column, _to_java_column
 
+
 @since(3.0)
-def vector_to_dense_array(col):
+def vector_to_array(col):
     """
     Convert MLlib sparse/dense vectors in a DataFrame into dense arrays.
 
     >>> from pyspark.ml.linalg import Vectors
-    >>> from pyspark.ml.functions import vector_to_dense_array
+    >>> from pyspark.ml.functions import vector_to_array
+    >>> from pyspark.mllib.linalg import Vectors as OldVectors
     >>> df = spark.createDataFrame([
-    ...     (Vectors.dense(1.0, 2.0, 3.0),),
-    ...     (Vectors.sparse(3, [(0, 2.0), (2, 3.0)]),)], ["vec"])
-    >>> df.select(vector_to_dense_array("vec").alias("arr")).collect()
-    [Row(arr=[1.0, 2.0, 3.0]), Row(arr=[2.0, 0.0, 3.0])]
+    ...     (Vectors.dense(1.0, 2.0, 3.0), OldVectors.dense(10.0, 20.0, 30.0)),
+    ...     (Vectors.sparse(3, [(0, 2.0), (2, 3.0)]),
+    ...      OldVectors.sparse(3, [(0, 20.0), (2, 30.0)]))],
+    ...     ["vec", "oldVec"])
+    >>> df.select(vector_to_array("vec").alias("vec"),
+    ...           vector_to_array("oldVec").alias("oldVec")).collect()
+    [Row(vec=[1.0, 2.0, 3.0], oldVec=[10.0, 20.0, 30.0]),
+     Row(vec=[2.0, 0.0, 3.0], oldVec=[20.0, 0.0, 30.0])]
     """
     sc = SparkContext._active_spark_context
     return Column(
-        sc._jvm.org.apache.spark.ml.functions.vector_to_dense_array(_to_java_column(col)))
+        sc._jvm.org.apache.spark.ml.functions.vector_to_array(_to_java_column(col)))

--- a/python/pyspark/ml/functions.py
+++ b/python/pyspark/ml/functions.py
@@ -22,7 +22,7 @@ from pyspark.sql.column import Column, _to_java_column
 @since(3.0)
 def vector_to_array(col):
     """
-    Convert MLlib sparse/dense vectors in a DataFrame into dense arrays.
+    Converts a column of MLlib sparse/dense vectors into a column of dense arrays.
 
     >>> from pyspark.ml.linalg import Vectors
     >>> from pyspark.ml.functions import vector_to_array


### PR DESCRIPTION
### What changes were proposed in this pull request?

PySpark UDF to convert MLlib vectors to dense arrays.
Example:
```
from pyspark.ml.functions import vector_to_array
df.select(vector_to_array(col("features"))
```

### Why are the changes needed?
If a PySpark user wants to convert MLlib sparse/dense vectors in a DataFrame into dense arrays, an efficient approach is to do that in JVM. However, it requires PySpark user to write Scala code and register it as a UDF. Often this is infeasible for a pure python project.

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
UT.
