### PR TITLE
[SPARK-30294][SS] Explicitly defines read-only StateStore and optimize for HDFSBackedStateStore

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -58,7 +58,6 @@ import org.apache.spark.util.{SizeEstimator, Utils}
  * - store.remove(...)
  * - store.commit()    // commits all the updates to made; the new version will be returned
  * - store.iterator()  // key-value data after last commit as an iterator
- * - store.updates()   // updates made in the last commit as an iterator
  *
  * Fault-tolerance model:
  * - Every set of updates is written to a delta file before committing.
@@ -78,6 +77,23 @@ private[state] class HDFSBackedStateStoreProvider extends StateStoreProvider wit
   // - Any updates to the map while iterating through the filtered iterator does not throw
   //   java.util.ConcurrentModificationException
   type MapType = java.util.concurrent.ConcurrentHashMap[UnsafeRow, UnsafeRow]
+
+  class HDFSBackedReadOnlyStateStore(val version: Long, map: MapType)
+    extends ReadOnlyStateStore {
+
+    override def id: StateStoreId = HDFSBackedStateStoreProvider.this.stateStoreId
+
+    override def get(key: UnsafeRow): UnsafeRow = map.get(key)
+
+    override def abort(): Unit = {}
+
+    override def iterator(): Iterator[UnsafeRowPair] = {
+      val unsafeRowPair = new UnsafeRowPair()
+      map.entrySet.asScala.iterator.map { entry =>
+        unsafeRowPair.withRows(entry.getKey, entry.getValue)
+      }
+    }
+  }
 
   /** Implementation of [[StateStore]] API which is backed by an HDFS-compatible file system */
   class HDFSBackedStateStore(val version: Long, mapToUpdate: MapType)
@@ -142,9 +158,8 @@ private[state] class HDFSBackedStateStoreProvider extends StateStoreProvider wit
 
     /** Abort all the updates made on this store. This store will not be usable any more. */
     override def abort(): Unit = {
-      // This if statement is to ensure that files are deleted only if there are changes to the
-      // StateStore. We have two StateStores for each task, one which is used only for reading, and
-      // the other used for read+write. We don't want the read-only to delete state files.
+      // This if statement is to ensure that files are deleted only once: if either commit or abort
+      // is called before, it will be no-op.
       if (state == UPDATING) {
         state = ABORTED
         cancelDeltaFile(compressedStream, deltaFileStream)
@@ -197,15 +212,24 @@ private[state] class HDFSBackedStateStoreProvider extends StateStoreProvider wit
   }
 
   /** Get the state store for making updates to create a new `version` of the store. */
-  override def getStore(version: Long): StateStore = synchronized {
+  override def getStore(version: Long): StateStore = getStore(version, readOnly = false)
+
+  /** Get the state store for reading to specific `version` of the store. */
+  override def getReadOnlyStore(version: Long): StateStore = getStore(version, readOnly = true)
+
+  private def getStore(version: Long, readOnly: Boolean): StateStore = synchronized {
     require(version >= 0, "Version cannot be less than 0")
     val newMap = new MapType()
     if (version > 0) {
       newMap.putAll(loadMap(version))
     }
-    val store = new HDFSBackedStateStore(version, newMap)
-    logInfo(s"Retrieved version $version of ${HDFSBackedStateStoreProvider.this} for update")
-    store
+    if (readOnly) {
+      logInfo(s"Retrieved version $version of ${HDFSBackedStateStoreProvider.this} for readonly")
+      new HDFSBackedReadOnlyStateStore(version, newMap)
+    } else {
+      logInfo(s"Retrieved version $version of ${HDFSBackedStateStoreProvider.this} for update")
+      new HDFSBackedStateStore(version, newMap)
+    }
   }
 
   override def init(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -219,7 +219,7 @@ private[state] class HDFSBackedStateStoreProvider extends StateStoreProvider wit
   }
 
   /** Get the state store for reading to specific `version` of the store. */
-  override def getReadOnlyStore(version: Long): ReadStateStore = {
+  override def getReadStore(version: Long): ReadStateStore = {
     val newMap = getLoadedMapForStore(version)
     logInfo(s"Retrieved version $version of ${HDFSBackedStateStoreProvider.this} for readonly")
     new HDFSBackedReadStateStore(version, newMap)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -78,8 +78,8 @@ private[state] class HDFSBackedStateStoreProvider extends StateStoreProvider wit
   //   java.util.ConcurrentModificationException
   type MapType = java.util.concurrent.ConcurrentHashMap[UnsafeRow, UnsafeRow]
 
-  class HDFSBackedReadOnlyStateStore(val version: Long, map: MapType)
-    extends ReadOnlyStateStore {
+  class HDFSBackedReadStateStore(val version: Long, map: MapType)
+    extends ReadStateStore {
 
     override def id: StateStoreId = HDFSBackedStateStoreProvider.this.stateStoreId
 
@@ -219,10 +219,10 @@ private[state] class HDFSBackedStateStoreProvider extends StateStoreProvider wit
   }
 
   /** Get the state store for reading to specific `version` of the store. */
-  override def getReadOnlyStore(version: Long): ReadOnlyStateStore = {
+  override def getReadOnlyStore(version: Long): ReadStateStore = {
     val newMap = getLoadedMapForStore(version)
     logInfo(s"Retrieved version $version of ${HDFSBackedStateStoreProvider.this} for readonly")
-    new HDFSBackedReadOnlyStateStore(version, newMap)
+    new HDFSBackedReadStateStore(version, newMap)
   }
 
   private def getLoadedMapForStore(version: Long): MapType = synchronized {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -92,7 +92,7 @@ private[state] class HDFSBackedStateStoreProvider extends StateStoreProvider wit
       }
     }
 
-    override def close(): Unit = {}
+    override def abort(): Unit = {}
   }
 
   /** Implementation of [[StateStore]] API which is backed by an HDFS-compatible file system */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -92,7 +92,7 @@ private[state] class HDFSBackedStateStoreProvider extends StateStoreProvider wit
       }
     }
 
-    override def abort(): Unit = {}
+    override def close(): Unit = {}
   }
 
   /** Implementation of [[StateStore]] API which is backed by an HDFS-compatible file system */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -93,6 +93,10 @@ private[state] class HDFSBackedStateStoreProvider extends StateStoreProvider wit
     }
 
     override def abort(): Unit = {}
+
+    override def toString(): String = {
+      s"HDFSReadStateStore[id=(op=${id.operatorId},part=${id.partitionId}),dir=$baseDir]"
+    }
   }
 
   /** Implementation of [[StateStore]] API which is backed by an HDFS-compatible file system */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -246,8 +246,7 @@ trait StateStoreProvider {
    * Return an instance of [[ReadOnlyStateStore]] representing state data of the given version.
    * By default it will return the same instance as getStore(version) but wrapped to prevent
    * modification. Providers can override and return optimized version of [[ReadOnlyStateStore]]
-   * based on the fact the instance will be only used for reading - [[ReadOnlyStateStore]] is the
-   * good base class to extend when providers implement their own.
+   * based on the fact the instance will be only used for reading.
    */
   def getReadOnlyStore(version: Long): ReadOnlyStateStore =
     new WrappedReadOnlyStateStore(getStore(version))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -40,7 +40,7 @@ import org.apache.spark.util.{ThreadUtils, Utils}
  * `StateStore` represents a specific version of state data, and such instances are created
  * through a [[StateStoreProvider]].
  *
- * `close` method will be called when the task is completed - please clean up the resources in
+ * `abort` method will be called when the task is completed - please clean up the resources in
  * the method.
  */
 trait ReadStateStore {
@@ -82,8 +82,10 @@ trait ReadStateStore {
 
   /**
    * Clean up the resource.
+   *
+   * The method name is to respect backward compatibility on [[StateStore]].
    */
-  def close(): Unit = throw new UnsupportedOperationException("Not implemented")
+  def abort(): Unit
 }
 
 /**
@@ -91,12 +93,10 @@ trait ReadStateStore {
  * instance of a `StateStore` represents a specific version of state data, and such instances are
  * created through a [[StateStoreProvider]].
  *
- * `close` method will be called when the task is completed - please clean up the resources in
- * the method.
- *
- * Existing implementations which don't override `close` need to clean up the resources in both
- * `commit` and `abort` methods, with caution that there's a case `commit` and `abort` methods
- * can be called sequentially. The implementation needs to guard with double resource cleanup.
+ * Unlike [[ReadStateStore]], `abort` method may not be called if the `commit` method succeeds
+ * to commit the change. (`hasCommitted` returns `true`.) Otherwise, `abort` method will be called.
+ * Implementation should deal with resource cleanup in both methods, and also need to guard with
+ * double resource cleanup.
  */
 trait StateStore extends ReadStateStore {
 
@@ -122,7 +122,7 @@ trait StateStore extends ReadStateStore {
    * Abort all the updates that have been made to the store. Implementations should ensure that
    * no more updates (puts, removes) can be after an abort in order to avoid incorrect usage.
    */
-  def abort(): Unit
+  override def abort(): Unit
 
   /** Current metrics of the state store */
   def metrics: StateStoreMetrics
@@ -135,7 +135,6 @@ trait StateStore extends ReadStateStore {
 
 /** Wraps the instance of StateStore to make the instance read-only. */
 class WrappedReadStateStore(store: StateStore) extends ReadStateStore {
-
   override def id: StateStoreId = store.id
 
   override def version: Long = store.version
@@ -144,10 +143,7 @@ class WrappedReadStateStore(store: StateStore) extends ReadStateStore {
 
   override def iterator(): Iterator[UnsafeRowPair] = store.iterator()
 
-  override def close(): Unit = {
-    store.abort()
-    store.close()
-  }
+  override def abort(): Unit = store.abort()
 }
 
 /**
@@ -250,9 +246,7 @@ trait StateStoreProvider {
   /**
    * Return an instance of [[ReadStateStore]] representing state data of the given version.
    * By default it will return the same instance as getStore(version) but wrapped to prevent
-   * modification.
-   *
-   * Providers can override and return optimized version of [[ReadStateStore]]
+   * modification. Providers can override and return optimized version of [[ReadStateStore]]
    * based on the fact the instance will be only used for reading.
    */
   def getReadOnlyStore(version: Long): ReadStateStore =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -252,7 +252,7 @@ trait StateStoreProvider {
    * modification. Providers can override and return optimized version of [[ReadStateStore]]
    * based on the fact the instance will be only used for reading.
    */
-  def getReadOnlyStore(version: Long): ReadStateStore =
+  def getReadStore(version: Long): ReadStateStore =
     new WrappedReadStateStore(getStore(version))
 
   /** Optional method for providers to allow for background maintenance (e.g. compactions) */
@@ -440,7 +440,7 @@ object StateStore extends Logging {
     require(version >= 0)
     val storeProvider = getStateStoreProvider(storeProviderId, keySchema, valueSchema,
       indexOrdinal, storeConf, hadoopConf)
-    storeProvider.getReadOnlyStore(version)
+    storeProvider.getReadStore(version)
   }
 
   /** Get or create a store associated with the id. */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -447,8 +447,7 @@ object StateStore extends Logging {
       indexOrdinal: Option[Int],
       version: Long,
       storeConf: StateStoreConf,
-      hadoopConf: Configuration,
-      readOnly: Boolean = false): StateStore = {
+      hadoopConf: Configuration): StateStore = {
     require(version >= 0)
     val storeProvider = getStateStoreProvider(storeProviderId, keySchema, valueSchema,
       indexOrdinal, storeConf, hadoopConf)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -116,16 +116,16 @@ trait StateStore extends ReadStateStore {
   def commit(): Long
 
   /**
-   * Return an iterator containing all the key-value pairs in the StateStore. Implementations must
-   * ensure that updates (puts, removes) can be made while iterating over this iterator.
-   */
-  override def iterator(): Iterator[UnsafeRowPair]
-
-  /**
    * Abort all the updates that have been made to the store. Implementations should ensure that
    * no more updates (puts, removes) can be after an abort in order to avoid incorrect usage.
    */
   override def abort(): Unit
+
+  /**
+   * Return an iterator containing all the key-value pairs in the StateStore. Implementations must
+   * ensure that updates (puts, removes) can be made while iterating over this iterator.
+   */
+  override def iterator(): Iterator[UnsafeRowPair]
 
   /** Current metrics of the state store */
   def metrics: StateStoreMetrics

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -37,7 +37,7 @@ import org.apache.spark.util.{ThreadUtils, Utils}
 
 /**
  * Base trait for a versioned key-value store which provides read operations. Each instance of a
- * `StateStore` represents a specific version of state data, and such instances are created
+ * `ReadStateStore` represents a specific version of state data, and such instances are created
  * through a [[StateStoreProvider]].
  *
  * `abort` method will be called when the task is completed - please clean up the resources in
@@ -74,10 +74,7 @@ trait ReadStateStore {
     iterator()
   }
 
-  /**
-   * Return an iterator containing all the key-value pairs in the StateStore. Implementations must
-   * ensure that updates (puts, removes) can be made while iterating over this iterator.
-   */
+  /** Return an iterator containing all the key-value pairs in the StateStore. */
   def iterator(): Iterator[UnsafeRowPair]
 
   /**
@@ -117,6 +114,12 @@ trait StateStore extends ReadStateStore {
    * order to avoid incorrect usage.
    */
   def commit(): Long
+
+  /**
+   * Return an iterator containing all the key-value pairs in the StateStore. Implementations must
+   * ensure that updates (puts, removes) can be made while iterating over this iterator.
+   */
+  override def iterator(): Iterator[UnsafeRowPair]
 
   /**
    * Abort all the updates that have been made to the store. Implementations should ensure that

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRDD.scala
@@ -44,7 +44,7 @@ abstract class BaseStateStoreRDD[T: ClassTag, U: ClassTag](
   protected val hadoopConfBroadcast = dataRDD.context.broadcast(
     new SerializableConfiguration(sessionState.newHadoopConf()))
 
-  override protected def getPartitions: Array[Partition] = dataRDD.partitions
+  override def getPartitions: Array[Partition] = dataRDD.partitions
 
   /**
    * Set the preferred location of each partition using the executor that has the related

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRDD.scala
@@ -48,13 +48,13 @@ class ReadOnlyStateStoreRDD[T: ClassTag, U: ClassTag](
     @transient private val storeCoordinator: Option[StateStoreCoordinatorRef],
     extraOptions: Map[String, String] = Map.empty) extends RDD[U](dataRDD) {
 
-  protected val storeConf = new StateStoreConf(sessionState.conf, extraOptions)
+  private val storeConf = new StateStoreConf(sessionState.conf, extraOptions)
 
   // A Hadoop Configuration can be about 10 KB, which is pretty big, so broadcast it
-  protected val hadoopConfBroadcast = dataRDD.context.broadcast(
+  private val hadoopConfBroadcast = dataRDD.context.broadcast(
     new SerializableConfiguration(sessionState.newHadoopConf()))
 
-  override def getPartitions: Array[Partition] = dataRDD.partitions
+  override protected def getPartitions: Array[Partition] = dataRDD.partitions
 
   /**
    * Set the preferred location of each partition using the executor that has the related
@@ -99,13 +99,13 @@ class StateStoreRDD[T: ClassTag, U: ClassTag](
     @transient private val storeCoordinator: Option[StateStoreCoordinatorRef],
     extraOptions: Map[String, String] = Map.empty) extends RDD[U](dataRDD) {
 
-  protected val storeConf = new StateStoreConf(sessionState.conf, extraOptions)
+  private val storeConf = new StateStoreConf(sessionState.conf, extraOptions)
 
   // A Hadoop Configuration can be about 10 KB, which is pretty big, so broadcast it
-  protected val hadoopConfBroadcast = dataRDD.context.broadcast(
+  private val hadoopConfBroadcast = dataRDD.context.broadcast(
     new SerializableConfiguration(sessionState.newHadoopConf()))
 
-  override def getPartitions: Array[Partition] = dataRDD.partitions
+  override protected def getPartitions: Array[Partition] = dataRDD.partitions
 
   /**
    * Set the preferred location of each partition using the executor that has the related

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRDD.scala
@@ -46,8 +46,8 @@ class StateStoreRDD[T: ClassTag, U: ClassTag](
     indexOrdinal: Option[Int],
     sessionState: SessionState,
     @transient private val storeCoordinator: Option[StateStoreCoordinatorRef],
-    extraOptions: Map[String, String] = Map.empty)
-  extends RDD[U](dataRDD) {
+    extraOptions: Map[String, String] = Map.empty,
+    readOnly: Boolean) extends RDD[U](dataRDD) {
 
   private val storeConf = new StateStoreConf(sessionState.conf, extraOptions)
 
@@ -76,7 +76,7 @@ class StateStoreRDD[T: ClassTag, U: ClassTag](
 
     store = StateStore.get(
       storeProviderId, keySchema, valueSchema, indexOrdinal, storeVersion,
-      storeConf, hadoopConfBroadcast.value.value)
+      storeConf, hadoopConfBroadcast.value.value, readOnly)
     val inputIter = dataRDD.iterator(partition, ctxt)
     storeUpdateFunction(store, inputIter)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRDD.scala
@@ -30,13 +30,13 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
 
 /**
- * An RDD that allows computations to be executed against [[ReadOnlyStateStore]]s. It
+ * An RDD that allows computations to be executed against [[ReadStateStore]]s. It
  * uses the [[StateStoreCoordinator]] to get the locations of loaded state stores
  * and use that as the preferred locations.
  */
 class ReadOnlyStateStoreRDD[T: ClassTag, U: ClassTag](
     dataRDD: RDD[T],
-    storeReadFunction: (ReadOnlyStateStore, Iterator[T]) => Iterator[U],
+    storeReadFunction: (ReadStateStore, Iterator[T]) => Iterator[U],
     checkpointLocation: String,
     queryRunId: UUID,
     operatorId: Long,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRDD.scala
@@ -29,6 +29,43 @@ import org.apache.spark.sql.internal.SessionState
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
 
+// This doesn't directly override RDD methods as MiMa complains it.
+abstract class BaseStateStoreRDD[T: ClassTag, U: ClassTag](
+    dataRDD: RDD[T],
+    checkpointLocation: String,
+    queryRunId: UUID,
+    operatorId: Long,
+    sessionState: SessionState,
+    @transient private val storeCoordinator: Option[StateStoreCoordinatorRef],
+    extraOptions: Map[String, String] = Map.empty) extends RDD[U](dataRDD) {
+
+  protected val storeConf = new StateStoreConf(sessionState.conf, extraOptions)
+
+  // A Hadoop Configuration can be about 10 KB, which is pretty big, so broadcast it
+  protected val hadoopConfBroadcast = dataRDD.context.broadcast(
+    new SerializableConfiguration(sessionState.newHadoopConf()))
+
+  /** Implementations can simply call this method in getPreferredLocations. */
+  protected def _getPartitions: Array[Partition] = dataRDD.partitions
+
+  /**
+   * Set the preferred location of each partition using the executor that has the related
+   * [[StateStoreProvider]] already loaded.
+   *
+   * Implementations can simply call this method in getPreferredLocations.
+   */
+  protected def _getPreferredLocations(partition: Partition): Seq[String] = {
+    val stateStoreProviderId = getStateProviderId(partition)
+    storeCoordinator.flatMap(_.getLocation(stateStoreProviderId)).toSeq
+  }
+
+  protected def getStateProviderId(partition: Partition): StateStoreProviderId = {
+    StateStoreProviderId(
+      StateStoreId(checkpointLocation, operatorId, partition.index),
+      queryRunId)
+  }
+}
+
 /**
  * An RDD that allows computations to be executed against [[ReadStateStore]]s. It
  * uses the [[StateStoreCoordinator]] to get the locations of loaded state stores
@@ -46,31 +83,17 @@ class ReadOnlyStateStoreRDD[T: ClassTag, U: ClassTag](
     indexOrdinal: Option[Int],
     sessionState: SessionState,
     @transient private val storeCoordinator: Option[StateStoreCoordinatorRef],
-    extraOptions: Map[String, String] = Map.empty) extends RDD[U](dataRDD) {
+    extraOptions: Map[String, String] = Map.empty)
+  extends BaseStateStoreRDD[T, U](dataRDD, checkpointLocation, queryRunId, operatorId,
+    sessionState, storeCoordinator, extraOptions) {
 
-  private val storeConf = new StateStoreConf(sessionState.conf, extraOptions)
+  override protected def getPartitions: Array[Partition] = _getPartitions
 
-  // A Hadoop Configuration can be about 10 KB, which is pretty big, so broadcast it
-  private val hadoopConfBroadcast = dataRDD.context.broadcast(
-    new SerializableConfiguration(sessionState.newHadoopConf()))
-
-  override protected def getPartitions: Array[Partition] = dataRDD.partitions
-
-  /**
-   * Set the preferred location of each partition using the executor that has the related
-   * [[StateStoreProvider]] already loaded.
-   */
-  override def getPreferredLocations(partition: Partition): Seq[String] = {
-    val stateStoreProviderId = StateStoreProviderId(
-      StateStoreId(checkpointLocation, operatorId, partition.index),
-      queryRunId)
-    storeCoordinator.flatMap(_.getLocation(stateStoreProviderId)).toSeq
-  }
+  override def getPreferredLocations(partition: Partition): Seq[String] =
+    _getPreferredLocations(partition)
 
   override def compute(partition: Partition, ctxt: TaskContext): Iterator[U] = {
-    val storeProviderId = StateStoreProviderId(
-      StateStoreId(checkpointLocation, operatorId, partition.index),
-      queryRunId)
+    val storeProviderId = getStateProviderId(partition)
 
     val store = StateStore.getReadOnly(
       storeProviderId, keySchema, valueSchema, indexOrdinal, storeVersion,
@@ -97,31 +120,17 @@ class StateStoreRDD[T: ClassTag, U: ClassTag](
     indexOrdinal: Option[Int],
     sessionState: SessionState,
     @transient private val storeCoordinator: Option[StateStoreCoordinatorRef],
-    extraOptions: Map[String, String] = Map.empty) extends RDD[U](dataRDD) {
+    extraOptions: Map[String, String] = Map.empty)
+  extends BaseStateStoreRDD[T, U](dataRDD, checkpointLocation, queryRunId, operatorId,
+    sessionState, storeCoordinator, extraOptions) {
 
-  private val storeConf = new StateStoreConf(sessionState.conf, extraOptions)
+  override protected def getPartitions: Array[Partition] = _getPartitions
 
-  // A Hadoop Configuration can be about 10 KB, which is pretty big, so broadcast it
-  private val hadoopConfBroadcast = dataRDD.context.broadcast(
-    new SerializableConfiguration(sessionState.newHadoopConf()))
-
-  override protected def getPartitions: Array[Partition] = dataRDD.partitions
-
-  /**
-   * Set the preferred location of each partition using the executor that has the related
-   * [[StateStoreProvider]] already loaded.
-   */
-  override def getPreferredLocations(partition: Partition): Seq[String] = {
-    val stateStoreProviderId = StateStoreProviderId(
-      StateStoreId(checkpointLocation, operatorId, partition.index),
-      queryRunId)
-    storeCoordinator.flatMap(_.getLocation(stateStoreProviderId)).toSeq
-  }
+  override def getPreferredLocations(partition: Partition): Seq[String] =
+    _getPreferredLocations(partition)
 
   override def compute(partition: Partition, ctxt: TaskContext): Iterator[U] = {
-    val storeProviderId = StateStoreProviderId(
-      StateStoreId(checkpointLocation, operatorId, partition.index),
-      queryRunId)
+    val storeProviderId = getStateProviderId(partition)
 
     val store = StateStore.get(
       storeProviderId, keySchema, valueSchema, indexOrdinal, storeVersion,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRDD.scala
@@ -71,7 +71,7 @@ abstract class BaseStateStoreRDD[T: ClassTag, U: ClassTag](
  * uses the [[StateStoreCoordinator]] to get the locations of loaded state stores
  * and use that as the preferred locations.
  */
-class ReadOnlyStateStoreRDD[T: ClassTag, U: ClassTag](
+class ReadStateStoreRDD[T: ClassTag, U: ClassTag](
     dataRDD: RDD[T],
     storeReadFunction: (ReadStateStore, Iterator[T]) => Iterator[U],
     checkpointLocation: String,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRDD.scala
@@ -58,6 +58,11 @@ abstract class BaseStateStoreRDD[T: ClassTag, U: ClassTag](
   }
 }
 
+/**
+ * An RDD that allows computations to be executed against [[ReadOnlyStateStore]]s. It
+ * uses the [[StateStoreCoordinator]] to get the locations of loaded state stores
+ * and use that as the preferred locations.
+ */
 class ReadOnlyStateStoreRDD[T: ClassTag, U: ClassTag](
     dataRDD: RDD[T],
     storeReadFunction: (ReadOnlyStateStore, Iterator[T]) => Iterator[U],

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StreamingAggregationStateManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StreamingAggregationStateManager.scala
@@ -34,7 +34,7 @@ sealed trait StreamingAggregationStateManager extends Serializable {
   def getStateValueSchema: StructType
 
   /** Get the current value of a non-null key from the target state store. */
-  def get(store: StateStore, key: UnsafeRow): UnsafeRow
+  def get(store: ReadOnlyStateStore, key: UnsafeRow): UnsafeRow
 
   /**
    * Put a new value for a non-null key to the target state store. Note that key will be
@@ -52,13 +52,13 @@ sealed trait StreamingAggregationStateManager extends Serializable {
   def remove(store: StateStore, key: UnsafeRow): Unit
 
   /** Return an iterator containing all the key-value pairs in target state store. */
-  def iterator(store: StateStore): Iterator[UnsafeRowPair]
+  def iterator(store: ReadOnlyStateStore): Iterator[UnsafeRowPair]
 
   /** Return an iterator containing all the keys in target state store. */
-  def keys(store: StateStore): Iterator[UnsafeRow]
+  def keys(store: ReadOnlyStateStore): Iterator[UnsafeRow]
 
   /** Return an iterator containing all the values in target state store. */
-  def values(store: StateStore): Iterator[UnsafeRow]
+  def values(store: ReadOnlyStateStore): Iterator[UnsafeRow]
 }
 
 object StreamingAggregationStateManager extends Logging {
@@ -90,7 +90,7 @@ abstract class StreamingAggregationStateManagerBaseImpl(
 
   override def remove(store: StateStore, key: UnsafeRow): Unit = store.remove(key)
 
-  override def keys(store: StateStore): Iterator[UnsafeRow] = {
+  override def keys(store: ReadOnlyStateStore): Iterator[UnsafeRow] = {
     // discard and don't convert values to avoid computation
     store.getRange(None, None).map(_.key)
   }
@@ -113,7 +113,7 @@ class StreamingAggregationStateManagerImplV1(
 
   override def getStateValueSchema: StructType = inputRowAttributes.toStructType
 
-  override def get(store: StateStore, key: UnsafeRow): UnsafeRow = {
+  override def get(store: ReadOnlyStateStore, key: UnsafeRow): UnsafeRow = {
     store.get(key)
   }
 
@@ -121,11 +121,11 @@ class StreamingAggregationStateManagerImplV1(
     store.put(getKey(row), row)
   }
 
-  override def iterator(store: StateStore): Iterator[UnsafeRowPair] = {
+  override def iterator(store: ReadOnlyStateStore): Iterator[UnsafeRowPair] = {
     store.iterator()
   }
 
-  override def values(store: StateStore): Iterator[UnsafeRow] = {
+  override def values(store: ReadOnlyStateStore): Iterator[UnsafeRow] = {
     store.iterator().map(_.value)
   }
 }
@@ -167,7 +167,7 @@ class StreamingAggregationStateManagerImplV2(
 
   override def getStateValueSchema: StructType = valueExpressions.toStructType
 
-  override def get(store: StateStore, key: UnsafeRow): UnsafeRow = {
+  override def get(store: ReadOnlyStateStore, key: UnsafeRow): UnsafeRow = {
     val savedState = store.get(key)
     if (savedState == null) {
       return savedState
@@ -182,11 +182,11 @@ class StreamingAggregationStateManagerImplV2(
     store.put(key, value)
   }
 
-  override def iterator(store: StateStore): Iterator[UnsafeRowPair] = {
+  override def iterator(store: ReadOnlyStateStore): Iterator[UnsafeRowPair] = {
     store.iterator().map(rowPair => new UnsafeRowPair(rowPair.key, restoreOriginalRow(rowPair)))
   }
 
-  override def values(store: StateStore): Iterator[UnsafeRow] = {
+  override def values(store: ReadOnlyStateStore): Iterator[UnsafeRow] = {
     store.iterator().map(rowPair => restoreOriginalRow(rowPair))
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StreamingAggregationStateManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StreamingAggregationStateManager.scala
@@ -34,7 +34,7 @@ sealed trait StreamingAggregationStateManager extends Serializable {
   def getStateValueSchema: StructType
 
   /** Get the current value of a non-null key from the target state store. */
-  def get(store: ReadOnlyStateStore, key: UnsafeRow): UnsafeRow
+  def get(store: ReadStateStore, key: UnsafeRow): UnsafeRow
 
   /**
    * Put a new value for a non-null key to the target state store. Note that key will be
@@ -52,13 +52,13 @@ sealed trait StreamingAggregationStateManager extends Serializable {
   def remove(store: StateStore, key: UnsafeRow): Unit
 
   /** Return an iterator containing all the key-value pairs in target state store. */
-  def iterator(store: ReadOnlyStateStore): Iterator[UnsafeRowPair]
+  def iterator(store: ReadStateStore): Iterator[UnsafeRowPair]
 
   /** Return an iterator containing all the keys in target state store. */
-  def keys(store: ReadOnlyStateStore): Iterator[UnsafeRow]
+  def keys(store: ReadStateStore): Iterator[UnsafeRow]
 
   /** Return an iterator containing all the values in target state store. */
-  def values(store: ReadOnlyStateStore): Iterator[UnsafeRow]
+  def values(store: ReadStateStore): Iterator[UnsafeRow]
 }
 
 object StreamingAggregationStateManager extends Logging {
@@ -90,7 +90,7 @@ abstract class StreamingAggregationStateManagerBaseImpl(
 
   override def remove(store: StateStore, key: UnsafeRow): Unit = store.remove(key)
 
-  override def keys(store: ReadOnlyStateStore): Iterator[UnsafeRow] = {
+  override def keys(store: ReadStateStore): Iterator[UnsafeRow] = {
     // discard and don't convert values to avoid computation
     store.getRange(None, None).map(_.key)
   }
@@ -113,7 +113,7 @@ class StreamingAggregationStateManagerImplV1(
 
   override def getStateValueSchema: StructType = inputRowAttributes.toStructType
 
-  override def get(store: ReadOnlyStateStore, key: UnsafeRow): UnsafeRow = {
+  override def get(store: ReadStateStore, key: UnsafeRow): UnsafeRow = {
     store.get(key)
   }
 
@@ -121,11 +121,11 @@ class StreamingAggregationStateManagerImplV1(
     store.put(getKey(row), row)
   }
 
-  override def iterator(store: ReadOnlyStateStore): Iterator[UnsafeRowPair] = {
+  override def iterator(store: ReadStateStore): Iterator[UnsafeRowPair] = {
     store.iterator()
   }
 
-  override def values(store: ReadOnlyStateStore): Iterator[UnsafeRow] = {
+  override def values(store: ReadStateStore): Iterator[UnsafeRow] = {
     store.iterator().map(_.value)
   }
 }
@@ -167,7 +167,7 @@ class StreamingAggregationStateManagerImplV2(
 
   override def getStateValueSchema: StructType = valueExpressions.toStructType
 
-  override def get(store: ReadOnlyStateStore, key: UnsafeRow): UnsafeRow = {
+  override def get(store: ReadStateStore, key: UnsafeRow): UnsafeRow = {
     val savedState = store.get(key)
     if (savedState == null) {
       return savedState
@@ -182,11 +182,11 @@ class StreamingAggregationStateManagerImplV2(
     store.put(key, value)
   }
 
-  override def iterator(store: ReadOnlyStateStore): Iterator[UnsafeRowPair] = {
+  override def iterator(store: ReadStateStore): Iterator[UnsafeRowPair] = {
     store.iterator().map(rowPair => new UnsafeRowPair(rowPair.key, restoreOriginalRow(rowPair)))
   }
 
-  override def values(store: ReadOnlyStateStore): Iterator[UnsafeRow] = {
+  override def values(store: ReadStateStore): Iterator[UnsafeRow] = {
     store.iterator().map(rowPair => restoreOriginalRow(rowPair))
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/package.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/package.scala
@@ -56,7 +56,8 @@ package object state {
         indexOrdinal: Option[Int],
         sessionState: SessionState,
         storeCoordinator: Option[StateStoreCoordinatorRef],
-        extraOptions: Map[String, String] = Map.empty)(
+        extraOptions: Map[String, String] = Map.empty,
+        readOnly: Boolean = false)(
         storeUpdateFunction: (StateStore, Iterator[T]) => Iterator[U]): StateStoreRDD[T, U] = {
 
       val cleanedF = dataRDD.sparkContext.clean(storeUpdateFunction)
@@ -80,7 +81,8 @@ package object state {
         indexOrdinal,
         sessionState,
         storeCoordinator,
-        extraOptions)
+        extraOptions,
+        readOnly)
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/package.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/package.scala
@@ -83,7 +83,7 @@ package object state {
         extraOptions)
     }
 
-    /** Map each partition of an RDD along with data in a [[ReadOnlyStateStore]]. */
+    /** Map each partition of an RDD along with data in a [[ReadStateStore]]. */
     private[streaming] def mapPartitionsWithReadOnlyStateStore[U: ClassTag](
         stateInfo: StatefulOperatorStateInfo,
         keySchema: StructType,
@@ -92,11 +92,11 @@ package object state {
         sessionState: SessionState,
         storeCoordinator: Option[StateStoreCoordinatorRef],
         extraOptions: Map[String, String] = Map.empty)(
-        storeReadFn: (ReadOnlyStateStore, Iterator[T]) => Iterator[U])
+        storeReadFn: (ReadStateStore, Iterator[T]) => Iterator[U])
       : ReadOnlyStateStoreRDD[T, U] = {
 
       val cleanedF = dataRDD.sparkContext.clean(storeReadFn)
-      val wrappedF = (store: ReadOnlyStateStore, iter: Iterator[T]) => {
+      val wrappedF = (store: ReadStateStore, iter: Iterator[T]) => {
         // Clean up the state store.
         TaskContext.get().addTaskCompletionListener[Unit](_ => {
           store.abort()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/package.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/package.scala
@@ -64,6 +64,11 @@ package object state {
         // Abort the state store in case of error
         TaskContext.get().addTaskCompletionListener[Unit](_ => {
           if (!store.hasCommitted) store.abort()
+          try {
+            store.close()
+          } catch {
+            case _: UnsupportedOperationException => // no-op, default implementation
+          }
         })
         cleanedF(store, iter)
       }
@@ -99,7 +104,11 @@ package object state {
       val wrappedF = (store: ReadStateStore, iter: Iterator[T]) => {
         // Clean up the state store.
         TaskContext.get().addTaskCompletionListener[Unit](_ => {
-          store.abort()
+          try {
+            store.close()
+          } catch {
+            case _: UnsupportedOperationException => // no-op, default implementation
+          }
         })
         cleanedF(store, iter)
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/package.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/package.scala
@@ -64,11 +64,6 @@ package object state {
         // Abort the state store in case of error
         TaskContext.get().addTaskCompletionListener[Unit](_ => {
           if (!store.hasCommitted) store.abort()
-          try {
-            store.close()
-          } catch {
-            case _: UnsupportedOperationException => // no-op, default implementation
-          }
         })
         cleanedF(store, iter)
       }
@@ -104,11 +99,7 @@ package object state {
       val wrappedF = (store: ReadStateStore, iter: Iterator[T]) => {
         // Clean up the state store.
         TaskContext.get().addTaskCompletionListener[Unit](_ => {
-          try {
-            store.close()
-          } catch {
-            case _: UnsupportedOperationException => // no-op, default implementation
-          }
+          store.abort()
         })
         cleanedF(store, iter)
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/package.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/package.scala
@@ -84,7 +84,7 @@ package object state {
     }
 
     /** Map each partition of an RDD along with data in a [[ReadStateStore]]. */
-    private[streaming] def mapPartitionsWithReadOnlyStateStore[U: ClassTag](
+    private[streaming] def mapPartitionsWithReadStateStore[U: ClassTag](
         stateInfo: StatefulOperatorStateInfo,
         keySchema: StructType,
         valueSchema: StructType,
@@ -93,7 +93,7 @@ package object state {
         storeCoordinator: Option[StateStoreCoordinatorRef],
         extraOptions: Map[String, String] = Map.empty)(
         storeReadFn: (ReadStateStore, Iterator[T]) => Iterator[U])
-      : ReadOnlyStateStoreRDD[T, U] = {
+      : ReadStateStoreRDD[T, U] = {
 
       val cleanedF = dataRDD.sparkContext.clean(storeReadFn)
       val wrappedF = (store: ReadStateStore, iter: Iterator[T]) => {
@@ -103,7 +103,7 @@ package object state {
         })
         cleanedF(store, iter)
       }
-      new ReadOnlyStateStoreRDD(
+      new ReadStateStoreRDD(
         dataRDD,
         wrappedF,
         stateInfo.checkpointLocation,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
@@ -253,7 +253,8 @@ case class StateStoreRestoreExec(
       stateManager.getStateValueSchema,
       indexOrdinal = None,
       sqlContext.sessionState,
-      Some(sqlContext.streams.stateStoreCoordinator)) { case (store, iter) =>
+      Some(sqlContext.streams.stateStoreCoordinator),
+      readOnly = true) { case (store, iter) =>
         val hasInput = iter.hasNext
         if (!hasInput && keyExpressions.isEmpty) {
           // If our `keyExpressions` are empty, we're getting a global aggregation. In that case

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
@@ -247,14 +247,13 @@ case class StateStoreRestoreExec(
   override protected def doExecute(): RDD[InternalRow] = {
     val numOutputRows = longMetric("numOutputRows")
 
-    child.execute().mapPartitionsWithStateStore(
+    child.execute().mapPartitionsWithReadOnlyStateStore(
       getStateInfo,
       keyExpressions.toStructType,
       stateManager.getStateValueSchema,
       indexOrdinal = None,
       sqlContext.sessionState,
-      Some(sqlContext.streams.stateStoreCoordinator),
-      readOnly = true) { case (store, iter) =>
+      Some(sqlContext.streams.stateStoreCoordinator)) { case (store, iter) =>
         val hasInput = iter.hasNext
         if (!hasInput && keyExpressions.isEmpty) {
           // If our `keyExpressions` are empty, we're getting a global aggregation. In that case

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
@@ -247,7 +247,7 @@ case class StateStoreRestoreExec(
   override protected def doExecute(): RDD[InternalRow] = {
     val numOutputRows = longMetric("numOutputRows")
 
-    child.execute().mapPartitionsWithReadOnlyStateStore(
+    child.execute().mapPartitionsWithReadStateStore(
       getStateInfo,
       keyExpressions.toStructType,
       stateManager.getStateValueSchema,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -939,6 +939,25 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
     checkInvalidVersion(3)
   }
 
+  test("write operations on read-only StateStore") {
+    def assertUnsupportedOperation(fn: => Unit): Unit = {
+      intercept[UnsupportedOperationException] {
+        fn
+      }
+    }
+
+    val provider = newStoreProvider()
+    val store = provider.getStore(0)
+    put(store, "a", 1)
+    store.commit()
+    assert(rowsToSet(store.iterator()) === Set("a" -> 1))
+
+    val storeReadOnly = provider.getReadOnlyStore(1)
+    assertUnsupportedOperation(put(storeReadOnly, "b", 2))
+    assertUnsupportedOperation(remove(storeReadOnly, _ => true))
+    assertUnsupportedOperation(storeReadOnly.commit())
+  }
+
   test("two concurrent StateStores - one for read-only and one for read-write") {
     // During Streaming Aggregation, we have two StateStores per task, one used as read-only in
     // `StateStoreRestoreExec`, and one read-write used in `StateStoreSaveExec`. `StateStore.abort`
@@ -957,7 +976,7 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
 
     // two state stores
     val provider1 = newStoreProvider(storeId)
-    val restoreStore = provider1.getStore(1)
+    val restoreStore = provider1.getReadOnlyStore(1)
     val saveStore = provider1.getStore(1)
 
     put(saveStore, key, get(restoreStore, key).get + 1)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -1033,7 +1033,7 @@ object StateStoreTestsHelper {
     store.put(stringToRow(key), intToRow(value))
   }
 
-  def get(store: ReadOnlyStateStore, key: String): Option[Int] = {
+  def get(store: ReadStateStore, key: String): Option[Int] = {
     Option(store.get(stringToRow(key))).map(rowToInt)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -939,25 +939,6 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
     checkInvalidVersion(3)
   }
 
-  test("write operations on read-only StateStore") {
-    def assertUnsupportedOperation(fn: => Unit): Unit = {
-      intercept[UnsupportedOperationException] {
-        fn
-      }
-    }
-
-    val provider = newStoreProvider()
-    val store = provider.getStore(0)
-    put(store, "a", 1)
-    store.commit()
-    assert(rowsToSet(store.iterator()) === Set("a" -> 1))
-
-    val storeReadOnly = provider.getReadOnlyStore(1)
-    assertUnsupportedOperation(put(storeReadOnly, "b", 2))
-    assertUnsupportedOperation(remove(storeReadOnly, _ => true))
-    assertUnsupportedOperation(storeReadOnly.commit())
-  }
-
   test("two concurrent StateStores - one for read-only and one for read-write") {
     // During Streaming Aggregation, we have two StateStores per task, one used as read-only in
     // `StateStoreRestoreExec`, and one read-write used in `StateStoreSaveExec`. `StateStore.abort`
@@ -1052,7 +1033,7 @@ object StateStoreTestsHelper {
     store.put(stringToRow(key), intToRow(value))
   }
 
-  def get(store: StateStore, key: String): Option[Int] = {
+  def get(store: ReadOnlyStateStore, key: String): Option[Int] = {
     Option(store.get(stringToRow(key))).map(rowToInt)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -957,7 +957,7 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
 
     // two state stores
     val provider1 = newStoreProvider(storeId)
-    val restoreStore = provider1.getReadOnlyStore(1)
+    val restoreStore = provider1.getReadStore(1)
     val saveStore = provider1.getStore(1)
 
     put(saveStore, key, get(restoreStore, key).get + 1)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -962,7 +962,7 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
 
     put(saveStore, key, get(restoreStore, key).get + 1)
     saveStore.commit()
-    restoreStore.abort()
+    restoreStore.close()
 
     // check that state is correct for next batch
     val provider2 = newStoreProvider(storeId)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -962,7 +962,7 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
 
     put(saveStore, key, get(restoreStore, key).get + 1)
     saveStore.commit()
-    restoreStore.close()
+    restoreStore.abort()
 
     // check that state is correct for next batch
     val provider2 = newStoreProvider(storeId)


### PR DESCRIPTION
### What changes were proposed in this pull request?

There's a concept of 'read-only' and 'read+write' state store in Spark which is defined "implicitly". Spark doesn't prevent write for 'read-only' state store; Spark just assumes read-only stateful operator will not modify the state store. Given it's not defined explicitly, the instance of state store has to be implemented as 'read+write' even it's being used as 'read-only', which sometimes brings confusion.

For example, abort() in HDFSBackedStateStore - https://github.com/apache/spark/blob/d38f8167483d4d79e8360f24a8c0bffd51460659/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala#L143-L155

The comment sounds as if statement works differently between 'read-only' and 'read+write', but that's not true as both state store has state initialized as UPDATING (no difference). So 'read-only' state also creates the temporary file, initializes output streams to write to temporary file, closes output streams, and finally deletes the temporary file. This unnecessary operations are being done per batch/partition.

This patch explicitly defines 'read-only' StateStore, and enables state store provider to create 'read-only' StateStore instance if requested. Relevant code paths are modified, as well as 'read-only' StateStore implementation for HDFSBackedStateStore is introduced. The new implementation gets rid of unnecessary operations explained above.

In point of backward-compatibility view, the only thing being changed in public API side is `StateStoreProvider`. The trait `StateStoreProvider` has to be changed to allow requesting 'read-only' StateStore; this patch adds default implementation which leverages 'read+write' StateStore but wrapping with 'write-protected' StateStore instance, so that custom providers don't need to change their code to reflect the change. But if the providers can optimize for read-only workload, they'll be happy to make a change.

Please note that this patch makes ReadOnlyStateStore extend StateStore and being referred as StateStore, as StateStore is being used in so many places and it's not easy to support both traits if we differentiate them. So unfortunately these write methods are still exposed for read-only state; it just throws UnsupportedOperationException.

### Why are the changes needed?

The new API opens the chance to optimize read-only state store instance compared with read+write state store instance. HDFSBackedStateStoreProvider is modified to provide read-only version of state store which doesn't deal with temporary file as well as state machine.

### Does this PR introduce any user-facing change?

Clearly "no" for most end users, and also "no" for custom state store providers as it doesn't touch trait `StateStore` as well as provides default implementation for added method in trait `StateStoreProvider`.

### How was this patch tested?

Modified UT. Existing UTs ensure the change doesn't break anything.