### PR TITLE
[SPARK-30296][SQL] Add Dataset diffing feature

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2342,6 +2342,116 @@ class Dataset[T] private[sql](
   }
 
   /**
+   * Returns a new DataFrame that contains the differences
+   * between this and the other Dataset of the same type `T`.
+   *
+   * Optional id columns are used to uniquely identify rows that relate.
+   * If values in any non-id column are differing between this and the other Dataset,
+   * then that row is marked as `"C"`hange and `"N"`o-change otherwise.
+   * Rows of the other Dataset, that do not exist in this Dataset
+   * (w.r.t. the values in the id columns) are marked as `"I"`nsert.
+   * And rows of this Dataset, that do not exist in the other Dataset
+   * are marked as `"D"`elete.
+   *
+   * If no id columns are given, all columns are considered id columns. Then,
+   * no `"C"`hange rows will appear, as all changes will exists as respective
+   * `"D"`elete and `"I"`nsert.
+   *
+   * The returned DataFrame has the `diff` column as the first column.
+   * This holds the `"N"`, `"C"`, `"I"` or `"D"` strings. The id columns follow.
+   * For all non-id columns
+   *
+   * The id columns are in order as given to the method.
+   * If none are given, in the order of this Dataset.
+   * The non-id columns are in the order of this Dataset.
+   *
+   * @group untypedrel
+   * @since 3.0.0
+   */
+  def diff(other: Dataset[T], idColumns: String*): DataFrame = {
+    Diff.of(this, other, idColumns: _*)
+  }
+
+  /**
+   * Returns a new DataFrame that contains the differences
+   * between this and the other Dataset of the same type `T`.
+   *
+   * See `diff(Dataset[T], String*`.
+   *
+   * The schema of the returned DataFrame can be configured by the given `DiffOptions`.
+   *
+   * @group untypedrel
+   * @since 3.0.0
+   */
+  def diff(other: Dataset[T], options: DiffOptions, idColumns: String*): DataFrame = {
+    new Diff(options).of(this, other, idColumns: _*)
+  }
+
+  /**
+   * Returns a new Dataset that contains the differences
+   * between this and the other Dataset of the same type `T`.
+   *
+   * See `diff(Dataset[T], String*`.
+   *
+   * @group typedrel
+   * @since 3.0.0
+   */
+  def diffAs[U](other: Dataset[T], idColumns: String*)
+               (implicit diffEncoder: Encoder[U]): Dataset[U] = {
+    Diff.ofAs(this, other, idColumns: _*)
+  }
+
+  /**
+   * Returns a new Dataset that contains the differences
+   * between this and the other Dataset of the same type `T`.
+   *
+   * See `diff(Dataset[T], String*)`.
+   *
+   * This requires an additional implicit `Encoder[U]` for the return type `Dataset[U]`.
+   *
+   * @group typedrel
+   * @since 3.0.0
+   */
+  def diffAs[U](other: Dataset[T], options: DiffOptions, idColumns: String*)
+               (implicit diffEncoder: Encoder[U]): Dataset[U] = {
+    new Diff(options).ofAs(this, other, idColumns: _*)
+  }
+
+  /**
+   * Returns a new Dataset that contains the differences
+   * between this and the other Dataset of the same type `T`.
+   *
+   * See `diff(Dataset[T], String*`.
+   *
+   * This requires an additional explicit `Encoder[U]` for the return type `Dataset[U]`.
+   *
+   * @group typedrel
+   * @since 3.0.0
+   */
+  def diffAs[U](other: Dataset[T], diffEncoder: Encoder[U], idColumns: String*): Dataset[U] = {
+    Diff.ofAs(this, other, diffEncoder, idColumns: _*)
+  }
+
+  /**
+   * Returns a new Dataset that contains the differences
+   * between this and the other Dataset of the same type `T`.
+   *
+   * See `diff(Dataset[T], DiffOptions, String*`.
+   *
+   * This requires an additional explicit `Encoder[U]` for the return type `Dataset[U]`.
+   * The schema of the returned Dataset can be configured by the given `DiffOptions`.
+   *
+   * @group typedrel
+   * @since 3.0.0
+   */
+  def diffAs[U](other: Dataset[T],
+                options: DiffOptions,
+                diffEncoder: Encoder[U],
+                idColumns: String*): Dataset[U] = {
+    new Diff(options).ofAs(this, other, diffEncoder, idColumns: _*)
+  }
+
+  /**
    * Returns a new Dataset with a column dropped. This is a no-op if schema doesn't contain
    * column name.
    *

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2359,7 +2359,6 @@ class Dataset[T] private[sql](
    *
    * The returned DataFrame has the `diff` column as the first column.
    * This holds the `"N"`, `"C"`, `"I"` or `"D"` strings. The id columns follow.
-   * For all non-id columns
    *
    * The id columns are in order as given to the method.
    * If none are given, in the order of this Dataset.
@@ -2393,6 +2392,8 @@ class Dataset[T] private[sql](
    *
    * See `diff(Dataset[T], String*`.
    *
+   * This requires an additional implicit `Encoder[U]` for the return type `Dataset[U]`.
+   *
    * @group typedrel
    * @since 3.0.0
    */
@@ -2408,6 +2409,7 @@ class Dataset[T] private[sql](
    * See `diff(Dataset[T], String*)`.
    *
    * This requires an additional implicit `Encoder[U]` for the return type `Dataset[U]`.
+   * The schema of the returned Dataset can be configured by the given `DiffOptions`.
    *
    * @group typedrel
    * @since 3.0.0
@@ -2436,7 +2438,7 @@ class Dataset[T] private[sql](
    * Returns a new Dataset that contains the differences
    * between this and the other Dataset of the same type `T`.
    *
-   * See `diff(Dataset[T], DiffOptions, String*`.
+   * See `diff(Dataset[T], String*`.
    *
    * This requires an additional explicit `Encoder[U]` for the return type `Dataset[U]`.
    * The schema of the returned Dataset can be configured by the given `DiffOptions`.

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2342,31 +2342,29 @@ class Dataset[T] private[sql](
   }
 
   /**
-   * Returns a new DataFrame that contains the differences
-   * between this and the other Dataset of the same type `T`.
+   * Returns a new DataFrame that contains the differences between this and the other Dataset
+   * of the same type `T`.
    *
-   * Optional id columns are used to uniquely identify rows that relate.
-   * If values in any non-id column are differing between this and the other Dataset,
-   * then that row is marked as `"C"`hange and `"N"`o-change otherwise.
-   * Rows of the other Dataset, that do not exist in this Dataset
-   * (w.r.t. the values in the id columns) are marked as `"I"`nsert.
-   * And rows of this Dataset, that do not exist in the other Dataset
-   * are marked as `"D"`elete.
+   * Optional id columns are used to uniquely identify rows that relate. If values in any non-id
+   * column are differing between this and the other Dataset, then that row is marked as `"C"`hange
+   * and `"N"`o-change otherwise. Rows of the other Dataset, that do not exist in this Dataset
+   * (w.r.t. the values in the id columns) are marked as `"I"`nsert. And rows of this Dataset, that
+   * do not exist in the other Dataset are marked as `"D"`elete.
    *
-   * If no id columns are given, all columns are considered id columns. Then,
-   * no `"C"`hange rows will appear, as all changes will exists as respective
-   * `"D"`elete and `"I"`nsert.
+   * If no id columns are given, all columns are considered id columns. Then, no `"C"`hange rows
+   * will appear, as all changes will exists as respective `"D"`elete and `"I"`nsert.
    *
-   * The returned DataFrame has the `diff` column as the first column.
-   * This holds the `"N"`, `"C"`, `"I"` or `"D"` strings. The id columns follow.
+   * The returned DataFrame has the `diff` column as the first column. This holds the `"N"`, `"C"`,
+   * `"I"` or `"D"` strings. The id columns follow, then the non-id columns (all remaining columns).
    *
-   * The id columns are in order as given to the method.
-   * If none are given, in the order of this Dataset.
-   * The non-id columns are in the order of this Dataset.
+   * The id columns are in order as given to the method. If no id columns are given then all
+   * columns of this Dataset are id columns and appear in the same order. The remaining non-id
+   * columns are in the order of this Dataset.
    *
    * @group untypedrel
    * @since 3.0.0
    */
+  @scala.annotation.varargs
   def diff(other: Dataset[T], idColumns: String*): DataFrame = {
     Diff.of(this, other, idColumns: _*)
   }
@@ -2382,6 +2380,7 @@ class Dataset[T] private[sql](
    * @group untypedrel
    * @since 3.0.0
    */
+  @scala.annotation.varargs
   def diff(other: Dataset[T], options: DiffOptions, idColumns: String*): DataFrame = {
     new Diff(options).of(this, other, idColumns: _*)
   }
@@ -2397,6 +2396,7 @@ class Dataset[T] private[sql](
    * @group typedrel
    * @since 3.0.0
    */
+  @scala.annotation.varargs
   def diffAs[U](other: Dataset[T], idColumns: String*)
                (implicit diffEncoder: Encoder[U]): Dataset[U] = {
     Diff.ofAs(this, other, idColumns: _*)
@@ -2414,6 +2414,7 @@ class Dataset[T] private[sql](
    * @group typedrel
    * @since 3.0.0
    */
+  @scala.annotation.varargs
   def diffAs[U](other: Dataset[T], options: DiffOptions, idColumns: String*)
                (implicit diffEncoder: Encoder[U]): Dataset[U] = {
     new Diff(options).ofAs(this, other, idColumns: _*)
@@ -2430,6 +2431,7 @@ class Dataset[T] private[sql](
    * @group typedrel
    * @since 3.0.0
    */
+  @scala.annotation.varargs
   def diffAs[U](other: Dataset[T], diffEncoder: Encoder[U], idColumns: String*): Dataset[U] = {
     Diff.ofAs(this, other, diffEncoder, idColumns: _*)
   }
@@ -2446,6 +2448,7 @@ class Dataset[T] private[sql](
    * @group typedrel
    * @since 3.0.0
    */
+  @scala.annotation.varargs
   def diffAs[U](other: Dataset[T],
                 options: DiffOptions,
                 diffEncoder: Encoder[U],

--- a/sql/core/src/main/scala/org/apache/spark/sql/Diff.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Diff.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.functions.{coalesce, lit, not, when}
  * Differ class to diff two Datasets.
  * @param options options for the diffing process
  */
-class Diff(options: DiffOptions) {
+private[sql] class Diff(options: DiffOptions) {
 
   def checkSchema[T](left: Dataset[T], right: Dataset[T], idColumns: String*): Unit = {
     require(left.columns.length == right.columns.length,
@@ -129,7 +129,7 @@ class Diff(options: DiffOptions) {
 /**
  * Diffing singleton with default diffing options.
  */
-object Diff {
+private[sql] object Diff {
   val default = new Diff(DiffOptions.default)
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/Diff.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Diff.scala
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.sql.functions.{coalesce, lit, not, when}
+
+/**
+ * Differ class to diff two Datasets.
+ * @param options options for the diffing process
+ */
+class Diff(options: DiffOptions) {
+
+  def checkSchema[T](left: Dataset[T], right: Dataset[T], idColumns: String*): Unit = {
+    require(left.columns.length == right.columns.length,
+      "The number of columns doesn't match.\n" +
+        s"Left column names (${left.columns.length}): ${left.columns.mkString(", ")}\n" +
+        s"Right column names (${right.columns.length}): ${right.columns.mkString(", ")}")
+
+    require(left.columns.length > 0, "The schema must not be empty")
+
+    // we ignore the nullability of fields
+    val leftFields = left.schema.fields.map(f => (f.name, f.dataType))
+    val rightFields = right.schema.fields.map(f => (f.name, f.dataType))
+    val leftExtraSchema = leftFields.diff(rightFields)
+    val rightExtraSchema = rightFields.diff(leftFields)
+    val extraSchema = leftExtraSchema.union(rightExtraSchema)
+    require(extraSchema.isEmpty,
+      "The datasets do not have the same schema.\n" +
+        s"Left extra columns: ${leftExtraSchema.map(t => s"${t._1} (${t._2})").mkString(", ")}\n" +
+        s"Right extra columns: ${rightExtraSchema.map(t => s"${t._1} (${t._2})").mkString(", ")}")
+
+    val missingIdColumns = idColumns.diff(left.columns)
+    require(missingIdColumns.isEmpty,
+      s"Some id columns do not exist: ${missingIdColumns.mkString(", ")}")
+  }
+
+  def of[T](left: Dataset[T], right: Dataset[T], idColumns: String*): DataFrame = {
+    checkSchema(left, right, idColumns: _*)
+
+    val pkColumns = if (idColumns.isEmpty) left.columns.toList else idColumns
+    val otherColumns = left.columns.diff(pkColumns)
+
+    val existsColumnName = "exists" // make it not exist in schema T
+    val l = left.withColumn(existsColumnName, lit(1))
+    val r = right.withColumn(existsColumnName, lit(1))
+    val joinCondition = pkColumns.map(c => l(c) <=> r(c)).reduce(_ && _)
+    val unChanged = otherColumns.map(c => l(c) <=> r(c)).reduceOption(_ && _)
+    val changeCondition = not(unChanged.getOrElse(lit(true)))
+
+    val diffCondition =
+      when(l(existsColumnName).isNull, lit(options.insertDiffValue)).
+        when(r(existsColumnName).isNull, lit(options.deleteDiffValue)).
+        when(changeCondition, lit(options.changeDiffValue)).
+        otherwise(lit(options.nochangeDiffValue))
+
+    val diffColumns =
+      pkColumns.map(c => coalesce(l(c), r(c)).as(c)) ++
+        otherColumns.flatMap(c =>
+          Seq(
+            left(c).as(s"${options.leftColumnPrefix}_$c"),
+            right(c).as(s"${options.rightColumnPrefix}_$c")
+          )
+        )
+
+    l.join(r, joinCondition, "fullouter")
+      .select(diffCondition.as(options.diffColumn) +: diffColumns: _*)
+  }
+
+  def ofAs[T, U](left: Dataset[T], right: Dataset[T], idColumns: String*)
+               (implicit diffEncoder: Encoder[U]): Dataset[U] = {
+    ofAs(left, right, diffEncoder, idColumns: _*)
+  }
+
+  def ofAs[T, U](left: Dataset[T], right: Dataset[T],
+                 diffEncoder: Encoder[U], idColumns: String*): Dataset[U] = {
+    // TODO: require schema of encoder to be correct
+    of(left, right, idColumns: _*).as[U](diffEncoder)
+  }
+
+}
+
+/**
+ * Diffing singleton with default diffing options.
+ */
+object Diff {
+  val default = new Diff(DiffOptions.default)
+
+  def of[T](left: Dataset[T], right: Dataset[T], idColumns: String*): DataFrame =
+    default.of(left, right, idColumns: _*)
+
+  def ofAs[T, U](left: Dataset[T], right: Dataset[T], idColumns: String*)
+                (implicit diffEncoder: Encoder[U]): Dataset[U] =
+    default.ofAs(left, right, idColumns: _*)
+
+  def ofAs[T, U](left: Dataset[T], right: Dataset[T],
+                 diffEncoder: Encoder[U], idColumns: String*): Dataset[U] =
+    default.ofAs(left, right, diffEncoder, idColumns: _*)
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/DiffOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DiffOptions.scala
@@ -23,7 +23,23 @@ case class DiffOptions(diffColumn: String,
                        insertDiffValue: String,
                        changeDiffValue: String,
                        deleteDiffValue: String,
-                       nochangeDiffValue: String)
+                       nochangeDiffValue: String) {
+
+  require(diffColumn.nonEmpty, "Diff column name must not be empty")
+
+  require(leftColumnPrefix.nonEmpty, "Left column prefix must not be empty")
+  require(rightColumnPrefix.nonEmpty, "Right column prefix must not be empty")
+  require(leftColumnPrefix != rightColumnPrefix,
+    s"Left and right column prefix must be distinct: $leftColumnPrefix")
+
+  require(insertDiffValue.nonEmpty, "Insert diff value must not be empty")
+  require(changeDiffValue.nonEmpty, "Change diff value must not be empty")
+  require(deleteDiffValue.nonEmpty, "Delete diff value must not be empty")
+  require(nochangeDiffValue.nonEmpty, "No-change diff value must not be empty")
+
+  val diffValues = Seq(insertDiffValue, changeDiffValue, deleteDiffValue, nochangeDiffValue)
+  require(diffValues.distinct.length == 4, s"Diff values must be distinct: $diffValues")
+}
 
 object DiffOptions {
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/DiffOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DiffOptions.scala
@@ -38,7 +38,8 @@ case class DiffOptions(diffColumn: String,
   require(nochangeDiffValue.nonEmpty, "No-change diff value must not be empty")
 
   val diffValues = Seq(insertDiffValue, changeDiffValue, deleteDiffValue, nochangeDiffValue)
-  require(diffValues.distinct.length == 4, s"Diff values must be distinct: $diffValues")
+  require(diffValues.distinct.length == diffValues.length,
+    s"Diff values must be distinct: $diffValues")
 }
 
 object DiffOptions {

--- a/sql/core/src/main/scala/org/apache/spark/sql/DiffOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DiffOptions.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+case class DiffOptions(diffColumn: String,
+                       leftColumnPrefix: String,
+                       rightColumnPrefix: String,
+                       insertDiffValue: String,
+                       changeDiffValue: String,
+                       deleteDiffValue: String,
+                       nochangeDiffValue: String)
+
+object DiffOptions {
+  /**
+   * Default diffing options.
+   */
+  val default = DiffOptions("diff", "left", "right", "I", "C", "D", "N")
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/DiffSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DiffSuite.scala
@@ -1,0 +1,434 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.{DataFrame, Dataset, Diff, DiffOptions, Encoders, Row}
+import org.apache.spark.sql.expressions.SparkUserDefinedFunction
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.StructType
+
+case class Empty()
+case class Value(id: Int, value: Option[String])
+case class Value2(id: Int, seq: Option[Int], value: Option[String])
+
+case class DiffAs(diff: String,
+                  id: Int,
+                  left_value: Option[String],
+                  right_value: Option[String])
+case class DiffAsCustom(action: String,
+                        id: Int,
+                        before_value: Option[String],
+                        after_value: Option[String])
+
+class DiffSuite extends SparkFunSuite with SharedSparkSession with Logging {
+
+  import testImplicits._
+
+  lazy val left: Dataset[Value] = Seq(
+    Value(1, Some("one")),
+    Value(2, Some("two")),
+    Value(3, Some("three"))
+  ).toDS()
+
+  lazy val right: Dataset[Value] = Seq(
+    Value(1, Some("one")),
+    Value(2, Some("Two")),
+    Value(4, Some("four"))
+  ).toDS()
+
+  lazy val expectedDiffColumns: Seq[String] =
+    Seq("diff", "id", "left_value", "right_value")
+
+  lazy val expectedDiff: Seq[Row] = Seq(
+    Row("N", 1, "one", "one"),
+    Row("C", 2, "two", "Two"),
+    Row("D", 3, "three", null),
+    Row("I", 4, null, "four")
+  )
+
+  lazy val expectedDiffAs: Seq[DiffAs] = expectedDiff.map( r =>
+    DiffAs(r.getString(0), r.getInt(1), Option(r.getString(2)), Option(r.getString(3)))
+  )
+
+  test("diff with no id column") {
+    val expected = Seq(
+      Row("N", 1, "one"),
+      Row("D", 2, "two"),
+      Row("I", 2, "Two"),
+      Row("D", 3, "three"),
+      Row("I", 4, "four")
+    )
+
+    val actual = left.diff(right).orderBy("id", "diff")
+
+    assert(actual.columns === Seq("diff", "id", "value"))
+    assert(actual.collect() === expected)
+  }
+
+  test("diff with one id column") {
+    val actual = left.diff(right, "id").orderBy("id")
+
+    assert(actual.columns === expectedDiffColumns)
+    assert(actual.collect() === expectedDiff)
+  }
+
+  test("diff with two id columns") {
+    val left = Seq(
+      Value2(1, Some(1), Some("one")),
+      Value2(2, Some(1), Some("two.one")),
+      Value2(2, Some(2), Some("two.two")),
+      Value2(3, Some(1), Some("three"))
+    ).toDS()
+
+    val right = Seq(
+      Value2(1, Some(1), Some("one")),
+      Value2(2, Some(1), Some("two.one")),
+      Value2(2, Some(2), Some("two.Two")),
+      Value2(4, Some(1), Some("four"))
+    ).toDS()
+
+    val expected = Seq(
+      Row("N", 1, 1, "one", "one"),
+      Row("N", 2, 1, "two.one", "two.one"),
+      Row("C", 2, 2, "two.two", "two.Two"),
+      Row("D", 3, 1, "three", null),
+      Row("I", 4, 1, null, "four")
+    )
+
+    val actual = left.diff(right, "id", "seq")
+      .orderBy("id", "seq")
+
+    assert(actual.columns === Seq("diff", "id", "seq", "left_value", "right_value"))
+    assert(actual.collect() === expected)
+  }
+
+  test("diff with all id columns") {
+    val expected = Seq(
+      Row("N", 1, "one"),
+      Row("D", 2, "two"),
+      Row("I", 2, "Two"),
+      Row("D", 3, "three"),
+      Row("I", 4, "four")
+    )
+
+    val actual = left.diff(right, "id", "value")
+      .orderBy("id", "diff")
+
+    assert(actual.columns === Seq("diff", "id", "value"))
+    assert(actual.collect() === expected)
+  }
+
+  test("diff with null values") {
+    val left = Seq(
+      Value(1, None),
+      Value(2, None),
+      Value(3, Some("three")),
+      Value(4, None)
+    ).toDS()
+
+    val right = Seq(
+      Value(1, None),
+      Value(2, Some("two")),
+      Value(3, None),
+      Value(5, None)
+    ).toDS()
+
+    val expected = Seq(
+      Row("N", 1, null, null),
+      Row("C", 2, null, "two"),
+      Row("C", 3, "three", null),
+      Row("D", 4, null, null),
+      Row("I", 5, null, null)
+    )
+
+    val actual = left.diff(right, "id").orderBy("id")
+
+    assert(actual.columns === Seq("diff", "id", "left_value", "right_value"))
+    assert(actual.collect() === expected)
+  }
+
+  test("diff with null id values") {
+    val left = Seq(
+      Value2(1, None, Some("one")),
+      Value2(2, Some(1), Some("two.one")),
+      Value2(2, Some(2), Some("two.two")),
+      Value2(3, None, Some("three"))
+    ).toDS()
+
+    val right = Seq(
+      Value2(1, None, Some("one")),
+      Value2(2, Some(1), Some("two.one")),
+      Value2(2, Some(2), Some("two.Two")),
+      Value2(4, None, Some("four"))
+    ).toDS()
+
+    val expected = Seq(
+      Row("N", 1, None.orNull, "one", "one"),
+      Row("N", 2, 1, "two.one", "two.one"),
+      Row("C", 2, 2, "two.two", "two.Two"),
+      Row("D", 3, None.orNull, "three", None.orNull),
+      Row("I", 4, None.orNull, None.orNull, "four")
+    )
+
+    val actual = left.diff(right, "id", "seq")
+      .orderBy("id", "seq")
+
+    assert(actual.columns === Seq("diff", "id", "seq", "left_value", "right_value"))
+    assert(actual.collect() === expected)
+  }
+
+  /**
+   * Tests the column order of the produced diff DataFrame.
+   */
+  test("diff column order") {
+    // left has same schema as right but different column order
+    val left = Seq(
+      // value1, id, value2, seq, value3
+      ("val1.1.1", 1, "val1.1.2", 1, "val1.1.3"),
+      ("val1.2.1", 1, "val1.2.2", 2, "val1.2.3"),
+      ("val2.1.1", 2, "val2.1.2", 1, "val2.1.3")
+    ).toDF("value1", "id", "value2", "seq", "value3")
+    val right = Seq(
+      // value2, seq, value3, id, value1
+      ("val1.1.2", 1, "val1.1.3", 1, "val1.1.1"),
+      ("val1.2.2", 2, "val1.2.3 changed", 1, "val1.2.1"),
+      ("val2.2.2", 2, "val2.2.3", 2, "val2.2.1")
+    ).toDF("value2", "seq", "value3", "id", "value1")
+
+    // diffing left to right provides schema of result DataFrame different to right-to-left diff
+    {
+      val expected = Seq(
+        Row("N", 1, 1, "val1.1.1", "val1.1.1", "val1.1.2", "val1.1.2", "val1.1.3", "val1.1.3"),
+        Row("C", 1, 2, "val1.2.1", "val1.2.1", "val1.2.2", "val1.2.2", "val1.2.3", "val1.2.3 changed"),
+        Row("D", 2, 1, "val2.1.1", null, "val2.1.2", null, "val2.1.3", null),
+        Row("I", 2, 2, null, "val2.2.1", null, "val2.2.2", null, "val2.2.3")
+      )
+      val expectedColumns = Seq(
+        "diff",
+        "id", "seq",
+        "left_value1", "right_value1",
+        "left_value2", "right_value2",
+        "left_value3", "right_value3"
+      )
+
+      val actual = left.diff(right, "id", "seq").orderBy("id", "seq")
+
+      assert(actual.columns === expectedColumns)
+      assert(actual.collect() === expected)
+    }
+
+    // diffing right to left provides different schema of result DataFrame
+    {
+      val expected = Seq(
+        Row("N", 1, 1, "val1.1.2", "val1.1.2", "val1.1.3", "val1.1.3", "val1.1.1", "val1.1.1"),
+        Row("C", 1, 2, "val1.2.2", "val1.2.2", "val1.2.3 changed", "val1.2.3", "val1.2.1", "val1.2.1"),
+        Row("I", 2, 1, null, "val2.1.2", null, "val2.1.3", null, "val2.1.1"),
+        Row("D", 2, 2, "val2.2.2", null, "val2.2.3", null, "val2.2.1", null)
+      )
+      val expectedColumns = Seq(
+        "diff",
+        "id", "seq",
+        "left_value2", "right_value2",
+        "left_value3", "right_value3",
+        "left_value1", "right_value1"
+      )
+
+      val actual = right.diff(left, "id", "seq").orderBy("id", "seq")
+
+      assert(actual.columns === expectedColumns)
+      assert(actual.collect() === expected)
+    }
+
+    // diffing left to right without id columns takes column order of left
+    {
+      val expected = Seq(
+        Row("N", "val1.1.1", 1, "val1.1.2", 1, "val1.1.3"),
+        Row("D", "val1.2.1", 1, "val1.2.2", 2, "val1.2.3"),
+        Row("I", "val1.2.1", 1, "val1.2.2", 2, "val1.2.3 changed"),
+        Row("D", "val2.1.1", 2, "val2.1.2", 1, "val2.1.3"),
+        Row("I", "val2.2.1", 2, "val2.2.2", 2, "val2.2.3")
+      )
+      val expectedColumns = Seq(
+        "diff", "value1", "id", "value2", "seq", "value3"
+      )
+
+      val actual = left.diff(right).orderBy("id", "seq", "diff")
+
+      assert(actual.columns === expectedColumns)
+      assert(actual.collect() === expected)
+    }
+
+    // diffing right to left without id columns takes column order of right
+    {
+      val expected = Seq(
+        Row("N", "val1.1.1", 1, "val1.1.2", 1, "val1.1.3"),
+        Row("D", "val1.2.1", 1, "val1.2.2", 2, "val1.2.3"),
+        Row("I", "val1.2.1", 1, "val1.2.2", 2, "val1.2.3 changed"),
+        Row("D", "val2.1.1", 2, "val2.1.2", 1, "val2.1.3"),
+        Row("I", "val2.2.1", 2, "val2.2.2", 2, "val2.2.3")
+      )
+      val expectedColumns = Seq(
+        "diff", "value1", "id", "value2", "seq", "value3"
+      )
+
+      val actual = left.diff(right).orderBy("id", "seq", "diff")
+
+      assert(actual.columns === expectedColumns)
+      assert(actual.collect() === expected)
+    }
+  }
+
+  test("diff DataFrames") {
+    val actual = left.toDF().diff(right.toDF(), "id").orderBy("id")
+
+    assert(actual.columns === expectedDiffColumns)
+    assert(actual.collect() === expectedDiff)
+  }
+
+  test("diff with custom diff options") {
+    val options = DiffOptions("action", "before", "after", "new", "change", "del", "eq")
+
+    val expected = Seq(
+      Row("eq", 1, "one", "one"),
+      Row("change", 2, "two", "Two"),
+      Row("del", 3, "three", null),
+      Row("new", 4, null, "four")
+    )
+
+    val actual = left.diff(right, options, "id")
+      .orderBy("id", "action")
+
+    assert(actual.columns === Seq("action", "id", "before_value", "after_value"))
+    assert(actual.collect() === expected)
+  }
+
+  test("diff of empty schema") {
+    val left = Seq(Empty()).toDS()
+    val right = Seq(Empty()).toDS()
+
+    val message = intercept[IllegalArgumentException]{ left.diff(right) }.getMessage
+
+    assert(message === "requirement failed: The schema must not be empty")
+  }
+
+  test("diff with different types") {
+    // different value types only compiles with DataFrames
+    val left = Seq((1, "str")).toDF("id", "value")
+    val right = Seq((1, 2)).toDF("id", "value")
+
+    val message = intercept[IllegalArgumentException]{ left.diff(right) }.getMessage
+
+    assert(message === "requirement failed: The datasets do not have the same schema.\n" +
+      "Left extra columns: value (StringType)\n" +
+      "Right extra columns: value (IntegerType)")
+  }
+
+  test("diff with different nullability") {
+    val leftSchema = StructType(left.schema.fields.map(_.copy(nullable = true)))
+    val rightSchema = StructType(right.schema.fields.map(_.copy(nullable = false)))
+
+    // different value types only compiles with DataFrames
+    val left2 = sqlContext.createDataFrame(left.toDF().rdd, leftSchema)
+    val right2 = sqlContext.createDataFrame(right.toDF().rdd, rightSchema)
+
+    val actual = left2.diff(right2, "id").orderBy("id")
+
+    assert(actual.columns === expectedDiffColumns)
+    assert(actual.collect() === expectedDiff)
+  }
+
+  test("diff with different column names") {
+    // different column names only compiles with DataFrames
+    val left = Seq((1, "str")).toDF("id", "value")
+    val right = Seq((1, "str")).toDF("id", "comment")
+
+    val message = intercept[IllegalArgumentException] {
+      left.diff(right, "id")
+    }.getMessage
+
+    assert(message === "requirement failed: The datasets do not have the same schema.\n" +
+      "Left extra columns: value (StringType)\n" +
+      "Right extra columns: comment (StringType)")
+  }
+
+  test("diff of non-existing id column") {
+    val message = intercept[IllegalArgumentException] {
+      left.diff(right, "does not exists")
+    }.getMessage
+
+    assert(message === "requirement failed: Some id columns do not exist: does not exists")
+  }
+
+  test("diff with different number of column") {
+    // different column names only compiles with DataFrames
+    val left = Seq((1, "str")).toDF("id", "value")
+    val right = Seq((1, 1, "str")).toDF("id", "seq", "value")
+
+    val message = intercept[IllegalArgumentException] {
+      left.diff(right, "id")
+    }.getMessage
+
+    assert(message === "requirement failed: The number of columns doesn't match.\n" +
+      "Left column names (2): id, value\n" +
+      "Right column names (3): id, seq, value")
+  }
+
+  test("diff as U") {
+    val actual = left.diffAs[DiffAs](right, "id").orderBy("id")
+
+    assert(actual.columns === Seq("diff", "id", "left_value", "right_value"))
+    assert(actual.collect() === expectedDiffAs)
+  }
+
+  test("diff as U with encoder") {
+    val encoder = Encoders.product[DiffAs]
+
+    val actual = left.diffAs(right, encoder, "id").orderBy("id")
+
+    assert(actual.columns === Seq("diff", "id", "left_value", "right_value"))
+    assert(actual.collect() === expectedDiffAs)
+  }
+
+  test("diff as U with encoder and custom options") {
+    val options = DiffOptions("action", "before", "after", "new", "change", "del", "eq")
+    val encoder = Encoders.product[DiffAsCustom]
+
+    val actions = Seq(
+      (DiffOptions.default.insertDiffValue, "new"),
+      (DiffOptions.default.changeDiffValue, "change"),
+      (DiffOptions.default.deleteDiffValue, "del"),
+      (DiffOptions.default.nochangeDiffValue, "eq"),
+    ).toDF("diff", "action")
+
+    val expected = expectedDiffAs.toDS()
+      .join(actions, "diff")
+      .select($"action", $"id", $"left_value".as("before_value"), $"right_value".as("after_value"))
+      .as[DiffAsCustom]
+      .collect()
+
+    val actual = left.diffAs(right, options, encoder, "id").orderBy("id")
+
+    assert(actual.columns === Seq("action", "id", "before_value", "after_value"))
+    assert(actual.collect() === expected)
+  }
+
+}
+


### PR DESCRIPTION
### What changes were proposed in this pull request?
Adds a `diff` transformation to `Dataset` that computes the differences between the two datasets, i.e. which rows of `this` dataset to _add_, _delete_ or _change_ to get to the given dataset.

With
```
val left = Seq((1, "one"), (2, "two"), (3, "three")).toDF("id", "value")
val right = Seq((1, "one"), (2, "Two"), (4, "four")).toDF("id", "value")
```
Diffing becomes as easy as:
```
left.diff(right).show()
```
|diff| id|value|
|----|---|-----|
|   N|  1|  one|
|   D|  2|  two|
|   I|  2|  Two|
|   D|  3|three|
|   I|  4| four|

With columns that provide unique identifiers per row (here `id`), the diff looks like:
```
left.diff(right, "id").show()
```
|diff| id|left_value|right_value|
|----|---|----------|-----------|
|   N|  1|       one|        one|
|   C|  2|       two|        Two|
|   D|  3|     three|       null|
|   I|  4|      null|       four|


Equivalent alternative is this hand-crafted transformation
```
left.withColumn("exists", lit(1)).as("l")
  .join(right.withColumn("exists", lit(1)).as("r"),
    $"l.id" <=> $"r.id",
    "fullouter")
  .withColumn("diff",
    when($"l.exists".isNull, "I").
      when($"r.exists".isNull, "D").
      when(!($"l.value" <=> $"r.value"), "C").
      otherwise("N"))
  .show()
```

Statistics on the differences can be obtained by
```
left.diff(right, "id").groupBy("diff").count().show()
```

|diff|count|
|----|-----|
|   N|    1|
|   I|    1|
|   D|    1|
|   C|    1|

This `diff` provides the following features:
* id columns are optional
* provides typed `diffAs` transformations
* supports null values in id and non-id columns
* detects null value insertion / deletion
* configurable via `DiffOptions`:
  * diff column name (default: `"diff"`), for diffing datasets that already contain `diff` column
  * diff action labels (defaults: `"N"`, `"I"`, `"D"`, `"C"`), allows custom diff notation,
e.g. Unix diff left-right notation (<, >) or git before-after format (+, -, -+)

### Why are the changes needed?
Your evolving code need frequent regression testing to prove it still produces identical results, or if changes are expected, to investigate those changes. Diffing the results of two code paths provides the confidence you need. Diffing small schemata is easy, but with wide schema the Spark query becomes laborious and error-prone. With a single proven and tested method, diffing becomes easier and a more reliable operation. This has proven to be useful for interactive spark as well as deployed production code.

### Does this PR introduce any user-facing change?
Yes, it provides new transformations added to `Dataset`:

* `def diff(other: Dataset[T], idColumns: String*): DataFrame`
* `def diff(other: Dataset[T], options: DiffOptions, idColumns: String*): DataFrame`
* `def diffAs[U](other: Dataset[T], idColumns: String*)(implicit diffEncoder: Encoder[U]): Dataset[U]`
* `def diffAs[U](other: Dataset[T], options: DiffOptions, idColumns: String*)(implicit diffEncoder: Encoder[U]): Dataset[U]`
* `def diffAs[U](other: Dataset[T], diffEncoder: Encoder[U], idColumns: String*): Dataset[U]`
* `def diffAs[U](other: Dataset[T], options: DiffOptions, diffEncoder: Encoder[U], idColumns: String*): Dataset[U]`

### How was this patch tested?
There is a new suite with plenty of tests: `DiffSuite`.