### PR TITLE
[SPARK-30036][SQL] Fix: REPARTITION hint does not work with order by

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -55,10 +55,8 @@ case class EnsureRequirements(conf: SQLConf) extends Rule[SparkPlan] {
         child
       case (child, BroadcastDistribution(mode)) =>
         BroadcastExchangeExec(mode, child)
-      case (ShuffleExchangeExec(partitioning: RoundRobinPartitioning, child, _),
-          distribution: OrderedDistribution) =>
-        ShuffleExchangeExec(
-          distribution.createPartitioning(partitioning.numPartitions), child)
+      case (ShuffleExchangeExec(partitioning, child, _), distribution: OrderedDistribution) =>
+        ShuffleExchangeExec(distribution.createPartitioning(partitioning.numPartitions), child)
       case (child, distribution) =>
         val numPartitions = distribution.requiredNumPartitions
           .getOrElse(defaultNumPreShufflePartitions)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -55,6 +55,10 @@ case class EnsureRequirements(conf: SQLConf) extends Rule[SparkPlan] {
         child
       case (child, BroadcastDistribution(mode)) =>
         BroadcastExchangeExec(mode, child)
+      case (ShuffleExchangeExec(partitioning: RoundRobinPartitioning, child, _),
+          distribution: OrderedDistribution) =>
+        ShuffleExchangeExec(
+          distribution.createPartitioning(partitioning.numPartitions), child)
       case (child, distribution) =>
         val numPartitions = distribution.requiredNumPartitions
           .getOrElse(defaultNumPreShufflePartitions)

--- a/sql/core/src/test/scala/org/apache/spark/sql/ConfigBehaviorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ConfigBehaviorSuite.scala
@@ -39,9 +39,8 @@ class ConfigBehaviorSuite extends QueryTest with SharedSparkSession {
     def computeChiSquareTest(): Double = {
       val n = 10000
       // Trigger a sort
-      // Range has range partitioning in its output now. To have a range shuffle, we
-      // need to run a repartition first.
-      val data = spark.range(0, n, 1, 1).repartition(10).sort($"id".desc)
+      // Range has range partitioning in its output now.
+      val data = spark.range(0, n, 1, 10).sort($"id".desc)
         .selectExpr("SPARK_PARTITION_ID() pid", "id").as[(Int, Long)].collect()
 
       // Compute histogram for the number of records per partition post sort
@@ -55,12 +54,12 @@ class ConfigBehaviorSuite extends QueryTest with SharedSparkSession {
 
     withSQLConf(SQLConf.SHUFFLE_PARTITIONS.key -> numPartitions.toString) {
       // The default chi-sq value should be low
-      assert(computeChiSquareTest() < 100)
+      assert(computeChiSquareTest() < 10)
 
       withSQLConf(SQLConf.RANGE_EXCHANGE_SAMPLE_SIZE_PER_PARTITION.key -> "1") {
         // If we only sample one point, the range boundaries will be pretty bad and the
         // chi-sq value would be very high.
-        assert(computeChiSquareTest() > 300)
+        assert(computeChiSquareTest() > 100)
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/ConfigBehaviorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ConfigBehaviorSuite.scala
@@ -39,7 +39,6 @@ class ConfigBehaviorSuite extends QueryTest with SharedSparkSession {
     def computeChiSquareTest(): Double = {
       val n = 10000
       // Trigger a sort
-      // Range has range partitioning in its output now.
       val data = spark.range(0, n, 1, 10).sort($"id".desc)
         .selectExpr("SPARK_PARTITION_ID() pid", "id").as[(Int, Long)].collect()
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -421,7 +421,7 @@ class PlannerSuite extends SharedSparkSession {
     }
   }
 
-  test("EnsureRequirements replace Exchange " +
+  test("SPARK-30036: EnsureRequirements replace Exchange " +
       "if child has SortExec and RoundRobinPartitioning") {
     val distribution = OrderedDistribution(SortOrder(Literal(1), Ascending) :: Nil)
     val partitioning = RoundRobinPartitioning(5)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -421,7 +421,7 @@ class PlannerSuite extends SharedSparkSession {
     }
   }
 
-  test("SPARK-30036: Romove unnecessary RoundRobinPartitioning " +
+  test("SPARK-30036: Remove unnecessary RoundRobinPartitioning " +
       "if SortExec is followed by RoundRobinPartitioning") {
     val distribution = OrderedDistribution(SortOrder(Literal(1), Ascending) :: Nil)
     val partitioning = RoundRobinPartitioning(5)
@@ -444,7 +444,7 @@ class PlannerSuite extends SharedSparkSession {
     assert(query.rdd.collectPartitions()(0).map(_.get(0)).toSeq == (1 to 50))
   }
 
-  test("SPARK-30036: Romove unnecessary HashPartitioning " +
+  test("SPARK-30036: Remove unnecessary HashPartitioning " +
     "if SortExec is followed by HashPartitioning") {
     val distribution = OrderedDistribution(SortOrder(Literal(1), Ascending) :: Nil)
     val partitioning = HashPartitioning(Literal(1) :: Nil, 5)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -440,10 +440,6 @@ class PlannerSuite extends SharedSparkSession {
       "RoundRobinPartitioning should be changed to RangePartitioning")
 
     val query = testData.select('key, 'value).repartition(2).sort('key.asc)
-    assert(query.queryExecution.sparkPlan.collectLeaves().count{
-      case _: ShuffleExchangeExec => true
-      case _ => false
-    } == 1)
     assert(query.rdd.getNumPartitions == 2)
     assert(query.rdd.collectPartitions()(0).map(_.get(0)).toSeq == (1 to 50))
   }
@@ -467,10 +463,6 @@ class PlannerSuite extends SharedSparkSession {
       "HashPartitioning should be changed to RangePartitioning")
 
     val query = testData.select('key, 'value).repartition(5, 'key).sort('key.asc)
-    assert(query.queryExecution.sparkPlan.collectLeaves().count{
-      case _: ShuffleExchangeExec => true
-      case _ => false
-    } == 1)
     assert(query.rdd.getNumPartitions == 5)
     assert(query.rdd.collectPartitions()(0).map(_.get(0)).toSeq == (1 to 20))
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -435,7 +435,8 @@ class PlannerSuite extends SharedSparkSession {
     val outputPlan = EnsureRequirements(spark.sessionState.conf).apply(inputPlan)
     assert(outputPlan.find {
       case ShuffleExchangeExec(_: RoundRobinPartitioning, _, _) => true
-      case _ => false}.isEmpty,
+      case _ => false
+    }.isEmpty,
       "RoundRobinPartitioning should be changed to RangePartitioning")
   }
 
@@ -453,7 +454,8 @@ class PlannerSuite extends SharedSparkSession {
     val outputPlan = EnsureRequirements(spark.sessionState.conf).apply(inputPlan)
     assert(outputPlan.find {
       case ShuffleExchangeExec(_: HashPartitioning, _, _) => true
-      case _ => false}.isEmpty,
+      case _ => false
+    }.isEmpty,
       "HashPartitioning should be changed to RangePartitioning")
   }
 


### PR DESCRIPTION
### Why are the changes needed?
`EnsureRequirements` adds `ShuffleExchangeExec` (RangePartitioning) after Sort if `RoundRobinPartitioning` behinds it. This will cause 2 shuffles, and the number of partitions in the final stage is not the number specified by `RoundRobinPartitioning.

**Example SQL**
```
SELECT /*+ REPARTITION(5) */ * FROM test ORDER BY a
```

**BEFORE**
```
== Physical Plan ==
*(1) Sort [a#0 ASC NULLS FIRST], true, 0
+- Exchange rangepartitioning(a#0 ASC NULLS FIRST, 200), true, [id=#11]
   +- Exchange RoundRobinPartitioning(5), false, [id=#9]
      +- Scan hive default.test [a#0, b#1], HiveTableRelation `default`.`test`, org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe, [a#0, b#1]
```

**AFTER**
```
== Physical Plan ==
*(1) Sort [a#0 ASC NULLS FIRST], true, 0
+- Exchange rangepartitioning(a#0 ASC NULLS FIRST, 5), true, [id=#11]
   +- Scan hive default.test [a#0, b#1], HiveTableRelation `default`.`test`, org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe, [a#0, b#1]
```

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Run suite Tests and add new test for this.
