### PR TITLE
[SPARK-30303][SQL] Fix match error in percentile function when the percentage is null

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -657,7 +657,7 @@ object TypeCoercion {
       case NaNvl(l, r) if r.dataType == NullType => NaNvl(l, Cast(r, l.dataType))
 
       case p @ Percentile(child, pe @ NumericType(), _, _, _) =>
-        val newChild = if (TypeCollection(NullType, StringType).acceptsType(child.dataType)) {
+        val newChild = if (child.dataType == StringType || child.dataType == NullType) {
           Cast(child, DoubleType)
         } else {
           child
@@ -666,7 +666,7 @@ object TypeCoercion {
         p.copy(child = newChild, percentageExpression = newPe)
       case p @ Percentile(child, pe, _, _, _) if ArrayType.acceptsType(pe.dataType) &&
         pe.dataType.asInstanceOf[ArrayType].elementType.isInstanceOf[NumericType] =>
-        val newChild = if (TypeCollection(NullType, StringType).acceptsType(child.dataType)) {
+        val newChild = if (child.dataType == StringType || child.dataType == NullType) {
           Cast(child, DoubleType)
         } else {
           child

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -655,29 +655,6 @@ object TypeCoercion {
       case NaNvl(l, r) if l.dataType == FloatType && r.dataType == DoubleType =>
         NaNvl(Cast(l, DoubleType), r)
       case NaNvl(l, r) if r.dataType == NullType => NaNvl(l, Cast(r, l.dataType))
-
-      case p @ Percentile(child, pe @ NumericType(), _, _, _) =>
-        val newChild = if (child.dataType == StringType || child.dataType == NullType) {
-          Cast(child, DoubleType)
-        } else {
-          child
-        }
-        val newPe = if (pe.dataType == DoubleType) pe else Cast(pe, DoubleType)
-        p.copy(child = newChild, percentageExpression = newPe)
-      case p @ Percentile(child, pe, _, _, _) if ArrayType.acceptsType(pe.dataType) &&
-        pe.dataType.asInstanceOf[ArrayType].elementType.isInstanceOf[NumericType] =>
-        val newChild = if (child.dataType == StringType || child.dataType == NullType) {
-          Cast(child, DoubleType)
-        } else {
-          child
-        }
-        val ArrayType(elementType, containsNull) = pe.dataType
-        val newPe = if (elementType == DoubleType) {
-          pe
-        } else {
-          Cast(pe, ArrayType(DoubleType, containsNull))
-        }
-        p.copy(child = newChild, percentageExpression = newPe)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Percentile.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Percentile.scala
@@ -110,7 +110,7 @@ case class Percentile(
     case _ => DoubleType
   }
 
-  def inputTypes: Seq[AbstractDataType] = {
+  override def inputTypes: Seq[AbstractDataType] = {
     val percentageExpType = percentageExpression.dataType match {
       case _: ArrayType => ArrayType(DoubleType, false)
       case _ => DoubleType

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PercentileSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PercentileSuite.scala
@@ -236,7 +236,7 @@ class PercentileSuite extends SparkFunSuite {
       val percentile4 = new Percentile(child, percentage)
       val checkResult = percentile4.checkInputDataTypes()
       assert(checkResult.isFailure)
-      Seq("argument 2 requires double type, however, ",
+      Seq("argument 2 requires (double or array<double>) type, however, ",
           s"is of ${dataType.simpleString} type.").foreach { errMsg =>
         assert(checkResult.asInstanceOf[TypeCheckFailure].message.contains(errMsg))
       }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PercentileSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PercentileSuite.scala
@@ -243,6 +243,23 @@ class PercentileSuite extends SparkFunSuite {
     }
   }
 
+  test("nulls in percentage expression") {
+    val nullPercentageExprs = Seq(Literal(null), CreateArray(Seq(0.1D, null).map(Literal(_))))
+
+    nullPercentageExprs.foreach {
+      percentageExpression =>
+        val wrongPercentage = new Percentile(
+          AttributeReference("a", DoubleType)(),
+          percentageExpression = percentageExpression)
+        assert(
+          wrongPercentage.checkInputDataTypes() match {
+            case TypeCheckFailure(msg)
+              if msg.contains("argument 2 requires (double or array<double>) type") =>
+              true
+            case _ => false
+          })
+    }
+  }
   test("null handling") {
 
     // Percentile without frequency column


### PR DESCRIPTION


### What changes were proposed in this pull request?

Similar to #26905

```sql
spark-sql> select percentile(1, null);
19/12/19 16:35:04 ERROR SparkSQLDriver: Failed in [select percentile(1, null)]
scala.MatchError: null


spark-sql> select percentile(1, array(0.0, null)); -- null is illegal but treat as zero
``` 


### Why are the changes needed?
bugfix


### Does this PR introduce any user-facing change?

yes, select percentile(1, null); throws AnalysisException instead.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
add ut