### PR TITLE
[SPARK-30120][ML] LSH approxNearestNeighbors should use BoundedPriorityQueue when numNearestNeighbors is small

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/LSH.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/LSH.scala
@@ -188,7 +188,9 @@ private[ml] abstract class LSHModel[T <: LSHModel[T]]
     }
 
     if (!singleProbe) {
-      println(s"numNearestNeighbors=$numNearestNeighbors, modelSubset.size=${modelSubset.count}")
+      val threshold = modelSubset.select(max(distCol)).first().getDouble(0)
+      println(s"numNearestNeighbors=$numNearestNeighbors, modelSubset.size=${modelSubset.count}," +
+        s" threshold=$threshold")
     }
 
     // Get the top k nearest neighbor by their distance to the key

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/LSH.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/LSH.scala
@@ -140,6 +140,7 @@ private[ml] abstract class LSHModel[T <: LSHModel[T]]
       val modelDatasetWithDist = modelDataset.withColumn(distCol, hashDistCol)
 
       if (numNearestNeighbors < 10000) {
+        log.info(s"using topK")
         val topKThreshold = modelDatasetWithDist
           .select(distCol)
           .rdd
@@ -152,6 +153,7 @@ private[ml] abstract class LSHModel[T <: LSHModel[T]]
           ).toSeq.max
         modelDatasetWithDist.filter(hashDistCol <= topKThreshold)
       } else {
+        log.info(s"using quantile")
         val count = dataset.count()
         // Compute threshold to get around k elements.
         // To guarantee to have enough neighbors in one pass, we need (p - err) * N >= M
@@ -197,7 +199,7 @@ private[ml] abstract class LSHModel[T <: LSHModel[T]]
       key: Vector,
       numNearestNeighbors: Int,
       distCol: String): Dataset[_] = {
-      approxNearestNeighbors(dataset, key, numNearestNeighbors, true, distCol)
+      approxNearestNeighbors(dataset, key, numNearestNeighbors, false, distCol)
   }
 
   /**
@@ -207,7 +209,7 @@ private[ml] abstract class LSHModel[T <: LSHModel[T]]
       dataset: Dataset[_],
       key: Vector,
       numNearestNeighbors: Int): Dataset[_] = {
-    approxNearestNeighbors(dataset, key, numNearestNeighbors, true, "distCol")
+    approxNearestNeighbors(dataset, key, numNearestNeighbors, false, "distCol")
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/LSH.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/LSH.scala
@@ -139,8 +139,7 @@ private[ml] abstract class LSHModel[T <: LSHModel[T]]
       val hashDistCol = hashDistUDF(col($(outputCol)))
       val modelDatasetWithDist = modelDataset.withColumn(distCol, hashDistCol)
 
-      if (numNearestNeighbors < 10000) {
-        log.info(s"using topK")
+      if (numNearestNeighbors < 1000) {
         val topKThreshold = modelDatasetWithDist
           .select(distCol)
           .rdd
@@ -153,7 +152,6 @@ private[ml] abstract class LSHModel[T <: LSHModel[T]]
           ).toSeq.max
         modelDatasetWithDist.filter(hashDistCol <= topKThreshold)
       } else {
-        log.info(s"using quantile")
         val count = dataset.count()
         // Compute threshold to get around k elements.
         // To guarantee to have enough neighbors in one pass, we need (p - err) * N >= M


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use Top-K aggregation instead of approxNearestNeighbors

### Why are the changes needed?
performance improvement:
1, avoid count job to estimate `quantile`
2, exact threshold, make filtered dataset `modelSubset` probably smaller

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
existing testsuite & manually performance test
