### PR TITLE
[SPARK-30304][CORE]When the specified shufflemanager is incorrect, print the prompt.

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -334,7 +334,15 @@ object SparkEnv extends Logging {
     val shuffleMgrName = conf.get(config.SHUFFLE_MANAGER)
     val shuffleMgrClass =
       shortShuffleMgrNames.getOrElse(shuffleMgrName.toLowerCase(Locale.ROOT), shuffleMgrName)
-    val shuffleManager = instantiateClass[ShuffleManager](shuffleMgrClass)
+    var shuffleManager: ShuffleManager = null
+    try {
+      shuffleManager = instantiateClass[ShuffleManager](shuffleMgrClass)
+    } catch {
+      case e: Throwable =>
+        logError(s"Init shuffle manager error. Maybe $shuffleMgrName " +
+          s"shuffle manager doesn't exist.")
+        throw e
+    }
 
     val memoryManager: MemoryManager = UnifiedMemoryManager(conf, numUsableCores)
 

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -340,7 +340,7 @@ object SparkEnv extends Logging {
     } catch {
       case e: Throwable =>
         logError(s"Init shuffle manager error. Maybe $shuffleMgrName " +
-          s"shuffle manager doesn't exist.")
+          "shuffle manager doesn't exist.")
         throw e
     }
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1060,6 +1060,7 @@ package object config {
 
   private[spark] val SHUFFLE_MANAGER =
     ConfigBuilder("spark.shuffle.manager")
+      .doc("specify short names for shuffle managers.")
       .stringConf
       .createWithDefault("sort")
 

--- a/core/src/test/scala/org/apache/spark/SortShuffleSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SortShuffleSuite.scala
@@ -61,6 +61,16 @@ class SortShuffleSuite extends ShuffleSuite with BeforeAndAfterAll {
     }
   }
 
+  test("specify different short names for shuffle managers") {
+    conf.set(config.SHUFFLE_MANAGER, "hash")
+    assertThrows[ClassNotFoundException]{
+      sc = new SparkContext("local", "test", conf)
+    }
+    conf.set(config.SHUFFLE_MANAGER, "sort")
+    sc = new SparkContext("local", "test", conf)
+    assert(sc.env.shuffleManager.isInstanceOf[SortShuffleManager])
+  }
+
   test("SortShuffleManager properly cleans up files for shuffles that use the serialized path") {
     sc = new SparkContext("local", "test", conf)
     // Create a shuffled RDD and verify that it actually uses the new serialized map output path


### PR DESCRIPTION

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
During the instantiation of the specified `ShuffleManager`, if the configuration is wrong, whether the log can print some tips.

before:
```log
java.lang.ClassNotFoundException: hash
	at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:348)
	at org.apache.spark.util.Utils$.classForName(Utils.scala:206)
	at org.apache.spark.SparkEnv$.instantiateClass$1(SparkEnv.scala:274)
	at org.apache.spark.SparkEnv$.create(SparkEnv.scala:338)
	at org.apache.spark.SparkEnv$.createDriverEnv(SparkEnv.scala:188)
	at org.apache.spark.SparkContext.createSparkEnv(SparkContext.scala:277)
	at org.apache.spark.SparkContext.<init>(SparkContext.scala:462)
	at org.apache.spark.SparkContext.<init>(SparkContext.scala:131)
	at org.apache.spark.SortShuffleSuite.$anonfun$new$1(SortShuffleSuite.scala:67)
	at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
```

Now it's not just printing out stack exceptions, but also printing error prompt logs.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
It is convenient to quickly locate problems through logs.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Add test in `SortShuffleSuite`.