### PR TITLE
[SPARK-30312][SQL] Preserve path permission and acl when truncate table

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1988,6 +1988,14 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val TRUNCATE_TABLE_IGNORE_PERMISSION_ACL =
+    buildConf("spark.sql.truncateTable.ignorePermissionAcl")
+      .internal()
+      .doc("When set to true, TRUNCATE TABLE command will not try to set back original " +
+        "permission and ACLs when re-creating the table/partition paths.")
+      .booleanConf
+      .createWithDefault(false)
+
   val NAME_NON_STRUCT_GROUPING_KEY_AS_VALUE =
     buildConf("spark.sql.legacy.dataset.nameNonStructGroupingKeyAsValue")
       .internal()
@@ -2593,6 +2601,9 @@ class SQLConf extends Serializable with Logging {
     getConf(SQLConf.LEGACY_CREATE_HIVE_TABLE_BY_DEFAULT_ENABLED)
 
   def integralDivideReturnLong: Boolean = getConf(SQLConf.LEGACY_INTEGRALDIVIDE_RETURN_LONG)
+
+  def truncateTableIgnorePermissionAcl: Boolean =
+    getConf(SQLConf.TRUNCATE_TABLE_IGNORE_PERMISSION_ACL)
 
   def nameNonStructGroupingKeyAsValue: Boolean =
     getConf(SQLConf.NAME_NON_STRUCT_GROUPING_KEY_AS_VALUE)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -512,19 +512,19 @@ case class TruncateTableCommand(
           fs.mkdirs(path)
           optPermission.foreach { permission =>
             Try(fs.setPermission(path, permission)) match {
-              case Failure(e) if e.isInstanceOf[UnsupportedOperationException] =>
-                log.warn(s"Can not set original permission $permission back to " +
-                  s"the created path: $path. Exception: ${e.getMessage}")
-              case Failure(e) => throw e
+              case Failure(e) =>
+                throw new AnalysisException(
+                  s"Failed to set original permission $permission back to " +
+                    s"the created path: $path. Exception: ${e.getMessage}")
               case _ =>
             }
           }
           optAcls.foreach { acls =>
             Try(fs.setAcl(path, acls)) match {
-              case Failure(e) if e.isInstanceOf[UnsupportedOperationException] =>
-                log.warn(s"Can not set original ACL $acls back to " +
-                  s"the created path: $path. Exception: ${e.getMessage}")
-              case Failure(e) => throw e
+              case Failure(e) =>
+                throw new AnalysisException(
+                  s"Failed to set original ACL $acls back to " +
+                    s"the created path: $path. Exception: ${e.getMessage}")
               case _ =>
             }
           }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -506,14 +506,14 @@ case class TruncateTableCommand(
           try {
             optPermission = Some(fileStatus.getPermission())
           } catch {
-            case NonFatal(e) =>
+            case NonFatal(_) => // do nothing
           }
 
           var optAcls: Option[java.util.List[AclEntry]] = None
           try {
             optAcls = Some(fs.getAclStatus(path).getEntries)
           } catch {
-            case NonFatal(e) =>
+            case NonFatal(_) => // do nothing
           }
 
           fs.delete(path, true)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -527,7 +527,7 @@ case class TruncateTableCommand(
               fs.setPermission(path, permission)
             } catch {
               case NonFatal(e) =>
-                throw new AnalysisException(
+                throw new SecurityException(
                   s"Failed to set original permission $permission back to " +
                     s"the created path: $path. Exception: ${e.getMessage}")
             }
@@ -537,7 +537,7 @@ case class TruncateTableCommand(
               fs.setAcl(path, acls)
             } catch {
               case NonFatal(e) =>
-                throw new AnalysisException(
+                throw new SecurityException(
                   s"Failed to set original ACL $acls back to " +
                     s"the created path: $path. Exception: ${e.getMessage}")
             }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -501,16 +501,13 @@ case class TruncateTableCommand(
           val fs = path.getFileSystem(hadoopConf)
           val fileStatus = fs.getFileStatus(path)
           val permission = fileStatus.getPermission()
-          val owner = fileStatus.getOwner()
-          val group = fileStatus.getGroup()
           // Not all fs support acl APIs.
           val optAcls = Try(fs.getAclStatus(path).getEntries)
 
           fs.delete(path, true)
 
-          // We should keep original owner/permission/acl of the path.
+          // We should keep original permission/acl of the path.
           fs.mkdirs(path)
-          fs.setOwner(path, owner, group)
           fs.setPermission(path, permission)
           optAcls.foreach(acls => fs.setAcl(path, acls))
         } catch {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -21,8 +21,8 @@ import java.io.{File, PrintWriter}
 import java.net.URI
 import java.util.Locale
 
-import org.apache.hadoop.fs.Path
-import org.apache.hadoop.fs.permission.FsPermission
+import org.apache.hadoop.fs.{Path, RawLocalFileSystem}
+import org.apache.hadoop.fs.permission.{AclEntry, AclEntryScope, AclEntryType, AclStatus, FsAction, FsPermission}
 
 import org.apache.spark.internal.config
 import org.apache.spark.internal.config.RDD_PARALLEL_LISTING_THRESHOLD
@@ -1982,29 +1982,45 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
     }
   }
 
-  test("truncate table - keep permission") {
+  test("truncate table - keep acl/permission") {
     import testImplicits._
 
-    withTable("tab1") {
-      sql("CREATE TABLE tab1 (col INT) USING parquet")
-      sql("INSERT INTO tab1 SELECT 1")
-      checkAnswer(spark.table("tab1"), Row(1))
+    withSQLConf(
+      "fs.file.impl" -> classOf[FakeLocalFsFileSystem].getName,
+      "fs.file.impl.disable.cache" -> "true") {
+      withTable("tab1") {
+        sql("CREATE TABLE tab1 (col INT) USING parquet")
+        sql("INSERT INTO tab1 SELECT 1")
+        checkAnswer(spark.table("tab1"), Row(1))
 
-      val tablePath = new Path(spark.sessionState.catalog
-        .getTableMetadata(TableIdentifier("tab1")).storage.locationUri.get)
+        val tablePath = new Path(spark.sessionState.catalog
+          .getTableMetadata(TableIdentifier("tab1")).storage.locationUri.get)
 
-      val hadoopConf = spark.sessionState.newHadoopConf()
-      val fs = tablePath.getFileSystem(hadoopConf)
-      val fileStatus = fs.getFileStatus(tablePath);
+        val hadoopConf = spark.sessionState.newHadoopConf()
+        val fs = tablePath.getFileSystem(hadoopConf)
+        val fileStatus = fs.getFileStatus(tablePath);
 
-      fs.setPermission(tablePath, new FsPermission("777"))
-      assert(fileStatus.getPermission().toString() == "rwxrwxrwx")
+        fs.setPermission(tablePath, new FsPermission("777"))
+        assert(fileStatus.getPermission().toString() == "rwxrwxrwx")
 
-      sql("TRUNCATE TABLE tab1")
-      assert(spark.table("tab1").collect().isEmpty)
+        // Set ACL to table path.
+        val customAcl = new java.util.ArrayList[AclEntry]()
+        customAcl.add(new AclEntry.Builder()
+          .setType(AclEntryType.USER)
+          .setScope(AclEntryScope.ACCESS)
+          .setPermission(FsAction.READ).build())
+        fs.setAcl(tablePath, customAcl)
+        assert(fs.getAclStatus(tablePath).getEntries().get(0) == customAcl.get(0))
 
-      val fileStatus2 = fs.getFileStatus(tablePath)
-      assert(fileStatus2.getPermission().toString() == "rwxrwxrwx")
+        sql("TRUNCATE TABLE tab1")
+        assert(spark.table("tab1").collect().isEmpty)
+
+        val fileStatus2 = fs.getFileStatus(tablePath)
+        assert(fileStatus2.getPermission().toString() == "rwxrwxrwx")
+        val aclEntries = fs.getAclStatus(tablePath).getEntries()
+        assert(aclEntries.size() == 1)
+        assert(aclEntries.get(0) == customAcl.get(0))
+      }
     }
   }
 
@@ -2904,5 +2920,27 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
         assert(table.provider == Some("parquet"))
       }
     }
+  }
+}
+
+object FakeLocalFsFileSystem {
+  var aclStatus = new AclStatus.Builder().build()
+}
+
+// A fake test local filesystem used to test ACL. It keeps a ACL status. If deletes
+// a path of this filesystem, it will clean up the ACL status. Note that for test purpose,
+// it has only one ACL status for all paths.
+class FakeLocalFsFileSystem extends RawLocalFileSystem {
+  import FakeLocalFsFileSystem._
+
+  override def delete(f: Path, recursive: Boolean): Boolean = {
+    aclStatus = new AclStatus.Builder().build()
+    super.delete(f, recursive)
+  }
+
+  override def getAclStatus(path: Path): AclStatus = aclStatus
+
+  override def setAcl(path: Path, aclSpec: java.util.List[AclEntry]): Unit = {
+    aclStatus = new AclStatus.Builder().addEntries(aclSpec).build()
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -1982,7 +1982,7 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
     }
   }
 
-  test("truncate table - keep acl/permission") {
+  test("SPARK-30312: truncate table - keep acl/permission") {
     import testImplicits._
 
     withSQLConf(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This patch proposes to preserve existing permission/acls of paths when truncate table/partition.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

When Spark SQL truncates table, it deletes the paths of table/partitions, then re-create new ones. If permission/acls were set on the paths, the existing permission/acls will be deleted.

We should preserve the permission/acls if possible.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

Yes. When truncate table/partition, Spark will keep permission/acls of paths.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Unit test.

Manual test:

1. Create a table.
2. Manually change it permission/acl
3. Truncate table
4. Check permission/acl

```scala
val df = Seq(1, 2, 3).toDF
df.write.mode("overwrite").saveAsTable("test.test_truncate_table")
val testTable = spark.table("test.test_truncate_table")
testTable.show()
+-----+
|value|
+-----+
|    1|
|    2|
|    3|
+-----+
// hdfs dfs -setfacl ...
// hdfs dfs -getfacl ...
sql("truncate table test.test_truncate_table")
// hdfs dfs -getfacl ...
val testTable2 = spark.table("test.test_truncate_table")
testTable2.show()
+-----+
|value|
+-----+
+-----+
```

![Screen Shot 2019-12-30 at 3 12 15 PM](https://user-images.githubusercontent.com/68855/71604577-c7875a00-2b17-11ea-913a-ba88096d20ab.jpg)
