### PR TITLE
[SPARK-28083][SQL][FOLLOW-UP] Fix incorrect comment for LIKE ... ESCAPE

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
@@ -38,7 +38,7 @@ object StringUtils extends Logging {
    * throw an [[AnalysisException]].
    *
    * @param pattern the SQL pattern to convert
-   * @param escapeChar the escape string contains one character.
+   * @param escapeChar the escape character.
    * @return the equivalent Java regular expression of the pattern
    */
   def escapeLikeRegex(pattern: String, escapeChar: Char): String = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR is a follow-up to #25001
The comment of StringUtils.escapeLikeRegex has one mistake.

### Why are the changes needed?
Comment mistake.


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
Exists UT
