### PR TITLE
[SPARK-30318] [Core] Upgrade jetty to 9.3.27.v20190418

### DIFF
--- a/dev/deps/spark-deps-hadoop-3.1
+++ b/dev/deps/spark-deps-hadoop-3.1
@@ -116,8 +116,8 @@ jersey-container-servlet-core-2.22.2.jar
 jersey-guava-2.22.2.jar
 jersey-media-jaxb-2.22.2.jar
 jersey-server-2.22.2.jar
-jetty-webapp-9.3.24.v20180605.jar
-jetty-xml-9.3.24.v20180605.jar
+jetty-webapp-9.3.27.v20190418.jar
+jetty-xml-9.3.27.v20190418.jar
 jline-2.14.6.jar
 joda-time-2.9.3.jar
 jodd-core-3.5.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
     <orc.version>1.5.5</orc.version>
     <orc.classifier>nohive</orc.classifier>
     <hive.parquet.version>1.6.0</hive.parquet.version>
-    <jetty.version>9.3.24.v20180605</jetty.version>
+    <jetty.version>9.3.27.v20190418</jetty.version>
     <javaxservlet.version>3.1.0</javaxservlet.version>
     <chill.version>0.9.3</chill.version>
     <ivy.version>2.4.0</ivy.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Upgrade jetty to 9.3.27.v20190418 to fix below CVE

https://nvd.nist.gov/vuln/detail/CVE-2019-10247
https://nvd.nist.gov/vuln/detail/CVE-2019-10241

tag: https://github.com/eclipse/jetty.project/releases/tag/jetty-9.3.27.v20190418


### Why are the changes needed?
To fix  CVE-2019-10247 and CVE-2019-10241 


### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Existing Test