### PR TITLE
[SPARK-30324][SQL] Simplify JSON field access through dot notation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
@@ -20,8 +20,8 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis._
-import org.apache.spark.sql.catalyst.expressions.codegen.{CodeGenerator, CodegenContext, ExprCode}
-import org.apache.spark.sql.catalyst.util.{ArrayData, GenericArrayData, MapData, TypeUtils, quoteIdentifier}
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodeGenerator, ExprCode}
+import org.apache.spark.sql.catalyst.util.{quoteIdentifier, ArrayData, GenericArrayData, MapData, TypeUtils}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
@@ -20,8 +20,8 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis._
-import org.apache.spark.sql.catalyst.expressions.codegen.{CodeGenerator, CodegenContext, ExprCode}
-import org.apache.spark.sql.catalyst.util.{ArrayData, GenericArrayData, MapData, TypeUtils, quoteIdentifier}
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodeGenerator, ExprCode}
+import org.apache.spark.sql.catalyst.util.{quoteIdentifier, ArrayData, GenericArrayData, MapData, TypeUtils}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1233,6 +1233,13 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val ENABLE_STRING_NESTED_FIELD_ACCESS =
+    buildConf("spark.sql.semiStructured.string.enabled")
+        .doc("Whether to treat a string column as a JSON string if someone wants to access a " +
+          "nested field from it.")
+        .booleanConf
+        .createWithDefault(true)
+
   val FILE_SINK_LOG_DELETION = buildConf("spark.sql.streaming.fileSink.log.deletion")
     .internal()
     .doc("Whether to delete the expired log files in file stream sink.")

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -134,6 +134,20 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
       Seq(Row("value1"), Row("value2")))
   }
 
+  test("json parsing through dot and bracket notation disabled with flag") {
+    val df: DataFrame = tuples.toDF("key", "jstring")
+
+    withSQLConf(SQLConf.ENABLE_STRING_NESTED_FIELD_ACCESS.key -> "false") {
+      intercept[AnalysisException] {
+        df.selectExpr("key", "jstring.f1")
+      }
+
+      intercept[AnalysisException] {
+        df.selectExpr("key", "jstring['f1']")
+      }
+    }
+  }
+
   test("json_tuple select") {
     val df: DataFrame = tuples.toDF("key", "jstring")
     val expected =


### PR DESCRIPTION
### What changes were proposed in this pull request?

Allows JSON strings to be parsed through dot and bracket notation instead of having to write "get_json_object". We add a feature flag to control this behavior.

The column needs to be a JSON object for this to work. JSON arrays are not supported and would return nulls. If a column is a JSON array, e.g. `[{"a":1},{"a":2},...]`, `explode(from_json(colName, expr("array<string>")))` can be used to first explode the array into the JSON objects.

While the JSON column can be resolved case insensitively, the JSON fields are case sensitive.
For example, imagine the column `foo`:
```
{"a":"bar", "b":{"field1":"v1"}}
```

`foo.b.field1`, `FOO.b.field1` would work, but `foo.B.FIELD1` would return a null value.

### Why are the changes needed?

get_json_object is a hard to use and verbose API. This API would greatly help data engineers store their data as raw json columns, and data analysts access the fields that they care about, without having to deal with complicated UDFs, and JSON parsing code.

### Does this PR introduce any user-facing change?

Yes, StringType fields that contain JSON now will be accessible through dot notation.


### How was this patch tested?

Unit tests