### PR TITLE
[SPARK-27641][CORE] Fix MetricsSystem to remove metrics of the specific source by exactly match

### DIFF
--- a/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
@@ -156,10 +156,10 @@ private[spark] class MetricsSystem private (
     } else { defaultName }
   }
 
-  private[spark] def getRegisteredNames(source: Source): mutable.Set[String] = {
+  private[spark] def getRegisteredNames(source: Source): Seq[String] = {
     val sourceNamePrefix = buildRegistryName(source)
-    val metricNames = source.metricRegistry.getMetrics.keySet()
-    metricNames.asScala.map(k => MetricRegistry.name(sourceNamePrefix, k))
+    val metricNames = source.metricRegistry.getMetrics.keySet
+    metricNames.asScala.map(k => MetricRegistry.name(sourceNamePrefix, k)).toSeq
   }
 
   def getSourcesByName(sourceName: String): Seq[Source] =


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Only remove the registered metrics  of the specific source when perform `MetricsSystem.removeSource`

## How was this patch tested?
* add new unit tests