### PR TITLE
[SPARK-30333][CORE][BUILD][BRANCH-2.4] Upgrade jackson-databind to 2.6.7.3

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.6
+++ b/dev/deps/spark-deps-hadoop-2.6
@@ -89,7 +89,7 @@ ivy-2.4.0.jar
 jackson-annotations-2.6.7.jar
 jackson-core-2.6.7.jar
 jackson-core-asl-1.9.13.jar
-jackson-databind-2.6.7.1.jar
+jackson-databind-2.6.7.3.jar
 jackson-dataformat-yaml-2.6.7.jar
 jackson-jaxrs-1.9.13.jar
 jackson-mapper-asl-1.9.13.jar

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -89,7 +89,7 @@ ivy-2.4.0.jar
 jackson-annotations-2.6.7.jar
 jackson-core-2.6.7.jar
 jackson-core-asl-1.9.13.jar
-jackson-databind-2.6.7.1.jar
+jackson-databind-2.6.7.3.jar
 jackson-dataformat-yaml-2.6.7.jar
 jackson-jaxrs-1.9.13.jar
 jackson-mapper-asl-1.9.13.jar

--- a/dev/deps/spark-deps-hadoop-3.1
+++ b/dev/deps/spark-deps-hadoop-3.1
@@ -89,7 +89,7 @@ ivy-2.4.0.jar
 jackson-annotations-2.6.7.jar
 jackson-core-2.6.7.jar
 jackson-core-asl-1.9.13.jar
-jackson-databind-2.6.7.1.jar
+jackson-databind-2.6.7.3.jar
 jackson-dataformat-yaml-2.6.7.jar
 jackson-jaxrs-base-2.7.8.jar
 jackson-jaxrs-json-provider-2.7.8.jar

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,8 @@
     <scala.binary.version>2.11</scala.binary.version>
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
     <fasterxml.jackson.version>2.6.7</fasterxml.jackson.version>
-    <fasterxml.jackson.databind.version>2.6.7.1</fasterxml.jackson.databind.version>
+    <fasterxml.jackson-module-scala.version>2.6.7.1</fasterxml.jackson-module-scala.version>
+    <fasterxml.jackson.databind.version>2.6.7.3</fasterxml.jackson.databind.version>
     <snappy.version>1.1.7.3</snappy.version>
     <netlib.java.version>1.1.2</netlib.java.version>
     <calcite.version>1.2.0-incubating</calcite.version>
@@ -646,7 +647,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
-        <version>${fasterxml.jackson.databind.version}</version>
+        <version>${fasterxml.jackson-module-scala.version}</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade jackson-databind to 2.6.7.3 to following CVE

CVE-2018-14718 - CVE-2018-14721 
https://github.com/FasterXML/jackson-databind/issues/2097

CVE-2018-19360, CVE-2018-19361, CVE-2018-19362 
https://github.com/FasterXML/jackson-databind/issues/2186

tag: https://github.com/FasterXML/jackson-databind/commits/jackson-databind-2.6.7.3



### Why are the changes needed?
CVE-2018-14718,CVE-2018-14719,CVE-2018-14720,CVE-2018-14721,CVE-2018-19360,CVE-2018-19361,CVE-2018-19362


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
Existing UT