### PR TITLE
[SPARK-30334][SQL] Introduce as_json for marking a column as JSON data

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -348,6 +348,7 @@ object FunctionRegistry {
     expression[StringLocate]("locate"),
     expression[StringLPad]("lpad"),
     expression[StringTrimLeft]("ltrim"),
+    expression[AsJson]("as_json"),
     expression[JsonTuple]("json_tuple"),
     expression[ParseUrl]("parse_url"),
     expression[StringLocate]("position"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SemiStructuredColumn.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SemiStructuredColumn.scala
@@ -17,14 +17,13 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
-import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.types.{Metadata, MetadataBuilder}
 
 /**
  * Adds metadata to a column containing semi-structured data. This information can be passed down
  * to data sources for potential optimizations.
  */
-trait SemiStructuredColumn extends UnaryExpression with Unevaluable with ExpectsInputTypes {
+trait SemiStructuredColumn extends UnaryExpression with ExpectsInputTypes with RuntimeReplaceable {
 
   /** The format of the semi-structured column, e.g. json, xml, avro, csv. */
   def format: String
@@ -50,12 +49,6 @@ trait SemiStructuredColumn extends UnaryExpression with Unevaluable with Expects
 }
 
 object SemiStructuredColumn {
-
-  def unapply(expr: SemiStructuredColumn): Option[Attribute] = expr.child match {
-    case a: Attribute => Some(a.withMetadata(expr.toMetadata))
-    case _ => throw new AnalysisException(
-      s"${expr.prettyName()} needs to be called on a named column.")
-  }
 
   val FORMAT_KEY = "format"
   val FORMAT_OPTIONS_KEY = "options"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SemiStructuredColumn.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SemiStructuredColumn.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.types.{Metadata, MetadataBuilder}
+
+/**
+ * Adds metadata to a column containing semi-structured data. This information can be passed down
+ * to data sources for potential optimizations.
+ */
+trait SemiStructuredColumn extends UnaryExpression with Unevaluable with ExpectsInputTypes {
+
+  /** The format of the semi-structured column, e.g. json, xml, avro, csv. */
+  def format: String
+
+  /**
+   * Options that can be used to parse values from the column. Typically these will be options
+   * that get passed to Spark's JSON or CSV parsers.
+   */
+  def formatOptions: Map[String, String]
+
+  /** Encode the column information as metadata */
+  final def toMetadata: Metadata = {
+    val options = new MetadataBuilder
+    formatOptions.foreach { case (key, value) =>
+      options.putString(key, value)
+    }
+
+    new MetadataBuilder()
+      .putString(SemiStructuredColumn.FORMAT_KEY, format)
+      .putMetadata(SemiStructuredColumn.FORMAT_OPTIONS_KEY, options.build())
+      .build()
+  }
+}
+
+object SemiStructuredColumn {
+
+  def unapply(expr: SemiStructuredColumn): Option[Attribute] = expr.child match {
+    case a: Attribute => Some(a.withMetadata(expr.toMetadata))
+    case _ => throw new AnalysisException(
+      s"${expr.prettyName()} needs to be called on a named column.")
+  }
+
+  val FORMAT_KEY = "format"
+  val FORMAT_OPTIONS_KEY = "options"
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -782,3 +782,26 @@ case class SchemaOfJson(
 
   override def prettyName: String = "schema_of_json"
 }
+
+/**
+ * A function that marks a StringType column with extra metadata indicating that it is a JSON
+ * object.
+ */
+@ExpressionDescription(
+  usage = "_FUNC_(json[, options]) - Marks the column as a JSON object. JSON strings indicating " +
+    "arrays of JSON objects are not allowed.",
+  examples = """
+    Examples:
+      > INSERT INTO my_table VALUES _FUNC_(raw);
+      > INSERT INTO TABLE my_table VALUES _FUNC_(raw, map('allowNumericLeadingZeros', 'true'));
+  """,
+  since = "3.0.0")
+case class AsJson(child: Expression, formatOptions: Map[String, String])
+    extends SemiStructuredColumn {
+
+  override def dataType: DataType = StringType
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(StringType)
+
+  override val format: String = "json"
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -799,6 +799,9 @@ case class SchemaOfJson(
 case class AsJson(child: Expression, formatOptions: Map[String, String])
     extends SemiStructuredColumn {
 
+  // Constructor for SQL
+  def this(child: Expression) = this(child, Map.empty)
+
   override def dataType: DataType = StringType
 
   override def inputTypes: Seq[AbstractDataType] = Seq(StringType)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
@@ -46,6 +46,7 @@ import org.apache.spark.sql.types._
 object ReplaceExpressions extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan transformAllExpressions {
     case e: RuntimeReplaceable => e.child
+    case SemiStructuredColumn(c) => c
     case CountIf(predicate) => Count(new NullIf(predicate, Literal.FalseLiteral))
     case BoolOr(arg) => Max(arg)
     case BoolAnd(arg) => Min(arg)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
@@ -46,7 +46,6 @@ import org.apache.spark.sql.types._
 object ReplaceExpressions extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan transformAllExpressions {
     case e: RuntimeReplaceable => e.child
-    case SemiStructuredColumn(c) => c
     case CountIf(predicate) => Count(new NullIf(predicate, Literal.FalseLiteral))
     case BoolOr(arg) => Max(arg)
     case BoolAnd(arg) => Min(arg)

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3871,6 +3871,28 @@ object functions {
     to_json(e, Map.empty[String, String])
 
   /**
+   * Marks a column as a field that contains JSON objects.
+   *
+   * @param e a column containing JSON objects
+   *
+   * @group collection_funcs
+   * @since 3.0.0
+   */
+  def as_json(e: Column): Column = as_json(e, Map.empty)
+
+  /**
+   * Marks a column as a field that contains JSON objects.
+   * @param e a column containing JSON objects
+   * @param options Options that can be used to parse the JSON objects
+   *
+   * @group collection_funcs
+   * @since 3.0.0
+   */
+  def as_json(e: Column, options: Map[String, String]): Column = withExpr {
+    AsJson(e.expr, options)
+  }
+
+  /**
    * Returns length of array or map.
    *
    * @group collection_funcs

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3889,7 +3889,7 @@ object functions {
    * @since 3.0.0
    */
   def as_json(e: Column, options: Map[String, String]): Column = withExpr {
-    AsJson(e.expr, options)
+    new AsJson(e.expr, options)
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -703,6 +703,9 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
   }
 
   test("as_json - performs type checks") {
-
+    val e = intercept[AnalysisException] {
+      Seq(1L, 2L).toDF("raw").select(as_json('raw)).collect()
+    }
+    assert(e.getMessage.contains("requires string type"))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Semi-structured data is used widely in the data industry for reporting events in a wide variety of formats. Click events in product analytics can be stored as json. Some application logs can be in the form of delimited key=value text. Some data may be in xml.

The goal of this project is to be able to signal Spark that such a column exists. This will then enable Spark to "auto-parse" these columns on the fly. The proposal is to store this information as part of the column metadata, in the fields:
 - format: The format of the semi-structured column, e.g. json, xml, avro
 - options: Options for parsing these columns

This PR introduces the function "as_json", which accomplishes this for JSON columns.

### Why are the changes needed?

Simplify the handling of semi-structured columns in Spark, initially for JSON data.

### Does this PR introduce any user-facing change?

Introduces a new function called as_json

### How was this patch tested?

Unit tests