### PR TITLE
[SPARK-18409][ML][FOLLOWUP] LSH approxNearestNeighbors optimization

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/LSH.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/LSH.scala
@@ -25,6 +25,7 @@ import org.apache.spark.ml.param.{IntParam, ParamValidators}
 import org.apache.spark.ml.param.shared.{HasInputCol, HasOutputCol}
 import org.apache.spark.ml.util._
 import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.util.QuantileSummaries
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 
@@ -112,9 +113,7 @@ private[ml] abstract class LSHModel[T <: LSHModel[T]]
       numNearestNeighbors: Int,
       singleProbe: Boolean,
       distCol: String): Dataset[_] = {
-    val count = dataset.count()
-    require(numNearestNeighbors > 0 && numNearestNeighbors <= count, "The number of" +
-      " nearest neighbors cannot be less than 1 or greater than the number of elements in dataset")
+    require(numNearestNeighbors > 0, "The number of nearest neighbors cannot be less than 1")
     // Get Hash Value of the key
     val keyHash = hashFunction(key)
     val modelDataset: DataFrame = if (!dataset.columns.contains($(outputCol))) {
@@ -138,21 +137,37 @@ private[ml] abstract class LSHModel[T <: LSHModel[T]]
       // Limit the use of hashDist since it's controversial
       val hashDistUDF = udf((x: Seq[Vector]) => hashDistance(x, keyHash), DataTypes.DoubleType)
       val hashDistCol = hashDistUDF(col($(outputCol)))
+      val modelDatasetWithDist = modelDataset.withColumn(distCol, hashDistCol)
+
+      val relativeError = 0.05
+      val (summary, count) = modelDatasetWithDist.select(distCol)
+        .rdd
+        .mapPartitions { iter =>
+          if (iter.hasNext) {
+            var s = new QuantileSummaries(
+              QuantileSummaries.defaultCompressThreshold, relativeError)
+            var c = 0L
+            while (iter.hasNext) {
+              val Row(dist: Double) = iter.next
+              s = s.insert(dist)
+              c += 1
+            }
+            Iterator.single((s.compress, c))
+          } else Iterator.empty
+        }.treeReduce { case ((s1, c1), (s2, c2)) => (s1.merge(s2), c1 + c2) }
 
       // Compute threshold to get around k elements.
       // To guarantee to have enough neighbors in one pass, we need (p - err) * N >= M
       // so we pick quantile p = M / N + err
       // M: the number of nearest neighbors; N: the number of elements in dataset
-      val relativeError = 0.05
       val approxQuantile = numNearestNeighbors.toDouble / count + relativeError
-      val modelDatasetWithDist = modelDataset.withColumn(distCol, hashDistCol)
+
       if (approxQuantile >= 1) {
         modelDatasetWithDist
       } else {
-        val hashThreshold = modelDatasetWithDist.stat
-          .approxQuantile(distCol, Array(approxQuantile), relativeError)
+        val hashThreshold = summary.query(approxQuantile).get
         // Filter the dataset where the hash value is less than the threshold.
-        modelDatasetWithDist.filter(hashDistCol <= hashThreshold(0))
+        modelDatasetWithDist.filter(hashDistCol <= hashThreshold)
       }
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
compute count and quantile on one pass

### Why are the changes needed?
to avoid extra pass


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
existing testsuites
