### PR TITLE
[SPARK-30346][CORE]Improve logging when events dropped

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
@@ -67,11 +67,11 @@ private class AsyncEventQueue(
   /** A counter for dropped events. It will be reset every time we log it. */
   private val droppedEventsCounter = new AtomicLong(0L)
 
-  /** A counter to keep dropped events count last time it was logged */
+  /** A counter to keep number of dropped events last time it was logged */
   private var lastDroppedEventsCounter: Long = 0L
 
   /** When `droppedEventsCounter` was logged last time in milliseconds. */
-  @volatile private var lastReportTimestamp = new AtomicLong(0L)
+  @volatile private val lastReportTimestamp = new AtomicLong(0L)
 
   private val logDroppedEvent = new AtomicBoolean(false)
 
@@ -175,7 +175,7 @@ private class AsyncEventQueue(
     val curTime = System.currentTimeMillis()
     if (droppedCount > 0) {
       // Don't log too frequently
-      if (curTime - lastReportTime >= 60 * 1000) {
+      if (curTime - lastReportTime >= LOGGING_INTERVAL) {
         // There may be multiple threads trying to logging dropped events,
         // Use 'compareAndSet' to make sure only one thread can win.
         // After set the 'lastReportTimestamp', the next time we come here will
@@ -224,5 +224,7 @@ private class AsyncEventQueue(
 private object AsyncEventQueue {
 
   val POISON_PILL = new SparkListenerEvent() { }
+
+  val LOGGING_INTERVAL = 60 * 1000
 
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
@@ -173,9 +173,8 @@ private class AsyncEventQueue(
     val droppedCount = droppedEventsCounter.get - lastDroppedEventsCounter
     val lastReportTime = lastReportTimestamp.get
     val curTime = System.currentTimeMillis()
-    if (droppedCount > 0) {
-      // Don't log too frequently
-      if (curTime - lastReportTime >= LOGGING_INTERVAL) {
+    // Don't log too frequently
+    if (droppedCount > 0 && curTime - lastReportTime >= LOGGING_INTERVAL) {
         // There may be multiple threads trying to logging dropped events,
         // Use 'compareAndSet' to make sure only one thread can win.
         if (lastReportTimestamp.compareAndSet(lastReportTime, curTime)) {
@@ -184,7 +183,6 @@ private class AsyncEventQueue(
           logWarning(s"Dropped $droppedCount events from $name since " +
             s"${if (lastReportTime == 0) "the application started" else s"$previous"}.")
         }
-      }
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
@@ -179,18 +179,10 @@ private class AsyncEventQueue(
         // There may be multiple threads trying to logging dropped events,
         // Use 'compareAndSet' to make sure only one thread can win.
         if (lastReportTimestamp.compareAndSet(lastReportTime, curTime)) {
-          val lastReportTime = lastReportTimestamp.get
           val previous = new java.util.Date(lastReportTime)
           lastDroppedEventsCounter = droppedCount
           logWarning(s"Dropped $droppedCount events from $name since " +
             s"${if (lastReportTime == 0) "the application started" else s"$previous"}.")
-          // Logging thread dump when events from appStatus was dropped
-          Utils.getThreadDumpForThread(dispatchThread.getId).foreach { thread =>
-            if (thread.threadName.contains(LiveListenerBus.APP_STATUS_QUEUE)) {
-              logWarning(s"Event dropped!!!Thread dump from dispatch thread " +
-                s"${dispatchThread.getName} :\n${thread.stackTrace}")
-            }
-          }
         }
       }
     }

--- a/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
@@ -170,19 +170,20 @@ private class AsyncEventQueue(
     }
     logTrace(s"Dropping event $event")
 
-    val droppedCount = droppedEventsCounter.get - lastDroppedEventsCounter
+    val droppedEventsCount = droppedEventsCounter.get
+    val droppedCountIncreased = droppedEventsCount - lastDroppedEventsCounter
     val lastReportTime = lastReportTimestamp.get
     val curTime = System.currentTimeMillis()
     // Don't log too frequently
-    if (droppedCount > 0 && curTime - lastReportTime >= LOGGING_INTERVAL) {
-        // There may be multiple threads trying to logging dropped events,
-        // Use 'compareAndSet' to make sure only one thread can win.
-        if (lastReportTimestamp.compareAndSet(lastReportTime, curTime)) {
-          val previous = new java.util.Date(lastReportTime)
-          lastDroppedEventsCounter = droppedCount
-          logWarning(s"Dropped $droppedCount events from $name since " +
-            s"${if (lastReportTime == 0) "the application started" else s"$previous"}.")
-        }
+    if (droppedCountIncreased > 0 && curTime - lastReportTime >= LOGGING_INTERVAL) {
+      // There may be multiple threads trying to logging dropped events,
+      // Use 'compareAndSet' to make sure only one thread can win.
+      if (lastReportTimestamp.compareAndSet(lastReportTime, curTime)) {
+        val previous = new java.util.Date(lastReportTime)
+        lastDroppedEventsCounter = droppedEventsCount
+        logWarning(s"Dropped $droppedCountIncreased events from $name since " +
+          s"${if (lastReportTime == 0) "the application started" else s"$previous"}.")
+      }
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make logging events dropping every 60s works fine, the orignal implementaion some times not working due to susequent events comming and updating the DroppedEventCounter

### Why are the changes needed?

Currenly, the logging may be skipped and delayed a long time under high concurrency, that make debugging hard. So This PR will try to fix it.

### Does this PR introduce any user-facing change?

No


### How was this patch tested?

NA
