### PR TITLE
[SPARK-30348][CORE][TEST] Fix flaky test failure on "MasterSuite.SPARK-27510: Master should avoid ..."

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -75,8 +75,7 @@ private[deploy] class Master(
 
   private val endpointToApp = new HashMap[RpcEndpointRef, ApplicationInfo]
   private val addressToApp = new HashMap[RpcAddress, ApplicationInfo]
-  // Expose for testing
-  private[master] val completedApps = new ArrayBuffer[ApplicationInfo]
+  private val completedApps = new ArrayBuffer[ApplicationInfo]
   private var nextAppNumber = 0
 
   private val drivers = new HashSet[DriverInfo]

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -75,7 +75,8 @@ private[deploy] class Master(
 
   private val endpointToApp = new HashMap[RpcEndpointRef, ApplicationInfo]
   private val addressToApp = new HashMap[RpcAddress, ApplicationInfo]
-  private val completedApps = new ArrayBuffer[ApplicationInfo]
+  // Expose for testing
+  private[master] val completedApps = new ArrayBuffer[ApplicationInfo]
   private var nextAppNumber = 0
 
   private val drivers = new HashSet[DriverInfo]

--- a/core/src/test/scala/org/apache/spark/deploy/master/MasterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/master/MasterSuite.scala
@@ -107,7 +107,7 @@ class MockExecutorLaunchFailWorker(master: Master, conf: SparkConf = new SparkCo
   var failedCnt = 0
 
   override def receive: PartialFunction[Any, Unit] = {
-    case LaunchDriver(driverId, desc, resources_) =>
+    case LaunchDriver(driverId, _, _) =>
       master.self.send(RegisterApplication(appDesc, newDriver(driverId)))
 
       // Below code doesn't make driver stuck, as newDriver opens another rpc endpoint for

--- a/core/src/test/scala/org/apache/spark/deploy/master/MasterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/master/MasterSuite.scala
@@ -682,7 +682,11 @@ class MasterSuite extends SparkFunSuite
         // an app would be registered with Master once Driver set up
         assert(worker.apps.nonEmpty)
         appId = worker.apps.head._1
-        assert(master.idToApp.contains(appId))
+
+        // we found the case where the test was too fast which all steps were done within
+        // an interval - in this case, we have to check either app is available in master
+        // or marked as completed. See SPARK-30348 for details.
+        assert(master.idToApp.contains(appId) || master.completedApps.exists(_.id == appId))
       }
 
       eventually(timeout(10.seconds)) {

--- a/core/src/test/scala/org/apache/spark/deploy/master/MasterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/master/MasterSuite.scala
@@ -108,8 +108,6 @@ class MockExecutorLaunchFailWorker(master: Master, conf: SparkConf = new SparkCo
 
   override def receive: PartialFunction[Any, Unit] = {
     case LaunchDriver(driverId, desc, resources_) =>
-      drivers += driverId
-      driverResources(driverId) = resources_.map(r => (r._1, r._2.addresses.toSet))
       master.self.send(RegisterApplication(appDesc, newDriver(driverId)))
 
       // Below code doesn't make driver stuck, as newDriver opens another rpc endpoint for


### PR DESCRIPTION
### What changes were proposed in this pull request?

This patch fixes the flaky test failure on MasterSuite, "SPARK-27510: Master should avoid dead loop while launching executor failed in Worker".

The culprit of test failure was ironically the test ran too fast; the interval of `eventually` is by default "15 ms", but it took only "8 ms" from submitting driver to removing app from master.

```
19/12/23 15:45:06.533 dispatcher-event-loop-6 INFO Master: Registering worker localhost:9999 with 10 cores, 3.6 GiB RAM
19/12/23 15:45:06.534 dispatcher-event-loop-6 INFO Master: Driver submitted org.apache.spark.FakeClass
19/12/23 15:45:06.535 dispatcher-event-loop-6 INFO Master: Launching driver driver-20191223154506-0000 on worker 10001
19/12/23 15:45:06.536 dispatcher-event-loop-9 INFO Master: Registering app name
19/12/23 15:45:06.537 dispatcher-event-loop-9 INFO Master: Registered app name with ID app-20191223154506-0000
19/12/23 15:45:06.537 dispatcher-event-loop-9 INFO Master: Launching executor app-20191223154506-0000/0 on worker 10001
19/12/23 15:45:06.537 dispatcher-event-loop-10 INFO Master: Removing executor app-20191223154506-0000/0 because it is FAILED
...
19/12/23 15:45:06.542 dispatcher-event-loop-19 ERROR Master: Application name with ID app-20191223154506-0000 failed 10 times; removing it
```

Given the interval is already tiny, instead of lowering interval, the patch considers above case as well when verifying the status.

### Why are the changes needed?

We observed intermittent test failure in Jenkins build which should be fixed.
https://amplab.cs.berkeley.edu/jenkins/job/SparkPullRequestBuilder/115664/testReport/

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Modified UT.