### PR TITLE
[SPARK-30360][UI] Avoid Redact classpath entries in History Server UI

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -256,13 +256,10 @@ private[spark] class EventLoggingListener(
     // where jvmInformation, sparkProperties, etc. are sequence of tuples.
     // We go through the various  of properties and redact sensitive information from them.
     val noRedactProps = Seq("Classpath Entries")
-    val redactedProps = event.environmentDetails
-      .map {
-        case (name, props) if (noRedactProps.contains(name)) =>
-          name -> props
-        case (name, props) =>
-          name -> Utils.redact(sparkConf, props)
-      }
+    val redactedProps = event.environmentDetails.map {
+      case (name, props) if noRedactProps.contains(name) => name -> props
+      case (name, props) => name -> Utils.redact(sparkConf, props)
+    }
     SparkListenerEnvironmentUpdate(redactedProps)
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -255,9 +255,14 @@ private[spark] class EventLoggingListener(
     // ...
     // where jvmInformation, sparkProperties, etc. are sequence of tuples.
     // We go through the various  of properties and redact sensitive information from them.
-    val redactedProps = event.environmentDetails.map{ case (name, props) =>
-      name -> Utils.redact(sparkConf, props)
-    }
+    val noRedactProps = Seq("Classpath Entries")
+    val redactedProps = event.environmentDetails
+      .map {
+        case (name, props) if (noRedactProps.contains(name)) =>
+          name -> props
+        case (name, props) =>
+          name -> Utils.redact(sparkConf, props)
+      }
     SparkListenerEnvironmentUpdate(redactedProps)
   }
 


### PR DESCRIPTION
Currently SPARK history server display the classpath entries in the Environment tab with classpaths redacted, this is because EventLog file has the entry values redacted while writing. But when same is seen from a running application UI, its seen that it is not redacted. Classpath entries redact is not needed and can be avoided

### What changes were proposed in this pull request?
Event logs will not redect the classpath entries


### Why are the changes needed?
Redact of classpath entries is not needed


### Does this PR introduce any user-facing change?
NO


### How was this patch tested?
Tested manually to verify on UI
