### PR TITLE
[SPARK-29854]lpad and rpad built in function should throw Error or Exception for invalid length value

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -26,6 +26,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.commons.codec.binary.{Base64 => CommonsBase64}
 
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.expressions.codegen._
@@ -1227,6 +1228,19 @@ case class StringLPad(str: Expression, len: Expression, pad: Expression = Litera
   override def dataType: DataType = StringType
   override def inputTypes: Seq[DataType] = Seq(StringType, IntegerType, StringType)
 
+  override def checkInputDataTypes(): TypeCheckResult = {
+    val inputTypeCheck = super.checkInputDataTypes()
+    if (inputTypeCheck.isFailure) {
+      try {
+        if (len != null && len.toString.toInt.isValidInt) inputTypeCheck
+      } catch {
+        case _: NumberFormatException =>
+          throw new AnalysisException(s"Invalid argument, $inputTypeCheck")
+      }
+    }
+    inputTypeCheck
+  }
+
   override def nullSafeEval(str: Any, len: Any, pad: Any): Any = {
     str.asInstanceOf[UTF8String].lpad(len.asInstanceOf[Int], pad.asInstanceOf[UTF8String])
   }
@@ -1267,6 +1281,19 @@ case class StringRPad(str: Expression, len: Expression, pad: Expression = Litera
   override def children: Seq[Expression] = str :: len :: pad :: Nil
   override def dataType: DataType = StringType
   override def inputTypes: Seq[DataType] = Seq(StringType, IntegerType, StringType)
+
+  override def checkInputDataTypes(): TypeCheckResult = {
+    val inputTypeCheck = super.checkInputDataTypes()
+    if (inputTypeCheck.isFailure) {
+      try {
+        if (len != null && len.toString.toInt.isValidInt) inputTypeCheck
+      } catch {
+        case _: NumberFormatException =>
+          throw new AnalysisException(s"Invalid argument, $inputTypeCheck")
+      }
+    }
+    inputTypeCheck
+  }
 
   override def nullSafeEval(str: Any, len: Any, pad: Any): Any = {
     str.asInstanceOf[UTF8String].rpad(len.asInstanceOf[Int], pad.asInstanceOf[UTF8String])

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.expressions.codegen.BufferHolderSparkSubmitSuite.{assert, intercept}
 import org.apache.spark.sql.types._
 
 class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
@@ -720,6 +721,16 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(StringRPad(s1, s2, s3), null, row5)
     checkEvaluation(StringRPad(Literal("hi"), Literal(5)), "hi   ")
     checkEvaluation(StringRPad(Literal("hi"), Literal(1)), "h")
+
+    assert(intercept[AnalysisException] {
+      checkEvaluation(StringRPad(Literal("hi"), Literal("invalidLength")), "Exception")
+    }.getMessage.contains("Invalid argument, TypeCheckFailure(argument 2 " +
+      "requires int type, however, ''invalidLength'' is of string type.);"))
+
+    assert(intercept[AnalysisException] {
+      checkEvaluation(StringLPad(Literal("hi"), Literal("invalidLength")), "Exception")
+    }.getMessage.contains("Invalid argument, TypeCheckFailure(argument 2 " +
+      "requires int type, however, ''invalidLength'' is of string type.);"))
   }
 
   test("REPEAT") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
lpad and rpad built in function should throw Error or Exception for invalid length value Instead of empty string.

### Why are the changes needed?
We should throw Error or Exception message, if user trying to perform LPAD/RPAD operation using invalid argument.

```
SELECT lpad('hi', 'ankit', '?') => ""   <previous behaviours>
SELECT lpad('hi', 'ankit', '?') => "Error in query: Invalid argument, TypeCheckFailure(argument 2 requires int type, however, ''ankit'' is of string type.);"   <After this PR>

SELECT rpad('hi', 'raj', '?') => ""   <previous behaviours>
SELECT lpad('hi', 'raj', '?') => "Error in query: Invalid argument, TypeCheckFailure(argument 2 requires int type, however, ''raj'' is of string type.);"   <After this PR>
```


### Does this PR introduce any user-facing change?
YES
![Screenshot 2019-12-27 at 4 09 46 PM](https://user-images.githubusercontent.com/8948111/71514275-e8577180-28c3-11ea-9d0b-9b4f3027ddeb.png)

![Screenshot 2019-12-27 at 4 15 55 PM](https://user-images.githubusercontent.com/8948111/71514356-37050b80-28c4-11ea-87ab-0406db6d720e.png)
![Screenshot 2019-12-27 at 4 16 52 PM](https://user-images.githubusercontent.com/8948111/71514395-674caa00-28c4-11ea-91dc-37c253f451b0.png)

![Screenshot 2019-12-27 at 4 17 05 PM](https://user-images.githubusercontent.com/8948111/71514392-5dc34200-28c4-11ea-94bd-70d439c5216f.png)


### How was this patch tested?
Added new test case to check invalid length value. 
