### PR TITLE
[SPARK-30132][CORE] Avoid Scala 2.13 compile error by delegating to rather than subclassing Hadoop FS classes

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1072,7 +1072,8 @@ class SparkContext(config: SparkConf) extends Logging {
 
     // This is a hack to enforce loading hdfs-site.xml.
     // See SPARK-11227 for details.
-    FileSystem.getLocal(conf)
+    // Same implementation as FileSystem.getLocal without the cast
+    FileSystem.get(URI.create("file:///"), hadoopConfiguration)
 
     // Add necessary security credentials to the JobConf before broadcasting it.
     SparkHadoopUtil.get.addCredentials(conf)
@@ -1224,7 +1225,8 @@ class SparkContext(config: SparkConf) extends Logging {
 
     // This is a hack to enforce loading hdfs-site.xml.
     // See SPARK-11227 for details.
-    FileSystem.getLocal(hadoopConfiguration)
+    // Same implementation as FileSystem.getLocal without the cast
+    FileSystem.get(URI.create("file:///"), hadoopConfiguration)
 
     // The call to NewHadoopJob automatically adds security credentials to conf,
     // so we don't need to explicitly add them ourselves
@@ -1263,7 +1265,8 @@ class SparkContext(config: SparkConf) extends Logging {
 
     // This is a hack to enforce loading hdfs-site.xml.
     // See SPARK-11227 for details.
-    FileSystem.getLocal(conf)
+    // Same implementation as FileSystem.getLocal without the cast
+    FileSystem.get(URI.create("file:///"), hadoopConfiguration)
 
     // Add necessary security credentials to the JobConf. Required to access secure HDFS.
     val jconf = new JobConf(conf)

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1104,7 +1104,8 @@ class SparkContext(config: SparkConf) extends Logging {
 
     // This is a hack to enforce loading hdfs-site.xml.
     // See SPARK-11227 for details.
-    FileSystem.getLocal(hadoopConfiguration)
+    // Same implementation as FileSystem.getLocal without the cast
+    FileSystem.get(URI.create("file:///"), hadoopConfiguration)
 
     // A Hadoop configuration can be about 10 KiB, which is pretty big, so broadcast it.
     val confBroadcast = broadcast(new SerializableConfiguration(hadoopConfiguration))

--- a/core/src/test/scala/org/apache/spark/DebugFilesystem.scala
+++ b/core/src/test/scala/org/apache/spark/DebugFilesystem.scala
@@ -24,6 +24,7 @@ import java.nio.ByteBuffer
 
 import scala.collection.mutable
 
+import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, FileSystem, FSDataInputStream, FSDataOutputStream,
   LocalFileSystem, Path}
 import org.apache.hadoop.fs.permission.FsPermission
@@ -65,6 +66,7 @@ object DebugFilesystem extends Logging {
  * to check that connections are not leaked.
  */
 // TODO(ekl) we should consider always interposing this to expose num open conns as a metric
+// SPARK-30132: delegation rather than inheritance to work around Scala 2.13 compiler issue
 class DebugFilesystem extends FileSystem {
 
   private val delegateFS = new LocalFileSystem()
@@ -127,6 +129,8 @@ class DebugFilesystem extends FileSystem {
       override def hashCode(): Int = wrapped.hashCode()
     }
   }
+
+  override def initialize(name: URI, conf: Configuration): Unit = delegateFS.initialize(name, conf)
 
   override def create(f: Path, permission: FsPermission, overwrite: Boolean, bufferSize: Int,
       replication: Short, blockSize: Long, progress: Progressable): FSDataOutputStream =

--- a/core/src/test/scala/org/apache/spark/DebugFilesystem.scala
+++ b/core/src/test/scala/org/apache/spark/DebugFilesystem.scala
@@ -130,6 +130,8 @@ class DebugFilesystem extends FileSystem {
     }
   }
 
+  override def setConf(conf: Configuration): Unit = delegateFS.setConf(conf)
+
   override def initialize(name: URI, conf: Configuration): Unit = delegateFS.initialize(name, conf)
 
   override def create(f: Path, permission: FsPermission, overwrite: Boolean, bufferSize: Int,

--- a/core/src/test/scala/org/apache/spark/DebugFilesystem.scala
+++ b/core/src/test/scala/org/apache/spark/DebugFilesystem.scala
@@ -66,9 +66,9 @@ object DebugFilesystem extends Logging {
  */
 // TODO(ekl) we should consider always interposing this to expose num open conns as a metric
 class DebugFilesystem extends FileSystem {
-  
+
   private val delegateFS = new LocalFileSystem()
-  
+
   override def getUri: URI = delegateFS.getUri
 
   override def open(f: Path, bufferSize: Int): FSDataInputStream = {

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -1507,7 +1507,7 @@ object UserClasspathFirstTest {
 }
 
 class TestFileSystem extends FileSystem {
-  
+
   private val delegateFS = new LocalFileSystem()
 
   private def local(path: Path): Path = {
@@ -1520,7 +1520,7 @@ class TestFileSystem extends FileSystem {
     status.setPath(new Path(path))
     status
   }
-  
+
   override def getUri: URI = delegateFS.getUri
 
   override def open(f: Path, bufferSize: Int): FSDataInputStream = delegateFS.open(local(f))

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -1522,6 +1522,8 @@ class TestFileSystem extends FileSystem {
     status
   }
 
+  override def setConf(conf: Configuration): Unit = delegateFS.setConf(conf)
+
   override def initialize(name: URI, conf: Configuration): Unit = delegateFS.initialize(name, conf)
 
   override def getUri: URI = delegateFS.getUri

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -1506,6 +1506,7 @@ object UserClasspathFirstTest {
   }
 }
 
+// SPARK-30132: delegation rather than inheritance to work around Scala 2.13 compiler issue
 class TestFileSystem extends FileSystem {
 
   private val delegateFS = new LocalFileSystem()
@@ -1520,6 +1521,8 @@ class TestFileSystem extends FileSystem {
     status.setPath(new Path(path))
     status
   }
+
+  override def initialize(name: URI, conf: Configuration): Unit = delegateFS.initialize(name, conf)
 
   override def getUri: URI = delegateFS.getUri
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

For some reason, some Hadoop classes themselves cause errors in Scala 2.13 when subclassed. It complains that Hadoop's LocalFileSystem hierarchy for example has an invalid override of `append`, when I'm not sure I see the issue. 

Anyway, rather than potentially wait on a fix, we can simply prefer delegation to subclassing, and other tricks.

### Why are the changes needed?

Cross building for 2.13.

### Does this PR introduce any user-facing change?

No. All changed code is test code.

### How was this patch tested?

Manually ran 2.13 compilation to ensure it fixes the compile issue.
Existing tests will show whether it still works in 2.12.