### PR TITLE
[SPARK-30122][K8S] Support spark.kubernetes.authenticate.executor.serviceAccountName

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -120,7 +120,8 @@ private[spark] object Config extends Logging {
 
   val KUBERNETES_EXECUTOR_SERVICE_ACCOUNT_NAME =
     ConfigBuilder(s"$KUBERNETES_AUTH_EXECUTOR_CONF_PREFIX.serviceAccountName")
-      .doc("Service account that is used when running the executor pod.")
+      .doc("Service account that is used when running the executor pod." +
+        "If this parameter is not setup, the fallback logic will use the driver's service account.")
       .stringConf
       .createOptional
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -109,12 +109,18 @@ private[spark] object Config extends Logging {
       .intConf
       .createWithDefault(10000)
 
-  val KUBERNETES_SERVICE_ACCOUNT_NAME =
+  val KUBERNETES_DRIVER_SERVICE_ACCOUNT_NAME =
     ConfigBuilder(s"$KUBERNETES_AUTH_DRIVER_CONF_PREFIX.serviceAccountName")
       .doc("Service account that is used when running the driver pod. The driver pod uses " +
         "this service account when requesting executor pods from the API server. If specific " +
         "credentials are given for the driver pod to use, the driver will favor " +
         "using those credentials instead.")
+      .stringConf
+      .createOptional
+
+  val KUBERNETES_EXECUTOR_SERVICE_ACCOUNT_NAME =
+    ConfigBuilder(s"$KUBERNETES_AUTH_EXECUTOR_CONF_PREFIX.serviceAccountName")
+      .doc("Service account that is used when running the executor pod.")
       .stringConf
       .createOptional
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/DriverKubernetesCredentialsFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/DriverKubernetesCredentialsFeatureStep.scala
@@ -42,7 +42,7 @@ private[spark] class DriverKubernetesCredentialsFeatureStep(kubernetesConf: Kube
     s"$KUBERNETES_AUTH_DRIVER_MOUNTED_CONF_PREFIX.$CLIENT_CERT_FILE_CONF_SUFFIX")
   private val maybeMountedCaCertFile = kubernetesConf.getOption(
     s"$KUBERNETES_AUTH_DRIVER_MOUNTED_CONF_PREFIX.$CA_CERT_FILE_CONF_SUFFIX")
-  private val driverServiceAccount = kubernetesConf.get(KUBERNETES_SERVICE_ACCOUNT_NAME)
+  private val driverServiceAccount = kubernetesConf.get(KUBERNETES_DRIVER_SERVICE_ACCOUNT_NAME)
 
   private val oauthTokenBase64 = kubernetesConf
     .getOption(s"$KUBERNETES_AUTH_DRIVER_CONF_PREFIX.$OAUTH_TOKEN_CONF_SUFFIX")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/ExecutorKubernetesCredentialsFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/ExecutorKubernetesCredentialsFeatureStep.scala
@@ -17,19 +17,21 @@
 package org.apache.spark.deploy.k8s.features
 
 import org.apache.spark.deploy.k8s.{KubernetesConf, SparkPod}
-import org.apache.spark.deploy.k8s.Config.KUBERNETES_SERVICE_ACCOUNT_NAME
+import org.apache.spark.deploy.k8s.Config.{KUBERNETES_EXECUTOR_SERVICE_ACCOUNT_NAME, KUBERNETES_DRIVER_SERVICE_ACCOUNT_NAME}
 import org.apache.spark.deploy.k8s.KubernetesUtils.buildPodWithServiceAccount
 
 private[spark] class ExecutorKubernetesCredentialsFeatureStep(kubernetesConf: KubernetesConf)
   extends KubernetesFeatureConfigStep {
-  private lazy val driverServiceAccount = kubernetesConf.get(KUBERNETES_SERVICE_ACCOUNT_NAME)
+
+  private lazy val executorServiceAccount =
+    kubernetesConf.get(KUBERNETES_EXECUTOR_SERVICE_ACCOUNT_NAME)
 
   override def configurePod(pod: SparkPod): SparkPod = {
       pod.copy(
         // if not setup by the pod template fallback to the driver's sa,
         // last option is the default sa.
         pod = if (Option(pod.pod.getSpec.getServiceAccount).isEmpty) {
-          buildPodWithServiceAccount(driverServiceAccount, pod).getOrElse(pod.pod)
+          buildPodWithServiceAccount(executorServiceAccount, pod).getOrElse(pod.pod)
         } else {
           pod.pod
         })

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/ExecutorKubernetesCredentialsFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/ExecutorKubernetesCredentialsFeatureStep.scala
@@ -17,12 +17,13 @@
 package org.apache.spark.deploy.k8s.features
 
 import org.apache.spark.deploy.k8s.{KubernetesConf, SparkPod}
-import org.apache.spark.deploy.k8s.Config.KUBERNETES_EXECUTOR_SERVICE_ACCOUNT_NAME
+import org.apache.spark.deploy.k8s.Config.{KUBERNETES_DRIVER_SERVICE_ACCOUNT_NAME, KUBERNETES_EXECUTOR_SERVICE_ACCOUNT_NAME}
 import org.apache.spark.deploy.k8s.KubernetesUtils.buildPodWithServiceAccount
 
 private[spark] class ExecutorKubernetesCredentialsFeatureStep(kubernetesConf: KubernetesConf)
   extends KubernetesFeatureConfigStep {
 
+  private lazy val driverServiceAccount = kubernetesConf.get(KUBERNETES_DRIVER_SERVICE_ACCOUNT_NAME)
   private lazy val executorServiceAccount =
     kubernetesConf.get(KUBERNETES_EXECUTOR_SERVICE_ACCOUNT_NAME)
 
@@ -31,7 +32,8 @@ private[spark] class ExecutorKubernetesCredentialsFeatureStep(kubernetesConf: Ku
         // if not setup by the pod template fallback to the driver's sa,
         // last option is the default sa.
         pod = if (Option(pod.pod.getSpec.getServiceAccount).isEmpty) {
-          buildPodWithServiceAccount(executorServiceAccount, pod).getOrElse(pod.pod)
+          buildPodWithServiceAccount(executorServiceAccount
+            .orElse(driverServiceAccount), pod).getOrElse(pod.pod)
         } else {
           pod.pod
         })

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/ExecutorKubernetesCredentialsFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/ExecutorKubernetesCredentialsFeatureStep.scala
@@ -29,8 +29,8 @@ private[spark] class ExecutorKubernetesCredentialsFeatureStep(kubernetesConf: Ku
 
   override def configurePod(pod: SparkPod): SparkPod = {
       pod.copy(
-        // if not setup by the pod template fallback to the driver's sa,
-        // last option is the default sa.
+        // if not setup by the pod template, fallback to the executor's sa,
+        // if executor's sa is not setup, the last option is driver's sa.
         pod = if (Option(pod.pod.getSpec.getServiceAccount).isEmpty) {
           buildPodWithServiceAccount(executorServiceAccount
             .orElse(driverServiceAccount), pod).getOrElse(pod.pod)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/ExecutorKubernetesCredentialsFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/ExecutorKubernetesCredentialsFeatureStep.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.deploy.k8s.features
 
 import org.apache.spark.deploy.k8s.{KubernetesConf, SparkPod}
-import org.apache.spark.deploy.k8s.Config.{KUBERNETES_EXECUTOR_SERVICE_ACCOUNT_NAME}
+import org.apache.spark.deploy.k8s.Config.KUBERNETES_EXECUTOR_SERVICE_ACCOUNT_NAME
 import org.apache.spark.deploy.k8s.KubernetesUtils.buildPodWithServiceAccount
 
 private[spark] class ExecutorKubernetesCredentialsFeatureStep(kubernetesConf: KubernetesConf)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/ExecutorKubernetesCredentialsFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/ExecutorKubernetesCredentialsFeatureStep.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.deploy.k8s.features
 
 import org.apache.spark.deploy.k8s.{KubernetesConf, SparkPod}
-import org.apache.spark.deploy.k8s.Config.{KUBERNETES_EXECUTOR_SERVICE_ACCOUNT_NAME, KUBERNETES_DRIVER_SERVICE_ACCOUNT_NAME}
+import org.apache.spark.deploy.k8s.Config.{KUBERNETES_EXECUTOR_SERVICE_ACCOUNT_NAME}
 import org.apache.spark.deploy.k8s.KubernetesUtils.buildPodWithServiceAccount
 
 private[spark] class ExecutorKubernetesCredentialsFeatureStep(kubernetesConf: KubernetesConf)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/ExecutorKubernetesCredentialsFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/ExecutorKubernetesCredentialsFeatureStepSuite.scala
@@ -22,7 +22,7 @@ import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.deploy.k8s.{KubernetesExecutorConf, KubernetesTestConf, SparkPod}
 import org.apache.spark.deploy.k8s.Config._
 
-class ExecutorKubernetesCredentialsFeatureStepTest extends SparkFunSuite with BeforeAndAfter {
+class ExecutorKubernetesCredentialsFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
 
   private var baseConf: SparkConf = _
 
@@ -30,8 +30,8 @@ class ExecutorKubernetesCredentialsFeatureStepTest extends SparkFunSuite with Be
     baseConf = new SparkConf(false)
   }
 
-  private def newExecutorConf(
-          environment: Map[String, String] = Map.empty): KubernetesExecutorConf = {
+  private def newExecutorConf(environment: Map[String, String] = Map.empty):
+  KubernetesExecutorConf = {
     KubernetesTestConf.createExecutorConf(
       sparkConf = baseConf,
       environment = environment)
@@ -47,8 +47,7 @@ class ExecutorKubernetesCredentialsFeatureStepTest extends SparkFunSuite with Be
 
     val serviceAccountName = spec.getServiceAccountName
     val accountName = spec.getServiceAccount
-    assert(serviceAccountName.equals("executor-name"))
-    assert(accountName.equals("executor-name"))
+    assertSAName(serviceAccountName, accountName)
   }
 
   test("configure spark pod with with driver service account " +
@@ -62,8 +61,7 @@ class ExecutorKubernetesCredentialsFeatureStepTest extends SparkFunSuite with Be
 
     val serviceAccountName = spec.getServiceAccountName
     val accountName = spec.getServiceAccount
-    assert(serviceAccountName.equals("driver-name"))
-    assert(accountName.equals("driver-name"))
+    assertSAName(serviceAccountName, accountName)
   }
 
   test("configure spark pod with with driver service account " +
@@ -79,7 +77,11 @@ class ExecutorKubernetesCredentialsFeatureStepTest extends SparkFunSuite with Be
 
     val serviceAccountName = spec.getServiceAccountName
     val accountName = spec.getServiceAccount
-    assert(serviceAccountName.equals("executor-name"))
-    assert(accountName.equals("executor-name"))
+    assertSAName(serviceAccountName, accountName)
+  }
+
+  def assertSAName(serviceAccountName: String, accountName: String): Unit = {
+    assert(serviceAccountName.equals(serviceAccountName))
+    assert(accountName.equals(accountName))
   }
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/ExecutorKubernetesCredentialsFeatureStepTest.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/ExecutorKubernetesCredentialsFeatureStepTest.scala
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.k8s.features
+
+import org.scalatest.BeforeAndAfter
+
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.deploy.k8s.{KubernetesExecutorConf, KubernetesTestConf, SparkPod}
+import org.apache.spark.deploy.k8s.Config._
+
+class ExecutorKubernetesCredentialsFeatureStepTest extends SparkFunSuite with BeforeAndAfter {
+
+  private var baseConf: SparkConf = _
+
+  before {
+    baseConf = new SparkConf(false)
+  }
+
+  private def newExecutorConf(
+          environment: Map[String, String] = Map.empty): KubernetesExecutorConf = {
+    KubernetesTestConf.createExecutorConf(
+      sparkConf = baseConf,
+      environment = environment)
+  }
+
+  test("configure spark pod with executor service account") {
+    baseConf.set(KUBERNETES_EXECUTOR_SERVICE_ACCOUNT_NAME, "executor-name")
+    val step = new ExecutorKubernetesCredentialsFeatureStep(newExecutorConf())
+    val spec = step
+      .configurePod(SparkPod.initialPod())
+      .pod
+      .getSpec
+
+    val serviceAccountName = spec.getServiceAccountName
+    val accountName = spec.getServiceAccount
+    assert(serviceAccountName.equals("executor-name"))
+    assert(accountName.equals("executor-name"))
+  }
+
+  test("configure spark pod with with driver service account " +
+    "and without executor service account") {
+    baseConf.set(KUBERNETES_DRIVER_SERVICE_ACCOUNT_NAME, "driver-name")
+    val step = new ExecutorKubernetesCredentialsFeatureStep(newExecutorConf())
+    val spec = step
+      .configurePod(SparkPod.initialPod())
+      .pod
+      .getSpec
+
+    val serviceAccountName = spec.getServiceAccountName
+    val accountName = spec.getServiceAccount
+    assert(serviceAccountName.equals("driver-name"))
+    assert(accountName.equals("driver-name"))
+  }
+
+  test("configure spark pod with with driver service account " +
+    "and with executor service account") {
+    baseConf.set(KUBERNETES_DRIVER_SERVICE_ACCOUNT_NAME, "driver-name")
+    baseConf.set(KUBERNETES_EXECUTOR_SERVICE_ACCOUNT_NAME, "executor-name")
+
+    val step = new ExecutorKubernetesCredentialsFeatureStep(newExecutorConf())
+    val spec = step
+      .configurePod(SparkPod.initialPod())
+      .pod
+      .getSpec
+
+    val serviceAccountName = spec.getServiceAccountName
+    val accountName = spec.getServiceAccount
+    assert(serviceAccountName.equals("executor-name"))
+    assert(accountName.equals("executor-name"))
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Currently, it doesn't seem to be possible to have Spark Driver set the serviceAccountName for executor pods it launches.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
it will allow settings serviceAccountName for executors pods.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
It was covered by unit test. 