### PR TITLE
[SPARK-25061][SQL] Precedence for ThriftServer hiveconf commandline parameter

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -176,7 +176,12 @@ private[hive] class HiveClientImpl(
     // is not set to builtin. When spark.sql.hive.metastore.jars is builtin, the classpath
     // has hive-site.xml. So, HiveConf will use that to override its default values.
     // 2: we set all spark confs to this hiveConf.
-    // 3: we set all entries in config to this hiveConf.
+    // 3: we take the conf passed as --hiveconf which would be set as system properties
+    // by org.apache.hive.service.server.HiveServer2.ServerOptionsProcessor.parse in
+    // org.apache.spark.sql.hive.thriftserver.HiveThriftServer2.main.
+    // 4: we set all entries in extraConfig to this hiveConf which have the highest precedence.
+    // To summarize, the order of precedence will be
+    // hadoopConf < sparkConf < overrideProps < extraConfig
 
     // not to lose command line overwritten properties
     // make a copy overridden props so that it can be reinserted finally

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -178,13 +178,12 @@ private[hive] class HiveClientImpl(
     // 2: we set all spark confs to this hiveConf.
     // 3: we set all entries in config to this hiveConf.
 
-    // not to loose command line overwritten properties
+    // not to lose command line overwritten properties
     // make a copy overridden props so that it can be reinserted finally
     val overriddenHiveProps = HiveConf.getConfSystemProperties.asScala
     val confMap = (hadoopConf.iterator().asScala.map(kv => kv.getKey -> kv.getValue) ++
-      sparkConf.getAll.toMap ++ extraConfig).toMap
+      sparkConf.getAll.toMap ++ overriddenHiveProps ++ extraConfig).toMap
     confMap.foreach { case (k, v) => hiveConf.set(k, v) }
-    overriddenHiveProps.foreach { case (k, v) => hiveConf.set(k, v) }
     SQLConf.get.redactOptions(confMap).foreach { case (k, v) =>
       logDebug(
         s"""

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -177,9 +177,14 @@ private[hive] class HiveClientImpl(
     // has hive-site.xml. So, HiveConf will use that to override its default values.
     // 2: we set all spark confs to this hiveConf.
     // 3: we set all entries in config to this hiveConf.
+
+    // not to loose command line overwritten properties
+    // make a copy overridden props so that it can be reinserted finally
+    val overriddenHiveProps = HiveConf.getConfSystemProperties.asScala
     val confMap = (hadoopConf.iterator().asScala.map(kv => kv.getKey -> kv.getValue) ++
       sparkConf.getAll.toMap ++ extraConfig).toMap
     confMap.foreach { case (k, v) => hiveConf.set(k, v) }
+    overriddenHiveProps.foreach { case (k, v) => hiveConf.set(k, v) }
     SQLConf.get.redactOptions(confMap).foreach { case (k, v) =>
       logDebug(
         s"""

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -185,6 +185,9 @@ private[hive] class HiveClientImpl(
 
     // not to lose command line overwritten properties
     // make a copy overridden props so that it can be reinserted finally
+    // HiveConf.getConfSystemProperties returns all the system properties
+    // which were considered on creation of HiveConf constructor
+    // Refer: org.apache.hadoop.hive.conf.HiveConf#applySystemProperties
     val overriddenHiveProps = HiveConf.getConfSystemProperties.asScala
     val confMap = (hadoopConf.iterator().asScala.map(kv => kv.getKey -> kv.getValue) ++
       sparkConf.getAll.toMap ++ overriddenHiveProps ++ extraConfig).toMap


### PR DESCRIPTION
### What changes were proposed in this pull request?
In `HiveClientImpl.scala` when we create new SessionState, we prepare configuration and the options passed to `start-thriftserver.sh` via  `--hiveConf` need to take precedence when creating `HiveConf`  i.e  in order 
`hadoopConf < sparkConf < overrideProps(--hiveconf) < extraConfig`

### Why are the changes needed?
As per the documentation here, https://spark.apache.org/docs/latest/sql-distributed-sql-engine.html user can provide `--hiveconf` to override the hive configurations when using `start-thriftserver.sh` but as per the code, https://github.com/apache/spark/blob/master/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala#L182 here, the hive-site properties (part of hadoopConf) will override the configuration done from command line which is not as per expectation

### Does this PR introduce any user-facing change?
No


### How was this patch tested?
Added UT along with Base UTs can Pass