### PR TITLE
[SPARK-30384][WEBUI]Needs to improve the Column name and Add tooltips for the Fair Scheduler Pool Table

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/jobs/PoolTable.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/PoolTable.scala
@@ -34,11 +34,17 @@ private[ui] class PoolTable(pools: Map[Schedulable, PoolData], parent: StagesTab
     <table class="table table-bordered table-striped table-condensed sortable table-fixed">
       <thead>
         <th>Pool Name</th>
-        <th>Minimum Share</th>
-        <th>Pool Weight</th>
+        <th>
+          <span data-toggle="tooltip" data-placement="top" title="Pool's minimum share of CPU
+           cores">Minimum Share</span>
+        </th>
+        <th>
+          <span data-toggle="tooltip" data-placement="top" title="Pool's share of cluster resources
+           relative to others pools">Pool Weight</span>
+        </th>
         <th>Active Stages</th>
         <th>Running Tasks</th>
-        <th>SchedulingMode</th>
+        <th>Scheduling Mode</th>
       </thead>
       <tbody>
         {pools.map { case (s, p) => poolRow(request, s, p) }}

--- a/core/src/main/scala/org/apache/spark/ui/jobs/PoolTable.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/PoolTable.scala
@@ -40,7 +40,7 @@ private[ui] class PoolTable(pools: Map[Schedulable, PoolData], parent: StagesTab
         </th>
         <th>
           <span data-toggle="tooltip" data-placement="top" title="Pool's share of cluster resources
-           relative to others pools">Pool Weight</span>
+           relative to others">Pool Weight</span>
         </th>
         <th>Active Stages</th>
         <th>Running Tasks</th>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Needs to improve the Column name and tooltips for the Fair Scheduler Pool Table.

### Why are the changes needed?
Need to correct SchedulingMode  column name to  -> 'Scheduling Mode' and tooltips need to add for Minimum Share, Pool Weight and Scheduling Mode (require meaning full Tool tips for the end user to understand.)

### Does this PR introduce any user-facing change?
YES
![Screenshot 2020-01-03 at 10 10 47 AM](https://user-images.githubusercontent.com/8948111/71707687-7aee9800-2e11-11ea-93cc-52df0b9114dd.png)


### How was this patch tested?
Manual Testing.
