### PR TITLE
[SPARK-30389][SQL]Validate file type extension during add jar command.

### DIFF
--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -28,7 +28,7 @@ import com.google.common.io.Files
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.{BytesWritable, LongWritable, Text}
-import org.apache.hadoop.mapred.TextInputFormat
+import org.apache.hadoop.mapred.{InvalidFileTypeException, TextInputFormat}
 import org.apache.hadoop.mapreduce.lib.input.{TextInputFormat => NewTextInputFormat}
 import org.json4s.{DefaultFormats, Extraction}
 import org.scalatest.Matchers._
@@ -345,6 +345,25 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
        } finally {
          sc.stop()
        }
+    }
+  }
+
+  test("add jar with unsupported file extension") {
+    withTempDir { dir =>
+      try {
+        val sep = File.separator
+        val tmpDir = Utils.createTempDir(dir.getAbsolutePath + sep + "test space")
+        val tmpJar = File.createTempFile("test", ".csv", tmpDir)
+
+        sc = new SparkContext(new SparkConf().setAppName("test").setMaster("local"))
+
+        assert(intercept[InvalidFileTypeException] {
+          sc.addJar(tmpJar.getAbsolutePath)
+      }.getMessage.contains("Unsupported file type extension CSV, please add .jar extension file"))
+
+      } finally {
+        sc.stop()
+      }
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add jar should not allow to add other format except jar file.

### Why are the changes needed?
As per the Documentation of ADD Jar, we should only allow .jar extension file to be added using ADD JAR command, other type of extension file we should not allow (should throw InvalidFileTypeException).


### Does this PR introduce any user-facing change?
YES

![Screenshot 2019-12-30 at 7 33 02 PM](https://user-images.githubusercontent.com/8948111/71585368-4db59780-2b3c-11ea-930b-475d6c4e44c5.png)

![Screenshot 2019-12-30 at 7 34 55 PM](https://user-images.githubusercontent.com/8948111/71585384-5a39f000-2b3c-11ea-9908-102a699d9c6c.png)


### How was this patch tested?
added new test cases.


