### PR TITLE
[SPARK-30394]Skip DetermineTableStats rule when hive table can be converted to datasource table

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -382,11 +382,9 @@ case class DataSource(
           catalogTable.isDefined && catalogTable.get.tracksPartitionsInCatalog &&
           catalogTable.get.partitionColumnNames.nonEmpty
         val (fileCatalog, dataSchema, partitionSchema) = if (useCatalogFileIndex) {
-          val defaultTableSize = sparkSession.sessionState.conf.defaultSizeInBytes
           val index = new CatalogFileIndex(
             sparkSession,
-            catalogTable.get,
-            catalogTable.get.stats.map(_.sizeInBytes.toLong).getOrElse(defaultTableSize))
+            catalogTable.get)
           (index, catalogTable.get.dataSchema, catalogTable.get.partitionSchema)
         } else {
           val globbedPaths = checkAndGlobPathIfNecessary(

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -197,9 +197,8 @@ private[hive] class HiveMetastoreCatalog(sparkSession: SparkSession) extends Log
           Some(partitionSchema))
 
         val logicalRelation = cached.getOrElse {
-          val sizeInBytes = relation.stats.sizeInBytes.toLong
           val fileIndex = {
-            val index = new CatalogFileIndex(sparkSession, relation.tableMeta, sizeInBytes)
+            val index = new CatalogFileIndex(sparkSession, relation.tableMeta)
             if (lazyPruningEnabled) {
               index
             } else {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/CachedTableSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/CachedTableSuite.scala
@@ -320,7 +320,7 @@ class CachedTableSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
     withTable("test") {
       sql("CREATE TABLE test(i int) PARTITIONED BY (p int) STORED AS parquet")
       val tableMeta = spark.sharedState.externalCatalog.getTable("default", "test")
-      val catalogFileIndex = new CatalogFileIndex(spark, tableMeta, 0)
+      val catalogFileIndex = new CatalogFileIndex(spark, tableMeta)
 
       val dataSchema = StructType(tableMeta.schema.filterNot { f =>
         tableMeta.partitionColumnNames.contains(f.name)
@@ -338,7 +338,7 @@ class CachedTableSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
 
       assert(spark.sharedState.cacheManager.lookupCachedData(plan).isDefined)
 
-      val sameCatalog = new CatalogFileIndex(spark, tableMeta, 0)
+      val sameCatalog = new CatalogFileIndex(spark, tableMeta)
       val sameRelation = HadoopFsRelation(
         location = sameCatalog,
         partitionSchema = tableMeta.partitionSchema,

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/PruneFileSourcePartitionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/PruneFileSourcePartitionsSuite.scala
@@ -51,7 +51,7 @@ class PruneFileSourcePartitionsSuite extends QueryTest with SQLTestUtils with Te
             |LOCATION '${dir.toURI}'""".stripMargin)
 
         val tableMeta = spark.sharedState.externalCatalog.getTable("default", "test")
-        val catalogFileIndex = new CatalogFileIndex(spark, tableMeta, 0)
+        val catalogFileIndex = new CatalogFileIndex(spark, tableMeta)
 
         val dataSchema = StructType(tableMeta.schema.filterNot { f =>
           tableMeta.partitionColumnNames.contains(f.name)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently,  the sizeInBytes of HiveTableRelation will be `defaultSizeInBytes`(Long.MaxValue) if `spark.sql.statistics.fallBackToHdfs` not enabled, and there are risks that Long type overflows when we set `spark.sql.sources.fileCompressionFactor` to a value greater than 1.

https://github.com/apache/spark/blob/cb9fc4bb6ffe542e526a6006582606eb709fb311/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelation.scala#L72

This PR will bring three major improvements:
1.  Skip `DetermineTableStats` rule when hive table can be converted to datasource table, and compute the stats on demand in HadoopFsRelation. This size estimation can be more accurate for columnar-based files like parquet.
2. It solves the overflows issue. 
3. It make the code path for sizeEstimation consistent. This will do the estimation on demand just like  what the `PruneFileSourcePartitions` may do.

### Why are the changes needed?
This PR fix potential bugs and bring some other benefits.

### Does this PR introduce any user-facing change?
No


### How was this patch tested?
UT & test on real clusters
