### PR TITLE
[SPARK-30398][ML] PCA/RegressionMetrics/RowMatrix avoid unnecessary computation

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LinearSVC.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LinearSVC.scala
@@ -32,7 +32,7 @@ import org.apache.spark.ml.optim.aggregator.HingeAggregator
 import org.apache.spark.ml.optim.loss.{L2Regularization, RDDLossFunction}
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared._
-import org.apache.spark.ml.stat.SummaryBuilderImpl._
+import org.apache.spark.ml.stat._
 import org.apache.spark.ml.util._
 import org.apache.spark.ml.util.Instrumentation.instrumented
 import org.apache.spark.sql.{Dataset, Row}
@@ -170,7 +170,7 @@ class LinearSVC @Since("2.2.0") (
       regParam, maxIter, fitIntercept, tol, standardization, threshold, aggregationDepth)
 
     val (summarizer, labelSummarizer) = instances.treeAggregate(
-      (createSummarizerBuffer("mean", "std", "count"), new MultiClassSummarizer))(
+      (Summarizer.createSummarizerBuffer("mean", "std", "count"), new MultiClassSummarizer))(
       seqOp = (c: (SummarizerBuffer, MultiClassSummarizer), instance: Instance) =>
         (c._1.add(instance.features, instance.weight), c._2.add(instance.label, instance.weight)),
       combOp = (c1: (SummarizerBuffer, MultiClassSummarizer),

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -34,7 +34,7 @@ import org.apache.spark.ml.optim.aggregator.LogisticAggregator
 import org.apache.spark.ml.optim.loss.{L2Regularization, RDDLossFunction}
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared._
-import org.apache.spark.ml.stat.SummaryBuilderImpl._
+import org.apache.spark.ml.stat._
 import org.apache.spark.ml.util._
 import org.apache.spark.ml.util.Instrumentation.instrumented
 import org.apache.spark.mllib.evaluation.{BinaryClassificationMetrics, MulticlassMetrics}
@@ -501,7 +501,7 @@ class LogisticRegression @Since("1.2.0") (
       fitIntercept)
 
     val (summarizer, labelSummarizer) = instances.treeAggregate(
-      (createSummarizerBuffer("mean", "std", "count"), new MultiClassSummarizer))(
+      (Summarizer.createSummarizerBuffer("mean", "std", "count"), new MultiClassSummarizer))(
       seqOp = (c: (SummarizerBuffer, MultiClassSummarizer), instance: Instance) =>
         (c._1.add(instance.features, instance.weight), c._2.add(instance.label, instance.weight)),
       combOp = (c1: (SummarizerBuffer, MultiClassSummarizer),

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
@@ -31,7 +31,7 @@ import org.apache.spark.ml.{Estimator, Model}
 import org.apache.spark.ml.linalg.{BLAS, Vector, Vectors, VectorUDT}
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared._
-import org.apache.spark.ml.stat.SummaryBuilderImpl._
+import org.apache.spark.ml.stat._
 import org.apache.spark.ml.util._
 import org.apache.spark.ml.util.Instrumentation.instrumented
 import org.apache.spark.mllib.util.MLUtils
@@ -215,7 +215,7 @@ class AFTSurvivalRegression @Since("1.6.0") (@Since("1.6.0") override val uid: S
     if (handlePersistence) instances.persist(StorageLevel.MEMORY_AND_DISK)
 
     val featuresSummarizer = instances.treeAggregate(
-      createSummarizerBuffer("mean", "std", "count"))(
+      Summarizer.createSummarizerBuffer("mean", "std", "count"))(
       seqOp = (c: SummarizerBuffer, v: AFTPoint) => c.add(v.features),
       combOp = (c1: SummarizerBuffer, c2: SummarizerBuffer) => c1.merge(c2),
       depth = $(aggregationDepth)

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
@@ -36,7 +36,7 @@ import org.apache.spark.ml.optim.aggregator.{HuberAggregator, LeastSquaresAggreg
 import org.apache.spark.ml.optim.loss.{L2Regularization, RDDLossFunction}
 import org.apache.spark.ml.param.{DoubleParam, Param, ParamMap, ParamValidators}
 import org.apache.spark.ml.param.shared._
-import org.apache.spark.ml.stat.SummaryBuilderImpl._
+import org.apache.spark.ml.stat._
 import org.apache.spark.ml.util._
 import org.apache.spark.ml.util.Instrumentation.instrumented
 import org.apache.spark.mllib.evaluation.RegressionMetrics
@@ -358,8 +358,8 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
     if (handlePersistence) instances.persist(StorageLevel.MEMORY_AND_DISK)
 
     val (featuresSummarizer, ySummarizer) = instances.treeAggregate(
-      (createSummarizerBuffer("mean", "std"),
-        createSummarizerBuffer("mean", "std", "count")))(
+      (Summarizer.createSummarizerBuffer("mean", "std"),
+        Summarizer.createSummarizerBuffer("mean", "std", "count")))(
       seqOp = (c: (SummarizerBuffer, SummarizerBuffer), instance: Instance) =>
         (c._1.add(instance.features, instance.weight),
           c._2.add(Vectors.dense(instance.label), instance.weight)),

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/Summarizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/Summarizer.scala
@@ -197,6 +197,11 @@ object Summarizer extends Logging {
     val c1 = metrics(metric).summary(col, weightCol)
     c1.getField(metric).as(s"$metric($col)")
   }
+
+  private[spark] def createSummarizerBuffer(requested: String*): SummarizerBuffer = {
+    val (metrics, computeMetrics) = getRelevantMetrics(requested)
+    new SummarizerBuffer(metrics, computeMetrics)
+  }
 }
 
 private[ml] class SummaryBuilderImpl(
@@ -246,11 +251,6 @@ private[spark] object SummaryBuilderImpl extends Logging {
       StructField(name, dataType, nullable = false)
     }
     StructType(fields)
-  }
-
-  private[spark] def createSummarizerBuffer(requested: String*): SummarizerBuffer = {
-    val (metrics, computeMetrics) = getRelevantMetrics(requested)
-    new SummarizerBuffer(metrics, computeMetrics)
   }
 
   private val vectorUDT = new VectorUDT
@@ -304,333 +304,6 @@ private[spark] object SummaryBuilderImpl extends Logging {
   private[stat] case object ComputeMax extends ComputeMetric
   private[stat] case object ComputeMin extends ComputeMetric
 
-  private[spark] class SummarizerBuffer(
-      requestedMetrics: Seq[Metric],
-      requestedCompMetrics: Seq[ComputeMetric]
-  ) extends Serializable {
-
-    private var n = 0
-    private var currMean: Array[Double] = null
-    private var currM2n: Array[Double] = null
-    private var currM2: Array[Double] = null
-    private var currL1: Array[Double] = null
-    private var totalCnt: Long = 0
-    private var totalWeightSum: Double = 0.0
-    private var weightSquareSum: Double = 0.0
-    private var currWeightSum: Array[Double] = null
-    private var nnz: Array[Long] = null
-    private var currMax: Array[Double] = null
-    private var currMin: Array[Double] = null
-
-    def this() {
-      this(
-        Seq(Mean, Sum, Variance, Std, Count, NumNonZeros,
-          Max, Min, NormL2, NormL1),
-        Seq(ComputeMean, ComputeM2n, ComputeM2, ComputeL1,
-          ComputeWeightSum, ComputeNNZ, ComputeMax, ComputeMin)
-      )
-    }
-
-    def add(nonZeroIterator: Iterator[(Int, Double)], size: Int, weight: Double): this.type = {
-      require(weight >= 0.0, s"sample weight, $weight has to be >= 0.0")
-      if (weight == 0.0) return this
-
-      if (n == 0) {
-        require(size > 0, s"Vector should have dimension larger than zero.")
-        n = size
-
-        if (requestedCompMetrics.contains(ComputeMean)) { currMean = Array.ofDim[Double](n) }
-        if (requestedCompMetrics.contains(ComputeM2n)) { currM2n = Array.ofDim[Double](n) }
-        if (requestedCompMetrics.contains(ComputeM2)) { currM2 = Array.ofDim[Double](n) }
-        if (requestedCompMetrics.contains(ComputeL1)) { currL1 = Array.ofDim[Double](n) }
-        if (requestedCompMetrics.contains(ComputeWeightSum)) {
-          currWeightSum = Array.ofDim[Double](n)
-        }
-        if (requestedCompMetrics.contains(ComputeNNZ)) { nnz = Array.ofDim[Long](n) }
-        if (requestedCompMetrics.contains(ComputeMax)) {
-          currMax = Array.fill[Double](n)(Double.MinValue)
-        }
-        if (requestedCompMetrics.contains(ComputeMin)) {
-          currMin = Array.fill[Double](n)(Double.MaxValue)
-        }
-      }
-
-      require(n == size, s"Dimensions mismatch when adding new sample." +
-        s" Expecting $n but got $size.")
-
-      if (nonZeroIterator.nonEmpty) {
-        val localCurrMean = currMean
-        val localCurrM2n = currM2n
-        val localCurrM2 = currM2
-        val localCurrL1 = currL1
-        val localCurrWeightSum = currWeightSum
-        val localNumNonzeros = nnz
-        val localCurrMax = currMax
-        val localCurrMin = currMin
-        nonZeroIterator.foreach { case (index, value) =>
-          if (localCurrMax != null && localCurrMax(index) < value) {
-            localCurrMax(index) = value
-          }
-          if (localCurrMin != null && localCurrMin(index) > value) {
-            localCurrMin(index) = value
-          }
-
-          if (localCurrWeightSum != null) {
-            if (localCurrMean != null) {
-              val prevMean = localCurrMean(index)
-              val diff = value - prevMean
-              localCurrMean(index) = prevMean +
-                weight * diff / (localCurrWeightSum(index) + weight)
-
-              if (localCurrM2n != null) {
-                localCurrM2n(index) += weight * (value - localCurrMean(index)) * diff
-              }
-            }
-            localCurrWeightSum(index) += weight
-          }
-
-          if (localCurrM2 != null) {
-            localCurrM2(index) += weight * value * value
-          }
-          if (localCurrL1 != null) {
-            localCurrL1(index) += weight * math.abs(value)
-          }
-
-          if (localNumNonzeros != null) {
-            localNumNonzeros(index) += 1
-          }
-        }
-      }
-
-      totalWeightSum += weight
-      weightSquareSum += weight * weight
-      totalCnt += 1
-      this
-    }
-
-    /**
-     * Add a new sample to this summarizer, and update the statistical summary.
-     */
-    def add(instance: Vector, weight: Double): this.type =
-      add(instance.nonZeroIterator, instance.size, weight)
-
-    def add(instance: Vector): this.type = add(instance, 1.0)
-
-    /**
-     * Merge another SummarizerBuffer, and update the statistical summary.
-     * (Note that it's in place merging; as a result, `this` object will be modified.)
-     *
-     * @param other The other MultivariateOnlineSummarizer to be merged.
-     */
-    def merge(other: SummarizerBuffer): this.type = {
-      if (this.totalWeightSum != 0.0 && other.totalWeightSum != 0.0) {
-        require(n == other.n, s"Dimensions mismatch when merging with another summarizer. " +
-          s"Expecting $n but got ${other.n}.")
-        totalCnt += other.totalCnt
-        totalWeightSum += other.totalWeightSum
-        weightSquareSum += other.weightSquareSum
-        var i = 0
-        while (i < n) {
-          if (currWeightSum != null) {
-            val thisWeightSum = currWeightSum(i)
-            val otherWeightSum = other.currWeightSum(i)
-            val totalWeightSum = thisWeightSum + otherWeightSum
-
-            if (totalWeightSum != 0.0) {
-              if (currMean != null) {
-                val deltaMean = other.currMean(i) - currMean(i)
-                // merge mean together
-                currMean(i) += deltaMean * otherWeightSum / totalWeightSum
-
-                if (currM2n != null) {
-                  // merge m2n together
-                  currM2n(i) += other.currM2n(i) +
-                    deltaMean * deltaMean * thisWeightSum * otherWeightSum / totalWeightSum
-                }
-              }
-            }
-            currWeightSum(i) = totalWeightSum
-          }
-
-          // merge m2 together
-          if (currM2 != null) { currM2(i) += other.currM2(i) }
-          // merge l1 together
-          if (currL1 != null) { currL1(i) += other.currL1(i) }
-          // merge max and min
-          if (currMax != null) { currMax(i) = math.max(currMax(i), other.currMax(i)) }
-          if (currMin != null) { currMin(i) = math.min(currMin(i), other.currMin(i)) }
-          if (nnz != null) { nnz(i) = nnz(i) + other.nnz(i) }
-          i += 1
-        }
-      } else if (totalWeightSum == 0.0 && other.totalWeightSum != 0.0) {
-        this.n = other.n
-        if (other.currMean != null) { this.currMean = other.currMean.clone() }
-        if (other.currM2n != null) { this.currM2n = other.currM2n.clone() }
-        if (other.currM2 != null) { this.currM2 = other.currM2.clone() }
-        if (other.currL1 != null) { this.currL1 = other.currL1.clone() }
-        this.totalCnt = other.totalCnt
-        this.totalWeightSum = other.totalWeightSum
-        this.weightSquareSum = other.weightSquareSum
-        if (other.currWeightSum != null) { this.currWeightSum = other.currWeightSum.clone() }
-        if (other.nnz != null) { this.nnz = other.nnz.clone() }
-        if (other.currMax != null) { this.currMax = other.currMax.clone() }
-        if (other.currMin != null) { this.currMin = other.currMin.clone() }
-      }
-      this
-    }
-
-    /**
-     * Sample mean of each dimension.
-     */
-    def mean: Vector = {
-      require(requestedMetrics.contains(Mean))
-      require(totalWeightSum > 0, s"Nothing has been added to this summarizer.")
-
-      val realMean = Array.ofDim[Double](n)
-      var i = 0
-      while (i < n) {
-        realMean(i) = currMean(i) * (currWeightSum(i) / totalWeightSum)
-        i += 1
-      }
-      Vectors.dense(realMean)
-    }
-
-    /**
-     * Sum of each dimension.
-     */
-    def sum: Vector = {
-      require(requestedMetrics.contains(Sum))
-      require(totalWeightSum > 0, s"Nothing has been added to this summarizer.")
-
-      val realSum = Array.ofDim[Double](n)
-      var i = 0
-      while (i < n) {
-        realSum(i) = currMean(i) * currWeightSum(i)
-        i += 1
-      }
-      Vectors.dense(realSum)
-    }
-
-    /**
-     * Unbiased estimate of sample variance of each dimension.
-     */
-    def variance: Vector = {
-      require(requestedMetrics.contains(Variance))
-      require(totalWeightSum > 0, s"Nothing has been added to this summarizer.")
-
-      val realVariance = computeVariance
-      Vectors.dense(realVariance)
-    }
-
-    /**
-     * Unbiased estimate of standard deviation of each dimension.
-     */
-    def std: Vector = {
-      require(requestedMetrics.contains(Std))
-      require(totalWeightSum > 0, s"Nothing has been added to this summarizer.")
-
-      val realVariance = computeVariance
-      Vectors.dense(realVariance.map(math.sqrt))
-    }
-
-    private def computeVariance: Array[Double] = {
-      val realVariance = Array.ofDim[Double](n)
-      val denominator = totalWeightSum - (weightSquareSum / totalWeightSum)
-
-      // Sample variance is computed, if the denominator is less than 0, the variance is just 0.
-      if (denominator > 0.0) {
-        val deltaMean = currMean
-        var i = 0
-        val len = currM2n.length
-        while (i < len) {
-          // We prevent variance from negative value caused by numerical error.
-          realVariance(i) = math.max((currM2n(i) + deltaMean(i) * deltaMean(i) * currWeightSum(i) *
-            (totalWeightSum - currWeightSum(i)) / totalWeightSum) / denominator, 0.0)
-          i += 1
-        }
-      }
-      realVariance
-    }
-
-    /**
-     * Sample size.
-     */
-    def count: Long = totalCnt
-
-    /**
-     * Sum of weights.
-     */
-    def weightSum: Double = totalWeightSum
-
-    /**
-     * Number of nonzero elements in each dimension.
-     *
-     */
-    def numNonzeros: Vector = {
-      require(requestedMetrics.contains(NumNonZeros))
-      require(totalCnt > 0, s"Nothing has been added to this summarizer.")
-
-      Vectors.dense(nnz.map(_.toDouble))
-    }
-
-    /**
-     * Maximum value of each dimension.
-     */
-    def max: Vector = {
-      require(requestedMetrics.contains(Max))
-      require(totalWeightSum > 0, s"Nothing has been added to this summarizer.")
-
-      var i = 0
-      while (i < n) {
-        if ((nnz(i) < totalCnt) && (currMax(i) < 0.0)) currMax(i) = 0.0
-        i += 1
-      }
-      Vectors.dense(currMax)
-    }
-
-    /**
-     * Minimum value of each dimension.
-     */
-    def min: Vector = {
-      require(requestedMetrics.contains(Min))
-      require(totalWeightSum > 0, s"Nothing has been added to this summarizer.")
-
-      var i = 0
-      while (i < n) {
-        if ((nnz(i) < totalCnt) && (currMin(i) > 0.0)) currMin(i) = 0.0
-        i += 1
-      }
-      Vectors.dense(currMin)
-    }
-
-    /**
-     * L2 (Euclidean) norm of each dimension.
-     */
-    def normL2: Vector = {
-      require(requestedMetrics.contains(NormL2))
-      require(totalWeightSum > 0, s"Nothing has been added to this summarizer.")
-
-      val realMagnitude = Array.ofDim[Double](n)
-
-      var i = 0
-      val len = currM2.length
-      while (i < len) {
-        realMagnitude(i) = math.sqrt(currM2(i))
-        i += 1
-      }
-      Vectors.dense(realMagnitude)
-    }
-
-    /**
-     * L1 norm of each dimension.
-     */
-    def normL1: Vector = {
-      require(requestedMetrics.contains(NormL1))
-      require(totalWeightSum > 0, s"Nothing has been added to this summarizer.")
-
-      Vectors.dense(currL1)
-    }
-  }
 
   private case class MetricsAggregate(
       requestedMetrics: Seq[Metric],
@@ -705,5 +378,349 @@ private[spark] object SummaryBuilderImpl extends Logging {
 
     override def prettyName: String = "aggregate_metrics"
 
+  }
+}
+
+private[spark] class SummarizerBuffer(
+    requestedMetrics: Seq[SummaryBuilderImpl.Metric],
+    requestedCompMetrics: Seq[SummaryBuilderImpl.ComputeMetric]) extends Serializable {
+  import SummaryBuilderImpl._
+
+  private var n = 0
+  private var currMean: Array[Double] = null
+  private var currM2n: Array[Double] = null
+  private var currM2: Array[Double] = null
+  private var currL1: Array[Double] = null
+  private var totalCnt: Long = 0
+  private var totalWeightSum: Double = 0.0
+  private var weightSquareSum: Double = 0.0
+  private var currWeightSum: Array[Double] = null
+  private var nnz: Array[Long] = null
+  private var currMax: Array[Double] = null
+  private var currMin: Array[Double] = null
+
+  def this() {
+    this(
+      Seq(
+        SummaryBuilderImpl.Mean,
+        SummaryBuilderImpl.Sum,
+        SummaryBuilderImpl.Variance,
+        SummaryBuilderImpl.Std,
+        SummaryBuilderImpl.Count,
+        SummaryBuilderImpl.NumNonZeros,
+        SummaryBuilderImpl.Max,
+        SummaryBuilderImpl.Min,
+        SummaryBuilderImpl.NormL2,
+        SummaryBuilderImpl.NormL1),
+      Seq(
+        SummaryBuilderImpl.ComputeMean,
+        SummaryBuilderImpl.ComputeM2n,
+        SummaryBuilderImpl.ComputeM2,
+        SummaryBuilderImpl.ComputeL1,
+        SummaryBuilderImpl.ComputeWeightSum,
+        SummaryBuilderImpl.ComputeNNZ,
+        SummaryBuilderImpl.ComputeMax,
+        SummaryBuilderImpl.ComputeMin)
+    )
+  }
+
+  def add(nonZeroIterator: Iterator[(Int, Double)], size: Int, weight: Double): this.type = {
+    require(weight >= 0.0, s"sample weight, $weight has to be >= 0.0")
+    if (weight == 0.0) return this
+
+    if (n == 0) {
+      require(size > 0, s"Vector should have dimension larger than zero.")
+      n = size
+
+      if (requestedCompMetrics.contains(ComputeMean)) { currMean = Array.ofDim[Double](n) }
+      if (requestedCompMetrics.contains(ComputeM2n)) { currM2n = Array.ofDim[Double](n) }
+      if (requestedCompMetrics.contains(ComputeM2)) { currM2 = Array.ofDim[Double](n) }
+      if (requestedCompMetrics.contains(ComputeL1)) { currL1 = Array.ofDim[Double](n) }
+      if (requestedCompMetrics.contains(ComputeWeightSum)) {
+        currWeightSum = Array.ofDim[Double](n)
+      }
+      if (requestedCompMetrics.contains(ComputeNNZ)) { nnz = Array.ofDim[Long](n) }
+      if (requestedCompMetrics.contains(ComputeMax)) {
+        currMax = Array.fill[Double](n)(Double.MinValue)
+      }
+      if (requestedCompMetrics.contains(ComputeMin)) {
+        currMin = Array.fill[Double](n)(Double.MaxValue)
+      }
+    }
+
+    require(n == size, s"Dimensions mismatch when adding new sample." +
+      s" Expecting $n but got $size.")
+
+    if (nonZeroIterator.nonEmpty) {
+      val localCurrMean = currMean
+      val localCurrM2n = currM2n
+      val localCurrM2 = currM2
+      val localCurrL1 = currL1
+      val localCurrWeightSum = currWeightSum
+      val localNumNonzeros = nnz
+      val localCurrMax = currMax
+      val localCurrMin = currMin
+      nonZeroIterator.foreach { case (index, value) =>
+        if (localCurrMax != null && localCurrMax(index) < value) {
+          localCurrMax(index) = value
+        }
+        if (localCurrMin != null && localCurrMin(index) > value) {
+          localCurrMin(index) = value
+        }
+
+        if (localCurrWeightSum != null) {
+          if (localCurrMean != null) {
+            val prevMean = localCurrMean(index)
+            val diff = value - prevMean
+            localCurrMean(index) = prevMean +
+              weight * diff / (localCurrWeightSum(index) + weight)
+
+            if (localCurrM2n != null) {
+              localCurrM2n(index) += weight * (value - localCurrMean(index)) * diff
+            }
+          }
+          localCurrWeightSum(index) += weight
+        }
+
+        if (localCurrM2 != null) {
+          localCurrM2(index) += weight * value * value
+        }
+        if (localCurrL1 != null) {
+          localCurrL1(index) += weight * math.abs(value)
+        }
+
+        if (localNumNonzeros != null) {
+          localNumNonzeros(index) += 1
+        }
+      }
+    }
+
+    totalWeightSum += weight
+    weightSquareSum += weight * weight
+    totalCnt += 1
+    this
+  }
+
+  /**
+   * Add a new sample to this summarizer, and update the statistical summary.
+   */
+  def add(instance: Vector, weight: Double): this.type =
+    add(instance.nonZeroIterator, instance.size, weight)
+
+  def add(instance: Vector): this.type = add(instance, 1.0)
+
+  /**
+   * Merge another SummarizerBuffer, and update the statistical summary.
+   * (Note that it's in place merging; as a result, `this` object will be modified.)
+   *
+   * @param other The other MultivariateOnlineSummarizer to be merged.
+   */
+  def merge(other: SummarizerBuffer): this.type = {
+    if (this.totalWeightSum != 0.0 && other.totalWeightSum != 0.0) {
+      require(n == other.n, s"Dimensions mismatch when merging with another summarizer. " +
+        s"Expecting $n but got ${other.n}.")
+      totalCnt += other.totalCnt
+      totalWeightSum += other.totalWeightSum
+      weightSquareSum += other.weightSquareSum
+      var i = 0
+      while (i < n) {
+        if (currWeightSum != null) {
+          val thisWeightSum = currWeightSum(i)
+          val otherWeightSum = other.currWeightSum(i)
+          val totalWeightSum = thisWeightSum + otherWeightSum
+
+          if (totalWeightSum != 0.0) {
+            if (currMean != null) {
+              val deltaMean = other.currMean(i) - currMean(i)
+              // merge mean together
+              currMean(i) += deltaMean * otherWeightSum / totalWeightSum
+
+              if (currM2n != null) {
+                // merge m2n together
+                currM2n(i) += other.currM2n(i) +
+                  deltaMean * deltaMean * thisWeightSum * otherWeightSum / totalWeightSum
+              }
+            }
+          }
+          currWeightSum(i) = totalWeightSum
+        }
+
+        // merge m2 together
+        if (currM2 != null) { currM2(i) += other.currM2(i) }
+        // merge l1 together
+        if (currL1 != null) { currL1(i) += other.currL1(i) }
+        // merge max and min
+        if (currMax != null) { currMax(i) = math.max(currMax(i), other.currMax(i)) }
+        if (currMin != null) { currMin(i) = math.min(currMin(i), other.currMin(i)) }
+        if (nnz != null) { nnz(i) = nnz(i) + other.nnz(i) }
+        i += 1
+      }
+    } else if (totalWeightSum == 0.0 && other.totalWeightSum != 0.0) {
+      this.n = other.n
+      if (other.currMean != null) { this.currMean = other.currMean.clone() }
+      if (other.currM2n != null) { this.currM2n = other.currM2n.clone() }
+      if (other.currM2 != null) { this.currM2 = other.currM2.clone() }
+      if (other.currL1 != null) { this.currL1 = other.currL1.clone() }
+      this.totalCnt = other.totalCnt
+      this.totalWeightSum = other.totalWeightSum
+      this.weightSquareSum = other.weightSquareSum
+      if (other.currWeightSum != null) { this.currWeightSum = other.currWeightSum.clone() }
+      if (other.nnz != null) { this.nnz = other.nnz.clone() }
+      if (other.currMax != null) { this.currMax = other.currMax.clone() }
+      if (other.currMin != null) { this.currMin = other.currMin.clone() }
+    }
+    this
+  }
+
+  /**
+   * Sample mean of each dimension.
+   */
+  def mean: Vector = {
+    require(requestedMetrics.contains(Mean))
+    require(totalWeightSum > 0, s"Nothing has been added to this summarizer.")
+
+    val realMean = Array.ofDim[Double](n)
+    var i = 0
+    while (i < n) {
+      realMean(i) = currMean(i) * (currWeightSum(i) / totalWeightSum)
+      i += 1
+    }
+    Vectors.dense(realMean)
+  }
+
+  /**
+   * Sum of each dimension.
+   */
+  def sum: Vector = {
+    require(requestedMetrics.contains(Sum))
+    require(totalWeightSum > 0, s"Nothing has been added to this summarizer.")
+
+    val realSum = Array.ofDim[Double](n)
+    var i = 0
+    while (i < n) {
+      realSum(i) = currMean(i) * currWeightSum(i)
+      i += 1
+    }
+    Vectors.dense(realSum)
+  }
+
+  /**
+   * Unbiased estimate of sample variance of each dimension.
+   */
+  def variance: Vector = {
+    require(requestedMetrics.contains(Variance))
+    require(totalWeightSum > 0, s"Nothing has been added to this summarizer.")
+
+    val realVariance = computeVariance
+    Vectors.dense(realVariance)
+  }
+
+  /**
+   * Unbiased estimate of standard deviation of each dimension.
+   */
+  def std: Vector = {
+    require(requestedMetrics.contains(Std))
+    require(totalWeightSum > 0, s"Nothing has been added to this summarizer.")
+
+    val realVariance = computeVariance
+    Vectors.dense(realVariance.map(math.sqrt))
+  }
+
+  private def computeVariance: Array[Double] = {
+    val realVariance = Array.ofDim[Double](n)
+    val denominator = totalWeightSum - (weightSquareSum / totalWeightSum)
+
+    // Sample variance is computed, if the denominator is less than 0, the variance is just 0.
+    if (denominator > 0.0) {
+      val deltaMean = currMean
+      var i = 0
+      val len = currM2n.length
+      while (i < len) {
+        // We prevent variance from negative value caused by numerical error.
+        realVariance(i) = math.max((currM2n(i) + deltaMean(i) * deltaMean(i) * currWeightSum(i) *
+          (totalWeightSum - currWeightSum(i)) / totalWeightSum) / denominator, 0.0)
+        i += 1
+      }
+    }
+    realVariance
+  }
+
+  /**
+   * Sample size.
+   */
+  def count: Long = totalCnt
+
+  /**
+   * Sum of weights.
+   */
+  def weightSum: Double = totalWeightSum
+
+  /**
+   * Number of nonzero elements in each dimension.
+   *
+   */
+  def numNonzeros: Vector = {
+    require(requestedMetrics.contains(NumNonZeros))
+    require(totalCnt > 0, s"Nothing has been added to this summarizer.")
+
+    Vectors.dense(nnz.map(_.toDouble))
+  }
+
+  /**
+   * Maximum value of each dimension.
+   */
+  def max: Vector = {
+    require(requestedMetrics.contains(Max))
+    require(totalWeightSum > 0, s"Nothing has been added to this summarizer.")
+
+    var i = 0
+    while (i < n) {
+      if ((nnz(i) < totalCnt) && (currMax(i) < 0.0)) currMax(i) = 0.0
+      i += 1
+    }
+    Vectors.dense(currMax)
+  }
+
+  /**
+   * Minimum value of each dimension.
+   */
+  def min: Vector = {
+    require(requestedMetrics.contains(Min))
+    require(totalWeightSum > 0, s"Nothing has been added to this summarizer.")
+
+    var i = 0
+    while (i < n) {
+      if ((nnz(i) < totalCnt) && (currMin(i) > 0.0)) currMin(i) = 0.0
+      i += 1
+    }
+    Vectors.dense(currMin)
+  }
+
+  /**
+   * L2 (Euclidean) norm of each dimension.
+   */
+  def normL2: Vector = {
+    require(requestedMetrics.contains(NormL2))
+    require(totalWeightSum > 0, s"Nothing has been added to this summarizer.")
+
+    val realMagnitude = Array.ofDim[Double](n)
+
+    var i = 0
+    val len = currM2.length
+    while (i < len) {
+      realMagnitude(i) = math.sqrt(currM2(i))
+      i += 1
+    }
+    Vectors.dense(realMagnitude)
+  }
+
+  /**
+   * L1 norm of each dimension.
+   */
+  def normL1: Vector = {
+    require(requestedMetrics.contains(NormL1))
+    require(totalWeightSum > 0, s"Nothing has been added to this summarizer.")
+
+    Vectors.dense(currL1)
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/PCA.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/PCA.scala
@@ -46,10 +46,11 @@ class PCA @Since("1.4.0") (@Since("1.4.0") val k: Int) {
       s"source vector size $numFeatures must be no less than k=$k")
 
     val mat = if (numFeatures > 65535) {
-      val summary = Statistics.colStats(sources, Seq("mean"))
-      val meanVector = summary.mean.asBreeze
-      val meanCentredRdd = sources.map { rowVector =>
-        Vectors.fromBreeze(rowVector.asBreeze - meanVector)
+      val summary = Statistics.colStats(sources.map((_, 1.0)), Seq("mean"))
+      val mean = Vectors.fromML(summary.mean)
+      val meanCentredRdd = sources.map { row =>
+        BLAS.axpy(-1, mean, row)
+        row
       }
       new RowMatrix(meanCentredRdd)
     } else {

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/PCA.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/PCA.scala
@@ -46,7 +46,8 @@ class PCA @Since("1.4.0") (@Since("1.4.0") val k: Int) {
       s"source vector size $numFeatures must be no less than k=$k")
 
     val mat = if (numFeatures > 65535) {
-      val meanVector = Statistics.colStats(sources).mean.asBreeze
+      val summary = Statistics.colStats(sources, Seq("mean"))
+      val meanVector = summary.mean.asBreeze
       val meanCentredRdd = sources.map { rowVector =>
         Vectors.fromBreeze(rowVector.asBreeze - meanVector)
       }

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/StandardScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/StandardScaler.scala
@@ -21,7 +21,7 @@ import org.apache.spark.annotation.{DeveloperApi, Since}
 import org.apache.spark.internal.Logging
 import org.apache.spark.ml.feature.{StandardScalerModel => NewStandardScalerModel}
 import org.apache.spark.mllib.linalg.{DenseVector, SparseVector, Vector, Vectors}
-import org.apache.spark.mllib.stat.MultivariateOnlineSummarizer
+import org.apache.spark.mllib.stat.Statistics
 import org.apache.spark.rdd.RDD
 
 /**
@@ -55,12 +55,11 @@ class StandardScaler @Since("1.1.0") (withMean: Boolean, withStd: Boolean) exten
   @Since("1.1.0")
   def fit(data: RDD[Vector]): StandardScalerModel = {
     // TODO: skip computation if both withMean and withStd are false
-    val summary = data.treeAggregate(new MultivariateOnlineSummarizer)(
-      (aggregator, data) => aggregator.add(data),
-      (aggregator1, aggregator2) => aggregator1.merge(aggregator2))
+    val summary = Statistics.colStats(data, Seq("mean", "std"))
+
     new StandardScalerModel(
-      Vectors.dense(summary.variance.toArray.map(v => math.sqrt(v))),
-      summary.mean,
+      Vectors.fromML(summary.std),
+      Vectors.fromML(summary.mean),
       withStd,
       withMean)
   }

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/StandardScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/StandardScaler.scala
@@ -55,7 +55,7 @@ class StandardScaler @Since("1.1.0") (withMean: Boolean, withStd: Boolean) exten
   @Since("1.1.0")
   def fit(data: RDD[Vector]): StandardScalerModel = {
     // TODO: skip computation if both withMean and withStd are false
-    val summary = Statistics.colStats(data, Seq("mean", "std"))
+    val summary = Statistics.colStats(data.map((_, 1.0)), Seq("mean", "std"))
 
     new StandardScalerModel(
       Vectors.fromML(summary.std),

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/RowMatrix.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/RowMatrix.scala
@@ -433,7 +433,7 @@ class RowMatrix @Since("1.0.0") (
     val n = numCols().toInt
     checkNumColumns(n)
 
-    val summary = Statistics.colStats(rows, Seq("count", "mean"))
+    val summary = Statistics.colStats(rows.map((_, 1.0)), Seq("count", "mean"))
     val m = summary.count
     require(m > 1, s"RowMatrix.computeCovariance called on matrix with only $m rows." +
       "  Cannot compute the covariance of a RowMatrix with <= 1 row.")
@@ -616,7 +616,7 @@ class RowMatrix @Since("1.0.0") (
       10 * math.log(numCols()) / threshold
     }
 
-    val summary = Statistics.colStats(rows, Seq("normL2"))
+    val summary = Statistics.colStats(rows.map((_, 1.0)), Seq("normL2"))
     columnSimilaritiesDIMSUM(summary.normL2.toArray, gamma)
   }
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/RowMatrix.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/RowMatrix.scala
@@ -29,7 +29,7 @@ import org.apache.spark.annotation.Since
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.MAX_RESULT_SIZE
 import org.apache.spark.mllib.linalg._
-import org.apache.spark.mllib.stat.{MultivariateOnlineSummarizer, MultivariateStatisticalSummary}
+import org.apache.spark.mllib.stat._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util.random.XORShiftRandom
@@ -433,11 +433,11 @@ class RowMatrix @Since("1.0.0") (
     val n = numCols().toInt
     checkNumColumns(n)
 
-    val summary = computeColumnSummaryStatistics()
+    val summary = Statistics.colStats(rows, Seq("count", "mean"))
     val m = summary.count
     require(m > 1, s"RowMatrix.computeCovariance called on matrix with only $m rows." +
       "  Cannot compute the covariance of a RowMatrix with <= 1 row.")
-    val mean = summary.mean
+    val mean = Vectors.fromML(summary.mean)
 
     if (rows.first().isInstanceOf[DenseVector]) {
       computeDenseVectorCovariance(mean, n, m)
@@ -616,7 +616,8 @@ class RowMatrix @Since("1.0.0") (
       10 * math.log(numCols()) / threshold
     }
 
-    columnSimilaritiesDIMSUM(computeColumnSummaryStatistics().normL2.toArray, gamma)
+    val summary = Statistics.colStats(rows, Seq("normL2"))
+    columnSimilaritiesDIMSUM(summary.normL2.toArray, gamma)
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/stat/Statistics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/stat/Statistics.scala
@@ -48,14 +48,15 @@ object Statistics {
   }
 
   /**
-   * Computes required column-wise summary statistics for the input RDD[Vector].
+   * Computes required column-wise summary statistics for the input RDD[(Vector, Double)].
    *
-   * @param X an RDD[Vector] for which column-wise summary statistics are to be computed.
+   * @param X an RDD containing vectors and weights for which column-wise summary statistics
+   *          are to be computed.
    * @return [[SummarizerBuffer]] object containing column-wise summary statistics.
    */
-  private[mllib] def colStats(X: RDD[Vector], requested: Seq[String]) = {
+  private[mllib] def colStats(X: RDD[(Vector, Double)], requested: Seq[String]) = {
     X.treeAggregate(createSummarizerBuffer(requested: _*))(
-      seqOp = { case (c, v) => c.add(v.nonZeroIterator, v.size, 1.0) },
+      seqOp = { case (c, (v, w)) => c.add(v.nonZeroIterator, v.size, w) },
       combOp = { case (c1, c2) => c1.merge(c2) },
       depth = 2
     )

--- a/mllib/src/main/scala/org/apache/spark/mllib/stat/Statistics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/stat/Statistics.scala
@@ -21,6 +21,7 @@ import scala.annotation.varargs
 
 import org.apache.spark.annotation.Since
 import org.apache.spark.api.java.{JavaDoubleRDD, JavaRDD}
+import org.apache.spark.ml.stat.SummaryBuilderImpl._
 import org.apache.spark.mllib.linalg.{Matrix, Vector}
 import org.apache.spark.mllib.linalg.distributed.RowMatrix
 import org.apache.spark.mllib.regression.LabeledPoint
@@ -44,6 +45,20 @@ object Statistics {
   @Since("1.1.0")
   def colStats(X: RDD[Vector]): MultivariateStatisticalSummary = {
     new RowMatrix(X).computeColumnSummaryStatistics()
+  }
+
+  /**
+   * Computes required column-wise summary statistics for the input RDD[Vector].
+   *
+   * @param X an RDD[Vector] for which column-wise summary statistics are to be computed.
+   * @return [[SummarizerBuffer]] object containing column-wise summary statistics.
+   */
+  private[mllib] def colStats(X: RDD[Vector], requested: Seq[String]) = {
+    X.treeAggregate(createSummarizerBuffer(requested: _*))(
+      seqOp = { case (c, v) => c.add(v.nonZeroIterator, v.size, 1.0) },
+      combOp = { case (c1, c2) => c1.merge(c2) },
+      depth = 2
+    )
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/stat/Statistics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/stat/Statistics.scala
@@ -21,7 +21,7 @@ import scala.annotation.varargs
 
 import org.apache.spark.annotation.Since
 import org.apache.spark.api.java.{JavaDoubleRDD, JavaRDD}
-import org.apache.spark.ml.stat.SummaryBuilderImpl._
+import org.apache.spark.ml.stat._
 import org.apache.spark.mllib.linalg.{Matrix, Vector}
 import org.apache.spark.mllib.linalg.distributed.RowMatrix
 import org.apache.spark.mllib.regression.LabeledPoint
@@ -55,7 +55,7 @@ object Statistics {
    * @return [[SummarizerBuffer]] object containing column-wise summary statistics.
    */
   private[mllib] def colStats(X: RDD[(Vector, Double)], requested: Seq[String]) = {
-    X.treeAggregate(createSummarizerBuffer(requested: _*))(
+    X.treeAggregate(Summarizer.createSummarizerBuffer(requested: _*))(
       seqOp = { case (c, (v, w)) => c.add(v.nonZeroIterator, v.size, w) },
       combOp = { case (c1, c2) => c1.merge(c2) },
       depth = 2


### PR DESCRIPTION
### What changes were proposed in this pull request?
use `.ml.Summarizer` instead of `.mllib.MultivariateOnlineSummarizer` to avoid computation of unused metrics


### Why are the changes needed?
to avoid computation of unused metrics


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
existing testsuites