### PR TITLE
[SPARK-30246][CORE] OneForOneStreamManager might leak memory in connectionTerminated

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/server/OneForOneStreamManager.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/OneForOneStreamManager.java
@@ -129,11 +129,15 @@ public class OneForOneStreamManager extends StreamManager {
 
     for (StreamState state: removedStates) {
       // Release all remaining buffers.
-      while (state.buffers.hasNext()) {
-        ManagedBuffer buffer = state.buffers.next();
-        if (buffer != null) {
-          buffer.release();
+      try {
+        while (state.buffers.hasNext()) {
+          ManagedBuffer buffer = state.buffers.next();
+          if (buffer != null) {
+            buffer.release();
+          }
         }
+      } catch (RuntimeException e) {
+        logger.error("Exception trying to release remaining StreamState buffers", e);
       }
     }
   }

--- a/common/network-common/src/test/java/org/apache/spark/network/server/OneForOneStreamManagerSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/server/OneForOneStreamManagerSuite.java
@@ -135,5 +135,4 @@ public class OneForOneStreamManagerSuite {
       Assert.assertEquals(0, manager.numStreamStates());
     }
   }
-
 }

--- a/common/network-common/src/test/java/org/apache/spark/network/server/OneForOneStreamManagerSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/server/OneForOneStreamManagerSuite.java
@@ -118,17 +118,22 @@ public class OneForOneStreamManagerSuite {
 
     Assert.assertEquals(2, manager.numStreamStates());
 
-    manager.connectionTerminated(dummyChannel);
+    try {
+      manager.connectionTerminated(dummyChannel);
+      Assert.fail("connectionTerminated should throw RuntimeException when fails to release all buffers");
 
-    Mockito.verify(buffers, Mockito.times(1)).hasNext();
-    Mockito.verify(buffers, Mockito.times(1)).next();
+    } catch (RuntimeException e) {
 
-    Mockito.verify(buffers2, Mockito.times(2)).hasNext();
-    Mockito.verify(buffers2, Mockito.times(2)).next();
+      Mockito.verify(buffers, Mockito.times(1)).hasNext();
+      Mockito.verify(buffers, Mockito.times(1)).next();
 
-    Mockito.verify(mockManagedBuffer, Mockito.times(1)).release();
+      Mockito.verify(buffers2, Mockito.times(2)).hasNext();
+      Mockito.verify(buffers2, Mockito.times(2)).next();
 
-    Assert.assertEquals(0, manager.numStreamStates());
+      Mockito.verify(mockManagedBuffer, Mockito.times(1)).release();
+
+      Assert.assertEquals(0, manager.numStreamStates());
+    }
   }
 
 }

--- a/common/network-common/src/test/java/org/apache/spark/network/server/OneForOneStreamManagerSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/server/OneForOneStreamManagerSuite.java
@@ -120,7 +120,7 @@ public class OneForOneStreamManagerSuite {
 
     try {
       manager.connectionTerminated(dummyChannel);
-      Assert.fail("connectionTerminated should throw RuntimeException when fails to release all buffers");
+      Assert.fail("connectionTerminated should throw exception when fails to release all buffers");
 
     } catch (RuntimeException e) {
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Ensure that all StreamStates are removed from OneForOneStreamManager memory map even if there's an error trying to release buffers

### Why are the changes needed?

OneForOneStreamManager may not remove all StreamStates from memory map when a connection is terminated. A RuntimeException might be thrown in StreamState$buffers.next() by one of ExternalShuffleBlockResolver$getBlockData... **breaking the loop through streams.entrySet(), keeping StreamStates in memory forever leaking memory.**
That may happen when an application is terminated abruptly and executors removed before the connection is terminated or if shuffleIndexCache fails to get ShuffleIndexInformation

References:
https://github.com/apache/spark/blob/ee050ddbc6eb6bc08c7751a0eb00e7a05b011b52/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockHandler.java#L319

https://github.com/apache/spark/blob/ee050ddbc6eb6bc08c7751a0eb00e7a05b011b52/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockHandler.java#L357

https://github.com/apache/spark/blob/ee050ddbc6eb6bc08c7751a0eb00e7a05b011b52/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java#L195

https://github.com/apache/spark/blob/ee050ddbc6eb6bc08c7751a0eb00e7a05b011b52/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java#L208

https://github.com/apache/spark/blob/ee050ddbc6eb6bc08c7751a0eb00e7a05b011b52/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java#L330


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
Unit test added