### PR TITLE
[SPARK-30405][BRANCH2.4] ArrayKeyIndexType should use Arrays.hashCode

### DIFF
--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/ArrayKeyIndexType.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/ArrayKeyIndexType.java
@@ -38,7 +38,7 @@ public class ArrayKeyIndexType {
 
   @Override
   public int hashCode() {
-    return key.hashCode();
+    return Arrays.hashCode(key) ^ Arrays.hashCode(id);
   }
 
 }


### PR DESCRIPTION
`hashCode` on array, returns arrays's identity hash and does not reflect the array's content instead. this can be corrected by using `Arrays.hashCode(array)`

### What changes were proposed in this pull request?
hashCode method in `ArrayKeyIndexType` depends on `Arrays.hashCode(key) ^ Arrays.hashCode(id)`

### Why are the changes needed?
`hashCode` on array, returns arrays's identity hash and does not reflect the array's content instead

### Does this PR introduce any user-facing change?
No


### How was this patch tested?
All Existing UTs can pass with change