### PR TITLE
[SPARK-30408][SQL] Should not remove orderBy in sortBy clause in Optimizer

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -990,7 +990,7 @@ object EliminateSorts extends Rule[LogicalPlan] {
   private def recursiveRemoveSort(parent: Sort, plan: LogicalPlan): LogicalPlan = plan match {
     case s @ Sort(_, _, child) =>
       if (parent.global == s.global) {
-        recursiveRemoveSort(child)
+        recursiveRemoveSort(s, child)
       } else {
         s.copy(child = recursiveRemoveSort(child))
       }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/EliminateSortsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/EliminateSortsSuite.scala
@@ -310,9 +310,25 @@ class EliminateSortsSuite extends PlanTest {
   }
 
   test("should not remove orderBy in sortBy clause") {
-    val plan = testRelation.orderBy('a.asc).sortBy('b.desc)
-    val optimized = Optimize.execute(plan.analyze)
-    val correctAnswer = testRelation.orderBy('a.asc).sortBy('b.desc).analyze
-    comparePlans(optimized, correctAnswer)
+    val plan1 = testRelation.orderBy('a.asc).sortBy('b.desc)
+    val optimized1 = Optimize.execute(plan1.analyze)
+    val correctAnswer1 = testRelation.orderBy('a.asc).sortBy('b.desc).analyze
+    comparePlans(optimized1, correctAnswer1)
+
+    val plan2 = testRelation
+      .orderBy('c.asc)
+      .select('a, 'b)
+      .where('a > Literal(10))
+      .orderBy('b.asc)
+      .orderBy('a.asc)
+      .sortBy('a.asc)
+      .sortBy('b.asc)
+    val optimized2 = Optimize.execute(plan2.analyze)
+    val correctAnswer2 = testRelation
+      .select('a, 'b)
+      .where('a > Literal(10))
+      .orderBy('a.asc)
+      .sortBy('b.asc).analyze
+    comparePlans(optimized2, correctAnswer2)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/EliminateSortsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/EliminateSortsSuite.scala
@@ -309,7 +309,7 @@ class EliminateSortsSuite extends PlanTest {
     comparePlans(optimized, correctAnswer)
   }
 
-  test("should not remove orderBy in sortBy clause") {
+  test("SPARK-30408 should not remove orderBy in sortBy clause") {
     val plan1 = testRelation.orderBy('a.asc).sortBy('b.desc)
     val optimized1 = Optimize.execute(plan1.analyze)
     val correctAnswer1 = testRelation.orderBy('a.asc).sortBy('b.desc).analyze

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/EliminateSortsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/EliminateSortsSuite.scala
@@ -308,4 +308,11 @@ class EliminateSortsSuite extends PlanTest {
     val correctAnswer = PushDownOptimizer.execute(noOrderByPlan.analyze)
     comparePlans(optimized, correctAnswer)
   }
+
+  test("should not remove orderBy in sortBy clause") {
+    val plan = testRelation.orderBy('a.asc).sortBy('b.desc)
+    val optimized = Optimize.execute(plan.analyze)
+    val correctAnswer = testRelation.orderBy('a.asc).sortBy('b.desc).analyze
+    comparePlans(optimized, correctAnswer)
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix defect [SPARK-30408](https://issues.apache.org/jira/browse/SPARK-30408) in EliminateSorts:  orderBy in sortBy clause was removed by EliminateSorts.
code to reproduce:
```
val dataset = Seq( ("a", 1, 4), ("b", 2, 5), ("b2", 2, 2), ("c", 3, 6) ).toDF("a", "b", "c") 
val groupData = dataset.orderBy("b")
val sortData = groupData.sortWithinPartitions("c")
```
The content of groupData is:
```
partition 0: 
    [a,1,4]
partition 1: 
    [b,2,5]
    [b2,2,2]
partition 2: 
    [c,3,6]
```
The content of sortData is:
```
partition 0: 
    [a,1,4]
    [b,2,5]
partition 1: 
    [b2,2,2]
    [c,3,6]
```
The content of sortData is not correct because the repartition operator introduced by orderBy was removed by EliminateSorts.
The content of sortData should be.
```
partition 0: 
    [a,1,4]
partition 1: 
    [b2,2,2]
    [b,2,5]
partition 2: 
    [c,3,6]
```

### Why are the changes needed?
This PR fixed defect [SPARK-30408](https://issues.apache.org/jira/browse/SPARK-30408).
Without this fix, the partition of 
    ```rdd.orderBy("b").sortWithinPartitions("c")```
is same as 
    ```rdd.sortWithinPartitions("c")```
which is not correct.

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
I add an UT in ```EliminateSortsSuite``` to test this patch.
