### PR TITLE
[SPARK-27996][WEBUI][2.4] Send HTTP redirect using the correct protocol when Spark History server is deployed behind the reverse proxy

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
@@ -31,7 +31,7 @@ import org.eclipse.jetty.servlet.FilterHolder
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.metrics.source.Source
-import org.apache.spark.ui.SparkUI
+import org.apache.spark.ui.{JettyUtils, SparkUI}
 import org.apache.spark.util.Clock
 
 /**
@@ -394,7 +394,7 @@ private[history] class ApplicationCacheCheckFilter(
     }
     val httpRequest = request.asInstanceOf[HttpServletRequest]
     val httpResponse = response.asInstanceOf[HttpServletResponse]
-    val requestURI = httpRequest.getRequestURI
+    val requestURL = httpRequest.getRequestURL.toString
     val operation = httpRequest.getMethod
 
     // if the request is for an attempt, check to see if it is in need of delete/refresh
@@ -410,8 +410,8 @@ private[history] class ApplicationCacheCheckFilter(
       loadedUI.lock.readLock.unlock()
       cache.invalidate(key)
       val queryStr = Option(httpRequest.getQueryString).map("?" + _).getOrElse("")
-      val redirectUrl = httpResponse.encodeRedirectURL(requestURI + queryStr)
-      httpResponse.sendRedirect(redirectUrl)
+      val redirectUrl = httpResponse.encodeRedirectURL(requestURL + queryStr)
+      httpResponse.sendRedirect(JettyUtils.updateProtocolFromHeader(httpRequest, redirectUrl))
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -109,12 +109,12 @@ class HistoryServer(
       // requested, and the proper data should be served at that point.
       // Also, make sure that the redirect url contains the query string present in the request.
       val redirect = if (shouldAppendAttemptId) {
-        req.getRequestURI.stripSuffix("/") + "/" + attemptId.get
+        req.getRequestURL.toString.stripSuffix("/") + "/" + attemptId.get
       } else {
-        req.getRequestURI
+        req.getRequestURL.toString
       }
       val query = Option(req.getQueryString).map("?" + _).getOrElse("")
-      res.sendRedirect(res.encodeRedirectURL(redirect + query))
+      res.sendRedirect(res.encodeRedirectURL(updateProtocolFromHeader(req, redirect) + query))
     }
 
     // SPARK-5983 ensure TRACE is not supported

--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -174,7 +174,7 @@ private[spark] object JettyUtils extends Logging {
         beforeRedirect(request)
         // Make sure we don't end up with "//" in the middle
         val newUrl = new URL(new URL(request.getRequestURL.toString), prefixedDestPath).toString
-        response.sendRedirect(newUrl)
+        response.sendRedirect(updateProtocolFromHeader(request, newUrl))
       }
       // SPARK-5983 ensure TRACE is not supported
       protected override def doTrace(req: HttpServletRequest, res: HttpServletResponse): Unit = {
@@ -182,6 +182,14 @@ private[spark] object JettyUtils extends Logging {
       }
     }
     createServletHandler(srcPath, servlet, basePath)
+  }
+
+  // SPARK-27996 update protocol from X-Forwarded-Proto if present
+  def updateProtocolFromHeader(request: HttpServletRequest, url: String): String = {
+    Option(request.getHeader("X-Forwarded-Proto")) match {
+      case Some(protocol) => protocol + url.drop(url.indexOf(":"))
+      case _ => url
+    }
   }
 
   /** Create a handler for serving files from a static directory */


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds method `updateProtocolFromHeader(request: HttpServletRequest, url: String): String` to JettyUtils.scala and calls this method from when Spark History Server is generating a redirect response.

### Why are the changes needed?
This change is needed to address bug SPARK-27996 in History Server. Please note that similar change is likely needed in Spark UI. The scope of this PR is only to address the problem in History Server.

### Does this PR introduce any user-facing change?
Yes, the Spark History server deployed in Kubernetes now correctly opens the job page.

### How was this patch tested?
The patch was tested by building and deploying Spark History Server to Kubernetes cluster and then observing the behavior of the History Server UI. The regression testing was not performed. I will appreciate is someone can can confirm the Spark History Server still works when deployed on regular infrastructure (e.g. not behind the reverse proxy).
