### PR TITLE
[SPARK-28148][SQL] Repartition after join is not optimized away

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.catalyst.util.StringUtils.PlanStringConcat
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.execution.adaptive.{AdaptiveExecutionContext, InsertAdaptiveSparkPlan}
 import org.apache.spark.sql.execution.dynamicpruning.PlanDynamicPruningFilters
-import org.apache.spark.sql.execution.exchange.{EnsureRequirements, ReuseExchange}
+import org.apache.spark.sql.execution.exchange.{EnsureRequirements, PruneShuffleAndSort, ReuseExchange}
 import org.apache.spark.sql.execution.streaming.{IncrementalExecution, OffsetSeqMetadata}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.OutputMode
@@ -285,6 +285,7 @@ object QueryExecution {
       PlanDynamicPruningFilters(sparkSession),
       PlanSubqueries(sparkSession),
       EnsureRequirements(sparkSession.sessionState.conf),
+      PruneShuffleAndSort(),
       ApplyColumnarRulesAndInsertTransitions(sparkSession.sessionState.conf,
         sparkSession.sessionState.columnarRules),
       CollapseCodegenStages(sparkSession.sessionState.conf),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -216,12 +216,6 @@ case class EnsureRequirements(conf: SQLConf) extends Rule[SparkPlan] {
   }
 
   def apply(plan: SparkPlan): SparkPlan = plan.transformUp {
-    // TODO: remove this after we create a physical operator for `RepartitionByExpression`.
-    case operator @ ShuffleExchangeExec(upper: HashPartitioning, child, _) =>
-      child.outputPartitioning match {
-        case lower: HashPartitioning if upper.semanticEquals(lower) => child
-        case _ => operator
-      }
     case operator: SparkPlan =>
       ensureDistributionAndOrdering(reorderJoinPredicates(operator))
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/PruneShuffleAndSort.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/PruneShuffleAndSort.scala
@@ -22,6 +22,10 @@ import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partition
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{SortExec, SparkPlan}
 
+/**
+ * Removes unnecessary shuffles and sorts after new ones are introduced by [[SparkPlan] SparkPlan]]
+ * [[Rule Rules]], such as [[EnsureRequirements]].
+ */
 case class PruneShuffleAndSort() extends Rule[SparkPlan] {
 
   override def apply(plan: SparkPlan): SparkPlan = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/PruneShuffleAndSort.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/PruneShuffleAndSort.scala
@@ -30,8 +30,9 @@ case class PruneShuffleAndSort() extends Rule[SparkPlan] {
         child.outputPartitioning match {
           case lower: HashPartitioning if upper.semanticEquals(lower) => child
           case _ @ PartitioningCollection(partitionings) =>
-            if (partitionings.exists{case lower: HashPartitioning =>
-              upper.semanticEquals(lower)
+            if (partitionings.exists{
+              case lower: HashPartitioning => upper.semanticEquals(lower)
+              case _ => false
             }) {
               child
             } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/PruneShuffleAndSort.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/PruneShuffleAndSort.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.exchange
+
+import org.apache.spark.sql.catalyst.expressions.SortOrder
+import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, PartitioningCollection}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.{SortExec, SparkPlan}
+
+case class PruneShuffleAndSort() extends Rule[SparkPlan] {
+
+  override def apply(plan: SparkPlan): SparkPlan = {
+    plan.transformUp {
+      case operator @ ShuffleExchangeExec(upper: HashPartitioning, child, _) =>
+        child.outputPartitioning match {
+          case lower: HashPartitioning if upper.semanticEquals(lower) => child
+          case _ @ PartitioningCollection(partitionings) =>
+            if (partitionings.exists{case lower: HashPartitioning =>
+              upper.semanticEquals(lower)
+            }) {
+              child
+            } else {
+              operator
+            }
+          case _ => operator
+        }
+      case SortExec(upper, false, child, _)
+        if SortOrder.orderingSatisfies(child.outputOrdering, upper) => child
+      case subPlan: SparkPlan => subPlan
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/PruneShuffleAndSort.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/PruneShuffleAndSort.scala
@@ -23,8 +23,8 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{SortExec, SparkPlan}
 
 /**
- * Removes unnecessary shuffles and sorts after new ones are introduced by [[SparkPlan] SparkPlan]]
- * [[Rule Rules]], such as [[EnsureRequirements]].
+ * Removes unnecessary shuffles and sorts after new ones are introduced by [[Rule]]s for
+ * [[SparkPlan]]s, such as [[EnsureRequirements]].
  */
 case class PruneShuffleAndSort() extends Rule[SparkPlan] {
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Extra shuffling was not eliminated after inner joins because they produce PartitioningCollection Partitioning and the current logic only matched on HashPartitioning. 

Nothing was present in EnsureRequirements to eliminate parent sorting (within partitions) which was unnecessary when the same sort order was introduced by sortmergejoin

Copied from jira:
Partitioning & sorting is usually retained after join.
```
spark.conf.set('spark.sql.shuffle.partitions', '42')

df1 = spark.range(5000000, numPartitions=5)
df2 = spark.range(10000000, numPartitions=5)
df3 = spark.range(20000000, numPartitions=5)

# Reuse previous partitions & sort.
df1.join(df2, on='id').join(df3, on='id').explain()
# == Physical Plan ==
# *(8) Project [id#367L]
# +- *(8) SortMergeJoin [id#367L], [id#374L], Inner
#    :- *(5) Project [id#367L]
#    :  +- *(5) SortMergeJoin [id#367L], [id#369L], Inner
#    :     :- *(2) Sort [id#367L ASC NULLS FIRST], false, 0
#    :     :  +- Exchange hashpartitioning(id#367L, 42)
#    :     :     +- *(1) Range (0, 5000000, step=1, splits=5)
#    :     +- *(4) Sort [id#369L ASC NULLS FIRST], false, 0
#    :        +- Exchange hashpartitioning(id#369L, 42)
#    :           +- *(3) Range (0, 10000000, step=1, splits=5)
#    +- *(7) Sort [id#374L ASC NULLS FIRST], false, 0
#       +- Exchange hashpartitioning(id#374L, 42)
#          +- *(6) Range (0, 20000000, step=1, splits=5)
```

However here: Partitions persist through left join, sort doesn't.

```
df1.join(df2, on='id', how='left').repartition('id').sortWithinPartitions('id').explain()
# == Physical Plan ==
# *(5) Sort [id#367L ASC NULLS FIRST], false, 0
# +- *(5) Project [id#367L]
#    +- SortMergeJoin [id#367L], [id#369L], LeftOuter
#       :- *(2) Sort [id#367L ASC NULLS FIRST], false, 0
#       :  +- Exchange hashpartitioning(id#367L, 42)
#       :     +- *(1) Range (0, 5000000, step=1, splits=5)
#       +- *(4) Sort [id#369L ASC NULLS FIRST], false, 0
#          +- Exchange hashpartitioning(id#369L, 42)
#             +- *(3) Range (0, 10000000, step=1, splits=5)
```
Also here: Partitions do not persist though inner join.

```
df1.join(df2, on='id').repartition('id').sortWithinPartitions('id').explain()
# == Physical Plan ==
# *(6) Sort [id#367L ASC NULLS FIRST], false, 0
# +- Exchange hashpartitioning(id#367L, 42)
#    +- *(5) Project [id#367L]
#       +- *(5) SortMergeJoin [id#367L], [id#369L], Inner
#          :- *(2) Sort [id#367L ASC NULLS FIRST], false, 0
#          :  +- Exchange hashpartitioning(id#367L, 42)
#          :     +- *(1) Range (0, 5000000, step=1, splits=5)
#          +- *(4) Sort [id#369L ASC NULLS FIRST], false, 0
#             +- Exchange hashpartitioning(id#369L, 42)
#                +- *(3) Range (0, 10000000, step=1, splits=5)
```
