### PR TITLE
[SPARK-30432][Graphx]reduce degree recomputation in StronglyConnectedComponents

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/StronglyConnectedComponents.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/StronglyConnectedComponents.scala
@@ -54,7 +54,7 @@ object StronglyConnectedComponents {
       iter += 1
       do {
         numVertices = sccWorkGraph.numVertices
-        if (!pregelDone) {
+        if (pregelDone == false) {
           sccWorkGraph = sccWorkGraph.outerJoinVertices(sccWorkGraph.outDegrees) {
             (vid, data, degreeOpt) => if (degreeOpt.isDefined) data else (vid, true)
           }.outerJoinVertices(sccWorkGraph.inDegrees) {

--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/StronglyConnectedComponents.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/StronglyConnectedComponents.scala
@@ -46,19 +46,22 @@ object StronglyConnectedComponents {
 
     // helper variables to unpersist cached graphs
     var prevSccGraph = sccGraph
-
+    
+    var pregelDone = false
     var numVertices = sccWorkGraph.numVertices
     var iter = 0
     while (sccWorkGraph.numVertices > 0 && iter < numIter) {
       iter += 1
       do {
         numVertices = sccWorkGraph.numVertices
-        sccWorkGraph = sccWorkGraph.outerJoinVertices(sccWorkGraph.outDegrees) {
-          (vid, data, degreeOpt) => if (degreeOpt.isDefined) data else (vid, true)
-        }.outerJoinVertices(sccWorkGraph.inDegrees) {
-          (vid, data, degreeOpt) => if (degreeOpt.isDefined) data else (vid, true)
-        }.cache()
-
+        if (!pregelDone) {
+          sccWorkGraph = sccWorkGraph.outerJoinVertices(sccWorkGraph.outDegrees) {
+            (vid, data, degreeOpt) => if (degreeOpt.isDefined) data else (vid, true)
+          }.outerJoinVertices(sccWorkGraph.inDegrees) {
+            (vid, data, degreeOpt) => if (degreeOpt.isDefined) data else (vid, true)
+          }.cache()
+        }
+        pregelDone = false 
         // get all vertices to be removed
         val finalVertices = sccWorkGraph.vertices
             .filter { case (vid, (scc, isFinal)) => isFinal}
@@ -120,6 +123,7 @@ object StronglyConnectedComponents {
           },
           (final1, final2) => final1 || final2)
       }
+      pregelDone = true
     }
     sccGraph
   }

--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/StronglyConnectedComponents.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/StronglyConnectedComponents.scala
@@ -46,7 +46,6 @@ object StronglyConnectedComponents {
 
     // helper variables to unpersist cached graphs
     var prevSccGraph = sccGraph
-    
     var pregelDone = false
     var numVertices = sccWorkGraph.numVertices
     var iter = 0
@@ -61,7 +60,7 @@ object StronglyConnectedComponents {
             (vid, data, degreeOpt) => if (degreeOpt.isDefined) data else (vid, true)
           }.cache()
         }
-        pregelDone = false 
+        pregelDone = false
         // get all vertices to be removed
         val finalVertices = sccWorkGraph.vertices
             .filter { case (vid, (scc, isFinal)) => isFinal}


### PR DESCRIPTION
It would be helpful when computing StronglyConnectedComponents to reduce degree computation.

I have done a small code proposal, because there is a problem when the pregel executions have done,  the degree no need to be recomputed.

I created a branch in my fork: https://github.com/xs-li/spark/blob/branch-2.4/graphx/src/main/scala/org/apache/spark/graphx/lib/StronglyConnectedComponents.scala

I hope you can consider this small code proposal.

Thank you very much,

Best regards,

xs-li