### PR TITLE
[SPARK-30433][SQL] Make conflict attributes resolution more scalable in ResolveReferences

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1091,7 +1091,7 @@ class Analyzer(
       }
 
       /*
-       * Note that it's possible for conflictPlans to be empty while it implies that there
+       * Note that it's possible `conflictPlans` can be empty which implies that there
        * is a logical plan node that produces new references that this rule cannot handle.
        * When that is the case, there must be another rule that resolves these conflicts.
        * Otherwise, the analysis will fail.
@@ -1103,9 +1103,9 @@ class Analyzer(
           case (oldRelation, newRelation) => oldRelation.output.zip(newRelation.output)})
         val conflictPlanMap = conflictPlans.toMap
         // transformDown so that we can replace all the old Relations in one turn due to
-        // the reason that conflictPlans are also collected in pre-order.
+        // the reason that `conflictPlans` are also collected in pre-order.
         right transformDown {
-          case r if conflictPlanMap.contains(r) => conflictPlanMap(r)
+          case r => conflictPlanMap.getOrElse(r, r)
         } transformUp {
           case other => other transformExpressions {
             case a: Attribute =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR tries to make conflict attributes resolution in `ResolveReferences` more scalable by doing resolution in batch way.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Currently, `ResolveReferences` rule only resolves conflict attributes of one single conflict plan pair in one iteration, which can be inefficient when there're many conflicts. 

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Covered by existed tests.
