### PR TITLE
[SPARK-30436][SQL] Allow CREATE EXTERNAL TABLE with only requiring LOCATION

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -115,16 +115,11 @@ statement
         createTableHeader ('(' colTypeList ')')? tableProvider
         createTableClauses
         (AS? query)?                                                   #createTable
+    | createExternalTableHeader ('(' columns=colTypeList ')')?
+        createHiveTableClauses
+        (AS? query)?                                                   #createExternalHiveTable
     | createTableHeader ('(' columns=colTypeList ')')?
-        ((COMMENT comment=STRING) |
-        (PARTITIONED BY '(' partitionColumns=colTypeList ')' |
-        PARTITIONED BY partitionColumnNames=identifierList) |
-        bucketSpec |
-        skewSpec |
-        rowFormat |
-        createFileFormat |
-        locationSpec |
-        (TBLPROPERTIES tableProps=tablePropertyList))*
+        createHiveTableClauses
         (AS? query)?                                                   #createHiveTable
     | CREATE TABLE (IF NOT EXISTS)? target=tableIdentifier
         LIKE source=tableIdentifier
@@ -283,7 +278,11 @@ unsupportedHiveNativeCommands
     ;
 
 createTableHeader
-    : CREATE TEMPORARY? EXTERNAL? TABLE (IF NOT EXISTS)? multipartIdentifier
+    : CREATE TEMPORARY? TABLE (IF NOT EXISTS)? multipartIdentifier
+    ;
+
+createExternalTableHeader
+    : CREATE EXTERNAL TABLE (IF NOT EXISTS)? multipartIdentifier
     ;
 
 replaceTableHeader
@@ -365,6 +364,18 @@ createTableClauses
      bucketSpec |
      locationSpec |
      (COMMENT comment=STRING) |
+     (TBLPROPERTIES tableProps=tablePropertyList))*
+    ;
+
+createHiveTableClauses
+    :((COMMENT comment=STRING) |
+     (PARTITIONED BY '(' partitionColumns=colTypeList ')' |
+     PARTITIONED BY partitionColumnNames=identifierList) |
+     bucketSpec |
+     skewSpec |
+     rowFormat |
+     createFileFormat |
+     locationSpec |
      (TBLPROPERTIES tableProps=tablePropertyList))*
     ;
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
@@ -170,23 +170,6 @@ class CreateTableAsSelectSuite extends DataSourceTest with SharedSparkSession {
     }
   }
 
-  test("disallows CREATE EXTERNAL TABLE ... USING ... AS query") {
-    withTable("t") {
-      val error = intercept[ParseException] {
-        sql(
-          s"""
-             |CREATE EXTERNAL TABLE t USING PARQUET
-             |OPTIONS (PATH '${path.toURI}')
-             |AS SELECT 1 AS a, 2 AS b
-           """.stripMargin
-        )
-      }.getMessage
-
-      assert(error.contains("Operation not allowed") &&
-        error.contains("CREATE EXTERNAL TABLE ..."))
-    }
-  }
-
   test("create table using as select - with partitioned by") {
     val catalog = spark.sessionState.catalog
     withTable("t") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This patch fixes CREATE EXTERNAL TABLE statement to follow the rule of create table for Hive table instead of normal table.

There're two major statements on supporting create table (createTable / createHiveTable in SqlBase.g4). As we support external table only for Hive table, the code seems to only allow `external` in createHiveTable which is only determined when there's any unique option for Hive in create table clauses, which is breaking change and don't seem to be intuitive.

As we only support external table for Hive table, we could simplify the parser rule via always referring Hive table for "CREATE EXTERNAL TABLE". We no longer need to verify createTable to check whether `external` is available.

### Why are the changes needed?

`CREATE EXTERNAL TABLE ... LOCATION` is broken, and it doesn't make sense to let end users specify the unique option only available for Hive table to make it work.

### Does this PR introduce any user-facing change?

Maybe yes, given the changes:

* CREATE EXTERNAL TABLE will always be considered as Hive table.
  * It doesn't allow to provide "USING", unlike CREATE TABLE.
  * CREATE EXTERNAL TABLE uses same createTableClauses as Hive table, instead of normal table.

### How was this patch tested?

Modified UTs. Jenkins build passed.