### PR TITLE
[SPARK-30432][Graphx]reduce degree recomputation in StronglyConnectedComponents

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/StronglyConnectedComponents.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/StronglyConnectedComponents.scala
@@ -54,7 +54,7 @@ object StronglyConnectedComponents {
       iter += 1
       do {
         numVertices = sccWorkGraph.numVertices
-        if (!pregelDone) {
+        if (pregelDone == false) {
           sccWorkGraph = sccWorkGraph.outerJoinVertices(sccWorkGraph.outDegrees) {
             (vid, data, degreeOpt) => if (degreeOpt.isDefined) data else (vid, true)
           }.outerJoinVertices(sccWorkGraph.inDegrees) {

--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/StronglyConnectedComponents.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/StronglyConnectedComponents.scala
@@ -48,16 +48,20 @@ object StronglyConnectedComponents {
     var prevSccGraph = sccGraph
 
     var numVertices = sccWorkGraph.numVertices
+    var pregelDone = false
     var iter = 0
     while (sccWorkGraph.numVertices > 0 && iter < numIter) {
       iter += 1
       do {
         numVertices = sccWorkGraph.numVertices
-        sccWorkGraph = sccWorkGraph.outerJoinVertices(sccWorkGraph.outDegrees) {
-          (vid, data, degreeOpt) => if (degreeOpt.isDefined) data else (vid, true)
-        }.outerJoinVertices(sccWorkGraph.inDegrees) {
-          (vid, data, degreeOpt) => if (degreeOpt.isDefined) data else (vid, true)
-        }.cache()
+        if (!pregelDone) {
+          sccWorkGraph = sccWorkGraph.outerJoinVertices(sccWorkGraph.outDegrees) {
+            (vid, data, degreeOpt) => if (degreeOpt.isDefined) data else (vid, true)
+          }.outerJoinVertices(sccWorkGraph.inDegrees) {
+            (vid, data, degreeOpt) => if (degreeOpt.isDefined) data else (vid, true)
+          }.cache()
+        }
+        pregelDone = false
 
         // get all vertices to be removed
         val finalVertices = sccWorkGraph.vertices
@@ -120,6 +124,7 @@ object StronglyConnectedComponents {
           },
           (final1, final2) => final1 || final2)
       }
+      pregelDone = true
     }
     sccGraph
   }

--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/StronglyConnectedComponents.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/StronglyConnectedComponents.scala
@@ -46,7 +46,6 @@ object StronglyConnectedComponents {
 
     // helper variables to unpersist cached graphs
     var prevSccGraph = sccGraph
-
     var numVertices = sccWorkGraph.numVertices
     var pregelDone = false
     var iter = 0
@@ -62,7 +61,6 @@ object StronglyConnectedComponents {
           }.cache()
         }
         pregelDone = false
-
         // get all vertices to be removed
         val finalVertices = sccWorkGraph.vertices
             .filter { case (vid, (scc, isFinal)) => isFinal}


### PR DESCRIPTION
 i have done a small code proposal, because there is a problem when the pregel executions have done,  the degree no need to be recomputed.

and I created a branch in my fork: https://github.com/xs-li/spark/blob/master/graphx/src/main/scala/org/apache/spark/graphx/lib/StronglyConnectedComponents.scala

the computation happens every time in the do-while loop, the first time the outer while loop executes. although just once per do-while loop after,  but it does reduce a lot of recomputation；because every time it jump out of the do-while loop，there are no vertices have only out-degree or in-degree，so it's no need to recompute degree and tag the vertices true.

for example，the Email-EuAll  data set：http://snap.stanford.edu/data/email-EuAll.html

do-while loop execute 10 times，and the reduce logic happend 2 times；so it would be helpful when computing StronglyConnectedComponents to reduce degree computation.
