### PR TITLE
[SPARK-30440][CORE][TESTS] Avoid race condition in TaskSetManagerSuite by not using resourceOffer

### DIFF
--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -1919,7 +1919,8 @@ class TaskSetManagerSuite
 
     TestUtils.waitUntilExecutorsUp(sc, 2, 60000)
 
-    val taskSet = FakeLongTasks.createTaskSet(2)
+    val tasks = Array.tabulate[Task[_]](2)(partition => new FakeLongTasks(stageId = 0, partition))
+    val taskSet : TaskSet = new TaskSet(tasks, stageId = 0, stageAttemptId = 0, priority = 0, null)
     val stageId = taskSet.stageId
     val stageAttemptId = taskSet.stageAttemptId
     sched.submitTasks(taskSet)
@@ -1971,18 +1972,5 @@ class FakeLongTasks(
       Thread.sleep(10000)
     }
     0
-  }
-}
-
-object FakeLongTasks {
-  def createTaskSet(
-      numTasks: Int,
-      stageId: Int = 0,
-      stageAttemptId: Int = 0,
-      priority: Int = 0): TaskSet = {
-    val tasks = Array.tabulate[Task[_]](numTasks) { i =>
-      new FakeLongTasks(stageId, i)
-    }
-    new TaskSet(tasks, stageId, stageAttemptId, priority, null)
   }
 }

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -32,7 +32,6 @@ import org.scalatest.PrivateMethodTester
 import org.scalatest.concurrent.Eventually
 
 import org.apache.spark._
-import org.apache.spark.executor.TaskMetrics
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config
 import org.apache.spark.resource.ResourceUtils._
@@ -1924,8 +1923,9 @@ class TaskSetManagerSuite
     val stageId = taskSet.stageId
     val stageAttemptId = taskSet.stageAttemptId
     sched.submitTasks(taskSet)
-    val taskSetManagers = PrivateMethod[mutable.HashMap[Int, mutable.HashMap[Int, TaskSetManager]]](
-      Symbol("taskSetsByStageIdAndAttempt"))
+    val taskSetManagers =
+      PrivateMethod[mutable.HashMap[Int, mutable.HashMap[Int, TaskSetManager]]](
+        Symbol("taskSetsByStageIdAndAttempt"))
     // get the TaskSetManager
     val manager = sched.invokePrivate(taskSetManagers()).get(stageId).get(stageAttemptId)
 
@@ -1959,10 +1959,7 @@ class TaskSetManagerSuite
   }
 }
 
-class FakeLongTasks(
-    stageId: Int,
-    partitionId: Int)
-    extends FakeTask(stageId, partitionId) {
+class FakeLongTasks(stageId: Int, partitionId: Int) extends FakeTask(stageId, partitionId) {
 
   override def runTask(context: TaskContext): Int = {
     while (true) {

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -1920,7 +1920,7 @@ class TaskSetManagerSuite
     TestUtils.waitUntilExecutorsUp(sc, 2, 60000)
 
     val tasks = Array.tabulate[Task[_]](2)(partition => new FakeLongTasks(stageId = 0, partition))
-    val taskSet : TaskSet = new TaskSet(tasks, stageId = 0, stageAttemptId = 0, priority = 0, null)
+    val taskSet: TaskSet = new TaskSet(tasks, stageId = 0, stageAttemptId = 0, priority = 0, null)
     val stageId = taskSet.stageId
     val stageAttemptId = taskSet.stageAttemptId
     sched.submitTasks(taskSet)

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -1930,14 +1930,11 @@ class TaskSetManagerSuite
     val manager = sched.invokePrivate(taskSetManagers()).get(stageId).get(stageAttemptId)
 
     val (task0, task1) = eventually(timeout(10.seconds), interval(100.milliseconds)) {
-      val task0 = Option(manager.taskInfos(0))
-      val task1 = Option(manager.taskInfos(1))
-      assert(task0.isDefined && task1.isDefined)
-      (task0, task1)
+      (manager.taskInfos(0), manager.taskInfos(1))
     }
 
-    val (taskId0, index0, exec0) = (task0.get.taskId, task0.get.index, task0.get.executorId)
-    val (taskId1, index1, exec1) = (task1.get.taskId, task1.get.index, task1.get.executorId)
+    val (taskId0, index0, exec0) = (task0.taskId, task0.index, task0.executorId)
+    val (taskId1, index1, exec1) = (task1.taskId, task1.index, task1.executorId)
     // set up two running tasks
     assert(manager.taskInfos(taskId0).running)
     assert(manager.taskInfos(taskId1).running)


### PR DESCRIPTION
### What changes were proposed in this pull request?
There is a race condition in test case introduced in SPARK-30359 between reviveOffers in org.apache.spark.scheduler.TaskSchedulerImpl#submitTasks and org.apache.spark.scheduler.TaskSetManager#resourceOffer, in the testcase

No need to do resourceOffers as submitTask will revive offers from task set

### Why are the changes needed?
Fix flaky test

### Does this PR introduce any user-facing change?
No


### How was this patch tested?
Test case can pass after the change