### PR TITLE
[SPARK-30440][CORE][TEST] Fix flaky test of SPARK-30359

### DIFF
--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -1919,7 +1919,12 @@ class TaskSetManagerSuite
     TestUtils.waitUntilExecutorsUp(sc, 2, 60000)
     val Seq(exec0, exec1) = backend.getExecutorIds()
 
-    val taskSet = FakeTask.createTaskSet(2)
+    // SPARK-30440: it's possible that tasks have already been scheduled after we call
+    // `sched.submitTasks(taskSet)` but before `manager.resourceOffer`. In this case,
+    // we'd get None task after `resourceOffer`. So, here, we intentionally set up a
+    // 4 tasks TaskSet in order to feed 2 tasks to the executors and leave another two
+    // tasks for our test purpose.
+    val taskSet = FakeTask.createTaskSet(4)
     val stageId = taskSet.stageId
     val stageAttemptId = taskSet.stageAttemptId
     sched.submitTasks(taskSet)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Fix flaky test: ```SPARK-30359: don't clean executorsPendingToRemove at the beginning of CoarseGrainedSchedulerBackend.reset```


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

There's a race condition between
https://github.com/apache/spark/blob/4a093176ea357b0578543e43cdca8b0b5182665f/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala#L1925
and
https://github.com/apache/spark/blob/4a093176ea357b0578543e43cdca8b0b5182665f/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala#L1931

It's possible that tasks have been scheduled after `sched.submitTasks` but before `manager.resourceOffer`.

The flaky issue is easy to reproduce if we insert `Thread.sleep(100)` after `sched.submitTasks` and has gone with this fix.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
NO.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Updated test.