### PR TITLE
[SPARK-30427][SQL] Add config item for limiting partition number when calculating statistics through File System

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1411,7 +1411,7 @@ object SQLConf {
         "is very time consuming. Setting this value to negative will disable statistic " +
         "calculation via file system.")
       .intConf
-      .createWithDefault(1000)
+      .createWithDefault(100)
 
   val NDV_MAX_ERROR =
     buildConf("spark.sql.statistics.ndv.maxError")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1403,6 +1403,16 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
+  val MAX_PARTITION_NUMBER_FOR_STATS_CALCULATION_VIA_FS =
+    buildConf("spark.sql.statistics.statisticViaFileSystem.maxPartitionNumber")
+      .doc("If the number of table (can be either hive table or data source table ) partitions " +
+        "exceed this value, statistic calculation via file system is not allowed. This is to " +
+        "avoid calculating size of large number of partitions via file system, eg. HDFS, which " +
+        "is very time consuming. Setting this value to negative will disable statistic " +
+        "calculation via file system.")
+      .intConf
+      .createWithDefault(1000)
+
   val NDV_MAX_ERROR =
     buildConf("spark.sql.statistics.ndv.maxError")
       .internal()
@@ -2563,6 +2573,9 @@ class SQLConf extends Serializable with Logging {
     getConf(SQLConf.PARALLEL_FILE_LISTING_IN_STATS_COMPUTATION)
 
   def fallBackToHdfsForStatsEnabled: Boolean = getConf(ENABLE_FALL_BACK_TO_HDFS_FOR_STATS)
+
+  def maxPartNumForStatsCalculateViaFS: Int =
+    getConf(MAX_PARTITION_NUMBER_FOR_STATS_CALCULATION_VIA_FS)
 
   def defaultSizeInBytes: Long = getConf(DEFAULT_SIZE_IN_BYTES)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
@@ -18,13 +18,12 @@
 package org.apache.spark.sql.execution.datasources
 
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.catalog.{CatalogStatistics, CatalogTable}
+import org.apache.spark.sql.catalyst.catalog.CatalogStatistics
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LeafNode, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2ScanRelation, FileScan}
-import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2ScanRelation, FileScan, FileTable}
 import org.apache.spark.sql.types.StructType
 
 private[sql] object PruneFileSourcePartitions extends Rule[LogicalPlan] {
@@ -60,21 +59,6 @@ private[sql] object PruneFileSourcePartitions extends Rule[LogicalPlan] {
     Project(projects, withFilter)
   }
 
-  private def getNewStatistics(
-              fileIndex: InMemoryFileIndex,
-              conf: SQLConf,
-              tableMeta: Option[CatalogTable]): CatalogStatistics = {
-    if (fileIndex.partitionSpec().partitions.size <= conf.maxPartNumForStatsCalculateViaFS) {
-      CatalogStatistics(sizeInBytes = BigInt(fileIndex.sizeInBytes))
-    } else {
-      if (tableMeta.isDefined && tableMeta.get.stats.isDefined) {
-        tableMeta.get.stats.get
-      } else {
-        CatalogStatistics(sizeInBytes = BigInt(conf.defaultSizeInBytes))
-      }
-    }
-  }
-
   override def apply(plan: LogicalPlan): LogicalPlan = plan transformDown {
     case op @ PhysicalOperation(projects, filters,
         logicalRelation @
@@ -89,20 +73,18 @@ private[sql] object PruneFileSourcePartitions extends Rule[LogicalPlan] {
             _,
             _,
             _))
-      if filters.nonEmpty && fsRelation.partitionSchemaOption.isDefined =>
+        if filters.nonEmpty && fsRelation.partitionSchemaOption.isDefined =>
       val (partitionKeyFilters, _) = getPartitionKeyFiltersAndDataFilters(
         fsRelation.sparkSession, logicalRelation, partitionSchema, filters, logicalRelation.output)
-      val tableMeta = logicalRelation.catalogTable
       if (partitionKeyFilters.nonEmpty) {
         val prunedFileIndex = catalogFileIndex.filterPartitions(partitionKeyFilters.toSeq)
         val prunedFsRelation =
           fsRelation.copy(location = prunedFileIndex)(fsRelation.sparkSession)
         // Change table stats based on the sizeInBytes of pruned files
-        val newStats =
-          getNewStatistics(prunedFileIndex, fsRelation.sparkSession.sessionState.conf, tableMeta)
-        val newTableMeta = tableMeta.map(_.copy(stats = Some(newStats)))
+        val withStats = logicalRelation.catalogTable.map(_.copy(
+          stats = Some(CatalogStatistics(sizeInBytes = BigInt(prunedFileIndex.sizeInBytes)))))
         val prunedLogicalRelation = logicalRelation.copy(
-          relation = prunedFsRelation, catalogTable = newTableMeta)
+          relation = prunedFsRelation, catalogTable = withStats)
         // Keep partition-pruning predicates so that they are visible in physical planning
         rebuildPhysicalOperation(projects, filters, prunedLogicalRelation)
       } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
@@ -64,8 +64,12 @@ private[sql] object PruneFileSourcePartitions extends Rule[LogicalPlan] {
               fileIndex: InMemoryFileIndex,
               conf: SQLConf,
               tableMeta: Option[CatalogTable]): CatalogStatistics = {
+<<<<<<< HEAD
     val partNum = fileIndex.partitionSpec().partitions.size
     if (partNum <= conf.maxPartNumForStatsCalculateViaFS) {
+=======
+    if (fileIndex.partitionSpec().partitions.size <= conf.maxPartNumForStatsCalculateViaFS) {
+>>>>>>> Refine code.
       CatalogStatistics(sizeInBytes = BigInt(fileIndex.sizeInBytes))
     } else {
       if (tableMeta.isDefined && tableMeta.get.stats.isDefined) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
@@ -64,12 +64,7 @@ private[sql] object PruneFileSourcePartitions extends Rule[LogicalPlan] {
               fileIndex: InMemoryFileIndex,
               conf: SQLConf,
               tableMeta: Option[CatalogTable]): CatalogStatistics = {
-<<<<<<< HEAD
-    val partNum = fileIndex.partitionSpec().partitions.size
-    if (partNum <= conf.maxPartNumForStatsCalculateViaFS) {
-=======
     if (fileIndex.partitionSpec().partitions.size <= conf.maxPartNumForStatsCalculateViaFS) {
->>>>>>> Refine code.
       CatalogStatistics(sizeInBytes = BigInt(fileIndex.sizeInBytes))
     } else {
       if (tableMeta.isDefined && tableMeta.get.stats.isDefined) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
@@ -99,7 +99,8 @@ private[sql] object PruneFileSourcePartitions extends Rule[LogicalPlan] {
         val prunedFsRelation =
           fsRelation.copy(location = prunedFileIndex)(fsRelation.sparkSession)
         // Change table stats based on the sizeInBytes of pruned files
-        val newStats = getNewStatistics(prunedFileIndex, fsRelation.sparkSession.sessionState.conf, tableMeta)
+        val newStats =
+          getNewStatistics(prunedFileIndex, fsRelation.sparkSession.sessionState.conf, tableMeta)
         val newTableMeta = tableMeta.map(_.copy(stats = Some(newStats)))
         val prunedLogicalRelation = logicalRelation.copy(
           relation = prunedFsRelation, catalogTable = newTableMeta)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
@@ -162,15 +162,7 @@ trait FileScan extends Scan with Batch with SupportsReportStatistics with Loggin
   override def estimateStatistics(): Statistics = {
     new Statistics {
       override def sizeInBytes(): OptionalLong = {
-        val conf = sparkSession.sessionState.conf
-        val compressionFactor = conf.fileCompressionFactor
-        val partNum = fileIndex.partitionSpec().partitions.size
-        if (conf.maxPartNumForStatsCalculateViaFS > 0
-          && partNum <= conf.maxPartNumForStatsCalculateViaFS) {
-          fileIndex.sizeInBytes
-        } else {
-          conf.defaultSizeInBytes
-        }
+        val compressionFactor = sparkSession.sessionState.conf.fileCompressionFactor
         val size = (compressionFactor * fileIndex.sizeInBytes).toLong
         OptionalLong.of(size)
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
@@ -162,7 +162,15 @@ trait FileScan extends Scan with Batch with SupportsReportStatistics with Loggin
   override def estimateStatistics(): Statistics = {
     new Statistics {
       override def sizeInBytes(): OptionalLong = {
-        val compressionFactor = sparkSession.sessionState.conf.fileCompressionFactor
+        val conf = sparkSession.sessionState.conf
+        val compressionFactor = conf.fileCompressionFactor
+        val partNum = fileIndex.partitionSpec().partitions.size
+        if (conf.maxPartNumForStatsCalculateViaFS > 0
+          && partNum <= conf.maxPartNumForStatsCalculateViaFS) {
+          fileIndex.sizeInBytes
+        } else {
+          conf.defaultSizeInBytes
+        }
         val size = (compressionFactor * fileIndex.sizeInBytes).toLong
         OptionalLong.of(size)
       }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/PruneHiveTablePartitions.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/PruneHiveTablePartitions.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.hive.execution
 
 import org.apache.hadoop.hive.common.StatsSetupConst
+
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.analysis.CastSupport
 import org.apache.spark.sql.catalyst.catalog.{CatalogStatistics, CatalogTable, CatalogTablePartition, ExternalCatalogUtils, HiveTableRelation}

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/PruneFileSourcePartitionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/PruneFileSourcePartitionsSuite.scala
@@ -43,56 +43,50 @@ class PruneFileSourcePartitionsSuite extends QueryTest with SQLTestUtils with Te
 
   test("PruneFileSourcePartitions should not change the output of LogicalRelation") {
     withTable("test") {
-      withTempDir { dir =>
-        sql(
-          s"""
-            |CREATE EXTERNAL TABLE test(i int)
-            |PARTITIONED BY (p int)
-            |STORED AS parquet
-            |LOCATION '${dir.toURI}'""".stripMargin)
+      sql(
+        s"""
+          |CREATE TABLE test(i int)
+          |PARTITIONED BY (p int)
+          |STORED AS parquet""".stripMargin)
 
-        val tableMeta = spark.sharedState.externalCatalog.getTable("default", "test")
-        val catalogFileIndex = new CatalogFileIndex(spark, tableMeta, 0)
+      val tableMeta = spark.sharedState.externalCatalog.getTable("default", "test")
+      val catalogFileIndex = new CatalogFileIndex(spark, tableMeta, 0)
+      val dataSchema = StructType(tableMeta.schema.filterNot { f =>
+        tableMeta.partitionColumnNames.contains(f.name)
+      })
+      val relation = HadoopFsRelation(
+        location = catalogFileIndex,
+        partitionSchema = tableMeta.partitionSchema,
+        dataSchema = dataSchema,
+        bucketSpec = None,
+        fileFormat = new ParquetFileFormat(),
+        options = Map.empty)(sparkSession = spark)
 
-        val dataSchema = StructType(tableMeta.schema.filterNot { f =>
-          tableMeta.partitionColumnNames.contains(f.name)
-        })
-        val relation = HadoopFsRelation(
-          location = catalogFileIndex,
-          partitionSchema = tableMeta.partitionSchema,
-          dataSchema = dataSchema,
-          bucketSpec = None,
-          fileFormat = new ParquetFileFormat(),
-          options = Map.empty)(sparkSession = spark)
+      val logicalRelation = LogicalRelation(relation, tableMeta)
+      val query = Project(Seq(Symbol("i"), Symbol("p")),
+        Filter(Symbol("p") === 1, logicalRelation)).analyze
 
-        val logicalRelation = LogicalRelation(relation, tableMeta)
-        val query = Project(Seq(Symbol("i"), Symbol("p")),
-          Filter(Symbol("p") === 1, logicalRelation)).analyze
-
-        val optimized = Optimize.execute(query)
-        assert(optimized.missingInput.isEmpty)
-      }
+      val optimized = Optimize.execute(query)
+      assert(optimized.missingInput.isEmpty)
     }
   }
 
-  test("SPARK-30427 statistics of pruned partitions can be controlled by " +
+  test("SPARK-30427 statistics of pruned partitions on file source table can be controlled by " +
     "spark.sql.statistics.fallBackToFs.maxPartitionNumber") {
     withTable("test", "temp") {
-      withTempDir { dir =>
-        sql(
-          s"""
-             |CREATE EXTERNAL TABLE test(i int)
-             |PARTITIONED BY (p int)
-             |STORED AS parquet
-             |LOCATION '${dir.toURI}'""".stripMargin)
+      sql(
+        s"""
+          |CREATE TABLE test(i int)
+          |PARTITIONED BY (p int)
+          |STORED AS parquet""".stripMargin)
 
         spark.range(0, 1000, 1).selectExpr("id as col")
           .createOrReplaceTempView("temp")
 
         for (part <- Seq(1, 2, 3, 4)) {
           sql(s"""
-                 |INSERT OVERWRITE TABLE test PARTITION (p='$part')
-                 |select col from temp""".stripMargin)
+                |INSERT OVERWRITE TABLE test PARTITION (p='$part')
+                |select col from temp""".stripMargin)
         }
         val singlePartitionSizeInBytes = 4425
         val catalogTable = spark.sharedState.externalCatalog.getTable("default", "test")
@@ -119,16 +113,13 @@ class PruneFileSourcePartitionsSuite extends QueryTest with SQLTestUtils with Te
           withSQLConf(
             SQLConf.MAX_PARTITION_NUMBER_FOR_STATS_CALCULATION_VIA_FS.key -> s"$maxPartNum") {
             val optimized = Optimize.execute(query)
-            val sizeInBytes =
-              if (maxPartNum>0 && prunedPartNum<=maxPartNum) {
-                singlePartitionSizeInBytes*2
-              } else {
-                singlePartitionSizeInBytes*4
-              }
-            assert(optimized.stats.sizeInBytes === sizeInBytes)
+            if (prunedPartNum <= maxPartNum) {
+              assert(optimized.stats.sizeInBytes / 2 === singlePartitionSizeInBytes)
+            } else {
+              assert(optimized.stats.sizeInBytes / 4 === singlePartitionSizeInBytes)
+            }
           }
         }
-      }
     }
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/PruneHiveTablePartitionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/PruneHiveTablePartitionsSuite.scala
@@ -18,10 +18,15 @@
 package org.apache.spark.sql.hive.execution
 
 import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.EliminateSubqueryAliases
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.catalog.{CatalogStatistics, HiveTableRelation}
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 import org.apache.spark.sql.hive.test.TestHiveSingleton
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SQLTestUtils
 
 class PruneHiveTablePartitionsSuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
@@ -32,7 +37,7 @@ class PruneHiveTablePartitionsSuite extends QueryTest with SQLTestUtils with Tes
         EliminateSubqueryAliases, new PruneHiveTablePartitions(spark)) :: Nil
   }
 
-  test("SPARK-15616 statistics pruned after going throuhg PruneHiveTablePartitions") {
+  test("SPARK-15616 statistics pruned after going through PruneHiveTablePartitions") {
     withTable("test", "temp") {
       sql(
         s"""
@@ -52,6 +57,57 @@ class PruneHiveTablePartitionsSuite extends QueryTest with SQLTestUtils with Tes
       val analyzed2 = sql("select i from test where p = 1").queryExecution.analyzed
       assert(Optimize.execute(analyzed1).stats.sizeInBytes / 4 ===
         Optimize.execute(analyzed2).stats.sizeInBytes)
+    }
+  }
+
+  test("SPARK-30427 spark.sql.statistics.fallBackToFs.maxPartitionNumber can not control " +
+    "the action of rule PruneHiveTablePartitions when sizeInBytes of all partitions are " +
+    "available in meta data.") {
+    withTable("test", "temp") {
+      sql(
+        s"""
+          |CREATE TABLE test(i int)
+          |PARTITIONED BY (p int)
+          |STORED AS textfile""".stripMargin)
+
+      spark.range(0, 1000, 1).selectExpr("id as col")
+        .createOrReplaceTempView("temp")
+      for (part <- Seq(1, 2, 3, 4)) {
+        sql(s"""
+              |INSERT OVERWRITE TABLE test PARTITION (p='$part')
+              |select col from temp""".stripMargin)
+      }
+
+      val tableMeta = spark.sharedState.externalCatalog.getTable("default", "test")
+      val relation =
+        HiveTableRelation(tableMeta,
+          tableMeta.dataSchema.asNullable.toAttributes,
+          tableMeta.partitionSchema.asNullable.toAttributes)
+      val query = Project(Seq(Symbol("i"), Symbol("p")),
+        Filter(Symbol("p") === 1, relation)).analyze
+      var plan1: LogicalPlan = null
+      var plan2: LogicalPlan = null
+      var plan3: LogicalPlan = null
+      var plan4: LogicalPlan = null
+      withSQLConf(
+        SQLConf.MAX_PARTITION_NUMBER_FOR_STATS_CALCULATION_VIA_FS.key -> s"-1") {
+        plan1 = Optimize.execute(query)
+      }
+      withSQLConf(
+        SQLConf.MAX_PARTITION_NUMBER_FOR_STATS_CALCULATION_VIA_FS.key -> s"1") {
+        plan2 = Optimize.execute(query)
+      }
+      withSQLConf(
+        SQLConf.MAX_PARTITION_NUMBER_FOR_STATS_CALCULATION_VIA_FS.key -> s"2") {
+        plan3 = Optimize.execute(query)
+      }
+      withSQLConf(
+        SQLConf.MAX_PARTITION_NUMBER_FOR_STATS_CALCULATION_VIA_FS.key -> s"3") {
+        plan4 = Optimize.execute(query)
+      }
+      assert(plan1.stats.sizeInBytes === plan2.stats.sizeInBytes)
+      assert(plan2.stats.sizeInBytes === plan3.stats.sizeInBytes)
+      assert(plan3.stats.sizeInBytes === plan4.stats.sizeInBytes)
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add config "spark.sql.statistics.fallBackToFs.maxPartitionNumber" and use it to control whether calculate statistics through file system.

### Why are the changes needed?
Currently, when spark need to calculate the statistics (eg. sizeInBytes) of table partition through file system (eg. HDFS), it does not consider the number of partitions. Then if the the number of partitions is huge, it will cost much time to calculate the statistics which may be not be that useful.

It should be reasonable to add a config item to control the limit of partition number allowable to calculate statistics through file system.


### Does this PR introduce any user-facing change?
Yes, statistics of logical plan may be changed which may impact some spark strategies part, eg. JoinSelection.


### How was this patch tested?
Added new unit test.
