### PR TITLE
[SPARK-25993][SQL][TESTS] Add test cases for CREATE EXTERNAL TABLE with subdirectories

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveParquetSourceSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveParquetSourceSuite.scala
@@ -249,9 +249,11 @@ class HiveParquetSourceSuite extends ParquetPartitioningTest {
                  |LOCATION '${s"${path.getCanonicalPath}"}'""".stripMargin
             sql(topDirStatement)
             if (parquetConversion == "true") {
-              checkAnswer(sql("select * from tbl1"), Nil)
+              checkAnswer(sql("SELECT * FROM tbl1"), Nil)
             } else {
-              intercept[IOException](sql("select * from tbl1").show())
+              val msg = intercept[IOException] {sql("SELECT * FROM tbl1").show()
+              }.getMessage
+                assert(msg.contains("Not a file:"))
             }
 
             val l1DirStatement =
@@ -264,10 +266,13 @@ class HiveParquetSourceSuite extends ParquetPartitioningTest {
                  |LOCATION '${s"${path.getCanonicalPath}/l1/"}'""".stripMargin
             sql(l1DirStatement)
             if (parquetConversion == "true") {
-              checkAnswer(sql("select * from tbl2"),
+              checkAnswer(sql("SELECT * FROM tbl2"),
                 (1 to 2).map(i => Row(i, i, s"parq$i")))
             } else {
-              intercept[IOException](sql("select * from tbl2").show())
+              val msg = intercept[IOException] {
+                sql("SELECT * FROM tbl2").show()
+              }.getMessage
+              assert(msg.contains("Not a file:"))
             }
 
             val l2DirStatement =
@@ -280,10 +285,12 @@ class HiveParquetSourceSuite extends ParquetPartitioningTest {
                  |LOCATION '${s"${path.getCanonicalPath}/l1/l2/"}'""".stripMargin
             sql(l2DirStatement)
             if (parquetConversion == "true") {
-              checkAnswer(sql("select * from tbl3"),
+              checkAnswer(sql("SELECT * FROM tbl3"),
                 (3 to 4).map(i => Row(i, i, s"parq$i")))
             } else {
-              intercept[IOException](sql("select * from tbl3").show())
+              val msg = intercept[IOException] {sql("SELECT * FROM tbl3").show()
+              }.getMessage
+              assert(msg.contains("Not a file:"))
             }
 
             val wildcardTopDirStatement =
@@ -296,10 +303,13 @@ class HiveParquetSourceSuite extends ParquetPartitioningTest {
                  |LOCATION '${new File(s"${path}/*").toURI}'""".stripMargin
             sql(wildcardTopDirStatement)
             if (parquetConversion == "true") {
-              checkAnswer(sql("select * from tbl4"),
+              checkAnswer(sql("SELECT * FROM tbl4"),
                 (1 to 2).map(i => Row(i, i, s"parq$i")))
             } else {
-              intercept[IOException](sql("select * from tbl4").show())
+              val msg = intercept[IOException] {
+                sql("SELECT * FROM tbl4").show()
+              }.getMessage
+              assert(msg.contains("Not a file:"))
             }
 
             val wildcardL1DirStatement =
@@ -312,10 +322,12 @@ class HiveParquetSourceSuite extends ParquetPartitioningTest {
                  |LOCATION '${new File(s"${path}/l1/*").toURI}'""".stripMargin
             sql(wildcardL1DirStatement)
             if (parquetConversion == "true") {
-              checkAnswer(sql("select * from tbl5"),
+              checkAnswer(sql("SELECT * FROM tbl5"),
                 (1 to 4).map(i => Row(i, i, s"parq$i")))
             } else {
-              intercept[IOException](sql("select * from tbl5").show())
+              val msg = intercept[IOException] {sql("SELECT * FROM tbl5").show()
+              }.getMessage
+              assert(msg.contains("Not a file:"))
             }
 
             val wildcardL2DirStatement =
@@ -327,7 +339,7 @@ class HiveParquetSourceSuite extends ParquetPartitioningTest {
                  |STORED AS parquet
                  |LOCATION '${new File(s"${path}/l1/l2/*").toURI}'""".stripMargin
             sql(wildcardL2DirStatement)
-            checkAnswer(sql("select * from tbl6"),
+            checkAnswer(sql("SELECT * FROM tbl6"),
               (3 to 6).map(i => Row(i, i, s"parq$i")))
           }
         }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveParquetSourceSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveParquetSourceSuite.scala
@@ -251,9 +251,10 @@ class HiveParquetSourceSuite extends ParquetPartitioningTest {
             if (parquetConversion == "true") {
               checkAnswer(sql("SELECT * FROM tbl1"), Nil)
             } else {
-              val msg = intercept[IOException] {sql("SELECT * FROM tbl1").show()
+              val msg = intercept[IOException] {
+                sql("SELECT * FROM tbl1").show()
               }.getMessage
-                assert(msg.contains("Not a file:"))
+              assert(msg.contains("Not a file:"))
             }
 
             val l1DirStatement =
@@ -266,8 +267,7 @@ class HiveParquetSourceSuite extends ParquetPartitioningTest {
                  |LOCATION '${s"${path.getCanonicalPath}/l1/"}'""".stripMargin
             sql(l1DirStatement)
             if (parquetConversion == "true") {
-              checkAnswer(sql("SELECT * FROM tbl2"),
-                (1 to 2).map(i => Row(i, i, s"parq$i")))
+              checkAnswer(sql("SELECT * FROM tbl2"), (1 to 2).map(i => Row(i, i, s"parq$i")))
             } else {
               val msg = intercept[IOException] {
                 sql("SELECT * FROM tbl2").show()
@@ -285,10 +285,10 @@ class HiveParquetSourceSuite extends ParquetPartitioningTest {
                  |LOCATION '${s"${path.getCanonicalPath}/l1/l2/"}'""".stripMargin
             sql(l2DirStatement)
             if (parquetConversion == "true") {
-              checkAnswer(sql("SELECT * FROM tbl3"),
-                (3 to 4).map(i => Row(i, i, s"parq$i")))
+              checkAnswer(sql("SELECT * FROM tbl3"), (3 to 4).map(i => Row(i, i, s"parq$i")))
             } else {
-              val msg = intercept[IOException] {sql("SELECT * FROM tbl3").show()
+              val msg = intercept[IOException] {
+                sql("SELECT * FROM tbl3").show()
               }.getMessage
               assert(msg.contains("Not a file:"))
             }
@@ -303,8 +303,7 @@ class HiveParquetSourceSuite extends ParquetPartitioningTest {
                  |LOCATION '${new File(s"${path}/*").toURI}'""".stripMargin
             sql(wildcardTopDirStatement)
             if (parquetConversion == "true") {
-              checkAnswer(sql("SELECT * FROM tbl4"),
-                (1 to 2).map(i => Row(i, i, s"parq$i")))
+              checkAnswer(sql("SELECT * FROM tbl4"), (1 to 2).map(i => Row(i, i, s"parq$i")))
             } else {
               val msg = intercept[IOException] {
                 sql("SELECT * FROM tbl4").show()
@@ -322,10 +321,10 @@ class HiveParquetSourceSuite extends ParquetPartitioningTest {
                  |LOCATION '${new File(s"${path}/l1/*").toURI}'""".stripMargin
             sql(wildcardL1DirStatement)
             if (parquetConversion == "true") {
-              checkAnswer(sql("SELECT * FROM tbl5"),
-                (1 to 4).map(i => Row(i, i, s"parq$i")))
+              checkAnswer(sql("SELECT * FROM tbl5"), (1 to 4).map(i => Row(i, i, s"parq$i")))
             } else {
-              val msg = intercept[IOException] {sql("SELECT * FROM tbl5").show()
+              val msg = intercept[IOException] {
+                sql("SELECT * FROM tbl5").show()
               }.getMessage
               assert(msg.contains("Not a file:"))
             }
@@ -339,8 +338,7 @@ class HiveParquetSourceSuite extends ParquetPartitioningTest {
                  |STORED AS parquet
                  |LOCATION '${new File(s"${path}/l1/l2/*").toURI}'""".stripMargin
             sql(wildcardL2DirStatement)
-            checkAnswer(sql("SELECT * FROM tbl6"),
-              (3 to 6).map(i => Row(i, i, s"parq$i")))
+            checkAnswer(sql("SELECT * FROM tbl6"), (3 to 6).map(i => Row(i, i, s"parq$i")))
           }
         }
       }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveParquetSourceSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveParquetSourceSuite.scala
@@ -228,16 +228,49 @@ class HiveParquetSourceSuite extends ParquetPartitioningTest {
     Seq("true", "false").foreach { parquetConversion =>
       withSQLConf(HiveUtils.CONVERT_METASTORE_PARQUET.key -> parquetConversion) {
         withTempPath { path =>
-          withTable("tbl1", "tbl2", "tbl3", "tbl4", "tbl5", "tbl6") {
-            val someDF1 = Seq((1, 1, "parq1"), (2, 2, "parq2")).
-              toDF("c1", "c2", "c3").repartition(1)
-            val someDF2 = Seq((3, 3, "parq3"), (4, 4, "parq4")).
-              toDF("c1", "c2", "c3").repartition(1)
-            val someDF3 = Seq((5, 5, "parq5"), (6, 6, "parq6")).
-              toDF("c1", "c2", "c3").repartition(1)
-            someDF1.write.parquet(s"${path.getCanonicalPath}/l1/")
-            someDF2.write.parquet(s"${path.getCanonicalPath}/l1/l2/")
-            someDF3.write.parquet(s"${path.getCanonicalPath}/l1/l2/l3/")
+          withTable("parq_tbl1", "parq_tbl2", "parq_tbl3",
+            "tbl1", "tbl2", "tbl3", "tbl4", "tbl5", "tbl6") {
+            val parquetTblStatement1 =
+              s"""
+                 |CREATE EXTERNAL TABLE parq_tbl1(
+                 |  c1 int,
+                 |  c2 int,
+                 |  c3 string)
+                 |STORED AS parquet
+                 |LOCATION '${s"${path.getCanonicalPath}/l1/"}'""".stripMargin
+            sql(parquetTblStatement1)
+
+            val parquetTblInsertL1 =
+              s"INSERT INTO TABLE parq_tbl1 VALUES (1, 1, 'parq1'), (2, 2, 'parq2')".stripMargin
+            sql(parquetTblInsertL1)
+
+            val parquetTblStatement2 =
+              s"""
+                 |CREATE EXTERNAL TABLE parq_tbl2(
+                 |  c1 int,
+                 |  c2 int,
+                 |  c3 string)
+                 |STORED AS parquet
+                 |LOCATION '${s"${path.getCanonicalPath}/l1/l2/"}'""".stripMargin
+            sql(parquetTblStatement2)
+
+            val parquetTblInsertL2 =
+              s"INSERT INTO TABLE parq_tbl2 VALUES (3, 3, 'parq3'), (4, 4, 'parq4')".stripMargin
+            sql(parquetTblInsertL2)
+
+            val parquetTblStatement3 =
+              s"""
+                 |CREATE EXTERNAL TABLE parq_tbl3(
+                 |  c1 int,
+                 |  c2 int,
+                 |  c3 string)
+                 |STORED AS parquet
+                 |LOCATION '${s"${path.getCanonicalPath}/l1/l2/l3/"}'""".stripMargin
+            sql(parquetTblStatement3)
+
+            val parquetTblInsertL3 =
+              s"INSERT INTO TABLE parq_tbl3 VALUES (5, 5, 'parq5'), (6, 6, 'parq6')".stripMargin
+            sql(parquetTblInsertL3)
 
             val topDirStatement =
               s"""

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcSourceSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcSourceSuite.scala
@@ -170,4 +170,155 @@ class HiveOrcSourceSuite extends OrcSuite with TestHiveSingleton {
   test("SPARK-11412 read and merge orc schemas in parallel") {
     testMergeSchemasInParallel(OrcFileOperator.readOrcSchemasInParallel)
   }
+
+  test("SPARK-25993 CREATE EXTERNAL TABLE with subdirectories") {
+    Seq(true, false).foreach { convertMetastore =>
+      withSQLConf(HiveUtils.CONVERT_METASTORE_ORC.key -> s"$convertMetastore") {
+        withTempDir { dir =>
+          try {
+            hiveClient.runSqlHive("USE default")
+            hiveClient.runSqlHive(
+              """
+                |CREATE EXTERNAL TABLE hive_orc(
+                |  C1 INT,
+                |  C2 INT,
+                |  C3 STRING)
+                |STORED AS orc""".stripMargin)
+            // Hive throws an exception if I assign the location in the create table statement.
+            hiveClient.runSqlHive(
+              s"ALTER TABLE hive_orc SET LOCATION " +
+                s"'${new File(s"${dir.getCanonicalPath}/l1/").toURI}'")
+            hiveClient.runSqlHive(
+              """
+                |INSERT INTO TABLE hive_orc
+                |VALUES (1, 1, 'orc1'), (2, 2, 'orc2')""".stripMargin)
+
+            hiveClient.runSqlHive(
+              s"ALTER TABLE hive_orc SET LOCATION " +
+                s"'${new File(s"${dir.getCanonicalPath}/l1/l2/").toURI}'")
+            hiveClient.runSqlHive(
+              """
+                |INSERT INTO TABLE hive_orc
+                |VALUES (3, 3, 'orc3'), (4, 4, 'orc4')""".stripMargin)
+
+            hiveClient.runSqlHive(
+              s"ALTER TABLE hive_orc SET LOCATION " +
+                s"'${new File(s"${dir.getCanonicalPath}/l1/l2/l3/").toURI}'")
+            hiveClient.runSqlHive(
+              """
+                |INSERT INTO TABLE hive_orc
+                |VALUES (5, 5, 'orc5'), (6, 6, 'orc6')""".stripMargin)
+
+            withTable("tbl1", "tbl2", "tbl3", "tbl4", "tbl5", "tbl6") {
+              val topDirStatement =
+                s"""
+                   |CREATE EXTERNAL TABLE tbl1(
+                   |  c1 int,
+                   |  c2 int,
+                   |  c3 string)
+                   |STORED AS orc
+                   |LOCATION '${s"${dir.getCanonicalPath}"}'""".stripMargin
+              sql(topDirStatement)
+              val topDirSqlStatement = s"select * from tbl1"
+              if (convertMetastore) {
+                checkAnswer(sql(topDirSqlStatement), Nil)
+              } else {
+                checkAnswer(sql(topDirSqlStatement),
+                  (1 to 6).map(i => Row(i, i, s"orc$i")))
+              }
+
+              val l1DirStatement =
+                s"""
+                   |CREATE EXTERNAL TABLE tbl2(
+                   |  c1 int,
+                   |  c2 int,
+                   |  c3 string)
+                   |STORED AS orc
+                   |LOCATION '${s"${dir.getCanonicalPath}/l1/"}'""".stripMargin
+              sql(l1DirStatement)
+              val l1DirSqlStatement = s"select * from tbl2"
+              if (convertMetastore) {
+                checkAnswer(sql(l1DirSqlStatement),
+                  (1 to 2).map(i => Row(i, i, s"orc$i")))
+              } else {
+                checkAnswer(sql(l1DirSqlStatement),
+                  (1 to 6).map(i => Row(i, i, s"orc$i")))
+              }
+
+              val l2DirStatement =
+                s"""
+                   |CREATE EXTERNAL TABLE tbl3(
+                   |  c1 int,
+                   |  c2 int,
+                   |  c3 string)
+                   |STORED AS orc
+                   |LOCATION '${s"${dir.getCanonicalPath}/l1/l2/"}'""".stripMargin
+              sql(l2DirStatement)
+              val l2DirSqlStatement = s"select * from tbl3"
+              if (convertMetastore) {
+                checkAnswer(sql(l2DirSqlStatement),
+                  (3 to 4).map(i => Row(i, i, s"orc$i")))
+              } else {
+                checkAnswer(sql(l2DirSqlStatement),
+                  (3 to 6).map(i => Row(i, i, s"orc$i")))
+              }
+
+              val wildcardTopDirStatement =
+                s"""
+                   |CREATE EXTERNAL TABLE tbl4(
+                   |  c1 int,
+                   |  c2 int,
+                   |  c3 string)
+                   |STORED AS orc
+                   |LOCATION '${new File(s"${dir}/*").toURI}'""".stripMargin
+              sql(wildcardTopDirStatement)
+              val wildcardTopDirSqlStatement = s"select * from tbl4"
+              if (convertMetastore) {
+                checkAnswer(sql(wildcardTopDirSqlStatement),
+                  (1 to 2).map(i => Row(i, i, s"orc$i")))
+              } else {
+                checkAnswer(sql(wildcardTopDirSqlStatement), Nil)
+              }
+
+              val wildcardL1DirStatement =
+                s"""
+                   |CREATE EXTERNAL TABLE tbl5(
+                   |  c1 int,
+                   |  c2 int,
+                   |  c3 string)
+                   |STORED AS orc
+                   |LOCATION '${new File(s"${dir}/l1/*").toURI}'""".stripMargin
+              sql(wildcardL1DirStatement)
+              val wildcardL1DirSqlStatement = s"select * from tbl5"
+              if (convertMetastore) {
+                checkAnswer(sql(wildcardL1DirSqlStatement),
+                  (1 to 4).map(i => Row(i, i, s"orc$i")))
+              } else {
+                checkAnswer(sql(wildcardL1DirSqlStatement), Nil)
+              }
+
+              val wildcardL2Statement =
+                s"""
+                   |CREATE EXTERNAL TABLE tbl6(
+                   |  c1 int,
+                   |  c2 int,
+                   |  c3 string)
+                   |STORED AS orc
+                   |LOCATION '${new File(s"${dir}/l1/l2/*").toURI}'""".stripMargin
+              sql(wildcardL2Statement)
+              val wildcardL2SqlStatement = s"select * from tbl6"
+              if (convertMetastore) {
+                checkAnswer(sql(wildcardL2SqlStatement),
+                  (3 to 6).map(i => Row(i, i, s"orc$i")))
+              } else {
+                checkAnswer(sql(wildcardL2SqlStatement), Nil)
+              }
+            }
+          } finally {
+            hiveClient.runSqlHive("DROP TABLE IF EXISTS hive_orc")
+          }
+        }
+      }
+    }
+  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcSourceSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcSourceSuite.scala
@@ -176,39 +176,47 @@ class HiveOrcSourceSuite extends OrcSuite with TestHiveSingleton {
       withSQLConf(HiveUtils.CONVERT_METASTORE_ORC.key -> s"$convertMetastore") {
         withTempDir { dir =>
           try {
-            sql("USE default")
-            sql(
-              """
-                |CREATE EXTERNAL TABLE hive_orc(
-                |  C1 INT,
-                |  C2 INT,
-                |  C3 STRING)
-                |STORED AS orc
-                |LOCATION '${new File(s"${dir.getCanonicalPath}").toURI}'""".stripMargin)
+            val orcTblStatement1 =
+              s"""
+                 |CREATE EXTERNAL TABLE orc_tbl1(
+                 |  c1 int,
+                 |  c2 int,
+                 |  c3 string)
+                 |STORED AS orc
+                 |LOCATION '${s"${dir.getCanonicalPath}/l1/"}'""".stripMargin
+            sql(orcTblStatement1)
 
-            // Hive throws an exception if I assign the location in the create table statement.
-            sql(s"ALTER TABLE hive_orc SET LOCATION " +
-                s"'${new File(s"${dir.getCanonicalPath}/l1/").toURI}'")
-            hiveClient.runSqlHive(
-              """
-                |INSERT INTO TABLE hive_orc
-                |VALUES (1, 1, 'orc1'), (2, 2, 'orc2')""".stripMargin)
+            val orcTblInsertL1 =
+              s"INSERT INTO TABLE orc_tbl1 VALUES (1, 1, 'orc1'), (2, 2, 'orc2')".stripMargin
+            sql(orcTblInsertL1)
 
-            sql(
-              s"ALTER TABLE hive_orc SET LOCATION " +
-                s"'${new File(s"${dir.getCanonicalPath}/l1/l2/").toURI}'")
-            hiveClient.runSqlHive(
-              """
-                |INSERT INTO TABLE hive_orc
-                |VALUES (3, 3, 'orc3'), (4, 4, 'orc4')""".stripMargin)
+            val orcTblStatement2 =
+            s"""
+               |CREATE EXTERNAL TABLE orc_tbl2(
+               |  c1 int,
+               |  c2 int,
+               |  c3 string)
+               |STORED AS orc
+               |LOCATION '${s"${dir.getCanonicalPath}/l1/l2/"}'""".stripMargin
+            sql(orcTblStatement2)
 
-            sql(
-              s"ALTER TABLE hive_orc SET LOCATION " +
-                s"'${new File(s"${dir.getCanonicalPath}/l1/l2/l3/").toURI}'")
-            hiveClient.runSqlHive(
-              """
-                |INSERT INTO TABLE hive_orc
-                |VALUES (5, 5, 'orc5'), (6, 6, 'orc6')""".stripMargin)
+            val orcTblInsertL2 =
+              s"INSERT INTO TABLE orc_tbl2 VALUES (3, 3, 'orc3'), (4, 4, 'orc4')".stripMargin
+            sql(orcTblInsertL2)
+
+            val orcTblStatement3 =
+            s"""
+               |CREATE EXTERNAL TABLE orc_tbl3(
+               |  c1 int,
+               |  c2 int,
+               |  c3 string)
+               |STORED AS orc
+               |LOCATION '${s"${dir.getCanonicalPath}/l1/l2/l3/"}'""".stripMargin
+            sql(orcTblStatement3)
+
+            val orcTblInsertL3 =
+              s"INSERT INTO TABLE orc_tbl3 VALUES (5, 5, 'orc5'), (6, 6, 'orc6')".stripMargin
+            sql(orcTblInsertL3)
 
             withTable("tbl1", "tbl2", "tbl3", "tbl4", "tbl5", "tbl6") {
               val topDirStatement =
@@ -316,7 +324,9 @@ class HiveOrcSourceSuite extends OrcSuite with TestHiveSingleton {
               }
             }
           } finally {
-            hiveClient.runSqlHive("DROP TABLE IF EXISTS hive_orc")
+            sql("DROP TABLE IF EXISTS orc_tbl1")
+            sql("DROP TABLE IF EXISTS orc_tbl2")
+            sql("DROP TABLE IF EXISTS orc_tbl3")
           }
         }
       }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcSourceSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcSourceSuite.scala
@@ -175,7 +175,7 @@ class HiveOrcSourceSuite extends OrcSuite with TestHiveSingleton {
     Seq(true, false).foreach { convertMetastore =>
       withSQLConf(HiveUtils.CONVERT_METASTORE_ORC.key -> s"$convertMetastore") {
         withTempDir { dir =>
-          try {
+          withTable("orc_tbl1", "orc_tbl2", "orc_tbl3") {
             val orcTblStatement1 =
               s"""
                  |CREATE EXTERNAL TABLE orc_tbl1(
@@ -232,8 +232,7 @@ class HiveOrcSourceSuite extends OrcSuite with TestHiveSingleton {
               if (convertMetastore) {
                 checkAnswer(sql(topDirSqlStatement), Nil)
               } else {
-                checkAnswer(sql(topDirSqlStatement),
-                  (1 to 6).map(i => Row(i, i, s"orc$i")))
+                checkAnswer(sql(topDirSqlStatement), (1 to 6).map(i => Row(i, i, s"orc$i")))
               }
 
               val l1DirStatement =
@@ -247,11 +246,9 @@ class HiveOrcSourceSuite extends OrcSuite with TestHiveSingleton {
               sql(l1DirStatement)
               val l1DirSqlStatement = s"SELECT * FROM tbl2"
               if (convertMetastore) {
-                checkAnswer(sql(l1DirSqlStatement),
-                  (1 to 2).map(i => Row(i, i, s"orc$i")))
+                checkAnswer(sql(l1DirSqlStatement), (1 to 2).map(i => Row(i, i, s"orc$i")))
               } else {
-                checkAnswer(sql(l1DirSqlStatement),
-                  (1 to 6).map(i => Row(i, i, s"orc$i")))
+                checkAnswer(sql(l1DirSqlStatement), (1 to 6).map(i => Row(i, i, s"orc$i")))
               }
 
               val l2DirStatement =
@@ -265,11 +262,9 @@ class HiveOrcSourceSuite extends OrcSuite with TestHiveSingleton {
               sql(l2DirStatement)
               val l2DirSqlStatement = s"SELECT * FROM tbl3"
               if (convertMetastore) {
-                checkAnswer(sql(l2DirSqlStatement),
-                  (3 to 4).map(i => Row(i, i, s"orc$i")))
+                checkAnswer(sql(l2DirSqlStatement), (3 to 4).map(i => Row(i, i, s"orc$i")))
               } else {
-                checkAnswer(sql(l2DirSqlStatement),
-                  (3 to 6).map(i => Row(i, i, s"orc$i")))
+                checkAnswer(sql(l2DirSqlStatement), (3 to 6).map(i => Row(i, i, s"orc$i")))
               }
 
               val wildcardTopDirStatement =
@@ -283,8 +278,7 @@ class HiveOrcSourceSuite extends OrcSuite with TestHiveSingleton {
               sql(wildcardTopDirStatement)
               val wildcardTopDirSqlStatement = s"SELECT * FROM tbl4"
               if (convertMetastore) {
-                checkAnswer(sql(wildcardTopDirSqlStatement),
-                  (1 to 2).map(i => Row(i, i, s"orc$i")))
+                checkAnswer(sql(wildcardTopDirSqlStatement), (1 to 2).map(i => Row(i, i, s"orc$i")))
               } else {
                 checkAnswer(sql(wildcardTopDirSqlStatement), Nil)
               }
@@ -300,8 +294,7 @@ class HiveOrcSourceSuite extends OrcSuite with TestHiveSingleton {
               sql(wildcardL1DirStatement)
               val wildcardL1DirSqlStatement = s"SELECT * FROM tbl5"
               if (convertMetastore) {
-                checkAnswer(sql(wildcardL1DirSqlStatement),
-                  (1 to 4).map(i => Row(i, i, s"orc$i")))
+                checkAnswer(sql(wildcardL1DirSqlStatement), (1 to 4).map(i => Row(i, i, s"orc$i")))
               } else {
                 checkAnswer(sql(wildcardL1DirSqlStatement), Nil)
               }
@@ -317,16 +310,11 @@ class HiveOrcSourceSuite extends OrcSuite with TestHiveSingleton {
               sql(wildcardL2Statement)
               val wildcardL2SqlStatement = s"SELECT * FROM tbl6"
               if (convertMetastore) {
-                checkAnswer(sql(wildcardL2SqlStatement),
-                  (3 to 6).map(i => Row(i, i, s"orc$i")))
+                checkAnswer(sql(wildcardL2SqlStatement), (3 to 6).map(i => Row(i, i, s"orc$i")))
               } else {
                 checkAnswer(sql(wildcardL2SqlStatement), Nil)
               }
             }
-          } finally {
-            sql("DROP TABLE IF EXISTS orc_tbl1")
-            sql("DROP TABLE IF EXISTS orc_tbl2")
-            sql("DROP TABLE IF EXISTS orc_tbl3")
           }
         }
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add these test cases for resolution of ORC table location reported by [SPARK-25993](https://issues.apache.org/jira/browse/SPARK-25993)
also add corresponding test cases for Parquet table.

### Why are the changes needed?

The current behavior is complex, this test case suites are designed to prevent the accidental behavior change. This pr is rebased on master, the original pr is [23108](https://github.com/apache/spark/pull/23108)

### Does this PR introduce any user-facing change?

No. This adds test cases only.

### How was this patch tested?

This is a new test case.
