### PR TITLE
[SPARK-30454][SQL] Handle Possible Null Pointer exception in HiveSQLException

### DIFF
--- a/sql/hive-thriftserver/v1.2/src/main/java/org/apache/hive/service/cli/HiveSQLException.java
+++ b/sql/hive-thriftserver/v1.2/src/main/java/org/apache/hive/service/cli/HiveSQLException.java
@@ -229,7 +229,7 @@ public class HiveSQLException extends SQLException {
       trace[i] = new StackTraceElement(className, methodName, fileName, lineNumber);
     }
     int common = trace.length - i;
-    if (common > 0) {
+    if (null != parent && common > 0 && common < parent.length) {
       System.arraycopy(parent, parent.length - common, trace, trace.length - common, common);
     }
     if (details.size() > index) {

--- a/sql/hive-thriftserver/v2.3/src/main/java/org/apache/hive/service/cli/HiveSQLException.java
+++ b/sql/hive-thriftserver/v2.3/src/main/java/org/apache/hive/service/cli/HiveSQLException.java
@@ -229,7 +229,7 @@ public class HiveSQLException extends SQLException {
       trace[i] = new StackTraceElement(className, methodName, fileName, lineNumber);
     }
     int common = trace.length - i;
-    if (common > 0) {
+    if (null != parent && common > 0 && common < parent.length) {
       System.arraycopy(parent, parent.length - common, trace, trace.length - common, common);
     }
     if (details.size() > index) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Null Handling missed in HiveSQLException class in  toStackTrace method.
![Screenshot from 2020-01-08 17-18-29](https://user-images.githubusercontent.com/51401130/71975872-0e253480-323b-11ea-8e41-6502a8ae63c4.png)
As seen in the above screenshot, **toCause** method passes NULL to **toStackTrace** method as Parent,
![Screenshot from 2020-01-08 17-19-19](https://user-images.githubusercontent.com/51401130/71975879-10878e80-323b-11ea-86c4-35623a67d485.png)
In  **toStackTrace** method there is no null check for parent and directly parent.length is called, which can cause a NULL Pointer Exception.
### Why are the changes needed?
Null handling should be present , inorder to not break the code flow.


### Does this PR introduce any user-facing change?
NA


### How was this patch tested?
Manual
