### PR TITLE
[SPARK-30468][SQL] Use multiple lines to display data columns for show create table command

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -1159,7 +1159,7 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
   private def showDataSourceTableDataColumns(
       metadata: CatalogTable, builder: StringBuilder): Unit = {
     val columns = metadata.schema.fields.map(_.toDDL)
-    builder ++= columns.mkString("(\n  ", ",\n  ", ")\n")
+    builder ++= concatWithMultiLines(columns)
   }
 
   private def showDataSourceTableOptions(metadata: CatalogTable, builder: StringBuilder): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -1040,11 +1040,11 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
         // view columns shouldn't have data type info
         s"${quoteIdentifier(f.name)}${comment.getOrElse("")}"
       }
-      builder ++= concatStrings(viewColumns)
+      builder ++= concatInMultiLines(viewColumns)
     }
   }
 
-  private def concatStrings(iter: Iterable[String]): String = {
+  private def concatInMultiLines(iter: Iterable[String]): String = {
     iter.mkString("(\n  ", ",\n  ", ")\n")
   }
 
@@ -1055,7 +1055,7 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
         s"'${escapeSingleQuotedString(key)}' = '${escapeSingleQuotedString(value)}'"
       }
 
-      builder ++= s"TBLPROPERTIES ${concatStrings(props)}"
+      builder ++= s"TBLPROPERTIES ${concatInMultiLines(props)}"
     }
   }
 
@@ -1069,7 +1069,7 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
     }.map(_.toDDL)
 
     if (columns.nonEmpty) {
-      builder ++= concatStrings(columns)
+      builder ++= concatInMultiLines(columns)
     }
   }
 
@@ -1101,7 +1101,7 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
           s"'${escapeSingleQuotedString(key)}' = '${escapeSingleQuotedString(value)}'"
       }
 
-      builder ++= s"WITH SERDEPROPERTIES ${concatStrings(serdeProps)})"
+      builder ++= s"WITH SERDEPROPERTIES ${concatInMultiLines(serdeProps)})"
     }
 
     if (storage.inputFormat.isDefined || storage.outputFormat.isDefined) {
@@ -1138,7 +1138,7 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
         s"'${escapeSingleQuotedString(key)}' = '${escapeSingleQuotedString(value)}'"
       }
 
-      builder ++= s"TBLPROPERTIES ${concatStrings(props)}"
+      builder ++= s"TBLPROPERTIES ${concatInMultiLines(props)}"
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -1040,8 +1040,12 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
         // view columns shouldn't have data type info
         s"${quoteIdentifier(f.name)}${comment.getOrElse("")}"
       }
-      builder ++= viewColumns.mkString("(", ", ", ")\n")
+      builder ++= concatStrings(viewColumns)
     }
+  }
+
+  private def concatStrings(iter: Iterable[String]): String = {
+    iter.mkString("(\n  ", ",\n  ", ")\n")
   }
 
   private def showViewProperties(metadata: CatalogTable, builder: StringBuilder): Unit = {
@@ -1051,7 +1055,7 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
         s"'${escapeSingleQuotedString(key)}' = '${escapeSingleQuotedString(value)}'"
       }
 
-      builder ++= props.mkString("TBLPROPERTIES (\n  ", ",\n  ", "\n)\n")
+      builder ++= s"TBLPROPERTIES ${concatStrings(props)}"
     }
   }
 
@@ -1065,7 +1069,7 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
     }.map(_.toDDL)
 
     if (columns.nonEmpty) {
-      builder ++= columns.mkString("(", ", ", ")\n")
+      builder ++= concatStrings(columns)
     }
   }
 
@@ -1077,7 +1081,7 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
 
     if (metadata.bucketSpec.isDefined) {
       val bucketSpec = metadata.bucketSpec.get
-      builder ++= s"CLUSTERED BY (${bucketSpec.bucketColumnNames.mkString(",")})\n"
+      builder ++= s"CLUSTERED BY (${bucketSpec.bucketColumnNames.mkString(", ")})\n"
 
       if (bucketSpec.sortColumnNames.nonEmpty) {
         builder ++= s"SORTED BY (${bucketSpec.sortColumnNames.map(_ + " ASC").mkString(", ")})\n"
@@ -1097,7 +1101,7 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
           s"'${escapeSingleQuotedString(key)}' = '${escapeSingleQuotedString(value)}'"
       }
 
-      builder ++= serdeProps.mkString("WITH SERDEPROPERTIES (\n  ", ",\n  ", "\n)\n")
+      builder ++= s"WITH SERDEPROPERTIES ${concatStrings(serdeProps)})"
     }
 
     if (storage.inputFormat.isDefined || storage.outputFormat.isDefined) {
@@ -1134,7 +1138,7 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
         s"'${escapeSingleQuotedString(key)}' = '${escapeSingleQuotedString(value)}'"
       }
 
-      builder ++= props.mkString("TBLPROPERTIES (\n  ", ",\n  ", "\n)\n")
+      builder ++= s"TBLPROPERTIES ${concatStrings(props)}"
     }
   }
 
@@ -1155,7 +1159,7 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
   private def showDataSourceTableDataColumns(
       metadata: CatalogTable, builder: StringBuilder): Unit = {
     val columns = metadata.schema.fields.map(_.toDDL)
-    builder ++= columns.mkString("(", ", ", ")\n")
+    builder ++= columns.mkString("(\n  ", ",\n  ", ")\n")
   }
 
   private def showDataSourceTableOptions(metadata: CatalogTable, builder: StringBuilder): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -1040,11 +1040,11 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
         // view columns shouldn't have data type info
         s"${quoteIdentifier(f.name)}${comment.getOrElse("")}"
       }
-      builder ++= concatInMultiLines(viewColumns)
+      builder ++= concatWithMultiLines(viewColumns)
     }
   }
 
-  private def concatInMultiLines(iter: Iterable[String]): String = {
+  private def concatWithMultiLines(iter: Iterable[String]): String = {
     iter.mkString("(\n  ", ",\n  ", ")\n")
   }
 
@@ -1055,7 +1055,7 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
         s"'${escapeSingleQuotedString(key)}' = '${escapeSingleQuotedString(value)}'"
       }
 
-      builder ++= s"TBLPROPERTIES ${concatInMultiLines(props)}"
+      builder ++= s"TBLPROPERTIES ${concatWithMultiLines(props)}"
     }
   }
 
@@ -1069,7 +1069,7 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
     }.map(_.toDDL)
 
     if (columns.nonEmpty) {
-      builder ++= concatInMultiLines(columns)
+      builder ++= concatWithMultiLines(columns)
     }
   }
 
@@ -1101,7 +1101,7 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
           s"'${escapeSingleQuotedString(key)}' = '${escapeSingleQuotedString(value)}'"
       }
 
-      builder ++= s"WITH SERDEPROPERTIES ${concatInMultiLines(serdeProps)})"
+      builder ++= s"WITH SERDEPROPERTIES ${concatWithMultiLines(serdeProps)})"
     }
 
     if (storage.inputFormat.isDefined || storage.outputFormat.isDefined) {
@@ -1138,7 +1138,7 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
         s"'${escapeSingleQuotedString(key)}' = '${escapeSingleQuotedString(value)}'"
       }
 
-      builder ++= s"TBLPROPERTIES ${concatInMultiLines(props)}"
+      builder ++= s"TBLPROPERTIES ${concatWithMultiLines(props)}"
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -1040,11 +1040,11 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
         // view columns shouldn't have data type info
         s"${quoteIdentifier(f.name)}${comment.getOrElse("")}"
       }
-      builder ++= concatWithMultiLines(viewColumns)
+      builder ++= concatByMultiLines(viewColumns)
     }
   }
 
-  private def concatWithMultiLines(iter: Iterable[String]): String = {
+  private def concatByMultiLines(iter: Iterable[String]): String = {
     iter.mkString("(\n  ", ",\n  ", ")\n")
   }
 
@@ -1055,7 +1055,7 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
         s"'${escapeSingleQuotedString(key)}' = '${escapeSingleQuotedString(value)}'"
       }
 
-      builder ++= s"TBLPROPERTIES ${concatWithMultiLines(props)}"
+      builder ++= s"TBLPROPERTIES ${concatByMultiLines(props)}"
     }
   }
 
@@ -1069,7 +1069,7 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
     }.map(_.toDDL)
 
     if (columns.nonEmpty) {
-      builder ++= concatWithMultiLines(columns)
+      builder ++= concatByMultiLines(columns)
     }
   }
 
@@ -1101,7 +1101,7 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
           s"'${escapeSingleQuotedString(key)}' = '${escapeSingleQuotedString(value)}'"
       }
 
-      builder ++= s"WITH SERDEPROPERTIES ${concatWithMultiLines(serdeProps)})"
+      builder ++= s"WITH SERDEPROPERTIES ${concatByMultiLines(serdeProps)}"
     }
 
     if (storage.inputFormat.isDefined || storage.outputFormat.isDefined) {
@@ -1138,7 +1138,7 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
         s"'${escapeSingleQuotedString(key)}' = '${escapeSingleQuotedString(value)}'"
       }
 
-      builder ++= s"TBLPROPERTIES ${concatWithMultiLines(props)}"
+      builder ++= s"TBLPROPERTIES ${concatByMultiLines(props)}"
     }
   }
 
@@ -1159,7 +1159,7 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
   private def showDataSourceTableDataColumns(
       metadata: CatalogTable, builder: StringBuilder): Unit = {
     val columns = metadata.schema.fields.map(_.toDDL)
-    builder ++= concatWithMultiLines(columns)
+    builder ++= concatByMultiLines(columns)
   }
 
   private def showDataSourceTableOptions(metadata: CatalogTable, builder: StringBuilder): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -1170,9 +1170,7 @@ case class ShowCreateTableCommand(table: TableIdentifier) extends RunnableComman
     }
 
     if (dataSourceOptions.nonEmpty) {
-      builder ++= "OPTIONS (\n"
-      builder ++= dataSourceOptions.mkString("  ", ",\n  ", "\n")
-      builder ++= ")\n"
+      builder ++= s"OPTIONS ${concatByMultiLines(dataSourceOptions)}"
     }
   }
 

--- a/sql/core/src/test/resources/sql-tests/results/show-create-table.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/show-create-table.sql.out
@@ -15,7 +15,10 @@ SHOW CREATE TABLE tbl
 -- !query 1 schema
 struct<createtab_stmt:string>
 -- !query 1 output
-CREATE TABLE `tbl` (`a` INT, `b` STRING, `c` INT)
+CREATE TABLE `tbl` (
+  `a` INT,
+  `b` STRING,
+  `c` INT)
 USING parquet
 
 
@@ -41,7 +44,10 @@ SHOW CREATE TABLE tbl
 -- !query 4 schema
 struct<createtab_stmt:string>
 -- !query 4 output
-CREATE TABLE `tbl` (`a` INT, `b` STRING, `c` INT)
+CREATE TABLE `tbl` (
+  `a` INT,
+  `b` STRING,
+  `c` INT)
 USING parquet
 OPTIONS (
   `a` '1'
@@ -70,7 +76,10 @@ SHOW CREATE TABLE tbl
 -- !query 7 schema
 struct<createtab_stmt:string>
 -- !query 7 output
-CREATE TABLE `tbl` (`a` INT, `b` STRING, `c` INT)
+CREATE TABLE `tbl` (
+  `a` INT,
+  `b` STRING,
+  `c` INT)
 USING parquet
 LOCATION 'file:/path/to/table'
 
@@ -97,7 +106,10 @@ SHOW CREATE TABLE tbl
 -- !query 10 schema
 struct<createtab_stmt:string>
 -- !query 10 output
-CREATE TABLE `tbl` (`a` INT, `b` STRING, `c` INT)
+CREATE TABLE `tbl` (
+  `a` INT,
+  `b` STRING,
+  `c` INT)
 USING parquet
 LOCATION 'file:/path/to/table'
 
@@ -124,7 +136,10 @@ SHOW CREATE TABLE tbl
 -- !query 13 schema
 struct<createtab_stmt:string>
 -- !query 13 output
-CREATE TABLE `tbl` (`b` STRING, `c` INT, `a` INT)
+CREATE TABLE `tbl` (
+  `b` STRING,
+  `c` INT,
+  `a` INT)
 USING parquet
 PARTITIONED BY (a)
 
@@ -151,7 +166,10 @@ SHOW CREATE TABLE tbl
 -- !query 16 schema
 struct<createtab_stmt:string>
 -- !query 16 output
-CREATE TABLE `tbl` (`a` INT, `b` STRING, `c` INT)
+CREATE TABLE `tbl` (
+  `a` INT,
+  `b` STRING,
+  `c` INT)
 USING parquet
 CLUSTERED BY (a)
 SORTED BY (b)
@@ -180,7 +198,10 @@ SHOW CREATE TABLE tbl
 -- !query 19 schema
 struct<createtab_stmt:string>
 -- !query 19 output
-CREATE TABLE `tbl` (`a` INT, `b` STRING, `c` INT)
+CREATE TABLE `tbl` (
+  `a` INT,
+  `b` STRING,
+  `c` INT)
 USING parquet
 COMMENT 'This is a comment'
 
@@ -207,11 +228,13 @@ SHOW CREATE TABLE tbl
 -- !query 22 schema
 struct<createtab_stmt:string>
 -- !query 22 output
-CREATE TABLE `tbl` (`a` INT, `b` STRING, `c` INT)
+CREATE TABLE `tbl` (
+  `a` INT,
+  `b` STRING,
+  `c` INT)
 USING parquet
 TBLPROPERTIES (
-  'a' = '1'
-)
+  'a' = '1')
 
 
 -- !query 23
@@ -235,7 +258,11 @@ SHOW CREATE TABLE tbl
 -- !query 25 schema
 struct<createtab_stmt:string>
 -- !query 25 output
-CREATE TABLE `tbl` (`a` FLOAT, `b` DECIMAL(10,0), `c` DECIMAL(10,0), `d` DECIMAL(10,1))
+CREATE TABLE `tbl` (
+  `a` FLOAT,
+  `b` DECIMAL(10,0),
+  `c` DECIMAL(10,0),
+  `d` DECIMAL(10,1))
 USING parquet
 
 
@@ -269,7 +296,9 @@ SHOW CREATE TABLE view_SPARK_30302
 -- !query 29 schema
 struct<createtab_stmt:string>
 -- !query 29 output
-CREATE VIEW `view_SPARK_30302`(`aaa`, `bbb`)
+CREATE VIEW `view_SPARK_30302`(
+  `aaa`,
+  `bbb`)
 AS SELECT a, b FROM tbl
 
 
@@ -296,7 +325,9 @@ SHOW CREATE TABLE view_SPARK_30302
 -- !query 32 schema
 struct<createtab_stmt:string>
 -- !query 32 output
-CREATE VIEW `view_SPARK_30302`(`aaa` COMMENT 'comment with \'quoted text\' for aaa', `bbb`)
+CREATE VIEW `view_SPARK_30302`(
+  `aaa` COMMENT 'comment with \'quoted text\' for aaa',
+  `bbb`)
 COMMENT 'This is a comment with \'quoted text\' for view'
 AS SELECT a, b FROM tbl
 
@@ -324,11 +355,12 @@ SHOW CREATE TABLE view_SPARK_30302
 -- !query 35 schema
 struct<createtab_stmt:string>
 -- !query 35 output
-CREATE VIEW `view_SPARK_30302`(`aaa`, `bbb`)
+CREATE VIEW `view_SPARK_30302`(
+  `aaa`,
+  `bbb`)
 TBLPROPERTIES (
   'a' = '1',
-  'b' = '2'
-)
+  'b' = '2')
 AS SELECT a, b FROM tbl
 
 

--- a/sql/core/src/test/resources/sql-tests/results/show-create-table.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/show-create-table.sql.out
@@ -50,8 +50,7 @@ CREATE TABLE `tbl` (
   `c` INT)
 USING parquet
 OPTIONS (
-  `a` '1'
-)
+  `a` '1')
 
 
 -- !query 5

--- a/sql/core/src/test/scala/org/apache/spark/sql/ShowCreateTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ShowCreateTableSuite.scala
@@ -186,15 +186,20 @@ abstract class ShowCreateTableSuite extends QueryTest with SQLTestUtils {
     withTable("t1") {
       val createTable = "CREATE TABLE `t1` (`a` STRUCT<`b`: STRING>)"
       sql(s"$createTable USING json")
-      val shownDDL = sql(s"SHOW CREATE TABLE t1")
-        .head()
-        .getString(0)
-        .split("\n")
-        .head
+      val shownDDL = getShowDDL("SHOW CREATE TABLE t1")
       assert(shownDDL == createTable)
 
       checkCreateTable("t1")
     }
+  }
+
+  protected def getShowDDL(showCreateTableSql: String): String = {
+    val result = sql(showCreateTableSql)
+      .head()
+      .getString(0)
+      .split("\n")
+      .map(_.trim)
+    if (result.length > 1) result(0) + result(1) else result.head
   }
 
   protected def checkCreateTable(table: String): Unit = {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveShowCreateTableSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveShowCreateTableSuite.scala
@@ -180,11 +180,7 @@ class HiveShowCreateTableSuite extends ShowCreateTableSuite with TestHiveSinglet
     withTable("t1") {
       val createTable = "CREATE TABLE `t1`(`a` STRUCT<`b`: STRING>) USING hive"
       sql(createTable)
-      val shownDDL = sql(s"SHOW CREATE TABLE t1")
-        .head()
-        .getString(0)
-        .split("\n")
-        .head
+      val shownDDL = getShowDDL("SHOW CREATE TABLE t1")
       assert(shownDDL == createTable.dropRight(" USING hive".length))
 
       checkCreateTable("t1")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently data columns are displayed in one line for show create table command, when the table has many columns (to make things even worse, columns may have long names or comments), the displayed result is really hard to read.

To improve readability, we print each column in a separate line. Note that other systems like Hive/MySQL also display in this way.

Also, for data columns, table properties and options, we put the right parenthesis to the end of the last column/property/option, instead of occupying a separate line.

### Why are the changes needed?
for better readability


### Does this PR introduce any user-facing change?
before the change:
```
spark-sql> show create table test_table;
CREATE TABLE `test_table` (`col1` INT COMMENT 'This is comment for column 1', `col2` STRING COMMENT 'This is comment for column 2', `col3` DOUBLE COMMENT 'This is comment for column 3')
USING parquet
OPTIONS (
  `bar` '2',
  `foo` '1'
)
TBLPROPERTIES (
  'a' = 'x',
  'b' = 'y'
)
```
after the change:
```
spark-sql> show create table test_table;
CREATE TABLE `test_table` (
  `col1` INT COMMENT 'This is comment for column 1',
  `col2` STRING COMMENT 'This is comment for column 2',
  `col3` DOUBLE COMMENT 'This is comment for column 3')
USING parquet
OPTIONS (
  `bar` '2',
  `foo` '1')
TBLPROPERTIES (
  'a' = 'x',
  'b' = 'y')
```


### How was this patch tested?
modified existing tests
