### PR TITLE
[SPARK-30469][SQL][WIP] Partition columns should not be involved when calculating sizeInBytes of Project logical plan

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/SizeInBytesOnlyStatsPlanVisitor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/SizeInBytesOnlyStatsPlanVisitor.scala
@@ -17,7 +17,9 @@
 
 package org.apache.spark.sql.catalyst.plans.logical.statsEstimation
 
+import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
 import org.apache.spark.sql.catalyst.expressions.AttributeMap
+import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.{LeftAnti, LeftSemi}
 import org.apache.spark.sql.catalyst.plans.logical._
 
@@ -125,7 +127,37 @@ object SizeInBytesOnlyStatsPlanVisitor extends LogicalPlanVisitor[Statistics] {
 
   override def visitPivot(p: Pivot): Statistics = default(p)
 
-  override def visitProject(p: Project): Statistics = visitUnaryNode(p)
+  //    // There should be some overhead in Row object, the size should not be zero when there is
+  //    // no columns, this help to prevent divide-by-zero error.
+  //    val childRowSize = EstimationUtils.getSizePerRow(p.child.output)
+  //    val outputRowSize = EstimationUtils.getSizePerRow(p.output)
+  //    // Assume there will be the same number of rows as child has.
+  //    var sizeInBytes = (p.child.stats.sizeInBytes * outputRowSize) / childRowSize
+  //    if (sizeInBytes == 0) {
+  //      // sizeInBytes can't be zero, or sizeInBytes of BinaryNode will also be zero
+  //      // (product of children).
+  //      sizeInBytes = 1
+  //    }
+  //
+  //    // Don't propagate rowCount and attributeStats, since they are not estimated here.
+  //    Statistics(sizeInBytes = sizeInBytes)
+
+  override def visitProject(p: Project): Statistics = {
+    p match {
+      case PhysicalOperation(_, _, relation: HiveTableRelation)
+        if (relation.partitionCols.nonEmpty) =>
+        val childRowSize =
+          EstimationUtils.getSizePerRow(p.child.output.filter(!relation.partitionCols.contains(_)))
+        val outputRowSize =
+          EstimationUtils.getSizePerRow(p.output.filter(!relation.partitionCols.contains(_)))
+        var sizeInBytes = (p.child.stats.sizeInBytes * outputRowSize) / childRowSize
+        if (sizeInBytes == 0) {
+          sizeInBytes = 1
+        }
+        Statistics(sizeInBytes = sizeInBytes)
+      case _ => visitUnaryNode(p)
+    }
+  }
 
   override def visitRepartition(p: Repartition): Statistics = default(p)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/SizeInBytesOnlyStatsPlanVisitor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/SizeInBytesOnlyStatsPlanVisitor.scala
@@ -127,21 +127,6 @@ object SizeInBytesOnlyStatsPlanVisitor extends LogicalPlanVisitor[Statistics] {
 
   override def visitPivot(p: Pivot): Statistics = default(p)
 
-  //    // There should be some overhead in Row object, the size should not be zero when there is
-  //    // no columns, this help to prevent divide-by-zero error.
-  //    val childRowSize = EstimationUtils.getSizePerRow(p.child.output)
-  //    val outputRowSize = EstimationUtils.getSizePerRow(p.output)
-  //    // Assume there will be the same number of rows as child has.
-  //    var sizeInBytes = (p.child.stats.sizeInBytes * outputRowSize) / childRowSize
-  //    if (sizeInBytes == 0) {
-  //      // sizeInBytes can't be zero, or sizeInBytes of BinaryNode will also be zero
-  //      // (product of children).
-  //      sizeInBytes = 1
-  //    }
-  //
-  //    // Don't propagate rowCount and attributeStats, since they are not estimated here.
-  //    Statistics(sizeInBytes = sizeInBytes)
-
   override def visitProject(p: Project): Statistics = {
     p match {
       case PhysicalOperation(_, _, relation: HiveTableRelation)


### PR DESCRIPTION
### What changes were proposed in this pull request?
 SizeInBytesOnlyStatsPlanVisitor.visitProject exclude partition columns when calculating sizeInBytes.

### Why are the changes needed?
When getting the statistics of a Project logical plan, if CBO not enabled, Spark will call SizeInBytesOnlyStatsPlanVisitor.visitUnaryNode to calculate the size in bytes, which will compute the ratio of the row size of the project plan and its child plan.
And the row size is computed based on the output attributes (columns). Currently, SizeInBytesOnlyStatsPlanVisitor.visitUnaryNode involve partition columns of hive table as well, which is not reasonable, because partition columns actually does not account for sizeInBytes.
This may make the sizeInBytes not accurate. This PR update to exclude partition columns in SizeInBytesOnlyStatsPlanVisitor.visitProject

### Does this PR introduce any user-facing change?
no

### How was this patch tested?
Existing unit test
