### PR TITLE
[SPARK-30471][SQL] Fix issue when comparing String and IntegerType

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -1305,12 +1305,18 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
    * @return If string contains valid numeric value then it returns the long value otherwise a
    * NumberFormatException  is thrown.
    */
-  public long toLongExact() {
+  public Long toLongExact(boolean ansiEnabled) {
     LongWrapper result = new LongWrapper();
-    if (toLong(result) && !result.formatInvalid) {
+    boolean hasResult = toLong(result);
+
+    if ((!hasResult && ansiEnabled) || result.formatInvalid) {
+      throw new NumberFormatException("invalid input syntax for type numeric: " + this);
+    }
+
+    if (hasResult) {
       return result.value;
     }
-    throw new NumberFormatException("invalid input syntax for type numeric: " + this);
+    return null;
   }
 
   /**

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -1077,6 +1077,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
    */
   public static class LongWrapper implements Serializable {
     public transient long value = 0;
+    public transient boolean formatInvalid = false;
   }
 
   /**
@@ -1088,6 +1089,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
    */
   public static class IntWrapper implements Serializable {
     public transient int value = 0;
+    public transient boolean formatInvalid = false;
   }
 
   /**
@@ -1133,6 +1135,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
         // We allow decimals and will return a truncated integral in that case.
         // Therefore we won't throw an exception here (checking the fractional
         // part happens below.)
+        toLongResult.formatInvalid = true;
         break;
       }
 
@@ -1140,6 +1143,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
       if (b >= '0' && b <= '9') {
         digit = b - '0';
       } else {
+        toLongResult.formatInvalid = false;
         return false;
       }
 
@@ -1233,6 +1237,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
       if (b >= '0' && b <= '9') {
         digit = b - '0';
       } else {
+        intWrapper.formatInvalid = true;
         return false;
       }
 
@@ -1302,7 +1307,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
    */
   public long toLongExact() {
     LongWrapper result = new LongWrapper();
-    if (toLong(result)) {
+    if (toLong(result) && !result.formatInvalid) {
       return result.value;
     }
     throw new NumberFormatException("invalid input syntax for type numeric: " + this);

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -136,11 +136,16 @@ object TypeCoercion {
     case (TimestampType, DateType) => Some(TimestampType)
     case (DateType, TimestampType) => Some(TimestampType)
 
-    // There is no proper decimal type we can pick,
-    // using double type is the best we can do.
-    // See SPARK-22469 for details.
-    case (n: DecimalType, s: StringType) => Some(DoubleType)
-    case (s: StringType, n: DecimalType) => Some(DoubleType)
+    case (s: StringType, n: IntegralType) => Some(LongType)
+    case (n: IntegralType, s: StringType) => Some(LongType)
+
+    case (s: StringType, n: DecimalType) => Some(DecimalType(DecimalType.MAX_PRECISION, n.scale))
+    case (n: DecimalType, s: StringType) => Some(DecimalType(DecimalType.MAX_PRECISION, n.scale))
+
+    case (StringType, FloatType) => Some(DoubleType)
+    case (FloatType, StringType) => Some(DoubleType)
+    case (StringType, DoubleType) => Some(DoubleType)
+    case (DoubleType, StringType) => Some(DoubleType)
 
     case (l: StringType, r: AtomicType) if r != StringType => Some(r)
     case (l: AtomicType, r: StringType) if l != StringType => Some(l)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -477,11 +477,8 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
 
   // LongConverter
   private[this] def castToLong(from: DataType): Any => Any = from match {
-    case StringType if ansiEnabled =>
-      buildCast[UTF8String](_, _.toLongExact())
     case StringType =>
-      val result = new LongWrapper()
-      buildCast[UTF8String](_, s => if (s.toLong(result)) result.value else null)
+      buildCast[UTF8String](_, _.toLongExact())
     case BooleanType =>
       buildCast[Boolean](_, b => if (b) 1L else 0L)
     case DateType =>
@@ -1466,20 +1463,8 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
   }
 
   private[this] def castToLongCode(from: DataType, ctx: CodegenContext): CastFunction = from match {
-    case StringType if ansiEnabled =>
-      (c, evPrim, evNull) => code"$evPrim = $c.toLongExact();"
     case StringType =>
-      val wrapper = ctx.freshVariable("longWrapper", classOf[UTF8String.LongWrapper])
-      (c, evPrim, evNull) =>
-        code"""
-          UTF8String.LongWrapper $wrapper = new UTF8String.LongWrapper();
-          if ($c.toLong($wrapper)) {
-            $evPrim = $wrapper.value;
-          } else {
-            $evNull = true;
-          }
-          $wrapper = null;
-        """
+      (c, evPrim, evNull) => code"$evPrim = $c.toLongExact();"
     case BooleanType =>
       (c, evPrim, evNull) => code"$evPrim = $c ? 1L : 0L;"
     case DateType =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -478,7 +478,7 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
   // LongConverter
   private[this] def castToLong(from: DataType): Any => Any = from match {
     case StringType =>
-      buildCast[UTF8String](_, _.toLongExact())
+      buildCast[UTF8String](_, _.toLongExact(ansiEnabled))
     case BooleanType =>
       buildCast[Boolean](_, b => if (b) 1L else 0L)
     case DateType =>
@@ -1464,7 +1464,7 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
 
   private[this] def castToLongCode(from: DataType, ctx: CodegenContext): CastFunction = from match {
     case StringType =>
-      (c, evPrim, evNull) => code"$evPrim = $c.toLongExact();"
+      (c, evPrim, evNull) => code"$evPrim = $c.toLongExact($ansiEnabled);"
     case BooleanType =>
       (c, evPrim, evNull) => code"$evPrim = $c ? 1L : 0L;"
     case DateType =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
@@ -1454,7 +1454,7 @@ class TypeCoercionSuite extends AnalysisTest {
     val rule = TypeCoercion.PromoteStrings(conf)
     ruleTest(rule,
       GreaterThan(Literal("123"), Literal(1)),
-      GreaterThan(Cast(Literal("123"), IntegerType), Literal(1)))
+      GreaterThan(Cast(Literal("123"), DoubleType), Cast(Literal(1), DoubleType)))
     ruleTest(rule,
       LessThan(Literal(true), Literal("123")),
       LessThan(Literal(true), Cast(Literal("123"), BooleanType)))

--- a/sql/core/src/test/resources/sql-tests/results/comparator.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/comparator.sql.out
@@ -21,7 +21,7 @@ true
 -- !query
 select '1 ' = 1Y
 -- !query schema
-struct<(CAST(1  AS TINYINT) = 1):boolean>
+struct<(CAST(1  AS BIGINT) = CAST(1 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -29,7 +29,7 @@ true
 -- !query
 select '\t1 ' = 1Y
 -- !query schema
-struct<(CAST(	1  AS TINYINT) = 1):boolean>
+struct<(CAST(	1  AS BIGINT) = CAST(1 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -37,7 +37,7 @@ true
 -- !query
 select '1 ' = 1S
 -- !query schema
-struct<(CAST(1  AS SMALLINT) = 1):boolean>
+struct<(CAST(1  AS BIGINT) = CAST(1 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -45,7 +45,7 @@ true
 -- !query
 select '1 ' = 1
 -- !query schema
-struct<(CAST(1  AS INT) = 1):boolean>
+struct<(CAST(1  AS BIGINT) = CAST(1 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -61,7 +61,7 @@ true
 -- !query
 select ' 1' = cast(1.0 as float)
 -- !query schema
-struct<(CAST( 1 AS FLOAT) = CAST(1.0 AS FLOAT)):boolean>
+struct<(CAST( 1 AS DOUBLE) = CAST(CAST(1.0 AS FLOAT) AS DOUBLE)):boolean>
 -- !query output
 true
 
@@ -77,6 +77,6 @@ true
 -- !query
 select ' 1.0 ' = 1.0BD
 -- !query schema
-struct<(CAST( 1.0  AS DOUBLE) = CAST(1.0 AS DOUBLE)):boolean>
+struct<(CAST( 1.0  AS DECIMAL(38,1)) = CAST(1.0 AS DECIMAL(38,1))):boolean>
 -- !query output
 true

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/float4.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/float4.sql.out
@@ -171,6 +171,7 @@ struct<four:string,f1:float>
 	0.0
 	1.2345679E-20
 	1.2345679E20
+	1004.3
 
 
 -- !query
@@ -178,7 +179,7 @@ SELECT '' AS one, f.* FROM FLOAT4_TBL f WHERE f.f1 = '1004.3'
 -- !query schema
 struct<one:string,f1:float>
 -- !query output
-	1004.3
+
 
 
 -- !query
@@ -189,6 +190,7 @@ struct<three:string,f1:float>
 	-34.84
 	0.0
 	1.2345679E-20
+	1004.3
 
 
 -- !query
@@ -199,6 +201,7 @@ struct<three:string,f1:float>
 	-34.84
 	0.0
 	1.2345679E-20
+	1004.3
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/predicate-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/predicate-functions.sql.out
@@ -13,7 +13,7 @@ true
 -- !query
 select 1 = '1'
 -- !query schema
-struct<(1 = CAST(1 AS INT)):boolean>
+struct<(CAST(1 AS BIGINT) = CAST(1 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -21,7 +21,7 @@ true
 -- !query
 select 1.0 = '1'
 -- !query schema
-struct<(CAST(1.0 AS DOUBLE) = CAST(1 AS DOUBLE)):boolean>
+struct<(CAST(1.0 AS DECIMAL(38,1)) = CAST(1 AS DECIMAL(38,1))):boolean>
 -- !query output
 true
 
@@ -29,15 +29,15 @@ true
 -- !query
 select 1.5 = '1.51'
 -- !query schema
-struct<(CAST(1.5 AS DOUBLE) = CAST(1.51 AS DOUBLE)):boolean>
+struct<(CAST(1.5 AS DECIMAL(38,1)) = CAST(1.51 AS DECIMAL(38,1))):boolean>
 -- !query output
-false
+true
 
 
 -- !query
 select 1 > '1'
 -- !query schema
-struct<(1 > CAST(1 AS INT)):boolean>
+struct<(CAST(1 AS BIGINT) > CAST(1 AS BIGINT)):boolean>
 -- !query output
 false
 
@@ -45,7 +45,7 @@ false
 -- !query
 select 2 > '1.0'
 -- !query schema
-struct<(2 > CAST(1.0 AS INT)):boolean>
+struct<(CAST(2 AS BIGINT) > CAST(1.0 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -53,7 +53,7 @@ true
 -- !query
 select 2 > '2.0'
 -- !query schema
-struct<(2 > CAST(2.0 AS INT)):boolean>
+struct<(CAST(2 AS BIGINT) > CAST(2.0 AS BIGINT)):boolean>
 -- !query output
 false
 
@@ -61,7 +61,7 @@ false
 -- !query
 select 2 > '2.2'
 -- !query schema
-struct<(2 > CAST(2.2 AS INT)):boolean>
+struct<(CAST(2 AS BIGINT) > CAST(2.2 AS BIGINT)):boolean>
 -- !query output
 false
 
@@ -69,7 +69,7 @@ false
 -- !query
 select '1.5' > 0.5
 -- !query schema
-struct<(CAST(1.5 AS DOUBLE) > CAST(0.5 AS DOUBLE)):boolean>
+struct<(CAST(1.5 AS DECIMAL(38,1)) > CAST(0.5 AS DECIMAL(38,1))):boolean>
 -- !query output
 true
 
@@ -93,7 +93,7 @@ false
 -- !query
 select 1 >= '1'
 -- !query schema
-struct<(1 >= CAST(1 AS INT)):boolean>
+struct<(CAST(1 AS BIGINT) >= CAST(1 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -101,7 +101,7 @@ true
 -- !query
 select 2 >= '1.0'
 -- !query schema
-struct<(2 >= CAST(1.0 AS INT)):boolean>
+struct<(CAST(2 AS BIGINT) >= CAST(1.0 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -109,7 +109,7 @@ true
 -- !query
 select 2 >= '2.0'
 -- !query schema
-struct<(2 >= CAST(2.0 AS INT)):boolean>
+struct<(CAST(2 AS BIGINT) >= CAST(2.0 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -117,7 +117,7 @@ true
 -- !query
 select 2.0 >= '2.2'
 -- !query schema
-struct<(CAST(2.0 AS DOUBLE) >= CAST(2.2 AS DOUBLE)):boolean>
+struct<(CAST(2.0 AS DECIMAL(38,1)) >= CAST(2.2 AS DECIMAL(38,1))):boolean>
 -- !query output
 false
 
@@ -125,7 +125,7 @@ false
 -- !query
 select '1.5' >= 0.5
 -- !query schema
-struct<(CAST(1.5 AS DOUBLE) >= CAST(0.5 AS DOUBLE)):boolean>
+struct<(CAST(1.5 AS DECIMAL(38,1)) >= CAST(0.5 AS DECIMAL(38,1))):boolean>
 -- !query output
 true
 
@@ -149,7 +149,7 @@ true
 -- !query
 select 1 < '1'
 -- !query schema
-struct<(1 < CAST(1 AS INT)):boolean>
+struct<(CAST(1 AS BIGINT) < CAST(1 AS BIGINT)):boolean>
 -- !query output
 false
 
@@ -157,7 +157,7 @@ false
 -- !query
 select 2 < '1.0'
 -- !query schema
-struct<(2 < CAST(1.0 AS INT)):boolean>
+struct<(CAST(2 AS BIGINT) < CAST(1.0 AS BIGINT)):boolean>
 -- !query output
 false
 
@@ -165,7 +165,7 @@ false
 -- !query
 select 2 < '2.0'
 -- !query schema
-struct<(2 < CAST(2.0 AS INT)):boolean>
+struct<(CAST(2 AS BIGINT) < CAST(2.0 AS BIGINT)):boolean>
 -- !query output
 false
 
@@ -173,7 +173,7 @@ false
 -- !query
 select 2.0 < '2.2'
 -- !query schema
-struct<(CAST(2.0 AS DOUBLE) < CAST(2.2 AS DOUBLE)):boolean>
+struct<(CAST(2.0 AS DECIMAL(38,1)) < CAST(2.2 AS DECIMAL(38,1))):boolean>
 -- !query output
 true
 
@@ -181,7 +181,7 @@ true
 -- !query
 select 0.5 < '1.5'
 -- !query schema
-struct<(CAST(0.5 AS DOUBLE) < CAST(1.5 AS DOUBLE)):boolean>
+struct<(CAST(0.5 AS DECIMAL(38,1)) < CAST(1.5 AS DECIMAL(38,1))):boolean>
 -- !query output
 true
 
@@ -205,7 +205,7 @@ false
 -- !query
 select 1 <= '1'
 -- !query schema
-struct<(1 <= CAST(1 AS INT)):boolean>
+struct<(CAST(1 AS BIGINT) <= CAST(1 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -213,7 +213,7 @@ true
 -- !query
 select 2 <= '1.0'
 -- !query schema
-struct<(2 <= CAST(1.0 AS INT)):boolean>
+struct<(CAST(2 AS BIGINT) <= CAST(1.0 AS BIGINT)):boolean>
 -- !query output
 false
 
@@ -221,7 +221,7 @@ false
 -- !query
 select 2 <= '2.0'
 -- !query schema
-struct<(2 <= CAST(2.0 AS INT)):boolean>
+struct<(CAST(2 AS BIGINT) <= CAST(2.0 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -229,7 +229,7 @@ true
 -- !query
 select 2.0 <= '2.2'
 -- !query schema
-struct<(CAST(2.0 AS DOUBLE) <= CAST(2.2 AS DOUBLE)):boolean>
+struct<(CAST(2.0 AS DECIMAL(38,1)) <= CAST(2.2 AS DECIMAL(38,1))):boolean>
 -- !query output
 true
 
@@ -237,7 +237,7 @@ true
 -- !query
 select 0.5 <= '1.5'
 -- !query schema
-struct<(CAST(0.5 AS DOUBLE) <= CAST(1.5 AS DOUBLE)):boolean>
+struct<(CAST(0.5 AS DECIMAL(38,1)) <= CAST(1.5 AS DECIMAL(38,1))):boolean>
 -- !query output
 true
 

--- a/sql/core/src/test/resources/sql-tests/results/typeCoercion/native/binaryComparison.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/typeCoercion/native/binaryComparison.sql.out
@@ -205,7 +205,7 @@ NULL
 -- !query
 SELECT cast(1 as tinyint) = '1' FROM t
 -- !query schema
-struct<(CAST(1 AS TINYINT) = CAST(1 AS TINYINT)):boolean>
+struct<(CAST(CAST(1 AS TINYINT) AS BIGINT) = CAST(1 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -213,7 +213,7 @@ true
 -- !query
 SELECT cast(1 as tinyint) > '2' FROM t
 -- !query schema
-struct<(CAST(1 AS TINYINT) > CAST(2 AS TINYINT)):boolean>
+struct<(CAST(CAST(1 AS TINYINT) AS BIGINT) > CAST(2 AS BIGINT)):boolean>
 -- !query output
 false
 
@@ -221,7 +221,7 @@ false
 -- !query
 SELECT cast(1 as tinyint) >= '2' FROM t
 -- !query schema
-struct<(CAST(1 AS TINYINT) >= CAST(2 AS TINYINT)):boolean>
+struct<(CAST(CAST(1 AS TINYINT) AS BIGINT) >= CAST(2 AS BIGINT)):boolean>
 -- !query output
 false
 
@@ -229,7 +229,7 @@ false
 -- !query
 SELECT cast(1 as tinyint) < '2' FROM t
 -- !query schema
-struct<(CAST(1 AS TINYINT) < CAST(2 AS TINYINT)):boolean>
+struct<(CAST(CAST(1 AS TINYINT) AS BIGINT) < CAST(2 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -237,7 +237,7 @@ true
 -- !query
 SELECT cast(1 as tinyint) <= '2' FROM t
 -- !query schema
-struct<(CAST(1 AS TINYINT) <= CAST(2 AS TINYINT)):boolean>
+struct<(CAST(CAST(1 AS TINYINT) AS BIGINT) <= CAST(2 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -245,7 +245,7 @@ true
 -- !query
 SELECT cast(1 as tinyint) <> '2' FROM t
 -- !query schema
-struct<(NOT (CAST(1 AS TINYINT) = CAST(2 AS TINYINT))):boolean>
+struct<(NOT (CAST(CAST(1 AS TINYINT) AS BIGINT) = CAST(2 AS BIGINT))):boolean>
 -- !query output
 true
 
@@ -253,7 +253,7 @@ true
 -- !query
 SELECT cast(1 as tinyint) = cast(null as string) FROM t
 -- !query schema
-struct<(CAST(1 AS TINYINT) = CAST(CAST(NULL AS STRING) AS TINYINT)):boolean>
+struct<(CAST(CAST(1 AS TINYINT) AS BIGINT) = CAST(CAST(NULL AS STRING) AS BIGINT)):boolean>
 -- !query output
 NULL
 
@@ -261,7 +261,7 @@ NULL
 -- !query
 SELECT cast(1 as tinyint) > cast(null as string) FROM t
 -- !query schema
-struct<(CAST(1 AS TINYINT) > CAST(CAST(NULL AS STRING) AS TINYINT)):boolean>
+struct<(CAST(CAST(1 AS TINYINT) AS BIGINT) > CAST(CAST(NULL AS STRING) AS BIGINT)):boolean>
 -- !query output
 NULL
 
@@ -269,7 +269,7 @@ NULL
 -- !query
 SELECT cast(1 as tinyint) >= cast(null as string) FROM t
 -- !query schema
-struct<(CAST(1 AS TINYINT) >= CAST(CAST(NULL AS STRING) AS TINYINT)):boolean>
+struct<(CAST(CAST(1 AS TINYINT) AS BIGINT) >= CAST(CAST(NULL AS STRING) AS BIGINT)):boolean>
 -- !query output
 NULL
 
@@ -277,7 +277,7 @@ NULL
 -- !query
 SELECT cast(1 as tinyint) < cast(null as string) FROM t
 -- !query schema
-struct<(CAST(1 AS TINYINT) < CAST(CAST(NULL AS STRING) AS TINYINT)):boolean>
+struct<(CAST(CAST(1 AS TINYINT) AS BIGINT) < CAST(CAST(NULL AS STRING) AS BIGINT)):boolean>
 -- !query output
 NULL
 
@@ -285,7 +285,7 @@ NULL
 -- !query
 SELECT cast(1 as tinyint) <= cast(null as string) FROM t
 -- !query schema
-struct<(CAST(1 AS TINYINT) <= CAST(CAST(NULL AS STRING) AS TINYINT)):boolean>
+struct<(CAST(CAST(1 AS TINYINT) AS BIGINT) <= CAST(CAST(NULL AS STRING) AS BIGINT)):boolean>
 -- !query output
 NULL
 
@@ -293,7 +293,7 @@ NULL
 -- !query
 SELECT cast(1 as tinyint) <> cast(null as string) FROM t
 -- !query schema
-struct<(NOT (CAST(1 AS TINYINT) = CAST(CAST(NULL AS STRING) AS TINYINT))):boolean>
+struct<(NOT (CAST(CAST(1 AS TINYINT) AS BIGINT) = CAST(CAST(NULL AS STRING) AS BIGINT))):boolean>
 -- !query output
 NULL
 
@@ -301,7 +301,7 @@ NULL
 -- !query
 SELECT '1' = cast(1 as tinyint) FROM t
 -- !query schema
-struct<(CAST(1 AS TINYINT) = CAST(1 AS TINYINT)):boolean>
+struct<(CAST(1 AS BIGINT) = CAST(CAST(1 AS TINYINT) AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -309,7 +309,7 @@ true
 -- !query
 SELECT '2' > cast(1 as tinyint) FROM t
 -- !query schema
-struct<(CAST(2 AS TINYINT) > CAST(1 AS TINYINT)):boolean>
+struct<(CAST(2 AS BIGINT) > CAST(CAST(1 AS TINYINT) AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -317,7 +317,7 @@ true
 -- !query
 SELECT '2' >= cast(1 as tinyint) FROM t
 -- !query schema
-struct<(CAST(2 AS TINYINT) >= CAST(1 AS TINYINT)):boolean>
+struct<(CAST(2 AS BIGINT) >= CAST(CAST(1 AS TINYINT) AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -325,7 +325,7 @@ true
 -- !query
 SELECT '2' < cast(1 as tinyint) FROM t
 -- !query schema
-struct<(CAST(2 AS TINYINT) < CAST(1 AS TINYINT)):boolean>
+struct<(CAST(2 AS BIGINT) < CAST(CAST(1 AS TINYINT) AS BIGINT)):boolean>
 -- !query output
 false
 
@@ -333,7 +333,7 @@ false
 -- !query
 SELECT '2' <= cast(1 as tinyint) FROM t
 -- !query schema
-struct<(CAST(2 AS TINYINT) <= CAST(1 AS TINYINT)):boolean>
+struct<(CAST(2 AS BIGINT) <= CAST(CAST(1 AS TINYINT) AS BIGINT)):boolean>
 -- !query output
 false
 
@@ -341,7 +341,7 @@ false
 -- !query
 SELECT '2' <> cast(1 as tinyint) FROM t
 -- !query schema
-struct<(NOT (CAST(2 AS TINYINT) = CAST(1 AS TINYINT))):boolean>
+struct<(NOT (CAST(2 AS BIGINT) = CAST(CAST(1 AS TINYINT) AS BIGINT))):boolean>
 -- !query output
 true
 
@@ -349,7 +349,7 @@ true
 -- !query
 SELECT cast(null as string) = cast(1 as tinyint) FROM t
 -- !query schema
-struct<(CAST(CAST(NULL AS STRING) AS TINYINT) = CAST(1 AS TINYINT)):boolean>
+struct<(CAST(CAST(NULL AS STRING) AS BIGINT) = CAST(CAST(1 AS TINYINT) AS BIGINT)):boolean>
 -- !query output
 NULL
 
@@ -357,7 +357,7 @@ NULL
 -- !query
 SELECT cast(null as string) > cast(1 as tinyint) FROM t
 -- !query schema
-struct<(CAST(CAST(NULL AS STRING) AS TINYINT) > CAST(1 AS TINYINT)):boolean>
+struct<(CAST(CAST(NULL AS STRING) AS BIGINT) > CAST(CAST(1 AS TINYINT) AS BIGINT)):boolean>
 -- !query output
 NULL
 
@@ -365,7 +365,7 @@ NULL
 -- !query
 SELECT cast(null as string) >= cast(1 as tinyint) FROM t
 -- !query schema
-struct<(CAST(CAST(NULL AS STRING) AS TINYINT) >= CAST(1 AS TINYINT)):boolean>
+struct<(CAST(CAST(NULL AS STRING) AS BIGINT) >= CAST(CAST(1 AS TINYINT) AS BIGINT)):boolean>
 -- !query output
 NULL
 
@@ -373,7 +373,7 @@ NULL
 -- !query
 SELECT cast(null as string) < cast(1 as tinyint) FROM t
 -- !query schema
-struct<(CAST(CAST(NULL AS STRING) AS TINYINT) < CAST(1 AS TINYINT)):boolean>
+struct<(CAST(CAST(NULL AS STRING) AS BIGINT) < CAST(CAST(1 AS TINYINT) AS BIGINT)):boolean>
 -- !query output
 NULL
 
@@ -381,7 +381,7 @@ NULL
 -- !query
 SELECT cast(null as string) <= cast(1 as tinyint) FROM t
 -- !query schema
-struct<(CAST(CAST(NULL AS STRING) AS TINYINT) <= CAST(1 AS TINYINT)):boolean>
+struct<(CAST(CAST(NULL AS STRING) AS BIGINT) <= CAST(CAST(1 AS TINYINT) AS BIGINT)):boolean>
 -- !query output
 NULL
 
@@ -389,7 +389,7 @@ NULL
 -- !query
 SELECT cast(null as string) <> cast(1 as tinyint) FROM t
 -- !query schema
-struct<(NOT (CAST(CAST(NULL AS STRING) AS TINYINT) = CAST(1 AS TINYINT))):boolean>
+struct<(NOT (CAST(CAST(NULL AS STRING) AS BIGINT) = CAST(CAST(1 AS TINYINT) AS BIGINT))):boolean>
 -- !query output
 NULL
 
@@ -397,7 +397,7 @@ NULL
 -- !query
 SELECT cast(1 as smallint) = '1' FROM t
 -- !query schema
-struct<(CAST(1 AS SMALLINT) = CAST(1 AS SMALLINT)):boolean>
+struct<(CAST(CAST(1 AS SMALLINT) AS BIGINT) = CAST(1 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -405,7 +405,7 @@ true
 -- !query
 SELECT cast(1 as smallint) > '2' FROM t
 -- !query schema
-struct<(CAST(1 AS SMALLINT) > CAST(2 AS SMALLINT)):boolean>
+struct<(CAST(CAST(1 AS SMALLINT) AS BIGINT) > CAST(2 AS BIGINT)):boolean>
 -- !query output
 false
 
@@ -413,7 +413,7 @@ false
 -- !query
 SELECT cast(1 as smallint) >= '2' FROM t
 -- !query schema
-struct<(CAST(1 AS SMALLINT) >= CAST(2 AS SMALLINT)):boolean>
+struct<(CAST(CAST(1 AS SMALLINT) AS BIGINT) >= CAST(2 AS BIGINT)):boolean>
 -- !query output
 false
 
@@ -421,7 +421,7 @@ false
 -- !query
 SELECT cast(1 as smallint) < '2' FROM t
 -- !query schema
-struct<(CAST(1 AS SMALLINT) < CAST(2 AS SMALLINT)):boolean>
+struct<(CAST(CAST(1 AS SMALLINT) AS BIGINT) < CAST(2 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -429,7 +429,7 @@ true
 -- !query
 SELECT cast(1 as smallint) <= '2' FROM t
 -- !query schema
-struct<(CAST(1 AS SMALLINT) <= CAST(2 AS SMALLINT)):boolean>
+struct<(CAST(CAST(1 AS SMALLINT) AS BIGINT) <= CAST(2 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -437,7 +437,7 @@ true
 -- !query
 SELECT cast(1 as smallint) <> '2' FROM t
 -- !query schema
-struct<(NOT (CAST(1 AS SMALLINT) = CAST(2 AS SMALLINT))):boolean>
+struct<(NOT (CAST(CAST(1 AS SMALLINT) AS BIGINT) = CAST(2 AS BIGINT))):boolean>
 -- !query output
 true
 
@@ -445,7 +445,7 @@ true
 -- !query
 SELECT cast(1 as smallint) = cast(null as string) FROM t
 -- !query schema
-struct<(CAST(1 AS SMALLINT) = CAST(CAST(NULL AS STRING) AS SMALLINT)):boolean>
+struct<(CAST(CAST(1 AS SMALLINT) AS BIGINT) = CAST(CAST(NULL AS STRING) AS BIGINT)):boolean>
 -- !query output
 NULL
 
@@ -453,7 +453,7 @@ NULL
 -- !query
 SELECT cast(1 as smallint) > cast(null as string) FROM t
 -- !query schema
-struct<(CAST(1 AS SMALLINT) > CAST(CAST(NULL AS STRING) AS SMALLINT)):boolean>
+struct<(CAST(CAST(1 AS SMALLINT) AS BIGINT) > CAST(CAST(NULL AS STRING) AS BIGINT)):boolean>
 -- !query output
 NULL
 
@@ -461,7 +461,7 @@ NULL
 -- !query
 SELECT cast(1 as smallint) >= cast(null as string) FROM t
 -- !query schema
-struct<(CAST(1 AS SMALLINT) >= CAST(CAST(NULL AS STRING) AS SMALLINT)):boolean>
+struct<(CAST(CAST(1 AS SMALLINT) AS BIGINT) >= CAST(CAST(NULL AS STRING) AS BIGINT)):boolean>
 -- !query output
 NULL
 
@@ -469,7 +469,7 @@ NULL
 -- !query
 SELECT cast(1 as smallint) < cast(null as string) FROM t
 -- !query schema
-struct<(CAST(1 AS SMALLINT) < CAST(CAST(NULL AS STRING) AS SMALLINT)):boolean>
+struct<(CAST(CAST(1 AS SMALLINT) AS BIGINT) < CAST(CAST(NULL AS STRING) AS BIGINT)):boolean>
 -- !query output
 NULL
 
@@ -477,7 +477,7 @@ NULL
 -- !query
 SELECT cast(1 as smallint) <= cast(null as string) FROM t
 -- !query schema
-struct<(CAST(1 AS SMALLINT) <= CAST(CAST(NULL AS STRING) AS SMALLINT)):boolean>
+struct<(CAST(CAST(1 AS SMALLINT) AS BIGINT) <= CAST(CAST(NULL AS STRING) AS BIGINT)):boolean>
 -- !query output
 NULL
 
@@ -485,7 +485,7 @@ NULL
 -- !query
 SELECT cast(1 as smallint) <> cast(null as string) FROM t
 -- !query schema
-struct<(NOT (CAST(1 AS SMALLINT) = CAST(CAST(NULL AS STRING) AS SMALLINT))):boolean>
+struct<(NOT (CAST(CAST(1 AS SMALLINT) AS BIGINT) = CAST(CAST(NULL AS STRING) AS BIGINT))):boolean>
 -- !query output
 NULL
 
@@ -493,7 +493,7 @@ NULL
 -- !query
 SELECT '1' = cast(1 as smallint) FROM t
 -- !query schema
-struct<(CAST(1 AS SMALLINT) = CAST(1 AS SMALLINT)):boolean>
+struct<(CAST(1 AS BIGINT) = CAST(CAST(1 AS SMALLINT) AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -501,7 +501,7 @@ true
 -- !query
 SELECT '2' > cast(1 as smallint) FROM t
 -- !query schema
-struct<(CAST(2 AS SMALLINT) > CAST(1 AS SMALLINT)):boolean>
+struct<(CAST(2 AS BIGINT) > CAST(CAST(1 AS SMALLINT) AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -509,7 +509,7 @@ true
 -- !query
 SELECT '2' >= cast(1 as smallint) FROM t
 -- !query schema
-struct<(CAST(2 AS SMALLINT) >= CAST(1 AS SMALLINT)):boolean>
+struct<(CAST(2 AS BIGINT) >= CAST(CAST(1 AS SMALLINT) AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -517,7 +517,7 @@ true
 -- !query
 SELECT '2' < cast(1 as smallint) FROM t
 -- !query schema
-struct<(CAST(2 AS SMALLINT) < CAST(1 AS SMALLINT)):boolean>
+struct<(CAST(2 AS BIGINT) < CAST(CAST(1 AS SMALLINT) AS BIGINT)):boolean>
 -- !query output
 false
 
@@ -525,7 +525,7 @@ false
 -- !query
 SELECT '2' <= cast(1 as smallint) FROM t
 -- !query schema
-struct<(CAST(2 AS SMALLINT) <= CAST(1 AS SMALLINT)):boolean>
+struct<(CAST(2 AS BIGINT) <= CAST(CAST(1 AS SMALLINT) AS BIGINT)):boolean>
 -- !query output
 false
 
@@ -533,7 +533,7 @@ false
 -- !query
 SELECT '2' <> cast(1 as smallint) FROM t
 -- !query schema
-struct<(NOT (CAST(2 AS SMALLINT) = CAST(1 AS SMALLINT))):boolean>
+struct<(NOT (CAST(2 AS BIGINT) = CAST(CAST(1 AS SMALLINT) AS BIGINT))):boolean>
 -- !query output
 true
 
@@ -541,7 +541,7 @@ true
 -- !query
 SELECT cast(null as string) = cast(1 as smallint) FROM t
 -- !query schema
-struct<(CAST(CAST(NULL AS STRING) AS SMALLINT) = CAST(1 AS SMALLINT)):boolean>
+struct<(CAST(CAST(NULL AS STRING) AS BIGINT) = CAST(CAST(1 AS SMALLINT) AS BIGINT)):boolean>
 -- !query output
 NULL
 
@@ -549,7 +549,7 @@ NULL
 -- !query
 SELECT cast(null as string) > cast(1 as smallint) FROM t
 -- !query schema
-struct<(CAST(CAST(NULL AS STRING) AS SMALLINT) > CAST(1 AS SMALLINT)):boolean>
+struct<(CAST(CAST(NULL AS STRING) AS BIGINT) > CAST(CAST(1 AS SMALLINT) AS BIGINT)):boolean>
 -- !query output
 NULL
 
@@ -557,7 +557,7 @@ NULL
 -- !query
 SELECT cast(null as string) >= cast(1 as smallint) FROM t
 -- !query schema
-struct<(CAST(CAST(NULL AS STRING) AS SMALLINT) >= CAST(1 AS SMALLINT)):boolean>
+struct<(CAST(CAST(NULL AS STRING) AS BIGINT) >= CAST(CAST(1 AS SMALLINT) AS BIGINT)):boolean>
 -- !query output
 NULL
 
@@ -565,7 +565,7 @@ NULL
 -- !query
 SELECT cast(null as string) < cast(1 as smallint) FROM t
 -- !query schema
-struct<(CAST(CAST(NULL AS STRING) AS SMALLINT) < CAST(1 AS SMALLINT)):boolean>
+struct<(CAST(CAST(NULL AS STRING) AS BIGINT) < CAST(CAST(1 AS SMALLINT) AS BIGINT)):boolean>
 -- !query output
 NULL
 
@@ -573,7 +573,7 @@ NULL
 -- !query
 SELECT cast(null as string) <= cast(1 as smallint) FROM t
 -- !query schema
-struct<(CAST(CAST(NULL AS STRING) AS SMALLINT) <= CAST(1 AS SMALLINT)):boolean>
+struct<(CAST(CAST(NULL AS STRING) AS BIGINT) <= CAST(CAST(1 AS SMALLINT) AS BIGINT)):boolean>
 -- !query output
 NULL
 
@@ -581,7 +581,7 @@ NULL
 -- !query
 SELECT cast(null as string) <> cast(1 as smallint) FROM t
 -- !query schema
-struct<(NOT (CAST(CAST(NULL AS STRING) AS SMALLINT) = CAST(1 AS SMALLINT))):boolean>
+struct<(NOT (CAST(CAST(NULL AS STRING) AS BIGINT) = CAST(CAST(1 AS SMALLINT) AS BIGINT))):boolean>
 -- !query output
 NULL
 
@@ -589,7 +589,7 @@ NULL
 -- !query
 SELECT cast(1 as int) = '1' FROM t
 -- !query schema
-struct<(CAST(1 AS INT) = CAST(1 AS INT)):boolean>
+struct<(CAST(CAST(1 AS INT) AS BIGINT) = CAST(1 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -597,7 +597,7 @@ true
 -- !query
 SELECT cast(1 as int) > '2' FROM t
 -- !query schema
-struct<(CAST(1 AS INT) > CAST(2 AS INT)):boolean>
+struct<(CAST(CAST(1 AS INT) AS BIGINT) > CAST(2 AS BIGINT)):boolean>
 -- !query output
 false
 
@@ -605,7 +605,7 @@ false
 -- !query
 SELECT cast(1 as int) >= '2' FROM t
 -- !query schema
-struct<(CAST(1 AS INT) >= CAST(2 AS INT)):boolean>
+struct<(CAST(CAST(1 AS INT) AS BIGINT) >= CAST(2 AS BIGINT)):boolean>
 -- !query output
 false
 
@@ -613,7 +613,7 @@ false
 -- !query
 SELECT cast(1 as int) < '2' FROM t
 -- !query schema
-struct<(CAST(1 AS INT) < CAST(2 AS INT)):boolean>
+struct<(CAST(CAST(1 AS INT) AS BIGINT) < CAST(2 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -621,7 +621,7 @@ true
 -- !query
 SELECT cast(1 as int) <= '2' FROM t
 -- !query schema
-struct<(CAST(1 AS INT) <= CAST(2 AS INT)):boolean>
+struct<(CAST(CAST(1 AS INT) AS BIGINT) <= CAST(2 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -629,7 +629,7 @@ true
 -- !query
 SELECT cast(1 as int) <> '2' FROM t
 -- !query schema
-struct<(NOT (CAST(1 AS INT) = CAST(2 AS INT))):boolean>
+struct<(NOT (CAST(CAST(1 AS INT) AS BIGINT) = CAST(2 AS BIGINT))):boolean>
 -- !query output
 true
 
@@ -637,7 +637,7 @@ true
 -- !query
 SELECT cast(1 as int) = cast(null as string) FROM t
 -- !query schema
-struct<(CAST(1 AS INT) = CAST(CAST(NULL AS STRING) AS INT)):boolean>
+struct<(CAST(CAST(1 AS INT) AS BIGINT) = CAST(CAST(NULL AS STRING) AS BIGINT)):boolean>
 -- !query output
 NULL
 
@@ -645,7 +645,7 @@ NULL
 -- !query
 SELECT cast(1 as int) > cast(null as string) FROM t
 -- !query schema
-struct<(CAST(1 AS INT) > CAST(CAST(NULL AS STRING) AS INT)):boolean>
+struct<(CAST(CAST(1 AS INT) AS BIGINT) > CAST(CAST(NULL AS STRING) AS BIGINT)):boolean>
 -- !query output
 NULL
 
@@ -653,7 +653,7 @@ NULL
 -- !query
 SELECT cast(1 as int) >= cast(null as string) FROM t
 -- !query schema
-struct<(CAST(1 AS INT) >= CAST(CAST(NULL AS STRING) AS INT)):boolean>
+struct<(CAST(CAST(1 AS INT) AS BIGINT) >= CAST(CAST(NULL AS STRING) AS BIGINT)):boolean>
 -- !query output
 NULL
 
@@ -661,7 +661,7 @@ NULL
 -- !query
 SELECT cast(1 as int) < cast(null as string) FROM t
 -- !query schema
-struct<(CAST(1 AS INT) < CAST(CAST(NULL AS STRING) AS INT)):boolean>
+struct<(CAST(CAST(1 AS INT) AS BIGINT) < CAST(CAST(NULL AS STRING) AS BIGINT)):boolean>
 -- !query output
 NULL
 
@@ -669,7 +669,7 @@ NULL
 -- !query
 SELECT cast(1 as int) <= cast(null as string) FROM t
 -- !query schema
-struct<(CAST(1 AS INT) <= CAST(CAST(NULL AS STRING) AS INT)):boolean>
+struct<(CAST(CAST(1 AS INT) AS BIGINT) <= CAST(CAST(NULL AS STRING) AS BIGINT)):boolean>
 -- !query output
 NULL
 
@@ -677,7 +677,7 @@ NULL
 -- !query
 SELECT cast(1 as int) <> cast(null as string) FROM t
 -- !query schema
-struct<(NOT (CAST(1 AS INT) = CAST(CAST(NULL AS STRING) AS INT))):boolean>
+struct<(NOT (CAST(CAST(1 AS INT) AS BIGINT) = CAST(CAST(NULL AS STRING) AS BIGINT))):boolean>
 -- !query output
 NULL
 
@@ -685,7 +685,7 @@ NULL
 -- !query
 SELECT '1' = cast(1 as int) FROM t
 -- !query schema
-struct<(CAST(1 AS INT) = CAST(1 AS INT)):boolean>
+struct<(CAST(1 AS BIGINT) = CAST(CAST(1 AS INT) AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -693,7 +693,7 @@ true
 -- !query
 SELECT '2' > cast(1 as int) FROM t
 -- !query schema
-struct<(CAST(2 AS INT) > CAST(1 AS INT)):boolean>
+struct<(CAST(2 AS BIGINT) > CAST(CAST(1 AS INT) AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -701,7 +701,7 @@ true
 -- !query
 SELECT '2' >= cast(1 as int) FROM t
 -- !query schema
-struct<(CAST(2 AS INT) >= CAST(1 AS INT)):boolean>
+struct<(CAST(2 AS BIGINT) >= CAST(CAST(1 AS INT) AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -709,7 +709,7 @@ true
 -- !query
 SELECT '2' < cast(1 as int) FROM t
 -- !query schema
-struct<(CAST(2 AS INT) < CAST(1 AS INT)):boolean>
+struct<(CAST(2 AS BIGINT) < CAST(CAST(1 AS INT) AS BIGINT)):boolean>
 -- !query output
 false
 
@@ -717,7 +717,7 @@ false
 -- !query
 SELECT '2' <> cast(1 as int) FROM t
 -- !query schema
-struct<(NOT (CAST(2 AS INT) = CAST(1 AS INT))):boolean>
+struct<(NOT (CAST(2 AS BIGINT) = CAST(CAST(1 AS INT) AS BIGINT))):boolean>
 -- !query output
 true
 
@@ -725,7 +725,7 @@ true
 -- !query
 SELECT '2' <= cast(1 as int) FROM t
 -- !query schema
-struct<(CAST(2 AS INT) <= CAST(1 AS INT)):boolean>
+struct<(CAST(2 AS BIGINT) <= CAST(CAST(1 AS INT) AS BIGINT)):boolean>
 -- !query output
 false
 
@@ -733,7 +733,7 @@ false
 -- !query
 SELECT cast(null as string) = cast(1 as int) FROM t
 -- !query schema
-struct<(CAST(CAST(NULL AS STRING) AS INT) = CAST(1 AS INT)):boolean>
+struct<(CAST(CAST(NULL AS STRING) AS BIGINT) = CAST(CAST(1 AS INT) AS BIGINT)):boolean>
 -- !query output
 NULL
 
@@ -741,7 +741,7 @@ NULL
 -- !query
 SELECT cast(null as string) > cast(1 as int) FROM t
 -- !query schema
-struct<(CAST(CAST(NULL AS STRING) AS INT) > CAST(1 AS INT)):boolean>
+struct<(CAST(CAST(NULL AS STRING) AS BIGINT) > CAST(CAST(1 AS INT) AS BIGINT)):boolean>
 -- !query output
 NULL
 
@@ -749,7 +749,7 @@ NULL
 -- !query
 SELECT cast(null as string) >= cast(1 as int) FROM t
 -- !query schema
-struct<(CAST(CAST(NULL AS STRING) AS INT) >= CAST(1 AS INT)):boolean>
+struct<(CAST(CAST(NULL AS STRING) AS BIGINT) >= CAST(CAST(1 AS INT) AS BIGINT)):boolean>
 -- !query output
 NULL
 
@@ -757,7 +757,7 @@ NULL
 -- !query
 SELECT cast(null as string) < cast(1 as int) FROM t
 -- !query schema
-struct<(CAST(CAST(NULL AS STRING) AS INT) < CAST(1 AS INT)):boolean>
+struct<(CAST(CAST(NULL AS STRING) AS BIGINT) < CAST(CAST(1 AS INT) AS BIGINT)):boolean>
 -- !query output
 NULL
 
@@ -765,7 +765,7 @@ NULL
 -- !query
 SELECT cast(null as string) <> cast(1 as int) FROM t
 -- !query schema
-struct<(NOT (CAST(CAST(NULL AS STRING) AS INT) = CAST(1 AS INT))):boolean>
+struct<(NOT (CAST(CAST(NULL AS STRING) AS BIGINT) = CAST(CAST(1 AS INT) AS BIGINT))):boolean>
 -- !query output
 NULL
 
@@ -773,7 +773,7 @@ NULL
 -- !query
 SELECT cast(null as string) <= cast(1 as int) FROM t
 -- !query schema
-struct<(CAST(CAST(NULL AS STRING) AS INT) <= CAST(1 AS INT)):boolean>
+struct<(CAST(CAST(NULL AS STRING) AS BIGINT) <= CAST(CAST(1 AS INT) AS BIGINT)):boolean>
 -- !query output
 NULL
 
@@ -973,7 +973,7 @@ NULL
 -- !query
 SELECT cast(1 as decimal(10, 0)) = '1' FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE) = CAST(1 AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0)) = CAST(1 AS DECIMAL(38,0))):boolean>
 -- !query output
 true
 
@@ -981,7 +981,7 @@ true
 -- !query
 SELECT cast(1 as decimal(10, 0)) > '2' FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE) > CAST(2 AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0)) > CAST(2 AS DECIMAL(38,0))):boolean>
 -- !query output
 false
 
@@ -989,7 +989,7 @@ false
 -- !query
 SELECT cast(1 as decimal(10, 0)) >= '2' FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE) >= CAST(2 AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0)) >= CAST(2 AS DECIMAL(38,0))):boolean>
 -- !query output
 false
 
@@ -997,7 +997,7 @@ false
 -- !query
 SELECT cast(1 as decimal(10, 0)) < '2' FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE) < CAST(2 AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0)) < CAST(2 AS DECIMAL(38,0))):boolean>
 -- !query output
 true
 
@@ -1005,7 +1005,7 @@ true
 -- !query
 SELECT cast(1 as decimal(10, 0)) <> '2' FROM t
 -- !query schema
-struct<(NOT (CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE) = CAST(2 AS DOUBLE))):boolean>
+struct<(NOT (CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0)) = CAST(2 AS DECIMAL(38,0)))):boolean>
 -- !query output
 true
 
@@ -1013,7 +1013,7 @@ true
 -- !query
 SELECT cast(1 as decimal(10, 0)) <= '2' FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE) <= CAST(2 AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0)) <= CAST(2 AS DECIMAL(38,0))):boolean>
 -- !query output
 true
 
@@ -1021,7 +1021,7 @@ true
 -- !query
 SELECT cast(1 as decimal(10, 0)) = cast(null as string) FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE) = CAST(CAST(NULL AS STRING) AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0)) = CAST(CAST(NULL AS STRING) AS DECIMAL(38,0))):boolean>
 -- !query output
 NULL
 
@@ -1029,7 +1029,7 @@ NULL
 -- !query
 SELECT cast(1 as decimal(10, 0)) > cast(null as string) FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE) > CAST(CAST(NULL AS STRING) AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0)) > CAST(CAST(NULL AS STRING) AS DECIMAL(38,0))):boolean>
 -- !query output
 NULL
 
@@ -1037,7 +1037,7 @@ NULL
 -- !query
 SELECT cast(1 as decimal(10, 0)) >= cast(null as string) FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE) >= CAST(CAST(NULL AS STRING) AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0)) >= CAST(CAST(NULL AS STRING) AS DECIMAL(38,0))):boolean>
 -- !query output
 NULL
 
@@ -1045,7 +1045,7 @@ NULL
 -- !query
 SELECT cast(1 as decimal(10, 0)) < cast(null as string) FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE) < CAST(CAST(NULL AS STRING) AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0)) < CAST(CAST(NULL AS STRING) AS DECIMAL(38,0))):boolean>
 -- !query output
 NULL
 
@@ -1053,7 +1053,7 @@ NULL
 -- !query
 SELECT cast(1 as decimal(10, 0)) <> cast(null as string) FROM t
 -- !query schema
-struct<(NOT (CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE) = CAST(CAST(NULL AS STRING) AS DOUBLE))):boolean>
+struct<(NOT (CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0)) = CAST(CAST(NULL AS STRING) AS DECIMAL(38,0)))):boolean>
 -- !query output
 NULL
 
@@ -1061,7 +1061,7 @@ NULL
 -- !query
 SELECT cast(1 as decimal(10, 0)) <= cast(null as string) FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE) <= CAST(CAST(NULL AS STRING) AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0)) <= CAST(CAST(NULL AS STRING) AS DECIMAL(38,0))):boolean>
 -- !query output
 NULL
 
@@ -1069,7 +1069,7 @@ NULL
 -- !query
 SELECT '1' = cast(1 as decimal(10, 0)) FROM t
 -- !query schema
-struct<(CAST(1 AS DOUBLE) = CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE)):boolean>
+struct<(CAST(1 AS DECIMAL(38,0)) = CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0))):boolean>
 -- !query output
 true
 
@@ -1077,7 +1077,7 @@ true
 -- !query
 SELECT '2' > cast(1 as decimal(10, 0)) FROM t
 -- !query schema
-struct<(CAST(2 AS DOUBLE) > CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE)):boolean>
+struct<(CAST(2 AS DECIMAL(38,0)) > CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0))):boolean>
 -- !query output
 true
 
@@ -1085,7 +1085,7 @@ true
 -- !query
 SELECT '2' >= cast(1 as decimal(10, 0)) FROM t
 -- !query schema
-struct<(CAST(2 AS DOUBLE) >= CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE)):boolean>
+struct<(CAST(2 AS DECIMAL(38,0)) >= CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0))):boolean>
 -- !query output
 true
 
@@ -1093,7 +1093,7 @@ true
 -- !query
 SELECT '2' < cast(1 as decimal(10, 0)) FROM t
 -- !query schema
-struct<(CAST(2 AS DOUBLE) < CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE)):boolean>
+struct<(CAST(2 AS DECIMAL(38,0)) < CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0))):boolean>
 -- !query output
 false
 
@@ -1101,7 +1101,7 @@ false
 -- !query
 SELECT '2' <= cast(1 as decimal(10, 0)) FROM t
 -- !query schema
-struct<(CAST(2 AS DOUBLE) <= CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE)):boolean>
+struct<(CAST(2 AS DECIMAL(38,0)) <= CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0))):boolean>
 -- !query output
 false
 
@@ -1109,7 +1109,7 @@ false
 -- !query
 SELECT '2' <> cast(1 as decimal(10, 0)) FROM t
 -- !query schema
-struct<(NOT (CAST(2 AS DOUBLE) = CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE))):boolean>
+struct<(NOT (CAST(2 AS DECIMAL(38,0)) = CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0)))):boolean>
 -- !query output
 true
 
@@ -1117,7 +1117,7 @@ true
 -- !query
 SELECT cast(null as string) = cast(1 as decimal(10, 0)) FROM t
 -- !query schema
-struct<(CAST(CAST(NULL AS STRING) AS DOUBLE) = CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE)):boolean>
+struct<(CAST(CAST(NULL AS STRING) AS DECIMAL(38,0)) = CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0))):boolean>
 -- !query output
 NULL
 
@@ -1125,7 +1125,7 @@ NULL
 -- !query
 SELECT cast(null as string) > cast(1 as decimal(10, 0)) FROM t
 -- !query schema
-struct<(CAST(CAST(NULL AS STRING) AS DOUBLE) > CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE)):boolean>
+struct<(CAST(CAST(NULL AS STRING) AS DECIMAL(38,0)) > CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0))):boolean>
 -- !query output
 NULL
 
@@ -1133,7 +1133,7 @@ NULL
 -- !query
 SELECT cast(null as string) >= cast(1 as decimal(10, 0)) FROM t
 -- !query schema
-struct<(CAST(CAST(NULL AS STRING) AS DOUBLE) >= CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE)):boolean>
+struct<(CAST(CAST(NULL AS STRING) AS DECIMAL(38,0)) >= CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0))):boolean>
 -- !query output
 NULL
 
@@ -1141,7 +1141,7 @@ NULL
 -- !query
 SELECT cast(null as string) < cast(1 as decimal(10, 0)) FROM t
 -- !query schema
-struct<(CAST(CAST(NULL AS STRING) AS DOUBLE) < CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE)):boolean>
+struct<(CAST(CAST(NULL AS STRING) AS DECIMAL(38,0)) < CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0))):boolean>
 -- !query output
 NULL
 
@@ -1149,7 +1149,7 @@ NULL
 -- !query
 SELECT cast(null as string) <= cast(1 as decimal(10, 0)) FROM t
 -- !query schema
-struct<(CAST(CAST(NULL AS STRING) AS DOUBLE) <= CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE)):boolean>
+struct<(CAST(CAST(NULL AS STRING) AS DECIMAL(38,0)) <= CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0))):boolean>
 -- !query output
 NULL
 
@@ -1157,7 +1157,7 @@ NULL
 -- !query
 SELECT cast(null as string) <> cast(1 as decimal(10, 0)) FROM t
 -- !query schema
-struct<(NOT (CAST(CAST(NULL AS STRING) AS DOUBLE) = CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE))):boolean>
+struct<(NOT (CAST(CAST(NULL AS STRING) AS DECIMAL(38,0)) = CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0)))):boolean>
 -- !query output
 NULL
 
@@ -1357,7 +1357,7 @@ NULL
 -- !query
 SELECT cast(1 as float) = '1' FROM t
 -- !query schema
-struct<(CAST(1 AS FLOAT) = CAST(1 AS FLOAT)):boolean>
+struct<(CAST(CAST(1 AS FLOAT) AS DOUBLE) = CAST(1 AS DOUBLE)):boolean>
 -- !query output
 true
 
@@ -1365,7 +1365,7 @@ true
 -- !query
 SELECT cast(1 as float) > '2' FROM t
 -- !query schema
-struct<(CAST(1 AS FLOAT) > CAST(2 AS FLOAT)):boolean>
+struct<(CAST(CAST(1 AS FLOAT) AS DOUBLE) > CAST(2 AS DOUBLE)):boolean>
 -- !query output
 false
 
@@ -1373,7 +1373,7 @@ false
 -- !query
 SELECT cast(1 as float) >= '2' FROM t
 -- !query schema
-struct<(CAST(1 AS FLOAT) >= CAST(2 AS FLOAT)):boolean>
+struct<(CAST(CAST(1 AS FLOAT) AS DOUBLE) >= CAST(2 AS DOUBLE)):boolean>
 -- !query output
 false
 
@@ -1381,7 +1381,7 @@ false
 -- !query
 SELECT cast(1 as float) < '2' FROM t
 -- !query schema
-struct<(CAST(1 AS FLOAT) < CAST(2 AS FLOAT)):boolean>
+struct<(CAST(CAST(1 AS FLOAT) AS DOUBLE) < CAST(2 AS DOUBLE)):boolean>
 -- !query output
 true
 
@@ -1389,7 +1389,7 @@ true
 -- !query
 SELECT cast(1 as float) <= '2' FROM t
 -- !query schema
-struct<(CAST(1 AS FLOAT) <= CAST(2 AS FLOAT)):boolean>
+struct<(CAST(CAST(1 AS FLOAT) AS DOUBLE) <= CAST(2 AS DOUBLE)):boolean>
 -- !query output
 true
 
@@ -1397,7 +1397,7 @@ true
 -- !query
 SELECT cast(1 as float) <> '2' FROM t
 -- !query schema
-struct<(NOT (CAST(1 AS FLOAT) = CAST(2 AS FLOAT))):boolean>
+struct<(NOT (CAST(CAST(1 AS FLOAT) AS DOUBLE) = CAST(2 AS DOUBLE))):boolean>
 -- !query output
 true
 
@@ -1405,7 +1405,7 @@ true
 -- !query
 SELECT cast(1 as float) = cast(null as string) FROM t
 -- !query schema
-struct<(CAST(1 AS FLOAT) = CAST(CAST(NULL AS STRING) AS FLOAT)):boolean>
+struct<(CAST(CAST(1 AS FLOAT) AS DOUBLE) = CAST(CAST(NULL AS STRING) AS DOUBLE)):boolean>
 -- !query output
 NULL
 
@@ -1413,7 +1413,7 @@ NULL
 -- !query
 SELECT cast(1 as float) > cast(null as string) FROM t
 -- !query schema
-struct<(CAST(1 AS FLOAT) > CAST(CAST(NULL AS STRING) AS FLOAT)):boolean>
+struct<(CAST(CAST(1 AS FLOAT) AS DOUBLE) > CAST(CAST(NULL AS STRING) AS DOUBLE)):boolean>
 -- !query output
 NULL
 
@@ -1421,7 +1421,7 @@ NULL
 -- !query
 SELECT cast(1 as float) >= cast(null as string) FROM t
 -- !query schema
-struct<(CAST(1 AS FLOAT) >= CAST(CAST(NULL AS STRING) AS FLOAT)):boolean>
+struct<(CAST(CAST(1 AS FLOAT) AS DOUBLE) >= CAST(CAST(NULL AS STRING) AS DOUBLE)):boolean>
 -- !query output
 NULL
 
@@ -1429,7 +1429,7 @@ NULL
 -- !query
 SELECT cast(1 as float) < cast(null as string) FROM t
 -- !query schema
-struct<(CAST(1 AS FLOAT) < CAST(CAST(NULL AS STRING) AS FLOAT)):boolean>
+struct<(CAST(CAST(1 AS FLOAT) AS DOUBLE) < CAST(CAST(NULL AS STRING) AS DOUBLE)):boolean>
 -- !query output
 NULL
 
@@ -1437,7 +1437,7 @@ NULL
 -- !query
 SELECT cast(1 as float) <= cast(null as string) FROM t
 -- !query schema
-struct<(CAST(1 AS FLOAT) <= CAST(CAST(NULL AS STRING) AS FLOAT)):boolean>
+struct<(CAST(CAST(1 AS FLOAT) AS DOUBLE) <= CAST(CAST(NULL AS STRING) AS DOUBLE)):boolean>
 -- !query output
 NULL
 
@@ -1445,7 +1445,7 @@ NULL
 -- !query
 SELECT cast(1 as float) <> cast(null as string) FROM t
 -- !query schema
-struct<(NOT (CAST(1 AS FLOAT) = CAST(CAST(NULL AS STRING) AS FLOAT))):boolean>
+struct<(NOT (CAST(CAST(1 AS FLOAT) AS DOUBLE) = CAST(CAST(NULL AS STRING) AS DOUBLE))):boolean>
 -- !query output
 NULL
 
@@ -1453,7 +1453,7 @@ NULL
 -- !query
 SELECT '1' = cast(1 as float) FROM t
 -- !query schema
-struct<(CAST(1 AS FLOAT) = CAST(1 AS FLOAT)):boolean>
+struct<(CAST(1 AS DOUBLE) = CAST(CAST(1 AS FLOAT) AS DOUBLE)):boolean>
 -- !query output
 true
 
@@ -1461,7 +1461,7 @@ true
 -- !query
 SELECT '2' > cast(1 as float) FROM t
 -- !query schema
-struct<(CAST(2 AS FLOAT) > CAST(1 AS FLOAT)):boolean>
+struct<(CAST(2 AS DOUBLE) > CAST(CAST(1 AS FLOAT) AS DOUBLE)):boolean>
 -- !query output
 true
 
@@ -1469,7 +1469,7 @@ true
 -- !query
 SELECT '2' >= cast(1 as float) FROM t
 -- !query schema
-struct<(CAST(2 AS FLOAT) >= CAST(1 AS FLOAT)):boolean>
+struct<(CAST(2 AS DOUBLE) >= CAST(CAST(1 AS FLOAT) AS DOUBLE)):boolean>
 -- !query output
 true
 
@@ -1477,7 +1477,7 @@ true
 -- !query
 SELECT '2' < cast(1 as float) FROM t
 -- !query schema
-struct<(CAST(2 AS FLOAT) < CAST(1 AS FLOAT)):boolean>
+struct<(CAST(2 AS DOUBLE) < CAST(CAST(1 AS FLOAT) AS DOUBLE)):boolean>
 -- !query output
 false
 
@@ -1485,7 +1485,7 @@ false
 -- !query
 SELECT '2' <= cast(1 as float) FROM t
 -- !query schema
-struct<(CAST(2 AS FLOAT) <= CAST(1 AS FLOAT)):boolean>
+struct<(CAST(2 AS DOUBLE) <= CAST(CAST(1 AS FLOAT) AS DOUBLE)):boolean>
 -- !query output
 false
 
@@ -1493,7 +1493,7 @@ false
 -- !query
 SELECT '2' <> cast(1 as float) FROM t
 -- !query schema
-struct<(NOT (CAST(2 AS FLOAT) = CAST(1 AS FLOAT))):boolean>
+struct<(NOT (CAST(2 AS DOUBLE) = CAST(CAST(1 AS FLOAT) AS DOUBLE))):boolean>
 -- !query output
 true
 
@@ -1501,7 +1501,7 @@ true
 -- !query
 SELECT cast(null as string) = cast(1 as float) FROM t
 -- !query schema
-struct<(CAST(CAST(NULL AS STRING) AS FLOAT) = CAST(1 AS FLOAT)):boolean>
+struct<(CAST(CAST(NULL AS STRING) AS DOUBLE) = CAST(CAST(1 AS FLOAT) AS DOUBLE)):boolean>
 -- !query output
 NULL
 
@@ -1509,7 +1509,7 @@ NULL
 -- !query
 SELECT cast(null as string) > cast(1 as float) FROM t
 -- !query schema
-struct<(CAST(CAST(NULL AS STRING) AS FLOAT) > CAST(1 AS FLOAT)):boolean>
+struct<(CAST(CAST(NULL AS STRING) AS DOUBLE) > CAST(CAST(1 AS FLOAT) AS DOUBLE)):boolean>
 -- !query output
 NULL
 
@@ -1517,7 +1517,7 @@ NULL
 -- !query
 SELECT cast(null as string) >= cast(1 as float) FROM t
 -- !query schema
-struct<(CAST(CAST(NULL AS STRING) AS FLOAT) >= CAST(1 AS FLOAT)):boolean>
+struct<(CAST(CAST(NULL AS STRING) AS DOUBLE) >= CAST(CAST(1 AS FLOAT) AS DOUBLE)):boolean>
 -- !query output
 NULL
 
@@ -1525,7 +1525,7 @@ NULL
 -- !query
 SELECT cast(null as string) < cast(1 as float) FROM t
 -- !query schema
-struct<(CAST(CAST(NULL AS STRING) AS FLOAT) < CAST(1 AS FLOAT)):boolean>
+struct<(CAST(CAST(NULL AS STRING) AS DOUBLE) < CAST(CAST(1 AS FLOAT) AS DOUBLE)):boolean>
 -- !query output
 NULL
 
@@ -1533,7 +1533,7 @@ NULL
 -- !query
 SELECT cast(null as string) <= cast(1 as float) FROM t
 -- !query schema
-struct<(CAST(CAST(NULL AS STRING) AS FLOAT) <= CAST(1 AS FLOAT)):boolean>
+struct<(CAST(CAST(NULL AS STRING) AS DOUBLE) <= CAST(CAST(1 AS FLOAT) AS DOUBLE)):boolean>
 -- !query output
 NULL
 
@@ -1541,7 +1541,7 @@ NULL
 -- !query
 SELECT cast(null as string) <> cast(1 as float) FROM t
 -- !query schema
-struct<(NOT (CAST(CAST(NULL AS STRING) AS FLOAT) = CAST(1 AS FLOAT))):boolean>
+struct<(NOT (CAST(CAST(NULL AS STRING) AS DOUBLE) = CAST(CAST(1 AS FLOAT) AS DOUBLE))):boolean>
 -- !query output
 NULL
 

--- a/sql/core/src/test/resources/sql-tests/results/typeCoercion/native/decimalPrecision.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/typeCoercion/native/decimalPrecision.sql.out
@@ -4961,7 +4961,7 @@ true
 -- !query
 SELECT cast(1 as decimal(3, 0))  = cast(1 as string) FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(3,0)) AS DOUBLE) = CAST(CAST(1 AS STRING) AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(3,0)) AS DECIMAL(38,0)) = CAST(CAST(1 AS STRING) AS DECIMAL(38,0))):boolean>
 -- !query output
 true
 
@@ -4969,7 +4969,7 @@ true
 -- !query
 SELECT cast(1 as decimal(5, 0))  = cast(1 as string) FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(5,0)) AS DOUBLE) = CAST(CAST(1 AS STRING) AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(5,0)) AS DECIMAL(38,0)) = CAST(CAST(1 AS STRING) AS DECIMAL(38,0))):boolean>
 -- !query output
 true
 
@@ -4977,7 +4977,7 @@ true
 -- !query
 SELECT cast(1 as decimal(10, 0)) = cast(1 as string) FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE) = CAST(CAST(1 AS STRING) AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0)) = CAST(CAST(1 AS STRING) AS DECIMAL(38,0))):boolean>
 -- !query output
 true
 
@@ -4985,7 +4985,7 @@ true
 -- !query
 SELECT cast(1 as decimal(20, 0)) = cast(1 as string) FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(20,0)) AS DOUBLE) = CAST(CAST(1 AS STRING) AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(20,0)) AS DECIMAL(38,0)) = CAST(CAST(1 AS STRING) AS DECIMAL(38,0))):boolean>
 -- !query output
 true
 
@@ -5689,7 +5689,7 @@ true
 -- !query
 SELECT cast(1 as decimal(3, 0))  <=> cast(1 as string) FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(3,0)) AS DOUBLE) <=> CAST(CAST(1 AS STRING) AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(3,0)) AS DECIMAL(38,0)) <=> CAST(CAST(1 AS STRING) AS DECIMAL(38,0))):boolean>
 -- !query output
 true
 
@@ -5697,7 +5697,7 @@ true
 -- !query
 SELECT cast(1 as decimal(5, 0))  <=> cast(1 as string) FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(5,0)) AS DOUBLE) <=> CAST(CAST(1 AS STRING) AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(5,0)) AS DECIMAL(38,0)) <=> CAST(CAST(1 AS STRING) AS DECIMAL(38,0))):boolean>
 -- !query output
 true
 
@@ -5705,7 +5705,7 @@ true
 -- !query
 SELECT cast(1 as decimal(10, 0)) <=> cast(1 as string) FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE) <=> CAST(CAST(1 AS STRING) AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0)) <=> CAST(CAST(1 AS STRING) AS DECIMAL(38,0))):boolean>
 -- !query output
 true
 
@@ -5713,7 +5713,7 @@ true
 -- !query
 SELECT cast(1 as decimal(20, 0)) <=> cast(1 as string) FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(20,0)) AS DOUBLE) <=> CAST(CAST(1 AS STRING) AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(20,0)) AS DECIMAL(38,0)) <=> CAST(CAST(1 AS STRING) AS DECIMAL(38,0))):boolean>
 -- !query output
 true
 
@@ -6417,7 +6417,7 @@ false
 -- !query
 SELECT cast(1 as decimal(3, 0))  < cast(1 as string) FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(3,0)) AS DOUBLE) < CAST(CAST(1 AS STRING) AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(3,0)) AS DECIMAL(38,0)) < CAST(CAST(1 AS STRING) AS DECIMAL(38,0))):boolean>
 -- !query output
 false
 
@@ -6425,7 +6425,7 @@ false
 -- !query
 SELECT cast(1 as decimal(5, 0))  < cast(1 as string) FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(5,0)) AS DOUBLE) < CAST(CAST(1 AS STRING) AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(5,0)) AS DECIMAL(38,0)) < CAST(CAST(1 AS STRING) AS DECIMAL(38,0))):boolean>
 -- !query output
 false
 
@@ -6433,7 +6433,7 @@ false
 -- !query
 SELECT cast(1 as decimal(10, 0)) < cast(1 as string) FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE) < CAST(CAST(1 AS STRING) AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0)) < CAST(CAST(1 AS STRING) AS DECIMAL(38,0))):boolean>
 -- !query output
 false
 
@@ -6441,7 +6441,7 @@ false
 -- !query
 SELECT cast(1 as decimal(20, 0)) < cast(1 as string) FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(20,0)) AS DOUBLE) < CAST(CAST(1 AS STRING) AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(20,0)) AS DECIMAL(38,0)) < CAST(CAST(1 AS STRING) AS DECIMAL(38,0))):boolean>
 -- !query output
 false
 
@@ -7149,7 +7149,7 @@ true
 -- !query
 SELECT cast(1 as decimal(3, 0))  <= cast(1 as string) FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(3,0)) AS DOUBLE) <= CAST(CAST(1 AS STRING) AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(3,0)) AS DECIMAL(38,0)) <= CAST(CAST(1 AS STRING) AS DECIMAL(38,0))):boolean>
 -- !query output
 true
 
@@ -7157,7 +7157,7 @@ true
 -- !query
 SELECT cast(1 as decimal(5, 0))  <= cast(1 as string) FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(5,0)) AS DOUBLE) <= CAST(CAST(1 AS STRING) AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(5,0)) AS DECIMAL(38,0)) <= CAST(CAST(1 AS STRING) AS DECIMAL(38,0))):boolean>
 -- !query output
 true
 
@@ -7165,7 +7165,7 @@ true
 -- !query
 SELECT cast(1 as decimal(10, 0)) <= cast(1 as string) FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE) <= CAST(CAST(1 AS STRING) AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0)) <= CAST(CAST(1 AS STRING) AS DECIMAL(38,0))):boolean>
 -- !query output
 true
 
@@ -7173,7 +7173,7 @@ true
 -- !query
 SELECT cast(1 as decimal(20, 0)) <= cast(1 as string) FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(20,0)) AS DOUBLE) <= CAST(CAST(1 AS STRING) AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(20,0)) AS DECIMAL(38,0)) <= CAST(CAST(1 AS STRING) AS DECIMAL(38,0))):boolean>
 -- !query output
 true
 
@@ -7881,7 +7881,7 @@ false
 -- !query
 SELECT cast(1 as decimal(3, 0))  > cast(1 as string) FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(3,0)) AS DOUBLE) > CAST(CAST(1 AS STRING) AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(3,0)) AS DECIMAL(38,0)) > CAST(CAST(1 AS STRING) AS DECIMAL(38,0))):boolean>
 -- !query output
 false
 
@@ -7889,7 +7889,7 @@ false
 -- !query
 SELECT cast(1 as decimal(5, 0))  > cast(1 as string) FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(5,0)) AS DOUBLE) > CAST(CAST(1 AS STRING) AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(5,0)) AS DECIMAL(38,0)) > CAST(CAST(1 AS STRING) AS DECIMAL(38,0))):boolean>
 -- !query output
 false
 
@@ -7897,7 +7897,7 @@ false
 -- !query
 SELECT cast(1 as decimal(10, 0)) > cast(1 as string) FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE) > CAST(CAST(1 AS STRING) AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0)) > CAST(CAST(1 AS STRING) AS DECIMAL(38,0))):boolean>
 -- !query output
 false
 
@@ -7905,7 +7905,7 @@ false
 -- !query
 SELECT cast(1 as decimal(20, 0)) > cast(1 as string) FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(20,0)) AS DOUBLE) > CAST(CAST(1 AS STRING) AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(20,0)) AS DECIMAL(38,0)) > CAST(CAST(1 AS STRING) AS DECIMAL(38,0))):boolean>
 -- !query output
 false
 
@@ -8613,7 +8613,7 @@ true
 -- !query
 SELECT cast(1 as decimal(3, 0))  >= cast(1 as string) FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(3,0)) AS DOUBLE) >= CAST(CAST(1 AS STRING) AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(3,0)) AS DECIMAL(38,0)) >= CAST(CAST(1 AS STRING) AS DECIMAL(38,0))):boolean>
 -- !query output
 true
 
@@ -8621,7 +8621,7 @@ true
 -- !query
 SELECT cast(1 as decimal(5, 0))  >= cast(1 as string) FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(5,0)) AS DOUBLE) >= CAST(CAST(1 AS STRING) AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(5,0)) AS DECIMAL(38,0)) >= CAST(CAST(1 AS STRING) AS DECIMAL(38,0))):boolean>
 -- !query output
 true
 
@@ -8629,7 +8629,7 @@ true
 -- !query
 SELECT cast(1 as decimal(10, 0)) >= cast(1 as string) FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE) >= CAST(CAST(1 AS STRING) AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0)) >= CAST(CAST(1 AS STRING) AS DECIMAL(38,0))):boolean>
 -- !query output
 true
 
@@ -8637,7 +8637,7 @@ true
 -- !query
 SELECT cast(1 as decimal(20, 0)) >= cast(1 as string) FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(20,0)) AS DOUBLE) >= CAST(CAST(1 AS STRING) AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(20,0)) AS DECIMAL(38,0)) >= CAST(CAST(1 AS STRING) AS DECIMAL(38,0))):boolean>
 -- !query output
 true
 
@@ -9345,7 +9345,7 @@ false
 -- !query
 SELECT cast(1 as decimal(3, 0))  <> cast(1 as string) FROM t
 -- !query schema
-struct<(NOT (CAST(CAST(1 AS DECIMAL(3,0)) AS DOUBLE) = CAST(CAST(1 AS STRING) AS DOUBLE))):boolean>
+struct<(NOT (CAST(CAST(1 AS DECIMAL(3,0)) AS DECIMAL(38,0)) = CAST(CAST(1 AS STRING) AS DECIMAL(38,0)))):boolean>
 -- !query output
 false
 
@@ -9353,7 +9353,7 @@ false
 -- !query
 SELECT cast(1 as decimal(5, 0))  <> cast(1 as string) FROM t
 -- !query schema
-struct<(NOT (CAST(CAST(1 AS DECIMAL(5,0)) AS DOUBLE) = CAST(CAST(1 AS STRING) AS DOUBLE))):boolean>
+struct<(NOT (CAST(CAST(1 AS DECIMAL(5,0)) AS DECIMAL(38,0)) = CAST(CAST(1 AS STRING) AS DECIMAL(38,0)))):boolean>
 -- !query output
 false
 
@@ -9361,7 +9361,7 @@ false
 -- !query
 SELECT cast(1 as decimal(10, 0)) <> cast(1 as string) FROM t
 -- !query schema
-struct<(NOT (CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE) = CAST(CAST(1 AS STRING) AS DOUBLE))):boolean>
+struct<(NOT (CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0)) = CAST(CAST(1 AS STRING) AS DECIMAL(38,0)))):boolean>
 -- !query output
 false
 
@@ -9369,7 +9369,7 @@ false
 -- !query
 SELECT cast(1 as decimal(20, 0)) <> cast(1 as string) FROM t
 -- !query schema
-struct<(NOT (CAST(CAST(1 AS DECIMAL(20,0)) AS DOUBLE) = CAST(CAST(1 AS STRING) AS DOUBLE))):boolean>
+struct<(NOT (CAST(CAST(1 AS DECIMAL(20,0)) AS DECIMAL(38,0)) = CAST(CAST(1 AS STRING) AS DECIMAL(38,0)))):boolean>
 -- !query output
 false
 

--- a/sql/core/src/test/resources/sql-tests/results/typeCoercion/native/promoteStrings.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/typeCoercion/native/promoteStrings.sql.out
@@ -1164,7 +1164,7 @@ cannot resolve 'pmod(CAST('2017-12-11 09:30:00' AS DATE), CAST('1' AS DOUBLE))' 
 -- !query
 SELECT '1' = cast(1 as tinyint)                         FROM t
 -- !query schema
-struct<(CAST(1 AS TINYINT) = CAST(1 AS TINYINT)):boolean>
+struct<(CAST(1 AS BIGINT) = CAST(CAST(1 AS TINYINT) AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -1172,7 +1172,7 @@ true
 -- !query
 SELECT '1' = cast(1 as smallint)                        FROM t
 -- !query schema
-struct<(CAST(1 AS SMALLINT) = CAST(1 AS SMALLINT)):boolean>
+struct<(CAST(1 AS BIGINT) = CAST(CAST(1 AS SMALLINT) AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -1180,7 +1180,7 @@ true
 -- !query
 SELECT '1' = cast(1 as int)                             FROM t
 -- !query schema
-struct<(CAST(1 AS INT) = CAST(1 AS INT)):boolean>
+struct<(CAST(1 AS BIGINT) = CAST(CAST(1 AS INT) AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -1196,7 +1196,7 @@ true
 -- !query
 SELECT '1' = cast(1 as float)                           FROM t
 -- !query schema
-struct<(CAST(1 AS FLOAT) = CAST(1 AS FLOAT)):boolean>
+struct<(CAST(1 AS DOUBLE) = CAST(CAST(1 AS FLOAT) AS DOUBLE)):boolean>
 -- !query output
 true
 
@@ -1212,7 +1212,7 @@ true
 -- !query
 SELECT '1' = cast(1 as decimal(10, 0))                  FROM t
 -- !query schema
-struct<(CAST(1 AS DOUBLE) = CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE)):boolean>
+struct<(CAST(1 AS DECIMAL(38,0)) = CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0))):boolean>
 -- !query output
 true
 
@@ -1260,7 +1260,7 @@ NULL
 -- !query
 SELECT cast(1 as tinyint)                         = '1' FROM t
 -- !query schema
-struct<(CAST(1 AS TINYINT) = CAST(1 AS TINYINT)):boolean>
+struct<(CAST(CAST(1 AS TINYINT) AS BIGINT) = CAST(1 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -1268,7 +1268,7 @@ true
 -- !query
 SELECT cast(1 as smallint)                        = '1' FROM t
 -- !query schema
-struct<(CAST(1 AS SMALLINT) = CAST(1 AS SMALLINT)):boolean>
+struct<(CAST(CAST(1 AS SMALLINT) AS BIGINT) = CAST(1 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -1276,7 +1276,7 @@ true
 -- !query
 SELECT cast(1 as int)                             = '1' FROM t
 -- !query schema
-struct<(CAST(1 AS INT) = CAST(1 AS INT)):boolean>
+struct<(CAST(CAST(1 AS INT) AS BIGINT) = CAST(1 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -1292,7 +1292,7 @@ true
 -- !query
 SELECT cast(1 as float)                           = '1' FROM t
 -- !query schema
-struct<(CAST(1 AS FLOAT) = CAST(1 AS FLOAT)):boolean>
+struct<(CAST(CAST(1 AS FLOAT) AS DOUBLE) = CAST(1 AS DOUBLE)):boolean>
 -- !query output
 true
 
@@ -1308,7 +1308,7 @@ true
 -- !query
 SELECT cast(1 as decimal(10, 0))                  = '1' FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE) = CAST(1 AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0)) = CAST(1 AS DECIMAL(38,0))):boolean>
 -- !query output
 true
 
@@ -1348,7 +1348,7 @@ NULL
 -- !query
 SELECT '1' <=> cast(1 as tinyint)                         FROM t
 -- !query schema
-struct<(CAST(1 AS TINYINT) <=> CAST(1 AS TINYINT)):boolean>
+struct<(CAST(1 AS BIGINT) <=> CAST(CAST(1 AS TINYINT) AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -1356,7 +1356,7 @@ true
 -- !query
 SELECT '1' <=> cast(1 as smallint)                        FROM t
 -- !query schema
-struct<(CAST(1 AS SMALLINT) <=> CAST(1 AS SMALLINT)):boolean>
+struct<(CAST(1 AS BIGINT) <=> CAST(CAST(1 AS SMALLINT) AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -1364,7 +1364,7 @@ true
 -- !query
 SELECT '1' <=> cast(1 as int)                             FROM t
 -- !query schema
-struct<(CAST(1 AS INT) <=> CAST(1 AS INT)):boolean>
+struct<(CAST(1 AS BIGINT) <=> CAST(CAST(1 AS INT) AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -1380,7 +1380,7 @@ true
 -- !query
 SELECT '1' <=> cast(1 as float)                           FROM t
 -- !query schema
-struct<(CAST(1 AS FLOAT) <=> CAST(1 AS FLOAT)):boolean>
+struct<(CAST(1 AS DOUBLE) <=> CAST(CAST(1 AS FLOAT) AS DOUBLE)):boolean>
 -- !query output
 true
 
@@ -1396,7 +1396,7 @@ true
 -- !query
 SELECT '1' <=> cast(1 as decimal(10, 0))                  FROM t
 -- !query schema
-struct<(CAST(1 AS DOUBLE) <=> CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE)):boolean>
+struct<(CAST(1 AS DECIMAL(38,0)) <=> CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0))):boolean>
 -- !query output
 true
 
@@ -1444,7 +1444,7 @@ false
 -- !query
 SELECT cast(1 as tinyint)                         <=> '1' FROM t
 -- !query schema
-struct<(CAST(1 AS TINYINT) <=> CAST(1 AS TINYINT)):boolean>
+struct<(CAST(CAST(1 AS TINYINT) AS BIGINT) <=> CAST(1 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -1452,7 +1452,7 @@ true
 -- !query
 SELECT cast(1 as smallint)                        <=> '1' FROM t
 -- !query schema
-struct<(CAST(1 AS SMALLINT) <=> CAST(1 AS SMALLINT)):boolean>
+struct<(CAST(CAST(1 AS SMALLINT) AS BIGINT) <=> CAST(1 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -1460,7 +1460,7 @@ true
 -- !query
 SELECT cast(1 as int)                             <=> '1' FROM t
 -- !query schema
-struct<(CAST(1 AS INT) <=> CAST(1 AS INT)):boolean>
+struct<(CAST(CAST(1 AS INT) AS BIGINT) <=> CAST(1 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -1476,7 +1476,7 @@ true
 -- !query
 SELECT cast(1 as float)                           <=> '1' FROM t
 -- !query schema
-struct<(CAST(1 AS FLOAT) <=> CAST(1 AS FLOAT)):boolean>
+struct<(CAST(CAST(1 AS FLOAT) AS DOUBLE) <=> CAST(1 AS DOUBLE)):boolean>
 -- !query output
 true
 
@@ -1492,7 +1492,7 @@ true
 -- !query
 SELECT cast(1 as decimal(10, 0))                  <=> '1' FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE) <=> CAST(1 AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0)) <=> CAST(1 AS DECIMAL(38,0))):boolean>
 -- !query output
 true
 
@@ -1532,7 +1532,7 @@ false
 -- !query
 SELECT '1' < cast(1 as tinyint)                         FROM t
 -- !query schema
-struct<(CAST(1 AS TINYINT) < CAST(1 AS TINYINT)):boolean>
+struct<(CAST(1 AS BIGINT) < CAST(CAST(1 AS TINYINT) AS BIGINT)):boolean>
 -- !query output
 false
 
@@ -1540,7 +1540,7 @@ false
 -- !query
 SELECT '1' < cast(1 as smallint)                        FROM t
 -- !query schema
-struct<(CAST(1 AS SMALLINT) < CAST(1 AS SMALLINT)):boolean>
+struct<(CAST(1 AS BIGINT) < CAST(CAST(1 AS SMALLINT) AS BIGINT)):boolean>
 -- !query output
 false
 
@@ -1548,7 +1548,7 @@ false
 -- !query
 SELECT '1' < cast(1 as int)                             FROM t
 -- !query schema
-struct<(CAST(1 AS INT) < CAST(1 AS INT)):boolean>
+struct<(CAST(1 AS BIGINT) < CAST(CAST(1 AS INT) AS BIGINT)):boolean>
 -- !query output
 false
 
@@ -1564,7 +1564,7 @@ false
 -- !query
 SELECT '1' < cast(1 as float)                           FROM t
 -- !query schema
-struct<(CAST(1 AS FLOAT) < CAST(1 AS FLOAT)):boolean>
+struct<(CAST(1 AS DOUBLE) < CAST(CAST(1 AS FLOAT) AS DOUBLE)):boolean>
 -- !query output
 false
 
@@ -1580,7 +1580,7 @@ false
 -- !query
 SELECT '1' < cast(1 as decimal(10, 0))                  FROM t
 -- !query schema
-struct<(CAST(1 AS DOUBLE) < CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE)):boolean>
+struct<(CAST(1 AS DECIMAL(38,0)) < CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0))):boolean>
 -- !query output
 false
 
@@ -1628,7 +1628,7 @@ NULL
 -- !query
 SELECT '1' <= cast(1 as tinyint)                         FROM t
 -- !query schema
-struct<(CAST(1 AS TINYINT) <= CAST(1 AS TINYINT)):boolean>
+struct<(CAST(1 AS BIGINT) <= CAST(CAST(1 AS TINYINT) AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -1636,7 +1636,7 @@ true
 -- !query
 SELECT '1' <= cast(1 as smallint)                        FROM t
 -- !query schema
-struct<(CAST(1 AS SMALLINT) <= CAST(1 AS SMALLINT)):boolean>
+struct<(CAST(1 AS BIGINT) <= CAST(CAST(1 AS SMALLINT) AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -1644,7 +1644,7 @@ true
 -- !query
 SELECT '1' <= cast(1 as int)                             FROM t
 -- !query schema
-struct<(CAST(1 AS INT) <= CAST(1 AS INT)):boolean>
+struct<(CAST(1 AS BIGINT) <= CAST(CAST(1 AS INT) AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -1660,7 +1660,7 @@ true
 -- !query
 SELECT '1' <= cast(1 as float)                           FROM t
 -- !query schema
-struct<(CAST(1 AS FLOAT) <= CAST(1 AS FLOAT)):boolean>
+struct<(CAST(1 AS DOUBLE) <= CAST(CAST(1 AS FLOAT) AS DOUBLE)):boolean>
 -- !query output
 true
 
@@ -1676,7 +1676,7 @@ true
 -- !query
 SELECT '1' <= cast(1 as decimal(10, 0))                  FROM t
 -- !query schema
-struct<(CAST(1 AS DOUBLE) <= CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE)):boolean>
+struct<(CAST(1 AS DECIMAL(38,0)) <= CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0))):boolean>
 -- !query output
 true
 
@@ -1724,7 +1724,7 @@ NULL
 -- !query
 SELECT '1' > cast(1 as tinyint)                         FROM t
 -- !query schema
-struct<(CAST(1 AS TINYINT) > CAST(1 AS TINYINT)):boolean>
+struct<(CAST(1 AS BIGINT) > CAST(CAST(1 AS TINYINT) AS BIGINT)):boolean>
 -- !query output
 false
 
@@ -1732,7 +1732,7 @@ false
 -- !query
 SELECT '1' > cast(1 as smallint)                        FROM t
 -- !query schema
-struct<(CAST(1 AS SMALLINT) > CAST(1 AS SMALLINT)):boolean>
+struct<(CAST(1 AS BIGINT) > CAST(CAST(1 AS SMALLINT) AS BIGINT)):boolean>
 -- !query output
 false
 
@@ -1740,7 +1740,7 @@ false
 -- !query
 SELECT '1' > cast(1 as int)                             FROM t
 -- !query schema
-struct<(CAST(1 AS INT) > CAST(1 AS INT)):boolean>
+struct<(CAST(1 AS BIGINT) > CAST(CAST(1 AS INT) AS BIGINT)):boolean>
 -- !query output
 false
 
@@ -1756,7 +1756,7 @@ false
 -- !query
 SELECT '1' > cast(1 as float)                           FROM t
 -- !query schema
-struct<(CAST(1 AS FLOAT) > CAST(1 AS FLOAT)):boolean>
+struct<(CAST(1 AS DOUBLE) > CAST(CAST(1 AS FLOAT) AS DOUBLE)):boolean>
 -- !query output
 false
 
@@ -1772,7 +1772,7 @@ false
 -- !query
 SELECT '1' > cast(1 as decimal(10, 0))                  FROM t
 -- !query schema
-struct<(CAST(1 AS DOUBLE) > CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE)):boolean>
+struct<(CAST(1 AS DECIMAL(38,0)) > CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0))):boolean>
 -- !query output
 false
 
@@ -1820,7 +1820,7 @@ NULL
 -- !query
 SELECT '1' >= cast(1 as tinyint)                         FROM t
 -- !query schema
-struct<(CAST(1 AS TINYINT) >= CAST(1 AS TINYINT)):boolean>
+struct<(CAST(1 AS BIGINT) >= CAST(CAST(1 AS TINYINT) AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -1828,7 +1828,7 @@ true
 -- !query
 SELECT '1' >= cast(1 as smallint)                        FROM t
 -- !query schema
-struct<(CAST(1 AS SMALLINT) >= CAST(1 AS SMALLINT)):boolean>
+struct<(CAST(1 AS BIGINT) >= CAST(CAST(1 AS SMALLINT) AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -1836,7 +1836,7 @@ true
 -- !query
 SELECT '1' >= cast(1 as int)                             FROM t
 -- !query schema
-struct<(CAST(1 AS INT) >= CAST(1 AS INT)):boolean>
+struct<(CAST(1 AS BIGINT) >= CAST(CAST(1 AS INT) AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -1852,7 +1852,7 @@ true
 -- !query
 SELECT '1' >= cast(1 as float)                           FROM t
 -- !query schema
-struct<(CAST(1 AS FLOAT) >= CAST(1 AS FLOAT)):boolean>
+struct<(CAST(1 AS DOUBLE) >= CAST(CAST(1 AS FLOAT) AS DOUBLE)):boolean>
 -- !query output
 true
 
@@ -1868,7 +1868,7 @@ true
 -- !query
 SELECT '1' >= cast(1 as decimal(10, 0))                  FROM t
 -- !query schema
-struct<(CAST(1 AS DOUBLE) >= CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE)):boolean>
+struct<(CAST(1 AS DECIMAL(38,0)) >= CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0))):boolean>
 -- !query output
 true
 
@@ -1916,7 +1916,7 @@ NULL
 -- !query
 SELECT '1' <> cast(1 as tinyint)                         FROM t
 -- !query schema
-struct<(NOT (CAST(1 AS TINYINT) = CAST(1 AS TINYINT))):boolean>
+struct<(NOT (CAST(1 AS BIGINT) = CAST(CAST(1 AS TINYINT) AS BIGINT))):boolean>
 -- !query output
 false
 
@@ -1924,7 +1924,7 @@ false
 -- !query
 SELECT '1' <> cast(1 as smallint)                        FROM t
 -- !query schema
-struct<(NOT (CAST(1 AS SMALLINT) = CAST(1 AS SMALLINT))):boolean>
+struct<(NOT (CAST(1 AS BIGINT) = CAST(CAST(1 AS SMALLINT) AS BIGINT))):boolean>
 -- !query output
 false
 
@@ -1932,7 +1932,7 @@ false
 -- !query
 SELECT '1' <> cast(1 as int)                             FROM t
 -- !query schema
-struct<(NOT (CAST(1 AS INT) = CAST(1 AS INT))):boolean>
+struct<(NOT (CAST(1 AS BIGINT) = CAST(CAST(1 AS INT) AS BIGINT))):boolean>
 -- !query output
 false
 
@@ -1948,7 +1948,7 @@ false
 -- !query
 SELECT '1' <> cast(1 as float)                           FROM t
 -- !query schema
-struct<(NOT (CAST(1 AS FLOAT) = CAST(1 AS FLOAT))):boolean>
+struct<(NOT (CAST(1 AS DOUBLE) = CAST(CAST(1 AS FLOAT) AS DOUBLE))):boolean>
 -- !query output
 false
 
@@ -1964,7 +1964,7 @@ false
 -- !query
 SELECT '1' <> cast(1 as decimal(10, 0))                  FROM t
 -- !query schema
-struct<(NOT (CAST(1 AS DOUBLE) = CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE))):boolean>
+struct<(NOT (CAST(1 AS DECIMAL(38,0)) = CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0)))):boolean>
 -- !query output
 false
 
@@ -2012,7 +2012,7 @@ NULL
 -- !query
 SELECT cast(1 as tinyint)                         < '1' FROM t
 -- !query schema
-struct<(CAST(1 AS TINYINT) < CAST(1 AS TINYINT)):boolean>
+struct<(CAST(CAST(1 AS TINYINT) AS BIGINT) < CAST(1 AS BIGINT)):boolean>
 -- !query output
 false
 
@@ -2020,7 +2020,7 @@ false
 -- !query
 SELECT cast(1 as smallint)                        < '1' FROM t
 -- !query schema
-struct<(CAST(1 AS SMALLINT) < CAST(1 AS SMALLINT)):boolean>
+struct<(CAST(CAST(1 AS SMALLINT) AS BIGINT) < CAST(1 AS BIGINT)):boolean>
 -- !query output
 false
 
@@ -2028,7 +2028,7 @@ false
 -- !query
 SELECT cast(1 as int)                             < '1' FROM t
 -- !query schema
-struct<(CAST(1 AS INT) < CAST(1 AS INT)):boolean>
+struct<(CAST(CAST(1 AS INT) AS BIGINT) < CAST(1 AS BIGINT)):boolean>
 -- !query output
 false
 
@@ -2044,7 +2044,7 @@ false
 -- !query
 SELECT cast(1 as float)                           < '1' FROM t
 -- !query schema
-struct<(CAST(1 AS FLOAT) < CAST(1 AS FLOAT)):boolean>
+struct<(CAST(CAST(1 AS FLOAT) AS DOUBLE) < CAST(1 AS DOUBLE)):boolean>
 -- !query output
 false
 
@@ -2060,7 +2060,7 @@ false
 -- !query
 SELECT cast(1 as decimal(10, 0))                  < '1' FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE) < CAST(1 AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0)) < CAST(1 AS DECIMAL(38,0))):boolean>
 -- !query output
 false
 
@@ -2108,7 +2108,7 @@ NULL
 -- !query
 SELECT cast(1 as tinyint)                         <= '1' FROM t
 -- !query schema
-struct<(CAST(1 AS TINYINT) <= CAST(1 AS TINYINT)):boolean>
+struct<(CAST(CAST(1 AS TINYINT) AS BIGINT) <= CAST(1 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -2116,7 +2116,7 @@ true
 -- !query
 SELECT cast(1 as smallint)                        <= '1' FROM t
 -- !query schema
-struct<(CAST(1 AS SMALLINT) <= CAST(1 AS SMALLINT)):boolean>
+struct<(CAST(CAST(1 AS SMALLINT) AS BIGINT) <= CAST(1 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -2124,7 +2124,7 @@ true
 -- !query
 SELECT cast(1 as int)                             <= '1' FROM t
 -- !query schema
-struct<(CAST(1 AS INT) <= CAST(1 AS INT)):boolean>
+struct<(CAST(CAST(1 AS INT) AS BIGINT) <= CAST(1 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -2140,7 +2140,7 @@ true
 -- !query
 SELECT cast(1 as float)                           <= '1' FROM t
 -- !query schema
-struct<(CAST(1 AS FLOAT) <= CAST(1 AS FLOAT)):boolean>
+struct<(CAST(CAST(1 AS FLOAT) AS DOUBLE) <= CAST(1 AS DOUBLE)):boolean>
 -- !query output
 true
 
@@ -2156,7 +2156,7 @@ true
 -- !query
 SELECT cast(1 as decimal(10, 0))                  <= '1' FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE) <= CAST(1 AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0)) <= CAST(1 AS DECIMAL(38,0))):boolean>
 -- !query output
 true
 
@@ -2204,7 +2204,7 @@ NULL
 -- !query
 SELECT cast(1 as tinyint)                         > '1' FROM t
 -- !query schema
-struct<(CAST(1 AS TINYINT) > CAST(1 AS TINYINT)):boolean>
+struct<(CAST(CAST(1 AS TINYINT) AS BIGINT) > CAST(1 AS BIGINT)):boolean>
 -- !query output
 false
 
@@ -2212,7 +2212,7 @@ false
 -- !query
 SELECT cast(1 as smallint)                        > '1' FROM t
 -- !query schema
-struct<(CAST(1 AS SMALLINT) > CAST(1 AS SMALLINT)):boolean>
+struct<(CAST(CAST(1 AS SMALLINT) AS BIGINT) > CAST(1 AS BIGINT)):boolean>
 -- !query output
 false
 
@@ -2220,7 +2220,7 @@ false
 -- !query
 SELECT cast(1 as int)                             > '1' FROM t
 -- !query schema
-struct<(CAST(1 AS INT) > CAST(1 AS INT)):boolean>
+struct<(CAST(CAST(1 AS INT) AS BIGINT) > CAST(1 AS BIGINT)):boolean>
 -- !query output
 false
 
@@ -2236,7 +2236,7 @@ false
 -- !query
 SELECT cast(1 as float)                           > '1' FROM t
 -- !query schema
-struct<(CAST(1 AS FLOAT) > CAST(1 AS FLOAT)):boolean>
+struct<(CAST(CAST(1 AS FLOAT) AS DOUBLE) > CAST(1 AS DOUBLE)):boolean>
 -- !query output
 false
 
@@ -2252,7 +2252,7 @@ false
 -- !query
 SELECT cast(1 as decimal(10, 0))                  > '1' FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE) > CAST(1 AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0)) > CAST(1 AS DECIMAL(38,0))):boolean>
 -- !query output
 false
 
@@ -2300,7 +2300,7 @@ NULL
 -- !query
 SELECT cast(1 as tinyint)                         >= '1' FROM t
 -- !query schema
-struct<(CAST(1 AS TINYINT) >= CAST(1 AS TINYINT)):boolean>
+struct<(CAST(CAST(1 AS TINYINT) AS BIGINT) >= CAST(1 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -2308,7 +2308,7 @@ true
 -- !query
 SELECT cast(1 as smallint)                        >= '1' FROM t
 -- !query schema
-struct<(CAST(1 AS SMALLINT) >= CAST(1 AS SMALLINT)):boolean>
+struct<(CAST(CAST(1 AS SMALLINT) AS BIGINT) >= CAST(1 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -2316,7 +2316,7 @@ true
 -- !query
 SELECT cast(1 as int)                             >= '1' FROM t
 -- !query schema
-struct<(CAST(1 AS INT) >= CAST(1 AS INT)):boolean>
+struct<(CAST(CAST(1 AS INT) AS BIGINT) >= CAST(1 AS BIGINT)):boolean>
 -- !query output
 true
 
@@ -2332,7 +2332,7 @@ true
 -- !query
 SELECT cast(1 as float)                           >= '1' FROM t
 -- !query schema
-struct<(CAST(1 AS FLOAT) >= CAST(1 AS FLOAT)):boolean>
+struct<(CAST(CAST(1 AS FLOAT) AS DOUBLE) >= CAST(1 AS DOUBLE)):boolean>
 -- !query output
 true
 
@@ -2348,7 +2348,7 @@ true
 -- !query
 SELECT cast(1 as decimal(10, 0))                  >= '1' FROM t
 -- !query schema
-struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE) >= CAST(1 AS DOUBLE)):boolean>
+struct<(CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0)) >= CAST(1 AS DECIMAL(38,0))):boolean>
 -- !query output
 true
 
@@ -2396,7 +2396,7 @@ NULL
 -- !query
 SELECT cast(1 as tinyint)                         <> '1' FROM t
 -- !query schema
-struct<(NOT (CAST(1 AS TINYINT) = CAST(1 AS TINYINT))):boolean>
+struct<(NOT (CAST(CAST(1 AS TINYINT) AS BIGINT) = CAST(1 AS BIGINT))):boolean>
 -- !query output
 false
 
@@ -2404,7 +2404,7 @@ false
 -- !query
 SELECT cast(1 as smallint)                        <> '1' FROM t
 -- !query schema
-struct<(NOT (CAST(1 AS SMALLINT) = CAST(1 AS SMALLINT))):boolean>
+struct<(NOT (CAST(CAST(1 AS SMALLINT) AS BIGINT) = CAST(1 AS BIGINT))):boolean>
 -- !query output
 false
 
@@ -2412,7 +2412,7 @@ false
 -- !query
 SELECT cast(1 as int)                             <> '1' FROM t
 -- !query schema
-struct<(NOT (CAST(1 AS INT) = CAST(1 AS INT))):boolean>
+struct<(NOT (CAST(CAST(1 AS INT) AS BIGINT) = CAST(1 AS BIGINT))):boolean>
 -- !query output
 false
 
@@ -2428,7 +2428,7 @@ false
 -- !query
 SELECT cast(1 as float)                           <> '1' FROM t
 -- !query schema
-struct<(NOT (CAST(1 AS FLOAT) = CAST(1 AS FLOAT))):boolean>
+struct<(NOT (CAST(CAST(1 AS FLOAT) AS DOUBLE) = CAST(1 AS DOUBLE))):boolean>
 -- !query output
 false
 
@@ -2444,7 +2444,7 @@ false
 -- !query
 SELECT cast(1 as decimal(10, 0))                  <> '1' FROM t
 -- !query schema
-struct<(NOT (CAST(CAST(1 AS DECIMAL(10,0)) AS DOUBLE) = CAST(1 AS DOUBLE))):boolean>
+struct<(NOT (CAST(CAST(1 AS DECIMAL(10,0)) AS DECIMAL(38,0)) = CAST(1 AS DECIMAL(38,0)))):boolean>
 -- !query output
 false
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3393,6 +3393,19 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
       )
     }
   }
+
+  test("SPARK-30471: Fix issue when comparing String and Numeric.") {
+    withTempView("ta") {
+//      sql(
+//        s"""
+//          | CREATE TEMPORARY VIEW ta AS SELECT * FROM VALUES(CAST ('2147483648' AS STRING))
+//          | AS ta(id)
+//          |""".stripMargin)
+//      checkAnswer(sql("SELECT * FROM ta WHERE id > 0"), Row("2147483648"))
+//      checkAnswer(sql("SELECT * FROM ta WHERE id > CAST(0 as Decimal(1, 0))"), Row("2147483648"))
+      sql("select '1 ' = 1Y").explain()
+    }
+  }
 }
 
 case class Foo(bar: Option[String])

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3396,14 +3396,14 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
 
   test("SPARK-30471: Fix issue when comparing String and Numeric.") {
     withTempView("ta") {
-//      sql(
-//        s"""
-//          | CREATE TEMPORARY VIEW ta AS SELECT * FROM VALUES(CAST ('2147483648' AS STRING))
-//          | AS ta(id)
-//          |""".stripMargin)
-//      checkAnswer(sql("SELECT * FROM ta WHERE id > 0"), Row("2147483648"))
-//      checkAnswer(sql("SELECT * FROM ta WHERE id > CAST(0 as Decimal(1, 0))"), Row("2147483648"))
-      sql("select '1 ' = 1Y").explain()
+      sql(
+        s"""
+          | CREATE TEMPORARY VIEW ta AS SELECT * FROM VALUES(CAST ('2147483648' AS STRING))
+          | AS ta(id)
+          |""".stripMargin)
+      checkAnswer(sql("SELECT * FROM ta WHERE id > 0"), Row("2147483648"))
+      checkAnswer(sql("SELECT * FROM ta WHERE id > CAST(0 as Decimal(1, 0))"), Row("2147483648"))
+      intercept[NumberFormatException](sql("select 2 = '2.1'").collect())
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

For StringType and IntegerType, such as Byte/Short/Int/Long, their common type should be DoubleType.
Other wise, the result may corrupted.
For example:

When we comparing a String Type and IntegerType:
'2147483648'(StringType, which exceed Int.MaxValue) > 0(IntegerType).

Now the result of findCommonTypeForBinaryComparison(StringType, IntegerType) is IntegerType.

But the value of string may exceed Int.MaxValue, then the result is corruputed.
In this PR, for StringType and IntegerType, return DoubleType as their common type for binary comparison.

### Why are the changes needed?

Result may be corrupted.


### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
Added Unit test.
