### PR TITLE
[SPARK-30472][SQL] ANSI SQL: Throw exception on format invalid and overflow when casting String to IntegerType.

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -1075,8 +1075,8 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
    * Wrapper over `long` to allow result of parsing long from string to be accessed via reference.
    * This is done solely for better performance and is not expected to be used by end users.
    */
-  public static class LongWrapper implements Serializable {
-    public transient long value = 0;
+  public static class LongWrapper extends IntWrapper {
+    public transient long value = 0l;
   }
 
   /**
@@ -1088,6 +1088,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
    */
   public static class IntWrapper implements Serializable {
     public transient int value = 0;
+    public transient boolean formatInvalid = false;
   }
 
   /**
@@ -1140,6 +1141,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
       if (b >= '0' && b <= '9') {
         digit = b - '0';
       } else {
+        toLongResult.formatInvalid = false;
         return false;
       }
 
@@ -1233,6 +1235,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
       if (b >= '0' && b <= '9') {
         digit = b - '0';
       } else {
+        intWrapper.formatInvalid = true;
         return false;
       }
 

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -1076,7 +1076,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
    * This is done solely for better performance and is not expected to be used by end users.
    */
   public static class LongWrapper extends IntWrapper {
-    public transient long value = 0l;
+    public transient long value = 0;
   }
 
   /**

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -1075,8 +1075,9 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
    * Wrapper over `long` to allow result of parsing long from string to be accessed via reference.
    * This is done solely for better performance and is not expected to be used by end users.
    */
-  public static class LongWrapper extends IntWrapper {
+  public static class LongWrapper implements Serializable {
     public transient long value = 0;
+    public transient boolean formatInvalid = false;
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -481,12 +481,11 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
   }
 
   private[this] def onStringToIntegerFailed(
-      intWrapper: IntWrapper,
       str: UTF8String,
-      ansiEnabled: Boolean,
+      formatInvalid: Boolean,
       typeName: String): Any = {
     if (ansiEnabled) {
-      if (intWrapper.formatInvalid) {
+      if (formatInvalid) {
         throw new ArithmeticException(s"Invalid input syntax for type integer: $str")
       } else {
         throw new ArithmeticException(s"Casting $str to $typeName causes overflow")
@@ -501,7 +500,7 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
     case StringType =>
       val result = new LongWrapper()
       buildCast[UTF8String](_, s => if (s.toLong(result)) result.value else {
-        onStringToIntegerFailed(result, s, ansiEnabled, "Long")
+        onStringToIntegerFailed(s, result.formatInvalid, "Long")
       })
     case BooleanType =>
       buildCast[Boolean](_, b => if (b) 1L else 0L)
@@ -520,7 +519,7 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
     case StringType =>
       val result = new IntWrapper()
       buildCast[UTF8String](_, s => if (s.toInt(result)) result.value else {
-        onStringToIntegerFailed(result, s, ansiEnabled, "Int")
+        onStringToIntegerFailed(s, result.formatInvalid, "Int")
       })
     case BooleanType =>
       buildCast[Boolean](_, b => if (b) 1 else 0)
@@ -543,7 +542,7 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
       buildCast[UTF8String](_, s => if (s.toShort(result)) {
         result.value.toShort
       } else {
-        onStringToIntegerFailed(result, s, ansiEnabled, "Short")
+        onStringToIntegerFailed(s, result.formatInvalid, "Short")
       })
     case BooleanType =>
       buildCast[Boolean](_, b => if (b) 1.toShort else 0.toShort)
@@ -584,7 +583,7 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
       buildCast[UTF8String](_, s => if (s.toByte(result)) {
         result.value.toByte
       } else {
-        onStringToIntegerFailed(result, s, ansiEnabled, "Byte")
+        onStringToIntegerFailed(s, result.formatInvalid, "Byte")
       })
     case BooleanType =>
       buildCast[Boolean](_, b => if (b) 1.toByte else 0.toByte)

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3385,9 +3385,15 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("SPARK-26128: Throw exception on overflow when casting string to Integer.") {
+  test("SPARK-30472: ANSI SQL: Throw exception on format invalid and overflow when casting " +
+    "String to Integer type.") {
     withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
-      sql("SELECT CAST(CAST(2147483648 as STRING) AS INTEGER)").show()
+      intercept[ArithmeticException](
+        sql("SELECT CAST(CAST('abc' as STRING) AS INTEGER)").collect()
+      )
+      intercept[ArithmeticException](
+        sql("SELECT CAST(CAST('2147483648' as STRING) AS INTEGER)").collect()
+      )
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3392,7 +3392,25 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession {
         sql("SELECT CAST(CAST('abc' as STRING) AS INTEGER)").collect()
       )
       intercept[ArithmeticException](
+        sql("SELECT CAST(CAST('abc' as STRING) AS BYTE)").collect()
+      )
+      intercept[ArithmeticException](
+        sql("SELECT CAST(CAST('abc' as STRING) AS SHORT)").collect()
+      )
+      intercept[ArithmeticException](
+        sql("SELECT CAST(CAST('abc' as STRING) AS LONG)").collect()
+      )
+      intercept[ArithmeticException](
         sql("SELECT CAST(CAST('2147483648' as STRING) AS INTEGER)").collect()
+      )
+      intercept[ArithmeticException](
+        sql("SELECT CAST(CAST('128' as STRING) AS BYTE)").collect()
+      )
+      intercept[ArithmeticException](
+        sql("SELECT CAST(CAST('32768' as STRING) AS SHORT)").collect()
+      )
+      intercept[ArithmeticException](
+        sql("SELECT CAST(CAST('9223372036854775808' as STRING) AS LONG)").collect()
       )
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3384,6 +3384,12 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession {
       assert(exp.getMessage.contains("Resources not found"))
     }
   }
+
+  test("SPARK-26128: Throw exception on overflow when casting string to Integer.") {
+    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
+      sql("SELECT CAST(CAST(2147483648 as STRING) AS INTEGER)").show()
+    }
+  }
 }
 
 case class Foo(bar: Option[String])


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this PR, when spark.sql.ansi.enabled is true.
When casting stringType to Int.
If the string format is invalid or its value overflow the range of Int, we would throw exception to keep consistent with ANSI.

### Why are the changes needed?

To keep consistent with ANSI, when spark.sql.ansi.enable is true.

### Does this PR introduce any user-facing change?
No.


### How was this patch tested?
Added Unit Test.