### PR TITLE
[SPARK-20384][SQL] Support value class in schema of Dataset (without breaking existing current projection)

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -338,11 +338,11 @@ object ScalaReflection extends ScalaReflection {
         Invoke(obj, "deserialize", ObjectType(udt.userClass), path :: Nil)
 
       case t if definedByConstructorParams(t) =>
-        val params = getConstructorParameters(t)
+        val unwrappedParams = getConstructorParameters(t).map(unwrapValueClassParam)
 
         val cls = getClassFromType(tpe)
 
-        val arguments = params.zipWithIndex.map { case ((fieldName, fieldType), i) =>
+        val arguments = unwrappedParams.zipWithIndex.map { case ((fieldName, fieldType), i) =>
           val Schema(dataType, nullable) = schemaFor(fieldType)
           val clsName = getClassNameFromType(fieldType)
           val newTypePath = walkedTypePath.recordField(clsName, fieldName)
@@ -537,8 +537,8 @@ object ScalaReflection extends ScalaReflection {
             s"cannot have circular references in class, but got the circular reference of class $t")
         }
 
-        val params = getConstructorParameters(t)
-        val fields = params.map { case (fieldName, fieldType) =>
+        val unwrappedParams = getConstructorParameters(t).map(unwrapValueClassParam)
+        val fields = unwrappedParams.map { case (fieldName, fieldType) =>
           if (javaKeywords.contains(fieldName)) {
             throw new UnsupportedOperationException(s"`$fieldName` is a reserved keyword and " +
               "cannot be used as field name\n" + walkedTypePath)
@@ -696,9 +696,9 @@ object ScalaReflection extends ScalaReflection {
       case t if isSubtype(t, definitions.ByteTpe) => Schema(ByteType, nullable = false)
       case t if isSubtype(t, definitions.BooleanTpe) => Schema(BooleanType, nullable = false)
       case t if definedByConstructorParams(t) =>
-        val params = getConstructorParameters(t)
+        val unwrappedParams = getConstructorParameters(t).map(unwrapValueClassParam)
         Schema(StructType(
-          params.map { case (fieldName, fieldType) =>
+          unwrappedParams.map { case (fieldName, fieldType) =>
             val Schema(dataType, nullable) = schemaFor(fieldType)
             StructField(fieldName, dataType, nullable)
           }), nullable = true)
@@ -751,6 +751,24 @@ object ScalaReflection extends ScalaReflection {
       case _ => isSubtype(tpe.dealias, localTypeOf[Product]) ||
         isSubtype(tpe.dealias, localTypeOf[DefinedByConstructorParams])
     }
+  }
+
+  /**
+   * [SPARK-20384] Create an underlying param for a given parameter of value class.
+   * When a member of case class is value class `extends AnyVal`, the member's parameter type
+   * for encoder should be the underlying type. This is to be consistent with the generated
+   * type of that member, and avoid compile error.
+   * @param param param (type is consistent with [[ScalaReflection.getConstructorParameters]])
+   * @return unwrapped param
+   */
+  private def unwrapValueClassParam(param: (String, `Type`)): (String, `Type`) = {
+    val (name, typ) = param
+    val unwrappedTyp = if (typ.typeSymbol.asClass.isDerivedValueClass) {
+      getConstructorParameters(typ.dealias).head._2
+    } else {
+      typ
+    }
+    (name, unwrappedTyp)
   }
 
   private val javaKeywords = Set("abstract", "assert", "boolean", "break", "byte", "case", "catch",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -762,13 +762,13 @@ object ScalaReflection extends ScalaReflection {
    * @return unwrapped param
    */
   private def unwrapValueClassParam(param: (String, `Type`)): (String, `Type`) = {
-    val (name, typ) = param
-    val unwrappedTyp = if (typ.typeSymbol.asClass.isDerivedValueClass) {
-      getConstructorParameters(typ.dealias).head._2
+    val (name, tpe) = param
+    val unwrappedTpe = if (tpe.typeSymbol.asClass.isDerivedValueClass) {
+      getConstructorParameters(tpe.dealias).head._2
     } else {
-      typ
+      tpe
     }
-    (name, unwrappedTyp)
+    (name, unwrappedTpe)
   }
 
   private val javaKeywords = Set("abstract", "assert", "boolean", "break", "byte", "case", "catch",

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
@@ -150,11 +150,10 @@ object TestingValueClass {
   case class IntWrapper(val i: Int) extends AnyVal
   case class StrWrapper(s: String) extends AnyVal
 
-  case class ValueClassData(
-                             intField: Int,
-                             wrappedInt: IntWrapper, // an int column
-                             strField: String,
-                             wrappedStr: StrWrapper) // a string column
+  case class ValueClassData(intField: Int,
+                            wrappedInt: IntWrapper, // an int column
+                            strField: String,
+                            wrappedStr: StrWrapper) // a string column
 }
 
 class ScalaReflectionSuite extends SparkFunSuite {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
@@ -457,9 +457,10 @@ class ScalaReflectionSuite extends SparkFunSuite {
       schema === Schema(
         StructType(Seq(
           StructField("intField", IntegerType, nullable = false),
-          StructField("wrappedInt", StructType(Seq(StructField("i", IntegerType, false)))),
+          StructField("wrappedInt", IntegerType, nullable = false),
           StructField("strField", StringType),
-          StructField("wrappedStr", StructType(Seq(StructField("s", StringType, true)))))),
+          StructField("wrappedStr", StringType)
+        )),
         nullable = true))
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
@@ -318,17 +318,17 @@ class ExpressionEncoderSuite extends CodegenInterpretedPlanTest with AnalysisTes
   encodeDecodeTest(ValueContainer(1, StringWrapper("b")), "nested value class")
   encodeDecodeTest(ValueContainer(1, StringWrapper(null)), "nested value class with null")
   encodeDecodeTest(ComplexValueClassContainer(1, ValueContainer(2, StringWrapper("b")),
-    new IntWrapper(3)), "complex value class")
+    IntWrapper(3)), "complex value class")
   encodeDecodeTest(
-    Array(new IntWrapper(1), new IntWrapper(2), new IntWrapper(3)),
+    Array(IntWrapper(1), IntWrapper(2), IntWrapper(3)),
     "array of value class")
   encodeDecodeTest(Array.empty[IntWrapper], "empty array of value class")
   encodeDecodeTest(
-    Seq(new IntWrapper(1), new IntWrapper(2), new IntWrapper(3)),
+    Seq(IntWrapper(1), IntWrapper(2), IntWrapper(3)),
     "seq of value class")
   encodeDecodeTest(Seq.empty[IntWrapper], "empty seq of value class")
   encodeDecodeTest(
-    Map(new IntWrapper(1) -> StringWrapper("a"), new IntWrapper(2) -> StringWrapper("b")),
+    Map(IntWrapper(1) -> StringWrapper("a"), IntWrapper(2) -> StringWrapper("b")),
     "map with value class")
 
   encodeDecodeTest(Option(31), "option of int")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
@@ -122,6 +122,10 @@ case class ComplexValueClassContainer(
                                        a: Int,
                                        b: ValueContainer,
                                        c: IntWrapper)
+case class SeqOfValueClass(s: Seq[StringWrapper])
+case class MapOfValueClassKey(m: Map[IntWrapper, String])
+case class MapOfValueClassValue(m: Map[String, StringWrapper])
+case class OptionOfValueClassValue(o: Option[StringWrapper])
 
 class ExpressionEncoderSuite extends CodegenInterpretedPlanTest with AnalysisTest {
   OuterScopes.addOuterScope(this)
@@ -308,6 +312,7 @@ class ExpressionEncoderSuite extends CodegenInterpretedPlanTest with AnalysisTes
     ExpressionEncoder.tuple(intEnc, ExpressionEncoder.tuple(intEnc, longEnc))
   }
 
+  // test for value classes
   encodeDecodeTest(
     PrimitiveValueClass(42), "primitive value class")
 
@@ -330,6 +335,20 @@ class ExpressionEncoderSuite extends CodegenInterpretedPlanTest with AnalysisTes
   encodeDecodeTest(
     Map(IntWrapper(1) -> StringWrapper("a"), IntWrapper(2) -> StringWrapper("b")),
     "map with value class")
+
+  // test for nested value class collections
+  encodeDecodeTest(
+    MapOfValueClassKey(Map(IntWrapper(1)-> "a")),
+    "case class with map of value class key")
+  encodeDecodeTest(
+    MapOfValueClassValue(Map("a"-> StringWrapper("b"))),
+    "case class with map of value class value")
+  encodeDecodeTest(
+    SeqOfValueClass(Seq(StringWrapper("a"))),
+    "case class with seq of class value")
+  encodeDecodeTest(
+    OptionOfValueClassValue(Some(StringWrapper("a"))),
+    "case class with option of class value")
 
   encodeDecodeTest(Option(31), "option of int")
   encodeDecodeTest(Option.empty[Int], "empty option of int")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
@@ -113,6 +113,16 @@ object ReferenceValueClass {
   case class Container(data: Int)
 }
 
+case class StringWrapper(s: String) extends AnyVal
+case class ValueContainer(
+                           a: Int,
+                           b: StringWrapper) // a string column
+case class IntWrapper(i: Int) extends AnyVal
+case class ComplexValueClassContainer(
+                                       a: Int,
+                                       b: ValueContainer,
+                                       c: IntWrapper)
+
 class ExpressionEncoderSuite extends CodegenInterpretedPlanTest with AnalysisTest {
   OuterScopes.addOuterScope(this)
 
@@ -303,6 +313,23 @@ class ExpressionEncoderSuite extends CodegenInterpretedPlanTest with AnalysisTes
 
   encodeDecodeTest(
     ReferenceValueClass(ReferenceValueClass.Container(1)), "reference value class")
+
+  encodeDecodeTest(StringWrapper("a"), "string value class")
+  encodeDecodeTest(ValueContainer(1, StringWrapper("b")), "nested value class")
+  encodeDecodeTest(ValueContainer(1, StringWrapper(null)), "nested value class with null")
+  encodeDecodeTest(ComplexValueClassContainer(1, ValueContainer(2, StringWrapper("b")),
+    new IntWrapper(3)), "complex value class")
+  encodeDecodeTest(
+    Array(new IntWrapper(1), new IntWrapper(2), new IntWrapper(3)),
+    "array of value class")
+  encodeDecodeTest(Array.empty[IntWrapper], "empty array of value class")
+  encodeDecodeTest(
+    Seq(new IntWrapper(1), new IntWrapper(2), new IntWrapper(3)),
+    "seq of value class")
+  encodeDecodeTest(Seq.empty[IntWrapper], "empty seq of value class")
+  encodeDecodeTest(
+    Map(new IntWrapper(1) -> StringWrapper("a"), new IntWrapper(2) -> StringWrapper("b")),
+    "map with value class")
 
   encodeDecodeTest(Option(31), "option of int")
   encodeDecodeTest(Option.empty[Int], "empty option of int")

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestData.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestData.scala
@@ -344,4 +344,7 @@ private[sql] object SQLTestData {
   case class CourseSales(course: String, year: Int, earnings: Double)
   case class TrainingSales(training: String, sales: CourseSales)
   case class IntervalData(data: CalendarInterval)
+  case class StringWrapper(s: String) extends AnyVal
+  case class ArrayStringWrapper(wrappers: Seq[StringWrapper])
+  case class ContainerStringWrapper(wrapper: StringWrapper)
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
- This PR revisits https://github.com/apache/spark/pull/22309, and [SPARK-20384](https://issues.apache.org/jira/browse/SPARK-20384) solving the original problem, but additionally will prevent backward-compat break on schema of top-level `AnyVal` value class.
- Why previous break? We currently support top-level value classes just as any other case class; field of the underlying type is present in schema. This means any dataframe SQL filtering on this expects the field name to be present. The previous PR changes this schema and would result in breaking current usage. See test `"schema for case class that is a value class"`. This PR keeps the schema.
- We actually currently support collection of value classes prior to this change, but not case class of nested value class. This means the schema of these classes shouldn't change to prevent breaking too. See the tests asserting schema before any changes in 0cdad3b
- However, what we can change, without breaking, is schema of nested value class, which will fails due to the compile problem, and thus its schema now isn't actually valid. After the change, the schema of this nested value class is now flattened: 
c7aaae8
- With this PR, there's flattening only for nested value class (new), but not for top-level and collection classes (existing behavior)


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- Currently, nested value class isn't supported. This is because when the generated code treats `anyVal` class in its unwrapped form, but we encode the type to be the wrapped case class. This results in compile of generated code
For example, 
For a given `AnyVal` wrapper and its root-level class container
```
case class IntWrapper(i: Int) extends AnyVal
case class ComplexValueClassContainer(c: IntWrapper)
```
The problematic part of generated code:
```
    private InternalRow If_1(InternalRow i) {
        boolean isNull_42 = i.isNullAt(0);
        // 1) ******** The root-level case class we care
        org.apache.spark.sql.catalyst.encoders.ComplexValueClassContainer value_46 = isNull_42 ?
            null : ((org.apache.spark.sql.catalyst.encoders.ComplexValueClassContainer) i.get(0, null));
        if (isNull_42) {
            throw new NullPointerException(((java.lang.String) references[5] /* errMsg */ ));
        }
        boolean isNull_39 = true;
        // 2) ******** We specify its member to be unwrapped case class extending `AnyVal`
        org.apache.spark.sql.catalyst.encoders.IntWrapper value_43 = null;
        if (!false) {

            isNull_39 = false;
            if (!isNull_39) {
                // 3) ******** ERROR: `c()` compiled however is of type `int` and thus we see error
                value_43 = value_46.c();
            }
        }
```
We get this errror: Assignment conversion not possible from type "int" to type "org.apache.spark.sql.catalyst.encoders.IntWrapper"
```
java.util.concurrent.ExecutionException: org.codehaus.commons.compiler.CompileException: 
File 'generated.java', Line 159, Column 1: failed to compile: org.codehaus.commons.compiler.CompileException: File 'generated.java', Line 159, Column 1: Assignment conversion not possible from type "int" to type "org.apache.spark.sql.catalyst.encoders.IntWrapper"
```

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
- Yes, this will fix the bug.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
- This PR ports all the tests from https://github.com/apache/spark/pull/22309 and added a few more.

cc @mt40 please let me know if i'm missing something from your previous PR
cc @joshrosen-stripe 