### PR TITLE
[SPARK-17636][SPARK-25557][SQL] Parquet and ORC predicate pushdown in nested fields

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -444,69 +444,83 @@ object DataSourceStrategy {
     }
   }
 
-  private def translateLeafNodeFilter(predicate: Expression): Option[Filter] = predicate match {
-    case expressions.EqualTo(a: Attribute, Literal(v, t)) =>
-      Some(sources.EqualTo(a.name, convertToScala(v, t)))
-    case expressions.EqualTo(Literal(v, t), a: Attribute) =>
-      Some(sources.EqualTo(a.name, convertToScala(v, t)))
+  private def translateLeafNodeFilter(predicate: Expression): Option[Filter] = {
+    // Recursively try to find an attribute name from the top level that can be pushed down.
+    def attrName(e: Expression): Option[String] = e match {
+      // In Spark and many data sources such as parquet, dots are used as a column path delimiter;
+      // thus, we don't translate such expressions.
+      case a: Attribute if !a.name.contains(".") =>
+        Some(a.name)
+      case s: GetStructField if !s.childSchema(s.ordinal).name.contains(".") =>
+        attrName(s.child).map(_ + s".${s.childSchema(s.ordinal).name}")
+      case _ =>
+        None
+    }
 
-    case expressions.EqualNullSafe(a: Attribute, Literal(v, t)) =>
-      Some(sources.EqualNullSafe(a.name, convertToScala(v, t)))
-    case expressions.EqualNullSafe(Literal(v, t), a: Attribute) =>
-      Some(sources.EqualNullSafe(a.name, convertToScala(v, t)))
+    predicate match {
+      case expressions.EqualTo(e: Expression, Literal(v, t)) =>
+        attrName(e).map(name => sources.EqualTo(name, convertToScala(v, t)))
+      case expressions.EqualTo(Literal(v, t), e: Expression) =>
+        attrName(e).map(name => sources.EqualTo(name, convertToScala(v, t)))
 
-    case expressions.GreaterThan(a: Attribute, Literal(v, t)) =>
-      Some(sources.GreaterThan(a.name, convertToScala(v, t)))
-    case expressions.GreaterThan(Literal(v, t), a: Attribute) =>
-      Some(sources.LessThan(a.name, convertToScala(v, t)))
+      case expressions.EqualNullSafe(e: Expression, Literal(v, t)) =>
+        attrName(e).map(name => sources.EqualNullSafe(name, convertToScala(v, t)))
+      case expressions.EqualNullSafe(Literal(v, t), e: Expression) =>
+        attrName(e).map(name => sources.EqualNullSafe(name, convertToScala(v, t)))
 
-    case expressions.LessThan(a: Attribute, Literal(v, t)) =>
-      Some(sources.LessThan(a.name, convertToScala(v, t)))
-    case expressions.LessThan(Literal(v, t), a: Attribute) =>
-      Some(sources.GreaterThan(a.name, convertToScala(v, t)))
+      case expressions.GreaterThan(e: Expression, Literal(v, t)) =>
+        attrName(e).map(name => sources.GreaterThan(name, convertToScala(v, t)))
+      case expressions.GreaterThan(Literal(v, t), e: Expression) =>
+        attrName(e).map(name => sources.LessThan(name, convertToScala(v, t)))
 
-    case expressions.GreaterThanOrEqual(a: Attribute, Literal(v, t)) =>
-      Some(sources.GreaterThanOrEqual(a.name, convertToScala(v, t)))
-    case expressions.GreaterThanOrEqual(Literal(v, t), a: Attribute) =>
-      Some(sources.LessThanOrEqual(a.name, convertToScala(v, t)))
+      case expressions.LessThan(e: Expression, Literal(v, t)) =>
+        attrName(e).map(name => sources.LessThan(name, convertToScala(v, t)))
+      case expressions.LessThan(Literal(v, t), e: Expression) =>
+        attrName(e).map(name => sources.GreaterThan(name, convertToScala(v, t)))
 
-    case expressions.LessThanOrEqual(a: Attribute, Literal(v, t)) =>
-      Some(sources.LessThanOrEqual(a.name, convertToScala(v, t)))
-    case expressions.LessThanOrEqual(Literal(v, t), a: Attribute) =>
-      Some(sources.GreaterThanOrEqual(a.name, convertToScala(v, t)))
+      case expressions.GreaterThanOrEqual(e: Expression, Literal(v, t)) =>
+        attrName(e).map(name => sources.GreaterThanOrEqual(name, convertToScala(v, t)))
+      case expressions.GreaterThanOrEqual(Literal(v, t), e: Expression) =>
+        attrName(e).map(name => sources.LessThanOrEqual(name, convertToScala(v, t)))
 
-    case expressions.InSet(a: Attribute, set) =>
-      val toScala = CatalystTypeConverters.createToScalaConverter(a.dataType)
-      Some(sources.In(a.name, set.toArray.map(toScala)))
+      case expressions.LessThanOrEqual(e: Expression, Literal(v, t)) =>
+        attrName(e).map(name => sources.LessThanOrEqual(name, convertToScala(v, t)))
+      case expressions.LessThanOrEqual(Literal(v, t), e: Expression) =>
+        attrName(e).map(name => sources.GreaterThanOrEqual(name, convertToScala(v, t)))
 
-    // Because we only convert In to InSet in Optimizer when there are more than certain
-    // items. So it is possible we still get an In expression here that needs to be pushed
-    // down.
-    case expressions.In(a: Attribute, list) if list.forall(_.isInstanceOf[Literal]) =>
-      val hSet = list.map(_.eval(EmptyRow))
-      val toScala = CatalystTypeConverters.createToScalaConverter(a.dataType)
-      Some(sources.In(a.name, hSet.toArray.map(toScala)))
+      case expressions.InSet(e: Expression, set) =>
+        val toScala = CatalystTypeConverters.createToScalaConverter(e.dataType)
+        attrName(e).map(name => sources.In(name, set.toArray.map(toScala)))
 
-    case expressions.IsNull(a: Attribute) =>
-      Some(sources.IsNull(a.name))
-    case expressions.IsNotNull(a: Attribute) =>
-      Some(sources.IsNotNull(a.name))
-    case expressions.StartsWith(a: Attribute, Literal(v: UTF8String, StringType)) =>
-      Some(sources.StringStartsWith(a.name, v.toString))
+      // Because we only convert In to InSet in Optimizer when there are more than certain
+      // items. So it is possible we still get an In expression here that needs to be pushed
+      // down.
+      case expressions.In(e: Expression, list) if list.forall(_.isInstanceOf[Literal]) =>
+        val hSet = list.map(_.eval(EmptyRow))
+        val toScala = CatalystTypeConverters.createToScalaConverter(e.dataType)
+        attrName(e).map(name => sources.In(name, hSet.toArray.map(toScala)))
 
-    case expressions.EndsWith(a: Attribute, Literal(v: UTF8String, StringType)) =>
-      Some(sources.StringEndsWith(a.name, v.toString))
+      case expressions.IsNull(e: Expression) =>
+        attrName(e).map(name => sources.IsNull(name))
+      case expressions.IsNotNull(e: Expression) =>
+        attrName(e).map(name => sources.IsNotNull(name))
+      case expressions.StartsWith(e: Expression, Literal(v: UTF8String, StringType)) =>
+        attrName(e).map(name => sources.StringStartsWith(name, v.toString))
 
-    case expressions.Contains(a: Attribute, Literal(v: UTF8String, StringType)) =>
-      Some(sources.StringContains(a.name, v.toString))
+      case expressions.EndsWith(e: Expression, Literal(v: UTF8String, StringType)) =>
+        attrName(e).map(name => sources.StringEndsWith(name, v.toString))
 
-    case expressions.Literal(true, BooleanType) =>
-      Some(sources.AlwaysTrue)
+      case expressions.Contains(e: Expression, Literal(v: UTF8String, StringType)) =>
+        attrName(e).map(name => sources.StringContains(name, v.toString))
 
-    case expressions.Literal(false, BooleanType) =>
-      Some(sources.AlwaysFalse)
+      case expressions.Literal(true, BooleanType) =>
+        Some(sources.AlwaysTrue)
 
-    case _ => None
+      case expressions.Literal(false, BooleanType) =>
+        Some(sources.AlwaysFalse)
+
+      case _ => None
+    }
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -447,11 +447,9 @@ object DataSourceStrategy {
   private def translateLeafNodeFilter(predicate: Expression): Option[Filter] = {
     // Recursively try to find an attribute name from the top level that can be pushed down.
     def attrName(e: Expression): Option[String] = e match {
-      // In Spark and many data sources such as parquet, dots are used as a column path delimiter;
-      // thus, we don't translate such expressions.
-      case a: Attribute if !a.name.contains(".") =>
+      case a: Attribute if a.dataType != StructType =>
         Some(a.name)
-      case s: GetStructField if !s.childSchema(s.ordinal).name.contains(".") =>
+      case s: GetStructField if s.childSchema(s.ordinal).dataType != StructType =>
         attrName(s.child).map(_ + s".${s.childSchema(s.ordinal).name}")
       case _ =>
         None

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScanBuilder.scala
@@ -59,8 +59,7 @@ case class OrcScanBuilder(
         // changed `hadoopConf` in executors.
         OrcInputFormat.setSearchArgument(hadoopConf, f, schema.fieldNames)
       }
-      val dataTypeMap = schema.map(f => f.name -> f.dataType).toMap
-      _pushedFilters = OrcFilters.convertibleFilters(schema, dataTypeMap, filters).toArray
+      _pushedFilters = OrcFilters.convertibleFilters(schema, filters).toArray
     }
     filters
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
@@ -22,76 +22,184 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.sources
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
 class DataSourceStrategySuite extends PlanTest with SharedSparkSession {
 
   test("translate simple expression") {
+    val fields = StructField("cint", IntegerType, nullable = true) ::
+      StructField("cstr", StringType, nullable = true) :: Nil
     val attrInt = 'cint.int
     val attrStr = 'cstr.string
+    val attrNested1 = 'a.struct(StructType(fields))
+    val attrNested2 = 'b.struct(StructType(
+      StructField("c", StructType(fields), nullable = true) :: Nil))
 
-    testTranslateFilter(EqualTo(attrInt, 1), Some(sources.EqualTo("cint", 1)))
-    testTranslateFilter(EqualTo(1, attrInt), Some(sources.EqualTo("cint", 1)))
+    val attrIntNested1 = GetStructField(attrNested1, 0, None)
+    val attrStrNested1 = GetStructField(attrNested1, 1, None)
+
+    val attrIntNested2 = GetStructField(GetStructField(attrNested2, 0, None), 0, None)
+    val attrStrNested2 = GetStructField(GetStructField(attrNested2, 0, None), 1, None)
+
+    Seq(('cint.int, 'cstr.string, "cint", "cstr"), // no nesting
+      (attrIntNested1, attrStrNested1, "a.cint", "a.cstr"), // one level nesting
+      (attrIntNested2, attrStrNested2, "b.c.cint", "b.c.cstr") // two level nesting
+    ).foreach { case (attrInt, attrStr, attrIntString, attrStrString) =>
+      testTranslateSimpleExpression(
+        attrInt, attrStr, attrIntString, attrStrString, isResultNone = false)
+    }
+  }
+
+  test("translate complex expression") {
+    val fields = StructField("cint", IntegerType, nullable = true) :: Nil
+
+    val attrNested1 = 'a.struct(StructType(fields))
+    val attrNested2 = 'b.struct(StructType(
+      StructField("c", StructType(fields), nullable = true) :: Nil))
+
+    val attrIntNested1 = GetStructField(attrNested1, 0, None)
+    val attrIntNested2 = GetStructField(GetStructField(attrNested2, 0, None), 0, None)
+
+    StructField("cint", IntegerType, nullable = true)
+
+    Seq(('cint.int, "cint"), // no nesting
+      (attrIntNested1, "a.cint"), // one level nesting
+      (attrIntNested2, "b.c.cint") // two level nesting
+    ).foreach { case (attrInt, attrIntString) =>
+      testTranslateComplexExpression(attrInt, attrIntString, isResultNone = false)
+    }
+  }
+
+  test("column name containing dot can not be pushed down") {
+    val fieldsWithoutDot = StructField("cint", IntegerType, nullable = true) ::
+      StructField("cstr", StringType, nullable = true) :: Nil
+
+    val fieldsWithDot = StructField("column.cint", IntegerType, nullable = true) ::
+      StructField("column.cstr", StringType, nullable = true) :: Nil
+
+    val attrNested1 = 'a.struct(StructType(fieldsWithDot))
+    val attrIntNested1 = GetStructField(attrNested1, 0, None)
+    val attrStrNested1 = GetStructField(attrNested1, 1, None)
+
+    val attrNested2 = 'b.struct(StructType(
+      StructField("c", StructType(fieldsWithDot), nullable = true) :: Nil))
+    val attrIntNested2 = GetStructField(GetStructField(attrNested2, 0, None), 0, None)
+    val attrStrNested2 = GetStructField(GetStructField(attrNested2, 0, None), 1, None)
+
+    val attrNestedWithDotInTopLevel = Symbol("column.a").struct(StructType(fieldsWithoutDot))
+    val attrIntNested1WithDotInTopLevel = GetStructField(attrNestedWithDotInTopLevel, 0, None)
+    val attrStrNested1WithDotInTopLevel = GetStructField(attrNestedWithDotInTopLevel, 1, None)
+
+    Seq((Symbol("column.cint").int, Symbol("column.cstr").string), // no nesting
+      (attrIntNested1, attrStrNested1), // one level nesting
+      (attrIntNested1WithDotInTopLevel, attrStrNested1WithDotInTopLevel), // one level nesting
+      (attrIntNested2, attrStrNested2) // two level nesting
+    ).foreach { case (attrInt, attrStr) =>
+      testTranslateSimpleExpression(
+        attrInt, attrStr, "", "", isResultNone = true)
+      testTranslateComplexExpression(attrInt, "", isResultNone = true)
+    }
+  }
+
+  // `isResultNone` is used when testing invalid input expression
+  // containing dots which translates into None
+  private def testTranslateSimpleExpression(
+     attrInt: Expression,
+     attrStr: Expression,
+     attrIntString: String,
+     attrStrString: String,
+     isResultNone: Boolean): Unit = {
+
+    def result(result: sources.Filter): Option[sources.Filter] = {
+      if (isResultNone) {
+        None
+      } else {
+        Some(result)
+      }
+    }
+
+    testTranslateFilter(EqualTo(attrInt, 1), result(sources.EqualTo(attrIntString, 1)))
+    testTranslateFilter(EqualTo(1, attrInt), result(sources.EqualTo(attrIntString, 1)))
 
     testTranslateFilter(EqualNullSafe(attrStr, Literal(null)),
-      Some(sources.EqualNullSafe("cstr", null)))
+      result(sources.EqualNullSafe(attrStrString, null)))
     testTranslateFilter(EqualNullSafe(Literal(null), attrStr),
-      Some(sources.EqualNullSafe("cstr", null)))
+      result(sources.EqualNullSafe(attrStrString, null)))
 
-    testTranslateFilter(GreaterThan(attrInt, 1), Some(sources.GreaterThan("cint", 1)))
-    testTranslateFilter(GreaterThan(1, attrInt), Some(sources.LessThan("cint", 1)))
+    testTranslateFilter(GreaterThan(attrInt, 1), result(sources.GreaterThan(attrIntString, 1)))
+    testTranslateFilter(GreaterThan(1, attrInt), result(sources.LessThan(attrIntString, 1)))
 
-    testTranslateFilter(LessThan(attrInt, 1), Some(sources.LessThan("cint", 1)))
-    testTranslateFilter(LessThan(1, attrInt), Some(sources.GreaterThan("cint", 1)))
+    testTranslateFilter(LessThan(attrInt, 1), result(sources.LessThan(attrIntString, 1)))
+    testTranslateFilter(LessThan(1, attrInt), result(sources.GreaterThan(attrIntString, 1)))
 
-    testTranslateFilter(GreaterThanOrEqual(attrInt, 1), Some(sources.GreaterThanOrEqual("cint", 1)))
-    testTranslateFilter(GreaterThanOrEqual(1, attrInt), Some(sources.LessThanOrEqual("cint", 1)))
+    testTranslateFilter(GreaterThanOrEqual(attrInt, 1),
+      result(sources.GreaterThanOrEqual(attrIntString, 1)))
+    testTranslateFilter(GreaterThanOrEqual(1, attrInt),
+      result(sources.LessThanOrEqual(attrIntString, 1)))
 
-    testTranslateFilter(LessThanOrEqual(attrInt, 1), Some(sources.LessThanOrEqual("cint", 1)))
-    testTranslateFilter(LessThanOrEqual(1, attrInt), Some(sources.GreaterThanOrEqual("cint", 1)))
+    testTranslateFilter(LessThanOrEqual(attrInt, 1),
+      result(sources.LessThanOrEqual(attrIntString, 1)))
+    testTranslateFilter(LessThanOrEqual(1, attrInt),
+      result(sources.GreaterThanOrEqual(attrIntString, 1)))
 
-    testTranslateFilter(InSet(attrInt, Set(1, 2, 3)), Some(sources.In("cint", Array(1, 2, 3))))
+    testTranslateFilter(InSet(attrInt, Set(1, 2, 3)),
+      result(sources.In(attrIntString, Array(1, 2, 3))))
 
-    testTranslateFilter(In(attrInt, Seq(1, 2, 3)), Some(sources.In("cint", Array(1, 2, 3))))
+    testTranslateFilter(In(attrInt, Seq(1, 2, 3)),
+      result(sources.In(attrIntString, Array(1, 2, 3))))
 
-    testTranslateFilter(IsNull(attrInt), Some(sources.IsNull("cint")))
-    testTranslateFilter(IsNotNull(attrInt), Some(sources.IsNotNull("cint")))
+    testTranslateFilter(IsNull(attrInt), result(sources.IsNull(attrIntString)))
+    testTranslateFilter(IsNotNull(attrInt), result(sources.IsNotNull(attrIntString)))
 
     // cint > 1 AND cint < 10
     testTranslateFilter(And(
       GreaterThan(attrInt, 1),
       LessThan(attrInt, 10)),
-      Some(sources.And(
-        sources.GreaterThan("cint", 1),
-        sources.LessThan("cint", 10))))
+      result(sources.And(
+        sources.GreaterThan(attrIntString, 1),
+        sources.LessThan(attrIntString, 10))))
 
     // cint >= 8 OR cint <= 2
     testTranslateFilter(Or(
       GreaterThanOrEqual(attrInt, 8),
       LessThanOrEqual(attrInt, 2)),
-      Some(sources.Or(
-        sources.GreaterThanOrEqual("cint", 8),
-        sources.LessThanOrEqual("cint", 2))))
+      result(sources.Or(
+        sources.GreaterThanOrEqual(attrIntString, 8),
+        sources.LessThanOrEqual(attrIntString, 2))))
 
     testTranslateFilter(Not(GreaterThanOrEqual(attrInt, 8)),
-      Some(sources.Not(sources.GreaterThanOrEqual("cint", 8))))
+      result(sources.Not(sources.GreaterThanOrEqual(attrIntString, 8))))
 
-    testTranslateFilter(StartsWith(attrStr, "a"), Some(sources.StringStartsWith("cstr", "a")))
+    testTranslateFilter(StartsWith(attrStr, "a"),
+      result(sources.StringStartsWith(attrStrString, "a")))
 
-    testTranslateFilter(EndsWith(attrStr, "a"), Some(sources.StringEndsWith("cstr", "a")))
+    testTranslateFilter(EndsWith(attrStr, "a"), result(sources.StringEndsWith(attrStrString, "a")))
 
-    testTranslateFilter(Contains(attrStr, "a"), Some(sources.StringContains("cstr", "a")))
+    testTranslateFilter(Contains(attrStr, "a"), result(sources.StringContains(attrStrString, "a")))
   }
 
-  test("translate complex expression") {
-    val attrInt = 'cint.int
+  // `isResultNone` is used when testing invalid input expression
+  // containing dots which translates into None
+  private def testTranslateComplexExpression(
+    attrInt: Expression,
+    attrIntString: String,
+    isResultNone: Boolean): Unit = {
 
-    // ABS(cint) - 2 <= 1
+    def result(result: sources.Filter): Option[sources.Filter] = {
+      if (isResultNone) {
+        None
+      } else {
+        Some(result)
+      }
+    }
+
+    // ABS(attrInt) - 2 <= 1
     testTranslateFilter(LessThanOrEqual(
       // Expressions are not supported
       // Functions such as 'Abs' are not supported
       Subtract(Abs(attrInt), 2), 1), None)
 
-    // (cin1 > 1 AND cint < 10) OR (cint > 50 AND cint > 100)
+    // (attrInt > 1 AND attrInt < 10) OR (attrInt > 50 AND attrInt > 100)
     testTranslateFilter(Or(
       And(
         GreaterThan(attrInt, 1),
@@ -100,16 +208,16 @@ class DataSourceStrategySuite extends PlanTest with SharedSparkSession {
       And(
         GreaterThan(attrInt, 50),
         LessThan(attrInt, 100))),
-      Some(sources.Or(
+      result(sources.Or(
         sources.And(
-          sources.GreaterThan("cint", 1),
-          sources.LessThan("cint", 10)),
+          sources.GreaterThan(attrIntString, 1),
+          sources.LessThan(attrIntString, 10)),
         sources.And(
-          sources.GreaterThan("cint", 50),
-          sources.LessThan("cint", 100)))))
+          sources.GreaterThan(attrIntString, 50),
+          sources.LessThan(attrIntString, 100)))))
 
     // SPARK-22548 Incorrect nested AND expression pushed down to JDBC data source
-    // (cint > 1 AND ABS(cint) < 10) OR (cint < 50 AND cint > 100)
+    // (attrInt > 1 AND ABS(attrInt) < 10) OR (attrInt < 50 AND attrInt > 100)
     testTranslateFilter(Or(
       And(
         GreaterThan(attrInt, 1),
@@ -120,7 +228,7 @@ class DataSourceStrategySuite extends PlanTest with SharedSparkSession {
         GreaterThan(attrInt, 50),
         LessThan(attrInt, 100))), None)
 
-    // NOT ((cint <= 1 OR ABS(cint) >= 10) AND (cint <= 50 OR cint >= 100))
+    // NOT ((attrInt <= 1 OR ABS(attrInt) >= 10) AND (attrInt <= 50 OR attrInt >= 100))
     testTranslateFilter(Not(And(
       Or(
         LessThanOrEqual(attrInt, 1),
@@ -131,7 +239,7 @@ class DataSourceStrategySuite extends PlanTest with SharedSparkSession {
         LessThanOrEqual(attrInt, 50),
         GreaterThanOrEqual(attrInt, 100)))), None)
 
-    // (cint = 1 OR cint = 10) OR (cint > 0 OR cint < -10)
+    // (attrInt = 1 OR attrInt = 10) OR (attrInt > 0 OR attrInt < -10)
     testTranslateFilter(Or(
       Or(
         EqualTo(attrInt, 1),
@@ -140,15 +248,15 @@ class DataSourceStrategySuite extends PlanTest with SharedSparkSession {
       Or(
         GreaterThan(attrInt, 0),
         LessThan(attrInt, -10))),
-      Some(sources.Or(
+      result(sources.Or(
         sources.Or(
-          sources.EqualTo("cint", 1),
-          sources.EqualTo("cint", 10)),
+          sources.EqualTo(attrIntString, 1),
+          sources.EqualTo(attrIntString, 10)),
         sources.Or(
-          sources.GreaterThan("cint", 0),
-          sources.LessThan("cint", -10)))))
+          sources.GreaterThan(attrIntString, 0),
+          sources.LessThan(attrIntString, -10)))))
 
-    // (cint = 1 OR ABS(cint) = 10) OR (cint > 0 OR cint < -10)
+    // (attrInt = 1 OR ABS(attrInt) = 10) OR (attrInt > 0 OR attrInt < -10)
     testTranslateFilter(Or(
       Or(
         EqualTo(attrInt, 1),
@@ -162,7 +270,7 @@ class DataSourceStrategySuite extends PlanTest with SharedSparkSession {
     // In end-to-end testing, conjunctive predicate should has been split
     // before reaching DataSourceStrategy.translateFilter.
     // This is for UT purpose to test each [[case]].
-    // (cint > 1 AND cint < 10) AND (cint = 6 AND cint IS NOT NULL)
+    // (attrInt > 1 AND attrInt < 10) AND (attrInt = 6 AND attrInt IS NOT NULL)
     testTranslateFilter(And(
       And(
         GreaterThan(attrInt, 1),
@@ -171,15 +279,15 @@ class DataSourceStrategySuite extends PlanTest with SharedSparkSession {
       And(
         EqualTo(attrInt, 6),
         IsNotNull(attrInt))),
-      Some(sources.And(
+      result(sources.And(
         sources.And(
-          sources.GreaterThan("cint", 1),
-          sources.LessThan("cint", 10)),
+          sources.GreaterThan(attrIntString, 1),
+          sources.LessThan(attrIntString, 10)),
         sources.And(
-          sources.EqualTo("cint", 6),
-          sources.IsNotNull("cint")))))
+          sources.EqualTo(attrIntString, 6),
+          sources.IsNotNull(attrIntString)))))
 
-    // (cint > 1 AND cint < 10) AND (ABS(cint) = 6 AND cint IS NOT NULL)
+    // (attrInt > 1 AND attrInt < 10) AND (ABS(attrInt) = 6 AND attrInt IS NOT NULL)
     testTranslateFilter(And(
       And(
         GreaterThan(attrInt, 1),
@@ -190,7 +298,7 @@ class DataSourceStrategySuite extends PlanTest with SharedSparkSession {
         EqualTo(Abs(attrInt), 6),
         IsNotNull(attrInt))), None)
 
-    // (cint > 1 OR cint < 10) AND (cint = 6 OR cint IS NOT NULL)
+    // (attrInt > 1 OR attrInt < 10) AND (attrInt = 6 OR attrInt IS NOT NULL)
     testTranslateFilter(And(
       Or(
         GreaterThan(attrInt, 1),
@@ -199,15 +307,16 @@ class DataSourceStrategySuite extends PlanTest with SharedSparkSession {
       Or(
         EqualTo(attrInt, 6),
         IsNotNull(attrInt))),
-      Some(sources.And(
+      result(sources.And(
         sources.Or(
-          sources.GreaterThan("cint", 1),
-          sources.LessThan("cint", 10)),
+          sources.GreaterThan(attrIntString, 1),
+          sources.LessThan(attrIntString, 10)),
         sources.Or(
-          sources.EqualTo("cint", 6),
-          sources.IsNotNull("cint")))))
+          sources.EqualTo(attrIntString, 6),
+          sources.IsNotNull(attrIntString)))))
 
-    // (cint > 1 OR cint < 10) AND (cint = 6 OR cint IS NOT NULL)
+    // (attrInt > 1 OR attrInt < 10) AND
+    // (attrInt = 6 OR attrInt IS NOT NULL)
     testTranslateFilter(And(
       Or(
         GreaterThan(attrInt, 1),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcV1FilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcV1FilterSuite.scala
@@ -40,7 +40,10 @@ class OrcV1FilterSuite extends OrcFilterSuite {
       checker: (SearchArgument) => Unit): Unit = {
     val output = predicate.collect { case a: Attribute => a }.distinct
     val query = df
-      .select(output.map(e => Column(e)): _*)
+      // SPARK-25557
+      // The following select will flatten the nested data structure,
+      // so comment it out for now until we find a better approach.
+      // .select(output.map(e => Column(e)): _*)
       .where(Column(predicate))
 
     var maybeRelation: Option[HadoopFsRelation] = None

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcV1FilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcV1FilterSuite.scala
@@ -84,7 +84,10 @@ class OrcV1FilterSuite extends OrcFilterSuite {
       (implicit df: DataFrame): Unit = {
     val output = predicate.collect { case a: Attribute => a }.distinct
     val query = df
-      .select(output.map(e => Column(e)): _*)
+      // SPARK-25557
+      // The following select will flatten the nested data structure,
+      // so comment it out for now until we find a better approach.
+      // .select(output.map(e => Column(e)): _*)
       .where(Column(predicate))
 
     var maybeRelation: Option[HadoopFsRelation] = None

--- a/sql/core/v1.2/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilters.scala
+++ b/sql/core/v1.2/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilters.scala
@@ -64,20 +64,18 @@ private[sql] object OrcFilters extends OrcFiltersBase {
    * Create ORC filter as a SearchArgument instance.
    */
   def createFilter(schema: StructType, filters: Seq[Filter]): Option[SearchArgument] = {
-    val dataTypeMap = schema.map(f => f.name -> f.dataType).toMap
     // Combines all convertible filters using `And` to produce a single conjunction
-    val conjunctionOptional = buildTree(convertibleFilters(schema, dataTypeMap, filters))
+    val conjunctionOptional = buildTree(convertibleFilters(schema, filters))
     conjunctionOptional.map { conjunction =>
       // Then tries to build a single ORC `SearchArgument` for the conjunction predicate.
       // The input predicate is fully convertible. There should not be any empty result in the
       // following recursive method call `buildSearchArgument`.
-      buildSearchArgument(dataTypeMap, conjunction, newBuilder).build()
+      buildSearchArgument(schema, conjunction, newBuilder).build()
     }
   }
 
   def convertibleFilters(
       schema: StructType,
-      dataTypeMap: Map[String, DataType],
       filters: Seq[Filter]): Seq[Filter] = {
     import org.apache.spark.sql.sources._
 
@@ -125,7 +123,7 @@ private[sql] object OrcFilters extends OrcFiltersBase {
         val childResultOptional = convertibleFiltersHelper(pred, canPartialPushDown = false)
         childResultOptional.map(Not)
       case other =>
-        for (_ <- buildLeafSearchArgument(dataTypeMap, other, newBuilder())) yield other
+        for (_ <- buildLeafSearchArgument(schema, other, newBuilder())) yield other
     }
     filters.flatMap { filter =>
       convertibleFiltersHelper(filter, true)
@@ -165,33 +163,33 @@ private[sql] object OrcFilters extends OrcFiltersBase {
   /**
    * Build a SearchArgument and return the builder so far.
    *
-   * @param dataTypeMap a map from the attribute name to its data type.
+   * @param schema the schema of the data
    * @param expression the input predicates, which should be fully convertible to SearchArgument.
    * @param builder the input SearchArgument.Builder.
    * @return the builder so far.
    */
   private def buildSearchArgument(
-      dataTypeMap: Map[String, DataType],
+      schema: StructType,
       expression: Filter,
       builder: Builder): Builder = {
     import org.apache.spark.sql.sources._
 
     expression match {
       case And(left, right) =>
-        val lhs = buildSearchArgument(dataTypeMap, left, builder.startAnd())
-        val rhs = buildSearchArgument(dataTypeMap, right, lhs)
+        val lhs = buildSearchArgument(schema, left, builder.startAnd())
+        val rhs = buildSearchArgument(schema, right, lhs)
         rhs.end()
 
       case Or(left, right) =>
-        val lhs = buildSearchArgument(dataTypeMap, left, builder.startOr())
-        val rhs = buildSearchArgument(dataTypeMap, right, lhs)
+        val lhs = buildSearchArgument(schema, left, builder.startOr())
+        val rhs = buildSearchArgument(schema, right, lhs)
         rhs.end()
 
       case Not(child) =>
-        buildSearchArgument(dataTypeMap, child, builder.startNot()).end()
+        buildSearchArgument(schema, child, builder.startNot()).end()
 
       case other =>
-        buildLeafSearchArgument(dataTypeMap, other, builder).getOrElse {
+        buildLeafSearchArgument(schema, other, builder).getOrElse {
           throw new SparkException(
             "The input filter of OrcFilters.buildSearchArgument should be fully convertible.")
         }
@@ -201,17 +199,35 @@ private[sql] object OrcFilters extends OrcFiltersBase {
   /**
    * Build a SearchArgument for a leaf predicate and return the builder so far.
    *
-   * @param dataTypeMap a map from the attribute name to its data type.
+   * @param schema the schema of the data
    * @param expression the input filter predicates.
    * @param builder the input SearchArgument.Builder.
    * @return the builder so far.
    */
   private def buildLeafSearchArgument(
-      dataTypeMap: Map[String, DataType],
+      schema: StructType,
       expression: Filter,
       builder: Builder): Option[Builder] = {
+
+    def getDataType(schema: StructType, attribute: String): DataType = {
+      val typeMap = schema.fields.map(f => f.name -> f.dataType).toMap
+      typeMap.get(attribute) match {
+        case Some(t) => t
+        case _ =>
+          val levels = attribute.split("\\.", 2)
+          if (levels.length <= 1) {
+            NullType
+          } else {
+            typeMap.get(levels.head) match {
+              case Some(s: StructType) => getDataType(s, levels.last)
+              case _ => NullType
+            }
+          }
+      }
+    }
+
     def getType(attribute: String): PredicateLeaf.Type =
-      getPredicateLeafType(dataTypeMap(attribute))
+      getPredicateLeafType(getDataType(schema, attribute))
 
     import org.apache.spark.sql.sources._
 
@@ -219,47 +235,47 @@ private[sql] object OrcFilters extends OrcFiltersBase {
     // call is mandatory. ORC `SearchArgument` builder requires that all leaf predicates must be
     // wrapped by a "parent" predicate (`And`, `Or`, or `Not`).
     expression match {
-      case EqualTo(attribute, value) if isSearchableType(dataTypeMap(attribute)) =>
+      case EqualTo(attribute, value) if isSearchableType(getDataType(schema, attribute)) =>
         val quotedName = quoteAttributeNameIfNeeded(attribute)
-        val castedValue = castLiteralValue(value, dataTypeMap(attribute))
+        val castedValue = castLiteralValue(value, getDataType(schema, attribute))
         Some(builder.startAnd().equals(quotedName, getType(attribute), castedValue).end())
 
-      case EqualNullSafe(attribute, value) if isSearchableType(dataTypeMap(attribute)) =>
+      case EqualNullSafe(attribute, value) if isSearchableType(getDataType(schema, attribute)) =>
         val quotedName = quoteAttributeNameIfNeeded(attribute)
-        val castedValue = castLiteralValue(value, dataTypeMap(attribute))
+        val castedValue = castLiteralValue(value, getDataType(schema, attribute))
         Some(builder.startAnd().nullSafeEquals(quotedName, getType(attribute), castedValue).end())
 
-      case LessThan(attribute, value) if isSearchableType(dataTypeMap(attribute)) =>
+      case LessThan(attribute, value) if isSearchableType(getDataType(schema, attribute)) =>
         val quotedName = quoteAttributeNameIfNeeded(attribute)
-        val castedValue = castLiteralValue(value, dataTypeMap(attribute))
+        val castedValue = castLiteralValue(value, getDataType(schema, attribute))
         Some(builder.startAnd().lessThan(quotedName, getType(attribute), castedValue).end())
 
-      case LessThanOrEqual(attribute, value) if isSearchableType(dataTypeMap(attribute)) =>
+      case LessThanOrEqual(attribute, value) if isSearchableType(getDataType(schema, attribute)) =>
         val quotedName = quoteAttributeNameIfNeeded(attribute)
-        val castedValue = castLiteralValue(value, dataTypeMap(attribute))
+        val castedValue = castLiteralValue(value, getDataType(schema, attribute))
         Some(builder.startAnd().lessThanEquals(quotedName, getType(attribute), castedValue).end())
 
-      case GreaterThan(attribute, value) if isSearchableType(dataTypeMap(attribute)) =>
+      case GreaterThan(attribute, value) if isSearchableType(getDataType(schema, attribute)) =>
         val quotedName = quoteAttributeNameIfNeeded(attribute)
-        val castedValue = castLiteralValue(value, dataTypeMap(attribute))
+        val castedValue = castLiteralValue(value, getDataType(schema, attribute))
         Some(builder.startNot().lessThanEquals(quotedName, getType(attribute), castedValue).end())
 
-      case GreaterThanOrEqual(attribute, value) if isSearchableType(dataTypeMap(attribute)) =>
+      case GreaterThanOrEqual(attribute, value) if isSearchableType(getDataType(schema, attribute)) =>
         val quotedName = quoteAttributeNameIfNeeded(attribute)
-        val castedValue = castLiteralValue(value, dataTypeMap(attribute))
+        val castedValue = castLiteralValue(value, getDataType(schema, attribute))
         Some(builder.startNot().lessThan(quotedName, getType(attribute), castedValue).end())
 
-      case IsNull(attribute) if isSearchableType(dataTypeMap(attribute)) =>
+      case IsNull(attribute) if isSearchableType(getDataType(schema, attribute)) =>
         val quotedName = quoteAttributeNameIfNeeded(attribute)
         Some(builder.startAnd().isNull(quotedName, getType(attribute)).end())
 
-      case IsNotNull(attribute) if isSearchableType(dataTypeMap(attribute)) =>
+      case IsNotNull(attribute) if isSearchableType(getDataType(schema, attribute)) =>
         val quotedName = quoteAttributeNameIfNeeded(attribute)
         Some(builder.startNot().isNull(quotedName, getType(attribute)).end())
 
-      case In(attribute, values) if isSearchableType(dataTypeMap(attribute)) =>
+      case In(attribute, values) if isSearchableType(getDataType(schema, attribute)) =>
         val quotedName = quoteAttributeNameIfNeeded(attribute)
-        val castedValues = values.map(v => castLiteralValue(v, dataTypeMap(attribute)))
+        val castedValues = values.map(v => castLiteralValue(v, getDataType(schema, attribute)))
         Some(builder.startAnd().in(quotedName, getType(attribute),
           castedValues.map(_.asInstanceOf[AnyRef]): _*).end())
 

--- a/sql/core/v1.2/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilterSuite.scala
+++ b/sql/core/v1.2/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilterSuite.scala
@@ -21,10 +21,10 @@ import java.math.MathContext
 import java.nio.charset.StandardCharsets
 import java.sql.{Date, Timestamp}
 
+import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf
+
 import scala.collection.JavaConverters._
-
 import org.apache.orc.storage.ql.io.sarg.{PredicateLeaf, SearchArgument}
-
 import org.apache.spark.sql.{AnalysisException, Column, DataFrame}
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions._
@@ -49,7 +49,10 @@ class OrcFilterSuite extends OrcTest with SharedSparkSession {
       checker: (SearchArgument) => Unit): Unit = {
     val output = predicate.collect { case a: Attribute => a }.distinct
     val query = df
-      .select(output.map(e => Column(e)): _*)
+      // SPARK-25557
+      // The following select will flatten the nested data structure,
+      // so comment it out for now until we find a better approach.
+      // .select(output.map(e => Column(e)): _*)
       .where(Column(predicate))
 
     query.queryExecution.optimizedPlan match {
@@ -190,24 +193,65 @@ class OrcFilterSuite extends OrcTest with SharedSparkSession {
     }
   }
 
+  case class N1[T](a: Option[T])
+  case class N2[T](b: Option[T])
   test("filter pushdown - boolean") {
-    withOrcDataFrame((true :: false :: Nil).map(b => Tuple1.apply(Option(b)))) { implicit df =>
-      checkFilterPredicate($"_1".isNull, PredicateLeaf.Operator.IS_NULL)
+    val data0 = (true :: false :: Nil).map(b => Tuple1.apply(Option(b)))
+    val data1 = data0.map(x => N1(Some(x)))
+    val data2 = data1.map(x => N2(Some(x)))
 
-      checkFilterPredicate($"_1" === true, PredicateLeaf.Operator.EQUALS)
-      checkFilterPredicate($"_1" <=> true, PredicateLeaf.Operator.NULL_SAFE_EQUALS)
+    // zero nesting
+    withOrcDataFrame(data0) { implicit df =>
+      val col = Symbol("_1")
+      checkFilterPredicate(col.isNull, PredicateLeaf.Operator.IS_NULL)
+      checkFilterPredicate(col === true, PredicateLeaf.Operator.EQUALS)
+      checkFilterPredicate(col <=> true, PredicateLeaf.Operator.NULL_SAFE_EQUALS)
+      checkFilterPredicate(col < true, PredicateLeaf.Operator.LESS_THAN)
+      checkFilterPredicate(col > false, PredicateLeaf.Operator.LESS_THAN_EQUALS)
+      checkFilterPredicate(col <= false, PredicateLeaf.Operator.LESS_THAN_EQUALS)
+      checkFilterPredicate(col >= false, PredicateLeaf.Operator.LESS_THAN)
+      checkFilterPredicate(Literal(false) === col, PredicateLeaf.Operator.EQUALS)
+      checkFilterPredicate(Literal(false) <=> col, PredicateLeaf.Operator.NULL_SAFE_EQUALS)
+      checkFilterPredicate(Literal(false) > col, PredicateLeaf.Operator.LESS_THAN)
+      checkFilterPredicate(Literal(true) < col, PredicateLeaf.Operator.LESS_THAN_EQUALS)
+      checkFilterPredicate(Literal(true) >= col, PredicateLeaf.Operator.LESS_THAN_EQUALS)
+      checkFilterPredicate(Literal(true) <= col, PredicateLeaf.Operator.LESS_THAN)
+    }
 
-      checkFilterPredicate($"_1" < true, PredicateLeaf.Operator.LESS_THAN)
-      checkFilterPredicate($"_1" > false, PredicateLeaf.Operator.LESS_THAN_EQUALS)
-      checkFilterPredicate($"_1" <= false, PredicateLeaf.Operator.LESS_THAN_EQUALS)
-      checkFilterPredicate($"_1" >= false, PredicateLeaf.Operator.LESS_THAN)
+    // one level nesting
+    withOrcDataFrame(data1) { implicit df =>
+      val col = Symbol("a._1")
+      checkFilterPredicate(col.isNull, PredicateLeaf.Operator.IS_NULL)
+      checkFilterPredicate(col === true, PredicateLeaf.Operator.EQUALS)
+      checkFilterPredicate(col <=> true, PredicateLeaf.Operator.NULL_SAFE_EQUALS)
+      checkFilterPredicate(col < true, PredicateLeaf.Operator.LESS_THAN)
+      checkFilterPredicate(col > false, PredicateLeaf.Operator.LESS_THAN_EQUALS)
+      checkFilterPredicate(col <= false, PredicateLeaf.Operator.LESS_THAN_EQUALS)
+      checkFilterPredicate(col >= false, PredicateLeaf.Operator.LESS_THAN)
+      checkFilterPredicate(Literal(false) === col, PredicateLeaf.Operator.EQUALS)
+      checkFilterPredicate(Literal(false) <=> col, PredicateLeaf.Operator.NULL_SAFE_EQUALS)
+      checkFilterPredicate(Literal(false) > col, PredicateLeaf.Operator.LESS_THAN)
+      checkFilterPredicate(Literal(true) < col, PredicateLeaf.Operator.LESS_THAN_EQUALS)
+      checkFilterPredicate(Literal(true) >= col, PredicateLeaf.Operator.LESS_THAN_EQUALS)
+      checkFilterPredicate(Literal(true) <= col, PredicateLeaf.Operator.LESS_THAN)
+    }
 
-      checkFilterPredicate(Literal(false) === $"_1", PredicateLeaf.Operator.EQUALS)
-      checkFilterPredicate(Literal(false) <=> $"_1", PredicateLeaf.Operator.NULL_SAFE_EQUALS)
-      checkFilterPredicate(Literal(false) > $"_1", PredicateLeaf.Operator.LESS_THAN)
-      checkFilterPredicate(Literal(true) < $"_1", PredicateLeaf.Operator.LESS_THAN_EQUALS)
-      checkFilterPredicate(Literal(true) >= $"_1", PredicateLeaf.Operator.LESS_THAN_EQUALS)
-      checkFilterPredicate(Literal(true) <= $"_1", PredicateLeaf.Operator.LESS_THAN)
+    // two level nesting
+    withOrcDataFrame(data2) { implicit df =>
+      val col = Symbol("b.a._1")
+      checkFilterPredicate(col.isNull, PredicateLeaf.Operator.IS_NULL)
+      checkFilterPredicate(col === true, PredicateLeaf.Operator.EQUALS)
+      checkFilterPredicate(col <=> true, PredicateLeaf.Operator.NULL_SAFE_EQUALS)
+      checkFilterPredicate(col < true, PredicateLeaf.Operator.LESS_THAN)
+      checkFilterPredicate(col > false, PredicateLeaf.Operator.LESS_THAN_EQUALS)
+      checkFilterPredicate(col <= false, PredicateLeaf.Operator.LESS_THAN_EQUALS)
+      checkFilterPredicate(col >= false, PredicateLeaf.Operator.LESS_THAN)
+      checkFilterPredicate(Literal(false) === col, PredicateLeaf.Operator.EQUALS)
+      checkFilterPredicate(Literal(false) <=> col, PredicateLeaf.Operator.NULL_SAFE_EQUALS)
+      checkFilterPredicate(Literal(false) > col, PredicateLeaf.Operator.LESS_THAN)
+      checkFilterPredicate(Literal(true) < col, PredicateLeaf.Operator.LESS_THAN_EQUALS)
+      checkFilterPredicate(Literal(true) >= col, PredicateLeaf.Operator.LESS_THAN_EQUALS)
+      checkFilterPredicate(Literal(true) <= col, PredicateLeaf.Operator.LESS_THAN)
     }
   }
 

--- a/sql/core/v1.2/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilterSuite.scala
+++ b/sql/core/v1.2/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilterSuite.scala
@@ -21,8 +21,6 @@ import java.math.MathContext
 import java.nio.charset.StandardCharsets
 import java.sql.{Date, Timestamp}
 
-import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf
-
 import scala.collection.JavaConverters._
 import org.apache.orc.storage.ql.io.sarg.{PredicateLeaf, SearchArgument}
 import org.apache.spark.sql.{AnalysisException, Column, DataFrame}

--- a/sql/core/v2.3/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilterSuite.scala
+++ b/sql/core/v2.3/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilterSuite.scala
@@ -50,7 +50,7 @@ class OrcFilterSuite extends OrcTest with SharedSparkSession {
       checker: (SearchArgument) => Unit): Unit = {
     val output = predicate.collect { case a: Attribute => a }.distinct
     val query = df
-      // SPARK-17636
+      // SPARK-25557
       // The following select will flatten the nested data structure,
       // so comment it out for now until we find a better approach.
       // .select(output.map(e => Column(e)): _*)
@@ -202,7 +202,7 @@ class OrcFilterSuite extends OrcTest with SharedSparkSession {
     val data1 = data0.map(x => N1(Some(x)))
     val data2 = data1.map(x => N2(Some(x)))
 
-//    // zero nesting
+    // zero nesting
     withOrcDataFrame(data0) { implicit df =>
       val col = Symbol("_1")
       checkFilterPredicate(col.isNull, PredicateLeaf.Operator.IS_NULL)
@@ -255,25 +255,6 @@ class OrcFilterSuite extends OrcTest with SharedSparkSession {
       checkFilterPredicate(Literal(true) >= col, PredicateLeaf.Operator.LESS_THAN_EQUALS)
       checkFilterPredicate(Literal(true) <= col, PredicateLeaf.Operator.LESS_THAN)
     }
-
-//    withOrcDataFrame((true :: false :: Nil).map(b => Tuple1.apply(Option(b)))) { implicit df =>
-//      checkFilterPredicate($"_1".isNull, PredicateLeaf.Operator.IS_NULL)
-//
-//      checkFilterPredicate($"_1" === true, PredicateLeaf.Operator.EQUALS)
-//      checkFilterPredicate($"_1" <=> true, PredicateLeaf.Operator.NULL_SAFE_EQUALS)
-//
-//      checkFilterPredicate($"_1" < true, PredicateLeaf.Operator.LESS_THAN)
-//      checkFilterPredicate($"_1" > false, PredicateLeaf.Operator.LESS_THAN_EQUALS)
-//      checkFilterPredicate($"_1" <= false, PredicateLeaf.Operator.LESS_THAN_EQUALS)
-//      checkFilterPredicate($"_1" >= false, PredicateLeaf.Operator.LESS_THAN)
-//
-//      checkFilterPredicate(Literal(false) === $"_1", PredicateLeaf.Operator.EQUALS)
-//      checkFilterPredicate(Literal(false) <=> $"_1", PredicateLeaf.Operator.NULL_SAFE_EQUALS)
-//      checkFilterPredicate(Literal(false) > $"_1", PredicateLeaf.Operator.LESS_THAN)
-//      checkFilterPredicate(Literal(true) < $"_1", PredicateLeaf.Operator.LESS_THAN_EQUALS)
-//      checkFilterPredicate(Literal(true) >= $"_1", PredicateLeaf.Operator.LESS_THAN_EQUALS)
-//      checkFilterPredicate(Literal(true) <= $"_1", PredicateLeaf.Operator.LESS_THAN)
-//    }
   }
 
   test("filter pushdown - decimal") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcFilterSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcFilterSuite.scala
@@ -47,7 +47,10 @@ class HiveOrcFilterSuite extends OrcTest with TestHiveSingleton {
       checker: (SearchArgument) => Unit): Unit = {
     val output = predicate.collect { case a: Attribute => a }.distinct
     val query = df
-      .select(output.map(e => Column(e)): _*)
+      // SPARK-25557
+      // The following select will flatten the nested data structure,
+      // so comment it out for now until we find a better approach.
+      // .select(output.map(e => Column(e)): _*)
       .where(Column(predicate))
 
     var maybeRelation: Option[HadoopFsRelation] = None


### PR DESCRIPTION
### What changes were proposed in this pull request?

Firstly, much of this PR is a rebase of https://github.com/apache/spark/pull/22535, much thanks to @dbtsai for his work.

Spark can now push down predicates on struct columns when reading Parquet and ORC tables.

### Why are the changes needed?
There are significant performance gains to be had from pushing down predicates.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Existing UT were extended to cover the new functionality.

Sanity check tests:
```
//// Setup ////
spark.range(1000 * 1000).toDF("id").selectExpr("id", "STRUCT(id x, STRUCT(CAST(id AS STRING) z) y) nested").write.mode("overwrite").parquet("/tmp/data")
spark.range(1000 * 1000).toDF("id").selectExpr("id", "STRUCT(id x, STRUCT(CAST(id AS STRING) z) y) nested").write.mode("overwrite").orc("/tmp/data_orc")
def hack_benchmark(f: (() => Any)): Double = {
	(0 to 100).map(i => {
		val start = System.currentTimeMillis
		f()
		(System.currentTimeMillis - start)
	}).sum / 100.0
}


//// Without patch ////
scala> spark.read.parquet("/tmp/data").filter("nested.x = 100").explain
== Physical Plan ==
*(1) Project [id#0L, nested#1]
+- *(1) Filter (isnotnull(nested#1) && (nested#1.x = 100))
   +- *(1) FileScan parquet [id#0L,nested#1] Batched: false, Format: Parquet, Location: InMemoryFileIndex[file:/tmp/data], PartitionFilters: [], PushedFilters: [IsNotNull(nested)], ReadSchema: struct<id:bigint,nested:struct<x:bigint,y:string>>

scala> spark.read.orc("/tmp/data_orc").filter("nested.x = 100").explain
== Physical Plan ==
*(1) Project [id#9253L, nested#9254]
+- *(1) Filter (isnotnull(nested#9254) && (nested#9254.x = 100))
   +- *(1) FileScan orc [id#9253L,nested#9254] Batched: false, Format: ORC, Location: InMemoryFileIndex[file:/tmp/data_orc], PartitionFilters: [], PushedFilters: [IsNotNull(nested)], ReadSchema: struct<id:bigint,nested:struct<x:bigint,y:string>>

scala> hack_benchmark(spark.read.parquet("/tmp/data").filter("nested.x < 100").count _)
res0: Double = 419.82 

scala> hack_benchmark(spark.read.orc("/tmp/data_orc").filter("nested.x < 100").count _)
res5: Double = 1525.83  

//// With patch ////
scala> spark.read.parquet("/tmp/data").filter("nested.x = 100").explain
== Physical Plan ==
*(1) Project [id#54L, nested#55]
+- *(1) Filter (isnotnull(nested#55) AND (nested#55.x = 100))
   +- BatchScan[id#54L, nested#55] ParquetScan Location: InMemoryFileIndex[file:/tmp/data], ReadSchema: struct<id:bigint,nested:struct<x:bigint,y:string>>, PushedFilters: [EqualTo(nested.x,100)]

scala> spark.read.orc("/tmp/data_orc").filter("nested.x = 100").explain
== Physical Plan ==
*(1) Project [id#0L, nested#1]
+- *(1) Filter (isnotnull(nested#1) AND (nested#1.x = 100))
   +- BatchScan[id#0L, nested#1] OrcScan Location: InMemoryFileIndex[file:/tmp/data_orc], ReadSchema: struct<id:bigint,nested:struct<x:bigint,y:struct<z:string>>>, PushedFilters: [EqualTo(nested.x,100)]
            
scala> hack_benchmark(spark.read.parquet("/tmp/data").filter("nested.x < 100").count _)
res0: Double = 192.15                                                           

scala> hack_benchmark(spark.read.orc("/tmp/data_orc").filter("nested.x < 100").count _)
res1: Double = 1029.57                                                   
```

Note the significant performance improvement and the inclusion of the filter in `PushedFilters` in both cases.
