### PR TITLE
[SPARK-30489][BUILD] Make build delete pyspark.zip file properly

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -117,7 +117,7 @@
           </executions>
           <configuration>
             <target>
-              <delete dir="${basedir}/../python/lib/pyspark.zip"/>
+              <delete file="${basedir}/../python/lib/pyspark.zip"/>
               <zip destfile="${basedir}/../python/lib/pyspark.zip">
                 <fileset dir="${basedir}/../python/" includes="pyspark/**/*"/>
               </zip>


### PR DESCRIPTION
### What changes were proposed in this pull request?

A small fix to the Maven build file under the `assembly` module by switch "dir" attribute to "file".

### Why are the changes needed?

To make the `<delete>` task properly delete an existing zip file.

### Does this PR introduce any user-facing change?

No


### How was this patch tested?

Ran a build with the change and confirmed that a corrupted zip file was replaced with the correct one.