### PR TITLE
[SPARK-30490][SQL] Eliminate compiler warnings in Avro datasource

### DIFF
--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
@@ -68,7 +68,6 @@ class AvroOptions(
    * If the option is not set, the Hadoop's config `avro.mapred.ignore.inputs.without.extension`
    * is taken into account. If the former one is not set too, file extensions are ignored.
    */
-  @deprecated("Use the general data source option pathGlobFilter for filtering file names", "3.0")
   val ignoreExtension: Boolean = {
     def warn(s: String): Unit = logWarning(
       s"$s is deprecated, and it will be not use by Avro datasource in the future releases. " +

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
@@ -70,6 +70,9 @@ class AvroOptions(
    */
   @deprecated("Use the general data source option pathGlobFilter for filtering file names", "3.0")
   val ignoreExtension: Boolean = {
+    def warn(s: String): Unit = logWarning(
+      s"$s is deprecated, and it will be not use by Avro datasource in the future releases. " +
+      "Use the general data source option pathGlobFilter for filtering file names.")
     val ignoreFilesWithoutExtensionByDefault = false
     val ignoreFilesWithoutExtension = conf.getBoolean(
       AvroFileFormat.IgnoreFilesWithoutExtensionProperty,
@@ -78,7 +81,17 @@ class AvroOptions(
     parameters
       .get(AvroOptions.ignoreExtensionKey)
       .map(_.toBoolean)
-      .getOrElse(!ignoreFilesWithoutExtension)
+      .map { ignoreExtensionOption =>
+        if (ignoreExtensionOption != !ignoreFilesWithoutExtensionByDefault) {
+          warn(s"The Avro option '${AvroOptions.ignoreExtensionKey}'")
+        }
+        ignoreExtensionOption
+      }.getOrElse {
+        if (ignoreFilesWithoutExtension != ignoreFilesWithoutExtensionByDefault) {
+          warn(s"The Hadoop's config '${AvroFileFormat.IgnoreFilesWithoutExtensionProperty}'")
+        }
+        !ignoreFilesWithoutExtension
+      }
   }
 
   /**

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
@@ -42,10 +42,6 @@ object AvroUtils extends Logging {
       options: Map[String, String],
       files: Seq[FileStatus]): Option[StructType] = {
     val conf = spark.sessionState.newHadoopConf()
-    if (options.contains("ignoreExtension")) {
-      logWarning(s"Option ${AvroOptions.ignoreExtensionKey} is deprecated. Please use the " +
-        "general data source option pathGlobFilter for filtering file names.")
-    }
     val parsedOptions = new AvroOptions(options, conf)
 
     // User can specify an optional avro json schema.


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Remove the `@deprecated` annotation for `AvroOptions. ignoreExtension`
- Output log warning if `avro.mapred.ignore.inputs.without.extension` is set to non-default value - `true`
- Output log warning if avro option `ignoreExtension` is set to non-default value - `true`

### Why are the changes needed?
1. Currently, the compiler output deprecation warning only during compilation of Spark source code but not user apps because `AvroOptions.ignoreExtension` is not used by users directly. In this ways, users are not aware of deprecated Hadoop's conf and avro option.
2. Elimination of unnecessary warnings highlights other warnings that can indicate about real problems. 

### Does this PR introduce any user-facing change?
Yes

### How was this patch tested?
By `AvroSuite`
