### PR TITLE
[SPARK-30492][SQL] Eliminate deprecation warnings in ORC datasource

### DIFF
--- a/sql/hive/src/main/java/org/apache/hadoop/hive/ql/io/orc/SparkOrcNewRecordReader.java
+++ b/sql/hive/src/main/java/org/apache/hadoop/hive/ql/io/orc/SparkOrcNewRecordReader.java
@@ -22,8 +22,10 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.orc.TypeDescription;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * This is based on hive-exec-1.2.1
@@ -41,10 +43,11 @@ public class SparkOrcNewRecordReader extends
 
   public SparkOrcNewRecordReader(Reader file, Configuration conf,
       long offset, long length) throws IOException {
-    if (file.getTypes().isEmpty()) {
+    List<TypeDescription> subTypes = file.getSchema().getChildren();
+    if (subTypes == null) {
       numColumns = 0;
     } else {
-      numColumns = file.getTypes().get(0).getSubtypesCount();
+      numColumns = subTypes.size();
     }
     value = new OrcStruct(numColumns);
     this.reader = OrcInputFormat.createReaderFromFile(file, conf, offset,


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to avoid usage of `getTypes()` in the `SparkOrcNewRecordReader` constructor, and replace it by `getSchema()`.

### Why are the changes needed?
To eliminate compiler warnings, and highlight other warnings that could indicate about real problems:
```
Warning:(44, 13) java: getTypes() in org.apache.orc.Reader has been deprecated
Warning:(47, 24) java: getTypes() in org.apache.orc.Reader has been deprecated
```

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
By existing tests from the `org.apache.spark.sql.hive.orc` package like `HiveOrcQuerySuite`.