### PR TITLE
[SPARK-27986][SQL][FOLLOWUP] Respect filter in sql/toString of AggregateExpression

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
@@ -152,7 +152,7 @@ case class AggregateExpression(
     }
     val aggFuncStr = prefix + aggregateFunction.toAggString(isDistinct)
     filter match {
-      case Some(predicate) => s"$aggFuncStr filter (where $predicate)"
+      case Some(predicate) => s"$aggFuncStr FILTER (WHERE $predicate)"
       case _ => aggFuncStr
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
@@ -149,10 +149,24 @@ case class AggregateExpression(
       case PartialMerge => "merge_"
       case Final | Complete => ""
     }
-    prefix + aggregateFunction.toAggString(isDistinct)
+    val aggFuncStr = prefix + aggregateFunction.toAggString(isDistinct)
+    mode match {
+      case Partial | Complete if filter.isDefined =>
+        s"$aggFuncStr filter ${filter.get.toString}"
+      case _ =>
+        aggFuncStr
+    }
   }
 
-  override def sql: String = aggregateFunction.sql(isDistinct)
+  override def sql: String = {
+    val aggFuncStr = aggregateFunction.sql(isDistinct)
+    mode match {
+      case Partial | Complete if filter.isDefined =>
+        s"$aggFuncStr FILTER ${filter.get.sql}"
+      case _ =>
+        aggFuncStr
+    }
+  }
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
@@ -150,21 +150,17 @@ case class AggregateExpression(
       case Final | Complete => ""
     }
     val aggFuncStr = prefix + aggregateFunction.toAggString(isDistinct)
-    mode match {
-      case Partial | Complete if filter.isDefined =>
-        s"$aggFuncStr filter ${filter.get.toString}"
-      case _ =>
-        aggFuncStr
+    filter match {
+      case Some(predicate) => s"$aggFuncStr filter $predicate"
+      case _ => aggFuncStr
     }
   }
 
   override def sql: String = {
     val aggFuncStr = aggregateFunction.sql(isDistinct)
-    mode match {
-      case Partial | Complete if filter.isDefined =>
-        s"$aggFuncStr FILTER ${filter.get.sql}"
-      case _ =>
-        aggFuncStr
+    filter match {
+      case Some(predicate) => s"$aggFuncStr FILTER ${predicate.sql}"
+      case _ => aggFuncStr
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
@@ -137,10 +137,11 @@ case class AggregateExpression(
 
   @transient
   override lazy val references: AttributeSet = {
-    mode match {
-      case Partial | Complete => aggregateFunction.references ++ filterAttributes
+    val aggAttributes = mode match {
+      case Partial | Complete => aggregateFunction.references
       case PartialMerge | Final => AttributeSet(aggregateFunction.aggBufferAttributes)
     }
+    aggAttributes ++ filterAttributes
   }
 
   override def toString: String = {
@@ -151,7 +152,7 @@ case class AggregateExpression(
     }
     val aggFuncStr = prefix + aggregateFunction.toAggString(isDistinct)
     filter match {
-      case Some(predicate) => s"$aggFuncStr filter $predicate"
+      case Some(predicate) => s"$aggFuncStr filter (where $predicate)"
       case _ => aggFuncStr
     }
   }
@@ -159,7 +160,7 @@ case class AggregateExpression(
   override def sql: String = {
     val aggFuncStr = aggregateFunction.sql(isDistinct)
     filter match {
-      case Some(predicate) => s"$aggFuncStr FILTER ${predicate.sql}"
+      case Some(predicate) => s"$aggFuncStr FILTER (WHERE ${predicate.sql})"
       case _ => aggFuncStr
     }
   }

--- a/sql/core/src/test/resources/sql-tests/results/group-by-filter.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-by-filter.sql.out
@@ -51,13 +51,13 @@ SELECT a, COUNT(b) FILTER (WHERE a >= 2) FROM testData
 struct<>
 -- !query 3 output
 org.apache.spark.sql.AnalysisException
-grouping expressions sequence is empty, and 'testdata.`a`' is not an aggregate function. Wrap '(count(testdata.`b`) FILTER (testdata.`a` >= 2) AS `count(b) FILTER (a >= 2)`)' in windowing function(s) or wrap 'testdata.`a`' in first() (or first_value) if you don't care which value you get.;
+grouping expressions sequence is empty, and 'testdata.`a`' is not an aggregate function. Wrap '(count(testdata.`b`) FILTER (WHERE (testdata.`a` >= 2)) AS `count(b) FILTER (WHERE (a >= 2))`)' in windowing function(s) or wrap 'testdata.`a`' in first() (or first_value) if you don't care which value you get.;
 
 
 -- !query 4
 SELECT COUNT(a) FILTER (WHERE a = 1), COUNT(b) FILTER (WHERE a > 1) FROM testData
 -- !query 4 schema
-struct<count(a) FILTER (a = 1):bigint,count(b) FILTER (a > 1):bigint>
+struct<count(a) FILTER (WHERE (a = 1)):bigint,count(b) FILTER (WHERE (a > 1)):bigint>
 -- !query 4 output
 2	4
 
@@ -65,7 +65,7 @@ struct<count(a) FILTER (a = 1):bigint,count(b) FILTER (a > 1):bigint>
 -- !query 5
 SELECT COUNT(id) FILTER (WHERE hiredate = date "2001-01-01") FROM emp
 -- !query 5 schema
-struct<count(id) FILTER (hiredate = DATE '2001-01-01'):bigint>
+struct<count(id) FILTER (WHERE (hiredate = DATE '2001-01-01')):bigint>
 -- !query 5 output
 2
 
@@ -73,7 +73,7 @@ struct<count(id) FILTER (hiredate = DATE '2001-01-01'):bigint>
 -- !query 6
 SELECT COUNT(id) FILTER (WHERE hiredate = to_date('2001-01-01 00:00:00')) FROM emp
 -- !query 6 schema
-struct<count(id) FILTER (hiredate = to_date('2001-01-01 00:00:00')):bigint>
+struct<count(id) FILTER (WHERE (hiredate = to_date('2001-01-01 00:00:00'))):bigint>
 -- !query 6 output
 2
 
@@ -81,7 +81,7 @@ struct<count(id) FILTER (hiredate = to_date('2001-01-01 00:00:00')):bigint>
 -- !query 7
 SELECT COUNT(id) FILTER (WHERE hiredate = to_timestamp("2001-01-01 00:00:00")) FROM emp
 -- !query 7 schema
-struct<count(id) FILTER (CAST(hiredate AS TIMESTAMP) = to_timestamp('2001-01-01 00:00:00')):bigint>
+struct<count(id) FILTER (WHERE (CAST(hiredate AS TIMESTAMP) = to_timestamp('2001-01-01 00:00:00'))):bigint>
 -- !query 7 output
 2
 
@@ -89,7 +89,7 @@ struct<count(id) FILTER (CAST(hiredate AS TIMESTAMP) = to_timestamp('2001-01-01 
 -- !query 8
 SELECT COUNT(id) FILTER (WHERE date_format(hiredate, "yyyy-MM-dd") = "2001-01-01") FROM emp
 -- !query 8 schema
-struct<count(id) FILTER (date_format(CAST(hiredate AS TIMESTAMP), yyyy-MM-dd) = 2001-01-01):bigint>
+struct<count(id) FILTER (WHERE (date_format(CAST(hiredate AS TIMESTAMP), yyyy-MM-dd) = 2001-01-01)):bigint>
 -- !query 8 output
 2
 
@@ -97,7 +97,7 @@ struct<count(id) FILTER (date_format(CAST(hiredate AS TIMESTAMP), yyyy-MM-dd) = 
 -- !query 9
 SELECT a, COUNT(b) FILTER (WHERE a >= 2) FROM testData GROUP BY a
 -- !query 9 schema
-struct<a:int,count(b) FILTER (a >= 2):bigint>
+struct<a:int,count(b) FILTER (WHERE (a >= 2)):bigint>
 -- !query 9 output
 1	0
 2	2
@@ -117,7 +117,7 @@ expression 'testdata.`a`' is neither present in the group by, nor is it an aggre
 -- !query 11
 SELECT COUNT(a) FILTER (WHERE a >= 0), COUNT(b) FILTER (WHERE a >= 3) FROM testData GROUP BY a
 -- !query 11 schema
-struct<count(a) FILTER (a >= 0):bigint,count(b) FILTER (a >= 3):bigint>
+struct<count(a) FILTER (WHERE (a >= 0)):bigint,count(b) FILTER (WHERE (a >= 3)):bigint>
 -- !query 11 output
 0	0
 2	0
@@ -128,7 +128,7 @@ struct<count(a) FILTER (a >= 0):bigint,count(b) FILTER (a >= 3):bigint>
 -- !query 12
 SELECT dept_id, SUM(salary) FILTER (WHERE hiredate > date "2003-01-01") FROM emp GROUP BY dept_id
 -- !query 12 schema
-struct<dept_id:int,sum(salary) FILTER (hiredate > DATE '2003-01-01'):double>
+struct<dept_id:int,sum(salary) FILTER (WHERE (hiredate > DATE '2003-01-01')):double>
 -- !query 12 output
 10	200.0
 100	400.0
@@ -141,7 +141,7 @@ NULL	NULL
 -- !query 13
 SELECT dept_id, SUM(salary) FILTER (WHERE hiredate > to_date("2003-01-01")) FROM emp GROUP BY dept_id
 -- !query 13 schema
-struct<dept_id:int,sum(salary) FILTER (hiredate > to_date('2003-01-01')):double>
+struct<dept_id:int,sum(salary) FILTER (WHERE (hiredate > to_date('2003-01-01'))):double>
 -- !query 13 output
 10	200.0
 100	400.0
@@ -154,7 +154,7 @@ NULL	NULL
 -- !query 14
 SELECT dept_id, SUM(salary) FILTER (WHERE hiredate > to_timestamp("2003-01-01 00:00:00")) FROM emp GROUP BY dept_id
 -- !query 14 schema
-struct<dept_id:int,sum(salary) FILTER (CAST(hiredate AS TIMESTAMP) > to_timestamp('2003-01-01 00:00:00')):double>
+struct<dept_id:int,sum(salary) FILTER (WHERE (CAST(hiredate AS TIMESTAMP) > to_timestamp('2003-01-01 00:00:00'))):double>
 -- !query 14 output
 10	200.0
 100	400.0
@@ -167,7 +167,7 @@ NULL	NULL
 -- !query 15
 SELECT dept_id, SUM(salary) FILTER (WHERE date_format(hiredate, "yyyy-MM-dd") > "2003-01-01") FROM emp GROUP BY dept_id
 -- !query 15 schema
-struct<dept_id:int,sum(salary) FILTER (date_format(CAST(hiredate AS TIMESTAMP), yyyy-MM-dd) > 2003-01-01):double>
+struct<dept_id:int,sum(salary) FILTER (WHERE (date_format(CAST(hiredate AS TIMESTAMP), yyyy-MM-dd) > 2003-01-01)):double>
 -- !query 15 output
 10	200.0
 100	400.0
@@ -180,7 +180,7 @@ NULL	NULL
 -- !query 16
 SELECT 'foo', COUNT(a) FILTER (WHERE b <= 2) FROM testData GROUP BY 1
 -- !query 16 schema
-struct<foo:string,count(a) FILTER (b <= 2):bigint>
+struct<foo:string,count(a) FILTER (WHERE (b <= 2)):bigint>
 -- !query 16 output
 foo	6
 
@@ -188,7 +188,7 @@ foo	6
 -- !query 17
 SELECT 'foo', SUM(salary) FILTER (WHERE hiredate >= date "2003-01-01") FROM emp GROUP BY 1
 -- !query 17 schema
-struct<foo:string,sum(salary) FILTER (hiredate >= DATE '2003-01-01'):double>
+struct<foo:string,sum(salary) FILTER (WHERE (hiredate >= DATE '2003-01-01')):double>
 -- !query 17 output
 foo	1350.0
 
@@ -196,7 +196,7 @@ foo	1350.0
 -- !query 18
 SELECT 'foo', SUM(salary) FILTER (WHERE hiredate >= to_date("2003-01-01")) FROM emp GROUP BY 1
 -- !query 18 schema
-struct<foo:string,sum(salary) FILTER (hiredate >= to_date('2003-01-01')):double>
+struct<foo:string,sum(salary) FILTER (WHERE (hiredate >= to_date('2003-01-01'))):double>
 -- !query 18 output
 foo	1350.0
 
@@ -204,7 +204,7 @@ foo	1350.0
 -- !query 19
 SELECT 'foo', SUM(salary) FILTER (WHERE hiredate >= to_timestamp("2003-01-01")) FROM emp GROUP BY 1
 -- !query 19 schema
-struct<foo:string,sum(salary) FILTER (CAST(hiredate AS TIMESTAMP) >= to_timestamp('2003-01-01')):double>
+struct<foo:string,sum(salary) FILTER (WHERE (CAST(hiredate AS TIMESTAMP) >= to_timestamp('2003-01-01'))):double>
 -- !query 19 output
 foo	1350.0
 
@@ -212,7 +212,7 @@ foo	1350.0
 -- !query 20
 select dept_id, count(distinct emp_name), count(distinct hiredate), sum(salary), sum(salary) filter (where id > 200) from emp group by dept_id
 -- !query 20 schema
-struct<dept_id:int,count(DISTINCT emp_name):bigint,count(DISTINCT hiredate):bigint,sum(salary):double,sum(salary) FILTER (id > 200):double>
+struct<dept_id:int,count(DISTINCT emp_name):bigint,count(DISTINCT hiredate):bigint,sum(salary):double,sum(salary) FILTER (WHERE (id > 200)):double>
 -- !query 20 output
 10	2	2	400.0	NULL
 100	2	2	800.0	800.0
@@ -225,7 +225,7 @@ NULL	1	1	400.0	400.0
 -- !query 21
 select dept_id, count(distinct emp_name), count(distinct hiredate), sum(salary), sum(salary) filter (where id + dept_id > 500) from emp group by dept_id
 -- !query 21 schema
-struct<dept_id:int,count(DISTINCT emp_name):bigint,count(DISTINCT hiredate):bigint,sum(salary):double,sum(salary) FILTER ((id + dept_id) > 500):double>
+struct<dept_id:int,count(DISTINCT emp_name):bigint,count(DISTINCT hiredate):bigint,sum(salary):double,sum(salary) FILTER (WHERE ((id + dept_id) > 500)):double>
 -- !query 21 output
 10	2	2	400.0	NULL
 100	2	2	800.0	800.0
@@ -238,7 +238,7 @@ NULL	1	1	400.0	NULL
 -- !query 22
 select dept_id, count(distinct emp_name), count(distinct hiredate), sum(salary) filter (where salary < 400.00D), sum(salary) filter (where id > 200) from emp group by dept_id
 -- !query 22 schema
-struct<dept_id:int,count(DISTINCT emp_name):bigint,count(DISTINCT hiredate):bigint,sum(salary) FILTER (salary < 400.0):double,sum(salary) FILTER (id > 200):double>
+struct<dept_id:int,count(DISTINCT emp_name):bigint,count(DISTINCT hiredate):bigint,sum(salary) FILTER (WHERE (salary < 400.0)):double,sum(salary) FILTER (WHERE (id > 200)):double>
 -- !query 22 output
 10	2	2	400.0	NULL
 100	2	2	NULL	800.0
@@ -251,7 +251,7 @@ NULL	1	1	NULL	400.0
 -- !query 23
 select dept_id, count(distinct emp_name), count(distinct hiredate), sum(salary) filter (where salary < 400.00D), sum(salary) filter (where id + dept_id > 500) from emp group by dept_id
 -- !query 23 schema
-struct<dept_id:int,count(DISTINCT emp_name):bigint,count(DISTINCT hiredate):bigint,sum(salary) FILTER (salary < 400.0):double,sum(salary) FILTER ((id + dept_id) > 500):double>
+struct<dept_id:int,count(DISTINCT emp_name):bigint,count(DISTINCT hiredate):bigint,sum(salary) FILTER (WHERE (salary < 400.0)):double,sum(salary) FILTER (WHERE ((id + dept_id) > 500)):double>
 -- !query 23 output
 10	2	2	400.0	NULL
 100	2	2	NULL	800.0
@@ -264,7 +264,7 @@ NULL	1	1	NULL	NULL
 -- !query 24
 SELECT 'foo', APPROX_COUNT_DISTINCT(a) FILTER (WHERE b >= 0) FROM testData WHERE a = 0 GROUP BY 1
 -- !query 24 schema
-struct<foo:string,approx_count_distinct(a) FILTER (b >= 0):bigint>
+struct<foo:string,approx_count_distinct(a) FILTER (WHERE (b >= 0)):bigint>
 -- !query 24 output
 
 
@@ -272,7 +272,7 @@ struct<foo:string,approx_count_distinct(a) FILTER (b >= 0):bigint>
 -- !query 25
 SELECT 'foo', MAX(STRUCT(a)) FILTER (WHERE b >= 1) FROM testData WHERE a = 0 GROUP BY 1
 -- !query 25 schema
-struct<foo:string,max(named_struct(a, a)) FILTER (b >= 1):struct<a:int>>
+struct<foo:string,max(named_struct(a, a)) FILTER (WHERE (b >= 1)):struct<a:int>>
 -- !query 25 output
 
 
@@ -280,7 +280,7 @@ struct<foo:string,max(named_struct(a, a)) FILTER (b >= 1):struct<a:int>>
 -- !query 26
 SELECT a + b, COUNT(b) FILTER (WHERE b >= 2) FROM testData GROUP BY a + b
 -- !query 26 schema
-struct<(a + b):int,count(b) FILTER (b >= 2):bigint>
+struct<(a + b):int,count(b) FILTER (WHERE (b >= 2)):bigint>
 -- !query 26 output
 2	0
 3	1
@@ -301,7 +301,7 @@ expression 'testdata.`a`' is neither present in the group by, nor is it an aggre
 -- !query 28
 SELECT a + 1 + 1, COUNT(b) FILTER (WHERE b > 0) FROM testData GROUP BY a + 1
 -- !query 28 schema
-struct<((a + 1) + 1):int,count(b) FILTER (b > 0):bigint>
+struct<((a + 1) + 1):int,count(b) FILTER (WHERE (b > 0)):bigint>
 -- !query 28 output
 3	2
 4	2
@@ -312,7 +312,7 @@ NULL	1
 -- !query 29
 SELECT a AS k, COUNT(b) FILTER (WHERE b > 0) FROM testData GROUP BY k
 -- !query 29 schema
-struct<k:int,count(b) FILTER (b > 0):bigint>
+struct<k:int,count(b) FILTER (WHERE (b > 0)):bigint>
 -- !query 29 output
 1	2
 2	2
@@ -327,7 +327,7 @@ SELECT emp.dept_id,
 FROM emp
 GROUP BY dept_id
 -- !query 30 schema
-struct<dept_id:int,avg(salary):double,avg(salary) FILTER (id > scalarsubquery()):double>
+struct<dept_id:int,avg(salary):double,avg(salary) FILTER (WHERE (id > scalarsubquery())):double>
 -- !query 30 output
 10	133.33333333333334	NULL
 100	400.0	400.0
@@ -344,7 +344,7 @@ SELECT emp.dept_id,
 FROM emp
 GROUP BY dept_id
 -- !query 31 schema
-struct<dept_id:int,avg(salary):double,avg(salary) FILTER (dept_id = scalarsubquery()):double>
+struct<dept_id:int,avg(salary):double,avg(salary) FILTER (WHERE (dept_id = scalarsubquery())):double>
 -- !query 31 output
 10	133.33333333333334	133.33333333333334
 100	400.0	NULL
@@ -366,7 +366,7 @@ GROUP BY dept_id
 struct<>
 -- !query 32 output
 org.apache.spark.sql.AnalysisException
-IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, avg(salary#x) AS avg(salary)#x, avg(salary#x) filter exists#x [dept_id#x] AS avg(salary) FILTER exists(dept_id)#x]
+IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, avg(salary#x) AS avg(salary)#x, avg(salary#x) filter (where exists#x [dept_id#x]) AS avg(salary) FILTER (WHERE exists(dept_id))#x]
 :  +- Project [state#x]
 :     +- Filter (dept_id#x = outer(dept_id#x))
 :        +- SubqueryAlias `dept`
@@ -392,7 +392,7 @@ GROUP BY dept_id
 struct<>
 -- !query 33 output
 org.apache.spark.sql.AnalysisException
-IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, sum(salary#x) AS sum(salary)#x, sum(salary#x) filter NOT exists#x [dept_id#x] AS sum(salary) FILTER (NOT exists(dept_id))#x]
+IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, sum(salary#x) AS sum(salary)#x, sum(salary#x) filter (where NOT exists#x [dept_id#x]) AS sum(salary) FILTER (WHERE (NOT exists(dept_id)))#x]
 :  +- Project [state#x]
 :     +- Filter (dept_id#x = outer(dept_id#x))
 :        +- SubqueryAlias `dept`
@@ -417,7 +417,7 @@ GROUP BY dept_id
 struct<>
 -- !query 34 output
 org.apache.spark.sql.AnalysisException
-IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, avg(salary#x) AS avg(salary)#x, avg(salary#x) filter dept_id#x IN (list#x []) AS avg(salary) FILTER (dept_id IN (listquery()))#x]
+IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, avg(salary#x) AS avg(salary)#x, avg(salary#x) filter (where dept_id#x IN (list#x [])) AS avg(salary) FILTER (WHERE (dept_id IN (listquery())))#x]
 :  +- Distinct
 :     +- Project [dept_id#x]
 :        +- SubqueryAlias `dept`
@@ -442,7 +442,7 @@ GROUP BY dept_id
 struct<>
 -- !query 35 output
 org.apache.spark.sql.AnalysisException
-IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, sum(salary#x) AS sum(salary)#x, sum(salary#x) filter NOT dept_id#x IN (list#x []) AS sum(salary) FILTER (NOT (dept_id IN (listquery())))#x]
+IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, sum(salary#x) AS sum(salary)#x, sum(salary#x) filter (where NOT dept_id#x IN (list#x [])) AS sum(salary) FILTER (WHERE (NOT (dept_id IN (listquery()))))#x]
 :  +- Distinct
 :     +- Project [dept_id#x]
 :        +- SubqueryAlias `dept`

--- a/sql/core/src/test/resources/sql-tests/results/group-by-filter.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-by-filter.sql.out
@@ -366,7 +366,7 @@ GROUP BY dept_id
 struct<>
 -- !query 32 output
 org.apache.spark.sql.AnalysisException
-IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, avg(salary#x) AS avg(salary)#x, avg(salary#x) filter (where exists#x [dept_id#x]) AS avg(salary) FILTER (WHERE exists(dept_id))#x]
+IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, avg(salary#x) AS avg(salary)#x, avg(salary#x) FILTER (WHERE exists#x [dept_id#x]) AS avg(salary) FILTER (WHERE exists(dept_id))#x]
 :  +- Project [state#x]
 :     +- Filter (dept_id#x = outer(dept_id#x))
 :        +- SubqueryAlias `dept`
@@ -392,7 +392,7 @@ GROUP BY dept_id
 struct<>
 -- !query 33 output
 org.apache.spark.sql.AnalysisException
-IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, sum(salary#x) AS sum(salary)#x, sum(salary#x) filter (where NOT exists#x [dept_id#x]) AS sum(salary) FILTER (WHERE (NOT exists(dept_id)))#x]
+IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, sum(salary#x) AS sum(salary)#x, sum(salary#x) FILTER (WHERE NOT exists#x [dept_id#x]) AS sum(salary) FILTER (WHERE (NOT exists(dept_id)))#x]
 :  +- Project [state#x]
 :     +- Filter (dept_id#x = outer(dept_id#x))
 :        +- SubqueryAlias `dept`
@@ -417,7 +417,7 @@ GROUP BY dept_id
 struct<>
 -- !query 34 output
 org.apache.spark.sql.AnalysisException
-IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, avg(salary#x) AS avg(salary)#x, avg(salary#x) filter (where dept_id#x IN (list#x [])) AS avg(salary) FILTER (WHERE (dept_id IN (listquery())))#x]
+IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, avg(salary#x) AS avg(salary)#x, avg(salary#x) FILTER (WHERE dept_id#x IN (list#x [])) AS avg(salary) FILTER (WHERE (dept_id IN (listquery())))#x]
 :  +- Distinct
 :     +- Project [dept_id#x]
 :        +- SubqueryAlias `dept`
@@ -442,7 +442,7 @@ GROUP BY dept_id
 struct<>
 -- !query 35 output
 org.apache.spark.sql.AnalysisException
-IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, sum(salary#x) AS sum(salary)#x, sum(salary#x) filter (where NOT dept_id#x IN (list#x [])) AS sum(salary) FILTER (WHERE (NOT (dept_id IN (listquery()))))#x]
+IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, sum(salary#x) AS sum(salary)#x, sum(salary#x) FILTER (WHERE NOT dept_id#x IN (list#x [])) AS sum(salary) FILTER (WHERE (NOT (dept_id IN (listquery()))))#x]
 :  +- Distinct
 :     +- Project [dept_id#x]
 :        +- SubqueryAlias `dept`

--- a/sql/core/src/test/resources/sql-tests/results/group-by-filter.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-by-filter.sql.out
@@ -51,13 +51,13 @@ SELECT a, COUNT(b) FILTER (WHERE a >= 2) FROM testData
 struct<>
 -- !query 3 output
 org.apache.spark.sql.AnalysisException
-grouping expressions sequence is empty, and 'testdata.`a`' is not an aggregate function. Wrap '(count(testdata.`b`) AS `count(b)`)' in windowing function(s) or wrap 'testdata.`a`' in first() (or first_value) if you don't care which value you get.;
+grouping expressions sequence is empty, and 'testdata.`a`' is not an aggregate function. Wrap '(count(testdata.`b`) FILTER (testdata.`a` >= 2) AS `count(b) FILTER (a >= 2)`)' in windowing function(s) or wrap 'testdata.`a`' in first() (or first_value) if you don't care which value you get.;
 
 
 -- !query 4
 SELECT COUNT(a) FILTER (WHERE a = 1), COUNT(b) FILTER (WHERE a > 1) FROM testData
 -- !query 4 schema
-struct<count(a):bigint,count(b):bigint>
+struct<count(a) FILTER (a = 1):bigint,count(b) FILTER (a > 1):bigint>
 -- !query 4 output
 2	4
 
@@ -65,7 +65,7 @@ struct<count(a):bigint,count(b):bigint>
 -- !query 5
 SELECT COUNT(id) FILTER (WHERE hiredate = date "2001-01-01") FROM emp
 -- !query 5 schema
-struct<count(id):bigint>
+struct<count(id) FILTER (hiredate = DATE '2001-01-01'):bigint>
 -- !query 5 output
 2
 
@@ -73,7 +73,7 @@ struct<count(id):bigint>
 -- !query 6
 SELECT COUNT(id) FILTER (WHERE hiredate = to_date('2001-01-01 00:00:00')) FROM emp
 -- !query 6 schema
-struct<count(id):bigint>
+struct<count(id) FILTER (hiredate = to_date('2001-01-01 00:00:00')):bigint>
 -- !query 6 output
 2
 
@@ -81,7 +81,7 @@ struct<count(id):bigint>
 -- !query 7
 SELECT COUNT(id) FILTER (WHERE hiredate = to_timestamp("2001-01-01 00:00:00")) FROM emp
 -- !query 7 schema
-struct<count(id):bigint>
+struct<count(id) FILTER (CAST(hiredate AS TIMESTAMP) = to_timestamp('2001-01-01 00:00:00')):bigint>
 -- !query 7 output
 2
 
@@ -89,7 +89,7 @@ struct<count(id):bigint>
 -- !query 8
 SELECT COUNT(id) FILTER (WHERE date_format(hiredate, "yyyy-MM-dd") = "2001-01-01") FROM emp
 -- !query 8 schema
-struct<count(id):bigint>
+struct<count(id) FILTER (date_format(CAST(hiredate AS TIMESTAMP), yyyy-MM-dd) = 2001-01-01):bigint>
 -- !query 8 output
 2
 
@@ -97,7 +97,7 @@ struct<count(id):bigint>
 -- !query 9
 SELECT a, COUNT(b) FILTER (WHERE a >= 2) FROM testData GROUP BY a
 -- !query 9 schema
-struct<a:int,count(b):bigint>
+struct<a:int,count(b) FILTER (a >= 2):bigint>
 -- !query 9 output
 1	0
 2	2
@@ -117,7 +117,7 @@ expression 'testdata.`a`' is neither present in the group by, nor is it an aggre
 -- !query 11
 SELECT COUNT(a) FILTER (WHERE a >= 0), COUNT(b) FILTER (WHERE a >= 3) FROM testData GROUP BY a
 -- !query 11 schema
-struct<count(a):bigint,count(b):bigint>
+struct<count(a) FILTER (a >= 0):bigint,count(b) FILTER (a >= 3):bigint>
 -- !query 11 output
 0	0
 2	0
@@ -128,7 +128,7 @@ struct<count(a):bigint,count(b):bigint>
 -- !query 12
 SELECT dept_id, SUM(salary) FILTER (WHERE hiredate > date "2003-01-01") FROM emp GROUP BY dept_id
 -- !query 12 schema
-struct<dept_id:int,sum(salary):double>
+struct<dept_id:int,sum(salary) FILTER (hiredate > DATE '2003-01-01'):double>
 -- !query 12 output
 10	200.0
 100	400.0
@@ -141,7 +141,7 @@ NULL	NULL
 -- !query 13
 SELECT dept_id, SUM(salary) FILTER (WHERE hiredate > to_date("2003-01-01")) FROM emp GROUP BY dept_id
 -- !query 13 schema
-struct<dept_id:int,sum(salary):double>
+struct<dept_id:int,sum(salary) FILTER (hiredate > to_date('2003-01-01')):double>
 -- !query 13 output
 10	200.0
 100	400.0
@@ -154,7 +154,7 @@ NULL	NULL
 -- !query 14
 SELECT dept_id, SUM(salary) FILTER (WHERE hiredate > to_timestamp("2003-01-01 00:00:00")) FROM emp GROUP BY dept_id
 -- !query 14 schema
-struct<dept_id:int,sum(salary):double>
+struct<dept_id:int,sum(salary) FILTER (CAST(hiredate AS TIMESTAMP) > to_timestamp('2003-01-01 00:00:00')):double>
 -- !query 14 output
 10	200.0
 100	400.0
@@ -167,7 +167,7 @@ NULL	NULL
 -- !query 15
 SELECT dept_id, SUM(salary) FILTER (WHERE date_format(hiredate, "yyyy-MM-dd") > "2003-01-01") FROM emp GROUP BY dept_id
 -- !query 15 schema
-struct<dept_id:int,sum(salary):double>
+struct<dept_id:int,sum(salary) FILTER (date_format(CAST(hiredate AS TIMESTAMP), yyyy-MM-dd) > 2003-01-01):double>
 -- !query 15 output
 10	200.0
 100	400.0
@@ -180,7 +180,7 @@ NULL	NULL
 -- !query 16
 SELECT 'foo', COUNT(a) FILTER (WHERE b <= 2) FROM testData GROUP BY 1
 -- !query 16 schema
-struct<foo:string,count(a):bigint>
+struct<foo:string,count(a) FILTER (b <= 2):bigint>
 -- !query 16 output
 foo	6
 
@@ -188,7 +188,7 @@ foo	6
 -- !query 17
 SELECT 'foo', SUM(salary) FILTER (WHERE hiredate >= date "2003-01-01") FROM emp GROUP BY 1
 -- !query 17 schema
-struct<foo:string,sum(salary):double>
+struct<foo:string,sum(salary) FILTER (hiredate >= DATE '2003-01-01'):double>
 -- !query 17 output
 foo	1350.0
 
@@ -196,7 +196,7 @@ foo	1350.0
 -- !query 18
 SELECT 'foo', SUM(salary) FILTER (WHERE hiredate >= to_date("2003-01-01")) FROM emp GROUP BY 1
 -- !query 18 schema
-struct<foo:string,sum(salary):double>
+struct<foo:string,sum(salary) FILTER (hiredate >= to_date('2003-01-01')):double>
 -- !query 18 output
 foo	1350.0
 
@@ -204,7 +204,7 @@ foo	1350.0
 -- !query 19
 SELECT 'foo', SUM(salary) FILTER (WHERE hiredate >= to_timestamp("2003-01-01")) FROM emp GROUP BY 1
 -- !query 19 schema
-struct<foo:string,sum(salary):double>
+struct<foo:string,sum(salary) FILTER (CAST(hiredate AS TIMESTAMP) >= to_timestamp('2003-01-01')):double>
 -- !query 19 output
 foo	1350.0
 
@@ -212,7 +212,7 @@ foo	1350.0
 -- !query 20
 select dept_id, count(distinct emp_name), count(distinct hiredate), sum(salary), sum(salary) filter (where id > 200) from emp group by dept_id
 -- !query 20 schema
-struct<dept_id:int,count(DISTINCT emp_name):bigint,count(DISTINCT hiredate):bigint,sum(salary):double,sum(salary):double>
+struct<dept_id:int,count(DISTINCT emp_name):bigint,count(DISTINCT hiredate):bigint,sum(salary):double,sum(salary) FILTER (id > 200):double>
 -- !query 20 output
 10	2	2	400.0	NULL
 100	2	2	800.0	800.0
@@ -225,7 +225,7 @@ NULL	1	1	400.0	400.0
 -- !query 21
 select dept_id, count(distinct emp_name), count(distinct hiredate), sum(salary), sum(salary) filter (where id + dept_id > 500) from emp group by dept_id
 -- !query 21 schema
-struct<dept_id:int,count(DISTINCT emp_name):bigint,count(DISTINCT hiredate):bigint,sum(salary):double,sum(salary):double>
+struct<dept_id:int,count(DISTINCT emp_name):bigint,count(DISTINCT hiredate):bigint,sum(salary):double,sum(salary) FILTER ((id + dept_id) > 500):double>
 -- !query 21 output
 10	2	2	400.0	NULL
 100	2	2	800.0	800.0
@@ -238,7 +238,7 @@ NULL	1	1	400.0	NULL
 -- !query 22
 select dept_id, count(distinct emp_name), count(distinct hiredate), sum(salary) filter (where salary < 400.00D), sum(salary) filter (where id > 200) from emp group by dept_id
 -- !query 22 schema
-struct<dept_id:int,count(DISTINCT emp_name):bigint,count(DISTINCT hiredate):bigint,sum(salary):double,sum(salary):double>
+struct<dept_id:int,count(DISTINCT emp_name):bigint,count(DISTINCT hiredate):bigint,sum(salary) FILTER (salary < 400.0):double,sum(salary) FILTER (id > 200):double>
 -- !query 22 output
 10	2	2	400.0	NULL
 100	2	2	NULL	800.0
@@ -251,7 +251,7 @@ NULL	1	1	NULL	400.0
 -- !query 23
 select dept_id, count(distinct emp_name), count(distinct hiredate), sum(salary) filter (where salary < 400.00D), sum(salary) filter (where id + dept_id > 500) from emp group by dept_id
 -- !query 23 schema
-struct<dept_id:int,count(DISTINCT emp_name):bigint,count(DISTINCT hiredate):bigint,sum(salary):double,sum(salary):double>
+struct<dept_id:int,count(DISTINCT emp_name):bigint,count(DISTINCT hiredate):bigint,sum(salary) FILTER (salary < 400.0):double,sum(salary) FILTER ((id + dept_id) > 500):double>
 -- !query 23 output
 10	2	2	400.0	NULL
 100	2	2	NULL	800.0
@@ -264,7 +264,7 @@ NULL	1	1	NULL	NULL
 -- !query 24
 SELECT 'foo', APPROX_COUNT_DISTINCT(a) FILTER (WHERE b >= 0) FROM testData WHERE a = 0 GROUP BY 1
 -- !query 24 schema
-struct<foo:string,approx_count_distinct(a):bigint>
+struct<foo:string,approx_count_distinct(a) FILTER (b >= 0):bigint>
 -- !query 24 output
 
 
@@ -272,7 +272,7 @@ struct<foo:string,approx_count_distinct(a):bigint>
 -- !query 25
 SELECT 'foo', MAX(STRUCT(a)) FILTER (WHERE b >= 1) FROM testData WHERE a = 0 GROUP BY 1
 -- !query 25 schema
-struct<foo:string,max(named_struct(a, a)):struct<a:int>>
+struct<foo:string,max(named_struct(a, a)) FILTER (b >= 1):struct<a:int>>
 -- !query 25 output
 
 
@@ -280,7 +280,7 @@ struct<foo:string,max(named_struct(a, a)):struct<a:int>>
 -- !query 26
 SELECT a + b, COUNT(b) FILTER (WHERE b >= 2) FROM testData GROUP BY a + b
 -- !query 26 schema
-struct<(a + b):int,count(b):bigint>
+struct<(a + b):int,count(b) FILTER (b >= 2):bigint>
 -- !query 26 output
 2	0
 3	1
@@ -301,7 +301,7 @@ expression 'testdata.`a`' is neither present in the group by, nor is it an aggre
 -- !query 28
 SELECT a + 1 + 1, COUNT(b) FILTER (WHERE b > 0) FROM testData GROUP BY a + 1
 -- !query 28 schema
-struct<((a + 1) + 1):int,count(b):bigint>
+struct<((a + 1) + 1):int,count(b) FILTER (b > 0):bigint>
 -- !query 28 output
 3	2
 4	2
@@ -312,7 +312,7 @@ NULL	1
 -- !query 29
 SELECT a AS k, COUNT(b) FILTER (WHERE b > 0) FROM testData GROUP BY k
 -- !query 29 schema
-struct<k:int,count(b):bigint>
+struct<k:int,count(b) FILTER (b > 0):bigint>
 -- !query 29 output
 1	2
 2	2
@@ -327,7 +327,7 @@ SELECT emp.dept_id,
 FROM emp
 GROUP BY dept_id
 -- !query 30 schema
-struct<dept_id:int,avg(salary):double,avg(salary):double>
+struct<dept_id:int,avg(salary):double,avg(salary) FILTER (id > scalarsubquery()):double>
 -- !query 30 output
 10	133.33333333333334	NULL
 100	400.0	400.0
@@ -344,7 +344,7 @@ SELECT emp.dept_id,
 FROM emp
 GROUP BY dept_id
 -- !query 31 schema
-struct<dept_id:int,avg(salary):double,avg(salary):double>
+struct<dept_id:int,avg(salary):double,avg(salary) FILTER (dept_id = scalarsubquery()):double>
 -- !query 31 output
 10	133.33333333333334	133.33333333333334
 100	400.0	NULL
@@ -366,7 +366,7 @@ GROUP BY dept_id
 struct<>
 -- !query 32 output
 org.apache.spark.sql.AnalysisException
-IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, avg(salary#x) AS avg(salary)#x, avg(salary#x) AS avg(salary)#x]
+IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, avg(salary#x) AS avg(salary)#x, avg(salary#x) filter exists#x [dept_id#x] AS avg(salary) FILTER exists(dept_id)#x]
 :  +- Project [state#x]
 :     +- Filter (dept_id#x = outer(dept_id#x))
 :        +- SubqueryAlias `dept`
@@ -392,7 +392,7 @@ GROUP BY dept_id
 struct<>
 -- !query 33 output
 org.apache.spark.sql.AnalysisException
-IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, sum(salary#x) AS sum(salary)#x, sum(salary#x) AS sum(salary)#x]
+IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, sum(salary#x) AS sum(salary)#x, sum(salary#x) filter NOT exists#x [dept_id#x] AS sum(salary) FILTER (NOT exists(dept_id))#x]
 :  +- Project [state#x]
 :     +- Filter (dept_id#x = outer(dept_id#x))
 :        +- SubqueryAlias `dept`
@@ -417,7 +417,7 @@ GROUP BY dept_id
 struct<>
 -- !query 34 output
 org.apache.spark.sql.AnalysisException
-IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, avg(salary#x) AS avg(salary)#x, avg(salary#x) AS avg(salary)#x]
+IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, avg(salary#x) AS avg(salary)#x, avg(salary#x) filter dept_id#x IN (list#x []) AS avg(salary) FILTER (dept_id IN (listquery()))#x]
 :  +- Distinct
 :     +- Project [dept_id#x]
 :        +- SubqueryAlias `dept`
@@ -442,7 +442,7 @@ GROUP BY dept_id
 struct<>
 -- !query 35 output
 org.apache.spark.sql.AnalysisException
-IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, sum(salary#x) AS sum(salary)#x, sum(salary#x) AS sum(salary)#x]
+IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, sum(salary#x) AS sum(salary)#x, sum(salary#x) filter NOT dept_id#x IN (list#x []) AS sum(salary) FILTER (NOT (dept_id IN (listquery())))#x]
 :  +- Distinct
 :     +- Project [dept_id#x]
 :        +- SubqueryAlias `dept`

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/aggregates_part3.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/aggregates_part3.sql.out
@@ -14,7 +14,7 @@ It is not allowed to use an aggregate function in the argument of another aggreg
 -- !query 1
 select min(unique1) filter (where unique1 > 100) from tenk1
 -- !query 1 schema
-struct<min(unique1) FILTER (unique1 > 100):int>
+struct<min(unique1) FILTER (WHERE (unique1 > 100)):int>
 -- !query 1 output
 101
 
@@ -22,7 +22,7 @@ struct<min(unique1) FILTER (unique1 > 100):int>
 -- !query 2
 select sum(1/ten) filter (where ten > 0) from tenk1
 -- !query 2 schema
-struct<sum((CAST(1 AS DOUBLE) / CAST(ten AS DOUBLE))) FILTER (ten > 0):double>
+struct<sum((CAST(1 AS DOUBLE) / CAST(ten AS DOUBLE))) FILTER (WHERE (ten > 0)):double>
 -- !query 2 output
 2828.9682539682954
 

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/aggregates_part3.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/aggregates_part3.sql.out
@@ -14,7 +14,7 @@ It is not allowed to use an aggregate function in the argument of another aggreg
 -- !query 1
 select min(unique1) filter (where unique1 > 100) from tenk1
 -- !query 1 schema
-struct<min(unique1):int>
+struct<min(unique1) FILTER (unique1 > 100):int>
 -- !query 1 output
 101
 
@@ -22,7 +22,7 @@ struct<min(unique1):int>
 -- !query 2
 select sum(1/ten) filter (where ten > 0) from tenk1
 -- !query 2 schema
-struct<sum((CAST(1 AS DOUBLE) / CAST(ten AS DOUBLE))):double>
+struct<sum((CAST(1 AS DOUBLE) / CAST(ten AS DOUBLE))) FILTER (ten > 0):double>
 -- !query 2 output
 2828.9682539682954
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This pr intends to add filter information in the explain output of an aggregate (This is a follow-up of #26656).

Without this pr:
```
scala> sql("select k, SUM(v) filter (where v > 3) from t group by k").explain(true)
== Parsed Logical Plan ==
'Aggregate ['k], ['k, unresolvedalias('SUM('v, ('v > 3)), None)]
+- 'UnresolvedRelation [t]

== Analyzed Logical Plan ==
k: int, sum(v): bigint
Aggregate [k#0], [k#0, sum(cast(v#1 as bigint)) AS sum(v)#3L]
+- SubqueryAlias `default`.`t`
   +- Relation[k#0,v#1] parquet

== Optimized Logical Plan ==
Aggregate [k#0], [k#0, sum(cast(v#1 as bigint)) AS sum(v)#3L]
+- Relation[k#0,v#1] parquet

== Physical Plan ==
HashAggregate(keys=[k#0], functions=[sum(cast(v#1 as bigint))], output=[k#0, sum(v)#3L])
+- Exchange hashpartitioning(k#0, 200), true, [id=#20]
   +- HashAggregate(keys=[k#0], functions=[partial_sum(cast(v#1 as bigint))], output=[k#0, sum#7L])
      +- *(1) ColumnarToRow
         +- FileScan parquet default.t[k#0,v#1] Batched: true, DataFilters: [], Format: Parquet, Location: InMemoryFileIndex[file:/Users/maropu/Repositories/spark/spark-master/spark-warehouse/t], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<k:int,v:int>


scala> sql("select k, SUM(v) filter (where v > 3) from t group by k").show()
+---+------+                                                                    
|  k|sum(v)|
+---+------+
+---+------+
```

With this pr:
```
scala> sql("select k, SUM(v) filter (where v > 3) from t group by k").explain(true)
== Parsed Logical Plan ==
'Aggregate ['k], ['k, unresolvedalias('SUM('v, ('v > 3)), None)]
+- 'UnresolvedRelation [t]

== Analyzed Logical Plan ==
k: int, sum(v) FILTER (v > 3): bigint
Aggregate [k#0], [k#0, sum(cast(v#1 as bigint)) filter (v#1 > 3) AS sum(v) FILTER (v > 3)#5L]
+- SubqueryAlias `default`.`t`
   +- Relation[k#0,v#1] parquet

== Optimized Logical Plan ==
Aggregate [k#0], [k#0, sum(cast(v#1 as bigint)) filter (v#1 > 3) AS sum(v) FILTER (v > 3)#5L]
+- Relation[k#0,v#1] parquet

== Physical Plan ==
HashAggregate(keys=[k#0], functions=[sum(cast(v#1 as bigint))], output=[k#0, sum(v) FILTER (v > 3)#5L])
+- Exchange hashpartitioning(k#0, 200), true, [id=#20]
   +- HashAggregate(keys=[k#0], functions=[partial_sum(cast(v#1 as bigint)) filter (v#1 > 3)], output=[k#0, sum#9L])
      +- *(1) ColumnarToRow
         +- FileScan parquet default.t[k#0,v#1] Batched: true, DataFilters: [], Format: Parquet, Location: InMemoryFileIndex[file:/Users/maropu/Repositories/spark/spark-master/spark-warehouse/t], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<k:int,v:int>


scala> sql("select k, SUM(v) filter (where v > 3) from t group by k").show()
+---+---------------------+                                                     
|  k|sum(v) FILTER (v > 3)|
+---+---------------------+
+---+---------------------+
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
For better usability.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Manually.
