### PR TITLE
[SPARK-30246][CORE][SHUFFLE] fix spark external shuffle service memory leak

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/server/OneForOneStreamManager.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/OneForOneStreamManager.java
@@ -45,7 +45,7 @@ public class OneForOneStreamManager extends StreamManager {
   private final ConcurrentHashMap<Long, StreamState> streams;
 
   /** State of a single stream. */
-  private static class StreamState {
+  public static class StreamState {
     final String appId;
     final Iterator<ManagedBuffer> buffers;
 
@@ -59,10 +59,18 @@ public class OneForOneStreamManager extends StreamManager {
     // Used to keep track of the number of chunks being transferred and not finished yet.
     volatile long chunksBeingTransferred = 0L;
 
-    StreamState(String appId, Iterator<ManagedBuffer> buffers, Channel channel) {
+    public StreamState(String appId, Iterator<ManagedBuffer> buffers, Channel channel) {
       this.appId = appId;
       this.buffers = Preconditions.checkNotNull(buffers);
       this.associatedChannel = channel;
+    }
+
+    public String getAppId() {
+      return appId;
+    }
+
+    public Iterator<ManagedBuffer> getBuffers() {
+      return buffers;
     }
   }
 
@@ -207,5 +215,9 @@ public class OneForOneStreamManager extends StreamManager {
   @VisibleForTesting
   public int numStreamStates() {
     return streams.size();
+  }
+
+  public ConcurrentHashMap<Long, StreamState> getStreams() {
+    return streams;
   }
 }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockHandler.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockHandler.java
@@ -201,7 +201,8 @@ public class ExternalBlockHandler extends RpcHandler {
     for (Map.Entry<Long, StreamState> entry: streams.entrySet()) {
       StreamState state = entry.getValue();
       if (state.getAppId().equals(appId)) {
-        logger.warn("Found finished app: {} , but streamState is still in memory, clean it now", appId);
+        logger.warn("Found finished app: {} , " +
+                "but streamState is still in memory, clean it now", appId);
         streams.remove(entry.getKey());
 
         // Release all remaining buffers.

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
@@ -76,6 +76,10 @@ public class ExternalShuffleBlockResolver {
   @VisibleForTesting
   final ConcurrentMap<AppExecId, ExecutorShuffleInfo> executors;
 
+  public ConcurrentMap<AppExecId, ExecutorShuffleInfo> getExecutors() {
+    return executors;
+  }
+
   /**
    *  Caches index file information so that we can avoid open/close the index files
    *  for each block fetch.

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalBlockHandlerSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalBlockHandlerSuite.java
@@ -169,7 +169,8 @@ public class ExternalBlockHandlerSuite {
     when(client.getClientId()).thenReturn("app0");
 
     // add app info to executors
-    ExecutorShuffleInfo shuffleInfo = new ExecutorShuffleInfo(new String[] {"/a", "/b"}, 16, "sort");
+    ExecutorShuffleInfo shuffleInfo = new ExecutorShuffleInfo(new String[] {"/a", "/b"},
+            16, "sort");
     ConcurrentMap<AppExecId, ExecutorShuffleInfo> executors =  Maps.newConcurrentMap();
     executors.put(new AppExecId("app0", "exec1"), shuffleInfo);
     when(blockResolver.getExecutors()).thenReturn(executors);
@@ -239,7 +240,8 @@ public class ExternalBlockHandlerSuite {
   @Test
   public void testDoNotRegisterStreamWhenAppHasFinished() {
     // add app info to executors
-    ExecutorShuffleInfo shuffleInfo = new ExecutorShuffleInfo(new String[] {"/a", "/b"}, 16, "sort");
+    ExecutorShuffleInfo shuffleInfo = new ExecutorShuffleInfo(new String[] {"/a", "/b"},
+            16, "sort");
     ConcurrentMap<AppExecId, ExecutorShuffleInfo> executors =  Maps.newConcurrentMap();
     executors.put(new AppExecId("app0", "exec1"), shuffleInfo);
     when(blockResolver.getExecutors()).thenReturn(executors);
@@ -268,13 +270,16 @@ public class ExternalBlockHandlerSuite {
   @Test
   public void testWhenApplicationRemovedCleanRelatedStreamState() {
     OneForOneStreamManager oneForOneStreamManager = new OneForOneStreamManager();
-    ExternalBlockHandler externalBlockHandler = new ExternalBlockHandler(oneForOneStreamManager, blockResolver);
+    ExternalBlockHandler externalBlockHandler = new ExternalBlockHandler(
+            oneForOneStreamManager,
+            blockResolver);
     Channel dummyChannel = mock(Channel.class, RETURNS_SMART_NULLS);
 
     List<ManagedBuffer> buffers = new ArrayList<>();
     buffers.add(new NioManagedBuffer(ByteBuffer.wrap(new byte[3])));
     buffers.add(new NioManagedBuffer(ByteBuffer.wrap(new byte[7])));
-    oneForOneStreamManager.getStreams().put(1L, new StreamState("app0", buffers.iterator(), dummyChannel));
+    oneForOneStreamManager.getStreams().put(1L,
+            new StreamState("app0", buffers.iterator(), dummyChannel));
     assertEquals(1, oneForOneStreamManager.numStreamStates());
 
     externalBlockHandler.applicationRemoved("app0", false);


### PR DESCRIPTION
### What changes were proposed in this pull request?
An app terminated abnormal sometimes may cause shuffe service memory leak. In one of our production cases, the app failed for Stage cancelled as SparkContext has already shut down. the strange is there are still requests for fetch shuffle data and cause error in server side as below:
```
2019-12-08 22:23:33,375 ERROR server.TransportRequestHandler (TransportRequestHandler.java:processFetchRequest(132)) - Error opening block StreamChunkId{streamId=1902064894814, chunkIndex=0} for request from /10.221.115.175:38582
java.lang.RuntimeException: Executor is not registered (appId=application_1574499669561_954327, execId=4514)
```
the client sie also show corresponding log like this:
```
org.apache.spark.shuffle.FetchFailedException: Failure while fetching StreamChunkId{streamId=1902064894814, chunkIndex=0}: java.lang.RuntimeException: Executor is not registered (appId=application_1574499669561_954327, execId=4514)
```
in some cases, the request for `OpenBlocks` or `FetchShuffleBlocks` is still on the fly. In the code `ExternalBlockHandler#handleMessage`, it will register a `StreamState` to `OneForOneStreamManager#streams`, then reply an success response to client unconditionally , the client receive the response and then fire `ChunkFetchRequest` to fetch chunk, but at this time, the app has got event `APPLICATION_STOP` and executed `ExternalShuffleService#applicationRemoved` method to clean the app's `ExecutorShuffleInfo`, this made `Executor is not registered` error happended. even though when the client channel is closing, the `TransportRequestHandler#channelInactive` was called to clean the StreamState with relate channel, but when cleanning the `StreamState buffter`, it also lookup `ManagedBuffer` with` appId` and `execId` info which have been cleaned in executors object. we can also find the log:  `StreamManager connectionTerminated() callback failed` in NM's log file.

so, when an `OpenBlocks` request come, we should lookup `ExternalShuffleBlockResolver#executors` , if the realted app is exited, we should not registering a `StreamState` then just close the client and reply a faild response. 
In addition, when an app get `APPLICATION_STOP` to call `applicationRemoved`, we should clean the the related `streamState` before `ExecutorShuffleInfo` has been cleaned, this is what the PR changes and prevents the shuffle service memory leak.

### Why are the changes needed?
The external shuffle service memory leak has a great impact on cluster with dynanic on and may cause NM crash.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
add ut