### PR TITLE
[SPARK-30452][ML][PYSPARK][FOLLOWUP]  Change IsotonicRegressionModel.numFeatures to property

### DIFF
--- a/python/pyspark/ml/regression.py
+++ b/python/pyspark/ml/regression.py
@@ -593,7 +593,7 @@ class IsotonicRegression(JavaEstimator, _IsotonicRegressionParams, HasWeightCol,
     >>> model = ir.fit(df)
     >>> model.setFeaturesCol("features")
     IsotonicRegressionModel...
-    >>> model.numFeatures()
+    >>> model.numFeatures
     1
     >>> test0 = spark.createDataFrame([(Vectors.dense(-1.0),)], ["features"])
     >>> model.transform(test0).head().prediction
@@ -731,6 +731,7 @@ class IsotonicRegressionModel(JavaModel, _IsotonicRegressionParams, JavaMLWritab
         """
         return self._call_java("predictions")
 
+    @property
     @since("3.0.0")
     def numFeatures(self):
         """


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Change `IsotonicRegressionModel.numFeatures` from plain method to property.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Consistency. Right now we use `numFeatures` in two other places in `pyspark.ml`

https://github.com/apache/spark/blob/0f3d744c3f19750ab03eeae3606e122dcffae5df/python/pyspark/ml/feature.py#L4289-L4291
https://github.com/apache/spark/blob/0f3d744c3f19750ab03eeae3606e122dcffae5df/python/pyspark/ml/wrapper.py#L437-L439

and one in `pyspark,mllib`

https://github.com/apache/spark/blob/0f3d744c3f19750ab03eeae3606e122dcffae5df/python/pyspark/mllib/classification.py#L177-L179

each time as a property.

Additionally all similar values in `ml` are exposed as properties, for example

https://github.com/apache/spark/blob/0f3d744c3f19750ab03eeae3606e122dcffae5df/python/pyspark/ml/regression.py#L451-L453

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

Yes, but current API hasn't been released yet.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Existing doctests.