### PR TITLE
[SPARK-18886][CORE] Make Locality wait time measure resource under utilization due to delay scheduling.

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -543,6 +543,11 @@ package object config {
       .version("1.2.0")
       .fallbackConf(DYN_ALLOCATION_SCHEDULER_BACKLOG_TIMEOUT)
 
+  private[spark] val LEGACY_LOCALITY_WAIT_RESET =
+    ConfigBuilder("spark.locality.wait.legacyResetOnTaskLaunch")
+    .booleanConf
+    .createWithDefault(false)
+
   private[spark] val LOCALITY_WAIT = ConfigBuilder("spark.locality.wait")
     .version("0.5.0")
     .timeConf(TimeUnit.MILLISECONDS)

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -545,6 +545,11 @@ package object config {
 
   private[spark] val LEGACY_LOCALITY_WAIT_RESET =
     ConfigBuilder("spark.locality.wait.legacyResetOnTaskLaunch")
+    .doc("Whether to use the legacy behavior of locality wait, which resets the delay timer " +
+      "anytime a task is scheduled. See Delay Scheduling section of TaskSchedulerImpl's class " +
+      "documentation for more details.")
+    .internal()
+    .version("3.0.0")
     .booleanConf
     .createWithDefault(false)
 

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -68,7 +68,7 @@ import org.apache.spark.util.{AccumulatorV2, Clock, SystemClock, ThreadUtils, Ut
  *  parameter "isAllFreeResources" is set to true. A "delay scheduling reject" is when a resource
  *  is not utilized despite there being pending tasks (implemented inside [[TaskSetManager]]).
  *  The legacy heuristic only measured the time since the [[TaskSetManager]] last launched a task,
- *  and can be re-enabled by setting [[LEGACY_LOCALITY_WAIT_RESET]] to true.
+ *  and can be re-enabled by setting spark.locality.wait.legacyResetOnTaskLaunch to true.
  */
 private[spark] class TaskSchedulerImpl(
     val sc: SparkContext,

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -57,6 +57,18 @@ import org.apache.spark.util.{AccumulatorV2, Clock, SystemClock, ThreadUtils, Ut
  *   * Periodic revival of all offers from the CoarseGrainedSchedulerBackend, to accommodate delay
  *      scheduling
  *   * task-result-getter threads
+ *
+ * Delay Scheduling:
+ *  Delay scheduling is an optimization that sacrifices job fairness for data locality in order to
+ *  improve cluster and workload throughput. One useful definition of "delay" is how much time
+ *  has passed since the TaskSet was using its fair share of resources. Since it is impractical to
+ *  calculate this delay without a full simulation, the heuristic used is the time since the
+ *  TaskSetManager last launched a task and has not rejected any resources due to delay scheduling
+ *  since it was last offered its "fair share". A "fair share" offer is when [[resourceOffers]]'s
+ *  parameter "isAllFreeResources" is set to true. A "delay scheduling reject" is when a resource
+ *  is not utilized despite there being pending tasks (implemented inside [[TaskSetManager]]).
+ *  The legacy heuristic only measured the time since the [[TaskSetManager]] last launched a task,
+ *  and can be re-enabled by setting [[LEGACY_LOCALITY_WAIT_RESET]] to true.
  */
 private[spark] class TaskSchedulerImpl(
     val sc: SparkContext,

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -384,7 +384,7 @@ private[spark] class TaskSchedulerImpl(
             val prof = sc.resourceProfileManager.resourceProfileFromId(taskSetRpID)
             val taskCpus = ResourceProfile.getTaskCpusOrDefaultForProfile(prof, conf)
             val (taskDescOption, didReject) =
-              taskSet.resourceOffer(execId, host, maxLocality, availableResources(i))
+              taskSet.resourceOffer(execId, host, maxLocality, taskResAssignments)
             noDelayScheduleRejects &= !didReject
             for (task <- taskDescOption) {
               tasks(i) += task

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -99,9 +99,9 @@ private[spark] class TaskSchedulerImpl(
   private val taskSetsByStageIdAndAttempt = new HashMap[Int, HashMap[Int, TaskSetManager]]
 
   // keyed by task set stage id
-  // value is true if there have been no resources rejected due to delay scheduling
-  // since the last "full" resource offer
-  private val noDelayScheduleRejects = new mutable.HashMap[Int, Boolean]()
+  // value is true if the task set's locality wait timer was reset on the last resource offer
+  private val resetOnPreviousOffer = new mutable.HashMap[Int, Boolean]()
+  private val legacyLocalityWaitReset = conf.get(LEGACY_LOCALITY_WAIT_RESET)
 
   // Protected by `this`
   private[scheduler] val taskIdToTaskSetManager = new ConcurrentHashMap[Long, TaskSetManager]
@@ -324,7 +324,7 @@ private[spark] class TaskSchedulerImpl(
         taskSetsByStageIdAndAttempt -= manager.taskSet.stageId
       }
     }
-    noDelayScheduleRejects -= manager.taskSet.stageId
+    resetOnPreviousOffer -= manager.taskSet.stageId
     manager.parent.removeSchedulable(manager)
     logInfo(s"Removed TaskSet ${manager.taskSet.id}, whose tasks have all completed, from pool" +
       s" ${manager.parent.name}")
@@ -340,7 +340,7 @@ private[spark] class TaskSchedulerImpl(
       addressesWithDescs: ArrayBuffer[(String, TaskDescription)]) :
   (Boolean, Boolean, Option[TaskLocality]) = {
     var launchedTask = false
-    var hasDelayScheduleReject = false
+    var noDelayScheduleRejects = true
     var minLaunchedLocality: Option[TaskLocality] = None
     // nodes and executors that are blacklisted for the entire application have already been
     // filtered out by this point
@@ -357,9 +357,9 @@ private[spark] class TaskSchedulerImpl(
           try {
             val prof = sc.resourceProfileManager.resourceProfileFromId(taskSetRpID)
             val taskCpus = ResourceProfile.getTaskCpusOrDefaultForProfile(prof, conf)
-            val (taskDescOption, reject) = taskSet.resourceOfferInternal(execId, host, maxLocality,
-              taskResAssignments)
-            hasDelayScheduleReject |= reject
+            val (taskDescOption, didReject) =
+              taskSet.resourceOfferInternal(execId, host, maxLocality, availableResources(i))
+            noDelayScheduleRejects &= !didReject
             for (task <- taskDescOption) {
               tasks(i) += task
               val tid = task.taskId
@@ -392,12 +392,12 @@ private[spark] class TaskSchedulerImpl(
               logError(s"Resource offer failed, task set ${taskSet.name} was not serializable")
               // Do not offer resources for this task, but don't throw an error to allow other
               // task sets to be submitted.
-              return (launchedTask, hasDelayScheduleReject, minLaunchedLocality)
+              return (launchedTask, noDelayScheduleRejects, minLaunchedLocality)
           }
         }
       }
     }
-    (launchedTask, hasDelayScheduleReject, minLaunchedLocality)
+    (launchedTask, noDelayScheduleRejects, minLaunchedLocality)
   }
 
   /**
@@ -499,7 +499,7 @@ private[spark] class TaskSchedulerImpl(
    */
   def resourceOffers(
       offers: IndexedSeq[WorkerOffer],
-      isAllFreeResources: Boolean = false): Seq[Seq[TaskDescription]] = synchronized {
+      isAllFreeResources: Boolean = true): Seq[Seq[TaskDescription]] = synchronized {
     // Mark each slave as alive and remember its hostname
     // Also track if new executor is added
     var newExecAvail = false
@@ -572,30 +572,32 @@ private[spark] class TaskSchedulerImpl(
           s"number of available slots is $numBarrierSlotsAvailable.")
       } else {
         var launchedAnyTask = false
-        var hadAnyDelaySchedulingReject = false
+        var noDelaySchedulingRejects = true
         var globalMinLocality: Option[TaskLocality] = None
         // Record all the executor IDs assigned barrier tasks on.
         val addressesWithDescs = ArrayBuffer[(String, TaskDescription)]()
         for (currentMaxLocality <- taskSet.myLocalityLevels) {
           var launchedTaskAtCurrentMaxLocality = false
           do {
-            val (launched, hadDelayScheduleReject, minLocality) = resourceOfferSingleTaskSet(
+            val (launched, noDelayScheduleReject, minLocality) = resourceOfferSingleTaskSet(
               taskSet, currentMaxLocality, shuffledOffers, availableCpus,
               availableResources, tasks, addressesWithDescs)
             launchedTaskAtCurrentMaxLocality = launched
             launchedAnyTask |= launchedTaskAtCurrentMaxLocality
-            hadAnyDelaySchedulingReject |= hadDelayScheduleReject
+            noDelaySchedulingRejects &= noDelayScheduleReject
             globalMinLocality = minTaskLocality(globalMinLocality, minLocality)
           } while (launchedTaskAtCurrentMaxLocality)
         }
 
-        if (!hadAnyDelaySchedulingReject) {
-          if (isAllFreeResources || noDelayScheduleRejects.getOrElse(taskSet.stageId, true)) {
-            taskSet.resetDelayScheduleTimer(globalMinLocality)
-            noDelayScheduleRejects.update(taskSet.stageId, true)
+        if (!legacyLocalityWaitReset) {
+          if (noDelaySchedulingRejects && launchedAnyTask) {
+            if (isAllFreeResources || resetOnPreviousOffer.getOrElse(taskSet.stageId, true)) {
+              taskSet.resetDelayScheduleTimer(globalMinLocality)
+              resetOnPreviousOffer.update(taskSet.stageId, true)
+            }
+          } else {
+            resetOnPreviousOffer.update(taskSet.stageId, false)
           }
-        } else {
-          noDelayScheduleRejects.update(taskSet.stageId, false)
         }
 
         if (!launchedAnyTask) {

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -345,7 +345,7 @@ private[spark] class TaskSchedulerImpl(
   /**
    * Offers resources to a single [[TaskSetManager]] at a given max allowed [[TaskLocality]].
    *
-   * @param taskSet task set to offer resources to
+   * @param taskSet task set manager to offer resources to
    * @param maxLocality max locality to allow when scheduling
    * @param shuffledOffers shuffled resource offers to use for scheduling,
    *                       remaining resources are tracked by below fields as tasks are scheduled
@@ -503,7 +503,7 @@ private[spark] class TaskSchedulerImpl(
     }.sum
   }
 
-  def minTaskLocality(
+  private def minTaskLocality(
       l1: Option[TaskLocality],
       l2: Option[TaskLocality]) : Option[TaskLocality] = {
     if (l1.isEmpty) {

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -98,9 +98,9 @@ private[spark] class TaskSchedulerImpl(
   // on this class.  Protected by `this`
   private val taskSetsByStageIdAndAttempt = new HashMap[Int, HashMap[Int, TaskSetManager]]
 
-  // keyed by task set stage id
+  // keyed by taskset
   // value is true if the task set's locality wait timer was reset on the last resource offer
-  private val resetOnPreviousOffer = new mutable.HashMap[Int, Boolean]()
+  private val resetOnPreviousOffer = new mutable.HashMap[TaskSet, Boolean]()
   private val legacyLocalityWaitReset = conf.get(LEGACY_LOCALITY_WAIT_RESET)
 
   // Protected by `this`
@@ -324,7 +324,7 @@ private[spark] class TaskSchedulerImpl(
         taskSetsByStageIdAndAttempt -= manager.taskSet.stageId
       }
     }
-    resetOnPreviousOffer -= manager.taskSet.stageId
+    resetOnPreviousOffer -= manager.taskSet
     manager.parent.removeSchedulable(manager)
     logInfo(s"Removed TaskSet ${manager.taskSet.id}, whose tasks have all completed, from pool" +
       s" ${manager.parent.name}")
@@ -337,8 +337,8 @@ private[spark] class TaskSchedulerImpl(
       availableCpus: Array[Int],
       availableResources: Array[Map[String, Buffer[String]]],
       tasks: IndexedSeq[ArrayBuffer[TaskDescription]],
-      addressesWithDescs: ArrayBuffer[(String, TaskDescription)]) :
-  (Boolean, Boolean, Option[TaskLocality]) = {
+      addressesWithDescs: ArrayBuffer[(String, TaskDescription)])
+    : (Boolean, Boolean, Option[TaskLocality]) = {
     var launchedTask = false
     var noDelayScheduleRejects = true
     var minLaunchedLocality: Option[TaskLocality] = None
@@ -358,7 +358,7 @@ private[spark] class TaskSchedulerImpl(
             val prof = sc.resourceProfileManager.resourceProfileFromId(taskSetRpID)
             val taskCpus = ResourceProfile.getTaskCpusOrDefaultForProfile(prof, conf)
             val (taskDescOption, didReject) =
-              taskSet.resourceOfferInternal(execId, host, maxLocality, availableResources(i))
+              taskSet.resourceOffer(execId, host, maxLocality, availableResources(i))
             noDelayScheduleRejects &= !didReject
             for (task <- taskDescOption) {
               tasks(i) += task
@@ -591,12 +591,12 @@ private[spark] class TaskSchedulerImpl(
 
         if (!legacyLocalityWaitReset) {
           if (noDelaySchedulingRejects && launchedAnyTask) {
-            if (isAllFreeResources || resetOnPreviousOffer.getOrElse(taskSet.stageId, true)) {
+            if (isAllFreeResources || resetOnPreviousOffer.getOrElse(taskSet.taskSet, true)) {
               taskSet.resetDelayScheduleTimer(globalMinLocality)
-              resetOnPreviousOffer.update(taskSet.stageId, true)
+              resetOnPreviousOffer.update(taskSet.taskSet, true)
             }
           } else {
-            resetOnPreviousOffer.update(taskSet.stageId, false)
+            resetOnPreviousOffer.update(taskSet.taskSet, false)
           }
         }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -493,11 +493,11 @@ private[spark] class TaskSetManager(
           taskResourceAssignments,
           serializedTask)
       }
+      val hasPendingTasks = pendingTasks.all.nonEmpty || pendingSpeculatableTasks.all.nonEmpty
       val hasScheduleDelayReject =
         taskDescription.isEmpty &&
           maxLocality == TaskLocality.ANY &&
-          pendingTasks.all.nonEmpty &&
-          pendingSpeculatableTasks.all.nonEmpty
+          hasPendingTasks
       (taskDescription, hasScheduleDelayReject)
     } else {
       (None, false)

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -387,15 +387,6 @@ private[spark] class TaskSetManager(
     None
   }
 
-  def resourceOffer(
-      execId: String,
-      host: String,
-      maxLocality: TaskLocality.TaskLocality,
-      availableResources: Map[String, Seq[String]] = Map.empty)
-  : Option[TaskDescription] = {
-    resourceOfferInternal(execId, host, maxLocality, availableResources)._1
-  }
-
   private[scheduler] def resetDelayScheduleTimer(
       minLocality: Option[TaskLocality.TaskLocality]): Unit = {
     lastLocalityWaitResetTime = clock.getTimeMillis()
@@ -414,9 +405,12 @@ private[spark] class TaskSetManager(
    * @param execId the executor Id of the offered resource
    * @param host  the host Id of the offered resource
    * @param maxLocality the maximum locality we want to schedule the tasks at
+   *
+   * @return Tuple containing:
+   *         (TaskDescription of launched task if any, rejected resource due to delay scheduling?)
    */
   @throws[TaskNotSerializableException]
-  def resourceOfferInternal(
+  def resourceOffer(
       execId: String,
       host: String,
       maxLocality: TaskLocality.TaskLocality,
@@ -442,7 +436,7 @@ private[spark] class TaskSetManager(
 
       val taskDescription =
         dequeueTask(execId, host, allowedLocality)
-          .map { case ((index, taskLocality, speculative)) =>
+          .map { case (index, taskLocality, speculative) =>
         // Found a task; do some bookkeeping and return a task description
         val task = tasks(index)
         val taskId = sched.newTaskId()
@@ -499,8 +493,9 @@ private[spark] class TaskSetManager(
           taskResourceAssignments,
           serializedTask)
       }
-      (taskDescription,
-        taskDescription.isEmpty && maxLocality == TaskLocality.ANY && pendingTasks.all.nonEmpty)
+      val hasScheduleDelayReject =
+        taskDescription.isEmpty && maxLocality == TaskLocality.ANY && pendingTasks.all.nonEmpty
+      (taskDescription, hasScheduleDelayReject)
     } else {
       (None, false)
     }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -386,6 +386,22 @@ private[spark] class TaskSetManager(
     None
   }
 
+  def resourceOffer(
+      execId: String,
+      host: String,
+      maxLocality: TaskLocality.TaskLocality,
+      availableResources: Map[String, Seq[String]] = Map.empty)
+  : Option[TaskDescription] = {
+    resourceOfferInternal(execId, host, maxLocality, availableResources)._1
+  }
+
+  def resetDelayScheduleTimer(minLocality: Option[TaskLocality.TaskLocality]): Unit = {
+    lastLaunchTime = clock.getTimeMillis()
+    for (locality <- minLocality) {
+      currentLocalityIndex = getLocalityIndex(locality)
+    }
+  }
+
   /**
    * Respond to an offer of a single executor from the scheduler by finding a task
    *
@@ -398,12 +414,12 @@ private[spark] class TaskSetManager(
    * @param maxLocality the maximum locality we want to schedule the tasks at
    */
   @throws[TaskNotSerializableException]
-  def resourceOffer(
+  def resourceOfferInternal(
       execId: String,
       host: String,
       maxLocality: TaskLocality.TaskLocality,
       taskResourceAssignments: Map[String, ResourceInformation] = Map.empty)
-    : Option[TaskDescription] =
+    : (Option[TaskDescription], Boolean) =
   {
     val offerBlacklisted = taskSetBlacklistHelperOpt.exists { blacklist =>
       blacklist.isNodeBlacklistedForTaskSet(host) ||
@@ -422,7 +438,9 @@ private[spark] class TaskSetManager(
         }
       }
 
-      dequeueTask(execId, host, allowedLocality).map { case ((index, taskLocality, speculative)) =>
+      val taskDescription =
+        dequeueTask(execId, host, allowedLocality)
+          .map { case ((index, taskLocality, speculative)) =>
         // Found a task; do some bookkeeping and return a task description
         val task = tasks(index)
         val taskId = sched.newTaskId()
@@ -433,12 +451,6 @@ private[spark] class TaskSetManager(
           execId, host, taskLocality, speculative)
         taskInfos(taskId) = info
         taskAttempts(index) = info :: taskAttempts(index)
-        // Update our locality level for delay scheduling
-        // NO_PREF will not affect the variables related to delay scheduling
-        if (maxLocality != TaskLocality.NO_PREF) {
-          currentLocalityIndex = getLocalityIndex(taskLocality)
-          lastLaunchTime = curTime
-        }
         // Serialize and return the task
         val serializedTask: ByteBuffer = try {
           ser.serialize(task)
@@ -482,8 +494,10 @@ private[spark] class TaskSetManager(
           taskResourceAssignments,
           serializedTask)
       }
+      (taskDescription,
+        taskDescription.isEmpty && maxLocality == TaskLocality.ANY && pendingTasks.all.nonEmpty)
     } else {
-      None
+      (None, false)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -395,7 +395,8 @@ private[spark] class TaskSetManager(
     resourceOfferInternal(execId, host, maxLocality, availableResources)._1
   }
 
-  def resetDelayScheduleTimer(minLocality: Option[TaskLocality.TaskLocality]): Unit = {
+  private[scheduler] def resetDelayScheduleTimer(
+      minLocality: Option[TaskLocality.TaskLocality]): Unit = {
     lastLaunchTime = clock.getTimeMillis()
     for (locality <- minLocality) {
       currentLocalityIndex = getLocalityIndex(locality)

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -494,7 +494,10 @@ private[spark] class TaskSetManager(
           serializedTask)
       }
       val hasScheduleDelayReject =
-        taskDescription.isEmpty && maxLocality == TaskLocality.ANY && pendingTasks.all.nonEmpty
+        taskDescription.isEmpty &&
+          maxLocality == TaskLocality.ANY &&
+          pendingTasks.all.nonEmpty &&
+          pendingSpeculatableTasks.all.nonEmpty
       (taskDescription, hasScheduleDelayReject)
     } else {
       (None, false)

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -331,7 +331,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
               executorData.resourcesInfo.map { case (rName, rInfo) =>
                 (rName, rInfo.availableAddrs.toBuffer)
               }, executorData.resourceProfileId))
-          scheduler.resourceOffers(workOffers)
+          scheduler.resourceOffers(workOffers, false)
         } else {
           Seq.empty
         }

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -303,7 +303,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
                 (rName, rInfo.availableAddrs.toBuffer)
               }, executorData.resourceProfileId)
         }.toIndexedSeq
-        scheduler.resourceOffers(workOffers)
+        scheduler.resourceOffers(workOffers, true)
       }
       if (taskDescs.nonEmpty) {
         launchTasks(taskDescs)

--- a/core/src/main/scala/org/apache/spark/scheduler/local/LocalSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/local/LocalSchedulerBackend.scala
@@ -88,7 +88,7 @@ private[spark] class LocalEndpoint(
     // local mode doesn't support extra resources like GPUs right now
     val offers = IndexedSeq(new WorkerOffer(localExecutorId, localExecutorHostname, freeCores,
       Some(rpcEnv.address.hostPort)))
-    for (task <- scheduler.resourceOffers(offers).flatten) {
+    for (task <- scheduler.resourceOffers(offers, true).flatten) {
       freeCores -= scheduler.CPUS_PER_TASK
       executor.launchTask(executorBackend, task)
     }

--- a/core/src/test/scala/org/apache/spark/deploy/StandaloneDynamicAllocationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/StandaloneDynamicAllocationSuite.scala
@@ -510,7 +510,7 @@ class StandaloneDynamicAllocationSuite
 
     val taskScheduler = mock(classOf[TaskSchedulerImpl])
     when(taskScheduler.nodeBlacklist()).thenReturn(Set("blacklisted-host"))
-    when(taskScheduler.resourceOffers(any())).thenReturn(Nil)
+    when(taskScheduler.resourceOffers(any(), any[Boolean])).thenReturn(Nil)
     when(taskScheduler.sc).thenReturn(sc)
 
     val rpcEnv = RpcEnv.create("test-rpcenv", "localhost", 0, conf, securityManager)

--- a/core/src/test/scala/org/apache/spark/scheduler/CoarseGrainedSchedulerBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/CoarseGrainedSchedulerBackendSuite.scala
@@ -248,7 +248,7 @@ class CoarseGrainedSchedulerBackendSuite extends SparkFunSuite with LocalSparkCo
       "t1", 0, 1, mutable.Map.empty[String, Long], mutable.Map.empty[String, Long],
       new Properties(), taskResources, bytebuffer)))
     val ts = backend.getTaskSchedulerImpl()
-    when(ts.resourceOffers(any[IndexedSeq[WorkerOffer]])).thenReturn(taskDescs)
+    when(ts.resourceOffers(any[IndexedSeq[WorkerOffer]], any[Boolean])).thenReturn(taskDescs)
 
     backend.driverEndpoint.send(ReviveOffers)
 

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -196,7 +196,7 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     assert(!failedTaskSet)
   }
 
-  def setupTaskScheduler(clock: ManualClock): TaskSchedulerImpl = {
+  private def setupTaskSchedulerForLocalityTests(clock: ManualClock): TaskSchedulerImpl = {
     val conf = new SparkConf()
     sc = new SparkContext("local", "TaskSchedulerImplSuite", conf)
     val taskScheduler = new TaskSchedulerImpl(sc,
@@ -243,7 +243,7 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     val clock = new ManualClock()
     // All tasks created here are local to exec1, host1.
     // Locality level starts at PROCESS_LOCAL.
-    val taskScheduler = setupTaskScheduler(clock)
+    val taskScheduler = setupTaskSchedulerForLocalityTests(clock)
     // Locality levels increase at 3000 ms.
     val advanceAmount = 3000
 
@@ -268,12 +268,12 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
       .flatten.isEmpty)
   }
 
-  test("SPARK-18886 - delay scheduling timer is reset when it accepts all resources offered when" +
+  test("SPARK-18886 - delay scheduling timer is reset when it accepts all resources offered when " +
     "isAllFreeResources = true") {
     val clock = new ManualClock()
     // All tasks created here are local to exec1, host1.
     // Locality level starts at PROCESS_LOCAL.
-    val taskScheduler = setupTaskScheduler(clock)
+    val taskScheduler = setupTaskSchedulerForLocalityTests(clock)
     // Locality levels increase at 3000 ms.
     val advanceAmount = 3000
 
@@ -302,7 +302,7 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     val clock = new ManualClock()
     // All tasks created here are local to exec1, host1.
     // Locality level starts at PROCESS_LOCAL.
-    val taskScheduler = setupTaskScheduler(clock)
+    val taskScheduler = setupTaskSchedulerForLocalityTests(clock)
     // Locality levels increase at 3000 ms.
     val advanceAmount = 3000
 
@@ -348,7 +348,6 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
       .flatten.isEmpty)
   }
 
-
   // This tests two cases
   // 1. partial resource offer doesn't reset timer after full resource offer had rejected resources
   // 2. partial resource offer doesn't reset timer after partial resource offer
@@ -358,7 +357,7 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     val clock = new ManualClock()
     // All tasks created here are local to exec1, host1.
     // Locality level starts at PROCESS_LOCAL.
-    val taskScheduler = setupTaskScheduler(clock)
+    val taskScheduler = setupTaskSchedulerForLocalityTests(clock)
     // Locality levels increase at 3000 ms.
     val advanceAmount = 3000
 

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -228,6 +228,11 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
       Seq(TaskLocation("host1", "exec1")),
       Seq(TaskLocation("host1", "exec1"))
     )
+
+    // Offer resources first so that when the taskset is submitted it can initialize
+    // with proper locality level. Otherwise, ANY would be the only locality level.
+    // See TaskSetManager.computeValidLocalityLevels()
+    // This begins the task set as PROCESS_LOCAL locality level
     taskScheduler.resourceOffers(IndexedSeq(WorkerOffer("exec1", "host1", 1)))
     taskScheduler.submitTasks(taskSet)
     taskScheduler

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -233,7 +233,7 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     taskScheduler
   }
 
-  test("SPARK-18886 -  partial offers (isAllFreeResources = false) reset timer before " +
+  test("SPARK-18886 - partial offers (isAllFreeResources = false) reset timer before " +
     "any resources have been rejected") {
     val clock = new ManualClock()
     val taskScheduler = setupTaskScheduler(clock)
@@ -253,11 +253,12 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     clock.advance(advanceAmount)
     assert(taskScheduler
       .resourceOffers(
-        IndexedSeq(WorkerOffer("exec2", "host1", 1)))
+        IndexedSeq(WorkerOffer("exec2", "host1", 1)),
+        isAllFreeResources = false)
       .flatten.isEmpty)
   }
 
-  test("SPARK-18886 -  delay scheduling timer is reset when it accepts all resources offered when" +
+  test("SPARK-18886 - delay scheduling timer is reset when it accepts all resources offered when" +
     "isAllFreeResources = true") {
     val clock = new ManualClock()
     val taskScheduler = setupTaskScheduler(clock)
@@ -276,7 +277,8 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     clock.advance(advanceAmount)
     assert(taskScheduler
       .resourceOffers(
-        IndexedSeq(WorkerOffer("exec2", "host1", 1)))
+        IndexedSeq(WorkerOffer("exec2", "host1", 1)),
+        isAllFreeResources = false)
       .flatten.isEmpty)
   }
 
@@ -310,7 +312,8 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     clock.advance(advanceAmount)
     assert(taskScheduler
       .resourceOffers(
-        IndexedSeq(WorkerOffer("exec2", "host1", 1)))
+        IndexedSeq(WorkerOffer("exec2", "host1", 1)),
+        isAllFreeResources = false)
       .flatten.isEmpty)
   }
 
@@ -345,7 +348,8 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     clock.advance(advanceAmount)
     assert(taskScheduler
       .resourceOffers(
-        IndexedSeq(WorkerOffer("exec2", "host1", 1)))
+        IndexedSeq(WorkerOffer("exec2", "host1", 1)),
+        isAllFreeResources = false)
       .flatten.length === 1)
 
 
@@ -377,7 +381,8 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     clock.advance(advanceAmount)
     assert(taskScheduler
       .resourceOffers(
-        IndexedSeq(WorkerOffer("exec2", "host1", 1)))
+        IndexedSeq(WorkerOffer("exec2", "host1", 1)),
+        isAllFreeResources = false)
       .flatten.length === 1)
   }
 

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -365,9 +365,9 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     // partial resource has rejected offer
     assert(taskScheduler
       .resourceOffers(
-        IndexedSeq(WorkerOffer("exec2", "host1", 1)),
+        IndexedSeq(WorkerOffer("exec2", "host1", 1), WorkerOffer("exec1", "host1", 1)),
         isAllFreeResources = false)
-      .flatten.isEmpty)
+      .flatten.size === 1)
 
     // This does not reset timer since last partial resource offer was rejected
     clock.advance(advanceAmount)

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -225,7 +225,7 @@ class TaskSetManagerSuite
 
     // Offer a host with NO_PREF as the constraint,
     // we should get a nopref task immediately since that's what we only have
-    val taskOption = manager.resourceOffer("exec1", "host1", NO_PREF)
+    val taskOption = manager.resourceOffer("exec1", "host1", NO_PREF)._1
     assert(taskOption.isDefined)
 
     clock.advance(1)
@@ -246,7 +246,7 @@ class TaskSetManagerSuite
 
     // First three offers should all find tasks
     for (i <- 0 until 3) {
-      val taskOption = manager.resourceOffer("exec1", "host1", NO_PREF)
+      val taskOption = manager.resourceOffer("exec1", "host1", NO_PREF)._1
       assert(taskOption.isDefined)
       val task = taskOption.get
       assert(task.executorId === "exec1")
@@ -254,7 +254,7 @@ class TaskSetManagerSuite
     assert(sched.startedTasks.toSet === Set(0, 1, 2))
 
     // Re-offer the host -- now we should get no more tasks
-    assert(manager.resourceOffer("exec1", "host1", NO_PREF) === None)
+    assert(manager.resourceOffer("exec1", "host1", NO_PREF)._1 === None)
 
     // Finish the first two tasks
     manager.handleSuccessfulTask(0, createTaskResult(0, accumUpdatesByTask(0)))
@@ -277,12 +277,12 @@ class TaskSetManagerSuite
     val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES, clock = clock)
 
     // An executor that is not NODE_LOCAL should be rejected.
-    assert(manager.resourceOffer("execC", "host2", ANY) === None)
+    assert(manager.resourceOffer("execC", "host2", ANY)._1 === None)
 
     // Because there are no alive PROCESS_LOCAL executors, the base locality level should be
     // NODE_LOCAL. So, we should schedule the task on this offered NODE_LOCAL executor before
     // any of the locality wait timers expire.
-    assert(manager.resourceOffer("execA", "host1", ANY).get.index === 0)
+    assert(manager.resourceOffer("execA", "host1", ANY)._1.get.index === 0)
   }
 
   test("basic delay scheduling") {
@@ -297,22 +297,22 @@ class TaskSetManagerSuite
     val clock = new ManualClock
     val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES, clock = clock)
     // First offer host1, exec1: first task should be chosen
-    assert(manager.resourceOffer("exec1", "host1", ANY).get.index === 0)
-    assert(manager.resourceOffer("exec1", "host1", PROCESS_LOCAL) == None)
+    assert(manager.resourceOffer("exec1", "host1", ANY)._1.get.index === 0)
+    assert(manager.resourceOffer("exec1", "host1", PROCESS_LOCAL)._1 === None)
 
     clock.advance(LOCALITY_WAIT_MS)
     // Offer host1, exec1 again, at NODE_LOCAL level: the node local (task 3) should
     // get chosen before the noPref task
-    assert(manager.resourceOffer("exec1", "host1", NODE_LOCAL).get.index == 2)
+    assert(manager.resourceOffer("exec1", "host1", NODE_LOCAL)._1.get.index == 2)
 
     // Offer host2, exec2, at NODE_LOCAL level: we should choose task 2
-    assert(manager.resourceOffer("exec2", "host2", NODE_LOCAL).get.index == 1)
+    assert(manager.resourceOffer("exec2", "host2", NODE_LOCAL)._1.get.index == 1)
 
     // Offer host2, exec2 again, at NODE_LOCAL level: we should get noPref task
     // after failing to find a node_Local task
-    assert(manager.resourceOffer("exec2", "host2", NODE_LOCAL) == None)
+    assert(manager.resourceOffer("exec2", "host2", NODE_LOCAL)._1 === None)
     clock.advance(LOCALITY_WAIT_MS)
-    assert(manager.resourceOffer("exec2", "host2", NO_PREF).get.index == 3)
+    assert(manager.resourceOffer("exec2", "host2", NO_PREF)._1.get.index == 3)
   }
 
   test("we do not need to delay scheduling when we only have noPref tasks in the queue") {
@@ -326,10 +326,10 @@ class TaskSetManagerSuite
     val clock = new ManualClock
     val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES, clock = clock)
     // First offer host1, exec1: first task should be chosen
-    assert(manager.resourceOffer("exec1", "host1", PROCESS_LOCAL).get.index === 0)
-    assert(manager.resourceOffer("exec3", "host2", PROCESS_LOCAL).get.index === 1)
-    assert(manager.resourceOffer("exec3", "host2", NODE_LOCAL) == None)
-    assert(manager.resourceOffer("exec3", "host2", NO_PREF).get.index === 2)
+    assert(manager.resourceOffer("exec1", "host1", PROCESS_LOCAL)._1.get.index === 0)
+    assert(manager.resourceOffer("exec3", "host2", PROCESS_LOCAL)._1.get.index === 1)
+    assert(manager.resourceOffer("exec3", "host2", NODE_LOCAL)._1 === None)
+    assert(manager.resourceOffer("exec3", "host2", NO_PREF)._1.get.index === 2)
   }
 
   test("delay scheduling with fallback") {
@@ -343,33 +343,34 @@ class TaskSetManagerSuite
       Seq(TaskLocation("host3")),
       Seq(TaskLocation("host2"))
     )
+    sc.conf.set(config.LEGACY_LOCALITY_WAIT_RESET, true)
     val clock = new ManualClock
     val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES, clock = clock)
 
     // First offer host1: first task should be chosen
-    assert(manager.resourceOffer("exec1", "host1", ANY).get.index === 0)
+    assert(manager.resourceOffer("exec1", "host1", ANY)._1.get.index === 0)
 
     // Offer host1 again: nothing should get chosen
-    assert(manager.resourceOffer("exec1", "host1", ANY) === None)
+    assert(manager.resourceOffer("exec1", "host1", ANY)._1 === None)
 
     clock.advance(LOCALITY_WAIT_MS)
 
     // Offer host1 again: second task (on host2) should get chosen
-    assert(manager.resourceOffer("exec1", "host1", ANY).get.index === 1)
+    assert(manager.resourceOffer("exec1", "host1", ANY)._1.get.index === 1)
 
     // Offer host1 again: third task (on host2) should get chosen
-    assert(manager.resourceOffer("exec1", "host1", ANY).get.index === 2)
+    assert(manager.resourceOffer("exec1", "host1", ANY)._1.get.index === 2)
 
     // Offer host2: fifth task (also on host2) should get chosen
-    assert(manager.resourceOffer("exec2", "host2", ANY).get.index === 4)
+    assert(manager.resourceOffer("exec2", "host2", ANY)._1.get.index === 4)
 
     // Now that we've launched a local task, we should no longer launch the task for host3
-    assert(manager.resourceOffer("exec2", "host2", ANY) === None)
+    assert(manager.resourceOffer("exec2", "host2", ANY)._1 === None)
 
     clock.advance(LOCALITY_WAIT_MS)
 
     // After another delay, we can go ahead and launch that task non-locally
-    assert(manager.resourceOffer("exec2", "host2", ANY).get.index === 3)
+    assert(manager.resourceOffer("exec2", "host2", ANY)._1.get.index === 3)
   }
 
   test("delay scheduling with failed hosts") {
@@ -385,28 +386,28 @@ class TaskSetManagerSuite
     val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES, clock = clock)
 
     // First offer host1: first task should be chosen
-    assert(manager.resourceOffer("exec1", "host1", ANY).get.index === 0)
+    assert(manager.resourceOffer("exec1", "host1", ANY)._1.get.index === 0)
 
     // After this, nothing should get chosen, because we have separated tasks with unavailable
     // preference from the noPrefPendingTasks
-    assert(manager.resourceOffer("exec1", "host1", ANY) === None)
+    assert(manager.resourceOffer("exec1", "host1", ANY)._1 === None)
 
     // Now mark host2 as dead
     sched.removeExecutor("exec2")
     manager.executorLost("exec2", "host2", SlaveLost())
 
     // nothing should be chosen
-    assert(manager.resourceOffer("exec1", "host1", ANY) === None)
+    assert(manager.resourceOffer("exec1", "host1", ANY)._1 === None)
 
     clock.advance(LOCALITY_WAIT_MS * 2)
 
     // task 1 and 2 would be scheduled as nonLocal task
-    assert(manager.resourceOffer("exec1", "host1", ANY).get.index === 1)
-    assert(manager.resourceOffer("exec1", "host1", ANY).get.index === 2)
+    assert(manager.resourceOffer("exec1", "host1", ANY)._1.get.index === 1)
+    assert(manager.resourceOffer("exec1", "host1", ANY)._1.get.index === 2)
 
     // all finished
-    assert(manager.resourceOffer("exec1", "host1", ANY) === None)
-    assert(manager.resourceOffer("exec2", "host2", ANY) === None)
+    assert(manager.resourceOffer("exec1", "host1", ANY)._1 === None)
+    assert(manager.resourceOffer("exec2", "host2", ANY)._1 === None)
   }
 
   test("task result lost") {
@@ -417,14 +418,14 @@ class TaskSetManagerSuite
     clock.advance(1)
     val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES, clock = clock)
 
-    assert(manager.resourceOffer("exec1", "host1", ANY).get.index === 0)
+    assert(manager.resourceOffer("exec1", "host1", ANY)._1.get.index === 0)
 
     // Tell it the task has finished but the result was lost.
     manager.handleFailedTask(0, TaskState.FINISHED, TaskResultLost)
     assert(sched.endedTasks(0) === TaskResultLost)
 
     // Re-offer the host -- now we should get task 0 again.
-    assert(manager.resourceOffer("exec1", "host1", ANY).get.index === 0)
+    assert(manager.resourceOffer("exec1", "host1", ANY)._1.get.index === 0)
   }
 
   test("repeated failures lead to task set abortion") {
@@ -438,7 +439,7 @@ class TaskSetManagerSuite
     // Fail the task MAX_TASK_FAILURES times, and check that the task set is aborted
     // after the last failure.
     (1 to manager.maxTaskFailures).foreach { index =>
-      val offerResult = manager.resourceOffer("exec1", "host1", ANY)
+      val offerResult = manager.resourceOffer("exec1", "host1", ANY)._1
       assert(offerResult.isDefined,
         "Expect resource offer on iteration %s to return a task".format(index))
       assert(offerResult.get.index === 0)
@@ -474,7 +475,7 @@ class TaskSetManagerSuite
     val manager = new TaskSetManager(sched, taskSet, 4, blacklistTrackerOpt, clock)
 
     {
-      val offerResult = manager.resourceOffer("exec1", "host1", PROCESS_LOCAL)
+      val offerResult = manager.resourceOffer("exec1", "host1", PROCESS_LOCAL)._1
       assert(offerResult.isDefined, "Expect resource offer to return a task")
 
       assert(offerResult.get.index === 0)
@@ -485,15 +486,15 @@ class TaskSetManagerSuite
       assert(!sched.taskSetsFailed.contains(taskSet.id))
 
       // Ensure scheduling on exec1 fails after failure 1 due to blacklist
-      assert(manager.resourceOffer("exec1", "host1", PROCESS_LOCAL).isEmpty)
-      assert(manager.resourceOffer("exec1", "host1", NODE_LOCAL).isEmpty)
-      assert(manager.resourceOffer("exec1", "host1", RACK_LOCAL).isEmpty)
-      assert(manager.resourceOffer("exec1", "host1", ANY).isEmpty)
+      assert(manager.resourceOffer("exec1", "host1", PROCESS_LOCAL)._1.isEmpty)
+      assert(manager.resourceOffer("exec1", "host1", NODE_LOCAL)._1.isEmpty)
+      assert(manager.resourceOffer("exec1", "host1", RACK_LOCAL)._1.isEmpty)
+      assert(manager.resourceOffer("exec1", "host1", ANY)._1.isEmpty)
     }
 
     // Run the task on exec1.1 - should work, and then fail it on exec1.1
     {
-      val offerResult = manager.resourceOffer("exec1.1", "host1", NODE_LOCAL)
+      val offerResult = manager.resourceOffer("exec1.1", "host1", NODE_LOCAL)._1
       assert(offerResult.isDefined,
         "Expect resource offer to return a task for exec1.1, offerResult = " + offerResult)
 
@@ -505,12 +506,12 @@ class TaskSetManagerSuite
       assert(!sched.taskSetsFailed.contains(taskSet.id))
 
       // Ensure scheduling on exec1.1 fails after failure 2 due to blacklist
-      assert(manager.resourceOffer("exec1.1", "host1", NODE_LOCAL).isEmpty)
+      assert(manager.resourceOffer("exec1.1", "host1", NODE_LOCAL)._1.isEmpty)
     }
 
     // Run the task on exec2 - should work, and then fail it on exec2
     {
-      val offerResult = manager.resourceOffer("exec2", "host2", ANY)
+      val offerResult = manager.resourceOffer("exec2", "host2", ANY)._1
       assert(offerResult.isDefined, "Expect resource offer to return a task")
 
       assert(offerResult.get.index === 0)
@@ -521,7 +522,7 @@ class TaskSetManagerSuite
       assert(!sched.taskSetsFailed.contains(taskSet.id))
 
       // Ensure scheduling on exec2 fails after failure 3 due to blacklist
-      assert(manager.resourceOffer("exec2", "host2", ANY).isEmpty)
+      assert(manager.resourceOffer("exec2", "host2", ANY)._1.isEmpty)
     }
 
     // Despite advancing beyond the time for expiring executors from within the blacklist,
@@ -529,17 +530,17 @@ class TaskSetManagerSuite
     clock.advance(rescheduleDelay)
 
     {
-      val offerResult = manager.resourceOffer("exec1", "host1", PROCESS_LOCAL)
+      val offerResult = manager.resourceOffer("exec1", "host1", PROCESS_LOCAL)._1
       assert(offerResult.isEmpty)
     }
 
     {
-      val offerResult = manager.resourceOffer("exec3", "host3", ANY)
+      val offerResult = manager.resourceOffer("exec3", "host3", ANY)._1
       assert(offerResult.isDefined)
       assert(offerResult.get.index === 0)
       assert(offerResult.get.executorId === "exec3")
 
-      assert(manager.resourceOffer("exec3", "host3", ANY).isEmpty)
+      assert(manager.resourceOffer("exec3", "host3", ANY)._1.isEmpty)
 
       // Cause exec3 to fail : failure 4
       manager.handleFailedTask(offerResult.get.taskId, TaskState.FINISHED, TaskResultLost)
@@ -598,14 +599,14 @@ class TaskSetManagerSuite
     manager.executorAdded()
     sched.addExecutor("execC", "host2")
     manager.executorAdded()
-    assert(manager.resourceOffer("exec1", "host1", ANY).isDefined)
+    assert(manager.resourceOffer("exec1", "host1", ANY)._1.isDefined)
     sched.removeExecutor("execA")
     manager.executorLost(
       "execA",
       "host1",
       ExecutorExited(143, false, "Terminated for reason unrelated to running tasks"))
     assert(!sched.taskSetsFailed.contains(taskSet.id))
-    assert(manager.resourceOffer("execC", "host2", ANY).isDefined)
+    assert(manager.resourceOffer("execC", "host2", ANY)._1.isDefined)
     sched.removeExecutor("execC")
     manager.executorLost(
       "execC", "host2", ExecutorExited(1, true, "Terminated due to issue with running tasks"))
@@ -633,12 +634,12 @@ class TaskSetManagerSuite
     clock.advance(LOCALITY_WAIT_MS * 3)
     // Offer host3
     // No task is scheduled if we restrict locality to RACK_LOCAL
-    assert(manager.resourceOffer("execC", "host3", RACK_LOCAL) === None)
+    assert(manager.resourceOffer("execC", "host3", RACK_LOCAL)._1 === None)
     // Task 0 can be scheduled with ANY
-    assert(manager.resourceOffer("execC", "host3", ANY).get.index === 0)
+    assert(manager.resourceOffer("execC", "host3", ANY)._1.get.index === 0)
     // Offer host2
     // Task 1 can be scheduled with RACK_LOCAL
-    assert(manager.resourceOffer("execB", "host2", RACK_LOCAL).get.index === 1)
+    assert(manager.resourceOffer("execB", "host2", RACK_LOCAL)._1.get.index === 1)
   }
 
   test("do not emit warning when serialized task is small") {
@@ -649,7 +650,7 @@ class TaskSetManagerSuite
 
     assert(!manager.emittedTaskSizeWarning)
 
-    assert(manager.resourceOffer("exec1", "host1", ANY).get.index === 0)
+    assert(manager.resourceOffer("exec1", "host1", ANY)._1.get.index === 0)
 
     assert(!manager.emittedTaskSizeWarning)
   }
@@ -664,7 +665,7 @@ class TaskSetManagerSuite
 
     assert(!manager.emittedTaskSizeWarning)
 
-    assert(manager.resourceOffer("exec1", "host1", ANY).get.index === 0)
+    assert(manager.resourceOffer("exec1", "host1", ANY)._1.get.index === 0)
 
     assert(manager.emittedTaskSizeWarning)
   }
@@ -752,13 +753,13 @@ class TaskSetManagerSuite
 
     // Offer host1, which should be accepted as a PROCESS_LOCAL location
     // by the one task in the task set
-    val task1 = manager.resourceOffer("execA", "host1", TaskLocality.PROCESS_LOCAL).get
+    val task1 = manager.resourceOffer("execA", "host1", TaskLocality.PROCESS_LOCAL)._1.get
 
     // Mark the task as available for speculation, and then offer another resource,
     // which should be used to launch a speculative copy of the task.
     manager.speculatableTasks += singleTask.partitionId
     manager.addPendingTask(singleTask.partitionId, speculatable = true)
-    val task2 = manager.resourceOffer("execB", "host2", TaskLocality.ANY).get
+    val task2 = manager.resourceOffer("execB", "host2", TaskLocality.ANY)._1.get
 
     assert(manager.runningTasks === 2)
     assert(manager.isZombie === false)
@@ -844,7 +845,7 @@ class TaskSetManagerSuite
       "exec1" -> "host1",
       "exec3" -> "host3",
       "exec2" -> "host2")) {
-      val taskOption = manager.resourceOffer(exec, host, NO_PREF)
+      val taskOption = manager.resourceOffer(exec, host, NO_PREF)._1
       assert(taskOption.isDefined)
       val task = taskOption.get
       assert(task.executorId === exec)
@@ -870,7 +871,7 @@ class TaskSetManagerSuite
     assert(sched.speculativeTasks.toSet === Set(2, 3))
 
     // Offer resource to start the speculative attempt for the running task 2.0
-    val taskOption = manager.resourceOffer("exec2", "host2", ANY)
+    val taskOption = manager.resourceOffer("exec2", "host2", ANY)._1
     assert(taskOption.isDefined)
     val task4 = taskOption.get
     assert(task4.index === 2)
@@ -899,20 +900,20 @@ class TaskSetManagerSuite
     val clock = new ManualClock
     val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES, clock = clock)
 
-    assert(manager.resourceOffer("execA", "host1", PROCESS_LOCAL).get.index === 0)
-    assert(manager.resourceOffer("execA", "host1", NODE_LOCAL) == None)
-    assert(manager.resourceOffer("execA", "host1", NO_PREF).get.index == 1)
+    assert(manager.resourceOffer("execA", "host1", PROCESS_LOCAL)._1.get.index === 0)
+    assert(manager.resourceOffer("execA", "host1", NODE_LOCAL)._1 === None)
+    assert(manager.resourceOffer("execA", "host1", NO_PREF)._1.get.index == 1)
 
     manager.speculatableTasks += 1
     manager.addPendingTask(1, speculatable = true)
     clock.advance(LOCALITY_WAIT_MS)
     // schedule the nonPref task
-    assert(manager.resourceOffer("execA", "host1", NO_PREF).get.index === 2)
+    assert(manager.resourceOffer("execA", "host1", NO_PREF)._1.get.index === 2)
     // schedule the speculative task
-    assert(manager.resourceOffer("execB", "host2", NO_PREF).get.index === 1)
+    assert(manager.resourceOffer("execB", "host2", NO_PREF)._1.get.index === 1)
     clock.advance(LOCALITY_WAIT_MS * 3)
     // schedule non-local tasks
-    assert(manager.resourceOffer("execB", "host2", ANY).get.index === 3)
+    assert(manager.resourceOffer("execB", "host2", ANY)._1.get.index === 3)
   }
 
   test("node-local tasks should be scheduled right away " +
@@ -929,13 +930,13 @@ class TaskSetManagerSuite
     val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES, clock = clock)
 
     // node-local tasks are scheduled without delay
-    assert(manager.resourceOffer("execA", "host1", NODE_LOCAL).get.index === 0)
-    assert(manager.resourceOffer("execA", "host2", NODE_LOCAL).get.index === 1)
-    assert(manager.resourceOffer("execA", "host3", NODE_LOCAL).get.index === 3)
-    assert(manager.resourceOffer("execA", "host3", NODE_LOCAL) === None)
+    assert(manager.resourceOffer("execA", "host1", NODE_LOCAL)._1.get.index === 0)
+    assert(manager.resourceOffer("execA", "host2", NODE_LOCAL)._1.get.index === 1)
+    assert(manager.resourceOffer("execA", "host3", NODE_LOCAL)._1.get.index === 3)
+    assert(manager.resourceOffer("execA", "host3", NODE_LOCAL)._1 === None)
 
     // schedule no-preference after node local ones
-    assert(manager.resourceOffer("execA", "host3", NO_PREF).get.index === 2)
+    assert(manager.resourceOffer("execA", "host3", NO_PREF)._1.get.index === 2)
   }
 
   test("SPARK-4939: node-local tasks should be scheduled right after process-local tasks finished")
@@ -951,13 +952,13 @@ class TaskSetManagerSuite
     val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES, clock = clock)
 
     // process-local tasks are scheduled first
-    assert(manager.resourceOffer("execA", "host1", NODE_LOCAL).get.index === 2)
-    assert(manager.resourceOffer("execB", "host2", NODE_LOCAL).get.index === 3)
+    assert(manager.resourceOffer("execA", "host1", NODE_LOCAL)._1.get.index === 2)
+    assert(manager.resourceOffer("execB", "host2", NODE_LOCAL)._1.get.index === 3)
     // node-local tasks are scheduled without delay
-    assert(manager.resourceOffer("execA", "host1", NODE_LOCAL).get.index === 0)
-    assert(manager.resourceOffer("execB", "host2", NODE_LOCAL).get.index === 1)
-    assert(manager.resourceOffer("execA", "host1", NODE_LOCAL) == None)
-    assert(manager.resourceOffer("execB", "host2", NODE_LOCAL) == None)
+    assert(manager.resourceOffer("execA", "host1", NODE_LOCAL)._1.get.index === 0)
+    assert(manager.resourceOffer("execB", "host2", NODE_LOCAL)._1.get.index === 1)
+    assert(manager.resourceOffer("execA", "host1", NODE_LOCAL)._1 === None)
+    assert(manager.resourceOffer("execB", "host2", NODE_LOCAL)._1 === None)
   }
 
   test("SPARK-4939: no-pref tasks should be scheduled after process-local tasks finished") {
@@ -971,13 +972,13 @@ class TaskSetManagerSuite
     val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES, clock = clock)
 
     // process-local tasks are scheduled first
-    assert(manager.resourceOffer("execA", "host1", PROCESS_LOCAL).get.index === 1)
-    assert(manager.resourceOffer("execB", "host2", PROCESS_LOCAL).get.index === 2)
+    assert(manager.resourceOffer("execA", "host1", PROCESS_LOCAL)._1.get.index === 1)
+    assert(manager.resourceOffer("execB", "host2", PROCESS_LOCAL)._1.get.index === 2)
     // no-pref tasks are scheduled without delay
-    assert(manager.resourceOffer("execA", "host1", PROCESS_LOCAL) == None)
-    assert(manager.resourceOffer("execA", "host1", NODE_LOCAL) == None)
-    assert(manager.resourceOffer("execA", "host1", NO_PREF).get.index === 0)
-    assert(manager.resourceOffer("execA", "host1", ANY) == None)
+    assert(manager.resourceOffer("execA", "host1", PROCESS_LOCAL)._1 === None)
+    assert(manager.resourceOffer("execA", "host1", NODE_LOCAL)._1 === None)
+    assert(manager.resourceOffer("execA", "host1", NO_PREF)._1.get.index === 0)
+    assert(manager.resourceOffer("execA", "host1", ANY)._1 === None)
   }
 
   test("Ensure TaskSetManager is usable after addition of levels") {
@@ -1061,7 +1062,7 @@ class TaskSetManagerSuite
       "exec1" -> "host1",
       "exec2" -> "host2",
       "exec2" -> "host2")) {
-      val taskOption = manager.resourceOffer(k, v, NO_PREF)
+      val taskOption = manager.resourceOffer(k, v, NO_PREF)._1
       assert(taskOption.isDefined)
       val task = taskOption.get
       assert(task.executorId === k)
@@ -1082,7 +1083,7 @@ class TaskSetManagerSuite
     assert(sched.speculativeTasks.toSet === Set(3))
 
     // Offer resource to start the speculative attempt for the running task
-    val taskOption5 = manager.resourceOffer("exec1", "host1", NO_PREF)
+    val taskOption5 = manager.resourceOffer("exec1", "host1", NO_PREF)._1
     assert(taskOption5.isDefined)
     val task5 = taskOption5.get
     assert(task5.index === 3)
@@ -1121,7 +1122,7 @@ class TaskSetManagerSuite
       "exec1" -> "host1",
       "exec2" -> "host2",
       "exec2" -> "host2")) {
-      val taskOption = manager.resourceOffer(k, v, NO_PREF)
+      val taskOption = manager.resourceOffer(k, v, NO_PREF)._1
       assert(taskOption.isDefined)
       val task = taskOption.get
       assert(task.executorId === k)
@@ -1154,7 +1155,7 @@ class TaskSetManagerSuite
         manager.handleFailedTask(task.taskId, TaskState.FAILED, endReason)
         sched.endedTasks(task.taskId) = endReason
         assert(!manager.isZombie)
-        val nextTask = manager.resourceOffer(s"exec2", s"host2", NO_PREF)
+        val nextTask = manager.resourceOffer(s"exec2", s"host2", NO_PREF)._1
         assert(nextTask.isDefined, s"no offer for attempt $attempt of $index")
         tasks += nextTask.get
       }
@@ -1170,7 +1171,7 @@ class TaskSetManagerSuite
     assert(manager.checkSpeculatableTasks(0))
     assert(sched.speculativeTasks.toSet === Set(3, 4))
     // Offer resource to start the speculative attempt for the running task
-    val taskOption5 = manager.resourceOffer("exec1", "host1", NO_PREF)
+    val taskOption5 = manager.resourceOffer("exec1", "host1", NO_PREF)._1
     assert(taskOption5.isDefined)
     val speculativeTask = taskOption5.get
     assert(speculativeTask.index === 3 || speculativeTask.index === 4)
@@ -1195,7 +1196,7 @@ class TaskSetManagerSuite
     assert(!manager.isZombie)
 
     // now run another speculative task
-    val taskOpt6 = manager.resourceOffer("exec1", "host1", NO_PREF)
+    val taskOpt6 = manager.resourceOffer("exec1", "host1", NO_PREF)._1
     assert(taskOpt6.isDefined)
     val speculativeTask2 = taskOpt6.get
     assert(speculativeTask2.index === 3 || speculativeTask2.index === 4)
@@ -1226,7 +1227,7 @@ class TaskSetManagerSuite
     val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES, clock = new ManualClock(1))
     when(mockDAGScheduler.taskEnded(any(), any(), any(), any(), any(), any())).thenAnswer(
       (invocationOnMock: InvocationOnMock) => assert(manager.isZombie))
-    val taskOption = manager.resourceOffer("exec1", "host1", NO_PREF)
+    val taskOption = manager.resourceOffer("exec1", "host1", NO_PREF)._1
     assert(taskOption.isDefined)
     // this would fail, inside our mock dag scheduler, if it calls dagScheduler.taskEnded() too soon
     manager.handleSuccessfulTask(0, createTaskResult(0))
@@ -1271,7 +1272,7 @@ class TaskSetManagerSuite
       "exec2" -> "host1"
     ).flatMap { case (exec, host) =>
       // offer each executor twice (simulating 2 cores per executor)
-      (0 until 2).flatMap{ _ => tsmSpy.resourceOffer(exec, host, TaskLocality.ANY)}
+      (0 until 2).flatMap{ _ => tsmSpy.resourceOffer(exec, host, TaskLocality.ANY)._1}
     }
     assert(taskDescs.size === 4)
 
@@ -1308,7 +1309,7 @@ class TaskSetManagerSuite
       "exec2" -> "host2"
     ).flatMap { case (exec, host) =>
       // offer each executor twice (simulating 2 cores per executor)
-      (0 until 2).flatMap{ _ => tsm.resourceOffer(exec, host, TaskLocality.ANY)}
+      (0 until 2).flatMap{ _ => tsm.resourceOffer(exec, host, TaskLocality.ANY)._1}
     }
     assert(taskDescs.size === 4)
 
@@ -1344,7 +1345,7 @@ class TaskSetManagerSuite
     val taskSetManager = new TaskSetManager(sched, taskSet, 1, Some(blacklistTracker))
     val taskSetManagerSpy = spy(taskSetManager)
 
-    val taskDesc = taskSetManagerSpy.resourceOffer(exec, host, TaskLocality.ANY)
+    val taskDesc = taskSetManagerSpy.resourceOffer(exec, host, TaskLocality.ANY)._1
 
     // Assert the task has been black listed on the executor it was last executed on.
     when(taskSetManagerSpy.addPendingTask(anyInt(), anyBoolean(), anyBoolean())).thenAnswer(
@@ -1372,9 +1373,9 @@ class TaskSetManagerSuite
     val manager1 = new TaskSetManager(sched, taskSet1, MAX_TASK_FAILURES, clock = new ManualClock)
 
     // all tasks from the first taskset have the same jars
-    val taskOption1 = manager1.resourceOffer("exec1", "host1", NO_PREF)
+    val taskOption1 = manager1.resourceOffer("exec1", "host1", NO_PREF)._1
     assert(taskOption1.get.addedJars === addedJarsPreTaskSet)
-    val taskOption2 = manager1.resourceOffer("exec1", "host1", NO_PREF)
+    val taskOption2 = manager1.resourceOffer("exec1", "host1", NO_PREF)._1
     assert(taskOption2.get.addedJars === addedJarsPreTaskSet)
 
     // even with a jar added mid-TaskSet
@@ -1382,7 +1383,7 @@ class TaskSetManagerSuite
     sc.addJar(jarPath.toString)
     val addedJarsMidTaskSet = Map[String, Long](sc.addedJars.toSeq: _*)
     assert(addedJarsPreTaskSet !== addedJarsMidTaskSet)
-    val taskOption3 = manager1.resourceOffer("exec1", "host1", NO_PREF)
+    val taskOption3 = manager1.resourceOffer("exec1", "host1", NO_PREF)._1
     // which should have the old version of the jars list
     assert(taskOption3.get.addedJars === addedJarsPreTaskSet)
 
@@ -1390,7 +1391,7 @@ class TaskSetManagerSuite
     val taskSet2 = FakeTask.createTaskSet(1)
     val manager2 = new TaskSetManager(sched, taskSet2, MAX_TASK_FAILURES, clock = new ManualClock)
 
-    val taskOption4 = manager2.resourceOffer("exec1", "host1", NO_PREF)
+    val taskOption4 = manager2.resourceOffer("exec1", "host1", NO_PREF)._1
     assert(taskOption4.get.addedJars === addedJarsMidTaskSet)
   }
 
@@ -1488,7 +1489,7 @@ class TaskSetManagerSuite
       "exec1" -> "host1",
       "exec3" -> "host3",
       "exec2" -> "host2")) {
-      val taskOption = manager.resourceOffer(exec, host, NO_PREF)
+      val taskOption = manager.resourceOffer(exec, host, NO_PREF)._1
       assert(taskOption.isDefined)
       val task = taskOption.get
       assert(task.executorId === exec)
@@ -1514,7 +1515,7 @@ class TaskSetManagerSuite
     assert(sched.speculativeTasks.toSet === Set(2, 3))
 
     // Offer resource to start the speculative attempt for the running task 2.0
-    val taskOption = manager.resourceOffer("exec2", "host2", ANY)
+    val taskOption = manager.resourceOffer("exec2", "host2", ANY)._1
     assert(taskOption.isDefined)
     val task4 = taskOption.get
     assert(task4.index === 2)
@@ -1560,7 +1561,7 @@ class TaskSetManagerSuite
       "exec1" -> "host1",
       "exec2" -> "host2",
       "exec2" -> "host2")) {
-      val taskOption = manager.resourceOffer(k, v, NO_PREF)
+      val taskOption = manager.resourceOffer(k, v, NO_PREF)._1
       assert(taskOption.isDefined)
       val task = taskOption.get
       assert(task.executorId === k)
@@ -1580,7 +1581,7 @@ class TaskSetManagerSuite
     assert(sched.speculativeTasks.toSet === Set(3))
 
     // Offer resource to start the speculative attempt for the running task
-    val taskOption5 = manager.resourceOffer("exec1", "host1", NO_PREF)
+    val taskOption5 = manager.resourceOffer("exec1", "host1", NO_PREF)._1
     assert(taskOption5.isDefined)
     val task5 = taskOption5.get
     assert(task5.index === 3)
@@ -1640,7 +1641,7 @@ class TaskSetManagerSuite
     assert(FakeRackUtil.numBatchInvocation === 1)
     assert(FakeRackUtil.numSingleHostInvocation === 0)
     // with rack locality, reject an offer on a host with an unknown rack
-    assert(manager.resourceOffer("otherExec", "otherHost", TaskLocality.RACK_LOCAL).isEmpty)
+    assert(manager.resourceOffer("otherExec", "otherHost", TaskLocality.RACK_LOCAL)._1.isEmpty)
     (0 until 20).foreach { rackIdx =>
       (0 until 5).foreach { offerIdx =>
         // if we offer hosts which are not in preferred locations,
@@ -1648,9 +1649,9 @@ class TaskSetManagerSuite
         // but accept them at RACK_LOCAL level if they're on OK racks
         val hostIdx = 100 + rackIdx
         assert(manager.resourceOffer("exec" + hostIdx, "host" + hostIdx, TaskLocality.NODE_LOCAL)
-          .isEmpty)
+          ._1.isEmpty)
         assert(manager.resourceOffer("exec" + hostIdx, "host" + hostIdx, TaskLocality.RACK_LOCAL)
-          .isDefined)
+          ._1.isDefined)
       }
     }
     // check no more expensive calls to the rack resolution.  manager.resourceOffer() will call
@@ -1670,7 +1671,7 @@ class TaskSetManagerSuite
 
     val taskResourceAssignments = Map(GPU -> new ResourceInformation(GPU, Array("0", "1")))
     val taskOption =
-      manager.resourceOffer("exec1", "host1", NO_PREF, taskResourceAssignments)
+      manager.resourceOffer("exec1", "host1", NO_PREF, taskResourceAssignments)._1
     assert(taskOption.isDefined)
     val allocatedResources = taskOption.get.resources
     assert(allocatedResources.size == 1)
@@ -1693,7 +1694,7 @@ class TaskSetManagerSuite
     // Offer resources for 4 tasks to start, 2 on each exec
     Seq("exec1" -> "host1", "exec2" -> "host2").foreach { case (exec, host) =>
       (0 until 2).foreach { _ =>
-        val taskOption = manager.resourceOffer(exec, host, NO_PREF)
+        val taskOption = manager.resourceOffer(exec, host, NO_PREF)._1
         assert(taskOption.isDefined)
         assert(taskOption.get.executorId === exec)
       }
@@ -1717,8 +1718,8 @@ class TaskSetManagerSuite
     // Offer resource to start the speculative attempt for the running task. We offer more
     // resources, and ensure that speculative tasks get scheduled appropriately -- only one extra
     // copy per speculatable task
-    val taskOption2 = manager.resourceOffer("exec1", "host1", NO_PREF)
-    val taskOption3 = manager.resourceOffer("exec2", "host2", NO_PREF)
+    val taskOption2 = manager.resourceOffer("exec1", "host1", NO_PREF)._1
+    val taskOption3 = manager.resourceOffer("exec2", "host2", NO_PREF)._1
     assert(taskOption2.isDefined)
     val task2 = taskOption2.get
     // Ensure that task index 3 is launched on host1 and task index 4 on host2
@@ -1738,9 +1739,9 @@ class TaskSetManagerSuite
     assert(manager.copiesRunning(1) === 2)
     assert(manager.copiesRunning(3) === 2)
     // Offering additional resources should not lead to any speculative tasks being respawned
-    assert(manager.resourceOffer("exec1", "host1", ANY).isEmpty)
-    assert(manager.resourceOffer("exec2", "host2", ANY).isEmpty)
-    assert(manager.resourceOffer("exec3", "host3", ANY).isEmpty)
+    assert(manager.resourceOffer("exec1", "host1", ANY)._1.isEmpty)
+    assert(manager.resourceOffer("exec2", "host2", ANY)._1.isEmpty)
+    assert(manager.resourceOffer("exec3", "host3", ANY)._1.isEmpty)
   }
 
   test("SPARK-26755 Ensure that a speculative task obeys original locality preferences") {
@@ -1763,7 +1764,7 @@ class TaskSetManagerSuite
     }
     // Offer resources for 3 tasks to start
     Seq("exec1" -> "host1", "exec2" -> "host2", "exec3" -> "host3").foreach { case (exec, host) =>
-      val taskOption = manager.resourceOffer(exec, host, NO_PREF)
+      val taskOption = manager.resourceOffer(exec, host, NO_PREF)._1
       assert(taskOption.isDefined)
       assert(taskOption.get.executorId === exec)
     }
@@ -1776,17 +1777,17 @@ class TaskSetManagerSuite
     assert(manager.checkSpeculatableTasks(0))
     assert(sched.speculativeTasks.toSet === Set(0, 1))
     // Ensure that the speculatable tasks obey the original locality preferences
-    assert(manager.resourceOffer("exec4", "host4", NODE_LOCAL).isEmpty)
+    assert(manager.resourceOffer("exec4", "host4", NODE_LOCAL)._1.isEmpty)
     // task 1 does have a node-local preference for host2 -- but we've already got a regular
     // task running there, so we should not schedule a speculative there as well.
-    assert(manager.resourceOffer("exec2", "host2", NODE_LOCAL).isEmpty)
-    assert(manager.resourceOffer("exec3", "host3", NODE_LOCAL).isDefined)
-    assert(manager.resourceOffer("exec4", "host4", ANY).isDefined)
+    assert(manager.resourceOffer("exec2", "host2", NODE_LOCAL)._1.isEmpty)
+    assert(manager.resourceOffer("exec3", "host3", NODE_LOCAL)._1.isDefined)
+    assert(manager.resourceOffer("exec4", "host4", ANY)._1.isDefined)
     // Since, all speculatable tasks have been launched, making another offer
     // should not schedule any more tasks
-    assert(manager.resourceOffer("exec1", "host1", ANY).isEmpty)
+    assert(manager.resourceOffer("exec1", "host1", ANY)._1.isEmpty)
     assert(!manager.checkSpeculatableTasks(0))
-    assert(manager.resourceOffer("exec1", "host1", ANY).isEmpty)
+    assert(manager.resourceOffer("exec1", "host1", ANY)._1.isEmpty)
   }
 
   private def testSpeculationDurationSetup(
@@ -1931,7 +1932,7 @@ class TaskSetManagerSuite
     val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
     assert(sched.taskSetsFailed.isEmpty)
 
-    val offerResult = manager.resourceOffer("exec1", "host1", ANY)
+    val offerResult = manager.resourceOffer("exec1", "host1", ANY)._1
     assert(offerResult.isDefined,
       "Expect resource offer on iteration 0 to return a task")
     assert(offerResult.get.index === 0)

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosFineGrainedSchedulerBackendSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosFineGrainedSchedulerBackendSuite.scala
@@ -303,7 +303,7 @@ class MesosFineGrainedSchedulerBackendSuite
     mesosOffers2.add(createOffer(1, minMem, minCpu))
     reset(taskScheduler)
     reset(driver)
-    when(taskScheduler.resourceOffers(any(classOf[IndexedSeq[WorkerOffer]]))).thenReturn(Seq(Seq()))
+    when(taskScheduler.resourceOffers(any(classOf[IndexedSeq[WorkerOffer]]), any[Boolean])).thenReturn(Seq(Seq()))
     when(taskScheduler.CPUS_PER_TASK).thenReturn(2)
     when(driver.declineOffer(mesosOffers2.get(0).getId)).thenReturn(Status.valueOf(1))
 

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosFineGrainedSchedulerBackendSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosFineGrainedSchedulerBackendSuite.scala
@@ -303,7 +303,8 @@ class MesosFineGrainedSchedulerBackendSuite
     mesosOffers2.add(createOffer(1, minMem, minCpu))
     reset(taskScheduler)
     reset(driver)
-    when(taskScheduler.resourceOffers(any(classOf[IndexedSeq[WorkerOffer]]), any[Boolean])).thenReturn(Seq(Seq()))
+    when(taskScheduler.resourceOffers(any(classOf[IndexedSeq[WorkerOffer]]), any[Boolean]))
+      .thenReturn(Seq(Seq()))
     when(taskScheduler.CPUS_PER_TASK).thenReturn(2)
     when(driver.declineOffer(mesosOffers2.get(0).getId)).thenReturn(Status.valueOf(1))
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

[Delay scheduling](http://elmeleegy.com/khaled/papers/delay_scheduling.pdf) is an optimization that sacrifices fairness for data locality in order to improve cluster and workload throughput.

One useful definition of "delay" here is how much time has passed since the TaskSet was using its fair share of resources.

However it is impractical to calculate this delay, as it would require running simulations assuming no delay scheduling. Tasks would be run in different orders with different run times.

Currently the heuristic used to estimate this delay is the time since a task was last launched for a TaskSet. The problem is that it essentially does not account for resource utilization, potentially leaving the cluster heavily underutilized.

This PR modifies the heuristic in an attempt to move closer to the useful definition of delay above.
The newly proposed delay is the time since a TasksSet last launched a task **and** did not reject any resources due to delay scheduling when offered its "fair share".

See the last comments of #26696 for more discussion.

### Why are the changes needed?

cluster can become heavily underutilized as described in [SPARK-18886](https://issues.apache.org/jira/browse/SPARK-18886?jql=project%20%3D%20SPARK%20AND%20text%20~%20delay)

### How was this patch tested?

TaskSchedulerImplSuite

@cloud-fan 
@tgravescs 
@squito 