### PR TITLE
[SPARK-30481][CORE] Integrate event log compactor into Spark History Server

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileCompactor.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileCompactor.scala
@@ -29,7 +29,6 @@ import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
 import org.apache.spark.SparkConf
 import org.apache.spark.deploy.history.EventFilter.FilterStatistics
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.config.{EVENT_LOG_COMPACTION_SCORE_THRESHOLD, EVENT_LOG_ROLLING_MAX_FILES_TO_RETAIN}
 import org.apache.spark.scheduler.ReplayListenerBus
 import org.apache.spark.util.Utils
 
@@ -49,9 +48,11 @@ import org.apache.spark.util.Utils
 class EventLogFileCompactor(
     sparkConf: SparkConf,
     hadoopConf: Configuration,
-    fs: FileSystem) extends Logging {
-  private val maxFilesToRetain: Int = sparkConf.get(EVENT_LOG_ROLLING_MAX_FILES_TO_RETAIN)
-  private val compactionThresholdScore: Double = sparkConf.get(EVENT_LOG_COMPACTION_SCORE_THRESHOLD)
+    fs: FileSystem,
+    maxFilesToRetain: Int,
+    compactionThresholdScore: Double) extends Logging {
+
+  require(maxFilesToRetain > 0, "Max event log files to retain should be higher than 0.")
 
   /**
    * Compacts the old event log files into one compact file, and clean old event log files being

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -582,13 +582,13 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
       case Some(lastIndex) =>
         try {
           val info = listing.read(classOf[LogInfo], reader.rootPath.toString)
-          if (info.lastIndexToRunCompaction.isEmpty ||
-              info.lastIndexToRunCompaction.get < lastIndex) {
+          if (info.lastEvaluatedForCompaction.isEmpty ||
+              info.lastEvaluatedForCompaction.get < lastIndex) {
             // haven't tried compaction for this index, do compaction
             val result = fileCompactor.compact(reader.listEventLogFiles)
             (result.code == CompactionResultCode.SUCCESS, Some(lastIndex))
           } else {
-            (false, info.lastIndexToRunCompaction)
+            (false, info.lastEvaluatedForCompaction)
           }
         } catch {
           case _: NoSuchElementException =>
@@ -1289,7 +1289,7 @@ private[history] case class LogInfo(
     @JsonDeserialize(contentAs = classOf[JLong])
     lastIndex: Option[Long],
     @JsonDeserialize(contentAs = classOf[JLong])
-    lastIndexToRunCompaction: Option[Long],
+    lastEvaluatedForCompaction: Option[Long],
     isComplete: Boolean)
 
 private[history] class AttemptInfoWrapper(

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -822,7 +822,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
           try {
             val info = listing.read(classOf[LogInfo], reader.rootPath.toString)
             if (info.lastEvaluatedForCompaction.isEmpty ||
-              info.lastEvaluatedForCompaction.get < lastIndex) {
+                info.lastEvaluatedForCompaction.get < lastIndex) {
               // haven't tried compaction for this index, do compaction
               fileCompactor.compact(reader.listEventLogFiles)
               listing.write(info.copy(lastEvaluatedForCompaction = Some(lastIndex)))

--- a/core/src/main/scala/org/apache/spark/internal/config/History.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/History.scala
@@ -84,6 +84,22 @@ private[spark] object History {
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("1m")
 
+  private[spark] val EVENT_LOG_ROLLING_MAX_FILES_TO_RETAIN =
+    ConfigBuilder("spark.history.fs.eventLog.rolling.maxFilesToRetain")
+      .doc("The maximum number of event log files which will be retained as non-compacted. " +
+        "By default, all event log files will be retained. Please set the configuration " +
+        s"and ${EVENT_LOG_ROLLING_MAX_FILE_SIZE.key} accordingly if you want to control " +
+        "the overall size of event log files.")
+      .intConf
+      .checkValue(_ > 0, "Max event log files to retain should be higher than 0.")
+      .createWithDefault(Integer.MAX_VALUE)
+
+  private[spark] val EVENT_LOG_COMPACTION_SCORE_THRESHOLD =
+    ConfigBuilder("spark.history.fs.eventLog.rolling.compaction.score.threshold")
+      .internal()
+      .doubleConf
+      .createWithDefault(0.7d)
+
   val DRIVER_LOG_CLEANER_ENABLED = ConfigBuilder("spark.history.fs.driverlog.cleaner.enabled")
     .fallbackConf(CLEANER_ENABLED)
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -197,8 +197,6 @@ package object config {
 
   private[spark] val EVENT_LOG_ROLLING_MAX_FILES_TO_RETAIN =
     ConfigBuilder("spark.eventLog.rolling.maxFilesToRetain")
-      // TODO: remove this when integrating compactor with FsHistoryProvider
-      .internal()
       .doc("The maximum number of event log files which will be retained as non-compacted. " +
         "By default, all event log files will be retained. Please set the configuration " +
         s"and ${EVENT_LOG_ROLLING_MAX_FILE_SIZE.key} accordingly if you want to control " +

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -195,22 +195,6 @@ package object config {
         "configured to be at least 10 MiB.")
       .createWithDefaultString("128m")
 
-  private[spark] val EVENT_LOG_ROLLING_MAX_FILES_TO_RETAIN =
-    ConfigBuilder("spark.eventLog.rolling.maxFilesToRetain")
-      .doc("The maximum number of event log files which will be retained as non-compacted. " +
-        "By default, all event log files will be retained. Please set the configuration " +
-        s"and ${EVENT_LOG_ROLLING_MAX_FILE_SIZE.key} accordingly if you want to control " +
-        "the overall size of event log files.")
-      .intConf
-      .checkValue(_ > 0, "Max event log files to retain should be higher than 0.")
-      .createWithDefault(Integer.MAX_VALUE)
-
-  private[spark] val EVENT_LOG_COMPACTION_SCORE_THRESHOLD =
-    ConfigBuilder("spark.eventLog.rolling.compaction.score.threshold")
-      .internal()
-      .doubleConf
-      .createWithDefault(0.7d)
-
   private[spark] val EXECUTOR_ID =
     ConfigBuilder("spark.executor.id").stringConf.createOptional
 

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -1415,7 +1415,7 @@ class FsHistoryProviderSuite extends SparkFunSuite with Matchers with Logging {
       updateAndCheck(provider) { _ =>
         verifyEventLogFiles(fs, writer.logPath, None, Seq(1))
         val info = provider.listing.read(classOf[LogInfo], writer.logPath)
-        assert(info.lastIndexToRunCompaction === Some(1))
+        assert(info.lastEvaluatedForCompaction === Some(1))
       }
 
       // writing event log file 2 - compact the event log file 1 into 1.compact
@@ -1426,7 +1426,7 @@ class FsHistoryProviderSuite extends SparkFunSuite with Matchers with Logging {
       updateAndCheck(provider) { _ =>
         verifyEventLogFiles(fs, writer.logPath, Some(1), Seq(2))
         val info = provider.listing.read(classOf[LogInfo], writer.logPath)
-        assert(info.lastIndexToRunCompaction === Some(2))
+        assert(info.lastEvaluatedForCompaction === Some(2))
       }
 
       // writing event log file 3 - compact two files - 1.compact & 2 into one, 2.compact
@@ -1442,7 +1442,7 @@ class FsHistoryProviderSuite extends SparkFunSuite with Matchers with Logging {
         verifyEventLogFiles(fs, writer.logPath, Some(2), Seq(3))
 
         val info = provider.listing.read(classOf[LogInfo], writer.logPath)
-        assert(info.lastIndexToRunCompaction === Some(3))
+        assert(info.lastEvaluatedForCompaction === Some(3))
 
         val store = new InMemoryStore
         val appStore = new AppStatusStore(store)

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -1460,7 +1460,8 @@ class FsHistoryProviderSuite extends SparkFunSuite with Matchers with Logging {
         assert(appInfo.id === "app")
         assert(appInfo.name === "app")
 
-        // all events in retained file should be available, even they're related to finished jobs
+        // All events in retained file(s) should be available, including events which would have
+        // been filtered out if compaction is applied. e.g. finished jobs, removed executors, etc.
         val exec1 = appStore.executorSummary("exec1")
         assert(exec1.hostPort === "host1")
         val job2 = appStore.job(2)

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -37,9 +37,11 @@ import org.mockito.Mockito.{doThrow, mock, spy, verify, when}
 import org.scalatest.Matchers
 import org.scalatest.concurrent.Eventually._
 
-import org.apache.spark.{SecurityManager, SPARK_VERSION, SparkConf, SparkFunSuite}
+import org.apache.spark.{JobExecutionStatus, SecurityManager, SPARK_VERSION, SparkConf, SparkFunSuite}
+import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.deploy.history.EventLogTestHelper._
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.config.DRIVER_LOG_DFS_DIR
+import org.apache.spark.internal.config.{DRIVER_LOG_DFS_DIR, EVENT_LOG_COMPACTION_SCORE_THRESHOLD, EVENT_LOG_ROLLING_MAX_FILES_TO_RETAIN}
 import org.apache.spark.internal.config.History._
 import org.apache.spark.internal.config.UI.{ADMIN_ACLS, ADMIN_ACLS_GROUPS, USER_GROUPS_MAPPING}
 import org.apache.spark.io._
@@ -50,10 +52,10 @@ import org.apache.spark.status.AppStatusStore
 import org.apache.spark.status.KVUtils.KVStoreScalaSerializer
 import org.apache.spark.status.api.v1.{ApplicationAttemptInfo, ApplicationInfo}
 import org.apache.spark.util.{Clock, JsonProtocol, ManualClock, Utils}
+import org.apache.spark.util.kvstore.InMemoryStore
 import org.apache.spark.util.logging.DriverLogger
 
 class FsHistoryProviderSuite extends SparkFunSuite with Matchers with Logging {
-
   private var testDir: File = null
 
   override def beforeEach(): Unit = {
@@ -164,8 +166,9 @@ class FsHistoryProviderSuite extends SparkFunSuite with Matchers with Logging {
       override private[history] def doMergeApplicationListing(
           reader: EventLogFileReader,
           lastSeen: Long,
-          enableSkipToEnd: Boolean): Unit = {
-        super.doMergeApplicationListing(reader, lastSeen, enableSkipToEnd)
+          enableSkipToEnd: Boolean,
+          lastCompactionIndex: Option[Long]): Unit = {
+        super.doMergeApplicationListing(reader, lastSeen, enableSkipToEnd, lastCompactionIndex)
         doMergeApplicationListingCall += 1
       }
     }
@@ -1167,7 +1170,7 @@ class FsHistoryProviderSuite extends SparkFunSuite with Matchers with Logging {
     var fileStatus = new FileStatus(200, false, 0, 0, 0, path)
     when(mockedFs.getFileStatus(path)).thenReturn(fileStatus)
     var logInfo = new LogInfo(path.toString, 0, LogType.EventLogs, Some("appId"),
-      Some("attemptId"), 100, None, false)
+      Some("attemptId"), 100, None, None, false)
     var reader = EventLogFileReader(mockedFs, path)
     assert(reader.isDefined)
     assert(mockedProvider.shouldReloadLog(logInfo, reader.get))
@@ -1177,14 +1180,14 @@ class FsHistoryProviderSuite extends SparkFunSuite with Matchers with Logging {
     when(mockedFs.getFileStatus(path)).thenReturn(fileStatus)
     // DFSInputStream.getFileLength is more than logInfo fileSize
     logInfo = new LogInfo(path.toString, 0, LogType.EventLogs, Some("appId"),
-      Some("attemptId"), 100, None, false)
+      Some("attemptId"), 100, None, None, false)
     reader = EventLogFileReader(mockedFs, path)
     assert(reader.isDefined)
     assert(mockedProvider.shouldReloadLog(logInfo, reader.get))
 
     // DFSInputStream.getFileLength is equal to logInfo fileSize
     logInfo = new LogInfo(path.toString, 0, LogType.EventLogs, Some("appId"),
-      Some("attemptId"), 200, None, false)
+      Some("attemptId"), 200, None, None, false)
     reader = EventLogFileReader(mockedFs, path)
     assert(reader.isDefined)
     assert(!mockedProvider.shouldReloadLog(logInfo, reader.get))
@@ -1292,11 +1295,11 @@ class FsHistoryProviderSuite extends SparkFunSuite with Matchers with Logging {
 
     val serializer = new KVStoreScalaSerializer()
     val logInfoWithIndexAsNone = LogInfo("dummy", 0, LogType.EventLogs, Some("appId"),
-      Some("attemptId"), 100, None, false)
+      Some("attemptId"), 100, None, None, false)
     assertSerDe(serializer, logInfoWithIndexAsNone)
 
     val logInfoWithIndex = LogInfo("dummy", 0, LogType.EventLogs, Some("appId"),
-      Some("attemptId"), 100, Some(3), false)
+      Some("attemptId"), 100, Some(3), None, false)
     assertSerDe(serializer, logInfoWithIndex)
   }
 
@@ -1359,6 +1362,110 @@ class FsHistoryProviderSuite extends SparkFunSuite with Matchers with Logging {
       // doesn't trigger unboxing and passes even without SPARK-29755, so don't remove
       // `.toLong` below. Please refer SPARK-29755 for more details.
       assert(opt.get.toLong === expected.get.toLong)
+    }
+  }
+
+  test("compact event log files") {
+    def verifyEventLogFiles(
+        fs: FileSystem,
+        rootPath: String,
+        expectedIndexForCompact: Option[Long],
+        expectedIndicesForNonCompact: Seq[Long]): Unit = {
+      val reader = EventLogFileReader(fs, new Path(rootPath)).get
+      var logFiles = reader.listEventLogFiles
+
+      expectedIndexForCompact.foreach { idx =>
+        val headFile = logFiles.head
+        assert(EventLogFileWriter.isCompacted(headFile.getPath))
+        assert(idx == RollingEventLogFilesWriter.getEventLogFileIndex(headFile.getPath.getName))
+        logFiles = logFiles.drop(1)
+      }
+
+      assert(logFiles.size === expectedIndicesForNonCompact.size)
+
+      logFiles.foreach { logFile =>
+        assert(RollingEventLogFilesWriter.isEventLogFile(logFile))
+        assert(!EventLogFileWriter.isCompacted(logFile.getPath))
+      }
+
+      val indices = logFiles.map { logFile =>
+        RollingEventLogFilesWriter.getEventLogFileIndex(logFile.getPath.getName)
+      }
+      assert(expectedIndicesForNonCompact === indices)
+    }
+
+    withTempDir { dir =>
+      val conf = createTestConf()
+      conf.set(HISTORY_LOG_DIR, dir.getAbsolutePath)
+      conf.set(EVENT_LOG_ROLLING_MAX_FILES_TO_RETAIN, 1)
+      conf.set(EVENT_LOG_COMPACTION_SCORE_THRESHOLD, 0.0d)
+      val hadoopConf = SparkHadoopUtil.newConfiguration(conf)
+      val fs = new Path(dir.getAbsolutePath).getFileSystem(hadoopConf)
+
+      val provider = new FsHistoryProvider(conf)
+
+      val writer = new RollingEventLogFilesWriter("app", None, dir.toURI, conf, hadoopConf)
+      writer.start()
+
+      // writing event log file 1 - don't compact for now
+      writeEventsToRollingWriter(writer, Seq(
+        SparkListenerApplicationStart("app", Some("app"), 0, "user", None),
+        SparkListenerJobStart(1, 0, Seq.empty)), rollFile = false)
+
+      updateAndCheck(provider) { _ =>
+        verifyEventLogFiles(fs, writer.logPath, None, Seq(1))
+        val info = provider.listing.read(classOf[LogInfo], writer.logPath)
+        assert(info.lastIndexToRunCompaction === Some(1))
+      }
+
+      // writing event log file 2 - compact the event log file 1 into 1.compact
+      writeEventsToRollingWriter(writer, Seq.empty, rollFile = true)
+      writeEventsToRollingWriter(writer, Seq(SparkListenerUnpersistRDD(1),
+        SparkListenerJobEnd(1, 1, JobSucceeded)), rollFile = false)
+
+      updateAndCheck(provider) { _ =>
+        verifyEventLogFiles(fs, writer.logPath, Some(1), Seq(2))
+        val info = provider.listing.read(classOf[LogInfo], writer.logPath)
+        assert(info.lastIndexToRunCompaction === Some(2))
+      }
+
+      // writing event log file 3 - compact two files - 1.compact & 2 into one, 2.compact
+      writeEventsToRollingWriter(writer, Seq.empty, rollFile = true)
+      writeEventsToRollingWriter(writer, Seq(
+        SparkListenerExecutorAdded(3, "exec1", new ExecutorInfo("host1", 1, Map.empty)),
+        SparkListenerJobStart(2, 4, Seq.empty),
+        SparkListenerJobEnd(2, 5, JobSucceeded)), rollFile = false)
+
+      writer.stop()
+
+      updateAndCheck(provider) { _ =>
+        verifyEventLogFiles(fs, writer.logPath, Some(2), Seq(3))
+
+        val info = provider.listing.read(classOf[LogInfo], writer.logPath)
+        assert(info.lastIndexToRunCompaction === Some(3))
+
+        val store = new InMemoryStore
+        val appStore = new AppStatusStore(store)
+
+        val reader = EventLogFileReader(fs, new Path(writer.logPath)).get
+        provider.rebuildAppStore(store, reader, 0L)
+
+        // replayed store doesn't have any job, as events for job are removed while compacting
+        intercept[NoSuchElementException] {
+          appStore.job(1)
+        }
+
+        // but other events should be available even they were in original files to compact
+        val appInfo = appStore.applicationInfo()
+        assert(appInfo.id === "app")
+        assert(appInfo.name === "app")
+
+        // all events in retained file should be available, even they're related to finished jobs
+        val exec1 = appStore.executorSummary("exec1")
+        assert(exec1.hostPort === "host1")
+        val job2 = appStore.job(2)
+        assert(job2.status === JobExecutionStatus.SUCCEEDED)
+      }
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -41,7 +41,7 @@ import org.apache.spark.{JobExecutionStatus, SecurityManager, SPARK_VERSION, Spa
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.deploy.history.EventLogTestHelper._
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.config.{DRIVER_LOG_DFS_DIR, EVENT_LOG_COMPACTION_SCORE_THRESHOLD, EVENT_LOG_ROLLING_MAX_FILES_TO_RETAIN}
+import org.apache.spark.internal.config.DRIVER_LOG_DFS_DIR
 import org.apache.spark.internal.config.History._
 import org.apache.spark.internal.config.UI.{ADMIN_ACLS, ADMIN_ACLS_GROUPS, USER_GROUPS_MAPPING}
 import org.apache.spark.io._

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1031,7 +1031,6 @@ Apart from these, the following properties are also available, and may be useful
     all event log files will be retained.<br/>
     Please note that compaction will happen in Spark History Server, which means this configuration
     should be set to the configuration of Spark History server, and the same value will be applied
-    should be set to the configuration of Spark History server, and the same value will be applied
     across applications which are being loaded in Spark History Server. This also means compaction
     and cleanup would require running Spark History Server.<br/>
     Please set the configuration in Spark History Server, and <code>spark.eventLog.rolling.maxFileSize</code>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1024,21 +1024,24 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
-  <td><code>spark.eventLog.rolling.maxFilesToRetain</code></td>
+  <td><code>spark.history.fs.eventLog.rolling.maxFilesToRetain</code></td>
   <td>Int.MaxValue</td>
   <td>
-    The maximum number of event log files which will be retained as non-compacted.
-    By default, all event log files will be retained. Please set the configuration and
-    <code>spark.eventLog.rolling.maxFileSize</code> accordingly if you want to control
-    the overall size of event log files. The event log files older than these retained
-    files will be compacted into single file and deleted afterwards.<br/>
-    NOTE 1: Compaction will happen in Spark History Server, which means the same value
-    will be applied across applications which are being loaded in Spark History Server,
-    as well as compaction and cleanup would require running Spark History Server.<br/>
-    NOTE 2: Spark History Server may not compact the old event log files if it figures
+    The maximum number of event log files which will be retained as non-compacted. By default,
+    all event log files will be retained.<br/>
+    Please note that compaction will happen in Spark History Server, which means this configuration
+    should be set to the configuration of Spark History server, and the same value will be applied
+    should be set to the configuration of Spark History server, and the same value will be applied
+    across applications which are being loaded in Spark History Server. This also means compaction
+    and cleanup would require running Spark History Server.<br/>
+    Please set the configuration in Spark History Server, and <code>spark.eventLog.rolling.maxFileSize</code>
+    in each application accordingly if you want to control the overall size of event log files.
+    The event log files older than these retained files will be compacted into single file and
+    deleted afterwards.<br/>
+    NOTE: Spark History Server may not compact the old event log files if it figures
     out not a lot of space would be reduced during compaction. For streaming query
     (including Structured Streaming) we normally expect compaction will run, but for
-    batch query compaction won't run in most cases.
+    batch query compaction won't run in many cases.
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1024,6 +1024,24 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
+  <td><code>spark.eventLog.rolling.maxFilesToRetain</code></td>
+  <td>Int.MaxValue</td>
+  <td>
+    The maximum number of event log files which will be retained as non-compacted.
+    By default, all event log files will be retained. Please set the configuration and
+    <code>spark.eventLog.rolling.maxFileSize</code> accordingly if you want to control
+    the overall size of event log files. The event log files older than these retained
+    files will be compacted into single file and deleted afterwards.<br/>
+    NOTE 1: Compaction will happen in Spark History Server, which means the same value
+    will be applied across applications which are being loaded in Spark History Server,
+    as well as compaction and cleanup would require running Spark History Server.<br/>
+    NOTE 2: Spark History Server may not compact the old event log files if it figures
+    out not a lot of space would be reduced during compaction. For streaming query
+    (including Structured Streaming) we normally expect compaction will run, but for
+    batch query compaction won't run in most cases.
+  </td>
+</tr>
+<tr>
   <td><code>spark.ui.dagGraph.retainedRootRDDs</code></td>
   <td>Int.MaxValue</td>
   <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1024,26 +1024,6 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
-  <td><code>spark.history.fs.eventLog.rolling.maxFilesToRetain</code></td>
-  <td>Int.MaxValue</td>
-  <td>
-    The maximum number of event log files which will be retained as non-compacted. By default,
-    all event log files will be retained.<br/>
-    Please note that compaction will happen in Spark History Server, which means this configuration
-    should be set to the configuration of Spark History server, and the same value will be applied
-    across applications which are being loaded in Spark History Server. This also means compaction
-    and cleanup would require running Spark History Server.<br/>
-    Please set the configuration in Spark History Server, and <code>spark.eventLog.rolling.maxFileSize</code>
-    in each application accordingly if you want to control the overall size of event log files.
-    The event log files older than these retained files will be compacted into single file and
-    deleted afterwards.<br/>
-    NOTE: Spark History Server may not compact the old event log files if it figures
-    out not a lot of space would be reduced during compaction. For streaming query
-    (including Structured Streaming) we normally expect compaction will run, but for
-    batch query compaction won't run in many cases.
-  </td>
-</tr>
-<tr>
   <td><code>spark.ui.dagGraph.retainedRootRDDs</code></td>
   <td>Int.MaxValue</td>
   <td>

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -300,7 +300,26 @@ Security options for the Spark History Server are covered more detail in the
         Even this is set to `true`, this configuration has no effect on a live application, it only affects the history server.
     </td>
   </tr>
-
+  <tr>
+    <td>spark.history.fs.eventLog.rolling.maxFilesToRetain</td>
+    <td>Int.MaxValue</td>
+    <td>
+      The maximum number of event log files which will be retained as non-compacted. By default,
+      all event log files will be retained.<br/>
+      Please note that compaction will happen in Spark History Server, which means this configuration
+      should be set to the configuration of Spark History server, and the same value will be applied
+      across applications which are being loaded in Spark History Server. This also means compaction
+      and cleanup would require running Spark History Server.<br/>
+      Please set the configuration in Spark History Server, and <code>spark.eventLog.rolling.maxFileSize</code>
+      in each application accordingly if you want to control the overall size of event log files.
+      The event log files older than these retained files will be compacted into single file and
+      deleted afterwards.<br/>
+      NOTE: Spark History Server may not compact the old event log files if it figures
+      out not a lot of space would be reduced during compaction. For streaming query
+      (including Structured Streaming) we normally expect compaction will run, but for
+      batch query compaction won't run in many cases.
+    </td>
+  </tr>
 </table>
 
 Note that in all of these UIs, the tables are sortable by clicking their headers,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This patch addresses remaining functionality on event log compaction: integrate compaction into FsHistoryProvider.

This patch is next task of SPARK-30479 (#27164), please refer the description of PR #27085 to see overall rationalization of this patch.

### Why are the changes needed?

One of major goal of SPARK-28594 is to prevent the event logs to become too huge, and SPARK-29779 achieves the goal. We've got another approach in prior, but the old approach required models in both KVStore and live entities to guarantee compatibility, while they're not designed to do so.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Added UT.