### PR TITLE
[SPARK-30517][SQL] Support SHOW TABLES EXTENDED

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -201,7 +201,7 @@ statement
     | DROP TEMPORARY? FUNCTION (IF EXISTS)? multipartIdentifier        #dropFunction
     | EXPLAIN (LOGICAL | FORMATTED | EXTENDED | CODEGEN | COST)?
         statement                                                      #explain
-    | SHOW TABLES ((FROM | IN) multipartIdentifier)?
+    | SHOW TABLES EXTENDED? ((FROM | IN) multipartIdentifier)?
         (LIKE? pattern=STRING)?                                        #showTables
     | SHOW TABLE EXTENDED ((FROM | IN) ns=multipartIdentifier)?
         LIKE pattern=STRING partitionSpec?                             #showTable

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -730,9 +730,10 @@ class Analyzer(
   case class ResolveNamespace(catalogManager: CatalogManager)
     extends Rule[LogicalPlan] with LookupCatalog {
     def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
-      case s @ ShowTables(UnresolvedNamespace(Seq()), _) =>
+      case s @ ShowTables(UnresolvedNamespace(Seq()), _, _) =>
         s.copy(namespace =
-          ResolvedNamespace(currentCatalog.asNamespaceCatalog, catalogManager.currentNamespace))
+          ResolvedNamespace(currentCatalog.asNamespaceCatalog, catalogManager.currentNamespace),
+          extended = s.extended)
       case UnresolvedNamespace(Seq()) =>
         ResolvedNamespace(currentCatalog.asNamespaceCatalog, Seq.empty[String])
       case UnresolvedNamespace(CatalogAndNamespace(catalog, ns)) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -2838,7 +2838,8 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
     val multiPart = Option(ctx.multipartIdentifier).map(visitMultipartIdentifier)
     ShowTables(
       UnresolvedNamespace(multiPart.getOrElse(Seq.empty[String])),
-      Option(ctx.pattern).map(string))
+      Option(ctx.pattern).map(string),
+      if (ctx.EXTENDED() == null) false else true)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statements.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statements.scala
@@ -344,7 +344,8 @@ case class InsertIntoStatement(
 case class ShowTableStatement(
     namespace: Option[Seq[String]],
     pattern: String,
-    partitionSpec: Option[TablePartitionSpec])
+    partitionSpec: Option[TablePartitionSpec],
+    extended: Boolean = false)
   extends ParsedStatement
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -436,7 +436,8 @@ case class RenameTable(
  */
 case class ShowTables(
     namespace: LogicalPlan,
-    pattern: Option[String]) extends Command {
+    pattern: Option[String],
+    extended: Boolean = false) extends Command {
   override def children: Seq[LogicalPlan] = Seq(namespace)
 
   override val output: Seq[Attribute] = Seq(

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -347,22 +347,22 @@ class ResolveSessionCatalog(
       }
       DropDatabaseCommand(ns.head, d.ifExists, d.cascade)
 
-    case ShowTables(SessionCatalogAndNamespace(_, ns), pattern) =>
+    case ShowTables(SessionCatalogAndNamespace(_, ns), pattern, extended) =>
       assert(ns.nonEmpty)
       if (ns.length != 1) {
           throw new AnalysisException(
             s"The database name is not valid: ${ns.quoted}")
       }
-      ShowTablesCommand(Some(ns.head), pattern)
+      ShowTablesCommand(Some(ns.head), pattern, extended)
 
-    case ShowTableStatement(ns, pattern, partitionsSpec) =>
+    case ShowTableStatement(ns, pattern, partitionsSpec, _) =>
       val db = ns match {
         case Some(ns) if ns.length != 1 =>
           throw new AnalysisException(
             s"The database name is not valid: ${ns.quoted}")
         case _ => ns.map(_.head)
       }
-      ShowTablesCommand(db, Some(pattern), true, partitionsSpec)
+      ShowTableCommand(db, Some(pattern), true, partitionsSpec)
 
     case AnalyzeTableStatement(tbl, partitionSpec, noScan) =>
       val v1TableName = parseV1Table(tbl, "ANALYZE TABLE")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -237,7 +237,7 @@ object DataSourceV2Strategy extends Strategy with PredicateHelper {
     case r @ ShowNamespaces(ResolvedNamespace(catalog, ns), pattern) =>
       ShowNamespacesExec(r.output, catalog, ns, pattern) :: Nil
 
-    case r @ ShowTables(ResolvedNamespace(catalog, ns), pattern) =>
+    case r @ ShowTables(ResolvedNamespace(catalog, ns), pattern, _) =>
       ShowTablesExec(r.output, catalog.asTableCatalog, ns, pattern) :: Nil
 
     case SetCatalogAndNamespace(catalogManager, catalogName, ns) =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
WIP 
Added a syntax for `SHOW TABLES EXTENDED` which can output a additional column compared to `SHOW TABLES` which prints the table type with possible values `MANAGED,EXTERNAL,VIEW`
Also to reduce complexity, this PR breaks `org.apache.spark.sql.execution.command.ShowTablesCommand` which was responsible for `SHOW TABLES` and `SHOW TABLE` command into separate classes

### Why are the changes needed?
Intention is to support show tables with a additional column 'type' where type can be `MANAGED,EXTERNAL,VIEW` using which user can query only tables of required types, like listing only views or only external tables (using a `where` clause over `type` column).

Usecase example:
Currently its not possible to list all the VIEWS, but other technologies like hive support it using `SHOW VIEWS`, mysql supports it using a more complex query `SHOW FULL TABLES WHERE table_type = 'VIEW;`

Decide to take mysql approach as it provides more flexibility for querying.

### Does this PR introduce any user-facing change?
Yes. New option `EXTENDED` for `SHOW TABLES` command


### How was this patch tested?


TODO: 
1. Add UTs
2. `where` clause support
3. V2 catalog support