### PR TITLE
[SPARK-30514][K8S] add python environment support for JavaMainAppResource

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -297,6 +297,12 @@ private[spark] object Config extends Logging {
       .stringConf
       .createOptional
 
+  val IS_PYTHON_APP =
+    ConfigBuilder("spark.kubernetes.isPython")
+      .doc("Whether to use python with spark-internal")
+      .booleanConf
+      .createWithDefault(false)
+
   val APP_RESOURCE_TYPE =
     ConfigBuilder("spark.kubernetes.resource.type")
       .doc("This sets the resource type internally")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
@@ -61,7 +61,8 @@ private[spark] class BasicExecutorFeatureStep(
       MEMORY_OVERHEAD_MIN_MIB))
   private val executorMemoryWithOverhead = executorMemoryMiB + memoryOverheadMiB
   private val executorMemoryTotal =
-    if (kubernetesConf.get(APP_RESOURCE_TYPE) == Some(APP_RESOURCE_TYPE_PYTHON)) {
+    if (kubernetesConf.get(APP_RESOURCE_TYPE).contains(APP_RESOURCE_TYPE_PYTHON) ||
+        kubernetesConf.get(org.apache.spark.deploy.k8s.Config.IS_PYTHON_APP)) {
       executorMemoryWithOverhead +
         kubernetesConf.get(PYSPARK_EXECUTOR_MEMORY).map(_.toInt).getOrElse(0)
     } else {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
@@ -226,7 +226,7 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
     val step = new BasicExecutorFeatureStep(newExecutorConf(), new SecurityManager(baseConf))
     val executor = step.configurePod(SparkPod.initialPod())
     // This is checking that basic executor + executorMemory = 1408 + 42 = 1450
-    assert(executor.container.getResources.getRequests.get("memory").getAmount === "1450Mi")
+    assert(executor.container.getResources.getRequests.get("memory").getAmount === "1450")
   }
 
   test("auth secret propagation") {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
@@ -214,18 +214,6 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
     val step = new BasicExecutorFeatureStep(newExecutorConf(), new SecurityManager(baseConf))
     val executor = step.configurePod(SparkPod.initialPod())
     // This is checking that basic executor + executorMemory = 1408 + 42 = 1450
-    assert(executor.container.getResources.getRequests.get("memory").getAmount === "1450Mi")
-  }
-
-  test("SPARK-30514: test executor pyspark memory " +
-      "with java resource and spark.kubernetes.isPython=true") {
-    baseConf.set("spark.kubernetes.resource.type", "java")
-    baseConf.set("spark.kubernetes.isPython", "true")
-    baseConf.set(PYSPARK_EXECUTOR_MEMORY, 42L)
-
-    val step = new BasicExecutorFeatureStep(newExecutorConf(), new SecurityManager(baseConf))
-    val executor = step.configurePod(SparkPod.initialPod())
-    // This is checking that basic executor + executorMemory = 1408 + 42 = 1450
     assert(executor.container.getResources.getRequests.get("memory").getAmount === "1450")
   }
 

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
@@ -217,6 +217,18 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
     assert(executor.container.getResources.getRequests.get("memory").getAmount === "1450Mi")
   }
 
+  test("SPARK-30514: test executor pyspark memory " +
+      "with java resource and spark.kubernetes.isPython=true") {
+    baseConf.set("spark.kubernetes.resource.type", "java")
+    baseConf.set("spark.kubernetes.isPython", "true")
+    baseConf.set(PYSPARK_EXECUTOR_MEMORY, 42L)
+
+    val step = new BasicExecutorFeatureStep(newExecutorConf(), new SecurityManager(baseConf))
+    val executor = step.configurePod(SparkPod.initialPod())
+    // This is checking that basic executor + executorMemory = 1408 + 42 = 1450
+    assert(executor.container.getResources.getRequests.get("memory").getAmount === "1450Mi")
+  }
+
   test("auth secret propagation") {
     val conf = baseConf.clone()
       .set(config.NETWORK_AUTH_ENABLED, true)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
@@ -205,6 +205,18 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
     assert(amountAndFormat(executor.container.getResources.getRequests.get("memory")) === "1450Mi")
   }
 
+  test("SPARK-30514: test executor pyspark memory " +
+      "with java resource and spark.kubernetes.isPython=true") {
+    baseConf.set("spark.kubernetes.resource.type", "java")
+    baseConf.set("spark.kubernetes.isPython", "true")
+    baseConf.set(PYSPARK_EXECUTOR_MEMORY, 42L)
+
+    val step = new BasicExecutorFeatureStep(newExecutorConf(), new SecurityManager(baseConf))
+    val executor = step.configurePod(SparkPod.initialPod())
+    // This is checking that basic executor + executorMemory = 1408 + 42 = 1450
+    assert(executor.container.getResources.getRequests.get("memory").getAmount === "1450Mi")
+  }
+
   test("auth secret propagation") {
     val conf = baseConf.clone()
       .set(config.NETWORK_AUTH_ENABLED, true)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
@@ -205,7 +205,7 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
     assert(amountAndFormat(executor.container.getResources.getRequests.get("memory")) === "1450Mi")
   }
 
-  test("SPARK-30514: test executor pyspark memory " +
+  test("SPARK-30514: test executor pyspark.memory " +
       "with java resource and spark.kubernetes.isPython=true") {
     baseConf.set("spark.kubernetes.resource.type", "java")
     baseConf.set("spark.kubernetes.isPython", "true")


### PR DESCRIPTION
### What changes were proposed in this pull request?
If application is started with JavaMainAppResource, no python environment, such as PYSPARK_MAJOR_PYTHON_VERSION and PYSPARK_EXECUTOR_MEMORY, won't be available in Executor Pods. It make it not easy to work with Livy. In apache Livy, the program is first started with JavaMainAppResource, and then start the Python worker. At this time, the program needs to be able to pass Python environment variables.

In spark on yarn, we support this through spark.yarn.isPython. In k8s, we should also support this.


### Why are the changes needed?
To support Livy on spark with k8s, we need this config.


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
Add new unit tests and run all unit tests
