### PR TITLE
[SPARK-28801][DOC] Document SELECT statement in SQL Reference (Main page)

### DIFF
--- a/docs/sql-ref-syntax-qry-select.md
+++ b/docs/sql-ref-syntax-qry-select.md
@@ -18,8 +18,119 @@ license: |
   See the License for the specific language governing permissions and
   limitations under the License.
 ---
+Spark supports a `SELECT` statement and conforms to the ANSI SQL standard. Queries are
+used to retrieve result sets from one or more tables. The following section 
+describes the overall query syntax and the sub-sections cover different constructs
+of a query along with examples. 
 
-Spark SQL is a Apache Spark's module for working with structured data.
-This guide is a reference for Structured Query Language (SQL) for Apache 
-Spark. This document describes the SQL constructs supported by Spark in detail
-along with usage examples when applicable.
+### Syntax
+{% highlight sql %}
+[WITH with_query [, ...]]
+SELECT [hints, ...] [ALL|DISTINCT] named_expression[, named_expression, ...]
+  FROM from_item [, from_item, ...]
+  [WHERE boolean_expression]
+  [GROUP BY expression [, ...] ]
+  [HAVING boolean_expression [, ...] ]
+  [ORDER BY expression [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [, ...] ]
+  [SORT  BY expression [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [, ...] ]
+  [CLUSTER BY [expression [, ...] ]
+  [DISTRIBUTE BY [expression [, ...] ]
+  { UNION | INTERSECT | EXCEPT } [ ALL | DISTINCT ] select ]
+  [WINDOW named_window[, WINDOW named_window, ...]]
+  [LIMIT {ALL | expression}]
+{% endhighlight %}
+
+### Parameters
+<dl>
+  <dt><code><em>with_query</em></code></dt>
+  <dd>
+    Specifies the common table expressions (CTEs) before the main <code>SELECT</code> query block.
+    These table expressions are allowed to be referenced later in the main query. This is useful to abstract
+    out repeated sub query blocks in the main query and improves readability of the query.
+  </dd>
+  <dt><code><em>hints</em></code></dt>
+  <dd>
+    Hints can be specified to help spark optimizer make better planning decisions. Currently spark supports hints
+    that influence selection of join strategies and repartitioning of the data. 
+  </dd>
+  <dt><code><em>ALL</em></code></dt>
+  <dd>
+    Select all matching rows from the relation and is enabled by default.
+  </dd>
+  <dt><code><em>DISTINCT</em></code></dt>
+  <dd>
+    Select all matching rows from the relation after removing duplicates in results.
+  </dd>
+  <dt><code><em>named_expression</em></code></dt>
+  <dd>
+    A expression with an assigned name. In general, it denotes a column expression.<br><br>
+    <b>Syntax:</b>
+      <code>
+        expression [AS] [alias]
+      </code>
+  </dd>
+  <dt><code><em>from_item</em></code></dt>
+  <dd>
+    Specifies a source of input for the query. It can be one of the following.
+    <ol>
+      <li>Table relation</li>
+      <li>Join relation</li>
+      <li>Table valued function</li>
+      <li>Inlined table</li>
+      <li>Subquery</li>    
+    </ol>
+  </dd>
+  <dt><code><em>WHERE</em></code></dt>
+  <dd>
+    Filters the result of the FROM clause based on the supplied predicates.
+  </dd>
+  <dt><code><em>GROUP BY</em></code></dt>
+  <dd>
+    Specifies the expressions that are used to group the rows. This is used in conjunction with aggregate functions
+    (MIN, MAX, COUNT, SUM, AVG) to group rows bsed on the grouping expressions.
+  </dd>
+  <dt><code><em>HAVING</em></code></dt>
+  <dd>
+    Specifies the predicates by which the rows produced by GROUP BY are filtered. The HAVING clause is used to
+    filter rows after the grouping is performed
+  </dd>
+  <dt><code><em>ORDER BY</em></code></dt>
+  <dd>
+    Specifies an ordering of the rows of the complete result set of the query. The output rows are ordered
+    across the partitions. This parameter is mutually exclusive with <code>SORT BY</code>,
+    <code>CLUSTER BY</code> and <code>DISTRIBUTE BY</code> and can not be specified together.
+  </dd>
+  <dt><code><em>SORT BY</em></code></dt>
+  <dd>
+    Specifies an ordering by which the rows are ordered within each partition. This parameter is mutually
+    exclusive with <code>ORDER BY</code> and <code>CLUSTER BY</code> and can not be specified together.
+  </dd>
+  <dt><code><em>CLUSTER BY</em></code></dt>
+  <dd>
+    Specifies a set of expressions that is used to repartition and sort the rows. Using this clause has
+    the same effect of using <code>DISTRIBUTE BY</code> and <code>SORT BY</code> together. 
+  </dd>
+  <dt><code><em>DISTRIBUTE BY</em></code></dt>
+  <dd>
+    Specifies a set of expressions by which the result rows are repartitioned. This parameter is mutually 
+    exclusive with <code>ORDER BY</code> and <code>CLUSTER BY</code> and can not be specified together. 
+  </dd>
+  <dt><code><em>LIMIT</em></code></dt>
+  <dd>
+    Specifies the maximum number of rows that can be returned by a statement or subquery. This clause 
+    is mostly used in the conjunction with <code>ORDER BY</code> to produce a deterministic result. 
+  </dd>
+  <dt><code><em>boolean_expression</em></code></dt>
+  <dd>
+    Specifies an expression with a return type of boolean.
+  </dd>
+  <dt><code><em>expression</em></code></dt>
+  <dd>
+    Specifies a combination of one or more values, operators, and SQL functions that evaluates to a value.
+  </dd>
+  <dt><code><em>named_window</em></code></dt>
+  <dd>
+    Specifies aliases for one or more source window specifications. The source window specifications can 
+    be referenced in the widow definitions in the query.
+  </dd>
+</dl>

--- a/docs/sql-ref-syntax-qry-select.md
+++ b/docs/sql-ref-syntax-qry-select.md
@@ -25,19 +25,19 @@ of a query along with examples.
 
 ### Syntax
 {% highlight sql %}
-[WITH with_query [, ...]]
-SELECT [hints, ...] [ALL|DISTINCT] named_expression[, named_expression, ...]
-  FROM from_item [, from_item, ...]
-  [WHERE boolean_expression]
-  [GROUP BY expression [, ...] ]
-  [HAVING boolean_expression [, ...] ]
-  [ORDER BY expression [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [, ...] ]
-  [SORT  BY expression [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [, ...] ]
-  [CLUSTER BY [expression [, ...] ]
-  [DISTRIBUTE BY [expression [, ...] ]
+[ WITH with_query [ , ... ] ]
+SELECT [ hints , ... ] [ ALL | DISTINCT ] { named_expression [ , ... ] }
+  FROM { from_item [ , ...] }
+  [ WHERE boolean_expression ]
+  [ GROUP BY expression [ , ...] ]
+  [ HAVING boolean_expression ]
+  [ ORDER BY { expression [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [ , ...] } ]
+  [ SORT  BY { expression [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [ , ...] } ]
+  [ CLUSTER BY { expression [ , ...] } ]
+  [ DISTRIBUTE BY { expression [, ...] } ]
   { UNION | INTERSECT | EXCEPT } [ ALL | DISTINCT ] select ]
-  [WINDOW named_window[, WINDOW named_window, ...]]
-  [LIMIT {ALL | expression}]
+  [ WINDOW { named_window [ , WINDOW named_window, ... ] } ]
+  [ LIMIT { ALL | expression } ]
 {% endhighlight %}
 
 ### Parameters
@@ -46,7 +46,7 @@ SELECT [hints, ...] [ALL|DISTINCT] named_expression[, named_expression, ...]
   <dd>
     Specifies the common table expressions (CTEs) before the main <code>SELECT</code> query block.
     These table expressions are allowed to be referenced later in the main query. This is useful to abstract
-    out repeated sub query blocks in the main query and improves readability of the query.
+    out repeated subquery blocks in the main query and improves readability of the query.
   </dd>
   <dt><code><em>hints</em></code></dt>
   <dd>
@@ -71,7 +71,7 @@ SELECT [hints, ...] [ALL|DISTINCT] named_expression[, named_expression, ...]
   </dd>
   <dt><code><em>from_item</em></code></dt>
   <dd>
-    Specifies a source of input for the query. It can be one of the following.
+    Specifies a source of input for the query. It can be one of the following:
     <ol>
       <li>Table relation</li>
       <li>Join relation</li>
@@ -87,12 +87,12 @@ SELECT [hints, ...] [ALL|DISTINCT] named_expression[, named_expression, ...]
   <dt><code><em>GROUP BY</em></code></dt>
   <dd>
     Specifies the expressions that are used to group the rows. This is used in conjunction with aggregate functions
-    (MIN, MAX, COUNT, SUM, AVG) to group rows bsed on the grouping expressions.
+    (MIN, MAX, COUNT, SUM, AVG) to group rows based on the grouping expressions.
   </dd>
   <dt><code><em>HAVING</em></code></dt>
   <dd>
     Specifies the predicates by which the rows produced by GROUP BY are filtered. The HAVING clause is used to
-    filter rows after the grouping is performed
+    filter rows after the grouping is performed.
   </dd>
   <dt><code><em>ORDER BY</em></code></dt>
   <dd>

--- a/docs/sql-ref-syntax-qry-select.md
+++ b/docs/sql-ref-syntax-qry-select.md
@@ -63,7 +63,7 @@ SELECT [ hints , ... ] [ ALL | DISTINCT ] { named_expression [ , ... ] }
   </dd>
   <dt><code><em>named_expression</em></code></dt>
   <dd>
-    A expression with an assigned name. In general, it denotes a column expression.<br><br>
+    An expression with an assigned name. In general, it denotes a column expression.<br><br>
     <b>Syntax:</b>
       <code>
         expression [AS] [alias]


### PR DESCRIPTION
### What changes were proposed in this pull request?
Document SELECT statement in SQL Reference Guide. In this PR includes the main
entry page for SELECT. I will open follow-up PRs for different clauses.

### Why are the changes needed?
Currently Spark lacks documentation on the supported SQL constructs causing
confusion among users who sometimes have to look at the code to understand the
usage. This is aimed at addressing this issue.

### Does this PR introduce any user-facing change?
Yes. 

**Before:**
There was no documentation for this.

**After.**
<img width="972" alt="Screen Shot 2020-01-19 at 11 20 41 PM" src="https://user-images.githubusercontent.com/14225158/72706257-6c42f900-3b12-11ea-821a-171ff035443f.png">
<img width="972" alt="Screen Shot 2020-01-19 at 11 21 55 PM" src="https://user-images.githubusercontent.com/14225158/72706313-91d00280-3b12-11ea-90e4-be7174b4593d.png">
<img width="972" alt="Screen Shot 2020-01-19 at 11 22 16 PM" src="https://user-images.githubusercontent.com/14225158/72706323-97c5e380-3b12-11ea-99e5-e7aaa3b4df68.png">



### How was this patch tested?
Tested using jykyll build --serve
