### PR TITLE
[SPARK-30523][SQL] - Collapse nested aggregates

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1651,6 +1651,13 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
+  val COMBINE_AGGREGATES = buildConf("spark.sql.optimizer.combineAggregates")
+    .internal()
+    .doc("When true, enable optimizer rule to identify and collapse two levels of aggregates that" +
+      " can be computed in a single aggregate.")
+    .booleanConf
+    .createWithDefault(true)
+
   val DECIMAL_OPERATIONS_ALLOW_PREC_LOSS =
     buildConf("spark.sql.decimalOperations.allowPrecisionLoss")
       .internal()
@@ -2637,6 +2644,8 @@ class SQLConf extends Serializable with Logging {
   def arrowSafeTypeConversion: Boolean = getConf(SQLConf.PANDAS_ARROW_SAFE_TYPE_CONVERSION)
 
   def replaceExceptWithFilter: Boolean = getConf(REPLACE_EXCEPT_WITH_FILTER)
+
+  def combineAggregates: Boolean = getConf(COMBINE_AGGREGATES)
 
   def decimalOperationsAllowPrecisionLoss: Boolean = getConf(DECIMAL_OPERATIONS_ALLOW_PREC_LOSS)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestData.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestData.scala
@@ -287,6 +287,17 @@ private[sql] trait SQLTestData { self =>
     df
   }
 
+  protected lazy val courseSalesWider: DataFrame = {
+    val df = spark.sparkContext.parallelize(
+      CourseSalesWider("dotNET", 2012, 10000, "bob", "beginner") ::
+        CourseSalesWider("Java", 2012, 20000, "megan", "advanced") ::
+        CourseSalesWider("dotNET", 2012, 5000, "tim", "beginner") ::
+        CourseSalesWider("dotNET", 2013, 48000, "angela", "beginner") ::
+        CourseSalesWider("Java", 2013, 30000, "tim", "advanced") :: Nil).toDF()
+    df.createOrReplaceTempView("courseSalesWider")
+    df
+  }
+
   /**
    * Initialize all test data such that all temp tables are properly registered.
    */
@@ -342,6 +353,8 @@ private[sql] object SQLTestData {
   case class Salary(personId: Int, salary: Double)
   case class ComplexData(m: Map[String, Int], s: TestData, a: Seq[Int], b: Boolean)
   case class CourseSales(course: String, year: Int, earnings: Double)
+  case class CourseSalesWider(course: String, year: Int, earnings: Double,
+                              instructor: String, level: String)
   case class TrainingSales(training: String, sales: CourseSales)
   case class IntervalData(data: CalendarInterval)
 }


### PR DESCRIPTION
~~Note to reviewers - I'm fixing some issues after moving this onto the master branch, it was developed on the 2.4 branch and some issues weren't caught during merge resolution.~~
Ready for review, the one automated lint check failure appears to be on other PRs, and I believe is unrelated to this changeset.

### What changes were proposed in this pull request?
Combines two adjacent Aggregate operators into one, if the first one is not necessary.

If we are referencing the outputs of aggregate functions in the inner aggregate from the outer
one, check if they are being used in outer aggregates in a way that can be collapsed into a
single aggregate. A sum of sums, or a max of max, or min of min are all collapsible.
avg over avg will not be collapsible because different number of raw rows will have contributed
to the partial averages of the inner aggregate.

Min an Max can be folded in the case described above, or if they are referencing
the group by columns from the inner aggregate, as they can safely be computed just
using the set of unique values.
```
SELECT sum(sumAgg) as a, year from (
      select sum(1) as sumAgg, course, year FROM courseSales GROUP BY course, year
) group by year

// can be collapsed to
SELECT sum(1) as `a`, year from courseSales group by year
```
```
SELECT sum(agg), min(a), b from (
     select sum(1) as agg, a, b FROM testData2 GROUP BY a, b
     ) group by b

// can be collapsed to
SELECT sum(1) as `sum(agg)`, min(a) as `min(a)`, b from testData2 group by b
```

### Why are the changes needed?
Improve performance of nested aggregation queries.


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
Lot's of tests added with the changeset.
