### PR TITLE
[SPARK-30434][FOLLOW-UP][PYTHON][SQL] Make the parameter list consistent in createDataFrame

### DIFF
--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -267,7 +267,7 @@ class SparkConversionMixin(object):
                     warnings.warn(msg)
                     raise
         data = self._convert_from_pandas(data, schema, timezone)
-        return self._create_dataframe(data, schema, samplingRatio, samplingRatio)
+        return self._create_dataframe(data, schema, samplingRatio, verifySchema)
 
     def _convert_from_pandas(self, pdf, schema, timezone):
         """

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -598,10 +598,10 @@ class SparkSession(SparkConversionMixin):
         if has_pandas and isinstance(data, pandas.DataFrame):
             # Create a DataFrame from pandas DataFrame.
             return super(SparkSession, self).createDataFrame(
-                data, schema, verifySchema, samplingRatio)
-        return self._create_dataframe(data, schema, verifySchema, samplingRatio)
+                data, schema, samplingRatio, verifySchema)
+        return self._create_dataframe(data, schema, samplingRatio, verifySchema)
 
-    def _create_dataframe(self, data, schema, verifySchema, samplingRatio):
+    def _create_dataframe(self, data, schema, samplingRatio, verifySchema):
         if isinstance(schema, StructType):
             verify_func = _make_type_verifier(schema) if verifySchema else lambda _: True
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a followup of https://github.com/apache/spark/pull/27109. It should match the parameter lists in `createDataFrame`.

### Why are the changes needed?

To pass parameters supposed to pass.

### Does this PR introduce any user-facing change?

No (it's only in master)

### How was this patch tested?

Manually tested and existing tests should cover.
