### PR TITLE
[SPARK-23626][CORE] DAGScheduler blocked due to JobSubmitted event

### DIFF
--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerIntegrationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerIntegrationSuite.scala
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scheduler
+
+import java.util.concurrent.{ConcurrentHashMap, Executors}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration._
+
+import org.scalatest.concurrent.Eventually._
+
+import org.apache.spark._
+import org.apache.spark.rdd.RDD
+
+class DAGSchedulerIntegrationSuite extends SparkFunSuite with LocalSparkContext {
+  implicit val submissionPool =
+    ExecutionContext.fromExecutor(Executors.newFixedThreadPool(3))
+
+  test("blocking of DAGEventQueue due to a heavy pause job") {
+    sc = new SparkContext("local", "DAGSchedulerIntegrationSuite")
+
+    // form 3 rdds (2 quick and 1 with heavy dependency calculation)
+    val simpleRDD1 = new DelegateRDD(sc, new PauseRDD(sc, 100))
+    val heavyRDD = new DelegateRDD(sc, new PauseRDD(sc, 1000000))
+    val simpleRDD2 = new DelegateRDD(sc, new PauseRDD(sc, 100))
+
+    // submit all concurrently
+    val finishedRDDs = new ConcurrentHashMap[DelegateRDD, String]()
+    List(simpleRDD1, heavyRDD, simpleRDD2).foreach(rdd =>
+      Future {
+        rdd.collect
+        finishedRDDs.put(rdd, rdd.toString)
+    })
+
+    // wait for certain time and see if quick jobs can finish
+    eventually(timeout(10.seconds)) {
+      assert(finishedRDDs.size() == 2)
+      assert(
+        finishedRDDs.contains(simpleRDD1.toString) &&
+          finishedRDDs.contains(simpleRDD2.toString))
+    }
+  }
+}
+
+class DelegateRDD(sc: SparkContext, var dependency: PauseRDD)
+    extends RDD[(Int, Int)](sc, List(new OneToOneDependency(dependency)))
+    with Serializable {
+  override def compute(split: Partition, context: TaskContext): Iterator[(Int, Int)] = {
+    Nil.toIterator
+  }
+
+  override protected def getPartitions: Array[Partition] = {
+    Seq(new Partition {
+      override def index: Int = 0
+    }).toArray
+  }
+
+  override def toString: String = "DelegateRDD " + id
+}
+
+class PauseRDD(sc: SparkContext, var pauseDuartion: Long)
+    extends RDD[(Int, Int)](sc, Seq.empty)
+    with Serializable {
+  override def compute(split: Partition, context: TaskContext): Iterator[(Int, Int)] = {
+    Nil.toIterator
+  }
+
+  override protected def getPartitions: Array[Partition] = {
+    Thread.sleep(pauseDuartion)
+    Seq(new Partition {
+      override def index: Int = 0
+    }).toArray
+  }
+
+  override def toString: String = "PauseRDD " + id
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Forcing partition evaluation in `callsite` thread before sending `org.apache.spark.scheduler.JobSubmitted` event to `org.apache.spark.scheduler.DAGScheduler#eventProcessLoop` can help in mitigation against job submission event blocking the `DAGScheduler` thread

### Why are the changes needed?
`DAGScheduler` becomes a bottleneck in cluster when multiple `JobSubmitted` events has to be processed as `DAGSchedulerEventProcessLoop` is single threaded and it will block other tasks in queue like `TaskCompletion`.
The `JobSubmitted` event is time consuming depending on the nature of the job (Example: calculating parent stage dependencies, shuffle dependencies, partitions) and thus it blocks all the events to be processed.

Similarly in my cluster some jobs partition calculation is time consuming (Similar to stack at SPARK-2647) hence it slows down the spark `DAGSchedulerEventProcessLoop` which results in user jobs to slowdown, even if its tasks are finished within seconds, as `TaskCompletion` Events are processed at a slower rate due to blockage.

Refer: http://apache-spark-developers-list.1001551.n3.nabble.com/Spark-Scheduler-Spark-DAGScheduler-scheduling-performance-hindered-on-JobSubmitted-Event-td23562.html

I see multiple JIRA referring to this behavior
https://issues.apache.org/jira/browse/SPARK-2647
https://issues.apache.org/jira/browse/SPARK-4961

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Added UT to reproduce and evaluate fix.