### PR TITLE
[SPARK-30530][SQL] Fix filter pushdown for bad CSV records

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -2292,7 +2292,7 @@ class CSVSuite extends QueryTest with SharedSparkSession with TestCsvData {
         .schema(schema)
         .csv(path.getAbsolutePath)
         .filter("floats is null")
-      readback.collect().foreach(println)
+      checkAnswer(readback, Seq(Row(null, 4.0), Row(null, 6.0)))
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to fix the bug reported in SPARK-30530. CSV datasource returns invalid records in the case when `parsedSchema` is shorter than number of tokens returned by UniVocity parser. In the case `UnivocityParser.convert()` always throws `BadRecordException` independently from the result of applying filters.

For the described case, I propose to save the exception in `badRecordException` and continue value conversion according to `parsedSchema`. If a bad record doesn't pass filters, `convert()` returns empty Seq otherwise throws `badRecordException`.

### Why are the changes needed?
It fixes the bug reported in the JIRA ticket.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Added new test from the JIRA ticket.