### PR TITLE
[SPARK-30539][PYTHON][SQL] Add DataFrame.tail in PySpark

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -609,10 +609,10 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
     @since(3.0)
     def tail(self, num):
         """
-        Returns the last `num` rows in the Dataset.
+        Returns the last ``num`` rows as a :class:`list` of :class:`Row`.
 
         Running tail requires moving data into the application's driver process, and doing so with
-        a very large `num` can crash the driver process with OutOfMemoryError.
+        a very large ``num`` can crash the driver process with OutOfMemoryError.
 
         >>> df.tail(1)
         [Row(age=5, name=u'Bob')]

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -605,6 +605,22 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         """
         return self.limit(num).collect()
 
+    @ignore_unicode_prefix
+    @since(3.0)
+    def tail(self, num):
+        """
+        Returns the last `num` rows in the Dataset.
+
+        Running tail requires moving data into the application's driver process, and doing so with
+        a very large `num` can crash the driver process with OutOfMemoryError.
+
+        >>> df.tail(1)
+        [Row(age=5, name=u'Bob')]
+        """
+        with SCCallSiteSync(self._sc):
+            sock_info = self._jdf.tailToPython(num)
+        return list(_load_from_socket(sock_info, BatchedSerializer(PickleSerializer())))
+
     @since(1.3)
     def foreach(self, f):
         """Applies the ``f`` function to all :class:`Row` of this :class:`DataFrame`.


### PR DESCRIPTION
### What changes were proposed in this pull request?

https://github.com/apache/spark/pull/26809 added `Dataset.tail` API. It should be good to have it in PySpark API as well.

### Why are the changes needed?

To support consistent APIs.

### Does this PR introduce any user-facing change?

No. It adds a new API.

### How was this patch tested?

Manually tested and doctest was added.