### PR TITLE
[SPARK-30333][BUILD][FOLLOWUP][2.4] Update sbt build together

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -549,7 +549,7 @@ object DockerIntegrationTests {
 object DependencyOverrides {
   lazy val settings = Seq(
     dependencyOverrides += "com.google.guava" % "guava" % "14.0.1",
-    dependencyOverrides += "com.fasterxml.jackson.core"  % "jackson-databind" % "2.6.7.1",
+    dependencyOverrides += "com.fasterxml.jackson.core"  % "jackson-databind" % "2.6.7.3",
     dependencyOverrides += "jline" % "jline" % "2.14.6")
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `SparkBuild.scala` as a follow-up of
[SPARK-30333 Upgrade jackson-databind to 2.6.7.3](https://github.com/apache/spark/pull/26986).

### Why are the changes needed?

Since SPARK-29781, we override SBT Jackson dependency like Maven.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Pass the Jenkins.