### PR TITLE
[SPARK-30555][SQL] MERGE INTO insert action should only access columns from source table

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1334,9 +1334,10 @@ class Analyzer(
         }
         val newNotMatchedActions = m.notMatchedActions.map {
           case InsertAction(insertCondition, assignments) =>
-            val resolvedInsertCondition = insertCondition.map(resolveExpressionTopDown(_, m))
-            // The insert action is used when not matched, so its value can only access columns
-            // from the source table.
+            // The insert action is used when not matched, so its condition and value can only
+            // access columns from the source table.
+            val resolvedInsertCondition =
+              insertCondition.map(resolveExpressionTopDown(_, Project(Nil, m.sourceTable)))
             InsertAction(
               resolvedInsertCondition,
               resolveAssignments(assignments, m, resolveValuesWithSourceOnly = true))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -1078,7 +1078,7 @@ class PlanResolutionSuite extends AnalysisTest {
       mergeCondition match {
         case EqualTo(l: AttributeReference, r: AttributeReference) =>
           assert(l.sameRef(ti) && r.sameRef(si))
-        case other => fail("unexpected merge condition" + other)
+        case other => fail("unexpected merge condition " + other)
       }
 
       deleteCondAttr.foreach(a => assert(a.sameRef(ts)))
@@ -1333,7 +1333,7 @@ class PlanResolutionSuite extends AnalysisTest {
       assert(e5.message.contains("Reference 's' is ambiguous"))
     }
 
-    val sql =
+    val sql6 =
       s"""
          |MERGE INTO non_exist_target
          |USING non_exist_source
@@ -1342,7 +1342,7 @@ class PlanResolutionSuite extends AnalysisTest {
          |WHEN MATCHED THEN UPDATE SET *
          |WHEN NOT MATCHED THEN INSERT *
        """.stripMargin
-    val parsed = parseAndResolve(sql)
+    val parsed = parseAndResolve(sql6)
     parsed match {
       case u: MergeIntoTable =>
         assert(u.targetTable.isInstanceOf[UnresolvedRelation])

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.{AnalysisException, SaveMode}
 import org.apache.spark.sql.catalyst.{AliasIdentifier, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis.{AnalysisTest, Analyzer, CTESubstitution, EmptyFunctionRegistry, NoSuchTableException, ResolveCatalogs, ResolvedTable, ResolveSessionCatalog, UnresolvedAttribute, UnresolvedRelation, UnresolvedStar, UnresolvedSubqueryColumnAliases, UnresolvedV2Relation}
 import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogStorageFormat, CatalogTable, CatalogTableType, InMemoryCatalog, SessionCatalog}
-import org.apache.spark.sql.catalyst.expressions.{EqualTo, InSubquery, IntegerLiteral, ListQuery, StringLiteral}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, InSubquery, IntegerLiteral, ListQuery, Literal, StringLiteral}
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.catalyst.plans.logical.{AlterTable, Assignment, CreateTableAsSelect, CreateV2Table, DeleteAction, DeleteFromTable, DescribeRelation, DropTable, InsertAction, LocalRelation, LogicalPlan, MergeIntoTable, OneRowRelation, Project, SubqueryAlias, UpdateAction, UpdateTable}
 import org.apache.spark.sql.connector.InMemoryTableProvider
@@ -45,13 +45,13 @@ class PlanResolutionSuite extends AnalysisTest {
 
   private val table: Table = {
     val t = mock(classOf[Table])
-    when(t.schema()).thenReturn(new StructType().add("i", "int"))
+    when(t.schema()).thenReturn(new StructType().add("i", "int").add("s", "string"))
     t
   }
 
   private val v1Table: V1Table = {
     val t = mock(classOf[CatalogTable])
-    when(t.schema).thenReturn(new StructType().add("i", "int"))
+    when(t.schema).thenReturn(new StructType().add("i", "int").add("s", "string"))
     when(t.tableType).thenReturn(CatalogTableType.MANAGED)
     V1Table(t)
   }
@@ -133,7 +133,10 @@ class PlanResolutionSuite extends AnalysisTest {
       analyzer.ResolveRelations,
       new ResolveCatalogs(catalogManager),
       new ResolveSessionCatalog(catalogManager, conf, _ == Seq("v")),
-      analyzer.ResolveTables)
+      analyzer.ResolveTables,
+      analyzer.ResolveReferences,
+      analyzer.ResolveSubqueryColumnAliases,
+      analyzer.ResolveReferences)
     rules.foldLeft(parsePlan(query)) {
       case (plan, rule) => rule.apply(plan)
     }
@@ -1127,128 +1130,150 @@ class PlanResolutionSuite extends AnalysisTest {
 
         parsed1 match {
           case MergeIntoTable(
-              SubqueryAlias(AliasIdentifier("target", None), _: DataSourceV2Relation),
-              SubqueryAlias(AliasIdentifier("source", None), _: DataSourceV2Relation),
-              EqualTo(l: UnresolvedAttribute, r: UnresolvedAttribute),
-              Seq(DeleteAction(Some(EqualTo(dl: UnresolvedAttribute, StringLiteral("delete")))),
-                UpdateAction(Some(EqualTo(ul: UnresolvedAttribute, StringLiteral("update"))),
+              SubqueryAlias(AliasIdentifier("target", None), target: DataSourceV2Relation),
+              SubqueryAlias(AliasIdentifier("source", None), source: DataSourceV2Relation),
+              EqualTo(l: AttributeReference, r: AttributeReference),
+              Seq(DeleteAction(Some(EqualTo(dl: AttributeReference, StringLiteral("delete")))),
+                UpdateAction(Some(EqualTo(ul: AttributeReference, StringLiteral("update"))),
                   updateAssigns)),
-              Seq(InsertAction(Some(EqualTo(il: UnresolvedAttribute, StringLiteral("insert"))),
+              Seq(InsertAction(Some(EqualTo(il: AttributeReference, StringLiteral("insert"))),
                 insertAssigns))) =>
-            assert(l.name == "target.i" && r.name == "source.i")
-            assert(dl.name == "target.s")
-            assert(ul.name == "target.s")
-            assert(il.name == "target.s")
+            val ti = target.output.find(_.name == "i").get
+            val ts = target.output.find(_.name == "s").get
+            val si = source.output.find(_.name == "i").get
+            val ss = source.output.find(_.name == "s").get
+
+            assert(l.sameRef(ti) && r.sameRef(si))
+            assert(dl.sameRef(ts))
+            assert(ul.sameRef(ts))
+            assert(il.sameRef(ts))
             assert(updateAssigns.size == 1)
-            assert(updateAssigns.head.key.isInstanceOf[UnresolvedAttribute] &&
-                updateAssigns.head.key.asInstanceOf[UnresolvedAttribute].name == "target.s")
-            assert(updateAssigns.head.value.isInstanceOf[UnresolvedAttribute] &&
-                updateAssigns.head.value.asInstanceOf[UnresolvedAttribute].name == "source.s")
+            assert(updateAssigns.head.key.asInstanceOf[AttributeReference].sameRef(ts))
+            assert(updateAssigns.head.value.asInstanceOf[AttributeReference].sameRef(ss))
             assert(insertAssigns.size == 2)
-            assert(insertAssigns.head.key.isInstanceOf[UnresolvedAttribute] &&
-                insertAssigns.head.key.asInstanceOf[UnresolvedAttribute].name == "target.i")
-            assert(insertAssigns.head.value.isInstanceOf[UnresolvedAttribute] &&
-                insertAssigns.head.value.asInstanceOf[UnresolvedAttribute].name == "source.i")
+            assert(insertAssigns(0).key.asInstanceOf[AttributeReference].sameRef(ti))
+            assert(insertAssigns(0).value.asInstanceOf[AttributeReference].sameRef(si))
+            assert(insertAssigns(1).key.asInstanceOf[AttributeReference].sameRef(ts))
+            assert(insertAssigns(1).value.asInstanceOf[AttributeReference].sameRef(ss))
 
           case _ => fail("Expect MergeIntoTable, but got:\n" + parsed1.treeString)
         }
 
         parsed2 match {
           case MergeIntoTable(
-              SubqueryAlias(AliasIdentifier("target", None), _: DataSourceV2Relation),
-              SubqueryAlias(AliasIdentifier("source", None), _: DataSourceV2Relation),
-              EqualTo(l: UnresolvedAttribute, r: UnresolvedAttribute),
-              Seq(DeleteAction(Some(EqualTo(dl: UnresolvedAttribute, StringLiteral("delete")))),
-                UpdateAction(Some(EqualTo(ul: UnresolvedAttribute,
-                  StringLiteral("update"))), Seq())),
-              Seq(InsertAction(Some(EqualTo(il: UnresolvedAttribute, StringLiteral("insert"))),
-                Seq()))) =>
-            assert(l.name == "target.i" && r.name == "source.i")
-            assert(dl.name == "target.s")
-            assert(ul.name == "target.s")
-            assert(il.name == "target.s")
+              SubqueryAlias(AliasIdentifier("target", None), target: DataSourceV2Relation),
+              SubqueryAlias(AliasIdentifier("source", None), source: DataSourceV2Relation),
+              EqualTo(l: AttributeReference, r: AttributeReference),
+              Seq(DeleteAction(Some(EqualTo(dl: AttributeReference, StringLiteral("delete")))),
+                UpdateAction(Some(EqualTo(ul: AttributeReference,
+                  StringLiteral("update"))), updateAssigns)),
+              Seq(InsertAction(Some(EqualTo(il: AttributeReference, StringLiteral("insert"))),
+                insertAssigns))) =>
+            val ti = target.output.find(_.name == "i").get
+            val ts = target.output.find(_.name == "s").get
+            val si = source.output.find(_.name == "i").get
+            val ss = source.output.find(_.name == "s").get
+
+            assert(l.sameRef(ti) && r.sameRef(si))
+            assert(dl.sameRef(ts))
+            assert(ul.sameRef(ts))
+            assert(il.sameRef(ts))
+            assert(updateAssigns.length == 2)
+            assert(updateAssigns(0).key.asInstanceOf[AttributeReference].sameRef(ti))
+            assert(updateAssigns(0).value.asInstanceOf[AttributeReference].sameRef(si))
+            assert(updateAssigns(1).key.asInstanceOf[AttributeReference].sameRef(ts))
+            assert(updateAssigns(1).value.asInstanceOf[AttributeReference].sameRef(ss))
+            assert(insertAssigns.length == 2)
+            assert(insertAssigns(0).key.asInstanceOf[AttributeReference].sameRef(ti))
+            assert(insertAssigns(0).value.asInstanceOf[AttributeReference].sameRef(si))
+            assert(insertAssigns(1).key.asInstanceOf[AttributeReference].sameRef(ts))
+            assert(insertAssigns(1).value.asInstanceOf[AttributeReference].sameRef(ss))
 
           case _ => fail("Expect MergeIntoTable, but got:\n" + parsed2.treeString)
         }
 
         parsed3 match {
           case MergeIntoTable(
-              SubqueryAlias(AliasIdentifier("target", None), _: DataSourceV2Relation),
-              SubqueryAlias(AliasIdentifier("source", None), _: DataSourceV2Relation),
-              EqualTo(l: UnresolvedAttribute, r: UnresolvedAttribute),
+              SubqueryAlias(AliasIdentifier("target", None), target: DataSourceV2Relation),
+              SubqueryAlias(AliasIdentifier("source", None), source: DataSourceV2Relation),
+              EqualTo(l: AttributeReference, r: AttributeReference),
               Seq(DeleteAction(None), UpdateAction(None, updateAssigns)),
               Seq(InsertAction(None, insertAssigns))) =>
-            assert(l.name == "target.i" && r.name == "source.i")
+            val ti = target.output.find(_.name == "i").get
+            val ts = target.output.find(_.name == "s").get
+            val si = source.output.find(_.name == "i").get
+            val ss = source.output.find(_.name == "s").get
+
+            assert(l.sameRef(ti) && r.sameRef(si))
             assert(updateAssigns.size == 1)
-            assert(updateAssigns.head.key.isInstanceOf[UnresolvedAttribute] &&
-                updateAssigns.head.key.asInstanceOf[UnresolvedAttribute].name == "target.s")
-            assert(updateAssigns.head.value.isInstanceOf[UnresolvedAttribute] &&
-                updateAssigns.head.value.asInstanceOf[UnresolvedAttribute].name == "source.s")
+            assert(updateAssigns.head.key.asInstanceOf[AttributeReference].sameRef(ts))
+            assert(updateAssigns.head.value.asInstanceOf[AttributeReference].sameRef(ss))
             assert(insertAssigns.size == 2)
-            assert(insertAssigns.head.key.isInstanceOf[UnresolvedAttribute] &&
-                insertAssigns.head.key.asInstanceOf[UnresolvedAttribute].name == "target.i")
-            assert(insertAssigns.head.value.isInstanceOf[UnresolvedAttribute] &&
-                insertAssigns.head.value.asInstanceOf[UnresolvedAttribute].name == "source.i")
+            assert(insertAssigns.head.key.asInstanceOf[AttributeReference].sameRef(ti))
+            assert(insertAssigns.head.value.asInstanceOf[AttributeReference].sameRef(si))
 
           case _ => fail("Expect MergeIntoTable, but got:\n" + parsed3.treeString)
         }
 
         parsed4 match {
           case MergeIntoTable(
-              SubqueryAlias(AliasIdentifier("target", None), _: DataSourceV2Relation),
-              SubqueryAlias(AliasIdentifier("source", None), _: Project),
-              EqualTo(l: UnresolvedAttribute, r: UnresolvedAttribute),
-              Seq(DeleteAction(Some(EqualTo(dl: UnresolvedAttribute, StringLiteral("delete")))),
-                UpdateAction(Some(EqualTo(ul: UnresolvedAttribute, StringLiteral("update"))),
+              SubqueryAlias(AliasIdentifier("target", None), target: DataSourceV2Relation),
+              SubqueryAlias(AliasIdentifier("source", None), source: Project),
+              EqualTo(l: AttributeReference, r: AttributeReference),
+              Seq(DeleteAction(Some(EqualTo(dl: AttributeReference, StringLiteral("delete")))),
+                UpdateAction(Some(EqualTo(ul: AttributeReference, StringLiteral("update"))),
                   updateAssigns)),
-              Seq(InsertAction(Some(EqualTo(il: UnresolvedAttribute, StringLiteral("insert"))),
+              Seq(InsertAction(Some(EqualTo(il: AttributeReference, StringLiteral("insert"))),
                 insertAssigns))) =>
-            assert(l.name == "target.i" && r.name == "source.i")
-            assert(dl.name == "target.s")
-            assert(ul.name == "target.s")
-            assert(il.name == "target.s")
+            val ti = target.output.find(_.name == "i").get
+            val ts = target.output.find(_.name == "s").get
+            val si = source.output.find(_.name == "i").get.asInstanceOf[AttributeReference]
+            val ss = source.output.find(_.name == "s").get.asInstanceOf[AttributeReference]
+
+            assert(l.sameRef(ti) && r.sameRef(si))
+            assert(dl.sameRef(ts))
+            assert(ul.sameRef(ts))
+            assert(il.sameRef(ts))
             assert(updateAssigns.size == 1)
-            assert(updateAssigns.head.key.isInstanceOf[UnresolvedAttribute] &&
-                updateAssigns.head.key.asInstanceOf[UnresolvedAttribute].name == "target.s")
-            assert(updateAssigns.head.value.isInstanceOf[UnresolvedAttribute] &&
-                updateAssigns.head.value.asInstanceOf[UnresolvedAttribute].name == "source.s")
-            assert(insertAssigns.head.key.isInstanceOf[UnresolvedAttribute] &&
-                insertAssigns.head.key.asInstanceOf[UnresolvedAttribute].name == "target.i")
-            assert(insertAssigns.head.value.isInstanceOf[UnresolvedAttribute] &&
-                insertAssigns.head.value.asInstanceOf[UnresolvedAttribute].name == "source.i")
+            assert(updateAssigns.head.key.asInstanceOf[AttributeReference].sameRef(ts))
+            assert(updateAssigns.head.value.asInstanceOf[AttributeReference].sameRef(ss))
+            assert(insertAssigns.size == 2)
+            assert(insertAssigns(0).key.asInstanceOf[AttributeReference].sameRef(ti))
+            assert(insertAssigns(0).value.asInstanceOf[AttributeReference].sameRef(si))
+            assert(insertAssigns(1).key.asInstanceOf[AttributeReference].sameRef(ts))
+            assert(insertAssigns(1).value.asInstanceOf[AttributeReference].sameRef(ss))
 
           case _ => fail("Expect MergeIntoTable, but got:\n" + parsed4.treeString)
         }
 
         parsed5 match {
           case MergeIntoTable(
-              SubqueryAlias(AliasIdentifier("target", None), _: DataSourceV2Relation),
-              SubqueryAlias(AliasIdentifier("source", None),
-                UnresolvedSubqueryColumnAliases(outputColumnNames,
-                  Project(projects, _: DataSourceV2Relation))),
-              EqualTo(l: UnresolvedAttribute, r: UnresolvedAttribute),
-              Seq(DeleteAction(Some(EqualTo(dl: UnresolvedAttribute, StringLiteral("delete")))),
-                UpdateAction(Some(EqualTo(ul: UnresolvedAttribute, StringLiteral("update"))),
+              SubqueryAlias(AliasIdentifier("target", None), target: DataSourceV2Relation),
+              SubqueryAlias(AliasIdentifier("source", None), source: Project),
+              EqualTo(l: AttributeReference, r: AttributeReference),
+              Seq(DeleteAction(Some(EqualTo(dl: AttributeReference, StringLiteral("delete")))),
+                UpdateAction(Some(EqualTo(ul: AttributeReference, StringLiteral("update"))),
                   updateAssigns)),
-              Seq(InsertAction(Some(EqualTo(il: UnresolvedAttribute, StringLiteral("insert"))),
+              Seq(InsertAction(Some(EqualTo(il: AttributeReference, StringLiteral("insert"))),
                 insertAssigns))) =>
-            assert(outputColumnNames.size == 2 &&
-              outputColumnNames.head == "i" &&
-              outputColumnNames.last == "s")
-            assert(projects.size == 1 && projects.head.isInstanceOf[UnresolvedStar])
-            assert(l.name == "target.i" && r.name == "source.i")
-            assert(dl.name == "target.s")
-            assert(ul.name == "target.s")
-            assert(il.name == "target.s")
+            assert(source.output.map(_.name) == Seq("i", "s"))
+            val ti = target.output.find(_.name == "i").get
+            val ts = target.output.find(_.name == "s").get
+            val si = source.output.find(_.name == "i").get.asInstanceOf[AttributeReference]
+            val ss = source.output.find(_.name == "s").get.asInstanceOf[AttributeReference]
+
+            assert(l.sameRef(ti) && r.sameRef(si))
+            assert(dl.sameRef(ts))
+            assert(ul.sameRef(ts))
+            assert(il.sameRef(ts))
             assert(updateAssigns.size == 1)
-            assert(updateAssigns.head.key.isInstanceOf[UnresolvedAttribute] &&
-              updateAssigns.head.key.asInstanceOf[UnresolvedAttribute].name == "target.s")
-            assert(updateAssigns.head.value.isInstanceOf[UnresolvedAttribute] &&
-              updateAssigns.head.value.asInstanceOf[UnresolvedAttribute].name == "source.s")
-            assert(insertAssigns.head.key.isInstanceOf[UnresolvedAttribute] &&
-              insertAssigns.head.key.asInstanceOf[UnresolvedAttribute].name == "target.i")
-            assert(insertAssigns.head.value.isInstanceOf[UnresolvedAttribute] &&
-              insertAssigns.head.value.asInstanceOf[UnresolvedAttribute].name == "source.i")
+            assert(updateAssigns.head.key.asInstanceOf[AttributeReference].sameRef(ts))
+            assert(updateAssigns.head.value.asInstanceOf[AttributeReference].sameRef(ss))
+            assert(insertAssigns.size == 2)
+            assert(insertAssigns(0).key.asInstanceOf[AttributeReference].sameRef(ti))
+            assert(insertAssigns(0).value.asInstanceOf[AttributeReference].sameRef(si))
+            assert(insertAssigns(1).key.asInstanceOf[AttributeReference].sameRef(ts))
+            assert(insertAssigns(1).value.asInstanceOf[AttributeReference].sameRef(ss))
 
           case _ => fail("Expect MergeIntoTable, but got:\n" + parsed5.treeString)
         }
@@ -1261,46 +1286,75 @@ class PlanResolutionSuite extends AnalysisTest {
       val target = pair._1
       val source = pair._2
 
-      val sql =
+      val sql1 =
         s"""
            |MERGE INTO $target
            |USING $source
-           |ON $target.i = $source.i
-           |WHEN MATCHED AND ($target.s='delete') THEN DELETE
-           |WHEN MATCHED AND ($target.s='update') THEN UPDATE SET $target.s = $source.s
-           |WHEN NOT MATCHED AND ($target.s='insert')
-           |THEN INSERT ($target.i, $target.s) values ($source.i, $source.s)
+           |ON 1 = 1
+           |WHEN MATCHED THEN DELETE
+           |WHEN MATCHED THEN UPDATE SET s = 1
+           |WHEN NOT MATCHED THEN INSERT (i) values (i)
          """.stripMargin
 
-      val parsed = parseAndResolve(sql)
-
-      parsed match {
+      parseAndResolve(sql1) match {
         case MergeIntoTable(
-        _: DataSourceV2Relation,
-        _: DataSourceV2Relation,
-        EqualTo(l: UnresolvedAttribute, r: UnresolvedAttribute),
-        Seq(DeleteAction(Some(EqualTo(dl: UnresolvedAttribute, StringLiteral("delete")))),
-        UpdateAction(Some(EqualTo(ul: UnresolvedAttribute, StringLiteral("update"))),
-          updateAssigns)),
-        Seq(InsertAction(Some(EqualTo(il: UnresolvedAttribute, StringLiteral("insert"))),
-          insertAssigns))) =>
-          assert(l.name == s"$target.i" && r.name == s"$source.i")
-          assert(dl.name == s"$target.s")
-          assert(ul.name == s"$target.s")
-          assert(il.name == s"$target.s")
-          assert(updateAssigns.size == 1)
-          assert(updateAssigns.head.key.isInstanceOf[UnresolvedAttribute] &&
-              updateAssigns.head.key.asInstanceOf[UnresolvedAttribute].name == s"$target.s")
-          assert(updateAssigns.head.value.isInstanceOf[UnresolvedAttribute] &&
-              updateAssigns.head.value.asInstanceOf[UnresolvedAttribute].name == s"$source.s")
-          assert(insertAssigns.size == 2)
-          assert(insertAssigns.head.key.isInstanceOf[UnresolvedAttribute] &&
-              insertAssigns.head.key.asInstanceOf[UnresolvedAttribute].name == s"$target.i")
-          assert(insertAssigns.head.value.isInstanceOf[UnresolvedAttribute] &&
-              insertAssigns.head.value.asInstanceOf[UnresolvedAttribute].name == s"$source.i")
+            target: DataSourceV2Relation,
+            source: DataSourceV2Relation,
+            _,
+            Seq(DeleteAction(None), UpdateAction(None, updateAssigns)),
+            Seq(InsertAction(None, insertAssigns))) =>
+          val ti = target.output.find(_.name == "i").get
+          val ts = target.output.find(_.name == "s").get
+          val si = source.output.find(_.name == "i").get
+          val ss = source.output.find(_.name == "s").get
 
-        case _ => fail("Expect MergeIntoTable, but got:\n" + parsed.treeString)
+          assert(updateAssigns.size == 1)
+          // UPDATE key is resolved with target table only, so column `s` is not ambiguous.
+          assert(updateAssigns.head.key.asInstanceOf[AttributeReference].sameRef(ts))
+          assert(insertAssigns.size == 1)
+          // INSERT key is resolved with target table only, so column `i` is not ambiguous.
+          assert(insertAssigns.head.key.asInstanceOf[AttributeReference].sameRef(ti))
+          // INSERT value is resolved with source table only, so column `i` is not ambiguous.
+          assert(insertAssigns.head.value.asInstanceOf[AttributeReference].sameRef(si))
+
+        case p => fail("Expect MergeIntoTable, but got:\n" + p.treeString)
       }
+
+      val sql2 =
+        s"""
+           |MERGE INTO $target
+           |USING $source
+           |ON i = 1
+           |WHEN MATCHED THEN DELETE
+         """.stripMargin
+      // merge condition is resolved with both target and source tables, and we can't
+      // resolve column `i` as it's ambiguous.
+      val e2 = intercept[AnalysisException](parseAndResolve(sql2))
+      assert(e2.message.contains("Reference 'i' is ambiguous"))
+
+      val sql3 =
+        s"""
+           |MERGE INTO $target
+           |USING $source
+           |ON 1 = 1
+           |WHEN MATCHED AND (s='delete') THEN DELETE
+         """.stripMargin
+      // delete condition is resolved with both target and source tables, and we can't
+      // resolve column `s` as it's ambiguous.
+      val e3 = intercept[AnalysisException](parseAndResolve(sql3))
+      assert(e3.message.contains("Reference 's' is ambiguous"))
+
+      val sql4 =
+        s"""
+           |MERGE INTO $target
+           |USING $source
+           |ON 1 = 1
+           |WHEN MATCHED THEN UPDATE SET s = s
+         """.stripMargin
+      // update value is resolved with both target and source tables, and we can't
+      // resolve column `s` as it's ambiguous.
+      val e4 = intercept[AnalysisException](parseAndResolve(sql4))
+      assert(e4.message.contains("Reference 's' is ambiguous"))
     }
 
     val sql =


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
when resolving the `Assignment` of insert action in MERGE INTO, only resolve with the source table, to avoid ambiguous attribute failure if there is a same-name column in the target table.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The insert action is used when NOT MATCHED, so it can't access the row from the target table anyway. 

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
on

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
new tests