### PR TITLE
[SPARK-22590][SQL] Copy sparkContext.localproperties to child thread in BroadcastExchangeExec.executionContext

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/ThreadUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/ThreadUtils.scala
@@ -313,6 +313,8 @@ private[spark] object ThreadUtils {
         case _ => future.get(atMost._1, atMost._2)
       }
     } catch {
+      case e: SparkFatalException =>
+        throw e.throwable
       case NonFatal(t)
         if !t.isInstanceOf[TimeoutException] && !t.isInstanceOf[RpcAbortException] =>
         throw new SparkException("Exception thrown in awaitResult: ", t)

--- a/core/src/main/scala/org/apache/spark/util/ThreadUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/ThreadUtils.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.util
 
 import java.util.concurrent._
+import java.util.concurrent.{Future => JFuture}
 import java.util.concurrent.locks.ReentrantLock
 
 import scala.concurrent.{Awaitable, ExecutionContext, ExecutionContextExecutor, Future}
@@ -303,6 +304,20 @@ private[spark] object ThreadUtils {
     }
   }
   // scalastyle:on awaitresult
+
+  @throws(classOf[SparkException])
+  def awaitResult[T](future: JFuture[T], atMost: Duration): T = {
+    try {
+      atMost match {
+        case Duration.Inf => future.get()
+        case _ => future.get(atMost._1, atMost._2)
+      }
+    } catch {
+      case NonFatal(t)
+        if !t.isInstanceOf[TimeoutException] && !t.isInstanceOf[RpcAbortException] =>
+        throw new SparkException("Exception thrown in awaitResult: ", t)
+    }
+  }
 
   // scalastyle:off awaitready
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
@@ -17,10 +17,8 @@
 
 package org.apache.spark.sql.execution
 
-import java.util.concurrent.{Callable, ConcurrentHashMap}
+import java.util.concurrent.{ConcurrentHashMap, ExecutorService, Future => JFuture}
 import java.util.concurrent.atomic.AtomicLong
-
-import scala.concurrent.{ExecutionContext, Future}
 
 import org.apache.spark.SparkContext
 import org.apache.spark.internal.config.Tests.IS_TESTING
@@ -172,11 +170,11 @@ object SQLExecution {
    * SparkContext local properties are forwarded to execution thread
    */
   def withThreadLocalCaptured[T](
-      sparkSession: SparkSession, exec: ExecutionContext)(body: => T): Future[T] = {
+      sparkSession: SparkSession, exec: ExecutorService) (body: => T): JFuture[T] = {
     val activeSession = sparkSession
     val sc = sparkSession.sparkContext
     val localProps = Utils.cloneProperties(sc.getLocalProperties)
-    Future {
+    exec.submit(() => {
       val originalSession = SparkSession.getActiveSession
       val originalLocalProps = sc.getLocalProperties
       SparkSession.setActiveSession(activeSession)
@@ -190,24 +188,6 @@ object SQLExecution {
         SparkSession.clearActiveSession()
       }
       res
-    }(exec)
-  }
-
-  /**
-   * Wrap passed function to ensure necessary thread-local variables like
-   * SparkContext local properties are forwarded to execution thread
-   */
-  def withThreadLocalCaptured[T](
-      sparkSession: SparkSession)(body: => T): Callable[T] = {
-    val activeSession = sparkSession
-    val sc = sparkSession.sparkContext
-    val localProps = Utils.cloneProperties(sc.getLocalProperties)
-    () => {
-      SparkSession.setActiveSession(activeSession)
-      sc.setLocalProperties(localProps)
-      withSQLConfPropagated(activeSession) {
-        body
-      }
-    }
+    })
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
@@ -205,7 +205,9 @@ object SQLExecution {
     () => {
       SparkSession.setActiveSession(activeSession)
       sc.setLocalProperties(localProps)
-      body
+      withSQLConfPropagated(activeSession) {
+        body
+      }
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -17,10 +17,11 @@
 
 package org.apache.spark.sql.execution
 
+import java.util.concurrent.{Future => JFuture}
 import java.util.concurrent.TimeUnit._
 
 import scala.collection.mutable
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext}
 import scala.concurrent.duration.Duration
 
 import org.apache.spark.{InterruptibleIterator, Partition, SparkContext, TaskContext}
@@ -746,7 +747,7 @@ case class SubqueryExec(name: String, child: SparkPlan)
     "collectTime" -> SQLMetrics.createTimingMetric(sparkContext, "time to collect"))
 
   @transient
-  private lazy val relationFuture: Future[Array[InternalRow]] = {
+  private lazy val relationFuture: JFuture[Array[InternalRow]] = {
     // relationFuture is used in "doExecute". Therefore we can get the execution id correctly here.
     val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
     SQLExecution.withThreadLocalCaptured[Array[InternalRow]](

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
@@ -73,8 +73,8 @@ case class BroadcastExchangeExec(
 
   @transient
   private[sql] lazy val relationFuture: Future[broadcast.Broadcast[Any]] = {
-    val task = SQLExecution.withThreadLocalCaptured[broadcast.Broadcast[Any]](
-      sqlContext.sparkSession) {
+    SQLExecution.withThreadLocalCaptured[broadcast.Broadcast[Any]](
+      sqlContext.sparkSession, BroadcastExchangeExec.executionContext) {
       try {
         // Setup a job group here so later it may get cancelled by groupId if necessary.
         sparkContext.setJobGroup(runId.toString, s"broadcast exchange (runId $runId)",
@@ -142,7 +142,6 @@ case class BroadcastExchangeExec(
           throw e
       }
     }
-    BroadcastExchangeExec.executionContext.submit[broadcast.Broadcast[Any]](task)
   }
 
   override protected def doPrepare(): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
@@ -75,72 +75,72 @@ case class BroadcastExchangeExec(
   private[sql] lazy val relationFuture: Future[broadcast.Broadcast[Any]] = {
     SQLExecution.withThreadLocalCaptured[broadcast.Broadcast[Any]](
       sqlContext.sparkSession, BroadcastExchangeExec.executionContext) {
-      try {
-        // Setup a job group here so later it may get cancelled by groupId if necessary.
-        sparkContext.setJobGroup(runId.toString, s"broadcast exchange (runId $runId)",
-          interruptOnCancel = true)
-        val beforeCollect = System.nanoTime()
-        // Use executeCollect/executeCollectIterator to avoid conversion to Scala types
-        val (numRows, input) = child.executeCollectIterator()
-        if (numRows >= 512000000) {
-          throw new SparkException(
-            s"Cannot broadcast the table with 512 million or more rows: $numRows rows")
-        }
+          try {
+            // Setup a job group here so later it may get cancelled by groupId if necessary.
+            sparkContext.setJobGroup(runId.toString, s"broadcast exchange (runId $runId)",
+              interruptOnCancel = true)
+            val beforeCollect = System.nanoTime()
+            // Use executeCollect/executeCollectIterator to avoid conversion to Scala types
+            val (numRows, input) = child.executeCollectIterator()
+            if (numRows >= 512000000) {
+              throw new SparkException(
+                s"Cannot broadcast the table with 512 million or more rows: $numRows rows")
+            }
 
-        val beforeBuild = System.nanoTime()
-        longMetric("collectTime") += NANOSECONDS.toMillis(beforeBuild - beforeCollect)
+            val beforeBuild = System.nanoTime()
+            longMetric("collectTime") += NANOSECONDS.toMillis(beforeBuild - beforeCollect)
 
-        // Construct the relation.
-        val relation = mode.transform(input, Some(numRows))
+            // Construct the relation.
+            val relation = mode.transform(input, Some(numRows))
 
-        val dataSize = relation match {
-          case map: HashedRelation =>
-            map.estimatedSize
-          case arr: Array[InternalRow] =>
-            arr.map(_.asInstanceOf[UnsafeRow].getSizeInBytes.toLong).sum
-          case _ =>
-            throw new SparkException("[BUG] BroadcastMode.transform returned unexpected " +
-              s"type: ${relation.getClass.getName}")
-        }
+            val dataSize = relation match {
+              case map: HashedRelation =>
+                map.estimatedSize
+              case arr: Array[InternalRow] =>
+                arr.map(_.asInstanceOf[UnsafeRow].getSizeInBytes.toLong).sum
+              case _ =>
+                throw new SparkException("[BUG] BroadcastMode.transform returned unexpected " +
+                  s"type: ${relation.getClass.getName}")
+            }
 
-        longMetric("dataSize") += dataSize
-        if (dataSize >= (8L << 30)) {
-          throw new SparkException(
-            s"Cannot broadcast the table that is larger than 8GB: ${dataSize >> 30} GB")
-        }
+            longMetric("dataSize") += dataSize
+            if (dataSize >= (8L << 30)) {
+              throw new SparkException(
+                s"Cannot broadcast the table that is larger than 8GB: ${dataSize >> 30} GB")
+            }
 
-        val beforeBroadcast = System.nanoTime()
-        longMetric("buildTime") += NANOSECONDS.toMillis(beforeBroadcast - beforeBuild)
+            val beforeBroadcast = System.nanoTime()
+            longMetric("buildTime") += NANOSECONDS.toMillis(beforeBroadcast - beforeBuild)
 
-        // Broadcast the relation
-        val broadcasted = sparkContext.broadcast(relation)
-        longMetric("broadcastTime") += NANOSECONDS.toMillis(
-          System.nanoTime() - beforeBroadcast)
-        val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
-        SQLMetrics.postDriverMetricUpdates(sparkContext, executionId, metrics.values.toSeq)
-        promise.success(broadcasted)
-        broadcasted
-      } catch {
-        // SPARK-24294: To bypass scala bug: https://github.com/scala/bug/issues/9554, we throw
-        // SparkFatalException, which is a subclass of Exception. ThreadUtils.awaitResult
-        // will catch this exception and re-throw the wrapped fatal throwable.
-        case oe: OutOfMemoryError =>
-          val ex = new SparkFatalException(
-            new OutOfMemoryError("Not enough memory to build and broadcast the table to all " +
-              "worker nodes. As a workaround, you can either disable broadcast by setting " +
-              s"${SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key} to -1 or increase the spark " +
-              s"driver memory by setting ${SparkLauncher.DRIVER_MEMORY} to a higher value.")
-              .initCause(oe.getCause))
-          promise.failure(ex)
-          throw ex
-        case e if !NonFatal(e) =>
-          val ex = new SparkFatalException(e)
-          promise.failure(ex)
-          throw ex
-        case e: Throwable =>
-          promise.failure(e)
-          throw e
-      }
+            // Broadcast the relation
+            val broadcasted = sparkContext.broadcast(relation)
+            longMetric("broadcastTime") += NANOSECONDS.toMillis(
+              System.nanoTime() - beforeBroadcast)
+            val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
+            SQLMetrics.postDriverMetricUpdates(sparkContext, executionId, metrics.values.toSeq)
+            promise.success(broadcasted)
+            broadcasted
+          } catch {
+            // SPARK-24294: To bypass scala bug: https://github.com/scala/bug/issues/9554, we throw
+            // SparkFatalException, which is a subclass of Exception. ThreadUtils.awaitResult
+            // will catch this exception and re-throw the wrapped fatal throwable.
+            case oe: OutOfMemoryError =>
+              val ex = new SparkFatalException(
+                new OutOfMemoryError("Not enough memory to build and broadcast the table to all " +
+                  "worker nodes. As a workaround, you can either disable broadcast by setting " +
+                  s"${SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key} to -1 or increase the spark " +
+                  s"driver memory by setting ${SparkLauncher.DRIVER_MEMORY} to a higher value.")
+                  .initCause(oe.getCause))
+              promise.failure(ex)
+              throw ex
+            case e if !NonFatal(e) =>
+              val ex = new SparkFatalException(e)
+              promise.failure(ex)
+              throw ex
+            case e: Throwable =>
+              promise.failure(e)
+              throw e
+          }
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
@@ -75,76 +75,72 @@ case class BroadcastExchangeExec(
   private[sql] lazy val relationFuture: Future[broadcast.Broadcast[Any]] = {
     SQLExecution.withThreadLocalCaptured[broadcast.Broadcast[Any]](
       sqlContext.sparkSession, BroadcastExchangeExec.executionContext) {
-          doBroadcast
-    }
-  }
+          try {
+            // Setup a job group here so later it may get cancelled by groupId if necessary.
+            sparkContext.setJobGroup(runId.toString, s"broadcast exchange (runId $runId)",
+              interruptOnCancel = true)
+            val beforeCollect = System.nanoTime()
+            // Use executeCollect/executeCollectIterator to avoid conversion to Scala types
+            val (numRows, input) = child.executeCollectIterator()
+            if (numRows >= 512000000) {
+              throw new SparkException(
+                s"Cannot broadcast the table with 512 million or more rows: $numRows rows")
+            }
 
-  private def doBroadcast = {
-    try {
-      // Setup a job group here so later it may get cancelled by groupId if necessary.
-      sparkContext.setJobGroup(runId.toString, s"broadcast exchange (runId $runId)",
-        interruptOnCancel = true)
-      val beforeCollect = System.nanoTime()
-      // Use executeCollect/executeCollectIterator to avoid conversion to Scala types
-      val (numRows, input) = child.executeCollectIterator()
-      if (numRows >= 512000000) {
-        throw new SparkException(
-          s"Cannot broadcast the table with 512 million or more rows: $numRows rows")
-      }
+            val beforeBuild = System.nanoTime()
+            longMetric("collectTime") += NANOSECONDS.toMillis(beforeBuild - beforeCollect)
 
-      val beforeBuild = System.nanoTime()
-      longMetric("collectTime") += NANOSECONDS.toMillis(beforeBuild - beforeCollect)
+            // Construct the relation.
+            val relation = mode.transform(input, Some(numRows))
 
-      // Construct the relation.
-      val relation = mode.transform(input, Some(numRows))
+            val dataSize = relation match {
+              case map: HashedRelation =>
+                map.estimatedSize
+              case arr: Array[InternalRow] =>
+                arr.map(_.asInstanceOf[UnsafeRow].getSizeInBytes.toLong).sum
+              case _ =>
+                throw new SparkException("[BUG] BroadcastMode.transform returned unexpected " +
+                  s"type: ${relation.getClass.getName}")
+            }
 
-      val dataSize = relation match {
-        case map: HashedRelation =>
-          map.estimatedSize
-        case arr: Array[InternalRow] =>
-          arr.map(_.asInstanceOf[UnsafeRow].getSizeInBytes.toLong).sum
-        case _ =>
-          throw new SparkException("[BUG] BroadcastMode.transform returned unexpected " +
-            s"type: ${relation.getClass.getName}")
-      }
+            longMetric("dataSize") += dataSize
+            if (dataSize >= (8L << 30)) {
+              throw new SparkException(
+                s"Cannot broadcast the table that is larger than 8GB: ${dataSize >> 30} GB")
+            }
 
-      longMetric("dataSize") += dataSize
-      if (dataSize >= (8L << 30)) {
-        throw new SparkException(
-          s"Cannot broadcast the table that is larger than 8GB: ${dataSize >> 30} GB")
-      }
+            val beforeBroadcast = System.nanoTime()
+            longMetric("buildTime") += NANOSECONDS.toMillis(beforeBroadcast - beforeBuild)
 
-      val beforeBroadcast = System.nanoTime()
-      longMetric("buildTime") += NANOSECONDS.toMillis(beforeBroadcast - beforeBuild)
-
-      // Broadcast the relation
-      val broadcasted = sparkContext.broadcast(relation)
-      longMetric("broadcastTime") += NANOSECONDS.toMillis(
-        System.nanoTime() - beforeBroadcast)
-      val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
-      SQLMetrics.postDriverMetricUpdates(sparkContext, executionId, metrics.values.toSeq)
-      promise.success(broadcasted)
-      broadcasted
-    } catch {
-      // SPARK-24294: To bypass scala bug: https://github.com/scala/bug/issues/9554, we throw
-      // SparkFatalException, which is a subclass of Exception. ThreadUtils.awaitResult
-      // will catch this exception and re-throw the wrapped fatal throwable.
-      case oe: OutOfMemoryError =>
-        val ex = new SparkFatalException(
-          new OutOfMemoryError("Not enough memory to build and broadcast the table to all " +
-            "worker nodes. As a workaround, you can either disable broadcast by setting " +
-            s"${SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key} to -1 or increase the spark " +
-            s"driver memory by setting ${SparkLauncher.DRIVER_MEMORY} to a higher value.")
-            .initCause(oe.getCause))
-        promise.failure(ex)
-        throw ex
-      case e if !NonFatal(e) =>
-        val ex = new SparkFatalException(e)
-        promise.failure(ex)
-        throw ex
-      case e: Throwable =>
-        promise.failure(e)
-        throw e
+            // Broadcast the relation
+            val broadcasted = sparkContext.broadcast(relation)
+            longMetric("broadcastTime") += NANOSECONDS.toMillis(
+              System.nanoTime() - beforeBroadcast)
+            val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
+            SQLMetrics.postDriverMetricUpdates(sparkContext, executionId, metrics.values.toSeq)
+            promise.success(broadcasted)
+            broadcasted
+          } catch {
+            // SPARK-24294: To bypass scala bug: https://github.com/scala/bug/issues/9554, we throw
+            // SparkFatalException, which is a subclass of Exception. ThreadUtils.awaitResult
+            // will catch this exception and re-throw the wrapped fatal throwable.
+            case oe: OutOfMemoryError =>
+              val ex = new SparkFatalException(
+                new OutOfMemoryError("Not enough memory to build and broadcast the table to all " +
+                  "worker nodes. As a workaround, you can either disable broadcast by setting " +
+                  s"${SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key} to -1 or increase the spark " +
+                  s"driver memory by setting ${SparkLauncher.DRIVER_MEMORY} to a higher value.")
+                  .initCause(oe.getCause))
+              promise.failure(ex)
+              throw ex
+            case e if !NonFatal(e) =>
+              val ex = new SparkFatalException(e)
+              promise.failure(ex)
+              throw ex
+            case e: Throwable =>
+              promise.failure(e)
+              throw e
+          }
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
@@ -17,10 +17,9 @@
 
 package org.apache.spark.sql.execution.exchange
 
-import java.util.{Properties, UUID}
+import java.util.UUID
 import java.util.concurrent._
 
-import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Promise}
 import scala.concurrent.duration.NANOSECONDS
 import scala.util.control.NonFatal

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
@@ -75,79 +75,74 @@ case class BroadcastExchangeExec(
   private[sql] lazy val relationFuture: Future[broadcast.Broadcast[Any]] = {
     // relationFuture is used in "doExecute". Therefore we can get the execution id correctly here.
     val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
-    val localProps = Utils.cloneProperties(sparkContext.getLocalProperties)
-    val task = new Callable[broadcast.Broadcast[Any]]() {
-      override def call(): broadcast.Broadcast[Any] = {
-        // This will run in another thread. Set the execution id so that we can connect these jobs
-        // with the correct execution.
-        sparkContext.setLocalProperties(localProps)
-        SQLExecution.withExecutionId(sqlContext.sparkSession, executionId) {
-          try {
-            // Setup a job group here so later it may get cancelled by groupId if necessary.
-            sparkContext.setJobGroup(runId.toString, s"broadcast exchange (runId $runId)",
-              interruptOnCancel = true)
-            val beforeCollect = System.nanoTime()
-            // Use executeCollect/executeCollectIterator to avoid conversion to Scala types
-            val (numRows, input) = child.executeCollectIterator()
-            if (numRows >= 512000000) {
-              throw new SparkException(
-                s"Cannot broadcast the table with 512 million or more rows: $numRows rows")
-            }
-
-            val beforeBuild = System.nanoTime()
-            longMetric("collectTime") += NANOSECONDS.toMillis(beforeBuild - beforeCollect)
-
-            // Construct the relation.
-            val relation = mode.transform(input, Some(numRows))
-
-            val dataSize = relation match {
-              case map: HashedRelation =>
-                map.estimatedSize
-              case arr: Array[InternalRow] =>
-                arr.map(_.asInstanceOf[UnsafeRow].getSizeInBytes.toLong).sum
-              case _ =>
-                throw new SparkException("[BUG] BroadcastMode.transform returned unexpected " +
-                  s"type: ${relation.getClass.getName}")
-            }
-
-            longMetric("dataSize") += dataSize
-            if (dataSize >= (8L << 30)) {
-              throw new SparkException(
-                s"Cannot broadcast the table that is larger than 8GB: ${dataSize >> 30} GB")
-            }
-
-            val beforeBroadcast = System.nanoTime()
-            longMetric("buildTime") += NANOSECONDS.toMillis(beforeBroadcast - beforeBuild)
-
-            // Broadcast the relation
-            val broadcasted = sparkContext.broadcast(relation)
-            longMetric("broadcastTime") += NANOSECONDS.toMillis(
-              System.nanoTime() - beforeBroadcast)
-
-            SQLMetrics.postDriverMetricUpdates(sparkContext, executionId, metrics.values.toSeq)
-            promise.success(broadcasted)
-            broadcasted
-          } catch {
-            // SPARK-24294: To bypass scala bug: https://github.com/scala/bug/issues/9554, we throw
-            // SparkFatalException, which is a subclass of Exception. ThreadUtils.awaitResult
-            // will catch this exception and re-throw the wrapped fatal throwable.
-            case oe: OutOfMemoryError =>
-              val ex = new SparkFatalException(
-                new OutOfMemoryError("Not enough memory to build and broadcast the table to all " +
-                  "worker nodes. As a workaround, you can either disable broadcast by setting " +
-                  s"${SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key} to -1 or increase the spark " +
-                  s"driver memory by setting ${SparkLauncher.DRIVER_MEMORY} to a higher value.")
-                  .initCause(oe.getCause))
-              promise.failure(ex)
-              throw ex
-            case e if !NonFatal(e) =>
-              val ex = new SparkFatalException(e)
-              promise.failure(ex)
-              throw ex
-            case e: Throwable =>
-              promise.failure(e)
-              throw e
+    val task = SQLExecution.withThreadLocalCaptured[broadcast.Broadcast[Any]](
+      sqlContext.sparkSession) {
+      SQLExecution.withExecutionId(sqlContext.sparkSession, executionId) {
+        try {
+          // Setup a job group here so later it may get cancelled by groupId if necessary.
+          sparkContext.setJobGroup(runId.toString, s"broadcast exchange (runId $runId)",
+            interruptOnCancel = true)
+          val beforeCollect = System.nanoTime()
+          // Use executeCollect/executeCollectIterator to avoid conversion to Scala types
+          val (numRows, input) = child.executeCollectIterator()
+          if (numRows >= 512000000) {
+            throw new SparkException(
+              s"Cannot broadcast the table with 512 million or more rows: $numRows rows")
           }
+
+          val beforeBuild = System.nanoTime()
+          longMetric("collectTime") += NANOSECONDS.toMillis(beforeBuild - beforeCollect)
+
+          // Construct the relation.
+          val relation = mode.transform(input, Some(numRows))
+
+          val dataSize = relation match {
+            case map: HashedRelation =>
+              map.estimatedSize
+            case arr: Array[InternalRow] =>
+              arr.map(_.asInstanceOf[UnsafeRow].getSizeInBytes.toLong).sum
+            case _ =>
+              throw new SparkException("[BUG] BroadcastMode.transform returned unexpected " +
+                s"type: ${relation.getClass.getName}")
+          }
+
+          longMetric("dataSize") += dataSize
+          if (dataSize >= (8L << 30)) {
+            throw new SparkException(
+              s"Cannot broadcast the table that is larger than 8GB: ${dataSize >> 30} GB")
+          }
+
+          val beforeBroadcast = System.nanoTime()
+          longMetric("buildTime") += NANOSECONDS.toMillis(beforeBroadcast - beforeBuild)
+
+          // Broadcast the relation
+          val broadcasted = sparkContext.broadcast(relation)
+          longMetric("broadcastTime") += NANOSECONDS.toMillis(
+            System.nanoTime() - beforeBroadcast)
+
+          SQLMetrics.postDriverMetricUpdates(sparkContext, executionId, metrics.values.toSeq)
+          promise.success(broadcasted)
+          broadcasted
+        } catch {
+          // SPARK-24294: To bypass scala bug: https://github.com/scala/bug/issues/9554, we throw
+          // SparkFatalException, which is a subclass of Exception. ThreadUtils.awaitResult
+          // will catch this exception and re-throw the wrapped fatal throwable.
+          case oe: OutOfMemoryError =>
+            val ex = new SparkFatalException(
+              new OutOfMemoryError("Not enough memory to build and broadcast the table to all " +
+                "worker nodes. As a workaround, you can either disable broadcast by setting " +
+                s"${SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key} to -1 or increase the spark " +
+                s"driver memory by setting ${SparkLauncher.DRIVER_MEMORY} to a higher value.")
+                .initCause(oe.getCause))
+            promise.failure(ex)
+            throw ex
+          case e if !NonFatal(e) =>
+            val ex = new SparkFatalException(e)
+            promise.failure(ex)
+            throw ex
+          case e: Throwable =>
+            promise.failure(e)
+            throw e
         }
       }
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
@@ -73,77 +73,73 @@ case class BroadcastExchangeExec(
 
   @transient
   private[sql] lazy val relationFuture: Future[broadcast.Broadcast[Any]] = {
-    // relationFuture is used in "doExecute". Therefore we can get the execution id correctly here.
-    val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
     val task = SQLExecution.withThreadLocalCaptured[broadcast.Broadcast[Any]](
       sqlContext.sparkSession) {
-      SQLExecution.withExecutionId(sqlContext.sparkSession, executionId) {
-        try {
-          // Setup a job group here so later it may get cancelled by groupId if necessary.
-          sparkContext.setJobGroup(runId.toString, s"broadcast exchange (runId $runId)",
-            interruptOnCancel = true)
-          val beforeCollect = System.nanoTime()
-          // Use executeCollect/executeCollectIterator to avoid conversion to Scala types
-          val (numRows, input) = child.executeCollectIterator()
-          if (numRows >= 512000000) {
-            throw new SparkException(
-              s"Cannot broadcast the table with 512 million or more rows: $numRows rows")
-          }
-
-          val beforeBuild = System.nanoTime()
-          longMetric("collectTime") += NANOSECONDS.toMillis(beforeBuild - beforeCollect)
-
-          // Construct the relation.
-          val relation = mode.transform(input, Some(numRows))
-
-          val dataSize = relation match {
-            case map: HashedRelation =>
-              map.estimatedSize
-            case arr: Array[InternalRow] =>
-              arr.map(_.asInstanceOf[UnsafeRow].getSizeInBytes.toLong).sum
-            case _ =>
-              throw new SparkException("[BUG] BroadcastMode.transform returned unexpected " +
-                s"type: ${relation.getClass.getName}")
-          }
-
-          longMetric("dataSize") += dataSize
-          if (dataSize >= (8L << 30)) {
-            throw new SparkException(
-              s"Cannot broadcast the table that is larger than 8GB: ${dataSize >> 30} GB")
-          }
-
-          val beforeBroadcast = System.nanoTime()
-          longMetric("buildTime") += NANOSECONDS.toMillis(beforeBroadcast - beforeBuild)
-
-          // Broadcast the relation
-          val broadcasted = sparkContext.broadcast(relation)
-          longMetric("broadcastTime") += NANOSECONDS.toMillis(
-            System.nanoTime() - beforeBroadcast)
-
-          SQLMetrics.postDriverMetricUpdates(sparkContext, executionId, metrics.values.toSeq)
-          promise.success(broadcasted)
-          broadcasted
-        } catch {
-          // SPARK-24294: To bypass scala bug: https://github.com/scala/bug/issues/9554, we throw
-          // SparkFatalException, which is a subclass of Exception. ThreadUtils.awaitResult
-          // will catch this exception and re-throw the wrapped fatal throwable.
-          case oe: OutOfMemoryError =>
-            val ex = new SparkFatalException(
-              new OutOfMemoryError("Not enough memory to build and broadcast the table to all " +
-                "worker nodes. As a workaround, you can either disable broadcast by setting " +
-                s"${SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key} to -1 or increase the spark " +
-                s"driver memory by setting ${SparkLauncher.DRIVER_MEMORY} to a higher value.")
-                .initCause(oe.getCause))
-            promise.failure(ex)
-            throw ex
-          case e if !NonFatal(e) =>
-            val ex = new SparkFatalException(e)
-            promise.failure(ex)
-            throw ex
-          case e: Throwable =>
-            promise.failure(e)
-            throw e
+      try {
+        // Setup a job group here so later it may get cancelled by groupId if necessary.
+        sparkContext.setJobGroup(runId.toString, s"broadcast exchange (runId $runId)",
+          interruptOnCancel = true)
+        val beforeCollect = System.nanoTime()
+        // Use executeCollect/executeCollectIterator to avoid conversion to Scala types
+        val (numRows, input) = child.executeCollectIterator()
+        if (numRows >= 512000000) {
+          throw new SparkException(
+            s"Cannot broadcast the table with 512 million or more rows: $numRows rows")
         }
+
+        val beforeBuild = System.nanoTime()
+        longMetric("collectTime") += NANOSECONDS.toMillis(beforeBuild - beforeCollect)
+
+        // Construct the relation.
+        val relation = mode.transform(input, Some(numRows))
+
+        val dataSize = relation match {
+          case map: HashedRelation =>
+            map.estimatedSize
+          case arr: Array[InternalRow] =>
+            arr.map(_.asInstanceOf[UnsafeRow].getSizeInBytes.toLong).sum
+          case _ =>
+            throw new SparkException("[BUG] BroadcastMode.transform returned unexpected " +
+              s"type: ${relation.getClass.getName}")
+        }
+
+        longMetric("dataSize") += dataSize
+        if (dataSize >= (8L << 30)) {
+          throw new SparkException(
+            s"Cannot broadcast the table that is larger than 8GB: ${dataSize >> 30} GB")
+        }
+
+        val beforeBroadcast = System.nanoTime()
+        longMetric("buildTime") += NANOSECONDS.toMillis(beforeBroadcast - beforeBuild)
+
+        // Broadcast the relation
+        val broadcasted = sparkContext.broadcast(relation)
+        longMetric("broadcastTime") += NANOSECONDS.toMillis(
+          System.nanoTime() - beforeBroadcast)
+        val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
+        SQLMetrics.postDriverMetricUpdates(sparkContext, executionId, metrics.values.toSeq)
+        promise.success(broadcasted)
+        broadcasted
+      } catch {
+        // SPARK-24294: To bypass scala bug: https://github.com/scala/bug/issues/9554, we throw
+        // SparkFatalException, which is a subclass of Exception. ThreadUtils.awaitResult
+        // will catch this exception and re-throw the wrapped fatal throwable.
+        case oe: OutOfMemoryError =>
+          val ex = new SparkFatalException(
+            new OutOfMemoryError("Not enough memory to build and broadcast the table to all " +
+              "worker nodes. As a workaround, you can either disable broadcast by setting " +
+              s"${SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key} to -1 or increase the spark " +
+              s"driver memory by setting ${SparkLauncher.DRIVER_MEMORY} to a higher value.")
+              .initCause(oe.getCause))
+          promise.failure(ex)
+          throw ex
+        case e if !NonFatal(e) =>
+          val ex = new SparkFatalException(e)
+          promise.failure(ex)
+          throw ex
+        case e: Throwable =>
+          promise.failure(e)
+          throw e
       }
     }
     BroadcastExchangeExec.executionContext.submit[broadcast.Broadcast[Any]](task)

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/ExecutorSideSQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/ExecutorSideSQLConfSuite.scala
@@ -164,8 +164,8 @@ class ExecutorSideSQLConfSuite extends SparkFunSuite with SQLTestUtils {
     withSQLConf(StaticSQLConf.BROADCAST_EXCHANGE_MAX_THREAD_THRESHOLD.key -> "1") {
       val df1 = Seq(true).toDF()
       val confKey = "spark.sql.y"
-      val confValue1 = "b"
-      val confValue2 = "c"
+      val confValue1 = UUID.randomUUID().toString()
+      val confValue2 = UUID.randomUUID().toString()
 
       def generateBroadcastDataFrame(confKey: String, confValue: String): Dataset[Boolean] = {
         val df = spark.range(1).mapPartitions { _ =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/ExecutorSideSQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/ExecutorSideSQLConfSuite.scala
@@ -172,7 +172,6 @@ class ExecutorSideSQLConfSuite extends SparkFunSuite with SQLTestUtils {
           Iterator(TaskContext.get.getLocalProperty(confKey) == confValue)
         }
         df.hint("broadcast")
-        df
       }
 
       // set local propert and assert


### PR DESCRIPTION
### What changes were proposed in this pull request?
In `org.apache.spark.sql.execution.exchange.BroadcastExchangeExec#relationFuture` make a copy of `org.apache.spark.SparkContext#localProperties` and pass it to the broadcast execution thread in `org.apache.spark.sql.execution.exchange.BroadcastExchangeExec#executionContext`

### Why are the changes needed?
When executing `BroadcastExchangeExec`, the relationFuture is evaluated via a separate thread. The threads inherit the `localProperties` from `sparkContext` as they are the child threads.
These threads are created in the executionContext (thread pools). Each Thread pool has a default `keepAliveSeconds` of 60 seconds for idle threads.
Scenarios where the thread pool has threads which are idle and reused for a subsequent new query, the thread local properties will not be inherited from spark context (thread properties are inherited only on thread creation) hence end up having old or no properties set. This will cause taskset properties to be missing when properties are transferred by child thread via `sparkContext.runJob/submitJob`

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Added UT