### PR TITLE
[SPARK-30556][SQL] Copy sparkContext.localproperties to child thread inSubqueryExec.executionContext

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -145,7 +145,7 @@ object StaticSQLConf {
         "cause longer waiting for other broadcasting. Also, increasing parallelism may " +
         "cause memory problem.")
       .intConf
-      .checkValue(thres => thres > 0 && thres <= 128, "The threshold must be in [0,128].")
+      .checkValue(thres => thres > 0 && thres <= 128, "The threshold must be in (0,128].")
       .createWithDefault(128)
 
   val SUBQUERY_MAX_THREAD_THRESHOLD =
@@ -153,7 +153,7 @@ object StaticSQLConf {
       .internal()
       .doc("The maximum degree of parallelism to execute the subquery. ")
       .intConf
-      .checkValue(thres => thres > 0 && thres <= 128, "The threshold must be in [0,128].")
+      .checkValue(thres => thres > 0 && thres <= 128, "The threshold must be in (0,128].")
       .createWithDefault(16)
 
   val SQL_EVENT_TRUNCATE_LENGTH = buildStaticConf("spark.sql.event.truncate.length")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -151,7 +151,7 @@ object StaticSQLConf {
   val SUBQUERY_MAX_THREAD_THRESHOLD =
     buildStaticConf("spark.sql.subquery.maxThreadThreshold")
       .internal()
-      .doc("The maximum degree of parallelism to execute the subquery. ")
+      .doc("The maximum degree of parallelism to execute the subquery.")
       .intConf
       .checkValue(thres => thres > 0 && thres <= 128, "The threshold must be in (0,128].")
       .createWithDefault(16)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -148,6 +148,14 @@ object StaticSQLConf {
       .checkValue(thres => thres > 0 && thres <= 128, "The threshold must be in [0,128].")
       .createWithDefault(128)
 
+  val SUBQUERY_MAX_THREAD_THRESHOLD =
+    buildStaticConf("spark.sql.subquery.maxThreadThreshold")
+      .internal()
+      .doc("The maximum degree of parallelism to execute the subquery. ")
+      .intConf
+      .checkValue(thres => thres > 0 && thres <= 128, "The threshold must be in [0,128].")
+      .createWithDefault(16)
+
   val SQL_EVENT_TRUNCATE_LENGTH = buildStaticConf("spark.sql.event.truncate.length")
     .doc("Threshold of SQL length beyond which it will be truncated before adding to " +
       "event. Defaults to no truncation. If set to 0, callsite will be logged instead.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
@@ -171,8 +171,8 @@ object SQLExecution {
    * Wrap passed function to ensure necessary thread-local variables like
    * SparkContext local properties are forwarded to execution thread
    */
-  def withThreadLocalCaptured[T](sparkSession: SparkSession, exec: ExecutionContext)(
-    body: => T): Future[T] = {
+  def withThreadLocalCaptured[T](
+      sparkSession: SparkSession, exec: ExecutionContext)(body: => T): Future[T] = {
     val activeSession = sparkSession
     val sc = sparkSession.sparkContext
     val localProps = Utils.cloneProperties(sc.getLocalProperties)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
@@ -174,10 +174,11 @@ object SQLExecution {
   def withThreadLocalCaptured[T](sparkSession: SparkSession, exec: ExecutionContext)(
     body: => T): Future[T] = {
     val activeSession = sparkSession
-    val localProps = Utils.cloneProperties(sparkSession.sparkContext.getLocalProperties)
+    val sc = sparkSession.sparkContext
+    val localProps = Utils.cloneProperties(sc.getLocalProperties)
     Future {
       SparkSession.setActiveSession(activeSession)
-      sparkSession.sparkContext.setLocalProperties(localProps)
+      sc.setLocalProperties(localProps)
       body
     }(exec)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
@@ -170,9 +170,8 @@ object SQLExecution {
   /**
    * Wrap passed function to ensure sparkContext local properties are forwarded to execution thread
    */
-  def withThreadLocalCaptured[T](sparkContext: SparkContext)
-                                (body: => T)
-                                (exec: ExecutionContext): Future[T] = {
+  def withThreadLocalCaptured[T](sparkContext: SparkContext)(body: => T)(
+    exec: ExecutionContext): Future[T] = {
     val localProps = Utils.cloneProperties(sparkContext.getLocalProperties)
     Future {
       sparkContext.setLocalProperties(localProps)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
@@ -168,7 +168,8 @@ object SQLExecution {
   }
 
   /**
-   * Wrap passed function to ensure sparkContext local properties are forwarded to execution thread
+   * Wrap passed function to ensure necessary thread-local variables like
+   * SparkContext local properties are forwarded to execution thread
    */
   def withThreadLocalCaptured[T](sparkSession: SparkSession)(body: => T)(
     exec: ExecutionContext): Future[T] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
@@ -170,11 +170,13 @@ object SQLExecution {
   /**
    * Wrap passed function to ensure sparkContext local properties are forwarded to execution thread
    */
-  def withThreadLocalCaptured[T](sparkContext: SparkContext)(body: => T)(
+  def withThreadLocalCaptured[T](sparkSession: SparkSession)(body: => T)(
     exec: ExecutionContext): Future[T] = {
-    val localProps = Utils.cloneProperties(sparkContext.getLocalProperties)
+    val activeSession = sparkSession
+    val localProps = Utils.cloneProperties(sparkSession.sparkContext.getLocalProperties)
     Future {
-      sparkContext.setLocalProperties(localProps)
+      SparkSession.setActiveSession(activeSession)
+      sparkSession.sparkContext.setLocalProperties(localProps)
       body
     }(exec)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
@@ -171,8 +171,8 @@ object SQLExecution {
    * Wrap passed function to ensure necessary thread-local variables like
    * SparkContext local properties are forwarded to execution thread
    */
-  def withThreadLocalCaptured[T](sparkSession: SparkSession)(body: => T)(
-    exec: ExecutionContext): Future[T] = {
+  def withThreadLocalCaptured[T](sparkSession: SparkSession, exec: ExecutionContext)(
+    body: => T): Future[T] = {
     val activeSession = sparkSession
     val localProps = Utils.cloneProperties(sparkSession.sparkContext.getLocalProperties)
     Future {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -750,7 +750,7 @@ case class SubqueryExec(name: String, child: SparkPlan)
   private lazy val relationFuture: Future[Array[InternalRow]] = {
     // relationFuture is used in "doExecute". Therefore we can get the execution id correctly here.
     val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
-    SQLExecution.withThreadLocalCaptured[Array[InternalRow]](sparkContext) {
+    SQLExecution.withThreadLocalCaptured[Array[InternalRow]](sqlContext.sparkSession) {
       // This will run in another thread. Set the execution id so that we can connect these jobs
       // with the correct execution.
       SQLExecution.withExecutionId(sqlContext.sparkSession, executionId) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.catalyst.expressions.BindReferences.bindReferences
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.execution.metric.SQLMetrics
+import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
 import org.apache.spark.sql.types.{LongType, StructType}
 import org.apache.spark.util.{ThreadUtils, Utils}
 import org.apache.spark.util.random.{BernoulliCellSampler, PoissonSampler}
@@ -790,7 +791,8 @@ case class SubqueryExec(name: String, child: SparkPlan)
 
 object SubqueryExec {
   private[execution] val executionContext = ExecutionContext.fromExecutorService(
-    ThreadUtils.newDaemonCachedThreadPool("subquery", 16))
+    ThreadUtils.newDaemonCachedThreadPool("subquery",
+      SQLConf.get.getConf(StaticSQLConf.SUBQUERY_MAX_THREAD_THRESHOLD)))
 }
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -750,11 +750,9 @@ case class SubqueryExec(name: String, child: SparkPlan)
   private lazy val relationFuture: Future[Array[InternalRow]] = {
     // relationFuture is used in "doExecute". Therefore we can get the execution id correctly here.
     val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
-    val localProps = Utils.cloneProperties(sparkContext.getLocalProperties)
-    Future {
+    SQLExecution.withThreadLocalCaptured[Array[InternalRow]](sparkContext) {
       // This will run in another thread. Set the execution id so that we can connect these jobs
       // with the correct execution.
-      sparkContext.setLocalProperties(localProps)
       SQLExecution.withExecutionId(sqlContext.sparkSession, executionId) {
         val beforeCollect = System.nanoTime()
         // Note that we use .executeCollect() because we don't want to convert data to Scala types

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -750,7 +750,9 @@ case class SubqueryExec(name: String, child: SparkPlan)
   private lazy val relationFuture: Future[Array[InternalRow]] = {
     // relationFuture is used in "doExecute". Therefore we can get the execution id correctly here.
     val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
-    SQLExecution.withThreadLocalCaptured[Array[InternalRow]](sqlContext.sparkSession) {
+    SQLExecution.withThreadLocalCaptured[Array[InternalRow]](
+      sqlContext.sparkSession,
+      SubqueryExec.executionContext) {
       // This will run in another thread. Set the execution id so that we can connect these jobs
       // with the correct execution.
       SQLExecution.withExecutionId(sqlContext.sparkSession, executionId) {
@@ -765,7 +767,7 @@ case class SubqueryExec(name: String, child: SparkPlan)
         SQLMetrics.postDriverMetricUpdates(sparkContext, executionId, metrics.values.toSeq)
         rows
       }
-    }(SubqueryExec.executionContext)
+    }
   }
 
   protected override def doCanonicalize(): SparkPlan = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/ExecutorSideSQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/ExecutorSideSQLConfSuite.scala
@@ -128,36 +128,39 @@ class ExecutorSideSQLConfSuite extends SparkFunSuite with SQLTestUtils {
 
   test("SPARK-30556 propagate local properties to subquery execution thread") {
     withSQLConf("spark.sql.subquery.maxThreadThreshold" -> "1") {
-      Seq(true)
-        .toDF()
-        .createOrReplaceTempView("l")
-      val confKey = "spark.sql.y"
-
-      def createDataframe(confKey: String, confValue: String): Dataset[Boolean] = {
+      withTempView("l", "m", "n") {
         Seq(true)
           .toDF()
-          .mapPartitions { _ =>
-            val conf = SQLConf.get
-            conf.isInstanceOf[ReadOnlySQLConf] && conf.getConfString(confKey) == confValue match {
-              case true => Iterator(true)
-              case false => Iterator.empty
+          .createOrReplaceTempView("l")
+        val confKey = "spark.sql.y"
+
+        def createDataframe(confKey: String, confValue: String): Dataset[Boolean] = {
+          Seq(true)
+            .toDF()
+            .mapPartitions { _ =>
+              val conf = SQLConf.get
+              conf
+                .isInstanceOf[ReadOnlySQLConf] && conf.getConfString(confKey) == confValue match {
+                case true => Iterator(true)
+                case false => Iterator.empty
+              }
             }
-          }
+        }
+
+        // set local configuration and assert
+        val confValue1 = "e"
+        createDataframe(confKey, confValue1)
+          .createOrReplaceTempView("m")
+        spark.sparkContext.setLocalProperty(confKey, confValue1)
+        assert(sql("select * from l where exists (select * from m)").collect.size == 1)
+
+        // change the conf value and assert again
+        val confValue2 = "f"
+        createDataframe(confKey, confValue2)
+          .createOrReplaceTempView("n")
+        spark.sparkContext.setLocalProperty(confKey, confValue2)
+        assert(sql("select value from l where exists (select * from n)").collect().size == 1)
       }
-
-      // set local configuration and assert
-      val confValue1 = "e"
-      createDataframe(confKey, confValue1)
-        .createOrReplaceTempView("m")
-      spark.sparkContext.setLocalProperty(confKey, confValue1)
-      assert(sql("select * from l where exists (select * from m )").collect.size == 1)
-
-      // change the conf value and assert again
-      val confValue2 = "f"
-      createDataframe(confKey, confValue2)
-        .createOrReplaceTempView("n")
-      spark.sparkContext.setLocalProperty(confKey, confValue2)
-      assert(sql("select value from l where exists (select * from n )").collect().size == 1)
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/ExecutorSideSQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/ExecutorSideSQLConfSuite.scala
@@ -127,7 +127,7 @@ class ExecutorSideSQLConfSuite extends SparkFunSuite with SQLTestUtils {
   }
 
   test("SPARK-30556 propagate local properties to subquery execution thread") {
-    withSQLConf("spark.sql.subquery.maxThreadThreshold" -> "1") {
+    withSQLConf(StaticSQLConf.SUBQUERY_MAX_THREAD_THRESHOLD.key -> "1") {
       withTempView("l", "m", "n") {
         Seq(true).toDF().createOrReplaceTempView("l")
         val confKey = "spark.sql.y"
@@ -147,13 +147,13 @@ class ExecutorSideSQLConfSuite extends SparkFunSuite with SQLTestUtils {
         val confValue1 = "e"
         createDataframe(confKey, confValue1).createOrReplaceTempView("m")
         spark.sparkContext.setLocalProperty(confKey, confValue1)
-        assert(sql("select * from l where exists (select * from m)").collect.size == 1)
+        assert(sql("SELECT * FROM l WHERE EXISTS (SELECT * FROM m)").collect.size == 1)
 
         // change the conf value and assert again
         val confValue2 = "f"
         createDataframe(confKey, confValue2).createOrReplaceTempView("n")
         spark.sparkContext.setLocalProperty(confKey, confValue2)
-        assert(sql("select value from l where exists (select * from n)").collect().size == 1)
+        assert(sql("SELECT * FROM l WHERE EXISTS (SELECT * FROM n)").collect().size == 1)
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In `org.apache.spark.sql.execution.SubqueryExec#relationFuture` make a copy of `org.apache.spark.SparkContext#localProperties` and pass it to the sub-execution thread in `org.apache.spark.sql.execution.SubqueryExec#executionContext`

### Why are the changes needed?
Local properties set via sparkContext are not available as TaskContext properties when executing  jobs and threadpools have idle threads which are reused

Explanation:
When `SubqueryExec`, the relationFuture is evaluated via a separate thread. The threads inherit the `localProperties` from `sparkContext` as they are the child threads.
These threads are created in the `executionContext` (thread pools). Each Thread pool has a default keepAliveSeconds of 60 seconds for idle threads.
Scenarios where the thread pool has threads which are idle and reused for a subsequent new query, the thread local properties will not be inherited from spark context (thread properties are inherited only on thread creation) hence end up having old or no properties set. This will cause taskset properties to be missing when properties are transferred by child thread via `sparkContext.runJob/submitJob`

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Added UT