### PR TITLE
[MINOR][DOCS] Remove note about -T for parallel build

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ To build Spark and its example programs, run:
 
 (You do not need to do this if you downloaded a pre-built package.)
 
-You can build Spark using more than one thread by using the -T option with Maven, see ["Parallel builds in Maven 3"](https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3).
 More detailed documentation is available from the project site, at
 ["Building Spark"](https://spark.apache.org/docs/latest/building-spark.html).
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Removes suggestion to use -T for parallel Maven build.

### Why are the changes needed?

Parallel builds don't necessarily work in the build right now.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

N/A