### PR TITLE
[SPARK-30570][BUILD] Update scalafmt plugin to 1.0.3 with onlyChangedFiles feature

### DIFF
--- a/dev/scalafmt
+++ b/dev/scalafmt
@@ -17,4 +17,6 @@
 # limitations under the License.
 #
 
-./build/mvn -Pscala-2.12 mvn-scalafmt_2.12:format -Dscalafmt.skip=false
+VERSION="${@:-2.12}"
+./build/mvn -Pscala-$VERSION mvn-scalafmt_$VERSION:format -Dscalafmt.skip=false
+

--- a/dev/scalafmt
+++ b/dev/scalafmt
@@ -17,7 +17,4 @@
 # limitations under the License.
 #
 
-# by default, format only files that differ from git master
-params="${@:---diff}"
-
-./build/mvn -Pscala-2.12 mvn-scalafmt_2.12:format -Dscalafmt.skip=false -Dscalafmt.parameters="$params"
+./build/mvn -Pscala-2.12 mvn-scalafmt_2.12:format -Dscalafmt.skip=false

--- a/pom.xml
+++ b/pom.xml
@@ -2863,6 +2863,27 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.antipathy</groupId>
+        <artifactId>mvn-scalafmt_${scala.binary.version}</artifactId>
+        <version>1.0.3</version>
+        <configuration>
+          <parameters>${scalafmt.parameters}</parameters> <!-- (Optional) Additional command line arguments -->
+          <skip>${scalafmt.skip}</skip> <!-- (Optional) skip formatting -->
+          <skipSources>${scalafmt.skip}</skipSources>
+          <skipTestSources>${scalafmt.skip}</skipTestSources>
+          <configLocation>dev/.scalafmt.conf</configLocation> <!-- (Optional) config location -->
+          <onlyChangedFiles>true</onlyChangedFiles>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>validate</phase>
+            <goals>
+              <goal>format</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <!--
         Couple of dependencies are coming in bundle format (bundle is just a normal jar which
         contains OSGi metadata in the manifest). If one don't use OSGi, then a bundle will work as
@@ -3027,28 +3048,6 @@
       <build>
         <pluginManagement>
           <plugins>
-            <!-- SPARK-29293 currently not able to update to 1.x for Scala 2.13 -->
-            <plugin>
-              <groupId>org.antipathy</groupId>
-              <artifactId>mvn-scalafmt_2.12</artifactId>
-              <version>1.0.3</version>
-              <configuration>
-                <parameters>${scalafmt.parameters}</parameters> <!-- (Optional) Additional command line arguments -->
-                <skip>${scalafmt.skip}</skip> <!-- (Optional) skip formatting -->
-                <skipSources>${scalafmt.skip}</skipSources>
-                <skipTestSources>${scalafmt.skip}</skipTestSources>
-                <configLocation>dev/.scalafmt.conf</configLocation> <!-- (Optional) config location -->
-                <onlyChangedFiles>true</onlyChangedFiles>
-              </configuration>
-              <executions>
-                <execution>
-                  <phase>validate</phase>
-                  <goals>
-                    <goal>format</goal>
-                  </goals>
-                </execution>
-              </executions>
-            </plugin>
           </plugins>
         </pluginManagement>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
     <commons.collections.version>3.2.2</commons.collections.version>
     <scala.version>2.12.10</scala.version>
     <scala.binary.version>2.12</scala.binary.version>
-    <scalafmt.parameters>--diff --test</scalafmt.parameters>
+    <scalafmt.parameters>--test</scalafmt.parameters>
     <!-- for now, not running scalafmt as part of default verify pipeline -->
     <scalafmt.skip>true</scalafmt.skip>
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
@@ -3031,13 +3031,14 @@
             <plugin>
               <groupId>org.antipathy</groupId>
               <artifactId>mvn-scalafmt_2.12</artifactId>
-              <version>0.12_1.5.1</version>
+              <version>1.0.3</version>
               <configuration>
                 <parameters>${scalafmt.parameters}</parameters> <!-- (Optional) Additional command line arguments -->
                 <skip>${scalafmt.skip}</skip> <!-- (Optional) skip formatting -->
                 <skipSources>${scalafmt.skip}</skipSources>
                 <skipTestSources>${scalafmt.skip}</skipTestSources>
                 <configLocation>dev/.scalafmt.conf</configLocation> <!-- (Optional) config location -->
+                <onlyChangedFiles>true</onlyChangedFiles>
               </configuration>
               <executions>
                 <execution>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Update the scalafmt plugin to 1.0.3 and use its new onlyChangedFiles feature rather than --diff

### Why are the changes needed?
Older versions of the plugin either didn't work with scala 2.13, or got rid of the --diff argument and didn't allow for formatting only changed files

### Does this PR introduce any user-facing change?
The /dev/scalafmt script no longer passes through arbitrary args, instead using the arg to select scala version.  The issue here is the plugin name literally contains the scala version, and doesn't appear to have a shorter way to refer to it.   If @srowen or someone else with better maven-fu has an idea I'm all ears.

### How was this patch tested?
Manually, e.g. edited a file and ran

dev/scalafmt

or

dev/scalafmt 2.13