### PR TITLE
[SPARK-30571][CORE] fix splitting shuffle fetch requests

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -332,37 +332,47 @@ final class ShuffleBlockFetcherIterator(
     val iterator = blockInfos.iterator
     var curRequestSize = 0L
     var curBlocks = new ArrayBuffer[FetchBlockInfo]
+
+    def createFetchRequest(blocks: Seq[FetchBlockInfo]): Unit = {
+      collectedRemoteRequests += FetchRequest(address, blocks)
+      logDebug(s"Creating fetch request of $curRequestSize at $address "
+        + s"with ${blocks.size} blocks")
+    }
+
+    def createFetchRequests(): Unit = {
+      val mergedBlocks = mergeContinuousShuffleBlockIdsIfNeeded(curBlocks)
+      curBlocks = new ArrayBuffer[FetchBlockInfo]
+      if (mergedBlocks.length <= maxBlocksInFlightPerAddress) {
+        createFetchRequest(mergedBlocks)
+      } else {
+        mergedBlocks.grouped(maxBlocksInFlightPerAddress).foreach { blocks =>
+          if (blocks.length == maxBlocksInFlightPerAddress) {
+            createFetchRequest(blocks)
+          } else {
+            // The last group does not exceed `maxBlocksInFlightPerAddress`. Put it back
+            // to `curBlocks`.
+            curBlocks = blocks
+            numBlocksToFetch -= blocks.size
+          }
+        }
+      }
+      curRequestSize = curBlocks.map(_.size).sum
+    }
+
     while (iterator.hasNext) {
       val (blockId, size, mapIndex) = iterator.next()
       assertPositiveBlockSize(blockId, size)
       curBlocks += FetchBlockInfo(blockId, size, mapIndex)
       curRequestSize += size
       // For batch fetch, the actual block in flight should count for merged block.
-      val exceedsMaxBlocksInFlightPerAddress = !doBatchFetch &&
-        curBlocks.size >= maxBlocksInFlightPerAddress
-      if (curRequestSize >= targetRemoteRequestSize || exceedsMaxBlocksInFlightPerAddress) {
-        // Add this FetchRequest
-        val mergedBlocks = mergeContinuousShuffleBlockIdsIfNeeded(curBlocks)
-          .grouped(maxBlocksInFlightPerAddress)
-        curBlocks = new ArrayBuffer[FetchBlockInfo]
-        mergedBlocks.foreach { mergedBlock =>
-          if (mergedBlock.size == maxBlocksInFlightPerAddress) {
-            collectedRemoteRequests += new FetchRequest(address, mergedBlock)
-            logDebug(s"Creating fetch request of $curRequestSize at $address "
-              + s"with ${mergedBlock.size} blocks")
-          } else {
-            // The last group does not exceed `maxBlocksInFlightPerAddress`. Put it back
-            // to `curBlocks`.
-            curBlocks = mergedBlock
-          }
-        }
-        curRequestSize = 0
+      val mayExceedsMaxBlocks = !doBatchFetch && curBlocks.size >= maxBlocksInFlightPerAddress
+      if (curRequestSize >= targetRemoteRequestSize || mayExceedsMaxBlocks) {
+        createFetchRequests()
       }
     }
     // Add in the final request
     if (curBlocks.nonEmpty) {
-      val mergedBlocks = mergeContinuousShuffleBlockIdsIfNeeded(curBlocks)
-      collectedRemoteRequests += new FetchRequest(address, mergedBlocks)
+      createFetchRequests()
     }
   }
 
@@ -380,35 +390,57 @@ final class ShuffleBlockFetcherIterator(
 
   private[this] def mergeContinuousShuffleBlockIdsIfNeeded(
       blocks: ArrayBuffer[FetchBlockInfo]): ArrayBuffer[FetchBlockInfo] = {
-
-    def mergeFetchBlockInfo(toBeMerged: ArrayBuffer[FetchBlockInfo]): FetchBlockInfo = {
-      val startBlockId = toBeMerged.head.blockId.asInstanceOf[ShuffleBlockId]
-      FetchBlockInfo(
-        ShuffleBlockBatchId(
-          startBlockId.shuffleId,
-          startBlockId.mapId,
-          startBlockId.reduceId,
-          toBeMerged.last.blockId.asInstanceOf[ShuffleBlockId].reduceId + 1),
-        toBeMerged.map(_.size).sum,
-        toBeMerged.head.mapIndex)
-    }
-
     val result = if (doBatchFetch) {
       var curBlocks = new ArrayBuffer[FetchBlockInfo]
       val mergedBlockInfo = new ArrayBuffer[FetchBlockInfo]
-      val iter = blocks.iterator
 
+      def mergeFetchBlockInfo(toBeMerged: ArrayBuffer[FetchBlockInfo]): FetchBlockInfo = {
+        val startBlockId = toBeMerged.head.blockId.asInstanceOf[ShuffleBlockId]
+
+        // The last merged block may comes from the input, and we can merge more blocks
+        // into it, if the map id is the same.
+        def shouldMergeIntoPreviousBatchBlockId =
+          mergedBlockInfo.last.blockId.asInstanceOf[ShuffleBlockBatchId].mapId == startBlockId.mapId
+
+        val startReduceId = if (mergedBlockInfo.nonEmpty && shouldMergeIntoPreviousBatchBlockId) {
+          // Remove the previous batch block id as we will add a new one to replace it.
+          mergedBlockInfo.remove(mergedBlockInfo.length - 1).blockId
+            .asInstanceOf[ShuffleBlockBatchId].startReduceId
+        } else {
+          startBlockId.reduceId
+        }
+
+        FetchBlockInfo(
+          ShuffleBlockBatchId(
+            startBlockId.shuffleId,
+            startBlockId.mapId,
+            startReduceId,
+            toBeMerged.last.blockId.asInstanceOf[ShuffleBlockId].reduceId + 1),
+          toBeMerged.map(_.size).sum,
+          toBeMerged.head.mapIndex)
+      }
+
+      val iter = blocks.iterator
       while (iter.hasNext) {
         val info = iter.next()
-        val curBlockId = info.blockId.asInstanceOf[ShuffleBlockId]
-        if (curBlocks.isEmpty) {
-          curBlocks += info
+        // It's possible that the input block id is already a batch ID. For example, we merge some
+        // blocks, and then make fetch requests with the merged blocks according to "max blocks per
+        // request". The last fetch request may be too small, and we give up and put the remaining
+        // merged blocks back to the input list.
+        if (info.blockId.isInstanceOf[ShuffleBlockBatchId]) {
+          mergedBlockInfo += info
         } else {
-          if (curBlockId.mapId != curBlocks.head.blockId.asInstanceOf[ShuffleBlockId].mapId) {
-            mergedBlockInfo += mergeFetchBlockInfo(curBlocks)
-            curBlocks.clear()
+          if (curBlocks.isEmpty) {
+            curBlocks += info
+          } else {
+            val curBlockId = info.blockId.asInstanceOf[ShuffleBlockId]
+            val currentMapId = curBlocks.head.blockId.asInstanceOf[ShuffleBlockId].mapId
+            if (curBlockId.mapId != currentMapId) {
+              mergedBlockInfo += mergeFetchBlockInfo(curBlocks)
+              curBlocks.clear()
+            }
+            curBlocks += info
           }
-          curBlocks += info
         }
       }
       if (curBlocks.nonEmpty) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This is a followup of https://github.com/apache/spark/pull/26930 to fix a bug.

When we create shuffle fetch requests, we first collect blocks until they reach the max size. Then we try to merge the blocks (the batch shuffle fetch feature) and split the merged blocks to several groups, to make sure each group doesn't reach the max numBlocks. For the last group, if it's smaller than the max numBlocks, put it back to the input list and deal with it again later.

The last step has a problem:
1. if we put a merged block back to the input list and merge it again, it fails.
2. when putting back some blocks, we should update `numBlocksToFetch`

This PR fixes these 2 problems.

### Why are the changes needed?
bug fix
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
new test