### PR TITLE
[SPARK-30572][BUILD] Add a fallback Maven repository

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -66,6 +66,13 @@ jobs:
         export MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=1g -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
         export MAVEN_CLI_OPTS="--no-transfer-progress"
         mkdir -p ~/.m2
+        # `Maven Central` is too flaky in terms of downloading artifacts in `GitHub Action` environment.
+        # `Google Maven Central Mirror` is too slow in terms of sycing upstream. To get the best combination,
+        #   1) we set `Google Maven Central` as a mirror of `central` in `GitHub Action` environment only.
+        #   2) we duplicates `Maven Central` in pom.xml with ID `central_without_mirror`.
+        # In other words, in GitHub Action environment, `central` is mirrored by `Google Maven Central` first.
+        # If `Google Maven Central` doesn't provide the artifact due to its slowness, `central_without_mirror` will be used.
+        # Note that we aim to achieve the above while keeping the existing behavior of non-`GitHub Action` environment unchanged.
         echo "<settings><mirrors><mirror><id>google-maven-central</id><name>GCS Maven Central mirror</name><url>https://maven-central.storage-download.googleapis.com/repos/central/data/</url><mirrorOf>central</mirrorOf></mirror></mirrors></settings>" > ~/.m2/settings.xml
         ./build/mvn $MAVEN_CLI_OPTS -DskipTests -Pyarn -Pmesos -Pkubernetes -Phive -P${{ matrix.hive }} -Phive-thriftserver -P${{ matrix.hadoop }} -Phadoop-cloud -Djava.version=${{ matrix.java }} install
         rm -rf ~/.m2/repository/org/apache/spark

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
     <hive.parquet.version>1.6.0</hive.parquet.version>
     <jetty.version>9.4.18.v20190429</jetty.version>
     <javaxservlet.version>3.1.0</javaxservlet.version>
-    <chill.version>0.9.5</chill.version>
+    <chill.version>0.9.3</chill.version>
     <ivy.version>2.4.0</ivy.version>
     <oro.version>2.0.8</oro.version>
     <codahale.metrics.version>4.1.1</codahale.metrics.version>

--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@
       <!--
         This is used as a fallback when a mirror to `central` fail.
         For example, when we use Google Maven Central in GitHub Action as a mirror of `central`,
-        this will be used when Google Maven Central is out of sync due to its late sync cycle. 
+        this will be used when Google Maven Central is out of sync due to its late sync cycle.
       -->
       <name>Maven Repository</name>
       <url>https://repo.maven.apache.org/maven2</url>

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
     <hive.parquet.version>1.6.0</hive.parquet.version>
     <jetty.version>9.4.18.v20190429</jetty.version>
     <javaxservlet.version>3.1.0</javaxservlet.version>
-    <chill.version>0.9.3</chill.version>
+    <chill.version>0.9.5</chill.version>
     <ivy.version>2.4.0</ivy.version>
     <oro.version>2.0.8</oro.version>
     <codahale.metrics.version>4.1.1</codahale.metrics.version>

--- a/pom.xml
+++ b/pom.xml
@@ -257,6 +257,22 @@
         <enabled>false</enabled>
       </snapshots>
     </repository>
+    <repository>
+      <id>central_without_mirror</id>
+      <!--
+        This is used as a fallback when a mirror to `central` fail.
+        For example, when we use Google Maven Central in GitHub Action as a mirror of `central`,
+        this will be used when Google Maven Central is out of sync due to its late sync cycle. 
+      -->
+      <name>Maven Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
   </repositories>
   <pluginRepositories>
     <pluginRepository>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a fallback Maven repository when a mirror to `central` fail.

### Why are the changes needed?

We use `Google Maven Central` in GitHub Action as a mirror of `central`.
However, `Google Maven Central` sometimes doesn't have newly published artifacts
and there is no guarantee when we get the newly published artifacts.

By duplicating `Maven Central` with a new ID, we can add a fallback Maven repository
which is not mirrored by `Google Maven Central`.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Manually testing with the new `Twitter` chill artifacts by switching `chill.version` from `0.9.3` to `0.9.5`.

```
$ rm -rf ~/.m2/repository/com/twitter/chill*
$ mvn compile | grep chill
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/repos/central/data/com/twitter/chill_2.12/0.9.5/chill_2.12-0.9.5.pom
Downloading from central_without_mirror: https://repo.maven.apache.org/maven2/com/twitter/chill_2.12/0.9.5/chill_2.12-0.9.5.pom
Downloaded from central_without_mirror: https://repo.maven.apache.org/maven2/com/twitter/chill_2.12/0.9.5/chill_2.12-0.9.5.pom (2.8 kB at 11 kB/s)
```