### PR TITLE
[SPARK-30573][DOC] Document WHERE Clause of SELECT statement in SQL Reference

### DIFF
--- a/docs/sql-ref-syntax-qry-select-where.md
+++ b/docs/sql-ref-syntax-qry-select-where.md
@@ -32,7 +32,9 @@ WHERE boolean_expression
   <dd>
     Specifies any expression that evaluates to a result type <code>boolean</code>. Two or
     more expressions may be combined together using comparision operators 
-    ('>', '>=', ‘>’, ‘>=’, ‘=’, ‘<’ and ‘<=’, '<=>') and logical operators (AND, NOT, OR).
+    ( <code>></code>, <code>>=</code>, <code>=</code>, <code><</code> , <code><=</code> and
+    <code><=></code> ) and logical operators ( <code>AND</code>, <code>NOT</code> 
+    and <code>OR</code> ).
   </dd>
 </dl>
 
@@ -98,7 +100,7 @@ SELECT * FROM person WHERE age > (SELECT avg(age) FROM person);
   |300|Mike|80 |
   +---+----+---+
 
--- Correlated column reference in `WHERE` clause of sub query.
+-- Correlated column reference in `WHERE` clause of subquery.
 SELECT * FROM person AS parent 
 WHERE EXISTS (
               SELECT 1 FROM person AS child

--- a/docs/sql-ref-syntax-qry-select-where.md
+++ b/docs/sql-ref-syntax-qry-select-where.md
@@ -1,0 +1,113 @@
+---
+layout: global
+title: SELECT
+displayTitle: WHERE clause
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+ 
+     http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+The <code>WHERE</code> clause is used to limit the results of the <code>FROM</code>
+clause of query or subquery based on the specified condition.
+
+### Syntax
+{% highlight sql %}
+WHERE boolean_expression
+{% endhighlight %}
+
+### Parameters
+<dl>
+  <dt><code><em>boolean_expression</em></code></dt>
+  <dd>
+    Specifies any expression that evaluates to a result type <code>boolean</code>. Two or
+    more expressions may be combined together using comparision operators 
+    ('>', '>=', ‘>’, ‘>=’, ‘=’, ‘<’ and ‘<=’, '<=>') and logical operators (AND, NOT, OR).
+  </dd>
+</dl>
+
+### Examples
+{% highlight sql %}
+CREATE TABLE person (id INT, name STRING, age INT);
+INSERT INTO person VALUES (100, 'John', 30),
+                          (200, 'Mary', NULL),
+                          (300, 'Mike', 80),
+                          (400, 'Dan',  50);
+
+-- Comparison operator in `WHERE` clause.
+SELECT * FROM person WHERE id > 200 ORDER BY id;
+  +---+----+---+
+  |id |name|age|
+  +---+----+---+
+  |300|Mike|80 |
+  |400|Dan |50 |
+  +---+----+---+
+
+-- Comparison and logical operators in `WHERE` clause.
+SELECT * FROM person WHERE id = 200 OR id = 300 ORDER BY id;
+  +---+----+----+
+  |id |name|age |
+  +---+----+----+
+  |200|Mary|null|
+  |300|Mike|80  |
+  +---+----+----+
+
+-- ISNULL expression in `WHERE` clause.
+SELECT * FROM person WHERE id > 300 OR age IS NULL ORDER BY id;
+  +---+----+----+
+  |id |name|age |
+  +---+----+----+
+  |200|Mary|null|
+  |400|Dan |50  |
+  +---+----+----+
+
+-- Function expression in `WHERE` clause.
+SELECT * FROM person WHERE length(name) > 3 ORDER BY id;
+  +---+----+----+
+  |id |name|age |
+  +---+----+----+
+  |100|John|30  |
+  |200|Mary|null|
+  |300|Mike|80  |
+  +---+----+----+
+
+-- `BETWEEN` expression in `WHERE` clause.
+SELECT * FROM person WHERE id BETWEEN 200 AND 300 ORDER BY id;
+  +---+----+----+
+  | id|name| age|
+  +---+----+----+
+  |200|Mary|null|
+  |300|Mike|  80|
+  +---+----+----+
+
+-- Scalar Subquery in `WHERE` clause.
+SELECT * FROM person WHERE age > (SELECT avg(age) FROM person);
+  +---+----+---+
+  |id |name|age|
+  +---+----+---+
+  |300|Mike|80 |
+  +---+----+---+
+
+-- Correlated column reference in `WHERE` clause of sub query.
+SELECT * FROM person AS parent 
+WHERE EXISTS (
+              SELECT 1 FROM person AS child
+              WHERE parent.id = child.id AND child.age IS NULL
+             );
+  +---+----+----+
+  |id |name|age |
+  +---+----+----+
+  |200|Mary|null|
+  +---+----+----+
+
+{% endhighlight %}

--- a/docs/sql-ref-syntax-qry-select-where.md
+++ b/docs/sql-ref-syntax-qry-select-where.md
@@ -31,10 +31,8 @@ WHERE boolean_expression
   <dt><code><em>boolean_expression</em></code></dt>
   <dd>
     Specifies any expression that evaluates to a result type <code>boolean</code>. Two or
-    more expressions may be combined together using comparision operators 
-    ( <code>></code>, <code>>=</code>, <code>=</code>, <code><</code>, <code><=</code>
-    , <code><=></code> ) and logical operators ( <code>AND</code>, <code>NOT</code>,
-    <code>OR</code> ).
+    more expressions may be combined together using the logical 
+    operators ( <code>AND</code>, <code>OR</code> ).
   </dd>
 </dl>
 

--- a/docs/sql-ref-syntax-qry-select-where.md
+++ b/docs/sql-ref-syntax-qry-select-where.md
@@ -32,9 +32,9 @@ WHERE boolean_expression
   <dd>
     Specifies any expression that evaluates to a result type <code>boolean</code>. Two or
     more expressions may be combined together using comparision operators 
-    ( <code>></code>, <code>>=</code>, <code>=</code>, <code><</code> , <code><=</code> and
-    <code><=></code> ) and logical operators ( <code>AND</code>, <code>NOT</code> 
-    and <code>OR</code> ).
+    ( <code>></code>, <code>>=</code>, <code>=</code>, <code><</code>, <code><=</code>
+    , <code><=></code> ) and logical operators ( <code>AND</code>, <code>NOT</code>,
+    <code>OR</code> ).
   </dd>
 </dl>
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Document WHERE Clause of SELECT statement in SQL Reference Guide. I

### Why are the changes needed?
Currently Spark lacks documentation on the supported SQL constructs causing
confusion among users who sometimes have to look at the code to understand the
usage. This is aimed at addressing this issue.

### Does this PR introduce any user-facing change?
Yes. 

**Before:**
There was no documentation for this.
**After**
<img width="1093" alt="Screen Shot 2020-01-19 at 5 03 49 PM" src="https://user-images.githubusercontent.com/14225158/72691938-ddb48480-3add-11ea-80e9-914c12bb2edd.png">
<img width="1093" alt="Screen Shot 2020-01-19 at 5 04 07 PM" src="https://user-images.githubusercontent.com/14225158/72691950-f329ae80-3add-11ea-8c5b-aeda67e214df.png">
<img width="1093" alt="Screen Shot 2020-01-19 at 5 04 23 PM" src="https://user-images.githubusercontent.com/14225158/72691958-02106100-3ade-11ea-891e-e38353e177af.png">


### How was this patch tested?
Tested using jykyll build --serve