### PR TITLE
[SPARK-30575][DOC] Document HAVING Clause of SELECT statement in SQL Reference

### DIFF
--- a/docs/sql-ref-syntax-qry-select-having.md
+++ b/docs/sql-ref-syntax-qry-select-having.md
@@ -18,5 +18,101 @@ license: |
   See the License for the specific language governing permissions and
   limitations under the License.
 ---
+The <code>HAVING</code> clause is used to filter the results produced by
+<code>GROUP BY</code> based on the specified condition. It is often used
+in the conjunction with a <code>GROUP BY</code> clause.
 
-**This page is under construction**
+### Syntax
+{% highlight sql %}
+HAVING boolean_expression
+{% endhighlight %}
+
+### Parameters
+<dl>
+  <dt><code><em>boolean_expression</em></code></dt>
+  <dd>
+    Specifies any expression that evaluates to a result type <code>boolean</code>. Two or
+    more expressions may be combined together using comparision operators 
+    ('>', '>=', ‘>’, ‘>=’, ‘=’, ‘<’ and ‘<=’, '<=>') and logical operators (AND, NOT, OR).<br><br>
+
+    <b>Note</b><br>
+    The expressions specified in the <code>HAVING</code> clause can only refer to:
+     <ol>
+      <li>Constants</li>
+      <li>Expressions that appear in GROUP BY</li>
+      <li>Aggregate functions</li>
+    </ol>
+  </dd>
+</dl>
+
+### Examples
+{% highlight sql %}
+CREATE TABLE dealer (id INT, city STRING, car_model STRING, quantity INT);
+INSERT INTO dealer  VALUES (100, 'Fremont', 'Honda Civic', 10),
+                          (100, 'Fremont', 'Honda Accord', 15),
+                          (100, 'Fremont', 'Honda CRV', 7),
+                          (200, 'Dublin', 'Honda Civic', 20),
+                          (200, 'Dublin', 'Honda Accord', 10),
+                          (200, 'Dublin', 'Honda CRV', 3),
+                          (300, 'San Jose', 'Honda Civic', 5),
+                          (300, 'San Jose', 'Honda Accord', 8);
+
+-- `HAVING` clause referring to column in `GROUP BY`.
+SELECT city, sum(quantity) AS sum FROM dealer GROUP BY city HAVING city = 'Fremont';
+
+  +-------+---+
+  |city   |sum|
+  +-------+---+
+  |Fremont|32 |
+  +-------+---+
+
+-- `HAVING` clause referring to aggregate function.
+SELECT city, sum(quantity) AS sum FROM dealer GROUP BY city HAVING sum(quantity) > 15;
+ 
+  +-------+---+
+  |   city|sum|
+  +-------+---+
+  | Dublin| 33|
+  |Fremont| 32|
+  +-------+---+
+
+-- `HAVING` clause referring to aggregate function by its alias.
+SELECT city, sum(quantity) AS sum FROM dealer GROUP BY city HAVING sum > 15;
+
+  +-------+---+
+  |   city|sum|
+  +-------+---+
+  | Dublin| 33|
+  |Fremont| 32|
+  +-------+---+
+
+-- `HAVING` clause referring to a different aggregate function than what is present in
+-- `SELECT` list.
+SELECT city, sum(quantity) AS sum FROM dealer GROUP BY city HAVING max(quantity) > 15;
+
+  +------+---+
+  |city  |sum|
+  +------+---+
+  |Dublin|33 |
+  +------+---+
+
+-- `HAVING` clause referring to constant expression.
+SELECT city, sum(quantity) AS sum FROM dealer GROUP BY city HAVING 1 > 0 ORDER BY city;
+  
+  +--------+---+
+  |    city|sum|
+  +--------+---+
+  |  Dublin| 33|
+  | Fremont| 32|
+  |San Jose| 13|
+  +--------+---+
+
+-- `HAVING` clause without a `GROUP BY` clause.
+SELECT  sum(quantity) AS sum FROM dealer HAVING sum(quantity) > 10;
+  +---+
+  |sum|
+  +---+
+  | 78|
+  +---+
+ 
+{% endhighlight %}

--- a/docs/sql-ref-syntax-qry-select-having.md
+++ b/docs/sql-ref-syntax-qry-select-having.md
@@ -33,9 +33,8 @@ HAVING boolean_expression
   <dt><code><em>boolean_expression</em></code></dt>
   <dd>
     Specifies any expression that evaluates to a result type <code>boolean</code>. Two or
-    more expressions may be combined together using comparision operators 
-    ( <code>></code>, <code>>=</code>, <code>=</code>, <code><</code>, <code><=</code>, <code><=></code> )
-    and logical operators ( <code>AND</code>, <code>NOT</code>, <code>OR</code> ).<br><br>
+    more expressions may be combined together using the logical 
+    operators ( <code>AND</code>, <code>OR</code> ).<br><br>
 
     <b>Note</b><br>
     The expressions specified in the <code>HAVING</code> clause can only refer to:

--- a/docs/sql-ref-syntax-qry-select-having.md
+++ b/docs/sql-ref-syntax-qry-select-having.md
@@ -20,7 +20,8 @@ license: |
 ---
 The <code>HAVING</code> clause is used to filter the results produced by
 <code>GROUP BY</code> based on the specified condition. It is often used
-in the conjunction with a <code>GROUP BY</code> clause.
+in the conjunction with a [GROUP BY](sql-ref-syntax-qry-select-groupby.html)
+clause.
 
 ### Syntax
 {% highlight sql %}
@@ -33,7 +34,9 @@ HAVING boolean_expression
   <dd>
     Specifies any expression that evaluates to a result type <code>boolean</code>. Two or
     more expressions may be combined together using comparision operators 
-    ('>', '>=', ‘>’, ‘>=’, ‘=’, ‘<’ and ‘<=’, '<=>') and logical operators (AND, NOT, OR).<br><br>
+    ( <code>></code>, <code>>=</code>, <code>=</code>, <code><</code> , <code><=</code> and
+    <code><=></code> ) and logical operators ( <code>AND</code>, <code>NOT</code> 
+    and <code>OR</code> ).<br><br>
 
     <b>Note</b><br>
     The expressions specified in the <code>HAVING</code> clause can only refer to:
@@ -108,7 +111,7 @@ SELECT city, sum(quantity) AS sum FROM dealer GROUP BY city HAVING 1 > 0 ORDER B
   +--------+---+
 
 -- `HAVING` clause without a `GROUP BY` clause.
-SELECT  sum(quantity) AS sum FROM dealer HAVING sum(quantity) > 10;
+SELECT sum(quantity) AS sum FROM dealer HAVING sum(quantity) > 10;
   +---+
   |sum|
   +---+

--- a/docs/sql-ref-syntax-qry-select-having.md
+++ b/docs/sql-ref-syntax-qry-select-having.md
@@ -34,9 +34,8 @@ HAVING boolean_expression
   <dd>
     Specifies any expression that evaluates to a result type <code>boolean</code>. Two or
     more expressions may be combined together using comparision operators 
-    ( <code>></code>, <code>>=</code>, <code>=</code>, <code><</code> , <code><=</code> and
-    <code><=></code> ) and logical operators ( <code>AND</code>, <code>NOT</code> 
-    and <code>OR</code> ).<br><br>
+    ( <code>></code>, <code>>=</code>, <code>=</code>, <code><</code>, <code><=</code>, <code><=></code> )
+    and logical operators ( <code>AND</code>, <code>NOT</code>, <code>OR</code> ).<br><br>
 
     <b>Note</b><br>
     The expressions specified in the <code>HAVING</code> clause can only refer to:


### PR DESCRIPTION
### What changes were proposed in this pull request?
Document HAVING clause of SELECT statement in SQL Reference Guide.

### Why are the changes needed?
Currently Spark lacks documentation on the supported SQL constructs causing
confusion among users who sometimes have to look at the code to understand the
usage. This is aimed at addressing this issue.

### Does this PR introduce any user-facing change?
Yes. 

**Before:**
There was no documentation for this.

**After.**
<img width="960" alt="Screen Shot 2020-01-19 at 6 03 52 PM" src="https://user-images.githubusercontent.com/14225158/72693609-56b7da00-3ae6-11ea-9bb8-22eae19047d6.png">
<img width="960" alt="Screen Shot 2020-01-19 at 6 04 11 PM" src="https://user-images.githubusercontent.com/14225158/72693611-5ae3f780-3ae6-11ea-9ce3-6a03400ae5d8.png">
<img width="960" alt="Screen Shot 2020-01-19 at 6 04 28 PM" src="https://user-images.githubusercontent.com/14225158/72693625-66cfb980-3ae6-11ea-8b2b-8d26ede9708f.png">

### How was this patch tested?
Tested using jykyll build --serve