### PR TITLE
[SPARK-30576] [SS]  block streaming batch commit, until completed。

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1836,4 +1836,12 @@ package object config {
       .version("3.1.0")
       .booleanConf
       .createWithDefault(false)
+
+  private[spark] val ONLY_ONE_BATCH =
+    ConfigBuilder("spark.only.one.batch")
+      .doc("Whether to block streaming batch commit, merge all blocking batchs " +
+        "as one batch commit.")
+      .booleanConf
+      .createWithDefault(false)
+
 }

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobScheduler.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobScheduler.scala
@@ -46,8 +46,8 @@ class JobScheduler(val ssc: StreamingContext) extends Logging {
 
   // Use of ConcurrentHashMap.keySet later causes an odd runtime problem due to Java 7/8 diff
   // https://gist.github.com/AlainODea/1375759b8720a3f9f094
-  private val jobSets: java.util.Map[Time, JobSet] = new ConcurrentHashMap[Time, JobSet]
-  private val numConcurrentJobs = ssc.conf.get(StreamingConf.CONCURRENT_JOBS)
+  private[streaming] val jobSets: java.util.Map[Time, JobSet] = new ConcurrentHashMap[Time, JobSet]
+  private val numConcurrentJobs = ssc.conf.getInt("spark.streaming.concurrentJobs", 1)
   private val jobExecutor =
     ThreadUtils.newDaemonFixedThreadPool(numConcurrentJobs, "streaming-job-executor")
   private[streaming] val jobGenerator = new JobGenerator(this)


### PR DESCRIPTION
## What changes were proposed in this pull request?
When the current job is not completed block streaming batch commit, until completed。The next job will merge all batch which  during the blocking.
## How was this patch tested?
 the input seq [1, 2, 3, 4, 5, 6]。 
batch duration: 1s。
The 3th batch will take a long time。Normally the other batches will be completed quickly.
We expect:
      1. the 4th batch will not be commited during the 3th batch computing, and 4th batch will be merge in the next batch. So that
the size of jobSets  is always less than 1。
      2. the num completedBatches less than the size of seq。
      3. the data is not lost