### PR TITLE
[SPARK-30579][DOC] Document ORDER BY Clause of SELECT statement in SQL Reference

### DIFF
--- a/docs/sql-ref-syntax-qry-select-orderby.md
+++ b/docs/sql-ref-syntax-qry-select-orderby.md
@@ -24,7 +24,7 @@ a total order in the output.
 
 ### Syntax
 {% highlight sql %}
-ORDER BY { expression [ sort_direction | nulls_sort_oder ] [ , ...] }
+ORDER BY { expression [ sort_direction | nulls_sort_oder ] [ , ... ] }
 {% endhighlight %}
 
 ### Parameters
@@ -38,7 +38,7 @@ ORDER BY { expression [ sort_direction | nulls_sort_oder ] [ , ...] }
   <dd>
     Optionally specifies whether to sort the rows in ascending or descending
     order. The valid values for the sort direction are <code>ASC</code> for ascending
-    and <code>DESC</code> for descending. If sort direction is not explicitly specified then by default
+    and <code>DESC</code> for descending. If sort direction is not explicitly specified, then by default
     rows are sorted ascending. <br><br>
     <b>Syntax:</b>
     <code>
@@ -50,7 +50,7 @@ ORDER BY { expression [ sort_direction | nulls_sort_oder ] [ , ...] }
     Optionally specifies whether NULL values are returned before/after non-NULL values, based on the 
     sort direction. In Spark, NULL values are considered to be lower than any non-NULL values by default.
     Therefore the ordering of NULL values depend on the sort direction. If <code>null_sort_order</code> is
-    not specified then NULLs sort first if sort order is <code>ASC</code> and NULLS sort last if 
+    not specified, then NULLs sort first if sort order is <code>ASC</code> and NULLS sort last if 
     sort order is <code>DESC</code>.<br><br>
     <ol>
       <li> If <code>NULLS FIRST</code> (the default) is specified, then NULL values are returned first 

--- a/docs/sql-ref-syntax-qry-select-orderby.md
+++ b/docs/sql-ref-syntax-qry-select-orderby.md
@@ -20,7 +20,7 @@ license: |
 ---
 The <code>ORDER BY</code> clause is used to return the result rows in a sorted manner
 in the user specified order. Unlike the <code>SORT BY</code> clause, this clause guarantees
-total order in the output. 
+a total order in the output. 
 
 ### Syntax
 {% highlight sql %}
@@ -68,11 +68,12 @@ ORDER BY { expression [ sort_direction | nulls_sort_oder ] [ , ...] }
 ### Examples
 {% highlight sql %}
 CREATE TABLE person (id INT, name STRING, age INT);
-INSERT INTO person VALUES (100, 'John', 30),
-                          (200, 'Mary', NULL),
-                          (300, 'Mike', 80),
-                          (400, 'Jerry', NULL),
-                          (500, 'Dan',  50);
+INSERT INTO person VALUES
+    (100, 'John', 30),
+    (200, 'Mary', NULL),
+    (300, 'Mike', 80),
+    (400, 'Jerry', NULL),
+    (500, 'Dan',  50);
 
 -- Sort rows by age. By default rows are sorted in ascending manner.
 SELECT name, age FROM person ORDER BY age;

--- a/docs/sql-ref-syntax-qry-select-orderby.md
+++ b/docs/sql-ref-syntax-qry-select-orderby.md
@@ -18,5 +18,121 @@ license: |
   See the License for the specific language governing permissions and
   limitations under the License.
 ---
+The <code>ORDER BY</code> clause is used to return the result rows in a sorted manner
+in the user specified order. Unlike the <code>SORT BY</code> clause, this clause guarantees
+total order in the output. 
 
-**This page is under construction**
+### Syntax
+{% highlight sql %}
+ORDER BY { expression [ sort_direction | nulls_sort_oder ] [ , ...] }
+{% endhighlight %}
+
+### Parameters
+<dl>
+  <dt><code><em>ORDER BY</em></code></dt>
+  <dd>
+    Specifies a comma separated list of expressions along with optional parameters sort_direction 
+    and nulls_sort_order which are used to sort the rows.
+  </dd>
+  <dt><code><em>sort_direction</em></code></dt>
+  <dd>
+    Optionally specifies whether to sort the rows in ascending (lowest to highest) or descending
+    (highest to lowest) order. The valid values for sort direction are <code>ASC</code> for ascending
+    and <code>DESC</code> for descending. If sort direction is not explicitly specified then by default
+    rows are sorted in ascending manner. <br><br>
+    <b>Syntax:</b>
+    <code>
+       [ ASC | DESC ]
+    </code>
+  </dd>
+  <dt><code><em>nulls_sort_order</em></code></dt>
+  <dd>
+    Optionally specifies whether NULL values are returned before/after non-NULL values, based on the 
+    sort direction. In spark, NULL values are considered to be lower than any non-NULL values. Therefore
+    the ordering of NULL values depend on the sort direction.<br><br>
+    <ol>
+      <li>If the sort order is ASC, NULLS are returned first; to force NULLS to be last, use NULLS LAST</li>
+      <li>If the sort order is DESC, NULLS are returned last; to force NULLS to be first, use NULLS FIRST</li>
+    </ol><br>
+    <b>Syntax:</b>
+    <code>
+       [ NULLS { FIRST | LAST } ] 
+    </code>
+  </dd>
+</dl>
+
+### Examples
+{% highlight sql %}
+CREATE TABLE person (id INT, name STRING, age INT);
+INSERT INTO person VALUES (100, 'John', 30),
+                          (200, 'Mary', NULL),
+                          (300, 'Mike', 80),
+                          (400, 'Jerry', NULL),
+                          (500, 'Dan',  50);
+
+-- Sort rows by age. By default rows are sorted in ascending manner.
+SELECT name, age FROM person ORDER BY age;
+
+  +-----+----+
+  |name |age |
+  +-----+----+
+  |Jerry|null|
+  |Mary |null|
+  |John |30  |
+  |Dan  |50  |
+  |Mike |80  |
+  +-----+----+
+
+-- Sort rows in ascending manner keeping null values to be last.
+SELECT name, age FROM person ORDER BY age NULLS LAST;
+
+  +-----+----+
+  |name |age |
+  +-----+----+
+  |John |30  |
+  |Dan  |50  |
+  |Mike |80  |
+  |Mary |null|
+  |Jerry|null|
+  +-----+----+
+
+-- Sort rows by age in descending manner.
+SELECT name, age FROM person ORDER BY age DESC;
+ 
+  +-----+----+
+  |name |age |
+  +-----+----+
+  |Mike |80  |
+  |Dan  |50  |
+  |John |30  |
+  |Jerry|null|
+  |Mary |null|
+  +-----+----+
+
+-- Sort rows in ascending manner keeping null values to be first.
+SELECT name, age FROM person ORDER BY age DESC NULLS FIRST;
+
+  +-----+----+
+  |name |age |
+  +-----+----+
+  |Jerry|null|
+  |Mary |null|
+  |Mike |80  |
+  |Dan  |50  |
+  |John |30  |
+  +-----+----+
+
+-- Sort rows based on more than one column with each column having different
+-- sort direction.
+SELECT * FROM person ORDER BY name ASC, age DESC;
+
+  +---+-----+----+
+  |id |name |age |
+  +---+-----+----+
+  |500|Dan  |50  |
+  |400|Jerry|null|
+  |100|John |30  |
+  |200|Mary |null|
+  |300|Mike |80  |
+  +---+-----+----+
+{% endhighlight %}

--- a/docs/sql-ref-syntax-qry-select-orderby.md
+++ b/docs/sql-ref-syntax-qry-select-orderby.md
@@ -36,8 +36,8 @@ ORDER BY { expression [ sort_direction | nulls_sort_oder ] [ , ...] }
   </dd>
   <dt><code><em>sort_direction</em></code></dt>
   <dd>
-    Optionally specifies whether to sort the rows in ascending (lowest to highest) or descending
-    (highest to lowest) order. The valid values for sort direction are <code>ASC</code> for ascending
+    Optionally specifies whether to sort the rows in ascending or descending
+    order. The valid values for the sort direction are <code>ASC</code> for ascending
     and <code>DESC</code> for descending. If sort direction is not explicitly specified then by default
     rows are sorted ascending. <br><br>
     <b>Syntax:</b>

--- a/docs/sql-ref-syntax-qry-select-orderby.md
+++ b/docs/sql-ref-syntax-qry-select-orderby.md
@@ -31,7 +31,7 @@ ORDER BY { expression [ sort_direction | nulls_sort_oder ] [ , ...] }
 <dl>
   <dt><code><em>ORDER BY</em></code></dt>
   <dd>
-    Specifies a comma separated list of expressions along with optional parameters <code>sort_direction</code>
+    Specifies a comma-separated list of expressions along with optional parameters <code>sort_direction</code>
     and <code>nulls_sort_order</code> which are used to sort the rows.
   </dd>
   <dt><code><em>sort_direction</em></code></dt>

--- a/docs/sql-ref-syntax-qry-select-orderby.md
+++ b/docs/sql-ref-syntax-qry-select-orderby.md
@@ -31,8 +31,8 @@ ORDER BY { expression [ sort_direction | nulls_sort_oder ] [ , ...] }
 <dl>
   <dt><code><em>ORDER BY</em></code></dt>
   <dd>
-    Specifies a comma separated list of expressions along with optional parameters sort_direction 
-    and nulls_sort_order which are used to sort the rows.
+    Specifies a comma separated list of expressions along with optional parameters <code>sort_direction</code>
+    and <code>nulls_sort_order</code> which are used to sort the rows.
   </dd>
   <dt><code><em>sort_direction</em></code></dt>
   <dd>
@@ -48,8 +48,8 @@ ORDER BY { expression [ sort_direction | nulls_sort_oder ] [ , ...] }
   <dt><code><em>nulls_sort_order</em></code></dt>
   <dd>
     Optionally specifies whether NULL values are returned before/after non-NULL values, based on the 
-    sort direction. In spark, NULL values are considered to be lower than any non-NULL values. Therefore
-    the ordering of NULL values depend on the sort direction.<br><br>
+    sort direction. In Spark, NULL values are considered to be lower than any non-NULL values by default.
+    Therefore the ordering of NULL values depend on the sort direction.<br><br>
     <ol>
       <li>If the sort order is ASC, NULLS are returned first; to force NULLS to be last, use NULLS LAST</li>
       <li>If the sort order is DESC, NULLS are returned last; to force NULLS to be first, use NULLS FIRST</li>

--- a/docs/sql-ref-syntax-qry-select-orderby.md
+++ b/docs/sql-ref-syntax-qry-select-orderby.md
@@ -39,7 +39,7 @@ ORDER BY { expression [ sort_direction | nulls_sort_oder ] [ , ...] }
     Optionally specifies whether to sort the rows in ascending (lowest to highest) or descending
     (highest to lowest) order. The valid values for sort direction are <code>ASC</code> for ascending
     and <code>DESC</code> for descending. If sort direction is not explicitly specified then by default
-    rows are sorted in ascending manner. <br><br>
+    rows are sorted ascending. <br><br>
     <b>Syntax:</b>
     <code>
        [ ASC | DESC ]
@@ -49,10 +49,14 @@ ORDER BY { expression [ sort_direction | nulls_sort_oder ] [ , ...] }
   <dd>
     Optionally specifies whether NULL values are returned before/after non-NULL values, based on the 
     sort direction. In Spark, NULL values are considered to be lower than any non-NULL values by default.
-    Therefore the ordering of NULL values depend on the sort direction.<br><br>
+    Therefore the ordering of NULL values depend on the sort direction. If <code>null_sort_order</code> is
+    not specified then NULLs sort first if sort order is <code>ASC</code> and NULLS sort last if 
+    sort order is <code>DESC</code>.<br><br>
     <ol>
-      <li>If the sort order is ASC, NULLS are returned first; to force NULLS to be last, use NULLS LAST</li>
-      <li>If the sort order is DESC, NULLS are returned last; to force NULLS to be first, use NULLS FIRST</li>
+      <li> If <code>NULLS FIRST</code> (the default) is specified, then NULL values are returned first 
+           regardless of the sort order.</li>
+      <li>If <code>NULLS LAST</code> is specified, then NULL values are returned last regardless of
+           the sort order. </li>
     </ol><br>
     <b>Syntax:</b>
     <code>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Document ORDER BY clause of SELECT statement in SQL Reference Guide.

### Why are the changes needed?
Currently Spark lacks documentation on the supported SQL constructs causing
confusion among users who sometimes have to look at the code to understand the
usage. This is aimed at addressing this issue.

### Does this PR introduce any user-facing change?
Yes. 

**Before:**
There was no documentation for this.

**After.**
<img width="972" alt="Screen Shot 2020-01-19 at 11 50 57 PM" src="https://user-images.githubusercontent.com/14225158/72708034-ac0bdf80-3b16-11ea-81f3-48d8087e4e98.png">
<img width="972" alt="Screen Shot 2020-01-19 at 11 51 14 PM" src="https://user-images.githubusercontent.com/14225158/72708042-b0d09380-3b16-11ea-939e-905b8c031608.png">
<img width="972" alt="Screen Shot 2020-01-19 at 11 51 33 PM" src="https://user-images.githubusercontent.com/14225158/72708050-b4fcb100-3b16-11ea-95d2-e4e302cace1b.png">


### How was this patch tested?
Tested using jykyll build --serve