### PR TITLE
[SPARK-30581][DOC] Document SORT BY Clause of SELECT statement in SQLReference

### DIFF
--- a/docs/sql-ref-syntax-qry-select-sortby.md
+++ b/docs/sql-ref-syntax-qry-select-sortby.md
@@ -1,0 +1,172 @@
+---
+layout: global
+title: SORT BY Clause
+displayTitle: SORT BY Clause
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+ 
+     http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+The <code>SORT BY</code> clause is used to return the result rows sorted
+within each partition in the user specified order. When there are more than one partition
+<code>SORT BY</code> may return results that is partially ordered. This is different
+than <code>ORDER BY</code> clause which guarantees total ordering of the output.
+
+### Syntax
+{% highlight sql %}
+SORT BY { expression [ sort_direction | nulls_sort_oder ] [ , ...] }
+{% endhighlight %}
+
+### Parameters
+<dl>
+  <dt><code><em>SORT BY</em></code></dt>
+  <dd>
+    Specifies a comma separated list of expression along with optional parameters sort_direction 
+    and nulls_sort_order which are used to sort the rows within each partition.
+  </dd>
+  <dt><code><em>sort_direction</em></code></dt>
+  <dd>
+    Optionally specifies whether to sort the rows in ascending (lowest to highest) or descending
+    (highest to lowest) order. The valid values for sort direction are <code>ASC</code> for ascending
+    and <code>DESC</code> for descending. If sort direction is not explicitly specified then by default
+    rows are sorted in ascending manner. <br><br>
+    <b>Syntax:</b>
+    <code>
+       [ ASC | DESC ]
+    </code>
+  </dd>
+  <dt><code><em>nulls_sort_order</em></code></dt>
+  <dd>
+    Optionally specifies whether NULL values are returned before/after non-NULL values, based on the 
+    sort direction. In spark, NULL values are considered to be lower than any non-NULL values. Therefore
+    the ordering of NULL values depend on the sort direction.<br><br>
+    <ol>
+      <li>If the sort order is ASC, NULLS are returned first; to force NULLS to be last, use NULLS LAST</li>
+      <li>If the sort order is DESC, NULLS are returned last; to force NULLS to be first, use NULLS FIRST</li>
+    </ol><br>
+    <b>Syntax:</b>
+    <code>
+       [ NULLS { FIRST | LAST } ] 
+    </code>
+  </dd>
+</dl>
+
+### Examples
+{% highlight sql %}
+CREATE TABLE person (zip_code INT, name STRING, age INT);
+INSERT INTO person VALUES (94588, 'Zen Hui', 50), 
+                          (94588, 'Dan Li', 18), 
+                          (94588, 'Anil K', 27),
+                          (94588, 'John V', NULL),
+                          (94511, 'David K', 42),
+                          (94511, 'Aryan B.', 18),
+                          (94511, 'Lalit B.', NULL);
+                          
+
+-- Use `REPARTITION` hint to partition the data by `zip_code` to 
+-- examine the `SORT BY` behavior. This is used in rest of the
+-- example.
+
+-- Sort rows by `name` within each partition in ascending manner
+SELECT /*+ REPARTITION(zip_code) */ name, age, zip_code FROM person SORT BY name;
+
+  +--------+----+--------+
+  |name    |age |zip_code|
+  +--------+----+--------+
+  |Anil K  |27  |94588   |
+  |Dan Li  |18  |94588   |
+  |John V  |null|94588   |
+  |Zen Hui |50  |94588   |
+  |Aryan B.|18  |94511   |
+  |David K |42  |94511   |
+  |Lalit B.|null|94511   |
+  +--------+----+--------+
+
+-- Sort rows within each partition using column position.
+SELECT /*+ REPARTITION(zip_code) */ name, age, zip_code FROM person SORT BY 1;
+
+  +--------+----+--------+
+  |name    |age |zip_code|
+  +--------+----+--------+
+  |Anil K  |27  |94588   |
+  |Dan Li  |18  |94588   |
+  |John V  |null|94588   |
+  |Zen Hui |50  |94588   |
+  |Aryan B.|18  |94511   |
+  |David K |42  |94511   |
+  |Lalit B.|null|94511   |
+  +--------+----+--------+
+
+-- Sort rows within partition in ascending manner keeping null values to be last.
+SELECT /*+ REPARTITION(zip_code) */ age, name, zip_code FROM person SORT BY age NULLS LAST;
+
+  +----+--------+--------+
+  |age |name    |zip_code|
+  +----+--------+--------+
+  |18  |Dan Li  |94588   |
+  |27  |Anil K  |94588   |
+  |50  |Zen Hui |94588   |
+  |null|John V  |94588   |
+  |18  |Aryan B.|94511   |
+  |42  |David K |94511   |
+  |null|Lalit B.|94511   |
+  +----+--------+--------+
+
+-- Sort rows by age within each partition in descending manner.
+SELECT /*+ REPARTITION(zip_code) */ age, name, zip_code FROM person SORT BY age DESC;
+ 
+  +----+--------+--------+
+  |age |name    |zip_code|
+  +----+--------+--------+
+  |50  |Zen Hui |94588   |
+  |27  |Anil K  |94588   |
+  |18  |Dan Li  |94588   |
+  |null|John V  |94588   |
+  |42  |David K |94511   |
+  |18  |Aryan B.|94511   |
+  |null|Lalit B.|94511   |
+  +----+--------+--------+
+
+-- Sort rows by age within each partition in ascending manner keeping null values to be first.
+SELECT /*+ REPARTITION(zip_code) */ age, name, zip_code FROM person SORT BY age DESC NULLS FIRST;
+
+  +----+--------+--------+
+  |age |name    |zip_code|
+  +----+--------+--------+
+  |null|John V  |94588   |
+  |50  |Zen Hui |94588   |
+  |27  |Anil K  |94588   |
+  |18  |Dan Li  |94588   |
+  |null|Lalit B.|94511   |
+  |42  |David K |94511   |
+  |18  |Aryan B.|94511   |
+  +----+--------+--------+
+
+-- Sort rows within each partition  based on more than one column with each column having
+-- different sort direction.
+SELECT /*+ REPARTITION(zip_code) */ name, age, zip_code FROM person
+   SORT BY name ASC, age DESC;
+
+  +--------+----+--------+
+  |name    |age |zip_code|
+  +--------+----+--------+
+  |Anil K  |27  |94588   |
+  |Dan Li  |18  |94588   |
+  |John V  |null|94588   |
+  |Zen Hui |50  |94588   |
+  |Aryan B.|18  |94511   |
+  |David K |42  |94511   |
+  |Lalit B.|null|94511   |
+  +--------+----+--------+
+{% endhighlight %}

--- a/docs/sql-ref-syntax-qry-select-sortby.md
+++ b/docs/sql-ref-syntax-qry-select-sortby.md
@@ -25,7 +25,7 @@ than <code>ORDER BY</code> clause which guarantees a total order of the output.
 
 ### Syntax
 {% highlight sql %}
-SORT BY { expression [ sort_direction | nulls_sort_oder ] [ , ... ] }
+SORT BY { expression [ sort_direction | nulls_sort_order ] [ , ... ] }
 {% endhighlight %}
 
 ### Parameters

--- a/docs/sql-ref-syntax-qry-select-sortby.md
+++ b/docs/sql-ref-syntax-qry-select-sortby.md
@@ -19,8 +19,8 @@ license: |
   limitations under the License.
 ---
 The <code>SORT BY</code> clause is used to return the result rows sorted
-within each partition in the user specified order. When there are more than one partition
-<code>SORT BY</code> may return results that is partially ordered. This is different
+within each partition in the user specified order. When there is more than one partition
+<code>SORT BY</code> may return result that is partially ordered. This is different
 than <code>ORDER BY</code> clause which guarantees total ordering of the output.
 
 ### Syntax

--- a/docs/sql-ref-syntax-qry-select-sortby.md
+++ b/docs/sql-ref-syntax-qry-select-sortby.md
@@ -32,8 +32,8 @@ SORT BY { expression [ sort_direction | nulls_sort_oder ] [ , ...] }
 <dl>
   <dt><code><em>SORT BY</em></code></dt>
   <dd>
-    Specifies a comma separated list of expression along with optional parameters sort_direction 
-    and nulls_sort_order which are used to sort the rows within each partition.
+    Specifies a comma-separated list of expressions along with optional parameters <code>sort_direction</code>
+    and <code>nulls_sort_order</code> which are used to sort the rows within each partition.
   </dd>
   <dt><code><em>sort_direction</em></code></dt>
   <dd>
@@ -49,8 +49,8 @@ SORT BY { expression [ sort_direction | nulls_sort_oder ] [ , ...] }
   <dt><code><em>nulls_sort_order</em></code></dt>
   <dd>
     Optionally specifies whether NULL values are returned before/after non-NULL values, based on the 
-    sort direction. In spark, NULL values are considered to be lower than any non-NULL values. Therefore
-    the ordering of NULL values depend on the sort direction.<br><br>
+    sort direction. In Spark, NULL values are considered to be lower than any non-NULL values by default.
+    Therefore the ordering of NULL values depend on the sort direction.<br><br>
     <ol>
       <li>If the sort order is ASC, NULLS are returned first; to force NULLS to be last, use NULLS LAST</li>
       <li>If the sort order is DESC, NULLS are returned last; to force NULLS to be first, use NULLS FIRST</li>

--- a/docs/sql-ref-syntax-qry-select-sortby.md
+++ b/docs/sql-ref-syntax-qry-select-sortby.md
@@ -40,7 +40,7 @@ SORT BY { expression [ sort_direction | nulls_sort_oder ] [ , ...] }
     Optionally specifies whether to sort the rows in ascending (lowest to highest) or descending
     (highest to lowest) order. The valid values for sort direction are <code>ASC</code> for ascending
     and <code>DESC</code> for descending. If sort direction is not explicitly specified then by default
-    rows are sorted in ascending manner. <br><br>
+    rows are sorted ascending. <br><br>
     <b>Syntax:</b>
     <code>
        [ ASC | DESC ]
@@ -48,16 +48,20 @@ SORT BY { expression [ sort_direction | nulls_sort_oder ] [ , ...] }
   </dd>
   <dt><code><em>nulls_sort_order</em></code></dt>
   <dd>
-    Optionally specifies whether NULL values are returned before/after non-NULL values, based on the 
+    Optionally specifies whether NULL values are returned before/after non-NULL values, based on the
     sort direction. In Spark, NULL values are considered to be lower than any non-NULL values by default.
-    Therefore the ordering of NULL values depend on the sort direction.<br><br>
+    Therefore the ordering of NULL values depend on the sort direction. If <code>null_sort_order</code> is
+    not specified then NULLs sort first if sort order is <code>ASC</code> and NULLS sort last if 
+    sort order is <code>DESC</code>.<br><br>
     <ol>
-      <li>If the sort order is ASC, NULLS are returned first; to force NULLS to be last, use NULLS LAST</li>
-      <li>If the sort order is DESC, NULLS are returned last; to force NULLS to be first, use NULLS FIRST</li>
+      <li> If <code>NULLS FIRST</code> (the default) is specified, then NULL values are returned first
+           regardless of the sort order.</li>
+      <li>If <code>NULLS LAST</code> is specified, then NULL values are returned last regardless of 
+           the sort order. </li>
     </ol><br>
     <b>Syntax:</b>
     <code>
-       [ NULLS { FIRST | LAST } ] 
+       [ NULLS { FIRST | LAST } ]
     </code>
   </dd>
 </dl>

--- a/docs/sql-ref-syntax-qry-select-sortby.md
+++ b/docs/sql-ref-syntax-qry-select-sortby.md
@@ -37,9 +37,10 @@ SORT BY { expression [ sort_direction | nulls_sort_order ] [ , ... ] }
   </dd>
   <dt><code><em>sort_direction</em></code></dt>
   <dd>
-    Optionally specifies whether to sort the rows in ascending or descending order. The valid values for
-    sort direction are <code>ASC</code> for ascending and <code>DESC</code> for descending. If the
-    sort direction is not explicitly specified, then by default rows are sorted ascending. <br><br>
+    Optionally specifies whether to sort the rows in ascending or descending
+    order. The valid values for the sort direction are <code>ASC</code> for ascending
+    and <code>DESC</code> for descending. If sort direction is not explicitly specified, then by default
+    rows are sorted ascending. <br><br>
     <b>Syntax:</b>
     <code>
        [ ASC | DESC ]
@@ -47,20 +48,20 @@ SORT BY { expression [ sort_direction | nulls_sort_order ] [ , ... ] }
   </dd>
   <dt><code><em>nulls_sort_order</em></code></dt>
   <dd>
-    Optionally specifies whether NULL values are returned before/after non-NULL values, based on the
+    Optionally specifies whether NULL values are returned before/after non-NULL values, based on the 
     sort direction. In Spark, NULL values are considered to be lower than any non-NULL values by default.
     Therefore the ordering of NULL values depend on the sort direction. If <code>null_sort_order</code> is
     not specified, then NULLs sort first if sort order is <code>ASC</code> and NULLS sort last if 
     sort order is <code>DESC</code>.<br><br>
     <ol>
-      <li> If <code>NULLS FIRST</code> (the default) is specified, then NULL values are returned first
+      <li> If <code>NULLS FIRST</code> (the default) is specified, then NULL values are returned first 
            regardless of the sort order.</li>
-      <li>If <code>NULLS LAST</code> is specified, then NULL values are returned last regardless of 
+      <li>If <code>NULLS LAST</code> is specified, then NULL values are returned last regardless of
            the sort order. </li>
     </ol><br>
     <b>Syntax:</b>
     <code>
-       [ NULLS { FIRST | LAST } ]
+       [ NULLS { FIRST | LAST } ] 
     </code>
   </dd>
 </dl>

--- a/docs/sql-ref-syntax-qry-select-sortby.md
+++ b/docs/sql-ref-syntax-qry-select-sortby.md
@@ -37,10 +37,9 @@ SORT BY { expression [ sort_direction | nulls_sort_oder ] [ , ...] }
   </dd>
   <dt><code><em>sort_direction</em></code></dt>
   <dd>
-    Optionally specifies whether to sort the rows in ascending (lowest to highest) or descending
-    (highest to lowest) order. The valid values for sort direction are <code>ASC</code> for ascending
-    and <code>DESC</code> for descending. If sort direction is not explicitly specified then by default
-    rows are sorted ascending. <br><br>
+    Optionally specifies whether to sort the rows in ascending or descending order. The valid values for
+    sort direction are <code>ASC</code> for ascending and <code>DESC</code> for descending. If the
+    sort direction is not explicitly specified then by default rows are sorted ascending. <br><br>
     <b>Syntax:</b>
     <code>
        [ ASC | DESC ]

--- a/docs/sql-ref-syntax-qry-select-sortby.md
+++ b/docs/sql-ref-syntax-qry-select-sortby.md
@@ -21,7 +21,7 @@ license: |
 The <code>SORT BY</code> clause is used to return the result rows sorted
 within each partition in the user specified order. When there is more than one partition
 <code>SORT BY</code> may return result that is partially ordered. This is different
-than <code>ORDER BY</code> clause which guarantees total ordering of the output.
+than <code>ORDER BY</code> clause which guarantees a total order of the output.
 
 ### Syntax
 {% highlight sql %}
@@ -69,14 +69,14 @@ SORT BY { expression [ sort_direction | nulls_sort_oder ] [ , ...] }
 ### Examples
 {% highlight sql %}
 CREATE TABLE person (zip_code INT, name STRING, age INT);
-INSERT INTO person VALUES (94588, 'Zen Hui', 50), 
-                          (94588, 'Dan Li', 18), 
-                          (94588, 'Anil K', 27),
-                          (94588, 'John V', NULL),
-                          (94511, 'David K', 42),
-                          (94511, 'Aryan B.', 18),
-                          (94511, 'Lalit B.', NULL);
-                          
+INSERT INTO person VALUES
+    (94588, 'Zen Hui', 50), 
+    (94588, 'Dan Li', 18), 
+    (94588, 'Anil K', 27),
+    (94588, 'John V', NULL),
+    (94511, 'David K', 42),
+    (94511, 'Aryan B.', 18),
+    (94511, 'Lalit B.', NULL);
 
 -- Use `REPARTITION` hint to partition the data by `zip_code` to 
 -- examine the `SORT BY` behavior. This is used in rest of the

--- a/docs/sql-ref-syntax-qry-select-sortby.md
+++ b/docs/sql-ref-syntax-qry-select-sortby.md
@@ -25,7 +25,7 @@ than <code>ORDER BY</code> clause which guarantees a total order of the output.
 
 ### Syntax
 {% highlight sql %}
-SORT BY { expression [ sort_direction | nulls_sort_oder ] [ , ...] }
+SORT BY { expression [ sort_direction | nulls_sort_oder ] [ , ... ] }
 {% endhighlight %}
 
 ### Parameters
@@ -39,7 +39,7 @@ SORT BY { expression [ sort_direction | nulls_sort_oder ] [ , ...] }
   <dd>
     Optionally specifies whether to sort the rows in ascending or descending order. The valid values for
     sort direction are <code>ASC</code> for ascending and <code>DESC</code> for descending. If the
-    sort direction is not explicitly specified then by default rows are sorted ascending. <br><br>
+    sort direction is not explicitly specified, then by default rows are sorted ascending. <br><br>
     <b>Syntax:</b>
     <code>
        [ ASC | DESC ]
@@ -50,7 +50,7 @@ SORT BY { expression [ sort_direction | nulls_sort_oder ] [ , ...] }
     Optionally specifies whether NULL values are returned before/after non-NULL values, based on the
     sort direction. In Spark, NULL values are considered to be lower than any non-NULL values by default.
     Therefore the ordering of NULL values depend on the sort direction. If <code>null_sort_order</code> is
-    not specified then NULLs sort first if sort order is <code>ASC</code> and NULLS sort last if 
+    not specified, then NULLs sort first if sort order is <code>ASC</code> and NULLS sort last if 
     sort order is <code>DESC</code>.<br><br>
     <ol>
       <li> If <code>NULLS FIRST</code> (the default) is specified, then NULL values are returned first
@@ -79,7 +79,7 @@ INSERT INTO person VALUES
 
 -- Use `REPARTITION` hint to partition the data by `zip_code` to 
 -- examine the `SORT BY` behavior. This is used in rest of the
--- example.
+-- examples.
 
 -- Sort rows by `name` within each partition in ascending manner
 SELECT /*+ REPARTITION(zip_code) */ name, age, zip_code FROM person SORT BY name;
@@ -156,7 +156,7 @@ SELECT /*+ REPARTITION(zip_code) */ age, name, zip_code FROM person SORT BY age 
   |18  |Aryan B.|94511   |
   +----+--------+--------+
 
--- Sort rows within each partition  based on more than one column with each column having
+-- Sort rows within each partition based on more than one column with each column having
 -- different sort direction.
 SELECT /*+ REPARTITION(zip_code) */ name, age, zip_code FROM person
    SORT BY name ASC, age DESC;


### PR DESCRIPTION
### What changes were proposed in this pull request?
Document SORT BY clause of SELECT statement in SQL Reference Guide.

### Why are the changes needed?
Currently Spark lacks documentation on the supported SQL constructs causing
confusion among users who sometimes have to look at the code to understand the
usage. This is aimed at addressing this issue.

### Does this PR introduce any user-facing change?
Yes. 

**Before:**
There was no documentation for this.

**After.**
<img width="972" alt="Screen Shot 2020-01-20 at 1 25 57 AM" src="https://user-images.githubusercontent.com/14225158/72714701-00698c00-3b24-11ea-810e-28400e196ae9.png">
<img width="972" alt="Screen Shot 2020-01-20 at 1 26 11 AM" src="https://user-images.githubusercontent.com/14225158/72714706-02cbe600-3b24-11ea-9072-6d5e6f256400.png">
<img width="972" alt="Screen Shot 2020-01-20 at 1 26 28 AM" src="https://user-images.githubusercontent.com/14225158/72714712-07909a00-3b24-11ea-9aed-51b6bb0849f2.png">
<img width="972" alt="Screen Shot 2020-01-20 at 1 26 46 AM" src="https://user-images.githubusercontent.com/14225158/72714722-0a8b8a80-3b24-11ea-9fea-4d2a166e9d92.png">
<img width="972" alt="Screen Shot 2020-01-20 at 1 27 02 AM" src="https://user-images.githubusercontent.com/14225158/72714731-0f503e80-3b24-11ea-9f6d-8223e5d88c65.png">



### How was this patch tested?
Tested using jykyll build --serve