### PR TITLE
[SPARK-30583][DOC] Document LIMIT Clause of SELECT statement in SQL Reference

### DIFF
--- a/docs/sql-ref-syntax-qry-select-limit.md
+++ b/docs/sql-ref-syntax-qry-select-limit.md
@@ -1,7 +1,7 @@
 ---
 layout: global
-title: LIMIT operator
-displayTitle: LIMIT operator
+title: LIMIT Clause
+displayTitle: LIMIT Clause
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -18,5 +18,71 @@ license: |
   See the License for the specific language governing permissions and
   limitations under the License.
 ---
+The <code>LIMIT</code> clause is used to constrain the number of rows returned by the <code>SELECT</code> statement. 
+In general, this clause is used in conjuction with <code>ORDER BY</code> to ensure that the results are deterministic.
 
-**This page is under construction**
+### Syntax
+{% highlight sql %}
+LIMIT { ALL | integer_expression }
+{% endhighlight %}
+
+### Parameters
+<dl>
+  <dt><code><em>ALL</em></code></dt>
+  <dd>
+    If specified, the query returns all the rows. In otherwords, no limit is applied if this
+    option is specified.
+  </dd>
+  <dt><code><em>integer_expression</em></code></dt>
+  <dd>
+    Specifies an expression that returns an integer. 
+  </dd>
+</dl>
+
+### Examples
+{% highlight sql %}
+CREATE TABLE person (name STRING, age INT);
+INSERT INTO person VALUES ('Zen Hui', 25), 
+                          ('Anil B', 18), 
+                          ('Shone S', 16), 
+                          ('Mike A', 25),
+                          ('John A', 18), 
+                          ('Jack N', 16);
+                        
+-- Select the first two rows.
+SELECT name, age FROM person ORDER BY name LIMIT 2;
+
+  +------+---+
+  |name  |age|
+  +------+---+
+  |Anil B|18 |
+  |Jack N|16 |
+  +------+---+
+
+-- Specifying ALL option on LIMIT returns all the rows.
+SELECT name, age FROM person ORDER BY name LIMIT ALL;
+
+  +-------+---+
+  |name   |age|
+  +-------+---+
+  |Anil B |18 |
+  |Jack N |16 |
+  |John A |18 |
+  |Mike A |25 |
+  |Shone S|16 |
+  |Zen Hui|25 |
+  +-------+---+
+
+-- A function expression as a input to limit.
+SELECT name, age FROM person ORDER BY name LIMIT length('SPARK')
+
+  +-------+---+
+  |   name|age|
+  +-------+---+
+  | Anil B| 18|
+  | Jack N| 16|
+  | John A| 18|
+  | Mike A| 25|
+  |Shone S| 16|
+  +-------+---+
+{% endhighlight %}

--- a/docs/sql-ref-syntax-qry-select-limit.md
+++ b/docs/sql-ref-syntax-qry-select-limit.md
@@ -73,7 +73,7 @@ SELECT name, age FROM person ORDER BY name LIMIT ALL;
   |Zen Hui|25 |
   +-------+---+
 
--- A function expression as a input to limit.
+-- A function expression as an input to limit.
 SELECT name, age FROM person ORDER BY name LIMIT length('SPARK')
 
   +-------+---+

--- a/docs/sql-ref-syntax-qry-select-limit.md
+++ b/docs/sql-ref-syntax-qry-select-limit.md
@@ -30,7 +30,7 @@ LIMIT { ALL | integer_expression }
 <dl>
   <dt><code><em>ALL</em></code></dt>
   <dd>
-    If specified, the query returns all the rows. In otherwords, no limit is applied if this
+    If specified, the query returns all the rows. In other words, no limit is applied if this
     option is specified.
   </dd>
   <dt><code><em>integer_expression</em></code></dt>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Document LIMIT clause of SELECT statement in SQL Reference Guide.

### Why are the changes needed?
Currently Spark lacks documentation on the supported SQL constructs causing
confusion among users who sometimes have to look at the code to understand the
usage. This is aimed at addressing this issue.

### Does this PR introduce any user-facing change?
Yes. 

**Before:**
There was no documentation for this.

**After.**
<img width="972" alt="Screen Shot 2020-01-20 at 1 37 28 AM" src="https://user-images.githubusercontent.com/14225158/72715533-7e7a6280-3b25-11ea-98fc-ed68b5d5024a.png">
<img width="972" alt="Screen Shot 2020-01-20 at 1 37 43 AM" src="https://user-images.githubusercontent.com/14225158/72715549-83d7ad00-3b25-11ea-98b3-610eca2628f6.png">



### How was this patch tested?
Tested using jykyll build --serve