### PR TITLE
[SPARK-30547][SQL][FOLLOWUP] Update since anotation for CalendarInterval class

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/CalendarInterval.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/CalendarInterval.java
@@ -41,7 +41,7 @@ import static org.apache.spark.sql.catalyst.util.DateTimeConstants.*;
  * they are two separated fields from microseconds. One month may be equal to 28, 29, 30 or 31 days
  * and one day may be equal to 23, 24 or 25 hours (daylight saving).
  *
- * @since 1.5.0
+ * @since 3.0.0
  */
 @Unstable
 public final class CalendarInterval implements Serializable {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Mark `CalendarInterval` class with `since 3.0.0`.
### Why are the changes needed?

https://www.oracle.com/technetwork/java/javase/documentation/index-137868.html#@since

This class is the first time going to the public, the annotation is the first time to add, and we don't want people to get confused and try to use it 2.4.x.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
no