### PR TITLE
[SPARK-30567][SQL] setDelegateCatalog should be called if catalog has…

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
@@ -49,7 +49,7 @@ class CatalogManager(
     if (name.equalsIgnoreCase(SESSION_CATALOG_NAME)) {
       v2SessionCatalog
     } else {
-      catalogs.getOrElseUpdate(name, Catalogs.load(name, conf))
+      catalogs.getOrElseUpdate(name, loadSessionCatalog(name))
     }
   }
 
@@ -62,8 +62,8 @@ class CatalogManager(
     }
   }
 
-  private def loadV2SessionCatalog(): CatalogPlugin = {
-    Catalogs.load(SESSION_CATALOG_NAME, conf) match {
+  private def loadSessionCatalog(name: String): CatalogPlugin = {
+    Catalogs.load(name, conf) match {
       case extension: CatalogExtension =>
         extension.setDelegateCatalog(defaultSessionCatalog)
         extension
@@ -83,7 +83,7 @@ class CatalogManager(
   private[sql] def v2SessionCatalog: CatalogPlugin = {
     conf.getConf(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION).map { customV2SessionCatalog =>
       try {
-        catalogs.getOrElseUpdate(SESSION_CATALOG_NAME, loadV2SessionCatalog())
+        catalogs.getOrElseUpdate(SESSION_CATALOG_NAME, loadSessionCatalog(SESSION_CATALOG_NAME))
       } catch {
         case NonFatal(_) =>
           logError(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add replace 'loadV2SessionCatalog' with 'loadSessionCatalog'  in CatalogManager which is used to load any session catalog.


### Why are the changes needed?
Catalogs.load is called to load a catalog which is not 'spark_catalog' . If the catalog has implemented CatalogExtension, setDelegateCatalog is not called when the catalog is loaded, that is not like what we have done for v2SessionCatalog, and that makes a confusion for customized session catalog, like iceberg SparkSessionCatalog.


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
No
