### PR TITLE
SPARK-30010 Remove deprecated SparkConf.setAll Traversable

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -173,15 +173,6 @@ class SparkConf(loadDefaults: Boolean) extends Cloneable with Logging with Seria
     this
   }
 
-  /**
-   * Set multiple parameters together
-   */
-  @deprecated("Use setAll(Iterable) instead", "3.0.0")
-  def setAll(settings: Traversable[(String, String)]): SparkConf = {
-    settings.foreach { case (k, v) => set(k, v) }
-    this
-  }
-
   /** Set a parameter if it isn't already configured */
   def setIfMissing(key: String, value: String): SparkConf = {
     if (settings.putIfAbsent(key, value) == null) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
As per [SPARK-30010](https://jira.apache.org/jira/browse/SPARK-30010) we need to remove deprecated SparkConf.setAll Traversable which I have done here.


### Why are the changes needed?
Deprecated setAll is set to be removed


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
By running tests locally
