### PR TITLE
[SPARK-30598][SQL] Detect equijoins better

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -222,7 +222,7 @@ object ExtractEquiJoinKeys extends Logging with PredicateHelper {
         case (xs, ys) => for { x <- xs; y <- ys } yield (x, y)
       }
 
-      val joinKeys = (explicitJoinKeys.toSet ++ implicitJoinKeys).toSeq
+      val joinKeys = (explicitJoinKeys.toSet ++ implicitJoinKeys).toList
 
       val otherPredicates = predicates.filterNot {
         case EqualTo(l, r) if l.references.isEmpty || r.references.isEmpty => false


### PR DESCRIPTION
# What changes were proposed in this pull request?
The improvement in this is PR can extract equalities from join conditions so that we can recognise implicit equijoins.

E.g. this example query:
```
SELECT * FROM t1 FULL OUTER JOIN t2 ON t1.c2 = 2 AND t2.c2 = 2
```
has the following plan currently:
```
BroadcastNestedLoopJoin BuildRight, FullOuter, ((c2#226 = 2) AND (c2#237 = 2))
:- *(1) Project [_1#220 AS c#225, _2#221 AS c2#226]
:  +- *(1) LocalTableScan [_1#220, _2#221]
+- BroadcastExchange IdentityBroadcastMode, [id=#146]
   +- *(2) Project [_1#231 AS c#236, _2#232 AS c2#237]
      +- *(2) LocalTableScan [_1#231, _2#232]
```
But if we take
```
SELECT * FROM t1 FULL OUTER JOIN t2 ON t1.c2 = 2 AND t2.c2 = 2 AND t1.c2 = t2.c2
```
where the equality between the sides explicitly defined (`t1.c2 = t2.c2`) the plan is:
```
SortMergeJoin [c#225], [c#236], FullOuter, ((c2#226 = 2) AND (c2#237 = 2))
:- *(2) Sort [c#225 ASC NULLS FIRST], false, 0
:  +- Exchange hashpartitioning(c#225, 5), true, [id=#101]
:     +- *(1) Project [_1#220 AS c#225, _2#221 AS c2#226]
:        +- *(1) LocalTableScan [_1#220, _2#221]
+- *(4) Sort [c#236 ASC NULLS FIRST], false, 0
   +- Exchange hashpartitioning(c#236, 5), true, [id=#106]
      +- *(3) Project [_1#231 AS c#236, _2#232 AS c2#237]
         +- *(3) LocalTableScan [_1#231, _2#232]
```
The second plan is better as SMJ doesn't have the broadcast size limitation as BNLJ do.
After this PR the implicit equalities are detected and the first query has the same plan as the second.

### Why are the changes needed?
Improve stability.

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
Existing and new UTs.