### PR TITLE
[SPARK-27996][WEBUI] Send HTTP redirect using the correct protocol when Spark History server is deployed behind the reverse proxy

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
@@ -31,7 +31,7 @@ import org.eclipse.jetty.servlet.FilterHolder
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.metrics.source.Source
-import org.apache.spark.ui.SparkUI
+import org.apache.spark.ui.{JettyUtils, SparkUI}
 import org.apache.spark.util.Clock
 
 /**
@@ -393,7 +393,7 @@ private[history] class ApplicationCacheCheckFilter(
     }
     val httpRequest = request.asInstanceOf[HttpServletRequest]
     val httpResponse = response.asInstanceOf[HttpServletResponse]
-    val requestURI = httpRequest.getRequestURI
+    val requestURL = httpRequest.getRequestURL.toString
     val operation = httpRequest.getMethod
 
     // if the request is for an attempt, check to see if it is in need of delete/refresh
@@ -409,8 +409,8 @@ private[history] class ApplicationCacheCheckFilter(
       loadedUI.lock.readLock.unlock()
       cache.invalidate(key)
       val queryStr = Option(httpRequest.getQueryString).map("?" + _).getOrElse("")
-      val redirectUrl = httpResponse.encodeRedirectURL(requestURI + queryStr)
-      httpResponse.sendRedirect(redirectUrl)
+      val redirectUrl = httpResponse.encodeRedirectURL(requestURL + queryStr)
+      httpResponse.sendRedirect(JettyUtils.updateProtocolFromHeader(httpRequest, redirectUrl))
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
@@ -382,7 +382,7 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
     verify(resp).sendRedirect("http://localhost:18080/history/local-123/jobs/job/?id=2")
   }
 
-  test("redirect respects X-Forwarded-Proto header") {
+  test("SPARK-27996: redirect respects X-Forwarded-Proto header") {
     val operations = new StubCacheOperations()
     val ui = operations.putAndAttach("foo", None, true, 0, 10)
     val cache = mock[ApplicationCache]


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds method `updateProtocolFromHeader(request: HttpServletRequest, url: String): String` to JettyUtils.scala and calls this method from when Spark History Server is generating a redirect response.

### Why are the changes needed?
This change is needed to address bug SPARK-27996 in History Server. Please note that similar change is likely needed in Spark UI. The scope of this PR is only to address the problem in History Server.

### Does this PR introduce any user-facing change?
Yes, the Spark History server deployed in Kubernetes now correctly opens the job page.

### How was this patch tested?
The patch was tested by building and deploying Spark History Server to Kubernetes cluster and then observing the behavior of the History Server UI. The regression testing was not performed. I will appreciate is someone can can confirm the Spark History Server still works when deployed on regular infrastructure (e.g. not behind the reverse proxy).
