### PR TITLE
[SPARK-30535][SQL][FOLLOWUP] Update error message for ALTER TABLE when table is resolved to temp view

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -93,7 +93,7 @@ trait CheckAnalysis extends PredicateHelper {
 
       case alter: AlterTable =>
         alter.table match {
-          case u @ UnresolvedTableWithViewExists(view) if !view.isTempView =>
+          case u @ UnresolvedTableWithViewExists(view) =>
             u.failAnalysis("Cannot alter a view with ALTER TABLE. Please use ALTER VIEW instead")
           case _ =>
         }

--- a/sql/core/src/test/resources/sql-tests/results/change-column.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/change-column.sql.out
@@ -195,7 +195,7 @@ ALTER TABLE temp_view CHANGE a TYPE INT COMMENT 'this is column a'
 struct<>
 -- !query 20 output
 org.apache.spark.sql.AnalysisException
-temp_view is a temp view not a table.; line 1 pos 0
+Cannot alter a view with ALTER TABLE. Please use ALTER VIEW instead; line 1 pos 0
 
 
 -- !query 21
@@ -212,7 +212,7 @@ ALTER TABLE global_temp.global_temp_view CHANGE a TYPE INT COMMENT 'this is colu
 struct<>
 -- !query 22 output
 org.apache.spark.sql.AnalysisException
-global_temp.global_temp_view is a temp view not a table.; line 1 pos 0
+Cannot alter a view with ALTER TABLE. Please use ALTER VIEW instead; line 1 pos 0
 
 
 -- !query 23

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
@@ -145,13 +145,13 @@ abstract class SQLViewSuite extends QueryTest with SQLTestUtils {
       // For v2 ALTER TABLE statements, we have better error message saying view is not supported.
       assertAnalysisError(
         s"ALTER TABLE $viewName SET LOCATION '/path/to/your/lovely/heart'",
-        s"$viewName is a temp view not a table")
+        "Cannot alter a view with ALTER TABLE. Please use ALTER VIEW instead")
 
       // For the following v2 ALERT TABLE statements, relations are first resolved before
       // unsupported operations are checked.
       assertAnalysisError(
         s"ALTER TABLE $viewName PARTITION (a='4') SET LOCATION '/path/to/home'",
-        s"$viewName is a temp view not a table")
+        "Cannot alter a view with ALTER TABLE. Please use ALTER VIEW instead")
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -2779,7 +2779,8 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
       val e = intercept[AnalysisException] {
         sql("ALTER TABLE tmp_v ADD COLUMNS (c3 INT)")
       }
-      assert(e.message.contains("tmp_v is a temp view not a table"))
+      assert(
+        e.message.contains("Cannot alter a view with ALTER TABLE. Please use ALTER VIEW instead"))
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR address: https://github.com/apache/spark/pull/27243#issuecomment-576145645.

The error is now the same whether a table is resolved to a view or a temp view for ALTER TABLE commands.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To unify the error message regardless of whether a table is resolved to a view or a temp view for ALTER TABLE commands.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
The previous error message:
```
temp_view is a temp view not a table.
```
New error message (same as view):
```
Cannot alter a view with ALTER TABLE. Please use ALTER VIEW instead
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Updated existing tests to reflect the new error message.