### PR TITLE
[SPARK-26509][SQL] Support DELTA_BYTE_ARRAY encoding for Parquet vectorized reader

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReader.java
@@ -580,10 +580,7 @@ public class VectorizedColumnReader {
       this.dataColumn = new VectorizedRleValuesReader();
       this.isCurrentPageDictionaryEncoded = true;
     } else {
-      if (dataEncoding != Encoding.PLAIN) {
-        throw new UnsupportedOperationException("Unsupported encoding: " + dataEncoding);
-      }
-      this.dataColumn = new VectorizedPlainValuesReader();
+      this.dataColumn = getValuesReader(dataEncoding);
       this.isCurrentPageDictionaryEncoded = false;
     }
 
@@ -591,6 +588,19 @@ public class VectorizedColumnReader {
       dataColumn.initFromPage(pageValueCount, in);
     } catch (IOException e) {
       throw new IOException("could not read page in col " + descriptor, e);
+    }
+  }
+
+  private ValuesReader getValuesReader(Encoding encoding) {
+    switch (encoding) {
+      case PLAIN:
+        return new VectorizedPlainValuesReader();
+      case DELTA_BYTE_ARRAY:
+        return new VectorizedDeltaByteArrayReader();
+      case DELTA_BINARY_PACKED:
+        return new VectorizedDeltaBinaryPackedReader();
+      default:
+        throw new UnsupportedOperationException("Unsupported encoding: " + encoding);
     }
   }
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaBinaryPackedReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaBinaryPackedReader.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.parquet;
+
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.column.values.ValuesReader;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesReader;
+import org.apache.parquet.io.api.Binary;
+import org.apache.spark.sql.execution.vectorized.WritableColumnVector;
+
+import java.io.IOException;
+
+/**
+ * An implementation of the Parquet DELTA_BINARY_PACKED decoder that supports the vectorized interface.
+ */
+public class VectorizedDeltaBinaryPackedReader extends ValuesReader implements VectorizedValuesReader {
+  private final DeltaBinaryPackingValuesReader deltaBinaryPackingValuesReader = new DeltaBinaryPackingValuesReader();
+
+  @Override
+  public void initFromPage(int valueCount, ByteBufferInputStream in) throws IOException {
+    deltaBinaryPackingValuesReader.initFromPage(valueCount, in);
+  }
+
+  @Override
+  public void skip() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public byte readByte() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Binary readBinary(int len) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void readBooleans(int total, WritableColumnVector c, int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void readBytes(int total, WritableColumnVector c, int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void readIntegers(int total, WritableColumnVector c, int rowId) {
+    for (int i =0; i<total; i++) {
+      c.putInt(rowId + i, deltaBinaryPackingValuesReader.readInteger());
+    }
+  }
+
+  @Override
+  public void readLongs(int total, WritableColumnVector c, int rowId) {
+    for (int i =0; i<total; i++) {
+      c.putLong(rowId + i, deltaBinaryPackingValuesReader.readLong());
+    }
+  }
+
+  @Override
+  public void readFloats(int total, WritableColumnVector c, int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void readDoubles(int total, WritableColumnVector c, int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void readBinary(int total, WritableColumnVector c, int rowId) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaBinaryPackedReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaBinaryPackedReader.java
@@ -25,14 +25,16 @@ import org.apache.spark.sql.execution.vectorized.WritableColumnVector;
 import java.io.IOException;
 
 /**
- * An implementation of the Parquet DELTA_BINARY_PACKED decoder that supports the vectorized interface.
+ * An implementation of the Parquet DELTA_BINARY_PACKED decoder
+ * that supports the vectorized interface.
  */
-public class VectorizedDeltaBinaryPackedReader extends ValuesReader implements VectorizedValuesReader {
-  private final DeltaBinaryPackingValuesReader deltaBinaryPackingValuesReader = new DeltaBinaryPackingValuesReader();
+public class VectorizedDeltaBinaryPackedReader extends ValuesReader
+    implements VectorizedValuesReader {
+  private final DeltaBinaryPackingValuesReader valuesReader = new DeltaBinaryPackingValuesReader();
 
   @Override
   public void initFromPage(int valueCount, ByteBufferInputStream in) throws IOException {
-    deltaBinaryPackingValuesReader.initFromPage(valueCount, in);
+    valuesReader.initFromPage(valueCount, in);
   }
 
   @Override
@@ -62,15 +64,15 @@ public class VectorizedDeltaBinaryPackedReader extends ValuesReader implements V
 
   @Override
   public void readIntegers(int total, WritableColumnVector c, int rowId) {
-    for (int i =0; i<total; i++) {
-      c.putInt(rowId + i, deltaBinaryPackingValuesReader.readInteger());
+    for (int i = 0; i < total; i++) {
+      c.putInt(rowId + i, valuesReader.readInteger());
     }
   }
 
   @Override
   public void readLongs(int total, WritableColumnVector c, int rowId) {
-    for (int i =0; i<total; i++) {
-      c.putLong(rowId + i, deltaBinaryPackingValuesReader.readLong());
+    for (int i = 0; i < total; i++) {
+      c.putLong(rowId + i, valuesReader.readLong());
     }
   }
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaByteArrayReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaByteArrayReader.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.parquet;
+
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.column.values.ValuesReader;
+import org.apache.parquet.column.values.deltastrings.DeltaByteArrayReader;
+import org.apache.parquet.io.api.Binary;
+import org.apache.spark.sql.execution.vectorized.WritableColumnVector;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * An implementation of the Parquet DELTA_BYTE_ARRAY decoder that supports the vectorized interface.
+ */
+public class VectorizedDeltaByteArrayReader extends ValuesReader implements VectorizedValuesReader {
+  private final DeltaByteArrayReader deltaByteArrayReader = new DeltaByteArrayReader();
+
+  @Override
+  public void initFromPage(int valueCount, ByteBufferInputStream in) throws IOException {
+    deltaByteArrayReader.initFromPage(valueCount, in);
+  }
+
+  @Override
+  public void skip() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public byte readByte() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Binary readBinary(int len) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void readBooleans(int total, WritableColumnVector c, int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void readBytes(int total, WritableColumnVector c, int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void readIntegers(int total, WritableColumnVector c, int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void readLongs(int total, WritableColumnVector c, int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void readFloats(int total, WritableColumnVector c, int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void readDoubles(int total, WritableColumnVector c, int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void readBinary(int total, WritableColumnVector c, int rowId) {
+    for (int i = 0; i < total; i++) {
+      Binary binary = deltaByteArrayReader.readBytes();
+      ByteBuffer buffer = binary.toByteBuffer();
+      if (buffer.hasArray()) {
+        c.putByteArray(rowId + i, buffer.array(), buffer.arrayOffset() + buffer.position(), binary.length());
+      } else {
+        byte[] bytes = new byte[binary.length()];
+        buffer.get(bytes);
+        c.putByteArray(rowId + i, bytes);
+      }
+    }
+  }
+}

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaByteArrayReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaByteArrayReader.java
@@ -87,7 +87,8 @@ public class VectorizedDeltaByteArrayReader extends ValuesReader implements Vect
       Binary binary = deltaByteArrayReader.readBytes();
       ByteBuffer buffer = binary.toByteBuffer();
       if (buffer.hasArray()) {
-        c.putByteArray(rowId + i, buffer.array(), buffer.arrayOffset() + buffer.position(), binary.length());
+        c.putByteArray(rowId + i, buffer.array(), buffer.arrayOffset() + buffer.position(),
+          binary.length());
       } else {
         byte[] bytes = new byte[binary.length()];
         buffer.get(bytes);

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetEncodingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetEncodingSuite.scala
@@ -18,8 +18,12 @@ package org.apache.spark.sql.execution.datasources.parquet
 
 import scala.collection.JavaConverters._
 
+import org.apache.hadoop.fs.Path
+import org.apache.parquet.column.{Encoding, ParquetProperties}
 import org.apache.parquet.hadoop.ParquetOutputFormat
 
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
 // TODO: this needs a lot more testing but it's currently not easy to test with the parquet
@@ -111,6 +115,38 @@ class ParquetEncodingSuite extends ParquetCompatibilityTest with SharedSparkSess
           assert(column.getUTF8String(3 * i + 2).toString == i.toString)
         }
         reader.close()
+      }
+    }
+  }
+
+  test("parquet v2 pages - delta encoding") {
+    val extraOptions = Map[String, String](
+      ParquetOutputFormat.WRITER_VERSION -> ParquetProperties.WriterVersion.PARQUET_2_0.toString,
+      ParquetOutputFormat.ENABLE_DICTIONARY -> "false"
+    )
+
+    val hadoopConf = spark.sessionState.newHadoopConfWithOptions(extraOptions)
+    withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "true",
+      ParquetOutputFormat.JOB_SUMMARY_LEVEL -> "ALL") {
+      withTempPath { dir =>
+        val path = s"${dir.getCanonicalPath}/test.parquet"
+        val data = (1 to 3).map { i =>
+          (i, i.toLong, s"test_${i}")
+        }
+
+        spark.createDataFrame(data).write.options(extraOptions).mode("overwrite").parquet(path)
+
+        val blockMetadata = readFooter(new Path(path), hadoopConf).getBlocks.asScala.head
+        val columnChunkMetadataList = blockMetadata.getColumns.asScala
+
+        // Verify that indeed delta encoding is used for each column
+        assert(columnChunkMetadataList.length === 3)
+        assert(columnChunkMetadataList(0).getEncodings.contains(Encoding.DELTA_BINARY_PACKED))
+        assert(columnChunkMetadataList(1).getEncodings.contains(Encoding.DELTA_BINARY_PACKED))
+        assert(columnChunkMetadataList(2).getEncodings.contains(Encoding.DELTA_BYTE_ARRAY))
+
+        val actual = spark.read.parquet(path).collect
+        assert(actual.sortBy(_.getInt(0)) === data.map(Row.fromTuple));
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implement Parquet delta encoding for the vectorized interface, which is needed for V2 pages. The implementation simply delegates the decoding to the Parquet implementation.

#### Reference:
[Parquet encodings](https://github.com/apache/parquet-format/blob/ee02ef8c8f33bd3d5ed0582ded7e20439e12d933/Encodings.md)
[DefaultV2ValuesWriterFactory](https://github.com/apache/parquet-mr/blob/30aa91012cf6019bb9720609c1d03b5386a87ffb/parquet-column/src/main/java/org/apache/parquet/column/values/factory/DefaultV2ValuesWriterFactory.java)

### Why are the changes needed?
Support for parquet DataPageV2.


### Does this PR introduce any user-facing change?


### How was this patch tested?
New UT.

Credit to @nandorKollar, Closes #23988.