### PR TITLE
[SPARK-29438][SS][FOLLOWUP] Add regression tests for Streaming Aggregation and flatMapGroupsWithState

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingAggregationSuite.scala
@@ -336,9 +336,7 @@ class StreamingAggregationSuite extends StateStoreMetricsTest with Assertions {
       val (input1, input2, unionDf) = constructUnionDf(2)
       testStream(unionDf, Update)(
         StartStream(checkpointLocation = checkpointDir.getAbsolutePath),
-        MultiAddData(
-          (input1, Seq(11, 12)),
-          (input2, Seq(21, 22))),
+        MultiAddData(input1, 11, 12)(input2, 21, 22),
         CheckNewAnswer(Row(11, 12), Row(12, 13), Row(21, 1), Row(22, 1)),
         StopStream
       )
@@ -355,9 +353,7 @@ class StreamingAggregationSuite extends StateStoreMetricsTest with Assertions {
 
       testStream(newUnionDf, Update)(
         StartStream(checkpointLocation = checkpointDir.getAbsolutePath),
-        MultiAddData(
-          (newInput1, Seq(13, 14)),
-          (newInput2, Seq(22, 23))),
+        MultiAddData(newInput1, 13, 14)(newInput2, 22, 23),
         CheckNewAnswer(Row(13, 14), Row(14, 15), Row(22, 2), Row(23, 1))
       )
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingAggregationSuite.scala
@@ -27,7 +27,7 @@ import org.scalatest.Assertions
 
 import org.apache.spark.{SparkEnv, SparkException}
 import org.apache.spark.rdd.BlockRDD
-import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset, SparkSession}
+import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset, Row, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.plans.logical.Aggregate
 import org.apache.spark.sql.catalyst.util.DateTimeConstants._
@@ -314,6 +314,55 @@ class StreamingAggregationSuite extends StateStoreMetricsTest with Assertions {
       AddData(inputData, 1, 2),
       CheckLastBatch((1, 2, 2), (2, 3, 2))
     )
+  }
+
+  testWithAllStateVersions("SPARK-29438: ensure UNION doesn't lead streaming aggregation to use" +
+    " shifted partition IDs") {
+    def constructUnionDf(desiredPartitionsForInput1: Int)
+      : (MemoryStream[Int], MemoryStream[Int], DataFrame) = {
+      val input1 = MemoryStream[Int](desiredPartitionsForInput1)
+      val input2 = MemoryStream[Int]
+      val df1 = input1.toDF()
+        .select($"value", $"value" + 1, $"value" + 2)
+      val df2 = input2.toDF()
+        .groupBy($"value", $"value" + 1)
+        .agg(count("*"))
+
+      // Unioned DF would have columns as (Int, Int, Int)
+      (input1, input2, df1.union(df2))
+    }
+
+    withTempDir { checkpointDir =>
+      val (input1, input2, unionDf) = constructUnionDf(2)
+      testStream(unionDf, Update)(
+        StartStream(checkpointLocation = checkpointDir.getAbsolutePath),
+        MultiAddData(
+          (input1, Seq(11, 12)),
+          (input2, Seq(11, 12, 13))),
+        CheckNewAnswer(Row(11, 12, 13), Row(12, 13, 14), Row(11, 12, 1), Row(12, 13, 1),
+          Row(13, 14, 1)),
+        StopStream
+      )
+
+      // We're restoring the query with different number of partitions in left side of UNION,
+      // which may lead right side of union to have mismatched partition IDs (e.g. if it relies on
+      // TaskContext.partitionId()). This test will verify streaming aggregation doesn't have
+      // such issue.
+
+      val (newInput1, newInput2, newUnionDf) = constructUnionDf(3)
+
+      newInput1.addData(11, 12)
+      newInput2.addData(11, 12, 13)
+
+      testStream(newUnionDf, Update)(
+        StartStream(checkpointLocation = checkpointDir.getAbsolutePath),
+        MultiAddData(
+          (newInput1, Seq(21, 22)),
+          (newInput2, Seq(21, 22, 23))),
+        CheckNewAnswer(Row(21, 22, 23), Row(22, 23, 24), Row(21, 22, 1), Row(22, 23, 1),
+          Row(23, 24, 1))
+      )
+    }
   }
 
   testQuietlyWithAllStateVersions("midbatch failure") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingAggregationSuite.scala
@@ -323,12 +323,12 @@ class StreamingAggregationSuite extends StateStoreMetricsTest with Assertions {
       val input1 = MemoryStream[Int](desiredPartitionsForInput1)
       val input2 = MemoryStream[Int]
       val df1 = input1.toDF()
-        .select($"value", $"value" + 1, $"value" + 2)
+        .select($"value", $"value" + 1)
       val df2 = input2.toDF()
-        .groupBy($"value", $"value" + 1)
+        .groupBy($"value")
         .agg(count("*"))
 
-      // Unioned DF would have columns as (Int, Int, Int)
+      // Unioned DF would have columns as (Int, Int)
       (input1, input2, df1.union(df2))
     }
 
@@ -338,9 +338,8 @@ class StreamingAggregationSuite extends StateStoreMetricsTest with Assertions {
         StartStream(checkpointLocation = checkpointDir.getAbsolutePath),
         MultiAddData(
           (input1, Seq(11, 12)),
-          (input2, Seq(11, 12, 13))),
-        CheckNewAnswer(Row(11, 12, 13), Row(12, 13, 14), Row(11, 12, 1), Row(12, 13, 1),
-          Row(13, 14, 1)),
+          (input2, Seq(21, 22))),
+        CheckNewAnswer(Row(11, 12), Row(12, 13), Row(21, 1), Row(22, 1)),
         StopStream
       )
 
@@ -352,15 +351,14 @@ class StreamingAggregationSuite extends StateStoreMetricsTest with Assertions {
       val (newInput1, newInput2, newUnionDf) = constructUnionDf(3)
 
       newInput1.addData(11, 12)
-      newInput2.addData(11, 12, 13)
+      newInput2.addData(21, 22)
 
       testStream(newUnionDf, Update)(
         StartStream(checkpointLocation = checkpointDir.getAbsolutePath),
         MultiAddData(
-          (newInput1, Seq(21, 22)),
-          (newInput2, Seq(21, 22, 23))),
-        CheckNewAnswer(Row(21, 22, 23), Row(22, 23, 24), Row(21, 22, 1), Row(22, 23, 1),
-          Row(23, 24, 1))
+          (newInput1, Seq(13, 14)),
+          (newInput2, Seq(22, 23))),
+        CheckNewAnswer(Row(13, 14), Row(14, 15), Row(22, 2), Row(23, 1))
       )
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.streaming
 
 import org.scalatest.BeforeAndAfterAll
 
+import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, HashPartitioning, SinglePartition}
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes._
 import org.apache.spark.sql.execution.streaming.{MemoryStream, StreamingDeduplicateExec}
@@ -287,4 +288,45 @@ class StreamingDeduplicationSuite extends StateStoreMetricsTest {
     testWithFlag(true)
     testWithFlag(false)
   }
+
+  test("SPARK-29438: ensure UNION doesn't lead streaming deduplication to use" +
+    " shifted partition IDs") {
+    def constructUnionDf(desiredPartitionsForInput1: Int)
+      : (MemoryStream[Int], MemoryStream[Int], DataFrame) = {
+      val input1 = MemoryStream[Int](desiredPartitionsForInput1)
+      val input2 = MemoryStream[Int]
+      val df1 = input1.toDF().select($"value")
+      val df2 = input2.toDF().dropDuplicates("value")
+
+      // Unioned DF would have columns as (Int)
+      (input1, input2, df1.union(df2))
+    }
+
+    withTempDir { checkpointDir =>
+      val (input1, input2, unionDf) = constructUnionDf(2)
+      testStream(unionDf, Append)(
+        StartStream(checkpointLocation = checkpointDir.getAbsolutePath),
+        MultiAddData(input1, 11, 12)(input2, 21, 22),
+        CheckNewAnswer(11, 12, 21, 22),
+        StopStream
+      )
+
+      // We're restoring the query with different number of partitions in left side of UNION,
+      // which may lead right side of union to have mismatched partition IDs (e.g. if it relies on
+      // TaskContext.partitionId()). This test will verify streaming deduplication doesn't have
+      // such issue.
+
+      val (newInput1, newInput2, newUnionDf) = constructUnionDf(3)
+
+      newInput1.addData(11, 12)
+      newInput2.addData(21, 22)
+
+      testStream(newUnionDf, Append)(
+        StartStream(checkpointLocation = checkpointDir.getAbsolutePath),
+        MultiAddData(newInput1, 13, 14)(newInput2, 22, 23),
+        CheckNewAnswer(13, 14, 23)
+      )
+    }
+  }
+
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This patch adds new UTs to prevent SPARK-29438 for streaming aggregation as well as flatMapGroupsWithState, as we agree about the review comment quote here:

https://github.com/apache/spark/pull/26162#issuecomment-576929692

> LGTM for this PR. But on a additional note, this is a very subtle and easy-to-make bug with TaskContext.getPartitionId. I wonder if this bug is present in any other stateful operation. I wonder if this bug is present in any other stateful operation. Can you please verify how partitionId is used in the other stateful operations?

For now they're not broken, but even better if we have UTs to prevent the case for the future.

### Why are the changes needed?

New UTs will prevent streaming aggregation and flatMapGroupsWithState to be broken in future where it is placed on the right side of UNION and the number of partition is changing on the left side of UNION. Please refer SPARK-29438 for more details.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Added UTs.