### PR TITLE
[SPARK-28962][SQL][FOLLOW-UP] Add the parameter description for the Scala function API filter

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3456,9 +3456,11 @@ object functions {
   /**
    * Returns an array of elements for which a predicate holds in a given array.
    * {{{
+   *   df.select(filter(col("s"), x -> x % 2 === 0))
    *   df.selectExpr("filter(col, x -> x % 2 == 0)")
    * }}}
    *
+   * @param column: the input array column
    * @param f: col => predicate, the boolean predicate to filter the input column
    *
    * @group collection_funcs
@@ -3471,9 +3473,11 @@ object functions {
   /**
    * Returns an array of elements for which a predicate holds in a given array.
    * {{{
+   *   df.select(filter(col("s"), (x, i) => i % 2 === 0))
    *   df.selectExpr("filter(col, (x, i) -> i % 2 == 0)")
    * }}}
    *
+   * @param column: the input array column
    * @param f: (col, index) => predicate, the boolean predicate to filter the input column
    *           given the index. Indices start at 0.
    *

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3456,7 +3456,7 @@ object functions {
   /**
    * Returns an array of elements for which a predicate holds in a given array.
    * {{{
-   *   df.select(filter(col("s"), x -> x % 2 === 0))
+   *   df.select(filter(col("s"), x => x % 2 === 0))
    *   df.selectExpr("filter(col, x -> x % 2 == 0)")
    * }}}
    *

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3455,6 +3455,11 @@ object functions {
 
   /**
    * Returns an array of elements for which a predicate holds in a given array.
+   * {{{
+   *   df.selectExpr("filter(col, x -> x % 2 == 0)")
+   * }}}
+   *
+   * @param f: col => predicate, the boolean predicate to filter the input column
    *
    * @group collection_funcs
    * @since 3.0.0
@@ -3465,6 +3470,12 @@ object functions {
 
   /**
    * Returns an array of elements for which a predicate holds in a given array.
+   * {{{
+   *   df.selectExpr("filter(col, (x, i) -> i % 2 == 0)")
+   * }}}
+   *
+   * @param f: (col, index) => predicate, the boolean predicate to filter the input column
+   *           given the index. Indices start at 0.
    *
    * @group collection_funcs
    * @since 3.0.0


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR is a follow-up PR https://github.com/apache/spark/pull/25666 for adding the description and example for the Scala function API `filter`.

### Why are the changes needed?
It is hard to tell which parameter is the index column. 

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
N/A