### PR TITLE
[SPARK-30545][ML][PYSPARK] Impl Extremely Randomized Trees

### DIFF
--- a/docs/ml-classification-regression.md
+++ b/docs/ml-classification-regression.md
@@ -289,6 +289,41 @@ Refer to the [R API docs](api/R/spark.randomForest.html) for more details.
 
 </div>
 
+## Extremely Randomized Trees classifier
+
+Extremely Randomized Trees (ExtraTrees) are a popular classification and regression method using ensembles of randomized decision trees. 
+More information about the `spark.ml` implementation can be found further in the [section on ExtraTrees](#extremely-randomized-trees).
+
+
+**Examples**
+
+The following examples load a dataset in LibSVM format, split it into training and test sets, train on the first dataset, and then evaluate on the held-out test set.
+We use two feature transformers to prepare the data; these help index categories for the label and categorical features, adding metadata to the `DataFrame` which the tree-based algorithms can recognize.
+
+<div class="codetabs">
+<div data-lang="scala" markdown="1">
+
+Refer to the [Scala API docs](api/scala/index.html#org.apache.spark.ml.classification.ExtraTreesClassifier) for more details.
+
+{% include_example scala/org/apache/spark/examples/ml/ExtraTreesClassifierExample.scala %}
+</div>
+
+<div data-lang="java" markdown="1">
+
+Refer to the [Java API docs](api/java/org/apache/spark/ml/classification/ExtraTreesClassifier.html) for more details.
+
+{% include_example java/org/apache/spark/examples/ml/JavaExtraTreesClassifierExample.java %}
+</div>
+
+<div data-lang="python" markdown="1">
+
+Refer to the [Python API docs](api/python/pyspark.ml.html#pyspark.ml.classification.ExtraTreesClassifier) for more details.
+
+{% include_example python/ml/extra_trees_classifier_example.py %}
+</div>
+
+</div>
+
 ## Gradient-boosted tree classifier
 
 Gradient-boosted trees (GBTs) are a popular classification and regression method using ensembles of decision trees. 
@@ -838,6 +873,41 @@ Refer to the [R API docs](api/R/spark.randomForest.html) for more details.
 
 </div>
 
+## Extremely Randomized Trees regression
+
+Extremely Randomized Trees (ExtraTrees) are a popular classification and regression method using ensembles of randomized decision trees. 
+More information about the `spark.ml` implementation can be found further in the [section on ExtraTrees](#extremely-randomized-trees).
+
+
+**Examples**
+
+The following examples load a dataset in LibSVM format, split it into training and test sets, train on the first dataset, and then evaluate on the held-out test set.
+We use two feature transformers to prepare the data; these help index categories for the label and categorical features, adding metadata to the `DataFrame` which the tree-based algorithms can recognize.
+
+<div class="codetabs">
+<div data-lang="scala" markdown="1">
+
+Refer to the [Scala API docs](api/scala/index.html#org.apache.spark.ml.classification.ExtraTreesRegressor) for more details.
+
+{% include_example scala/org/apache/spark/examples/ml/ExtraTreesRegressorExample.scala %}
+</div>
+
+<div data-lang="java" markdown="1">
+
+Refer to the [Java API docs](api/java/org/apache/spark/ml/classification/ExtraTreesRegressor.html) for more details.
+
+{% include_example java/org/apache/spark/examples/ml/JavaExtraTreesRegressorExample.java %}
+</div>
+
+<div data-lang="python" markdown="1">
+
+Refer to the [Python API docs](api/python/pyspark.ml.html#pyspark.ml.classification.ExtraTreesRegressor) for more details.
+
+{% include_example python/ml/extra_trees_regressor_example.py %}
+</div>
+
+</div>
+
 ## Gradient-boosted tree regression
 
 Gradient-boosted trees (GBTs) are a popular regression method using ensembles of decision trees. 
@@ -1280,6 +1350,89 @@ The `spark.ml` implementation supports random forests for binary and multiclass 
 using both continuous and categorical features.
 
 For more information on the algorithm itself, please see the [`spark.mllib` documentation on random forests](mllib-ensembles.html#random-forests).
+
+### Inputs and Outputs
+
+We list the input and output (prediction) column types here.
+All output columns are optional; to exclude an output column, set its corresponding Param to an empty string.
+
+#### Input Columns
+
+<table class="table">
+  <thead>
+    <tr>
+      <th align="left">Param name</th>
+      <th align="left">Type(s)</th>
+      <th align="left">Default</th>
+      <th align="left">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>labelCol</td>
+      <td>Double</td>
+      <td>"label"</td>
+      <td>Label to predict</td>
+    </tr>
+    <tr>
+      <td>featuresCol</td>
+      <td>Vector</td>
+      <td>"features"</td>
+      <td>Feature vector</td>
+    </tr>
+  </tbody>
+</table>
+
+#### Output Columns (Predictions)
+
+<table class="table">
+  <thead>
+    <tr>
+      <th align="left">Param name</th>
+      <th align="left">Type(s)</th>
+      <th align="left">Default</th>
+      <th align="left">Description</th>
+      <th align="left">Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>predictionCol</td>
+      <td>Double</td>
+      <td>"prediction"</td>
+      <td>Predicted label</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>rawPredictionCol</td>
+      <td>Vector</td>
+      <td>"rawPrediction"</td>
+      <td>Vector of length # classes, with the counts of training instance labels at the tree node which makes the prediction</td>
+      <td>Classification only</td>
+    </tr>
+    <tr>
+      <td>probabilityCol</td>
+      <td>Vector</td>
+      <td>"probability"</td>
+      <td>Vector of length # classes equal to rawPrediction normalized to a multinomial distribution</td>
+      <td>Classification only</td>
+    </tr>
+  </tbody>
+</table>
+
+
+## Extremely Randomized Trees
+
+[Extremely Randomized Trees](https://en.wikipedia.org/wiki/Random_forest#ExtraTrees)
+or ExtraTrees fits a number of randomized decision trees.
+It is similar to ordinary random forests in that they are an ensemble of individual trees, however,
+randomness goes one step further in the way splits are computed. On each leaf, candidate splits are drawn at random for
+each feature and the best of these randomly-chosen splits is selected. Another main difference is that each tree is trained
+on the whole training dataset by default.
+The `spark.ml` implementation supports extremely randomized trees for binary and multiclass classification and for regression,
+using both continuous and categorical features.
+
+For more information on the algorithm itself, please see [this paper](https://orbi.uliege.be/bitstream/2268/9357/1/geurts-mlj-advance.pdf).
 
 ### Inputs and Outputs
 

--- a/examples/src/main/java/org/apache/spark/examples/ml/JavaExtraTreesClassifierExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/ml/JavaExtraTreesClassifierExample.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.examples.ml;
+
+// $example on$
+import org.apache.spark.ml.Pipeline;
+import org.apache.spark.ml.PipelineModel;
+import org.apache.spark.ml.PipelineStage;
+import org.apache.spark.ml.classification.ExtraTreesClassificationModel;
+import org.apache.spark.ml.classification.ExtraTreesClassifier;
+import org.apache.spark.ml.evaluation.MulticlassClassificationEvaluator;
+import org.apache.spark.ml.feature.*;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+// $example off$
+
+public class JavaExtraTreesClassifierExample {
+  public static void main(String[] args) {
+    SparkSession spark = SparkSession
+      .builder()
+      .appName("JavaRandomForestClassifierExample")
+      .getOrCreate();
+
+    // $example on$
+    // Load and parse the data file, converting it to a DataFrame.
+    Dataset<Row> data = spark.read().format("libsvm").load("data/mllib/sample_libsvm_data.txt");
+
+    // Index labels, adding metadata to the label column.
+    // Fit on whole dataset to include all labels in index.
+    StringIndexerModel labelIndexer = new StringIndexer()
+      .setInputCol("label")
+      .setOutputCol("indexedLabel")
+      .fit(data);
+    // Automatically identify categorical features, and index them.
+    // Set maxCategories so features with > 4 distinct values are treated as continuous.
+    VectorIndexerModel featureIndexer = new VectorIndexer()
+      .setInputCol("features")
+      .setOutputCol("indexedFeatures")
+      .setMaxCategories(4)
+      .fit(data);
+
+    // Split the data into training and test sets (30% held out for testing)
+    Dataset<Row>[] splits = data.randomSplit(new double[] {0.7, 0.3});
+    Dataset<Row> trainingData = splits[0];
+    Dataset<Row> testData = splits[1];
+
+    // Train a ExtraTrees model.
+    ExtraTreesClassifier etc = new ExtraTreesClassifier()
+      .setLabelCol("indexedLabel")
+      .setFeaturesCol("indexedFeatures");
+
+    // Convert indexed labels back to original labels.
+    IndexToString labelConverter = new IndexToString()
+      .setInputCol("prediction")
+      .setOutputCol("predictedLabel")
+      .setLabels(labelIndexer.labelsArray()[0]);
+
+    // Chain indexers and forest in a Pipeline
+    Pipeline pipeline = new Pipeline()
+      .setStages(new PipelineStage[] {labelIndexer, featureIndexer, etc, labelConverter});
+
+    // Train model. This also runs the indexers.
+    PipelineModel model = pipeline.fit(trainingData);
+
+    // Make predictions.
+    Dataset<Row> predictions = model.transform(testData);
+
+    // Select example rows to display.
+    predictions.select("predictedLabel", "label", "features").show(5);
+
+    // Select (prediction, true label) and compute test error
+    MulticlassClassificationEvaluator evaluator = new MulticlassClassificationEvaluator()
+      .setLabelCol("indexedLabel")
+      .setPredictionCol("prediction")
+      .setMetricName("accuracy");
+    double accuracy = evaluator.evaluate(predictions);
+    System.out.println("Test Error = " + (1.0 - accuracy));
+
+      ExtraTreesClassificationModel etcModel = (ExtraTreesClassificationModel)(model.stages()[2]);
+    System.out.println("Learned classification extraTrees model:\n" + etcModel.toDebugString());
+    // $example off$
+
+    spark.stop();
+  }
+}

--- a/examples/src/main/java/org/apache/spark/examples/ml/JavaExtraTreesRegressorExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/ml/JavaExtraTreesRegressorExample.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.examples.ml;
+
+// $example on$
+import org.apache.spark.ml.Pipeline;
+import org.apache.spark.ml.PipelineModel;
+import org.apache.spark.ml.PipelineStage;
+import org.apache.spark.ml.evaluation.RegressionEvaluator;
+import org.apache.spark.ml.feature.VectorIndexer;
+import org.apache.spark.ml.feature.VectorIndexerModel;
+import org.apache.spark.ml.regression.ExtraTreesRegressionModel;
+import org.apache.spark.ml.regression.ExtraTreesRegressor;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+// $example off$
+
+public class JavaExtraTreesRegressorExample {
+  public static void main(String[] args) {
+    SparkSession spark = SparkSession
+      .builder()
+      .appName("JavaRandomForestRegressorExample")
+      .getOrCreate();
+
+    // $example on$
+    // Load and parse the data file, converting it to a DataFrame.
+    Dataset<Row> data = spark.read().format("libsvm").load("data/mllib/sample_libsvm_data.txt");
+
+    // Automatically identify categorical features, and index them.
+    // Set maxCategories so features with > 4 distinct values are treated as continuous.
+    VectorIndexerModel featureIndexer = new VectorIndexer()
+      .setInputCol("features")
+      .setOutputCol("indexedFeatures")
+      .setMaxCategories(4)
+      .fit(data);
+
+    // Split the data into training and test sets (30% held out for testing)
+    Dataset<Row>[] splits = data.randomSplit(new double[] {0.7, 0.3});
+    Dataset<Row> trainingData = splits[0];
+    Dataset<Row> testData = splits[1];
+
+    // Train a RandomForest model.
+    ExtraTreesRegressor etr = new ExtraTreesRegressor()
+      .setLabelCol("label")
+      .setFeaturesCol("indexedFeatures");
+
+    // Chain indexer and forest in a Pipeline
+    Pipeline pipeline = new Pipeline()
+      .setStages(new PipelineStage[] {featureIndexer, etr});
+
+    // Train model. This also runs the indexer.
+    PipelineModel model = pipeline.fit(trainingData);
+
+    // Make predictions.
+    Dataset<Row> predictions = model.transform(testData);
+
+    // Select example rows to display.
+    predictions.select("prediction", "label", "features").show(5);
+
+    // Select (prediction, true label) and compute test error
+    RegressionEvaluator evaluator = new RegressionEvaluator()
+      .setLabelCol("label")
+      .setPredictionCol("prediction")
+      .setMetricName("rmse");
+    double rmse = evaluator.evaluate(predictions);
+    System.out.println("Root Mean Squared Error (RMSE) on test data = " + rmse);
+
+    ExtraTreesRegressionModel etrModel = (ExtraTreesRegressionModel)(model.stages()[1]);
+    System.out.println("Learned regression extraTrees model:\n" + etrModel.toDebugString());
+    // $example off$
+
+    spark.stop();
+  }
+}

--- a/examples/src/main/python/ml/extra_trees_classifier_example.py
+++ b/examples/src/main/python/ml/extra_trees_classifier_example.py
@@ -1,0 +1,82 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Extra Trees Classifier Example.
+"""
+from __future__ import print_function
+
+# $example on$
+from pyspark.ml import Pipeline
+from pyspark.ml.classification import ExtraTreesClassifier
+from pyspark.ml.feature import IndexToString, StringIndexer, VectorIndexer
+from pyspark.ml.evaluation import MulticlassClassificationEvaluator
+# $example off$
+from pyspark.sql import SparkSession
+
+if __name__ == "__main__":
+    spark = SparkSession\
+        .builder\
+        .appName("ExtraTreesClassifierExample")\
+        .getOrCreate()
+
+    # $example on$
+    # Load and parse the data file, converting it to a DataFrame.
+    data = spark.read.format("libsvm").load("data/mllib/sample_libsvm_data.txt")
+
+    # Index labels, adding metadata to the label column.
+    # Fit on whole dataset to include all labels in index.
+    labelIndexer = StringIndexer(inputCol="label", outputCol="indexedLabel").fit(data)
+
+    # Automatically identify categorical features, and index them.
+    # Set maxCategories so features with > 4 distinct values are treated as continuous.
+    featureIndexer =\
+        VectorIndexer(inputCol="features", outputCol="indexedFeatures", maxCategories=4).fit(data)
+
+    # Split the data into training and test sets (30% held out for testing)
+    (trainingData, testData) = data.randomSplit([0.7, 0.3])
+
+    # Train a ExtraTrees model.
+    etc = ExtraTreesClassifier(labelCol="indexedLabel", featuresCol="indexedFeatures", numTrees=10)
+
+    # Convert indexed labels back to original labels.
+    labelConverter = IndexToString(inputCol="prediction", outputCol="predictedLabel",
+                                   labels=labelIndexer.labels)
+
+    # Chain indexers and forest in a Pipeline
+    pipeline = Pipeline(stages=[labelIndexer, featureIndexer, etc, labelConverter])
+
+    # Train model.  This also runs the indexers.
+    model = pipeline.fit(trainingData)
+
+    # Make predictions.
+    predictions = model.transform(testData)
+
+    # Select example rows to display.
+    predictions.select("predictedLabel", "label", "features").show(5)
+
+    # Select (prediction, true label) and compute test error
+    evaluator = MulticlassClassificationEvaluator(
+        labelCol="indexedLabel", predictionCol="prediction", metricName="accuracy")
+    accuracy = evaluator.evaluate(predictions)
+    print("Test Error = %g" % (1.0 - accuracy))
+
+    etcModel = model.stages[2]
+    print(etcModel)  # summary only
+    # $example off$
+
+    spark.stop()

--- a/examples/src/main/python/ml/extra_trees_regressor_example.py
+++ b/examples/src/main/python/ml/extra_trees_regressor_example.py
@@ -1,0 +1,74 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Extra Trees Regressor Example.
+"""
+from __future__ import print_function
+
+# $example on$
+from pyspark.ml import Pipeline
+from pyspark.ml.regression import ExtraTreesRegressor
+from pyspark.ml.feature import VectorIndexer
+from pyspark.ml.evaluation import RegressionEvaluator
+# $example off$
+from pyspark.sql import SparkSession
+
+if __name__ == "__main__":
+    spark = SparkSession\
+        .builder\
+        .appName("ExtraTreesRegressorExample")\
+        .getOrCreate()
+
+    # $example on$
+    # Load and parse the data file, converting it to a DataFrame.
+    data = spark.read.format("libsvm").load("data/mllib/sample_libsvm_data.txt")
+
+    # Automatically identify categorical features, and index them.
+    # Set maxCategories so features with > 4 distinct values are treated as continuous.
+    featureIndexer =\
+        VectorIndexer(inputCol="features", outputCol="indexedFeatures", maxCategories=4).fit(data)
+
+    # Split the data into training and test sets (30% held out for testing)
+    (trainingData, testData) = data.randomSplit([0.7, 0.3])
+
+    # Train a ExtraTrees model.
+    etr = ExtraTreesRegressor(featuresCol="indexedFeatures")
+
+    # Chain indexer and forest in a Pipeline
+    pipeline = Pipeline(stages=[featureIndexer, etr])
+
+    # Train model.  This also runs the indexer.
+    model = pipeline.fit(trainingData)
+
+    # Make predictions.
+    predictions = model.transform(testData)
+
+    # Select example rows to display.
+    predictions.select("prediction", "label", "features").show(5)
+
+    # Select (prediction, true label) and compute test error
+    evaluator = RegressionEvaluator(
+        labelCol="label", predictionCol="prediction", metricName="rmse")
+    rmse = evaluator.evaluate(predictions)
+    print("Root Mean Squared Error (RMSE) on test data = %g" % rmse)
+
+    etrModel = model.stages[1]
+    print(etrModel)  # summary only
+    # $example off$
+
+    spark.stop()

--- a/examples/src/main/scala/org/apache/spark/examples/ml/ExtraTreesClassifierExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/ExtraTreesClassifierExample.scala
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// scalastyle:off println
+package org.apache.spark.examples.ml
+
+// $example on$
+import org.apache.spark.ml.Pipeline
+import org.apache.spark.ml.classification.{ExtraTreesClassificationModel, ExtraTreesClassifier}
+import org.apache.spark.ml.evaluation.MulticlassClassificationEvaluator
+import org.apache.spark.ml.feature.{IndexToString, StringIndexer, VectorIndexer}
+// $example off$
+import org.apache.spark.sql.SparkSession
+
+object ExtraTreesClassifierExample {
+  def main(args: Array[String]): Unit = {
+    val spark = SparkSession
+      .builder
+      .appName("ExtraTreesClassifierExample")
+      .getOrCreate()
+
+    // $example on$
+    // Load and parse the data file, converting it to a DataFrame.
+    val data = spark.read.format("libsvm").load("data/mllib/sample_libsvm_data.txt")
+
+    // Index labels, adding metadata to the label column.
+    // Fit on whole dataset to include all labels in index.
+    val labelIndexer = new StringIndexer()
+      .setInputCol("label")
+      .setOutputCol("indexedLabel")
+      .fit(data)
+    // Automatically identify categorical features, and index them.
+    // Set maxCategories so features with > 4 distinct values are treated as continuous.
+    val featureIndexer = new VectorIndexer()
+      .setInputCol("features")
+      .setOutputCol("indexedFeatures")
+      .setMaxCategories(4)
+      .fit(data)
+
+    // Split the data into training and test sets (30% held out for testing).
+    val Array(trainingData, testData) = data.randomSplit(Array(0.7, 0.3))
+
+    // Train a ExtraTrees model.
+    val etc = new ExtraTreesClassifier()
+      .setLabelCol("indexedLabel")
+      .setFeaturesCol("indexedFeatures")
+      .setNumTrees(10)
+
+    // Convert indexed labels back to original labels.
+    val labelConverter = new IndexToString()
+      .setInputCol("prediction")
+      .setOutputCol("predictedLabel")
+      .setLabels(labelIndexer.labelsArray(0))
+
+    // Chain indexers and forest in a Pipeline.
+    val pipeline = new Pipeline()
+      .setStages(Array(labelIndexer, featureIndexer, etc, labelConverter))
+
+    // Train model. This also runs the indexers.
+    val model = pipeline.fit(trainingData)
+
+    // Make predictions.
+    val predictions = model.transform(testData)
+
+    // Select example rows to display.
+    predictions.select("predictedLabel", "label", "features").show(5)
+
+    // Select (prediction, true label) and compute test error.
+    val evaluator = new MulticlassClassificationEvaluator()
+      .setLabelCol("indexedLabel")
+      .setPredictionCol("prediction")
+      .setMetricName("accuracy")
+    val accuracy = evaluator.evaluate(predictions)
+    println(s"Test Error = ${(1.0 - accuracy)}")
+
+    val etcModel = model.stages(2).asInstanceOf[ExtraTreesClassificationModel]
+    println(s"Learned classification extra trees model:\n ${etcModel.toDebugString}")
+    // $example off$
+
+    spark.stop()
+  }
+}
+// scalastyle:on println

--- a/examples/src/main/scala/org/apache/spark/examples/ml/ExtraTreesRegressorExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/ExtraTreesRegressorExample.scala
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// scalastyle:off println
+package org.apache.spark.examples.ml
+
+// $example on$
+import org.apache.spark.ml.Pipeline
+import org.apache.spark.ml.evaluation.RegressionEvaluator
+import org.apache.spark.ml.feature.VectorIndexer
+import org.apache.spark.ml.regression.{ExtraTreesRegressionModel, ExtraTreesRegressor}
+// $example off$
+import org.apache.spark.sql.SparkSession
+
+object ExtraTreesRegressorExample {
+  def main(args: Array[String]): Unit = {
+    val spark = SparkSession
+      .builder
+      .appName("ExtraTreesRegressorExample")
+      .getOrCreate()
+
+    // $example on$
+    // Load and parse the data file, converting it to a DataFrame.
+    val data = spark.read.format("libsvm").load("data/mllib/sample_libsvm_data.txt")
+
+    // Automatically identify categorical features, and index them.
+    // Set maxCategories so features with > 4 distinct values are treated as continuous.
+    val featureIndexer = new VectorIndexer()
+      .setInputCol("features")
+      .setOutputCol("indexedFeatures")
+      .setMaxCategories(4)
+      .fit(data)
+
+    // Split the data into training and test sets (30% held out for testing).
+    val Array(trainingData, testData) = data.randomSplit(Array(0.7, 0.3))
+
+    // Train a ExtraTrees model.
+    val etr = new ExtraTreesRegressor()
+      .setLabelCol("label")
+      .setFeaturesCol("indexedFeatures")
+
+    // Chain indexer and forest in a Pipeline.
+    val pipeline = new Pipeline()
+      .setStages(Array(featureIndexer, etr))
+
+    // Train model. This also runs the indexer.
+    val model = pipeline.fit(trainingData)
+
+    // Make predictions.
+    val predictions = model.transform(testData)
+
+    // Select example rows to display.
+    predictions.select("prediction", "label", "features").show(5)
+
+    // Select (prediction, true label) and compute test error.
+    val evaluator = new RegressionEvaluator()
+      .setLabelCol("label")
+      .setPredictionCol("prediction")
+      .setMetricName("rmse")
+    val rmse = evaluator.evaluate(predictions)
+    println(s"Root Mean Squared Error (RMSE) on test data = $rmse")
+
+    val etrModel = model.stages(1).asInstanceOf[ExtraTreesRegressionModel]
+    println(s"Learned regression extra trees model:\n ${etrModel.toDebugString}")
+    // $example off$
+
+    spark.stop()
+  }
+}
+// scalastyle:on println

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ExtraTreesClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ExtraTreesClassifier.scala
@@ -1,0 +1,374 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.classification
+
+import org.json4s.{DefaultFormats, JObject}
+import org.json4s.JsonDSL._
+
+import org.apache.spark.annotation.Since
+import org.apache.spark.ml.linalg.{DenseVector, SparseVector, Vector, Vectors}
+import org.apache.spark.ml.param.ParamMap
+import org.apache.spark.ml.tree._
+import org.apache.spark.ml.tree.{TreeClassifierParams, TreeEnsembleModel}
+import org.apache.spark.ml.tree.impl.RandomForest
+import org.apache.spark.ml.util._
+import org.apache.spark.ml.util.{Identifiable, MetadataUtils}
+import org.apache.spark.ml.util.DefaultParamsReader.Metadata
+import org.apache.spark.ml.util.Instrumentation.instrumented
+import org.apache.spark.mllib.tree.configuration.{Algo => OldAlgo}
+import org.apache.spark.sql.{DataFrame, Dataset}
+import org.apache.spark.sql.functions.{col, udf}
+import org.apache.spark.sql.types.StructType
+
+
+/**
+ * <a href="https://en.wikipedia.org/wiki/Random_forest#ExtraTrees">Extra Trees</a> learning
+ * algorithm for classification. It is an ensemble of individual
+ * <a href="https://orbi.uliege.be/bitstream/2268/9357/1/geurts-mlj-advance.pdf">extremely
+ * randomized trees</a>.
+ * It supports both binary and multiclass labels, as well as both continuous and categorical
+ * features.
+ */
+@Since("3.0.0")
+class ExtraTreesClassifier (override val uid: String)
+  extends ProbabilisticClassifier[Vector, ExtraTreesClassifier, ExtraTreesClassificationModel]
+  with ExtraTreesClassifierParams with DefaultParamsWritable {
+
+  @Since("3.0.0")
+  def this() = this(Identifiable.randomUID("etc"))
+
+  // Override parameter setters from parent trait for Java API compatibility.
+
+  // Parameters from TreeClassifierParams:
+
+  /** @group setParam */
+  @Since("3.0.0")
+  def setMaxDepth(value: Int): this.type = set(maxDepth, value)
+
+  /** @group setParam */
+  @Since("3.0.0")
+  def setMaxBins(value: Int): this.type = set(maxBins, value)
+
+  /** @group setParam */
+  @Since("3.0.0")
+  def setMinInstancesPerNode(value: Int): this.type = set(minInstancesPerNode, value)
+
+  /** @group setParam */
+  @Since("3.0.0")
+  def setMinWeightFractionPerNode(value: Double): this.type = set(minWeightFractionPerNode, value)
+
+  /** @group setParam */
+  @Since("3.0.0")
+  def setMinInfoGain(value: Double): this.type = set(minInfoGain, value)
+
+  /** @group expertSetParam */
+  @Since("3.0.0")
+  def setMaxMemoryInMB(value: Int): this.type = set(maxMemoryInMB, value)
+
+  /** @group expertSetParam */
+  @Since("3.0.0")
+  def setCacheNodeIds(value: Boolean): this.type = set(cacheNodeIds, value)
+
+  /**
+   * Specifies how often to checkpoint the cached node IDs.
+   * E.g. 10 means that the cache will get checkpointed every 10 iterations.
+   * This is only used if cacheNodeIds is true and if the checkpoint directory is set in
+   * [[org.apache.spark.SparkContext]].
+   * Must be at least 1.
+   * (default = 10)
+   * @group setParam
+   */
+  @Since("3.0.0")
+  def setCheckpointInterval(value: Int): this.type = set(checkpointInterval, value)
+
+  /** @group setParam */
+  @Since("3.0.0")
+  def setImpurity(value: String): this.type = set(impurity, value)
+
+  // Parameters from TreeEnsembleParams:
+
+  /** @group setParam */
+  @Since("3.0.0")
+  def setSeed(value: Long): this.type = set(seed, value)
+
+  // Parameters from RandomForestParams:
+
+  /** @group setParam */
+  @Since("3.0.0")
+  def setNumTrees(value: Int): this.type = set(numTrees, value)
+
+  /** @group setParam */
+  @Since("3.0.0")
+  def setBootstrap(value: Boolean): this.type = set(bootstrap, value)
+
+  /** @group setParam */
+  @Since("3.0.0")
+  def setFeatureSubsetStrategy(value: String): this.type =
+    set(featureSubsetStrategy, value)
+
+  /**
+   * Sets the value of param [[weightCol]].
+   * If this is not set or empty, we treat all instance weights as 1.0.
+   * By default the weightCol is not set, so all instances have weight 1.0.
+   *
+   * @group setParam
+   */
+  @Since("3.0.0")
+  def setWeightCol(value: String): this.type = set(weightCol, value)
+
+  // Parameters from ExtraTreesParams:
+
+  /** @group expertSetParam */
+  @Since("3.0.0")
+  def setNumRandomSplitsPerFeature(value: Int): this.type =
+    set(numRandomSplitsPerFeature, value)
+
+  override protected def train(
+      dataset: Dataset[_]): ExtraTreesClassificationModel = instrumented { instr =>
+    instr.logPipelineStage(this)
+    instr.logDataset(dataset)
+    val categoricalFeatures: Map[Int, Int] =
+      MetadataUtils.getCategoricalFeatures(dataset.schema($(featuresCol)))
+    val numClasses: Int = getNumClasses(dataset)
+
+    if (isDefined(thresholds)) {
+      require($(thresholds).length == numClasses, this.getClass.getSimpleName +
+        ".train() called with non-matching numClasses and thresholds.length." +
+        s" numClasses=$numClasses, but thresholds has length ${$(thresholds).length}")
+    }
+
+    val instances = extractInstances(dataset, numClasses)
+    val strategy =
+      super.getOldStrategy(categoricalFeatures, numClasses, OldAlgo.Classification, getOldImpurity)
+    strategy.bootstrap = $(bootstrap)
+    strategy.numRandomSplitsPerFeature = $(numRandomSplitsPerFeature)
+
+    instr.logParams(this, labelCol, featuresCol, weightCol, predictionCol, probabilityCol,
+      rawPredictionCol, leafCol, impurity, numTrees, featureSubsetStrategy, maxDepth, maxBins,
+      maxMemoryInMB, minInfoGain, minInstancesPerNode, minWeightFractionPerNode, seed,
+      subsamplingRate, thresholds, cacheNodeIds, checkpointInterval, bootstrap,
+      numRandomSplitsPerFeature)
+
+    val trees = RandomForest
+      .run(instances, strategy, getNumTrees, getFeatureSubsetStrategy, getSeed, Some(instr))
+      .map(_.asInstanceOf[DecisionTreeClassificationModel])
+    trees.foreach(copyValues(_))
+
+    val numFeatures = trees.head.numFeatures
+    instr.logNumClasses(numClasses)
+    instr.logNumFeatures(numFeatures)
+    new ExtraTreesClassificationModel(uid, trees, numFeatures, numClasses)
+  }
+
+  @Since("3.0.0")
+  override def copy(extra: ParamMap): ExtraTreesClassifier = defaultCopy(extra)
+}
+
+@Since("3.0.0")
+object ExtraTreesClassifier extends DefaultParamsReadable[ExtraTreesClassifier] {
+  /** Accessor for supported impurity settings: entropy, gini */
+  @Since("3.0.0")
+  final val supportedImpurities: Array[String] = TreeClassifierParams.supportedImpurities
+
+  /** Accessor for supported featureSubsetStrategy settings: auto, all, onethird, sqrt, log2 */
+  @Since("3.0.0")
+  final val supportedFeatureSubsetStrategies: Array[String] =
+    TreeEnsembleParams.supportedFeatureSubsetStrategies
+
+  @Since("3.0.0")
+  override def load(path: String): ExtraTreesClassifier = super.load(path)
+}
+
+/**
+ * <a href="http://en.wikipedia.org/wiki/Random_forest">Random Forest</a> model for classification.
+ * It supports both binary and multiclass labels, as well as both continuous and categorical
+ * features.
+ *
+ * @param _trees  Decision trees in the ensemble.
+ *                Warning: These have null parents.
+ */
+@Since("3.0.0")
+class ExtraTreesClassificationModel private[ml] (
+    override val uid: String,
+    private val _trees: Array[DecisionTreeClassificationModel],
+    override val numFeatures: Int,
+    override val numClasses: Int)
+  extends ProbabilisticClassificationModel[Vector, ExtraTreesClassificationModel]
+  with ExtraTreesClassifierParams with TreeEnsembleModel[DecisionTreeClassificationModel]
+  with MLWritable with Serializable {
+
+  require(_trees.nonEmpty, "ExtraTreesClassificationModel requires at least 1 tree.")
+
+  /**
+   * Construct a extra trees classification model, with all trees weighted equally.
+   *
+   * @param trees  Component trees
+   */
+  private[ml] def this(
+      trees: Array[DecisionTreeClassificationModel],
+      numFeatures: Int,
+      numClasses: Int) =
+    this(Identifiable.randomUID("etc"), trees, numFeatures, numClasses)
+
+  @Since("3.0.0")
+  override def trees: Array[DecisionTreeClassificationModel] = _trees
+
+  // Note: We may add support for weights (based on tree performance) later on.
+  private lazy val _treeWeights: Array[Double] = Array.fill[Double](_trees.length)(1.0)
+
+  @Since("3.0.0")
+  override def treeWeights: Array[Double] = _treeWeights
+
+  @Since("3.0.0")
+  override def transformSchema(schema: StructType): StructType = {
+    var outputSchema = super.transformSchema(schema)
+    if ($(leafCol).nonEmpty) {
+      outputSchema = SchemaUtils.updateField(outputSchema, getLeafField($(leafCol)))
+    }
+    outputSchema
+  }
+
+  override def transform(dataset: Dataset[_]): DataFrame = {
+    val outputSchema = transformSchema(dataset.schema, logging = true)
+
+    val outputData = super.transform(dataset)
+    if ($(leafCol).nonEmpty) {
+      val leafUDF = udf { features: Vector => predictLeaf(features) }
+      outputData.withColumn($(leafCol), leafUDF(col($(featuresCol))),
+        outputSchema($(leafCol)).metadata)
+    } else {
+      outputData
+    }
+  }
+
+  @Since("3.0.0")
+  override def predictRaw(features: Vector): Vector = {
+    // TODO: When we add a generic Bagging class, handle transform there: SPARK-7128
+    // Classifies using majority votes.
+    // Ignore the tree weights since all are 1.0 for now.
+    val votes = Array.ofDim[Double](numClasses)
+    _trees.view.foreach { tree =>
+      val classCounts = tree.rootNode.predictImpl(features).impurityStats.stats
+      val total = classCounts.sum
+      if (total != 0) {
+        var i = 0
+        while (i < numClasses) {
+          votes(i) += classCounts(i) / total
+          i += 1
+        }
+      }
+    }
+    Vectors.dense(votes)
+  }
+
+  override protected def raw2probabilityInPlace(rawPrediction: Vector): Vector = {
+    rawPrediction match {
+      case dv: DenseVector =>
+        ProbabilisticClassificationModel.normalizeToProbabilitiesInPlace(dv)
+        dv
+      case sv: SparseVector =>
+        throw new RuntimeException("Unexpected error in ExtraTreesClassificationModel:" +
+          " raw2probabilityInPlace encountered SparseVector")
+    }
+  }
+
+  @Since("3.0.0")
+  override def copy(extra: ParamMap): ExtraTreesClassificationModel = {
+    copyValues(new ExtraTreesClassificationModel(uid, _trees, numFeatures, numClasses), extra)
+      .setParent(parent)
+  }
+
+  @Since("3.0.0")
+  override def toString: String = {
+    s"ExtraTreesClassificationModel: uid=$uid, numTrees=$getNumTrees, numClasses=$numClasses, " +
+      s"numFeatures=$numFeatures"
+  }
+
+  /**
+   * Estimate of the importance of each feature.
+   *
+   * Each feature's importance is the average of its importance across all trees in the ensemble
+   * The importance vector is normalized to sum to 1. This method is suggested by Hastie et al.
+   * (Hastie, Tibshirani, Friedman. "The Elements of Statistical Learning, 2nd Edition." 2001.)
+   * and follows the implementation from scikit-learn.
+   *
+   * @see `DecisionTreeClassificationModel.featureImportances`
+   */
+  @Since("3.0.0")
+  lazy val featureImportances: Vector = TreeEnsembleModel.featureImportances(trees, numFeatures)
+
+  @Since("3.0.0")
+  override def write: MLWriter =
+    new ExtraTreesClassificationModel.ExtraTreesClassificationModelWriter(this)
+}
+
+@Since("3.0.0")
+object ExtraTreesClassificationModel extends MLReadable[ExtraTreesClassificationModel] {
+
+  @Since("3.0.0")
+  override def read: MLReader[ExtraTreesClassificationModel] =
+    new ExtraTreesClassificationModelReader
+
+  @Since("3.0.0")
+  override def load(path: String): ExtraTreesClassificationModel = super.load(path)
+
+  private[ExtraTreesClassificationModel]
+  class ExtraTreesClassificationModelWriter(instance: ExtraTreesClassificationModel)
+    extends MLWriter {
+
+    override protected def saveImpl(path: String): Unit = {
+      // Note: numTrees is not currently used, but could be nice to store for fast querying.
+      val extraMetadata: JObject = Map(
+        "numFeatures" -> instance.numFeatures,
+        "numClasses" -> instance.numClasses,
+        "numTrees" -> instance.getNumTrees)
+      EnsembleModelReadWrite.saveImpl(instance, path, sparkSession, extraMetadata)
+    }
+  }
+
+  private class ExtraTreesClassificationModelReader
+    extends MLReader[ExtraTreesClassificationModel] {
+
+    /** Checked against metadata when loading model */
+    private val className = classOf[ExtraTreesClassificationModel].getName
+    private val treeClassName = classOf[DecisionTreeClassificationModel].getName
+
+    override def load(path: String): ExtraTreesClassificationModel = {
+      implicit val format = DefaultFormats
+      val (metadata: Metadata, treesData: Array[(Metadata, Node)], _) =
+        EnsembleModelReadWrite.loadImpl(path, sparkSession, className, treeClassName)
+      val numFeatures = (metadata.metadata \ "numFeatures").extract[Int]
+      val numClasses = (metadata.metadata \ "numClasses").extract[Int]
+      val numTrees = (metadata.metadata \ "numTrees").extract[Int]
+
+      val trees: Array[DecisionTreeClassificationModel] = treesData.map {
+        case (treeMetadata, root) =>
+          val tree =
+            new DecisionTreeClassificationModel(treeMetadata.uid, root, numFeatures, numClasses)
+          treeMetadata.getAndSetParams(tree)
+          tree
+      }
+      require(numTrees == trees.length, s"ExtraTreesClassificationModel.load expected $numTrees" +
+        s" trees based on metadata but found ${trees.length} trees.")
+
+      val model = new ExtraTreesClassificationModel(metadata.uid, trees, numFeatures, numClasses)
+      metadata.getAndSetParams(model)
+      model
+    }
+  }
+}

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/ExtraTreesRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/ExtraTreesRegressor.scala
@@ -1,0 +1,347 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.regression
+
+import org.json4s.{DefaultFormats, JObject}
+import org.json4s.JsonDSL._
+
+import org.apache.spark.annotation.Since
+import org.apache.spark.ml.linalg.Vector
+import org.apache.spark.ml.param.ParamMap
+import org.apache.spark.ml.tree._
+import org.apache.spark.ml.tree.impl.RandomForest
+import org.apache.spark.ml.util._
+import org.apache.spark.ml.util.DefaultParamsReader.Metadata
+import org.apache.spark.ml.util.Instrumentation.instrumented
+import org.apache.spark.mllib.tree.configuration.{Algo => OldAlgo}
+import org.apache.spark.sql.{Column, DataFrame, Dataset}
+import org.apache.spark.sql.functions.{col, udf}
+import org.apache.spark.sql.types.StructType
+
+/**
+ * <a href="https://en.wikipedia.org/wiki/Random_forest#ExtraTrees">Extra Trees</a> learning
+ * algorithm for regression. It is an ensemble of individual
+ * <a href="https://orbi.uliege.be/bitstream/2268/9357/1/geurts-mlj-advance.pdf">extremely
+ * randomized trees</a>.
+ * It supports both binary and multiclass labels, as well as both continuous and categorical
+ * features.
+ */
+@Since("3.0.0")
+class ExtraTreesRegressor (override val uid: String)
+  extends Regressor[Vector, ExtraTreesRegressor, ExtraTreesRegressionModel]
+  with ExtraTreesRegressorParams with DefaultParamsWritable {
+
+  @Since("3.0.0")
+  def this() = this(Identifiable.randomUID("etr"))
+
+  // Override parameter setters from parent trait for Java API compatibility.
+
+  // Parameters from TreeRegressorParams:
+
+  /** @group setParam */
+  @Since("3.0.0")
+  def setMaxDepth(value: Int): this.type = set(maxDepth, value)
+
+  /** @group setParam */
+  @Since("3.0.0")
+  def setMaxBins(value: Int): this.type = set(maxBins, value)
+
+  /** @group setParam */
+  @Since("3.0.0")
+  def setMinInstancesPerNode(value: Int): this.type = set(minInstancesPerNode, value)
+
+  /** @group setParam */
+  @Since("3.0.0")
+  def setMinWeightFractionPerNode(value: Double): this.type = set(minWeightFractionPerNode, value)
+
+  /** @group setParam */
+  @Since("3.0.0")
+  def setMinInfoGain(value: Double): this.type = set(minInfoGain, value)
+
+  /** @group expertSetParam */
+  @Since("3.0.0")
+  def setMaxMemoryInMB(value: Int): this.type = set(maxMemoryInMB, value)
+
+  /** @group expertSetParam */
+  @Since("3.0.0")
+  def setCacheNodeIds(value: Boolean): this.type = set(cacheNodeIds, value)
+
+  /**
+   * Specifies how often to checkpoint the cached node IDs.
+   * E.g. 10 means that the cache will get checkpointed every 10 iterations.
+   * This is only used if cacheNodeIds is true and if the checkpoint directory is set in
+   * [[org.apache.spark.SparkContext]].
+   * Must be at least 1.
+   * (default = 10)
+   * @group setParam
+   */
+  @Since("3.0.0")
+  def setCheckpointInterval(value: Int): this.type = set(checkpointInterval, value)
+
+  /** @group setParam */
+  @Since("3.0.0")
+  def setImpurity(value: String): this.type = set(impurity, value)
+
+  // Parameters from TreeEnsembleParams:
+
+  /** @group setParam */
+  @Since("3.0.0")
+  def setSeed(value: Long): this.type = set(seed, value)
+
+  // Parameters from RandomForestParams:
+
+  /** @group setParam */
+  @Since("3.0.0")
+  def setNumTrees(value: Int): this.type = set(numTrees, value)
+
+  /** @group setParam */
+  @Since("3.0.0")
+  def setBootstrap(value: Boolean): this.type = set(bootstrap, value)
+
+  /** @group setParam */
+  @Since("3.0.0")
+  def setFeatureSubsetStrategy(value: String): this.type =
+    set(featureSubsetStrategy, value)
+
+  /**
+   * Sets the value of param [[weightCol]].
+   * If this is not set or empty, we treat all instance weights as 1.0.
+   * By default the weightCol is not set, so all instances have weight 1.0.
+   *
+   * @group setParam
+   */
+  @Since("3.0.0")
+  def setWeightCol(value: String): this.type = set(weightCol, value)
+
+  // Parameters from ExtraTreesParams:
+
+  /** @group expertSetParam */
+  @Since("3.0.0")
+  def setNumRandomSplitsPerFeature(value: Int): this.type =
+    set(numRandomSplitsPerFeature, value)
+
+  override protected def train(
+      dataset: Dataset[_]): ExtraTreesRegressionModel = instrumented { instr =>
+    val categoricalFeatures: Map[Int, Int] =
+      MetadataUtils.getCategoricalFeatures(dataset.schema($(featuresCol)))
+
+    val instances = extractInstances(dataset)
+    val strategy =
+      super.getOldStrategy(categoricalFeatures, numClasses = 0, OldAlgo.Regression, getOldImpurity)
+    strategy.bootstrap = $(bootstrap)
+    strategy.numRandomSplitsPerFeature = $(numRandomSplitsPerFeature)
+
+    instr.logPipelineStage(this)
+    instr.logDataset(instances)
+    instr.logParams(this, labelCol, featuresCol, weightCol, predictionCol, leafCol, impurity,
+      numTrees, featureSubsetStrategy, maxDepth, maxBins, maxMemoryInMB, minInfoGain,
+      minInstancesPerNode, minWeightFractionPerNode, seed, subsamplingRate, cacheNodeIds,
+      checkpointInterval, bootstrap, numRandomSplitsPerFeature)
+
+    val trees = RandomForest
+      .run(instances, strategy, getNumTrees, getFeatureSubsetStrategy, getSeed, Some(instr))
+      .map(_.asInstanceOf[DecisionTreeRegressionModel])
+    trees.foreach(copyValues(_))
+
+    val numFeatures = trees.head.numFeatures
+    instr.logNamedValue(Instrumentation.loggerTags.numFeatures, numFeatures)
+    new ExtraTreesRegressionModel(uid, trees, numFeatures)
+  }
+
+  @Since("3.0.0")
+  override def copy(extra: ParamMap): ExtraTreesRegressor = defaultCopy(extra)
+}
+
+@Since("3.0.0")
+object ExtraTreesRegressor extends DefaultParamsReadable[ExtraTreesRegressor]{
+  /** Accessor for supported impurity settings: variance */
+  @Since("3.0.0")
+  final val supportedImpurities: Array[String] = HasVarianceImpurity.supportedImpurities
+
+  /** Accessor for supported featureSubsetStrategy settings: auto, all, onethird, sqrt, log2 */
+  @Since("3.0.0")
+  final val supportedFeatureSubsetStrategies: Array[String] =
+    TreeEnsembleParams.supportedFeatureSubsetStrategies
+
+  @Since("3.0.0")
+  override def load(path: String): ExtraTreesRegressor = super.load(path)
+
+}
+
+/**
+ * <a href="https://en.wikipedia.org/wiki/Random_forest#ExtraTrees">Extra Trees</a> learning
+ * algorithm for regression. It is an ensemble of individual
+ * <a href="https://orbi.uliege.be/bitstream/2268/9357/1/geurts-mlj-advance.pdf">extremely
+ * randomized trees</a>.
+ * It supports both binary and multiclass labels, as well as both continuous and categorical
+ * features.
+ * @param _trees  Decision trees in the ensemble.
+ * @param numFeatures  Number of features used by this model
+ */
+@Since("3.0.0")
+class ExtraTreesRegressionModel private[ml] (
+    override val uid: String,
+    private val _trees: Array[DecisionTreeRegressionModel],
+    override val numFeatures: Int)
+  extends RegressionModel[Vector, ExtraTreesRegressionModel]
+  with ExtraTreesRegressorParams with TreeEnsembleModel[DecisionTreeRegressionModel]
+  with MLWritable with Serializable {
+
+  require(_trees.nonEmpty, "ExtraTreesRegressionModel requires at least 1 tree.")
+
+  /**
+   * Construct a random forest regression model, with all trees weighted equally.
+   *
+   * @param trees  Component trees
+   */
+  private[ml] def this(trees: Array[DecisionTreeRegressionModel], numFeatures: Int) =
+    this(Identifiable.randomUID("etr"), trees, numFeatures)
+
+  @Since("3.0.0")
+  override def trees: Array[DecisionTreeRegressionModel] = _trees
+
+  // Note: We may add support for weights (based on tree performance) later on.
+  private lazy val _treeWeights: Array[Double] = Array.fill[Double](_trees.length)(1.0)
+
+  @Since("3.0.0")
+  override def treeWeights: Array[Double] = _treeWeights
+
+  @Since("3.0.0")
+  override def transformSchema(schema: StructType): StructType = {
+    var outputSchema = super.transformSchema(schema)
+    if ($(leafCol).nonEmpty) {
+      outputSchema = SchemaUtils.updateField(outputSchema, getLeafField($(leafCol)))
+    }
+    outputSchema
+  }
+
+  override def transform(dataset: Dataset[_]): DataFrame = {
+    val outputSchema = transformSchema(dataset.schema, logging = true)
+
+    var predictionColNames = Seq.empty[String]
+    var predictionColumns = Seq.empty[Column]
+
+    val bcastModel = dataset.sparkSession.sparkContext.broadcast(this)
+
+    if ($(predictionCol).nonEmpty) {
+      val predictUDF = udf { features: Vector => bcastModel.value.predict(features) }
+      predictionColNames :+= $(predictionCol)
+      predictionColumns :+= predictUDF(col($(featuresCol)))
+        .as($(predictionCol), outputSchema($(predictionCol)).metadata)
+    }
+
+    if ($(leafCol).nonEmpty) {
+      val leafUDF = udf { features: Vector => bcastModel.value.predictLeaf(features) }
+      predictionColNames :+= $(leafCol)
+      predictionColumns :+= leafUDF(col($(featuresCol)))
+        .as($(leafCol), outputSchema($(leafCol)).metadata)
+    }
+
+    if (predictionColNames.nonEmpty) {
+      dataset.withColumns(predictionColNames, predictionColumns)
+    } else {
+      this.logWarning(s"$uid: ExtraTreesRegressionModel.transform() does nothing" +
+        " because no output columns were set.")
+      dataset.toDF()
+    }
+  }
+
+  override def predict(features: Vector): Double = {
+    // TODO: When we add a generic Bagging class, handle transform there.  SPARK-7128
+    // Predict average of tree predictions.
+    // Ignore the weights since all are 1.0 for now.
+    _trees.map(_.rootNode.predictImpl(features).prediction).sum / getNumTrees
+  }
+
+  @Since("3.0.0")
+  override def copy(extra: ParamMap): ExtraTreesRegressionModel = {
+    copyValues(new ExtraTreesRegressionModel(uid, _trees, numFeatures), extra).setParent(parent)
+  }
+
+  @Since("3.0.0")
+  override def toString: String = {
+    s"ExtraTreesRegressionModel: uid=$uid, numTrees=$getNumTrees, numFeatures=$numFeatures"
+  }
+
+  /**
+   * Estimate of the importance of each feature.
+   *
+   * Each feature's importance is the average of its importance across all trees in the ensemble
+   * The importance vector is normalized to sum to 1. This method is suggested by Hastie et al.
+   * (Hastie, Tibshirani, Friedman. "The Elements of Statistical Learning, 2nd Edition." 2001.)
+   * and follows the implementation from scikit-learn.
+   *
+   * @see `DecisionTreeRegressionModel.featureImportances`
+   */
+  @Since("3.0.0")
+  lazy val featureImportances: Vector = TreeEnsembleModel.featureImportances(trees, numFeatures)
+
+  @Since("3.0.0")
+  override def write: MLWriter =
+    new ExtraTreesRegressionModel.ExtraTreesRegressionModelWriter(this)
+}
+
+@Since("3.0.0")
+object ExtraTreesRegressionModel extends MLReadable[ExtraTreesRegressionModel] {
+
+  @Since("3.0.0")
+  override def read: MLReader[ExtraTreesRegressionModel] = new ExtraTreesRegressionModelReader
+
+  @Since("3.0.0")
+  override def load(path: String): ExtraTreesRegressionModel = super.load(path)
+
+  private[ExtraTreesRegressionModel]
+  class ExtraTreesRegressionModelWriter(instance: ExtraTreesRegressionModel)
+    extends MLWriter {
+
+    override protected def saveImpl(path: String): Unit = {
+      val extraMetadata: JObject = Map(
+        "numFeatures" -> instance.numFeatures,
+        "numTrees" -> instance.getNumTrees)
+      EnsembleModelReadWrite.saveImpl(instance, path, sparkSession, extraMetadata)
+    }
+  }
+
+  private class ExtraTreesRegressionModelReader extends MLReader[ExtraTreesRegressionModel] {
+
+    /** Checked against metadata when loading model */
+    private val className = classOf[ExtraTreesRegressionModel].getName
+    private val treeClassName = classOf[DecisionTreeRegressionModel].getName
+
+    override def load(path: String): ExtraTreesRegressionModel = {
+      implicit val format = DefaultFormats
+      val (metadata: Metadata, treesData: Array[(Metadata, Node)], treeWeights: Array[Double]) =
+        EnsembleModelReadWrite.loadImpl(path, sparkSession, className, treeClassName)
+      val numFeatures = (metadata.metadata \ "numFeatures").extract[Int]
+      val numTrees = (metadata.metadata \ "numTrees").extract[Int]
+
+      val trees: Array[DecisionTreeRegressionModel] = treesData.map { case (treeMetadata, root) =>
+        val tree =
+          new DecisionTreeRegressionModel(treeMetadata.uid, root, numFeatures)
+        treeMetadata.getAndSetParams(tree)
+        tree
+      }
+      require(numTrees == trees.length, s"ExtraTreesRegressionModel.load expected $numTrees" +
+        s" trees based on metadata but found ${trees.length} trees.")
+
+      val model = new ExtraTreesRegressionModel(metadata.uid, trees, numFeatures)
+      metadata.getAndSetParams(model)
+      model
+    }
+  }
+}

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
@@ -496,7 +496,7 @@ private[ml] trait ExtraTreesClassifierParams
   extends ExtraTreesParams with TreeEnsembleClassifierParams with TreeClassifierParams
 
 private[ml] trait ExtraTreesRegressorParams
-  extends ExtraTreesParams with TreeEnsembleRegressorParams with TreeClassifierParams
+  extends ExtraTreesParams with TreeEnsembleRegressorParams with TreeRegressorParams
 
 /**
  * Parameters for Gradient-Boosted Tree algorithms.

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
@@ -22,6 +22,7 @@ import java.util.Locale
 import scala.util.Try
 
 import org.apache.spark.annotation.Since
+import org.apache.spark.internal.Logging
 import org.apache.spark.ml.PredictorParams
 import org.apache.spark.ml.classification.ProbabilisticClassifierParams
 import org.apache.spark.ml.linalg.VectorUDT
@@ -333,7 +334,7 @@ private[ml] trait TreeEnsembleParams extends DecisionTreeParams {
   setDefault(subsamplingRate -> 1.0)
 
   /** @group getParam */
-  final def getSubsamplingRate: Double = $(subsamplingRate)
+  def getSubsamplingRate: Double = $(subsamplingRate)
 
   /**
    * Create a Strategy instance to use with the old API.
@@ -470,6 +471,38 @@ private[ml] trait RandomForestClassifierParams
 
 private[ml] trait RandomForestRegressorParams
   extends RandomForestParams with TreeEnsembleRegressorParams with TreeRegressorParams
+
+/**
+ * Parameters for Extra Trees algorithms.
+ */
+private[ml] trait ExtraTreesParams extends TreeEnsembleParams with Logging {
+
+  /**
+   * Number of random drawn splits for each candidate feature before finding best split.
+   * (default = 1)
+   * @group expertParam
+   */
+  final val numRandomSplitsPerFeature: IntParam =
+    new IntParam(this, "numRandomSplitsPerFeature",
+      "Number of random drawn splits for each candidate feature before finding best split",
+      ParamValidators.gtEq(1))
+
+  setDefault(numRandomSplitsPerFeature -> 1)
+
+  /** @group expertGetParam */
+  final def getNumRandomSplitsPerFeature: Int = $(numRandomSplitsPerFeature)
+
+  final override def getSubsamplingRate: Double = {
+    logWarning("ExtraTreesParams.getSubsamplingRate should NOT be used")
+    $(subsamplingRate)
+  }
+}
+
+private[ml] trait ExtraTreesClassifierParams
+  extends ExtraTreesParams with RandomForestClassifierParams
+
+private[ml] trait ExtraTreesRegressorParams
+  extends ExtraTreesParams with RandomForestRegressorParams
 
 /**
  * Parameters for Gradient-Boosted Tree algorithms.

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
@@ -22,7 +22,6 @@ import java.util.Locale
 import scala.util.Try
 
 import org.apache.spark.annotation.Since
-import org.apache.spark.internal.Logging
 import org.apache.spark.ml.PredictorParams
 import org.apache.spark.ml.classification.ProbabilisticClassifierParams
 import org.apache.spark.ml.linalg.VectorUDT
@@ -334,7 +333,7 @@ private[ml] trait TreeEnsembleParams extends DecisionTreeParams {
   setDefault(subsamplingRate -> 1.0)
 
   /** @group getParam */
-  def getSubsamplingRate: Double = $(subsamplingRate)
+  final def getSubsamplingRate: Double = $(subsamplingRate)
 
   /**
    * Create a Strategy instance to use with the old API.
@@ -433,8 +432,6 @@ private[ml] trait RandomForestParams extends TreeEnsembleParams {
 
   /**
    * Number of trees to train (at least 1).
-   * If 1, then no bootstrapping is used.  If greater than 1, then bootstrapping is done.
-   * TODO: Change to always do bootstrapping (simpler).  SPARK-7130
    * (default = 20)
    *
    * Note: The reason that we cannot add this to both GBT and RF (i.e. in TreeEnsembleParams)
@@ -475,7 +472,7 @@ private[ml] trait RandomForestRegressorParams
 /**
  * Parameters for Extra Trees algorithms.
  */
-private[ml] trait ExtraTreesParams extends TreeEnsembleParams with Logging {
+private[ml] trait ExtraTreesParams extends RandomForestParams {
 
   /**
    * Number of random drawn splits for each candidate feature before finding best split.
@@ -492,17 +489,14 @@ private[ml] trait ExtraTreesParams extends TreeEnsembleParams with Logging {
   /** @group expertGetParam */
   final def getNumRandomSplitsPerFeature: Int = $(numRandomSplitsPerFeature)
 
-  final override def getSubsamplingRate: Double = {
-    logWarning("ExtraTreesParams.getSubsamplingRate should NOT be used")
-    $(subsamplingRate)
-  }
+  setDefault(bootstrap -> false)
 }
 
 private[ml] trait ExtraTreesClassifierParams
-  extends ExtraTreesParams with RandomForestClassifierParams
+  extends ExtraTreesParams with TreeEnsembleClassifierParams with TreeClassifierParams
 
 private[ml] trait ExtraTreesRegressorParams
-  extends ExtraTreesParams with RandomForestRegressorParams
+  extends ExtraTreesParams with TreeEnsembleRegressorParams with TreeClassifierParams
 
 /**
  * Parameters for Gradient-Boosted Tree algorithms.

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/Strategy.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/Strategy.scala
@@ -82,7 +82,8 @@ class Strategy @Since("1.3.0") (
     @Since("1.2.0") @BeanProperty var useNodeIdCache: Boolean = false,
     @Since("1.2.0") @BeanProperty var checkpointInterval: Int = 10,
     @Since("3.0.0") @BeanProperty var minWeightFractionPerNode: Double = 0.0,
-    @BeanProperty private[spark] var bootstrap: Boolean = false) extends Serializable {
+    @BeanProperty private[spark] var bootstrap: Boolean = false,
+    @BeanProperty private[spark] var numRandomSplitsPerFeature: Int = -1) extends Serializable {
 
   /**
    */

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/ExtraTreesClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/ExtraTreesClassifierSuite.scala
@@ -1,0 +1,300 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.classification
+
+import org.apache.spark.ml.classification.LinearSVCSuite.generateSVMInput
+import org.apache.spark.ml.feature.LabeledPoint
+import org.apache.spark.ml.linalg.{Vector, Vectors}
+import org.apache.spark.ml.param.ParamsSuite
+import org.apache.spark.ml.tree._
+import org.apache.spark.ml.tree.impl.TreeTests
+import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTest, MLTestingUtils}
+import org.apache.spark.mllib.tree.EnsembleTestHelper
+import org.apache.spark.mllib.util.TestingUtils._
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{DataFrame, Row}
+
+/**
+ * Test suite for [[ExtraTreesClassifier]].
+ */
+
+class ExtraTreesClassifierSuite extends MLTest with DefaultReadWriteTest {
+
+  import testImplicits._
+
+  private var orderedLabeledPoints50_1000: RDD[LabeledPoint] = _
+  private var orderedLabeledPoints5_20: RDD[LabeledPoint] = _
+  private var binaryDataset: DataFrame = _
+  private val seed = 42
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    orderedLabeledPoints50_1000 =
+      sc.parallelize(EnsembleTestHelper.generateOrderedLabeledPoints(numFeatures = 50, 1000))
+        .map(_.asML)
+    orderedLabeledPoints5_20 =
+      sc.parallelize(EnsembleTestHelper.generateOrderedLabeledPoints(numFeatures = 5, 20))
+        .map(_.asML)
+    binaryDataset = generateSVMInput(0.01, Array[Double](-1.5, 1.0), 1000, seed).toDF()
+  }
+
+  test("params") {
+    ParamsSuite.checkParams(new ExtraTreesClassifier)
+    val model = new ExtraTreesClassificationModel("etc",
+      Array(new DecisionTreeClassificationModel("dtc", new LeafNode(0.0, 0.0, null), 1, 2)), 2, 2)
+    ParamsSuite.checkParams(model)
+  }
+
+  test("Binary classification with continuous features") {
+    val categoricalFeatures = Map.empty[Int, Int]
+    val df = TreeTests.setMetadata(orderedLabeledPoints50_1000,
+      categoricalFeatures, numClasses = 2)
+
+    val etc = new ExtraTreesClassifier()
+      .setImpurity("gini")
+      .setMaxDepth(5)
+      .setSeed(seed)
+    val model = etc.fit(df)
+
+    MLTestingUtils.validateClassifier(model,
+      orderedLabeledPoints50_1000.collect, 0.98)
+  }
+
+  test("Binary classification with continuous features and node Id cache") {
+    val categoricalFeatures = Map.empty[Int, Int]
+    val df = TreeTests.setMetadata(orderedLabeledPoints50_1000,
+      categoricalFeatures, numClasses = 2)
+
+    val etc = new ExtraTreesClassifier()
+      .setImpurity("gini")
+      .setMaxDepth(5)
+      .setSeed(seed)
+      .setCacheNodeIds(true)
+    val model = etc.fit(df)
+
+    MLTestingUtils.validateClassifier(model,
+      orderedLabeledPoints50_1000.collect, 0.98)
+  }
+
+  test("alternating categorical and continuous features with multiclass labels to test indexing") {
+    val arr = new Array[LabeledPoint](4)
+    arr(0) = LabeledPoint(0.0, Vectors.dense(1.0, 0.0, 0.0, 3.0, 1.0))
+    arr(1) = LabeledPoint(1.0, Vectors.dense(0.0, 1.0, 1.0, 1.0, 2.0))
+    arr(2) = LabeledPoint(0.0, Vectors.dense(2.0, 0.0, 0.0, 6.0, 3.0))
+    arr(3) = LabeledPoint(2.0, Vectors.dense(0.0, 2.0, 1.0, 3.0, 2.0))
+    val categoricalFeatures = Map(0 -> 3, 2 -> 2, 4 -> 4)
+    val df = TreeTests.setMetadata(sc.parallelize(arr), categoricalFeatures, numClasses = 3)
+
+    val etc = new ExtraTreesClassifier()
+      .setImpurity("gini")
+      .setFeatureSubsetStrategy("sqrt")
+      .setMaxDepth(5)
+      .setSeed(seed)
+    val model = etc.fit(df)
+
+    MLTestingUtils.validateClassifier(model, arr, 1.0)
+  }
+
+  test("predictRaw and predictProbability") {
+    val rdd = orderedLabeledPoints5_20
+    val categoricalFeatures = Map.empty[Int, Int]
+    val df = TreeTests.setMetadata(rdd, categoricalFeatures, numClasses = 2)
+
+    val etc = new ExtraTreesClassifier()
+      .setImpurity("Gini")
+      .setMaxDepth(3)
+      .setNumTrees(3)
+      .setSeed(seed)
+    val model = etc.fit(df)
+
+    MLTestingUtils.checkCopyAndUids(etc, model)
+
+    testTransformer[(Vector, Double, Double)](df, model, "prediction", "rawPrediction",
+      "probability") { case Row(pred: Double, rawPred: Vector, probPred: Vector) =>
+      assert(pred === rawPred.argmax,
+        s"Expected prediction $pred but calculated ${rawPred.argmax} from rawPrediction.")
+      val sum = rawPred.toArray.sum
+      assert(Vectors.dense(rawPred.toArray.map(_ / sum)) === probPred,
+        "probability prediction mismatch")
+      assert(probPred.toArray.sum ~== 1.0 relTol 1E-5)
+    }
+
+    ProbabilisticClassifierSuite.testPredictMethods[
+      Vector, ExtraTreesClassificationModel](this, model, df)
+  }
+
+  test("prediction on single instance") {
+    val rdd = orderedLabeledPoints5_20
+    val categoricalFeatures = Map.empty[Int, Int]
+    val df = TreeTests.setMetadata(rdd, categoricalFeatures, numClasses = 2)
+
+    val etc = new ExtraTreesClassifier()
+      .setImpurity("Gini")
+      .setMaxDepth(3)
+      .setNumTrees(3)
+      .setSeed(123)
+    val model = etc.fit(df)
+
+    testPredictionModelSinglePrediction(model, df)
+    testClassificationModelSingleRawPrediction(model, df)
+    testProbClassificationModelSingleProbPrediction(model, df)
+  }
+
+  test("Fitting without numClasses in metadata") {
+    val df = TreeTests.featureImportanceData(sc).toDF()
+    val etc = new ExtraTreesClassifier()
+      .setMaxDepth(1)
+      .setNumTrees(1)
+    etc.fit(df)
+  }
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Tests of feature importance
+  /////////////////////////////////////////////////////////////////////////////
+  test("Feature importance with toy data") {
+    val categoricalFeatures = Map.empty[Int, Int]
+    // In this data, feature 1 is very important.
+    val data = TreeTests.featureImportanceData(sc)
+    val df = TreeTests.setMetadata(data, categoricalFeatures, numClasses = 2)
+
+    val etc = new ExtraTreesClassifier()
+      .setImpurity("Gini")
+      .setMaxDepth(3)
+      .setNumTrees(3)
+      .setFeatureSubsetStrategy("all")
+      .setSeed(123)
+
+    val importances = etc.fit(df).featureImportances
+    val mostImportantFeature = importances.argmax
+    assert(mostImportantFeature === 1)
+    assert(importances.toArray.sum === 1.0)
+    assert(importances.toArray.forall(_ >= 0.0))
+  }
+
+  test("model support predict leaf index") {
+    val model0 = new DecisionTreeClassificationModel("dtc", TreeTests.root0, 3, 2)
+    val model1 = new DecisionTreeClassificationModel("dtc", TreeTests.root1, 3, 2)
+    val model = new ExtraTreesClassificationModel("etc", Array(model0, model1), 3, 2)
+    model.setLeafCol("predictedLeafId")
+      .setRawPredictionCol("")
+      .setPredictionCol("")
+      .setProbabilityCol("")
+
+    val data = TreeTests.getTwoTreesLeafData
+    data.foreach { case (leafId, vec) => assert(leafId === model.predictLeaf(vec)) }
+
+    val df = sc.parallelize(data, 1).toDF("leafId", "features")
+    model.transform(df).select("leafId", "predictedLeafId")
+      .collect()
+      .foreach { case Row(leafId: Vector, predictedLeafId: Vector) =>
+        assert(leafId === predictedLeafId)
+    }
+  }
+
+  test("should support all NumericType labels and not support other types") {
+    val etc = new ExtraTreesClassifier().setMaxDepth(1)
+    MLTestingUtils.checkNumericTypes[ExtraTreesClassificationModel, ExtraTreesClassifier](
+      etc, spark) { (expected, actual) =>
+        TreeTests.checkEqual(expected, actual)
+      }
+  }
+
+  test("tree params") {
+    val rdd = orderedLabeledPoints5_20
+    val categoricalFeatures = Map.empty[Int, Int]
+    val df = TreeTests.setMetadata(rdd, categoricalFeatures, numClasses = 2)
+
+    val etc = new ExtraTreesClassifier()
+      .setImpurity("entropy")
+      .setMaxDepth(3)
+      .setNumTrees(3)
+      .setSeed(123)
+    val model = etc.fit(df)
+    model.setLeafCol("predictedLeafId")
+
+    val transformed = model.transform(df)
+    checkNominalOnDF(transformed, "prediction", model.numClasses)
+    checkVectorSizeOnDF(transformed, "predictedLeafId", model.trees.length)
+    checkVectorSizeOnDF(transformed, "rawPrediction", model.numClasses)
+    checkVectorSizeOnDF(transformed, "probability", model.numClasses)
+
+    model.trees.foreach (i => {
+      assert(i.getMaxDepth === model.getMaxDepth)
+      assert(i.getSeed === model.getSeed)
+      assert(i.getImpurity === model.getImpurity)
+    })
+  }
+
+  test("training with sample weights") {
+    val df = binaryDataset
+    val numClasses = 2
+    // (numTrees, maxDepth, fractionInTol)
+    val testParams = Seq(
+      (20, 5, 0.96),
+      (20, 10, 0.96),
+      (20, 10, 0.96)
+    )
+
+    for ((numTrees, maxDepth, tol) <- testParams) {
+      val estimator = new ExtraTreesClassifier()
+        .setNumTrees(numTrees)
+        .setMaxDepth(maxDepth)
+        .setSeed(seed)
+        .setMinWeightFractionPerNode(0.049)
+
+      MLTestingUtils.testArbitrarilyScaledWeights[ExtraTreesClassificationModel,
+        ExtraTreesClassifier](df.as[LabeledPoint], estimator,
+        MLTestingUtils.modelPredictionEquals(df, _ == _, tol))
+      MLTestingUtils.testOutliersWithSmallWeights[ExtraTreesClassificationModel,
+        ExtraTreesClassifier](df.as[LabeledPoint], estimator,
+        numClasses, MLTestingUtils.modelPredictionEquals(df, _ == _, tol),
+        outlierRatio = 2)
+      MLTestingUtils.testOversamplingVsWeighting[ExtraTreesClassificationModel,
+        ExtraTreesClassifier](df.as[LabeledPoint], estimator,
+        MLTestingUtils.modelPredictionEquals(df, _ == _, tol), seed)
+    }
+  }
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Tests of model save/load
+  /////////////////////////////////////////////////////////////////////////////
+
+  test("read/write") {
+    def checkModelData(
+        model: ExtraTreesClassificationModel,
+        model2: ExtraTreesClassificationModel): Unit = {
+      TreeTests.checkEqual(model, model2)
+      assert(model.numFeatures === model2.numFeatures)
+      assert(model.numClasses === model2.numClasses)
+    }
+
+    val rdd = TreeTests.getTreeReadWriteData(sc)
+    val categoricalFeatures = Map.empty[Int, Int]
+    val numClasses = 2
+    val continuousData = TreeTests.setMetadata(rdd, categoricalFeatures, numClasses)
+
+    val allParamSettings = TreeTests.allParamSettings ++ Map("impurity" -> "entropy")
+
+    val etc = new ExtraTreesClassifier()
+      .setNumTrees(2)
+
+    testEstimatorAndModelReadWrite(etc, continuousData, allParamSettings,
+      allParamSettings, checkModelData)
+  }
+}
+

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/ExtraTreesClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/ExtraTreesClassifierSuite.scala
@@ -85,6 +85,7 @@ class ExtraTreesClassifierSuite extends MLTest with DefaultReadWriteTest {
       .setMaxDepth(5)
       .setSeed(seed)
       .setCacheNodeIds(true)
+    assert(!etc.getBootstrap)
     val model = etc.fit(df)
 
     MLTestingUtils.validateClassifier(model,

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/ExtraTreesRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/ExtraTreesRegressorSuite.scala
@@ -65,6 +65,7 @@ class ExtraTreesRegressorSuite extends MLTest with DefaultReadWriteTest{
       .setMaxBins(10)
       .setNumTrees(3)
       .setSeed(seed)
+    assert(!etr.getBootstrap)
 
     val df = orderedLabeledPoints50_1000.toDF()
     val model = etr.fit(df)

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/ExtraTreesRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/ExtraTreesRegressorSuite.scala
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.regression
+
+import org.apache.spark.ml.feature.LabeledPoint
+import org.apache.spark.ml.linalg.{Vector, Vectors}
+import org.apache.spark.ml.param.ParamsSuite
+import org.apache.spark.ml.tree._
+import org.apache.spark.ml.tree.impl.TreeTests
+import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTest, MLTestingUtils}
+import org.apache.spark.ml.util.TestingUtils._
+import org.apache.spark.mllib.tree.EnsembleTestHelper
+import org.apache.spark.mllib.util.LinearDataGenerator
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{DataFrame, Row}
+
+/**
+ * Test suite for [[ExtraTreesRegressor]].
+ */
+class ExtraTreesRegressorSuite extends MLTest with DefaultReadWriteTest{
+
+  import testImplicits._
+
+  private var orderedLabeledPoints50_1000: RDD[LabeledPoint] = _
+  private var linearRegressionData: DataFrame = _
+  private val seed = 42
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    orderedLabeledPoints50_1000 =
+      sc.parallelize(EnsembleTestHelper.generateOrderedLabeledPoints(numFeatures = 50, 1000)
+        .map(_.asML))
+
+    linearRegressionData = sc.parallelize(LinearDataGenerator.generateLinearInput(
+      intercept = 6.3, weights = Array(4.7, 7.2), xMean = Array(0.9, -1.3),
+      xVariance = Array(0.7, 1.2), nPoints = 1000, seed, eps = 0.5), 2).map(_.asML).toDF()
+  }
+
+  test("params") {
+    ParamsSuite.checkParams(new ExtraTreesRegressor)
+    val model = new ExtraTreesRegressionModel("etr",
+      Array(new DecisionTreeRegressionModel("dtr", new LeafNode(0.0, 0.0, null), 1)), 2)
+    ParamsSuite.checkParams(model)
+  }
+
+  test("tree params") {
+    val etr = new ExtraTreesRegressor()
+      .setImpurity("variance")
+      .setMaxDepth(2)
+      .setMaxBins(10)
+      .setNumTrees(3)
+      .setSeed(seed)
+
+    val df = orderedLabeledPoints50_1000.toDF()
+    val model = etr.fit(df)
+
+    model.trees.foreach (i => {
+      assert(i.getMaxDepth === model.getMaxDepth)
+      assert(i.getSeed === model.getSeed)
+      assert(i.getImpurity === model.getImpurity)
+      assert(i.getMaxBins === model.getMaxBins)
+    })
+  }
+
+  test("Regression with continuous features") {
+    val categoricalFeatures = Map.empty[Int, Int]
+    val df = TreeTests.setMetadata(orderedLabeledPoints50_1000,
+      categoricalFeatures, numClasses = 0)
+
+    val etr = new ExtraTreesRegressor()
+      .setMaxDepth(8)
+      .setSeed(seed)
+    val model = etr.fit(df)
+
+    MLTestingUtils.validateRegressor(model,
+      orderedLabeledPoints50_1000.collect, 0.013, "mse")
+  }
+
+  test("Regression with continuous features and node Id cache") {
+    val categoricalFeatures = Map.empty[Int, Int]
+    val df = TreeTests.setMetadata(orderedLabeledPoints50_1000,
+      categoricalFeatures, numClasses = 0)
+
+    val etr = new ExtraTreesRegressor()
+      .setMaxDepth(8)
+      .setSeed(seed)
+      .setCacheNodeIds(true)
+    val model = etr.fit(df)
+
+    MLTestingUtils.validateRegressor(model,
+      orderedLabeledPoints50_1000.collect, 0.013, "mse")
+  }
+
+  test("alternating categorical and continuous features with multiclass labels to test indexing") {
+    val arr = new Array[LabeledPoint](4)
+    arr(0) = LabeledPoint(0.0, Vectors.dense(1.0, 0.0, 0.0, 3.0, 1.0))
+    arr(1) = LabeledPoint(1.0, Vectors.dense(0.0, 1.0, 1.0, 1.0, 2.0))
+    arr(2) = LabeledPoint(0.0, Vectors.dense(2.0, 0.0, 0.0, 6.0, 3.0))
+    arr(3) = LabeledPoint(2.0, Vectors.dense(0.0, 2.0, 1.0, 3.0, 2.0))
+    val categoricalFeatures = Map(0 -> 3, 2 -> 2, 4 -> 4)
+    val df = TreeTests.setMetadata(sc.parallelize(arr), categoricalFeatures, numClasses = 0)
+
+    val etc = new ExtraTreesRegressor()
+      .setFeatureSubsetStrategy("sqrt")
+      .setMaxDepth(7)
+    val model = etc.fit(df)
+
+    MLTestingUtils.validateRegressor(model, arr, 0.08, "mse")
+  }
+
+  test("prediction on single instance") {
+    val df = orderedLabeledPoints50_1000.toDF()
+
+    val etr = new ExtraTreesRegressor()
+      .setImpurity("variance")
+      .setMaxDepth(2)
+      .setMaxBins(10)
+      .setNumTrees(1)
+      .setFeatureSubsetStrategy("auto")
+      .setSeed(123)
+    val model = etr.fit(df)
+    testPredictionModelSinglePrediction(model, df)
+  }
+
+  test("Feature importance with toy data") {
+    // In this data, feature 1 is very important.
+    val data = TreeTests.featureImportanceData(sc)
+    val categoricalFeatures = Map.empty[Int, Int]
+    val df = TreeTests.setMetadata(data, categoricalFeatures, 0)
+
+    val etr = new ExtraTreesRegressor()
+      .setImpurity("variance")
+      .setMaxDepth(3)
+      .setNumTrees(3)
+      .setFeatureSubsetStrategy("all")
+      .setSeed(123)
+    val model = etr.fit(df)
+
+    MLTestingUtils.checkCopyAndUids(etr, model)
+
+    val importances = model.featureImportances
+    val mostImportantFeature = importances.argmax
+    assert(mostImportantFeature === 1)
+    assert(importances.toArray.sum === 1.0)
+    assert(importances.toArray.forall(_ >= 0.0))
+  }
+
+  test("model support predict leaf index") {
+    val model0 = new DecisionTreeRegressionModel("dtr", TreeTests.root0, 3)
+    val model1 = new DecisionTreeRegressionModel("dtr", TreeTests.root1, 3)
+    val model = new ExtraTreesRegressionModel("etr", Array(model0, model1), 3)
+    model.setLeafCol("predictedLeafId")
+      .setPredictionCol("")
+
+    val data = TreeTests.getTwoTreesLeafData
+    data.foreach { case (leafId, vec) => assert(leafId === model.predictLeaf(vec)) }
+
+    val df = sc.parallelize(data, 1).toDF("leafId", "features")
+    model.transform(df).select("leafId", "predictedLeafId")
+      .collect()
+      .foreach { case Row(leafId: Vector, predictedLeafId: Vector) =>
+        assert(leafId === predictedLeafId)
+    }
+  }
+
+  test("should support all NumericType labels and not support other types") {
+    val etr = new ExtraTreesRegressor()
+      .setMaxDepth(1)
+
+    MLTestingUtils.checkNumericTypes[ExtraTreesRegressionModel, ExtraTreesRegressor](
+      etr, spark, isClassification = false) { (expected, actual) =>
+        TreeTests.checkEqual(expected, actual)
+      }
+  }
+
+  test("training with sample weights") {
+    val df = linearRegressionData
+    val numClasses = 0
+    // (numTrees, maxDepth, fractionInTol)
+    val testParams = Seq(
+      (50, 5, 0.75),
+      (50, 10, 0.75),
+      (50, 10, 0.78)
+    )
+
+    for ((numTrees, maxDepth, tol) <- testParams) {
+      val estimator = new ExtraTreesRegressor()
+        .setNumTrees(numTrees)
+        .setMaxDepth(maxDepth)
+        .setSeed(seed)
+        .setMinWeightFractionPerNode(0.05)
+
+      MLTestingUtils.testArbitrarilyScaledWeights[ExtraTreesRegressionModel,
+        ExtraTreesRegressor](df.as[LabeledPoint], estimator,
+        MLTestingUtils.modelPredictionEquals(df, _ ~= _ relTol 0.2, tol))
+      MLTestingUtils.testOutliersWithSmallWeights[ExtraTreesRegressionModel,
+        ExtraTreesRegressor](df.as[LabeledPoint], estimator,
+        numClasses, MLTestingUtils.modelPredictionEquals(df, _ ~= _ relTol 0.2, tol),
+        outlierRatio = 2)
+      MLTestingUtils.testOversamplingVsWeighting[ExtraTreesRegressionModel,
+        ExtraTreesRegressor](df.as[LabeledPoint], estimator,
+        MLTestingUtils.modelPredictionEquals(df, _ ~= _ relTol 0.2, tol), seed)
+    }
+  }
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Tests of model save/load
+  /////////////////////////////////////////////////////////////////////////////
+
+  test("read/write") {
+    def checkModelData(
+        model: ExtraTreesRegressionModel,
+        model2: ExtraTreesRegressionModel): Unit = {
+      TreeTests.checkEqual(model, model2)
+      assert(model.numFeatures === model2.numFeatures)
+    }
+
+    val etr = new ExtraTreesRegressor().setNumTrees(2)
+    val rdd = TreeTests.getTreeReadWriteData(sc)
+
+    val allParamSettings = TreeTests.allParamSettings ++ Map("impurity" -> "variance")
+
+    val continuousData =
+      TreeTests.setMetadata(rdd, Map.empty[Int, Int], numClasses = 0)
+    testEstimatorAndModelReadWrite(etr, continuousData, allParamSettings,
+      allParamSettings, checkModelData)
+  }
+}

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
@@ -351,7 +351,7 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
     ))
     val nodeStack = new mutable.ListBuffer[(Int, LearningNode)]
     RandomForest.findBestSplits(baggedInput, metadata, Map(0 -> topNode),
-      nodesForGroup, treeToNodeToIndexInfo, bcSplits, nodeStack)
+      nodesForGroup, treeToNodeToIndexInfo, bcSplits, nodeStack, strategy)
     bcSplits.destroy()
 
     // don't enqueue leaf nodes into node queue
@@ -395,7 +395,7 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
     ))
     val nodeStack = new mutable.ListBuffer[(Int, LearningNode)]
     RandomForest.findBestSplits(baggedInput, metadata, Map(0 -> topNode),
-      nodesForGroup, treeToNodeToIndexInfo, bcSplits, nodeStack)
+      nodesForGroup, treeToNodeToIndexInfo, bcSplits, nodeStack, strategy)
     bcSplits.destroy()
 
     // don't enqueue a node into node queue if its impurity is 0.0

--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -1390,6 +1390,8 @@ class RandomForestClassifier(JavaProbabilisticClassifier, _RandomForestClassifie
     ...     leafCol="leafId")
     >>> rf.getMinWeightFractionPerNode()
     0.0
+    >>> rf.getBootstrap()
+    True
     >>> model = rf.fit(td)
     >>> model.getLabelCol()
     'indexed'
@@ -1619,16 +1621,11 @@ class RandomForestClassificationModel(_TreeEnsembleModel, JavaProbabilisticClass
 
 
 @inherit_doc
-class _ExtraTreesClassifierParams(_RandomForestClassifierParams, _ExtraTreesParams):
+class _ExtraTreesClassifierParams(_ExtraTreesParams, _TreeClassifierParams):
     """
     Params for :py:class:`ExtraTreesClassifier` and :py:class:`ExtraTreesClassificationModel`.
     """
-    def getSubsamplingRate(self):
-        """
-        Gets the value of subsamplingRate or its default value.
-        """
-        warnings.warn("ExtraTreesParams.getSubsamplingRate should NOT be used")
-        return self.getOrDefault(self.subsamplingRate)
+    pass
 
 
 @inherit_doc
@@ -1654,6 +1651,8 @@ class ExtraTreesClassifier(JavaProbabilisticClassifier, _ExtraTreesClassifierPar
     ...     leafCol="leafId")
     >>> etc.getMinWeightFractionPerNode()
     0.0
+    >>> etc.getBootstrap()
+    False
     >>> model = etc.fit(td)
     >>> model.getLabelCol()
     'indexed'
@@ -1703,49 +1702,49 @@ class ExtraTreesClassifier(JavaProbabilisticClassifier, _ExtraTreesClassifierPar
     """
 
     @keyword_only
-    def __init__(self, featuresCol="features", labelCol="label", predictionCol="prediction",
-                 probabilityCol="probability", rawPredictionCol="rawPrediction",
-                 maxDepth=5, maxBins=32, minInstancesPerNode=1, minInfoGain=0.0,
-                 maxMemoryInMB=256, cacheNodeIds=False, checkpointInterval=10, impurity="gini",
-                 numTrees=20, featureSubsetStrategy="auto", seed=None, leafCol="",
-                 minWeightFractionPerNode=0.0, weightCol=None, numRandomSplitsPerFeature=1,
-                 subsamplingRate=1.0):
+    def __init__(self, featuresCol="features", weightCol=None, labelCol="label",
+                 predictionCol="prediction", probabilityCol="probability",
+                 rawPredictionCol="rawPrediction", leafCol="", numTrees=20, bootstrap=False,
+                 subsamplingRate=1.0, maxDepth=5, maxBins=32, minInfoGain=0.0,
+                 featureSubsetStrategy="auto", impurity="gini", minInstancesPerNode=1,
+                 minWeightFractionPerNode=0.0, numRandomSplitsPerFeature=1, maxMemoryInMB=256,
+                 cacheNodeIds=False, checkpointInterval=10, seed=None):
         """
-        __init__(self, featuresCol="features", labelCol="label", predictionCol="prediction", \
-                 probabilityCol="probability", rawPredictionCol="rawPrediction", \
-                 maxDepth=5, maxBins=32, minInstancesPerNode=1, minInfoGain=0.0, \
-                 maxMemoryInMB=256, cacheNodeIds=False, checkpointInterval=10, impurity="gini", \
-                 numTrees=20, featureSubsetStrategy="auto", seed=None, leafCol="", \
-                 minWeightFractionPerNode=0.0, weightCol=None, numRandomSplitsPerFeature=1, \
-                 subsamplingRate=1.0)
+        __init__(self, featuresCol="features", weightCol=None, labelCol="label", \
+                 predictionCol="prediction", probabilityCol="probability", \
+                 rawPredictionCol="rawPrediction", leafCol="", numTrees=20, \
+                 subsamplingRate=1.0, maxDepth=5, maxBins=32, minInfoGain=0.0, \
+                 featureSubsetStrategy="auto", impurity="gini", minInstancesPerNode=1, \
+                 minWeightFractionPerNode=0.0, numRandomSplitsPerFeature=1, maxMemoryInMB=256, \
+                 cacheNodeIds=False, checkpointInterval=10, seed=None)
         """
         super(ExtraTreesClassifier, self).__init__()
         self._java_obj = self._new_java_obj(
             "org.apache.spark.ml.classification.ExtraTreesClassifier", self.uid)
-        self._setDefault(maxDepth=5, maxBins=32, minInstancesPerNode=1, minInfoGain=0.0,
-                         maxMemoryInMB=256, cacheNodeIds=False, checkpointInterval=10,
-                         impurity="gini", numTrees=20, featureSubsetStrategy="auto",
-                         leafCol="", minWeightFractionPerNode=0.0, numRandomSplitsPerFeature=1,
-                         subsamplingRate=1.0)
+        self._setDefault(leafCol="", numTrees=20, bootstrap=False, subsamplingRate=1.0,
+                         maxDepth=5, maxBins=32, minInfoGain=0.0, featureSubsetStrategy="auto",
+                         impurity="gini", minInstancesPerNode=1, minWeightFractionPerNode=0.0,
+                         numRandomSplitsPerFeature=1, maxMemoryInMB=256, cacheNodeIds=False,
+                         checkpointInterval=10)
         kwargs = self._input_kwargs
         self.setParams(**kwargs)
 
     @keyword_only
-    def setParams(self, featuresCol="features", labelCol="label", predictionCol="prediction",
-                  probabilityCol="probability", rawPredictionCol="rawPrediction",
-                  maxDepth=5, maxBins=32, minInstancesPerNode=1, minInfoGain=0.0,
-                  maxMemoryInMB=256, cacheNodeIds=False, checkpointInterval=10, seed=None,
-                  impurity="gini", numTrees=20, featureSubsetStrategy="auto", leafCol="",
-                  minWeightFractionPerNode=0.0, weightCol=None, numRandomSplitsPerFeature=1,
-                  subsamplingRate=1.0):
+    def setParams(self, featuresCol="features", weightCol=None, labelCol="label",
+                  predictionCol="prediction", probabilityCol="probability",
+                  rawPredictionCol="rawPrediction", leafCol="", numTrees=20, bootstrap=False,
+                  subsamplingRate=1.0, maxDepth=5, maxBins=32, minInfoGain=0.0,
+                  featureSubsetStrategy="auto", impurity="gini", minInstancesPerNode=1,
+                  minWeightFractionPerNode=0.0, numRandomSplitsPerFeature=1, maxMemoryInMB=256,
+                  cacheNodeIds=False, checkpointInterval=10, seed=None):
         """
-        setParams(self, featuresCol="features", labelCol="label", predictionCol="prediction", \
-                 probabilityCol="probability", rawPredictionCol="rawPrediction", \
-                  maxDepth=5, maxBins=32, minInstancesPerNode=1, minInfoGain=0.0, \
-                  maxMemoryInMB=256, cacheNodeIds=False, checkpointInterval=10, seed=None, \
-                  impurity="gini", numTrees=20, featureSubsetStrategy="auto", leafCol="", \
-                  minWeightFractionPerNode=0.0, weightCol=None, numRandomSplitsPerFeature=1, \
-                  subsamplingRate=1.0)
+        setParams(self, featuresCol="features", weightCol=None, labelCol="label", \
+                 predictionCol="prediction", probabilityCol="probability", \
+                 rawPredictionCol="rawPrediction", leafCol="", numTrees=20, \
+                 subsamplingRate=1.0, maxDepth=5, maxBins=32, minInfoGain=0.0, \
+                 featureSubsetStrategy="auto", impurity="gini", minInstancesPerNode=1, \
+                 minWeightFractionPerNode=0.0, numRandomSplitsPerFeature=1, maxMemoryInMB=256, \
+                 cacheNodeIds=False, checkpointInterval=10, seed=None)
         Sets params for linear classification.
         """
         kwargs = self._input_kwargs
@@ -1807,6 +1806,12 @@ class ExtraTreesClassifier(JavaProbabilisticClassifier, _ExtraTreesClassifierPar
         Sets the value of :py:attr:`bootstrap`.
         """
         return self._set(bootstrap=value)
+
+    def setSubsamplingRate(self, value):
+        """
+        Sets the value of :py:attr:`subsamplingRate`.
+        """
+        return self._set(subsamplingRate=value)
 
     def setFeatureSubsetStrategy(self, value):
         """

--- a/python/pyspark/ml/regression.py
+++ b/python/pyspark/ml/regression.py
@@ -1037,6 +1037,8 @@ class RandomForestRegressor(JavaRegressor, _RandomForestRegressorParams, JavaMLW
     >>> rf = RandomForestRegressor(numTrees=2, maxDepth=2)
     >>> rf.getMinWeightFractionPerNode()
     0.0
+    >>> rf.getBootstrap()
+    True
     >>> rf.setSeed(42)
     RandomForestRegressor...
     >>> model = rf.fit(df)
@@ -1268,12 +1270,7 @@ class _ExtraTreesRegressorParamsParams(_RandomForestRegressorParams, _ExtraTrees
 
     .. versionadded:: 3.0.0
     """
-    def getSubsamplingRate(self):
-        """
-        Gets the value of subsamplingRate or its default value.
-        """
-        warnings.warn("ExtraTreesParams.getSubsamplingRate should NOT be used")
-        return self.getOrDefault(self.subsamplingRate)
+    pass
 
 
 @inherit_doc
@@ -1294,6 +1291,8 @@ class ExtraTreesRegressor(JavaPredictor, _ExtraTreesRegressorParamsParams, JavaM
     0.0
     >>> etr.setSeed(42)
     ExtraTreesRegressor...
+    >>> etr.getBootstrap()
+    False
     >>> model = etr.fit(df)
     >>> model.getSeed()
     42
@@ -1337,46 +1336,46 @@ class ExtraTreesRegressor(JavaPredictor, _ExtraTreesRegressorParamsParams, JavaM
     """
 
     @keyword_only
-    def __init__(self, featuresCol="features", labelCol="label", predictionCol="prediction",
-                 maxDepth=5, maxBins=32, minInstancesPerNode=1, minInfoGain=0.0,
-                 maxMemoryInMB=256, cacheNodeIds=False, checkpointInterval=10,
-                 impurity="variance", seed=None, numTrees=20, featureSubsetStrategy="auto",
-                 leafCol="", minWeightFractionPerNode=0.0, weightCol=None,
-                 numRandomSplitsPerFeature=1, subsamplingRate=1.0):
+    def __init__(self, featuresCol="features", weightCol=None, labelCol="label",
+                 leafCol="", numTrees=20, bootstrap=False, subsamplingRate=1.0,
+                 maxDepth=5, maxBins=32, minInfoGain=0.0, featureSubsetStrategy="auto",
+                 impurity="variance", minInstancesPerNode=1, minWeightFractionPerNode=0.0,
+                 numRandomSplitsPerFeature=1, maxMemoryInMB=256, cacheNodeIds=False,
+                 checkpointInterval=10, seed=None):
         """
-        __init__(self, featuresCol="features", labelCol="label", predictionCol="prediction", \
-                 maxDepth=5, maxBins=32, minInstancesPerNode=1, minInfoGain=0.0, \
-                 maxMemoryInMB=256, cacheNodeIds=False, checkpointInterval=10, \
-                 impurity="variance", seed=None, numTrees=20, featureSubsetStrategy="auto", \
-                 leafCol=", minWeightFractionPerNode=0.0", weightCol=None, \
-                 numRandomSplitsPerFeature=1, subsamplingRate=1.0)
+        __init__(self, featuresCol="features", weightCol=None, labelCol="label", \
+                 leafCol="", numTrees=20, bootstrap=False, subsamplingRate=1.0, \
+                 maxDepth=5, maxBins=32, minInfoGain=0.0, featureSubsetStrategy="auto", \
+                 impurity="variance", minInstancesPerNode=1, minWeightFractionPerNode=0.0, \
+                 numRandomSplitsPerFeature=1, maxMemoryInMB=256, cacheNodeIds=False, \
+                 checkpointInterval=10, seed=None)
         """
         super(ExtraTreesRegressor, self).__init__()
         self._java_obj = self._new_java_obj(
             "org.apache.spark.ml.regression.ExtraTreesRegressor", self.uid)
-        self._setDefault(maxDepth=5, maxBins=32, minInstancesPerNode=1, minInfoGain=0.0,
-                         maxMemoryInMB=256, cacheNodeIds=False, checkpointInterval=10,
-                         impurity="variance", numTrees=20, featureSubsetStrategy="auto",
-                         leafCol="", minWeightFractionPerNode=0.0, numRandomSplitsPerFeature=1,
-                         subsamplingRate=1.0)
+        self._setDefault(leafCol="", numTrees=20, bootstrap=False, subsamplingRate=1.0,
+                         maxDepth=5, maxBins=32, minInfoGain=0.0, featureSubsetStrategy="auto",
+                         impurity="variance", minInstancesPerNode=1, minWeightFractionPerNode=0.0,
+                         numRandomSplitsPerFeature=1, maxMemoryInMB=256, cacheNodeIds=False,
+                         checkpointInterval=10, seed=None)
         kwargs = self._input_kwargs
         self.setParams(**kwargs)
 
     @keyword_only
     @since("1.4.0")
-    def setParams(self, featuresCol="features", labelCol="label", predictionCol="prediction",
-                  maxDepth=5, maxBins=32, minInstancesPerNode=1, minInfoGain=0.0,
-                  maxMemoryInMB=256, cacheNodeIds=False, checkpointInterval=10,
-                  impurity="variance", seed=None, numTrees=20, featureSubsetStrategy="auto",
-                  leafCol="", minWeightFractionPerNode=0.0, weightCol=None,
-                  numRandomSplitsPerFeature=1, subsamplingRate=1.0):
+    def setParams(self, featuresCol="features", weightCol=None, labelCol="label",
+                  leafCol="", numTrees=20, bootstrap=False, subsamplingRate=1.0,
+                  maxDepth=5, maxBins=32, minInfoGain=0.0, featureSubsetStrategy="auto",
+                  impurity="variance", minInstancesPerNode=1, minWeightFractionPerNode=0.0,
+                  numRandomSplitsPerFeature=1, maxMemoryInMB=256, cacheNodeIds=False,
+                  checkpointInterval=10, seed=None):
         """
-        setParams(self, featuresCol="features", labelCol="label", predictionCol="prediction", \
-                  maxDepth=5, maxBins=32, minInstancesPerNode=1, minInfoGain=0.0, \
-                  maxMemoryInMB=256, cacheNodeIds=False, checkpointInterval=10, \
-                  impurity="variance", seed=None, numTrees=20, featureSubsetStrategy="auto", \
-                  leafCol="", minWeightFractionPerNode=0.0, weightCol=None, \
-                  numRandomSplitsPerFeature=1, subsamplingRate=1.0)
+        setParams(self, featuresCol="features", weightCol=None, labelCol="label", \
+                 leafCol="", numTrees=20, bootstrap=False, subsamplingRate=1.0, \
+                 maxDepth=5, maxBins=32, minInfoGain=0.0, featureSubsetStrategy="auto", \
+                 impurity="variance", minInstancesPerNode=1, minWeightFractionPerNode=0.0, \
+                 numRandomSplitsPerFeature=1, maxMemoryInMB=256, cacheNodeIds=False, \
+                 checkpointInterval=10, seed=None)
         Sets params for linear regression.
         """
         kwargs = self._input_kwargs
@@ -1438,6 +1437,12 @@ class ExtraTreesRegressor(JavaPredictor, _ExtraTreesRegressorParamsParams, JavaM
         Sets the value of :py:attr:`bootstrap`.
         """
         return self._set(bootstrap=value)
+
+    def setSubsamplingRate(self, value):
+        """
+        Sets the value of :py:attr:`subsamplingRate`.
+        """
+        return self._set(subsamplingRate=value)
 
     def setFeatureSubsetStrategy(self, value):
         """

--- a/python/pyspark/ml/tree.py
+++ b/python/pyspark/ml/tree.py
@@ -355,7 +355,7 @@ class _TreeRegressorParams(_HasVarianceImpurity):
     pass
 
 
-class _ExtraTreesParams(Params):
+class _ExtraTreesParams(_RandomForestParams):
     """
     Private class to track supported Extra Trees algorithms.
 

--- a/python/pyspark/ml/tree.py
+++ b/python/pyspark/ml/tree.py
@@ -353,3 +353,26 @@ class _TreeRegressorParams(_HasVarianceImpurity):
     Private class to track supported impurity measures.
     """
     pass
+
+
+class _ExtraTreesParams(Params):
+    """
+    Private class to track supported Extra Trees algorithms.
+
+    .. versionadded:: 3.0.0
+    """
+
+    numRandomSplitsPerFeature = Param(Params._dummy(), "numRandomSplitsPerFeature",
+                                      "Number of random drawn splits for each candidate feature " +
+                                      "before finding best split (>=1).",
+                                      typeConverter=TypeConverters.toInt)
+
+    def __init__(self):
+        super(_ExtraTreesParams, self).__init__()
+
+    @since("3.0.0")
+    def getNumRandomSplitsPerFeature(self):
+        """
+        Gets the value of numRandomSplitsPerFeature or its default value.
+        """
+        return self.getOrDefault(self.numRandomSplitsPerFeature)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Impl ExtraTrees in ML,
the impl is quite similar to RandomForest, two main difference:
1, bootstrap sampling is disabled by default;
2, on each leaf, candidate splits (only one split per feature in Scikit-Learn's impl, refering to [`RandomSplitter`](https://github.com/scikit-learn/scikit-learn/blob/99d3d34d615a7d7b541b24d264b1108238c1953e/sklearn/tree/_splitter.pyx#L591) ) are drawn at random for each feature, and then the best of these randomly-chosen splits is selected. In this PR, I add an expert param `numRandomSplitsPerFeature` to control the number of random splits drawn in each feature.


### Why are the changes needed?
1, Extremely Randomized Trees or ExtraTrees is widely used and impled in Scikit-Learn and OpenCV;

2, ExtraTrees is quite similar to RandomForest, and the main difference lie in that,on each leaf, candidate splits (only one split in Scikit-Learn's impl) are drawn at random for each feature and the best of these randomly-chosen splits is selected.

### Does this PR introduce any user-facing change?
Yes


### How was this patch tested?
added testsuites
