### PR TITLE
[WIP][SPARK-30621][SQL] Dynamic Pruning thread propagates the localProperties to executionContext

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -156,6 +156,14 @@ object StaticSQLConf {
       .checkValue(thres => thres > 0 && thres <= 128, "The threshold must be in (0,128].")
       .createWithDefault(16)
 
+  val DYNAMIC_PRUNING_MAX_THREAD_THRESHOLD =
+    buildStaticConf("spark.sql.dynamic.pruning.maxThreadThreshold")
+      .internal()
+      .doc("The maximum degree of parallelism to execute the dynamic pruning.")
+      .intConf
+      .checkValue(thres => thres > 0 && thres <= 128, "The threshold must be in (0,128].")
+      .createWithDefault(16)
+
   val SQL_EVENT_TRUNCATE_LENGTH = buildStaticConf("spark.sql.event.truncate.length")
     .doc("Threshold of SQL length beyond which it will be truncated before adding to " +
       "event. Defaults to no truncation. If set to 0, callsite will be logged instead.")


### PR DESCRIPTION
### What changes were proposed in this pull request?
In `org.apache.spark.sql.execution.SubqueryBroadcastExec#relationFuture` make a copy of `org.apache.spark.SparkContext#localProperties` and pass it to the execution thread in `org.apache.spark.sql.execution.SubqueryBroadcastExec#executionContext`

### Why are the changes needed?
In Dynamic pruning feature, when executing `SubqueryBroadcastExec`, the relationFuture is evaluated via a separate thread. The threads inherit the `localProperties` from `sparkContext` as they are the child threads.
These threads are created in the executionContext (thread pools). Each Thread pool has a default `keepAliveSeconds` of 60 seconds for idle threads.
Scenarios where the thread pool has threads which are idle and reused for a subsequent new query, the thread local properties will not be inherited from spark context (thread properties are inherited only on thread creation) hence end up having old or no properties set. This will cause `SubqueryBroadcastExec#executionContext` local properties to be missing or stale

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
WIP