### PR TITLE
[SPARK-28554][SQL] JDBC v2 with catalog functionalities

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -133,7 +133,7 @@ statement
         createFileFormat |
         locationSpec |
         (TBLPROPERTIES tableProps=tablePropertyList))*                 #createTableLike
-    | replaceTableHeader ('(' colTypeList ')')? tableProvider
+    | replaceTableHeader ('(' colTypeList ')')? tableProvider?
         createTableClauses
         (AS? query)?                                                   #replaceTable
     | ANALYZE TABLE multipartIdentifier partitionSpec? COMPUTE STATISTICS

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -731,12 +731,11 @@ class Analyzer(
     extends Rule[LogicalPlan] with LookupCatalog {
     def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
       case s @ ShowTables(UnresolvedNamespace(Seq()), _) =>
-        s.copy(namespace =
-          ResolvedNamespace(currentCatalog.asNamespaceCatalog, catalogManager.currentNamespace))
+        s.copy(namespace = ResolvedNamespace(currentCatalog, catalogManager.currentNamespace))
       case UnresolvedNamespace(Seq()) =>
-        ResolvedNamespace(currentCatalog.asNamespaceCatalog, Seq.empty[String])
+        ResolvedNamespace(currentCatalog, Seq.empty[String])
       case UnresolvedNamespace(CatalogAndNamespace(catalog, ns)) =>
-        ResolvedNamespace(catalog.asNamespaceCatalog, ns)
+        ResolvedNamespace(catalog, ns)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/v2ResolutionPlans.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/v2ResolutionPlans.scala
@@ -18,8 +18,8 @@
 package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LogicalPlan}
-import org.apache.spark.sql.connector.catalog.{Identifier, SupportsNamespaces, Table, TableCatalog}
+import org.apache.spark.sql.catalyst.plans.logical.LeafNode
+import org.apache.spark.sql.connector.catalog.{CatalogPlugin, Identifier, Table, TableCatalog}
 
 /**
  * Holds the name of a namespace that has yet to be looked up in a catalog. It will be resolved to
@@ -53,7 +53,7 @@ case class UnresolvedTableOrView(multipartIdentifier: Seq[String]) extends LeafN
 /**
  * A plan containing resolved namespace.
  */
-case class ResolvedNamespace(catalog: SupportsNamespaces, namespace: Seq[String])
+case class ResolvedNamespace(catalog: CatalogPlugin, namespace: Seq[String])
   extends LeafNode {
   override def output: Seq[Attribute] = Nil
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -2813,7 +2813,9 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
     val (partitioning, bucketSpec, properties, options, location, comment) =
       visitCreateTableClauses(ctx.createTableClauses())
     val schema = Option(ctx.colTypeList()).map(createSchema)
-    val provider = ctx.tableProvider.multipartIdentifier.getText
+    val defaultProvider = conf.defaultDataSourceName
+    val provider =
+      Option(ctx.tableProvider).map(_.multipartIdentifier.getText).getOrElse(defaultProvider)
     val orCreate = ctx.replaceTableHeader().CREATE() != null
 
     Option(ctx.query).map(plan) match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -582,7 +582,7 @@ class ResolveSessionCatalog(
   }
 
   object SessionCatalogAndNamespace {
-    def unapply(resolved: ResolvedNamespace): Option[(SupportsNamespaces, Seq[String])] =
+    def unapply(resolved: ResolvedNamespace): Option[(CatalogPlugin, Seq[String])] =
       if (isSessionCatalog(resolved.catalog)) {
         Some(resolved.catalog -> resolved.namespace)
       } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcRelationProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcRelationProvider.scala
@@ -59,7 +59,7 @@ class JdbcRelationProvider extends CreatableRelationProvider
             } else {
               // Otherwise, do not truncate the table, instead drop and recreate it
               dropTable(conn, options.table, options)
-              createTable(conn, df, options)
+              createTable(conn, options.table, df.schema, isCaseSensitive, options)
               saveTable(df, Some(df.schema), isCaseSensitive, options)
             }
 
@@ -78,7 +78,7 @@ class JdbcRelationProvider extends CreatableRelationProvider
             // Therefore, it is okay to do nothing here and then just return the relation below.
         }
       } else {
-        createTable(conn, df, options)
+        createTable(conn, options.table, df.schema, isCaseSensitive, options)
         saveTable(df, Some(df.schema), isCaseSensitive, options)
       }
     } finally {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -183,7 +183,7 @@ object JdbcUtils extends Logging {
     }
   }
 
-  private def getJdbcType(dt: DataType, dialect: JdbcDialect): JdbcType = {
+  def getJdbcType(dt: DataType, dialect: JdbcDialect): JdbcType = {
     dialect.getJDBCType(dt).orElse(getCommonJDBCType(dt)).getOrElse(
       throw new IllegalArgumentException(s"Can't get JDBC type for ${dt.catalogString}"))
   }
@@ -745,15 +745,16 @@ object JdbcUtils extends Logging {
    * Compute the schema string for this RDD.
    */
   def schemaString(
-      df: DataFrame,
+      schema: StructType,
+      caseSensitive: Boolean,
       url: String,
       createTableColumnTypes: Option[String] = None): String = {
     val sb = new StringBuilder()
     val dialect = JdbcDialects.get(url)
     val userSpecifiedColTypesMap = createTableColumnTypes
-      .map(parseUserSpecifiedCreateTableColumnTypes(df, _))
+      .map(parseUserSpecifiedCreateTableColumnTypes(schema, caseSensitive, _))
       .getOrElse(Map.empty[String, String])
-    df.schema.fields.foreach { field =>
+    schema.fields.foreach { field =>
       val name = dialect.quoteIdentifier(field.name)
       val typ = userSpecifiedColTypesMap
         .getOrElse(field.name, getJdbcType(field.dataType, dialect).databaseTypeDefinition)
@@ -769,7 +770,8 @@ object JdbcUtils extends Logging {
    * use in-place of the default data type.
    */
   private def parseUserSpecifiedCreateTableColumnTypes(
-      df: DataFrame,
+      schema: StructType,
+      caseSensitive: Boolean,
       createTableColumnTypes: String): Map[String, String] = {
     def typeName(f: StructField): String = {
       // char/varchar gets translated to string type. Real data type specified by the user
@@ -782,7 +784,11 @@ object JdbcUtils extends Logging {
     }
 
     val userSchema = CatalystSqlParser.parseTableSchema(createTableColumnTypes)
-    val nameEquality = df.sparkSession.sessionState.conf.resolver
+    val nameEquality = if (caseSensitive) {
+      org.apache.spark.sql.catalyst.analysis.caseSensitiveResolution
+    } else {
+      org.apache.spark.sql.catalyst.analysis.caseInsensitiveResolution
+    }
 
     // checks duplicate columns in the user specified column types.
     SchemaUtils.checkColumnNameDuplication(
@@ -790,16 +796,15 @@ object JdbcUtils extends Logging {
 
     // checks if user specified column names exist in the DataFrame schema
     userSchema.fieldNames.foreach { col =>
-      df.schema.find(f => nameEquality(f.name, col)).getOrElse {
+      schema.find(f => nameEquality(f.name, col)).getOrElse {
         throw new AnalysisException(
           s"createTableColumnTypes option column $col not found in schema " +
-            df.schema.catalogString)
+            schema.catalogString)
       }
     }
 
     val userSchemaMap = userSchema.fields.map(f => f.name -> typeName(f)).toMap
-    val isCaseSensitive = df.sparkSession.sessionState.conf.caseSensitiveAnalysis
-    if (isCaseSensitive) userSchemaMap else CaseInsensitiveMap(userSchemaMap)
+    if (caseSensitive) userSchemaMap else CaseInsensitiveMap(userSchemaMap)
   }
 
   /**
@@ -864,17 +869,18 @@ object JdbcUtils extends Logging {
    */
   def createTable(
       conn: Connection,
-      df: DataFrame,
+      tableName: String,
+      schema: StructType,
+      caseSensitive: Boolean,
       options: JdbcOptionsInWrite): Unit = {
     val strSchema = schemaString(
-      df, options.url, options.createTableColumnTypes)
-    val table = options.table
+      schema, caseSensitive, options.url, options.createTableColumnTypes)
     val createTableOptions = options.createTableOptions
     // Create the table if the table does not exist.
     // To allow certain options to append when create a new table, which can be
     // table_options or partition_options.
     // E.g., "CREATE TABLE t (name string) ENGINE=InnoDB DEFAULT CHARSET=utf8"
-    val sql = s"CREATE TABLE $table ($strSchema) $createTableOptions"
+    val sql = s"CREATE TABLE $tableName ($strSchema) $createTableOptions"
     val statement = conn.createStatement
     try {
       statement.setQueryTimeout(options.queryTimeout)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTable.scala
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.jdbc
+
+import java.util
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{DataFrame, Row, SparkSession, SQLContext}
+import org.apache.spark.sql.connector.catalog.{Identifier, SupportsRead, SupportsWrite, Table, TableCapability}
+import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownFilters, SupportsPushDownRequiredColumns, V1Scan}
+import org.apache.spark.sql.connector.write.{LogicalWriteInfo, SupportsTruncate, V1WriteBuilder, WriteBuilder}
+import org.apache.spark.sql.execution.datasources.jdbc.{JDBCOptions, JdbcOptionsInWrite, JDBCRDD, JDBCRelation, JdbcUtils}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.jdbc.JdbcDialects
+import org.apache.spark.sql.sources.{BaseRelation, Filter, InsertableRelation, TableScan}
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+case class JDBCTable(
+    ident: Identifier,
+    schema: StructType,
+    jdbcOptions: JDBCOptions) extends Table with SupportsRead with SupportsWrite {
+  assert(ident.namespace().length == 1)
+
+  override def name(): String = ident.toString
+
+  override def capabilities(): util.Set[TableCapability] = {
+    import TableCapability._
+    Set(BATCH_READ, V1_BATCH_WRITE, TRUNCATE).asJava
+  }
+
+  override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
+    val mergedOptions = new JDBCOptions(
+      jdbcOptions.parameters.originalMap ++ options.asCaseSensitiveMap().asScala)
+    val session = SparkSession.active
+    val resolver = session.sessionState.conf.resolver
+    val timeZoneId = session.sessionState.conf.sessionLocalTimeZone
+    val parts = JDBCRelation.columnPartition(schema, resolver, timeZoneId, mergedOptions)
+    new JDBCScan(JDBCRelation(schema, parts, mergedOptions)(session))
+  }
+
+  override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {
+    val mergedOptions = new JdbcOptionsInWrite(
+      jdbcOptions.parameters.originalMap ++ info.options.asCaseSensitiveMap().asScala)
+    new JDBCWrite(schema, mergedOptions)
+  }
+}
+
+class JDBCScan(relation: JDBCRelation) extends ScanBuilder with V1Scan
+  with SupportsPushDownFilters with SupportsPushDownRequiredColumns {
+
+  private var pushed = Array.empty[Filter]
+
+  override def pushFilters(filters: Array[Filter]): Array[Filter] = {
+    val options = relation.jdbcOptions
+    if (options.pushDownPredicate) {
+      val dialect = JdbcDialects.get(options.url)
+      val (pushed, unSupported) = filters.partition(JDBCRDD.compileFilter(_, dialect).isDefined)
+      this.pushed = pushed
+      unSupported
+    } else {
+      filters
+    }
+  }
+
+  override def pushedFilters(): Array[Filter] = pushed
+
+  private var prunedSchema = relation.schema
+
+  override def pruneColumns(requiredSchema: StructType): Unit = {
+    // JDBC doesn't support nested column pruning.
+    val requiredCols = requiredSchema.map(_.name)
+    prunedSchema = StructType(relation.schema.fields.filter(f => requiredCols.contains(f.name)))
+  }
+
+  override def readSchema(): StructType = prunedSchema
+
+  override def build(): Scan = this
+
+  override def toV1TableScan[T <: BaseRelation with TableScan](context: SQLContext): T = {
+    new BaseRelation with TableScan {
+      override def sqlContext: SQLContext = context
+      override def schema: StructType = prunedSchema
+      override def needConversion: Boolean = relation.needConversion
+      override def buildScan(): RDD[Row] = {
+        relation.buildScan(prunedSchema.map(_.name).toArray, pushed)
+      }
+    }.asInstanceOf[T]
+  }
+}
+
+class JDBCWrite(schema: StructType, options: JdbcOptionsInWrite) extends V1WriteBuilder
+  with SupportsTruncate {
+
+  private var isTruncate = false
+
+  override def truncate(): WriteBuilder = {
+    isTruncate = true
+    this
+  }
+
+  override def buildForV1Write(): InsertableRelation = new InsertableRelation {
+    override def insert(data: DataFrame, overwrite: Boolean): Unit = {
+      // TODO: do truncate and append atomically.
+      if (isTruncate) {
+        val conn = JdbcUtils.createConnectionFactory(options)()
+        JdbcUtils.truncateTable(conn, options)
+      }
+      JdbcUtils.saveTable(data, Some(schema), SQLConf.get.caseSensitiveAnalysis, options)
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.jdbc
+
+import java.sql.{Connection, SQLException}
+import java.util
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.analysis.{NoSuchNamespaceException, NoSuchTableException}
+import org.apache.spark.sql.connector.catalog.{Identifier, Table, TableCatalog, TableChange}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.execution.datasources.jdbc.{JDBCOptions, JdbcOptionsInWrite, JDBCRDD, JdbcUtils}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.jdbc.{JdbcDialect, JdbcDialects}
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+class JDBCTableCatalog extends TableCatalog with Logging {
+
+  private var _name: String = _
+  private var options: JDBCOptions = _
+  private var dialect: JdbcDialect = _
+
+  override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {
+    _name = name
+    val map = options.asCaseSensitiveMap().asScala.toMap
+    // The `JDBCOptions` checks the existence of the table option. This is required by JDBC v1, but
+    // JDBC V2 only knows the table option when loading a table. Here we put a table option with a
+    // fake value, so that it can pass the check of `JDBCOptions`.
+    this.options = new JDBCOptions(map + (JDBCOptions.JDBC_TABLE_NAME -> "__invalid"))
+    this.dialect = JdbcDialects.get(this.options.url)
+  }
+
+  override def name(): String = {
+    _name
+  }
+
+  private def withConnection[T](f: Connection => T): T = {
+    val conn = JdbcUtils.createConnectionFactory(options)()
+    try {
+      f(conn)
+    } finally {
+      conn.close()
+    }
+  }
+
+  private def checkNamespace(namespace: Array[String]): Unit = {
+    // In JDBC there is no nested database/schema
+    if (namespace.length > 1) {
+      throw new NoSuchNamespaceException(namespace)
+    }
+  }
+
+  private def getTableName(ident: Identifier): String = {
+    (ident.namespace() :+ ident.name()).map(dialect.quoteIdentifier).mkString(".")
+  }
+
+  private def createOptionsWithTableName(ident: Identifier): JDBCOptions = {
+    new JDBCOptions(options.parameters + (JDBCOptions.JDBC_TABLE_NAME -> getTableName(ident)))
+  }
+
+  override def listTables(namespace: Array[String]): Array[Identifier] = {
+    checkNamespace(namespace)
+    withConnection { conn =>
+      val md = conn.getMetaData
+      val schemaPattern = if (namespace.length == 1) namespace.head else null
+      val rs = md.getTables(null, schemaPattern, "%", Array("TABLE"));
+      val tables = ArrayBuffer.empty[Identifier]
+      while (rs.next()) {
+        tables += Identifier.of(namespace, rs.getString("TABLE_NAME"))
+      }
+      tables.toArray
+    }
+  }
+
+  override def tableExists(ident: Identifier): Boolean = {
+    val ns = ident.namespace()
+    checkNamespace(ns)
+    withConnection { conn =>
+      val md = conn.getMetaData
+      val schemaPattern = if (ns.length == 1) ns.head else null
+      val rs = md.getTables(null, schemaPattern, ident.name(), Array("TABLE"));
+      rs.next()
+    }
+  }
+
+  override def renameTable(oldIdent: Identifier, newIdent: Identifier): Unit = {
+    // TODO: support this by adding more APIs to `JdbcDialect` which can generate the SQL statement
+    //       to rename a table.
+    throw new UnsupportedOperationException("rename table")
+  }
+
+  override def alterTable(ident: Identifier, changes: TableChange*): Table = {
+    // TODO: support this by adding more APIs to `JdbcDialect` which can generate the SQL statement
+    //       to alter a table.
+    throw new UnsupportedOperationException("alter table")
+  }
+
+  override def dropTable(ident: Identifier): Boolean = {
+    checkNamespace(ident.namespace())
+    try {
+      withConnection { conn =>
+        val statement = conn.createStatement
+        statement.setQueryTimeout(options.queryTimeout)
+        statement.executeUpdate(s"DROP TABLE ${getTableName(ident)}")
+        true
+      }
+    } catch {
+      case _: SQLException => false
+    }
+  }
+
+  override def loadTable(ident: Identifier): Table = {
+    checkNamespace(ident.namespace())
+    val optionsWithTableName = createOptionsWithTableName(ident)
+    try {
+      val schema = JDBCRDD.resolveTable(optionsWithTableName)
+      JDBCTable(ident, schema, optionsWithTableName)
+    } catch {
+      case _: SQLException => throw new NoSuchTableException(ident)
+    }
+  }
+
+  override def createTable(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): Table = {
+    checkNamespace(ident.namespace())
+    if (partitions.nonEmpty) {
+      throw new UnsupportedOperationException("Cannot create JDBC table with partition")
+    }
+    // TODO: we can support this, but we need to add an API to `JdbcDialect` to generate the SQL
+    //       statement to specify table options.
+    if (!properties.isEmpty) {
+      logWarning("Cannot create JDBC table with properties, these properties will be " +
+        "ignored: " + properties.asScala.map { case (k, v) => s"$k=$v" }.mkString("[", ", ", "]"))
+    }
+
+    val writeOptions = new JdbcOptionsInWrite(
+      options.parameters + (JDBCOptions.JDBC_TABLE_NAME -> getTableName(ident)))
+    val caseSensitive = SQLConf.get.caseSensitiveAnalysis
+    withConnection { conn =>
+      JdbcUtils.createTable(conn, getTableName(ident), schema, caseSensitive, writeOptions)
+    }
+
+    JDBCTable(ident, schema, writeOptions)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -1178,7 +1178,8 @@ class JDBCSuite extends QueryTest
 
   test("SPARK-16387: Reserved SQL words are not escaped by JDBC writer") {
     val df = spark.createDataset(Seq("a", "b", "c")).toDF("order")
-    val schema = JdbcUtils.schemaString(df, "jdbc:mysql://localhost:3306/temp")
+    val schema = JdbcUtils.schemaString(
+      df.schema, df.sqlContext.conf.caseSensitiveAnalysis, "jdbc:mysql://localhost:3306/temp")
     assert(schema.contains("`order` TEXT"))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.jdbc
+
+import java.sql.{Connection, DriverManager}
+import java.util.Properties
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.catalyst.analysis.CannotReplaceMissingTableException
+import org.apache.spark.sql.catalyst.plans.logical.Filter
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
+import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog
+import org.apache.spark.sql.functions.lit
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.util.Utils
+
+class JDBCV2Suite extends QueryTest with SharedSparkSession {
+  import testImplicits._
+
+  val tempDir = Utils.createTempDir()
+  val url = s"jdbc:h2:${tempDir.getCanonicalPath};user=testUser;password=testPass"
+  var conn: java.sql.Connection = null
+
+  override def sparkConf: SparkConf = super.sparkConf
+    .set("spark.sql.catalog.h2", classOf[JDBCTableCatalog].getName)
+    .set("spark.sql.catalog.h2.url", url)
+    .set("spark.sql.catalog.h2.driver", "org.h2.Driver")
+
+  private def withConnection[T](f: Connection => T): T = {
+    val conn = DriverManager.getConnection(url, new Properties())
+    try {
+      f(conn)
+    } finally {
+      conn.close()
+    }
+  }
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    Utils.classForName("org.h2.Driver")
+    withConnection { conn =>
+      conn.prepareStatement("CREATE SCHEMA \"test\"").executeUpdate()
+      conn.prepareStatement(
+        "CREATE TABLE \"test\".\"people\" (name TEXT(32) NOT NULL, id INTEGER NOT NULL)")
+        .executeUpdate()
+      conn.prepareStatement("INSERT INTO \"test\".\"people\" VALUES ('fred', 1)").executeUpdate()
+      conn.prepareStatement("INSERT INTO \"test\".\"people\" VALUES ('mary', 2)").executeUpdate()
+    }
+  }
+
+  override def afterAll(): Unit = {
+    Utils.deleteRecursively(tempDir)
+    super.afterAll()
+  }
+
+  test("simple scan") {
+    checkAnswer(sql("SELECT name, id FROM h2.test.people"), Seq(Row("fred", 1), Row("mary", 2)))
+  }
+
+  test("scan with filter push-down") {
+    val df = spark.table("h2.test.people").filter($"id" > 1)
+    val filters = df.queryExecution.optimizedPlan.collect {
+      case f: Filter => f
+    }
+    assert(filters.isEmpty)
+    checkAnswer(df, Row("mary", 2))
+  }
+
+  test("scan with column pruning") {
+    val df = spark.table("h2.test.people").select("id")
+    val scan = df.queryExecution.optimizedPlan.collectFirst {
+      case s: DataSourceV2ScanRelation => s
+    }.get
+    assert(scan.schema.names.sameElements(Seq("ID")))
+    checkAnswer(df, Seq(Row(1), Row(2)))
+  }
+
+  test("scan with filter push-down and column pruning") {
+    val df = spark.table("h2.test.people").filter($"id" > 1).select("name")
+    val filters = df.queryExecution.optimizedPlan.collect {
+      case f: Filter => f
+    }
+    assert(filters.isEmpty)
+    val scan = df.queryExecution.optimizedPlan.collectFirst {
+      case s: DataSourceV2ScanRelation => s
+    }.get
+    assert(scan.schema.names.sameElements(Seq("NAME")))
+    checkAnswer(df, Row("mary"))
+  }
+
+  // TODO: this doesn't work because `DataFrameReader.table` ignores the specified options.
+  ignore("scan with partition info") {
+    val df = spark.read
+      .option("partitionColumn", "id")
+      .option("lowerBound", "0")
+      .option("upperBound", "3")
+      .option("numPartitions", "2")
+      .table("h2.test.people")
+  }
+
+  test("show tables") {
+    checkAnswer(sql("SHOW TABLES IN h2.test"), Row("test", "people"))
+  }
+
+  test("create/drop table") {
+    sql("CREATE TABLE h2.test.abc(i INT, j STRING)")
+    checkAnswer(sql("SHOW TABLES IN h2.test"), Seq(Row("test", "people"), Row("test", "abc")))
+    sql("DROP TABLE h2.test.abc")
+    checkAnswer(sql("SHOW TABLES IN h2.test"), Row("test", "people"))
+  }
+
+  test("SQL API: create table as select") {
+    withTable("h2.test.abc") {
+      sql("CREATE TABLE h2.test.abc AS SELECT * FROM h2.test.people")
+      checkAnswer(sql("SELECT name, id FROM h2.test.abc"), Seq(Row("fred", 1), Row("mary", 2)))
+    }
+  }
+
+  test("DataFrameWriterV2: create table as select") {
+    withTable("h2.test.abc") {
+      spark.table("h2.test.people").writeTo("h2.test.abc").create()
+      checkAnswer(sql("SELECT name, id FROM h2.test.abc"), Seq(Row("fred", 1), Row("mary", 2)))
+    }
+  }
+
+  test("SQL API: replace table as select") {
+    withTable("h2.test.abc") {
+      intercept[CannotReplaceMissingTableException] {
+        sql("REPLACE TABLE h2.test.abc AS SELECT 1 as col")
+      }
+      sql("CREATE OR REPLACE TABLE h2.test.abc AS SELECT 1 as col")
+      checkAnswer(sql("SELECT col FROM h2.test.abc"), Row(1))
+      sql("REPLACE TABLE h2.test.abc AS SELECT * FROM h2.test.people")
+      checkAnswer(sql("SELECT name, id FROM h2.test.abc"), Seq(Row("fred", 1), Row("mary", 2)))
+    }
+  }
+
+  test("DataFrameWriterV2: replace table as select") {
+    withTable("h2.test.abc") {
+      intercept[CannotReplaceMissingTableException] {
+        sql("SELECT 1 AS col").writeTo("h2.test.abc").replace()
+      }
+      sql("SELECT 1 AS col").writeTo("h2.test.abc").createOrReplace()
+      checkAnswer(sql("SELECT col FROM h2.test.abc"), Row(1))
+      spark.table("h2.test.people").writeTo("h2.test.abc").replace()
+      checkAnswer(sql("SELECT name, id FROM h2.test.abc"), Seq(Row("fred", 1), Row("mary", 2)))
+    }
+  }
+
+  test("SQL API: insert and overwrite") {
+    withTable("h2.test.abc") {
+      sql("CREATE TABLE h2.test.abc AS SELECT * FROM h2.test.people")
+
+      sql("INSERT INTO h2.test.abc SELECT 'lucy', 3")
+      checkAnswer(
+        sql("SELECT name, id FROM h2.test.abc"),
+        Seq(Row("fred", 1), Row("mary", 2), Row("lucy", 3)))
+
+      sql("INSERT OVERWRITE h2.test.abc SELECT 'bob', 4")
+      checkAnswer(sql("SELECT name, id FROM h2.test.abc"), Row("bob", 4))
+    }
+  }
+
+  test("DataFrameWriterV2: insert and overwrite") {
+    withTable("h2.test.abc") {
+      sql("CREATE TABLE h2.test.abc AS SELECT * FROM h2.test.people")
+
+      // `DataFrameWriterV2` is by-name.
+      sql("SELECT 3 AS ID, 'lucy' AS NAME").writeTo("h2.test.abc").append()
+      checkAnswer(
+        sql("SELECT name, id FROM h2.test.abc"),
+        Seq(Row("fred", 1), Row("mary", 2), Row("lucy", 3)))
+
+      sql("SELECT 'bob' AS NAME, 4 AS ID").writeTo("h2.test.abc").overwrite(lit(true))
+      checkAnswer(sql("SELECT name, id FROM h2.test.abc"), Row("bob", 4))
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCWriteSuite.scala
@@ -390,7 +390,11 @@ class JDBCWriteSuite extends SharedSparkSession with BeforeAndAfter {
       val expectedSchemaStr =
         colTypes.map { case (col, dataType) => s""""$col" $dataType """ }.mkString(", ")
 
-      assert(JdbcUtils.schemaString(df, url1, Option(createTableColTypes)) == expectedSchemaStr)
+      assert(JdbcUtils.schemaString(
+        df.schema,
+        df.sqlContext.conf.caseSensitiveAnalysis,
+        url1,
+        Option(createTableColTypes)) == expectedSchemaStr)
     }
 
     testCreateTableColDataTypes(Seq("boolean"))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR implements `JDBCTableCatalog`, so that end-users can use the JDBC as a catalog.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
JDBC is a good fit for the new catalog plugin API. It's good to have one builtin implementation of the catalog plugin API.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
Yes, now end-users can register JDBC as a catalog.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
a new test suite.