### PR TITLE
[SPARK-30617][SQL] Stop check values of spark.sql.catalogImplementation to improve expansibility

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -36,12 +36,11 @@ object StaticSQLConf {
     .createWithDefault(Utils.resolveURI("spark-warehouse").toString)
 
   val CATALOG_IMPLEMENTATION = buildStaticConf("spark.sql.catalogImplementation")
-    .doc("Spark built-in implementation is in-memory and hive," +
+    .doc("Spark built-in implementation is in-memory and hive, " +
       "when set to yourImpl(can be any words), " +
-      "you need also provide following configuration to make everything going" +
-      "spark.sql.catalogImplementation.yourImpl.builder" +
-      "spark.sql.catalogImplementation.yourImpl.externalCatalog")
-    .internal()
+      "you need also provide following configurations to make everything going: " +
+      "`spark.sql.catalogImplementation.yourImpl.builder` " +
+      "`spark.sql.catalogImplementation.yourImpl.externalCatalog`.")
     .stringConf
     .createWithDefault("in-memory")
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -36,9 +36,13 @@ object StaticSQLConf {
     .createWithDefault(Utils.resolveURI("spark-warehouse").toString)
 
   val CATALOG_IMPLEMENTATION = buildStaticConf("spark.sql.catalogImplementation")
+    .doc("Spark built-in implementation is in-memory and hive," +
+      "when set to yourImpl(can be any words), " +
+      "you need also provide following configuration to make everything going" +
+      "spark.sql.catalogImplementation.yourImpl.builder" +
+      "spark.sql.catalogImplementation.yourImpl.externalCatalog")
     .internal()
     .stringConf
-    .checkValues(Set("hive", "in-memory"))
     .createWithDefault("in-memory")
 
   val GLOBAL_TEMP_DATABASE = buildStaticConf("spark.sql.globalTempDatabase")

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -1029,8 +1029,8 @@ object SparkSession extends Logging {
       case other => conf.getOption(s"spark.sql.catalogImplementation.$other.builder")
           .getOrElse {
         throw new IllegalArgumentException(
-          "You need to configure spark.sql.catalogImplementation.xx.builder when xx configured by" +
-              "spark.sql.catalogImplementation is not in-memory nor hive")
+          s"You need to configure spark.sql.catalogImplementation.$other.builder when " +
+            s"`$other` configured by spark.sql.catalogImplementation is not in-memory nor hive.")
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -1026,6 +1026,12 @@ object SparkSession extends Logging {
     conf.get(CATALOG_IMPLEMENTATION) match {
       case "hive" => HIVE_SESSION_STATE_BUILDER_CLASS_NAME
       case "in-memory" => classOf[SessionStateBuilder].getCanonicalName
+      case other => conf.getOption(s"spark.sql.catalogImplementation.$other.builder")
+          .getOrElse {
+        throw new IllegalArgumentException(
+          "You need to configure spark.sql.catalogImplementation.xx.builder when xx configured by" +
+              "spark.sql.catalogImplementation is not in-memory nor hive")
+      }
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -217,6 +217,12 @@ object SharedState extends Logging {
     conf.get(CATALOG_IMPLEMENTATION) match {
       case "hive" => HIVE_EXTERNAL_CATALOG_CLASS_NAME
       case "in-memory" => classOf[InMemoryCatalog].getCanonicalName
+      case other => conf.getOption(s"spark.sql.catalogImplementation.$other.externalCatalog")
+          .getOrElse {
+        throw new IllegalArgumentException(
+          "You need to configure spark.sql.catalogImplementation.xx.externalCatalog when xx " +
+              "configured by spark.sql.catalogImplementation is not in-memory nor hive")
+      }
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -220,8 +220,8 @@ object SharedState extends Logging {
       case other => conf.getOption(s"spark.sql.catalogImplementation.$other.externalCatalog")
           .getOrElse {
         throw new IllegalArgumentException(
-          "You need to configure spark.sql.catalogImplementation.xx.externalCatalog when xx " +
-              "configured by spark.sql.catalogImplementation is not in-memory nor hive")
+          s"You need to configure spark.sql.catalogImplementation.$other.externalCatalog when " +
+            s"`$other` configured by spark.sql.catalogImplementation is not in-memory nor hive.")
       }
     }
   }


### PR DESCRIPTION

### What changes were proposed in this pull request?

When user config spark.sql.catalogImplementation with value not in in-memory/hive, check if below properties is configured. If configured then instantiate SessionState with provided Class, or else throw Exception as usual. 
```
spark.sql.catalogImplementation.[value of spark.sql.catalogImplementation].builder
spark.sql.catalogImplementation.[value of spark.sql.catalogImplementation].externalCatalog
```
For example:
```
spark.sql.catalogImplementation = qihoo
spark.sql.catalogImplementation.qihoo.builder = org.apache.spark.sql.qihoo.QihooSessionStateBuilder
spark.sql.catalogImplementation.qihoo.externalCatalog = org.apache.spark.sql.qihoo.QihooExternalCatalog
```

### Why are the changes needed?
We have implemented a complex ExternalCatalog which is used for retrieving multi isomerism database's metadata(sush as elasticsearch、postgresql), so that we can make a mixture query between hive and our online data. But as spark require that value of spark.sql.catalogImplementation must be one of in-memory/hive, we have to modify SparkSession and rebuild spark to make our project work.
Finally, we hope spark removing above restriction, so that it's will be much easier to let us keep pace with new spark version. Thanks!

### Does this PR introduce any user-facing change?
no
### How was this patch tested?
no
