### PR TITLE
[SPARK-27166][SQL][FOLLOWUP] Refactor to build string once

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/ArrayType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/ArrayType.scala
@@ -66,10 +66,15 @@ case class ArrayType(elementType: DataType, containsNull: Boolean) extends DataT
   /** No-arg constructor for kryo. */
   protected def this() = this(null, false)
 
-  private[sql] def buildFormattedString(prefix: String, builder: StringBuilder): Unit = {
-    builder.append(
-      s"$prefix-- element: ${elementType.typeName} (containsNull = $containsNull)\n")
-    DataType.buildFormattedString(elementType, s"$prefix    |", builder)
+  private[sql] def buildFormattedString(
+      prefix: String,
+      builder: StringBuilder,
+      maxDepth: Int): Unit = {
+    if (maxDepth > 0) {
+      builder.append(
+        s"$prefix-- element: ${elementType.typeName} (containsNull = $containsNull)\n")
+      DataType.buildFormattedString(elementType, s"$prefix    |", builder, maxDepth)
+    }
   }
 
   override private[sql] def jsonValue =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/ArrayType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/ArrayType.scala
@@ -23,6 +23,7 @@ import org.json4s.JsonDSL._
 
 import org.apache.spark.annotation.Stable
 import org.apache.spark.sql.catalyst.util.ArrayData
+import org.apache.spark.sql.catalyst.util.StringUtils.StringConcat
 
 /**
  * Companion object for ArrayType.
@@ -68,12 +69,12 @@ case class ArrayType(elementType: DataType, containsNull: Boolean) extends DataT
 
   private[sql] def buildFormattedString(
       prefix: String,
-      builder: StringBuilder,
+      stringConcat: StringConcat,
       maxDepth: Int): Unit = {
     if (maxDepth > 0) {
-      builder.append(
+      stringConcat.append(
         s"$prefix-- element: ${elementType.typeName} (containsNull = $containsNull)\n")
-      DataType.buildFormattedString(elementType, s"$prefix    |", builder, maxDepth)
+      DataType.buildFormattedString(elementType, s"$prefix    |", stringConcat, maxDepth)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -35,6 +35,7 @@ import org.apache.spark.annotation.Stable
 import org.apache.spark.sql.catalyst.analysis.Resolver
 import org.apache.spark.sql.catalyst.expressions.{Cast, Expression}
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
+import org.apache.spark.sql.catalyst.util.StringUtils.StringConcat
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.StoreAssignmentPolicy
 import org.apache.spark.sql.internal.SQLConf.StoreAssignmentPolicy.{ANSI, STRICT}
@@ -226,15 +227,15 @@ object DataType {
   protected[types] def buildFormattedString(
       dataType: DataType,
       prefix: String,
-      builder: StringBuilder,
+      stringConcat: StringConcat,
       maxDepth: Int): Unit = {
     dataType match {
       case array: ArrayType =>
-        array.buildFormattedString(prefix, builder, maxDepth - 1)
+        array.buildFormattedString(prefix, stringConcat, maxDepth - 1)
       case struct: StructType =>
-        struct.buildFormattedString(prefix, builder, maxDepth - 1)
+        struct.buildFormattedString(prefix, stringConcat, maxDepth - 1)
       case map: MapType =>
-        map.buildFormattedString(prefix, builder, maxDepth - 1)
+        map.buildFormattedString(prefix, stringConcat, maxDepth - 1)
       case _ =>
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -224,16 +224,17 @@ object DataType {
   }
 
   protected[types] def buildFormattedString(
-    dataType: DataType,
-    prefix: String,
-    builder: StringBuilder): Unit = {
+      dataType: DataType,
+      prefix: String,
+      builder: StringBuilder,
+      maxDepth: Int): Unit = {
     dataType match {
       case array: ArrayType =>
-        array.buildFormattedString(prefix, builder)
+        array.buildFormattedString(prefix, builder, maxDepth - 1)
       case struct: StructType =>
-        struct.buildFormattedString(prefix, builder)
+        struct.buildFormattedString(prefix, builder, maxDepth - 1)
       case map: MapType =>
-        map.buildFormattedString(prefix, builder)
+        map.buildFormattedString(prefix, builder, maxDepth - 1)
       case _ =>
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/MapType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/MapType.scala
@@ -40,12 +40,17 @@ case class MapType(
   /** No-arg constructor for kryo. */
   def this() = this(null, null, false)
 
-  private[sql] def buildFormattedString(prefix: String, builder: StringBuilder): Unit = {
-    builder.append(s"$prefix-- key: ${keyType.typeName}\n")
-    DataType.buildFormattedString(keyType, s"$prefix    |", builder)
-    builder.append(s"$prefix-- value: ${valueType.typeName} " +
-      s"(valueContainsNull = $valueContainsNull)\n")
-    DataType.buildFormattedString(valueType, s"$prefix    |", builder)
+  private[sql] def buildFormattedString(
+      prefix: String,
+      builder: StringBuilder,
+      maxDepth: Int = Int.MaxValue): Unit = {
+    if (maxDepth > 0) {
+      builder.append(s"$prefix-- key: ${keyType.typeName}\n")
+      DataType.buildFormattedString(keyType, s"$prefix    |", builder, maxDepth)
+      builder.append(s"$prefix-- value: ${valueType.typeName} " +
+        s"(valueContainsNull = $valueContainsNull)\n")
+      DataType.buildFormattedString(valueType, s"$prefix    |", builder, maxDepth)
+    }
   }
 
   override private[sql] def jsonValue: JValue =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/MapType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/MapType.scala
@@ -21,6 +21,7 @@ import org.json4s.JsonAST.JValue
 import org.json4s.JsonDSL._
 
 import org.apache.spark.annotation.Stable
+import org.apache.spark.sql.catalyst.util.StringUtils.StringConcat
 
 /**
  * The data type for Maps. Keys in a map are not allowed to have `null` values.
@@ -42,14 +43,14 @@ case class MapType(
 
   private[sql] def buildFormattedString(
       prefix: String,
-      builder: StringBuilder,
+      stringConcat: StringConcat,
       maxDepth: Int = Int.MaxValue): Unit = {
     if (maxDepth > 0) {
-      builder.append(s"$prefix-- key: ${keyType.typeName}\n")
-      DataType.buildFormattedString(keyType, s"$prefix    |", builder, maxDepth)
-      builder.append(s"$prefix-- value: ${valueType.typeName} " +
+      stringConcat.append(s"$prefix-- key: ${keyType.typeName}\n")
+      DataType.buildFormattedString(keyType, s"$prefix    |", stringConcat, maxDepth)
+      stringConcat.append(s"$prefix-- value: ${valueType.typeName} " +
         s"(valueContainsNull = $valueContainsNull)\n")
-      DataType.buildFormattedString(valueType, s"$prefix    |", builder, maxDepth)
+      DataType.buildFormattedString(valueType, s"$prefix    |", stringConcat, maxDepth)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructField.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructField.scala
@@ -22,6 +22,7 @@ import org.json4s.JsonDSL._
 
 import org.apache.spark.annotation.Stable
 import org.apache.spark.sql.catalyst.util.{escapeSingleQuotedString, quoteIdentifier}
+import org.apache.spark.sql.catalyst.util.StringUtils.StringConcat
 
 /**
  * A field inside a StructType.
@@ -45,11 +46,11 @@ case class StructField(
 
   private[sql] def buildFormattedString(
       prefix: String,
-      builder: StringBuilder,
+      stringConcat: StringConcat,
       maxDepth: Int): Unit = {
     if (maxDepth > 0) {
-      builder.append(s"$prefix-- $name: ${dataType.typeName} (nullable = $nullable)\n")
-      DataType.buildFormattedString(dataType, s"$prefix    |", builder, maxDepth)
+      stringConcat.append(s"$prefix-- $name: ${dataType.typeName} (nullable = $nullable)\n")
+      DataType.buildFormattedString(dataType, s"$prefix    |", stringConcat, maxDepth)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructField.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructField.scala
@@ -43,9 +43,14 @@ case class StructField(
   /** No-arg constructor for kryo. */
   protected def this() = this(null, null)
 
-  private[sql] def buildFormattedString(prefix: String, builder: StringBuilder): Unit = {
-    builder.append(s"$prefix-- $name: ${dataType.typeName} (nullable = $nullable)\n")
-    DataType.buildFormattedString(dataType, s"$prefix    |", builder)
+  private[sql] def buildFormattedString(
+      prefix: String,
+      builder: StringBuilder,
+      maxDepth: Int): Unit = {
+    if (maxDepth > 0) {
+      builder.append(s"$prefix-- $name: ${dataType.typeName} (nullable = $nullable)\n")
+      DataType.buildFormattedString(dataType, s"$prefix    |", builder, maxDepth)
+    }
   }
 
   // override the default toString to be compatible with legacy parquet files.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -28,6 +28,7 @@ import org.apache.spark.annotation.Stable
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, InterpretedOrdering}
 import org.apache.spark.sql.catalyst.parser.{CatalystSqlParser, LegacyTypeStringParser}
 import org.apache.spark.sql.catalyst.util.{quoteIdentifier, truncatedString, StringUtils}
+import org.apache.spark.sql.catalyst.util.StringUtils.StringConcat
 import org.apache.spark.sql.internal.SQLConf
 
 /**
@@ -362,12 +363,12 @@ case class StructType(fields: Array[StructField]) extends DataType with Seq[Stru
   def treeString: String = treeString(Int.MaxValue)
 
   def treeString(maxDepth: Int): String = {
-    val builder = new StringBuilder
-    builder.append("root\n")
+    val stringConcat = new StringUtils.StringConcat()
+    stringConcat.append("root\n")
     val prefix = " |"
     val depth = if (maxDepth > 0) maxDepth else Int.MaxValue
-    fields.foreach(field => field.buildFormattedString(prefix, builder, depth))
-    builder.toString()
+    fields.foreach(field => field.buildFormattedString(prefix, stringConcat, depth))
+    stringConcat.toString()
   }
 
   // scalastyle:off println
@@ -376,9 +377,9 @@ case class StructType(fields: Array[StructField]) extends DataType with Seq[Stru
 
   private[sql] def buildFormattedString(
       prefix: String,
-      builder: StringBuilder,
+      stringConcat: StringConcat,
       maxDepth: Int): Unit = {
-    fields.foreach(field => field.buildFormattedString(prefix, builder, maxDepth))
+    fields.foreach(field => field.buildFormattedString(prefix, stringConcat, maxDepth))
   }
 
   override private[sql] def jsonValue =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -361,25 +361,24 @@ case class StructType(fields: Array[StructField]) extends DataType with Seq[Stru
 
   def treeString: String = treeString(Int.MaxValue)
 
-  def treeString(level: Int): String = {
+  def treeString(maxDepth: Int): String = {
     val builder = new StringBuilder
     builder.append("root\n")
     val prefix = " |"
-    fields.foreach(field => field.buildFormattedString(prefix, builder))
-
-    if (level <= 0 || level == Int.MaxValue) {
-      builder.toString()
-    } else {
-      builder.toString().split("\n").filter(_.lastIndexOf("|--") < level * 5 + 1).mkString("\n")
-    }
+    val depth = if (maxDepth > 0) maxDepth else Int.MaxValue
+    fields.foreach(field => field.buildFormattedString(prefix, builder, depth))
+    builder.toString()
   }
 
   // scalastyle:off println
   def printTreeString(): Unit = println(treeString)
   // scalastyle:on println
 
-  private[sql] def buildFormattedString(prefix: String, builder: StringBuilder): Unit = {
-    fields.foreach(field => field.buildFormattedString(prefix, builder))
+  private[sql] def buildFormattedString(
+      prefix: String,
+      builder: StringBuilder,
+      maxDepth: Int): Unit = {
+    fields.foreach(field => field.buildFormattedString(prefix, builder, maxDepth))
   }
 
   override private[sql] def jsonValue =

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.core.JsonParseException
 
 import org.apache.spark.{SparkException, SparkFunSuite}
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
+import org.apache.spark.sql.catalyst.util.StringUtils.StringConcat
 
 class DataTypeSuite extends SparkFunSuite {
 
@@ -462,7 +463,7 @@ class DataTypeSuite extends SparkFunSuite {
       StructField("c", DataTypes.IntegerType),
       StructField("d", DataTypes.IntegerType)))
 
-    val builder = new StringBuilder
+    val builder = new StringConcat
 
     MapType(keyType, valueType).buildFormattedString(prefix = "", builder = builder)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -463,11 +463,11 @@ class DataTypeSuite extends SparkFunSuite {
       StructField("c", DataTypes.IntegerType),
       StructField("d", DataTypes.IntegerType)))
 
-    val builder = new StringConcat
+    val stringConcat = new StringConcat
 
-    MapType(keyType, valueType).buildFormattedString(prefix = "", builder = builder)
+    MapType(keyType, valueType).buildFormattedString(prefix = "", stringConcat = stringConcat)
 
-    val result = builder.toString()
+    val result = stringConcat.toString()
     val expected =
       """-- key: struct
         |    |-- a: integer (nullable = true)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/StructTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/StructTypeSuite.scala
@@ -81,6 +81,22 @@ class StructTypeSuite extends SparkFunSuite {
     assert(7 == schema.treeString.split("\n").length)
     assert(7 == schema.treeString(0).split("\n").length)
     assert(7 == schema.treeString(-1).split("\n").length)
+
+    val schema2 = StructType.fromDDL(
+      "c1 INT, c2 ARRAY<STRUCT<c3: INT>>, c4 STRUCT<c5: INT, c6: ARRAY<ARRAY<INT>>>")
+    assert(4 == schema2.treeString(1).split("\n").length)
+    assert(7 == schema2.treeString(2).split("\n").length)
+    assert(9 == schema2.treeString(3).split("\n").length)
+    assert(10 == schema2.treeString(4).split("\n").length)
+    assert(10 == schema2.treeString(0).split("\n").length)
+
+    val schema3 = StructType.fromDDL(
+      "c1 MAP<INT, STRUCT<c2: MAP<INT, INT>>>, c3 STRUCT<c4: MAP<INT, MAP<INT, INT>>>")
+    assert(3 == schema3.treeString(1).split("\n").length)
+    assert(6 == schema3.treeString(2).split("\n").length)
+    assert(9 == schema3.treeString(3).split("\n").length)
+    assert(13 == schema3.treeString(4).split("\n").length)
+    assert(13 == schema3.treeString(0).split("\n").length)
   }
 
   test("interval keyword in schema string") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up for https://github.com/apache/spark/pull/24098 to refactor to build string once according to the [review comment](https://github.com/apache/spark/pull/24098#discussion_r369845234)

### Why are the changes needed?

Previously, we chose the minimal change way.
In this PR, we choose a more robust way than the previous post-step string processing.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

The test case is extended with more cases.