### PR TITLE
[SPARK-30664][Web UI] Add optional metrics to all-stages page

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllStagesPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllStagesPage.scala
@@ -17,9 +17,14 @@
 
 package org.apache.spark.ui.jobs
 
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets.UTF_8
+import java.util.Locale
 import javax.servlet.http.HttpServletRequest
 
-import scala.xml.{Attribute, Elem, Node, NodeSeq, Null, Text}
+import scala.collection.JavaConverters._
+import scala.collection.immutable.ListSet
+import scala.xml.{Attribute, Elem, Node, NodeSeq, Null, Text, Unparsed}
 
 import org.apache.spark.scheduler.Schedulable
 import org.apache.spark.status.{AppSummary, PoolData}
@@ -30,6 +35,18 @@ import org.apache.spark.ui.{UIUtils, WebUIPage}
 private[ui] class AllStagesPage(parent: StagesTab) extends WebUIPage("") {
   private val sc = parent.sc
   private val subPath = "stages"
+
+  private val optionalMetrics = ListSet(
+    "Input", "Output",
+    "Shuffle Read", "Shuffle Write",
+    "Peak Execution Memory",
+    "Spill (Memory)", "Spill (Disk)",
+    "GC Time"
+  )
+  private val defaultMetrics = ListSet(
+    "Input", "Output",
+    "Shuffle Read", "Shuffle Write"
+  )
 
   def render(request: HttpServletRequest): Seq[Node] = {
     // For now, pool information is only accessible in live UIs
@@ -46,8 +63,20 @@ private[ui] class AllStagesPage(parent: StagesTab) extends WebUIPage("") {
     val allStages = parent.store.stageList(null)
     val appSummary = parent.store.appSummary()
 
+    val parameterMetrics = optionalMetrics.map(m => m -> request.getParameter(s"metric.$m"))
+    val metrics = parameterMetrics.filter(m => Option(m._2).isDefined).toSeq match {
+      case Seq() => defaultMetrics
+      case seq => seq.filter(_._2.equalsIgnoreCase("true")).toMap.keySet
+    }
+
+    val parameterExceptMetrics = request.getParameterMap().asScala
+      .filterNot(_._1.startsWith("metric."))
+      .map(para => para._1 + "=" + para._2(0))
+    val parameterPath = UIUtils.prependBaseUri(request, parent.basePath) + s"/$subPath/?" +
+      parameterExceptMetrics.mkString("&")
+
     val (summaries, tables) = allStatuses.map(
-      summaryAndTableForStatus(allStages, appSummary, _, request)).unzip
+      summaryAndTableForStatus(allStages, metrics, appSummary, _, request)).unzip
 
     val summary: NodeSeq =
       <div>
@@ -71,13 +100,49 @@ private[ui] class AllStagesPage(parent: StagesTab) extends WebUIPage("") {
         Seq.empty[Node]
       }
 
-    val content = summary ++ poolsDescription ++ tables.flatten.flatten
+    val content = summary ++ additionalMetrics(metrics, parameterPath) ++
+      poolsDescription ++
+      <div id="parent-container">
+        <script src={UIUtils.prependBaseUri(request, "/static/utils.js")}></script>
+        <script src={UIUtils.prependBaseUri(request, "/static/allstagespage.js")}></script>
+      </div> ++
+      tables.flatten.flatten
 
     UIUtils.headerSparkPage(request, "Stages for All Jobs", content, parent)
   }
 
+  private def additionalMetrics(shownMetrics: Set[String], parameterPath: String): Seq[Node] = {
+        <div><a id='additionalMetrics'>
+        <span class='expand-input-rate-arrow arrow-closed' id='arrowtoggle1'></span>
+         Show Additional Metrics
+        </a></div>
+        <div class='container-fluid container-fluid-div' id='toggle-metrics' hidden="true">
+        <div id='select_all' class='select-all-checkbox-div'>
+          <input type='checkbox' class='toggle-vis'> Select All</input>
+        </div>
+        {optionalMetrics.map{metric =>
+          val checked = Option(shownMetrics.contains(metric)).filter(identity).map(_ => "checked")
+          def toggleMetric(m: String): Boolean = shownMetrics.contains(m) ^ metric == m
+          val metricLink =
+            Unparsed(
+              parameterPath +
+                optionalMetrics.map(m =>
+                  s"&metric.${URLEncoder.encode(m, UTF_8.name())}=${toggleMetric(m)}"
+                ).mkString("&")
+            )
+          val id = metric.toLowerCase(Locale.ROOT).replaceAll(" ", "_")
+          <div id={id}>
+            <a href={metricLink}>
+              <input type='checkbox' class='toggle-vis' checked={checked.orNull}> {metric}</input>
+            </a>
+          </div>
+        }}
+        </div>
+  }
+
   private def summaryAndTableForStatus(
       allStages: Seq[StageData],
+      metrics: Set[String],
       appSummary: AppSummary,
       status: StageStatus,
       request: HttpServletRequest): (Option[Elem], Option[NodeSeq]) = {
@@ -95,7 +160,7 @@ private[ui] class AllStagesPage(parent: StagesTab) extends WebUIPage("") {
 
       val stagesTable =
         new StageTableBase(parent.store, request, stages, statusName(status), stageTag(status),
-          parent.basePath, subPath, parent.isFairScheduler, killEnabled, isFailedStage)
+          parent.basePath, subPath, metrics, parent.isFairScheduler, killEnabled, isFailedStage)
       val stagesSize = stages.size
       (Some(summary(appSummary, status, stagesSize)),
         Some(table(appSummary, status, stagesTable, stagesSize)))

--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
@@ -274,6 +274,7 @@ private[ui] class JobPage(parent: JobsTab, store: AppStatusStore) extends WebUIP
         activeStages += stage
       }
     }
+    val metrics = StagePagedTable.selectedMetrics(request)
 
     val basePath = "jobs/job"
 
@@ -286,19 +287,19 @@ private[ui] class JobPage(parent: JobsTab, store: AppStatusStore) extends WebUIP
 
     val activeStagesTable =
       new StageTableBase(store, request, activeStages, "active", "activeStage", parent.basePath,
-        basePath, parent.isFairScheduler,
+        basePath, metrics, parent.isFairScheduler,
         killEnabled = parent.killEnabled, isFailedStage = false)
     val pendingOrSkippedStagesTable =
       new StageTableBase(store, request, pendingOrSkippedStages, pendingOrSkippedTableId,
-        "pendingStage", parent.basePath, basePath, parent.isFairScheduler,
+        "pendingStage", parent.basePath, basePath, metrics, parent.isFairScheduler,
         killEnabled = false, isFailedStage = false)
     val completedStagesTable =
       new StageTableBase(store, request, completedStages, "completed", "completedStage",
-        parent.basePath, basePath, parent.isFairScheduler,
+        parent.basePath, basePath, metrics, parent.isFairScheduler,
         killEnabled = false, isFailedStage = false)
     val failedStagesTable =
       new StageTableBase(store, request, failedStages, "failed", "failedStage", parent.basePath,
-        basePath, parent.isFairScheduler,
+        basePath, metrics, parent.isFairScheduler,
         killEnabled = false, isFailedStage = true)
 
     val shouldShowActiveStages = activeStages.nonEmpty
@@ -377,7 +378,7 @@ private[ui] class JobPage(parent: JobsTab, store: AppStatusStore) extends WebUIP
         </ul>
       </div>
 
-    var content = summary
+    var content = summary ++ StagePagedTable.additionalMetrics(metrics, request)
     val appStartTime = store.applicationInfo().attempts.head.startTime.getTime()
 
     content ++= makeTimeline(activeStages ++ completedStages ++ failedStages,

--- a/core/src/main/scala/org/apache/spark/ui/jobs/PoolPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/PoolPage.scala
@@ -39,12 +39,14 @@ private[ui] class PoolPage(parent: StagesTab) extends WebUIPage("pool") {
       throw new IllegalArgumentException(s"Unknown pool: $poolName")
     }
 
+    val metrics = StagePagedTable.selectedMetrics(request)
+
     val uiPool = parent.store.asOption(parent.store.pool(poolName)).getOrElse(
       new PoolData(poolName, Set()))
     val activeStages = uiPool.stageIds.toSeq.map(parent.store.lastStageAttempt(_))
     val activeStagesTable =
       new StageTableBase(parent.store, request, activeStages, "", "activeStage", parent.basePath,
-        "stages/pool", parent.isFairScheduler, parent.killEnabled, false)
+        "stages/pool", metrics, parent.isFairScheduler, parent.killEnabled, false)
 
     val poolTable = new PoolTable(Map(pool -> uiPool), parent)
     var content = <h4>Summary </h4> ++ poolTable.toNodeSeq(request)
@@ -58,6 +60,7 @@ private[ui] class PoolPage(parent: StagesTab) extends WebUIPage("pool") {
             <a>Active Stages ({activeStages.size})</a>
           </h4>
         </span> ++
+        StagePagedTable.additionalMetrics(metrics, request) ++
         <div class="aggregated-poolActiveStages collapsible-table">
           {activeStagesTable.toNodeSeq}
         </div>

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StageTable.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StageTable.scala
@@ -23,6 +23,7 @@ import java.util.Date
 import javax.servlet.http.HttpServletRequest
 
 import scala.collection.JavaConverters._
+import scala.collection.immutable.ListMap
 import scala.xml._
 
 import org.apache.commons.text.StringEscapeUtils
@@ -40,6 +41,7 @@ private[ui] class StageTableBase(
     stageTag: String,
     basePath: String,
     subPath: String,
+    metrics: Set[String],
     isFairScheduler: Boolean,
     killEnabled: Boolean,
     isFailedStage: Boolean) {
@@ -75,6 +77,7 @@ private[ui] class StageTableBase(
       isFairScheduler,
       killEnabled,
       currentTime,
+      metrics,
       stagePageSize,
       stageSortColumn,
       stageSortDesc,
@@ -111,14 +114,22 @@ private[ui] class StageTableRowData(
     val shuffleRead: Long,
     val shuffleReadWithUnit: String,
     val shuffleWrite: Long,
-    val shuffleWriteWithUnit: String)
+    val shuffleWriteWithUnit: String,
+    val peakExecutionMemory: Long,
+    val peakExecutionMemoryWithUnit: String,
+    val memoryBytesSpilled: Long,
+    val memoryBytesSpilledWithUnit: String,
+    val diskBytesSpilled: Long,
+    val diskBytesSpilledWithUnit: String,
+    val jvmGcTime: Long,
+    val formattedJvmGcTime: String)
 
 private[ui] class MissingStageTableRowData(
     stageInfo: v1.StageData,
     stageId: Int,
     attemptId: Int) extends StageTableRowData(
   stageInfo, None, stageId, attemptId, "", None, new Date(0), "", -1, "", 0, "", 0, "", 0, "", 0,
-    "")
+    "", 0, "", 0, "", 0, "", 0, "")
 
 /** Page showing list of all ongoing and recently finished stages */
 private[ui] class StagePagedTable(
@@ -131,6 +142,7 @@ private[ui] class StagePagedTable(
     isFairScheduler: Boolean,
     killEnabled: Boolean,
     currentTime: Long,
+    metrics: Set[String],
     pageSize: Int,
     sortColumn: String,
     desc: Boolean,
@@ -176,6 +188,23 @@ private[ui] class StagePagedTable(
   }
 
   override def headers: Seq[Node] = {
+    // must be in the same order than rowContent
+    val optionalHeaders = ListMap(
+      "Input" -> ("Input", ToolTips.INPUT, true),
+      "Output"-> ("Output", ToolTips.OUTPUT, true),
+      "Shuffle Read"-> ("Shuffle Read", ToolTips.SHUFFLE_READ, true),
+      "Shuffle Write" -> ("Shuffle Write", ToolTips.SHUFFLE_WRITE, true),
+      "Peak Execution Memory" -> ("Peak Execution Memory", ToolTips.PEAK_EXECUTION_MEMORY, true),
+      "Spill (Memory)" -> ("Spill (Memory)", ToolTips.SHUFFLE_READ, true),  // TODO
+      "Spill (Disk)" -> ("Spill (Disk)", ToolTips.SHUFFLE_WRITE, true),  // TODO
+      "GC Time" -> ("GC Time", ToolTips.GC_TIME, true)
+    )
+    if(metrics.exists(!optionalHeaders.contains(_))) {
+      throw new IllegalArgumentException(
+        s"Unknown metric: ${metrics.diff(optionalHeaders.keys.toSet).mkString(", ")}"
+      )
+    }
+
     // stageHeadersAndCssClasses has three parts: header title, tooltip information, and sortable.
     // The tooltip information could be None, which indicates it does not have a tooltip.
     // Otherwise, it has two parts: tooltip text, and position (true for left, false for default).
@@ -186,12 +215,9 @@ private[ui] class StagePagedTable(
         ("Description", null, true),
         ("Submitted", null, true),
         ("Duration", ToolTips.DURATION, true),
-        ("Tasks: Succeeded/Total", null, false),
-        ("Input", ToolTips.INPUT, true),
-        ("Output", ToolTips.OUTPUT, true),
-        ("Shuffle Read", ToolTips.SHUFFLE_READ, true),
-        ("Shuffle Write", ToolTips.SHUFFLE_WRITE, true)
+        ("Tasks: Succeeded/Total", null, false)
       ) ++
+      optionalHeaders.filterKeys(metrics.contains).values ++
       {if (isFailedStage) {Seq(("Failure Reason", null, false))} else Seq.empty}
 
     if (!stageHeadersAndCssClasses.filter(_._3).map(_._1).contains(sortColumn)) {
@@ -284,18 +310,52 @@ private[ui] class StagePagedTable(
           {UIUtils.makeProgressBar(started = stageData.numActiveTasks,
           completed = stageData.numCompleteTasks, failed = stageData.numFailedTasks,
           skipped = 0, reasonToNumKilled = stageData.killedTasksSummary, total = info.numTasks)}
-        </td>
-        <td>{data.inputReadWithUnit}</td>
-        <td>{data.outputWriteWithUnit}</td>
-        <td>{data.shuffleReadWithUnit}</td>
-        <td>{data.shuffleWriteWithUnit}</td> ++
-        {
-          if (isFailedStage) {
-            failureReasonHtml(info)
-          } else {
-            Seq.empty
-          }
-        }
+        </td> ++
+        {if (metrics.contains("Input")) {
+          <td>{data.inputReadWithUnit}</td>
+        } else {
+          Seq.empty
+        }} ++
+        {if (metrics.contains("Output")) {
+          <td>{data.outputWriteWithUnit}</td>
+        } else {
+          Seq.empty
+        }} ++
+        {if (metrics.contains("Shuffle Read")) {
+          <td>{data.shuffleReadWithUnit}</td>
+        } else {
+          Seq.empty
+        }} ++
+        {if (metrics.contains("Shuffle Write")) {
+          <td>{data.shuffleWriteWithUnit}</td>
+        } else {
+          Seq.empty
+        }} ++
+        {if (metrics.contains("Peak Execution Memory")) {
+          <td>{data.peakExecutionMemoryWithUnit}</td>
+        } else {
+          Seq.empty
+        }} ++
+        {if (metrics.contains("Spill (Memory)")) {
+          <td>{data.memoryBytesSpilledWithUnit}</td>
+        } else {
+          Seq.empty
+        }} ++
+        {if (metrics.contains("Spill (Disk)")) {
+          <td>{data.diskBytesSpilledWithUnit}</td>
+        } else {
+          Seq.empty
+        }} ++
+        {if (metrics.contains("GC Time")) {
+          <td>{data.formattedJvmGcTime}</td>
+        } else {
+          Seq.empty
+        }} ++
+        {if (isFailedStage) {
+          failureReasonHtml(info)
+        } else {
+          Seq.empty
+        }}
     }
   }
 
@@ -377,10 +437,9 @@ private[ui] class StagePagedTable(
     <td></td> ++ // Submitted
     <td></td> ++ // Duration
     <td></td> ++ // Tasks: Succeeded/Total
-    <td></td> ++ // Input
-    <td></td> ++ // Output
-    <td></td> ++ // Shuffle Read
-    <td></td> // Shuffle Write
+    {metrics.map(_ =>
+      <td></td> // selected metrics
+    )}
   }
 }
 
@@ -433,6 +492,17 @@ private[ui] class StageDataSource(
     val shuffleReadWithUnit = if (shuffleRead > 0) Utils.bytesToString(shuffleRead) else ""
     val shuffleWrite = stageData.shuffleWriteBytes
     val shuffleWriteWithUnit = if (shuffleWrite > 0) Utils.bytesToString(shuffleWrite) else ""
+    val peakExecMemory = stageData.peakExecutionMemory
+    val peakExecMemoryWithUnit = if (peakExecMemory > 0) Utils.bytesToString(peakExecMemory) else ""
+    val memorySpilled = stageData.memoryBytesSpilled
+    val memorySpilledWithUnit = if (memorySpilled > 0) Utils.bytesToString(memorySpilled) else ""
+    val diskSpilled = stageData.diskBytesSpilled
+    val diskSpilledWithUnit = if (diskSpilled > 0) Utils.bytesToString(diskSpilled) else ""
+    val jvmGcTime = stageData.jvmGcTime
+    val formattedJvmGcTime = if (jvmGcTime > 0) UIUtils.formatDuration(jvmGcTime) else ""
+    // TODO: add stageData.executorRunTime + stageData.executorCpuTime to jvm: Run / CPU / GC Time
+    // SPARK-26109: Duration of task as executorRunTime to make it consistent with the
+    // aggregated tasks summary metrics table and the previous versions of Spark.
 
 
     new StageTableRowData(
@@ -453,7 +523,15 @@ private[ui] class StageDataSource(
       shuffleRead,
       shuffleReadWithUnit,
       shuffleWrite,
-      shuffleWriteWithUnit
+      shuffleWriteWithUnit,
+      peakExecMemory,
+      peakExecMemoryWithUnit,
+      memorySpilled,
+      memorySpilledWithUnit,
+      diskSpilled,
+      diskSpilledWithUnit,
+      jvmGcTime,
+      formattedJvmGcTime
     )
   }
 
@@ -471,6 +549,10 @@ private[ui] class StageDataSource(
       case "Output" => Ordering.by(_.outputWrite)
       case "Shuffle Read" => Ordering.by(_.shuffleRead)
       case "Shuffle Write" => Ordering.by(_.shuffleWrite)
+      case "Peak Execution Memory" => Ordering.by(_.peakExecutionMemory)
+      case "Spill (Memory)" => Ordering.by(_.memoryBytesSpilled)
+      case "Spill (Disk)" => Ordering.by(_.diskBytesSpilled)
+      case "GC Time" => Ordering.by(_.jvmGcTime)
       case "Tasks: Succeeded/Total" =>
         throw new IllegalArgumentException(s"Unsortable column: $sortColumn")
       case unknownColumn => throw new IllegalArgumentException(s"Unknown column: $unknownColumn")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Adding more metrics to the all-stages page, some of those available at the individual stages pages, namely `Peak Execution Memory`, `Spill (Memory)`, `Spill (Disk)` and `GC Time`.

### Why are the changes needed?
Finding stages that perform poorly is difficult when you have hundreds or thousands of stages. Sorting all stages by those extra metrics helps to identify those stages.

### Does this PR introduce any user-facing change?
Yes, in the Web UI, not in the API.
![grafik](https://user-images.githubusercontent.com/44700269/73278310-b2234f80-41eb-11ea-8f38-ff6bda893678.png)
![grafik](https://user-images.githubusercontent.com/44700269/73278326-b8b1c700-41eb-11ea-8c09-714a18642691.png)

### How was this patch tested?
Manual tests.