### PR TITLE
[SPARK-30366][WebUI] Show cached subplan of InMemoryTableScan and remove redundant subplans

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -991,6 +991,26 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val EXTENDED_EVENT_INFO = buildConf("spark.sql.extendedEventInfo")
+    .doc("Enables extended SQL event information, for example storing additional information" +
+      " about certain operators such as InMemoryTableScan in SparkPlanInfo")
+    .booleanConf
+    .createWithDefault(true)
+
+  val UI_EXTENDED_INFO = buildConf("spark.sql.ui.extendedInfo")
+    .doc("Enables extended information in the SQL UI, for example displaying additional" +
+      " information about the child operators of InMemoryTableScan. Note that this" +
+      " setting depends on extended SQL event information " + EXTENDED_EVENT_INFO.key +
+      " being enabled during the duration of a query.")
+    .booleanConf
+    .createWithDefault(true)
+
+  val PRUNE_CACHED_IN_MEMORY_RELATION = buildConf("spark.sql.ui.pruneCachedInMemoryRelation")
+    .doc("Enables pruning of the children of InMemoryRelation operators that do 100% cached reads" +
+      " in the Spark SQL UI, eliminating redundant information about uncomputed operators.")
+    .booleanConf
+    .createWithDefault(true)
+
   val FILES_MAX_PARTITION_BYTES = buildConf("spark.sql.files.maxPartitionBytes")
     .doc("The maximum number of bytes to pack into a single partition when reading files. " +
       "This configuration is effective only when using file-based sources such as Parquet, JSON " +
@@ -2290,6 +2310,13 @@ class SQLConf extends Serializable with Logging {
 
   def wholeStageSplitConsumeFuncByOperator: Boolean =
     getConf(WHOLESTAGE_SPLIT_CONSUME_FUNC_BY_OPERATOR)
+
+  def extendedEventInfo: Boolean =
+    getConf(EXTENDED_EVENT_INFO)
+
+  def uiExtendedInfo: Boolean = getConf(UI_EXTENDED_INFO)
+
+  def pruneCachedInMemoryRelation: Boolean = getConf(PRUNE_CACHED_IN_MEMORY_RELATION)
 
   def tableRelationCacheSize: Int =
     getConf(StaticSQLConf.FILESOURCE_TABLE_RELATION_CACHE_SIZE)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -997,19 +997,20 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
-  val UI_EXTENDED_INFO = buildConf("spark.sql.ui.extendedInfo")
-    .doc("Enables extended information in the SQL UI, for example displaying additional" +
-      " information about the child operators of InMemoryTableScan. Note that this" +
-      " setting depends on extended SQL event information " + EXTENDED_EVENT_INFO.key +
-      " being enabled during the duration of a query.")
-    .booleanConf
-    .createWithDefault(true)
-
   val PRUNE_CACHED_IN_MEMORY_RELATION = buildConf("spark.sql.ui.pruneCachedInMemoryRelation")
     .doc("Enables pruning of the children of InMemoryRelation operators that do 100% cached reads" +
       " in the Spark SQL UI, eliminating redundant information about uncomputed operators.")
     .booleanConf
     .createWithDefault(true)
+
+  val UI_EXTENDED_INFO = buildConf("spark.sql.ui.extendedInfo")
+    .doc("Enables extended information in the SQL UI, for example displaying additional" +
+      " information about the child operators of InMemoryTableScan. Note that this" +
+      s" setting depends on extended SQL event information ${EXTENDED_EVENT_INFO.key}" +
+      " being enabled during the duration of a query.")
+    .booleanConf
+    .createWithDefault(true)
+
 
   val FILES_MAX_PARTITION_BYTES = buildConf("spark.sql.files.maxPartitionBytes")
     .doc("The maximum number of bytes to pack into a single partition when reading files. " +
@@ -2311,12 +2312,11 @@ class SQLConf extends Serializable with Logging {
   def wholeStageSplitConsumeFuncByOperator: Boolean =
     getConf(WHOLESTAGE_SPLIT_CONSUME_FUNC_BY_OPERATOR)
 
-  def extendedEventInfo: Boolean =
-    getConf(EXTENDED_EVENT_INFO)
-
-  def uiExtendedInfo: Boolean = getConf(UI_EXTENDED_INFO)
+  def extendedEventInfo: Boolean = getConf(EXTENDED_EVENT_INFO)
 
   def pruneCachedInMemoryRelation: Boolean = getConf(PRUNE_CACHED_IN_MEMORY_RELATION)
+
+  def uiExtendedInfo: Boolean = getConf(UI_EXTENDED_INFO)
 
   def tableRelationCacheSize: Int =
     getConf(StaticSQLConf.FILESOURCE_TABLE_RELATION_CACHE_SIZE)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLTab.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLTab.scala
@@ -24,6 +24,7 @@ class SQLTab(val sqlStore: SQLAppStatusStore, sparkUI: SparkUI)
   extends SparkUITab(sparkUI, "SQL") with Logging {
 
   val parent = sparkUI
+  val conf = parent.conf
 
   attachPage(new AllExecutionsPage(this))
   attachPage(new ExecutionPage(this))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraphUpdater.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraphUpdater.scala
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.ui
+
+import java.util.concurrent.atomic.AtomicLong
+
+import scala.annotation.tailrec
+import scala.util.Try
+
+/**
+ * Provides functions that can be used to update nodes from SparkPlanGraphs.
+ */
+private class SparkPlanGraphNodeTransformers {
+
+  /**
+   * Identify nodes that should be hidden from the Spark SQL UI (descendants of InMemoryRelations
+   * with no computed partitions i.e. cached InMemoryRelations).
+   *
+   * @param graph to identify hidden nodes for
+   * @param metricValues map of metric ids to values for associated graph
+   * @return predicate function that identifies node ids as corresponding to hidden nodes or not
+   */
+  def getIsHiddenNode(graph: SparkPlanGraph, metricValues: Map[Long, String]): Long => Boolean = {
+
+    def getAllDescendantsOfCachedInMemoryRelations: Set[Long] = {
+
+      @tailrec def getAllDescendantsOfNodes(nodeIds: Set[Long], outputAcc: Set[Long]): Set[Long] = {
+        val descendants = nodeIds.flatMap(graph.childrenForEachNode)
+          .filter(id => !outputAcc.contains(id) && !nodeIds.contains(id))
+        if (descendants.isEmpty) {
+          outputAcc
+        } else {
+          getAllDescendantsOfNodes(descendants, outputAcc ++ descendants)
+        }
+      }
+
+      val cachedInMemoryRelations = graph.allNodes
+        .filter(node => isCachedInMemoryRelation(node, metricValues)).map(_.id).toSet
+
+      getAllDescendantsOfNodes(cachedInMemoryRelations, Set.empty)
+    }
+
+    def getAllClustersWithOnlyHiddenSubnodes(hiddenNodes: Set[Long]): Set[Long] =
+      // Add formerly non-hidden clusters whose subnodes are all hidden
+      graph.allNodes.filter {
+        case cluster: SparkPlanGraphCluster => cluster.nodes.nonEmpty &&
+          cluster.nodes.forall(node => hiddenNodes(node.id))
+        case _ => false
+      }.map(_.id).toSet
+
+    val hiddenNodes = getAllDescendantsOfCachedInMemoryRelations
+    val allHiddenNodes = hiddenNodes ++ getAllClustersWithOnlyHiddenSubnodes(hiddenNodes)
+    allHiddenNodes.contains
+  }
+
+  /**
+   * Identify metrics that should be hidden from the Spark SQL UI (InMemoryRelations with no
+   * computed partitions i.e. cached InMemoryRelations).
+   *
+   * @param metricValues map of metric ids to values
+   * @return transformer function that filters out hidden metrics from a node
+   */
+  def getFilterHiddenMetricsForNode(metricValues: Map[Long, String]
+                                   ): SparkPlanGraphNode => SparkPlanGraphNode =
+    node => node.name match {
+      case "InMemoryRelation" =>
+        val filteredMetrics = node.metrics.filter(metric => !isNumComputedPartitions(metric))
+        node.copy(newMetrics = filteredMetrics)
+      case _ => node
+    }
+
+  /**
+   * Determine reassignment of node ids such that new ids are consecutively increasing from 0 to
+   * nodes.size.
+   *
+   * @param graph to find reassignment for
+   * @return transformer function that returns a new id given the old id for any node on the graph
+   */
+  def getNodeIdReassigner(graph: SparkPlanGraph): Long => Long = {
+    val nodeIdGenerator = new AtomicLong(0)
+    val allNodesSorted = graph.allNodes.sortBy(_.id)
+    val oldToNewIds: Map[Long, Long] = allNodesSorted.map(node =>
+      (node.id, nodeIdGenerator.getAndIncrement())).toMap
+
+    oldId => oldToNewIds.getOrElse(oldId,
+      throw new IllegalArgumentException("old id does not exist in reassignment mapping"))
+  }
+
+  private def isCachedInMemoryRelation(node: SparkPlanGraphNode,
+                                       metricValues: Map[Long, String]): Boolean =
+    node.name == "InMemoryRelation" && hasZeroComputedPartitions(node.metrics, metricValues)
+
+  private def hasZeroComputedPartitions(nodeMetrics: Seq[SQLPlanMetric],
+                                        metricValues: Map[Long, String]): Boolean =
+    nodeMetrics.exists { metric =>
+      isNumComputedPartitions(metric) &&
+          metricValues.get(metric.accumulatorId).exists(_.toLongOption.contains(0L))
+    }
+
+  private def isNumComputedPartitions(metric: SQLPlanMetric): Boolean =
+    metric.name == "numComputedPartitions" && metric.metricType == "sum"
+
+  private implicit class StringToLongOption(s: String) {
+    def toLongOption: Option[Long] = Try(s.toLong).toOption
+  }
+}
+
+/**
+ * Provides functions used to update SparkPlanGraphs before rendering. Uses transformer functions
+ * defined by SparkPlanGraphNodeTransformers by default.
+ *
+ * @param metricValues map of metric ids to values for a graph
+ * @param transformers node transformers class that can be overridden to provide different
+ *                     functionality than the default SparkPlanGraphNodeTransformer
+ */
+private class SparkPlanGraphUpdater(private val metricValues: Map[Long, String],
+                                    private val transformers: SparkPlanGraphNodeTransformers =
+                                    new SparkPlanGraphNodeTransformers) {
+
+  /**
+   * Prunes nodes that should be hidden from the Spark SQL UI.
+   *
+   * @param graph to prune hidden nodes from
+   * @return a new SparkPlanGraph with hidden nodes pruned
+   */
+  def pruneHiddenNodes(graph: SparkPlanGraph): SparkPlanGraph = {
+    val isHiddenNode = transformers.getIsHiddenNode(graph, metricValues)
+    val prunedNodes = filterNodes(graph.nodes, node => !isHiddenNode(node.id))
+    val prunedEdges = filterEdges(graph, isHiddenNode)
+    SparkPlanGraph(prunedNodes, prunedEdges)
+  }
+
+  /**
+   * Filters out metrics that should be hidden from the Spark SQL UI.
+   *
+   * @param graph to prune hidden nodes from
+   * @return a new SparkPlanGraph with hidden nodes pruned
+   */
+  def filterHiddenMetrics(graph: SparkPlanGraph): SparkPlanGraph = {
+    val filterHiddenMetricsForNode = transformers.getFilterHiddenMetricsForNode(metricValues)
+    val filteredNodes = mapNodes(graph.nodes, filterHiddenMetricsForNode)
+    SparkPlanGraph(filteredNodes, graph.edges)
+  }
+
+  /**
+   * Reassign node ids for a graph.
+   *
+   * @param graph to reassign node ids for
+   * @return a new SparkPlanGraph with node ids reassigned
+   */
+  def reassignNodeIds(graph: SparkPlanGraph): SparkPlanGraph = {
+    val reassigner = transformers.getNodeIdReassigner(graph)
+    val updatedNodes = mapNodes(graph.nodes, node => node.copy(newId = reassigner(node.id)))
+    val updatedEdges = graph.edges.map(
+      edge => edge.copy(reassigner(edge.fromId), reassigner(edge.toId)))
+    SparkPlanGraph(updatedNodes, updatedEdges)
+  }
+
+  private def mapNodes(nodes: Seq[SparkPlanGraphNode],
+                       transformer: SparkPlanGraphNode => SparkPlanGraphNode
+                      ): Seq[SparkPlanGraphNode] = {
+    def mapNodesRecursively(nodes: Seq[SparkPlanGraphNode]): Seq[SparkPlanGraphNode] = {
+      nodes.map {
+        case cluster: SparkPlanGraphCluster =>
+          transformer(cluster.updateNodes(mapNodesRecursively(cluster.nodes)))
+        case node => transformer(node)
+      }
+    }
+    mapNodesRecursively(nodes)
+  }
+
+  private def filterNodes(nodes: Seq[SparkPlanGraphNode],
+                          predicate: SparkPlanGraphNode => Boolean
+                         ): Seq[SparkPlanGraphNode] = {
+    def filterNodesRecursively(nodes: Seq[SparkPlanGraphNode]): Seq[SparkPlanGraphNode] = {
+      nodes collect {
+        case cluster: SparkPlanGraphCluster if predicate(cluster) =>
+          filterNodesRecursively(cluster.nodes) match {
+            case cluster.nodes => cluster
+            case subnodes => cluster.updateNodes(subnodes)
+          }
+        case node if predicate(node) => node
+      }
+    }
+    filterNodesRecursively(nodes)
+  }
+
+  private def filterEdges(graph: SparkPlanGraph,
+                          isHiddenNode: Long => Boolean): Seq[SparkPlanGraphEdge] = {
+    val isNodeOfHiddenCluster = graph.allNodes.collect {
+      case cluster: SparkPlanGraphCluster if isHiddenNode(cluster.id) => cluster.nodes
+    }.flatten.map(_.id).toSet
+
+    graph.edges.filter(edge => !isHiddenNode(edge.fromId) &&
+      !isHiddenNode(edge.toId) &&
+      !isNodeOfHiddenCluster(edge.fromId) &&
+      !isNodeOfHiddenCluster(edge.toId))
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanInfoSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanInfoSuite.scala
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import org.scalatest.Matchers._
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Expression, ExprId}
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.execution.columnar._
+import org.apache.spark.sql.execution.metric.SQLMetricInfo
+import org.apache.spark.sql.test.SharedSparkSession
+
+class SparkPlanInfoSuite extends SparkFunSuite with SharedSparkSession {
+
+  test ("Generating SparkPlanInfo from plan gives expected SparkPlanInfo") {
+    val plan = NamedDummyLeafNode("testPlan")
+    val planInfo = SparkPlanInfo.fromSparkPlan(plan)
+
+    planInfo.nodeName shouldBe "testPlan"
+  }
+
+  test ("Generating SparkPlanInfo from plan with SparkPlan child gives expected SparkPlanInfo") {
+    val childPlan = NamedDummyLeafNode("testChild")
+    val parentPlan = NamedDummyUnaryNode("testParent", childPlan)
+    val planInfo = SparkPlanInfo.fromSparkPlan(parentPlan)
+
+    planInfo.allNodeNames should contain inOrderOnly ("testParent", "testChild")
+  }
+
+  test("Generating SparkPlanInfo from InMemoryTableScan gives InMemoryRelation child," +
+    " cachedPlan grandchild") {
+    val cachedPlan = NamedDummyLeafNode("testChild")
+    val inMemoryTableScan = createInMemoryTableScan(cachedPlan)
+    val inMemoryTableScanInfo = SparkPlanInfo.fromSparkPlan(inMemoryTableScan)
+
+    inMemoryTableScanInfo.allNodeNames should contain inOrderOnly
+      ("InMemoryTableScan", "InMemoryRelation", "testChild")
+  }
+
+  test("Generating SparkPlanInfo from nested InMemoryTableScan gives nested correct children") {
+    val cachedPlan = NamedDummyLeafNode("testChild")
+    val inMemoryTableScanChild = createInMemoryTableScan(cachedPlan)
+    val inMemoryTableScanParent = createInMemoryTableScan(inMemoryTableScanChild)
+    val inMemoryTableScanInfo = SparkPlanInfo.fromSparkPlan(inMemoryTableScanParent)
+
+    inMemoryTableScanInfo.allNodeNames should contain theSameElementsInOrderAs Seq(
+      "InMemoryTableScan", "InMemoryRelation", "InMemoryTableScan", "InMemoryRelation", "testChild")
+  }
+
+  test("Generating SparkPlanInfo from InMemoryTableScan with subqueries gives subqueries and" +
+    " cachedPlan children") {
+    val subqueryExpression = ScalarSubquery(new SubqueryExec("testSubquery",
+      NamedDummyLeafNode("testSubqueryChild")), ExprId(0))
+    val cachedPlan = NamedDummyLeafNode("testChild")
+    val inMemoryTableScan = createInMemoryTableScan(cachedPlan, Seq(subqueryExpression))
+    val inMemoryTableScanInfo = SparkPlanInfo.fromSparkPlan(inMemoryTableScan)
+
+    inMemoryTableScanInfo.nodeName shouldBe "InMemoryTableScan"
+    inMemoryTableScanInfo.children.map(_.nodeName) should contain only
+      ("InMemoryRelation", "Subquery")
+  }
+
+  test("Generating SparkPlanInfo from child InMemoryRelation correctly propagates metadata and" +
+    " metrics for InMemoryRelation") {
+    val scan = createInMemoryTableScan(NamedDummyLeafNode("testCachedPlan"))
+    val relation = scan.relation
+
+    val scanInfo = SparkPlanInfo.fromSparkPlan(scan)
+    val relationInfo = scanInfo.children.head
+
+    relation.metrics.foreach { case (key, metric) =>
+      relationInfo.metrics should contain
+        new SQLMetricInfo(metric.name.getOrElse(key), metric.id, metric.metricType)
+    }
+    relationInfo.metadata shouldBe relation.metadata
+  }
+
+  private implicit class SparkPlanInfoAdditions(info: SparkPlanInfo) {
+    def allNodeNames: Seq[String] = allNodes(info).map(_.nodeName)
+
+    private def allNodes(info: SparkPlanInfo): Seq[SparkPlanInfo] =
+      info +: info.children.flatMap(allNodes)
+  }
+
+  private def createInMemoryTableScan(cachedPlan: SparkPlan,
+                                      predicates: Seq[Expression] = Nil): InMemoryTableScanExec = {
+    val cachedRDDBuilder = CachedRDDBuilder(useCompression = false, 0, null, cachedPlan, None)
+    val inMemoryRelation = new InMemoryRelation(Nil, cachedRDDBuilder, Nil)
+    InMemoryTableScanExec(Nil, predicates, inMemoryRelation)
+  }
+}
+
+private case class NamedDummyLeafNode(override val nodeName: String) extends LeafExecNode {
+  override protected def doExecute(): RDD[InternalRow] = throw new NotImplementedError
+  override def output: Seq[Attribute] = Seq.empty
+}
+
+private case class NamedDummyUnaryNode(override val nodeName: String, child: SparkPlan)
+  extends UnaryExecNode {
+  override protected def doExecute(): RDD[InternalRow] = throw new NotImplementedError
+  override def output: Seq[Attribute] = Seq.empty
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/CachedRDDBuilderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/CachedRDDBuilderSuite.scala
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.columnar
+
+import org.scalatest.Matchers._
+import scala.reflect.ClassTag
+
+import org.apache.spark.{Partition, SparkContext, SparkFunSuite, TaskContext}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.execution.{LeafExecNode, SparkPlan}
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.storage.StorageLevel
+
+class CachedRDDBuilderSuite extends SparkFunSuite with SharedSparkSession {
+
+  test("CachedRDDBuilder correctly generates and increments ids") {
+    val cacheBuilder1 = createCachedRDDBuilder()
+    val cacheBuilder2 = createCachedRDDBuilder()
+    val cacheBuilder3 = createCachedRDDBuilder()
+
+    cacheBuilder1.id should not be cacheBuilder2.id
+    cacheBuilder2.id should not be cacheBuilder3.id
+    cacheBuilder3.id should not be cacheBuilder1.id
+  }
+
+  test("CachedRDDBuilder correctly generates new id when copied") {
+    val cacheBuilder1 = createCachedRDDBuilder()
+    val cacheBuilder2 = cacheBuilder1.copy()
+
+    cacheBuilder1.id should not be cacheBuilder2.id
+  }
+
+  test("CachedRDDBuilder correctly stores id in metadata") {
+    val cacheBuilder = createCachedRDDBuilder()
+
+    cacheBuilder.metadata("cacheBuilderId") shouldBe cacheBuilder.id.toString
+  }
+
+  test("CachedRDDBuilder does not update numComputedPartitions metric with cached plan with" +
+    " no partitions") {
+    val sourceDataFrame = sqlContext.sparkSession.emptyDataFrame
+    val cachedPlan = sourceDataFrame.queryExecution.executedPlan
+    val cacheBuilder = createCachedRDDBuilder(cachedPlan)
+
+    cacheBuilder.metrics("numComputedPartitions").value shouldBe 0
+    cacheBuilder.cachedColumnBuffers.collect()
+    cacheBuilder.metrics("numComputedPartitions").value shouldBe 0
+  }
+
+  test("CachedRDDBuilder correctly updates numComputedPartitions metric with single empty" +
+    " partition") {
+    val sourceRDD = new emptyPartitionsRDD[Row](1, sparkContext)
+    val sourceDataFrame = sqlContext.sparkSession.createDataFrame(sourceRDD, StructType(Nil))
+    val cachedPlan = sourceDataFrame.queryExecution.executedPlan
+    val cacheBuilder = createCachedRDDBuilder(cachedPlan)
+
+    cacheBuilder.metrics("numComputedPartitions").value shouldBe 0
+    cacheBuilder.cachedColumnBuffers.collect()
+    cacheBuilder.metrics("numComputedPartitions").value shouldBe 1
+    cacheBuilder.cachedColumnBuffers.collect()
+    cacheBuilder.metrics("numComputedPartitions").value shouldBe 1
+  }
+
+  test("CachedRDDBuilder correctly updates numComputedPartitions metric with multiple empty" +
+    " partitions") {
+    val sourceRDD = new emptyPartitionsRDD[Row](3, sparkContext)
+    val sourceDataFrame = sqlContext.sparkSession.createDataFrame(sourceRDD, StructType(Nil))
+    val cachedPlan = sourceDataFrame.queryExecution.executedPlan
+    val cacheBuilder = createCachedRDDBuilder(cachedPlan)
+
+    cacheBuilder.metrics("numComputedPartitions").value shouldBe 0
+    cacheBuilder.cachedColumnBuffers.collect()
+    cacheBuilder.metrics("numComputedPartitions").value shouldBe 3
+    cacheBuilder.cachedColumnBuffers.collect()
+    cacheBuilder.metrics("numComputedPartitions").value shouldBe 3
+  }
+
+  test("CachedRDDBuilder correctly updates numComputedPartitions metric") {
+    val sourceDataFrame = sqlContext.sparkSession.createDataFrame(Seq(("1", "2")))
+    val cachedPlan = sourceDataFrame.queryExecution.executedPlan
+    val cacheBuilder = createCachedRDDBuilder(cachedPlan)
+
+    cacheBuilder.metrics("numComputedPartitions").value shouldBe 0
+    cacheBuilder.cachedColumnBuffers.collect()
+    cacheBuilder.metrics("numComputedPartitions").value shouldBe 1
+    cacheBuilder.cachedColumnBuffers.collect()
+    cacheBuilder.metrics("numComputedPartitions").value shouldBe 1
+  }
+
+  test("CachedRDDBuilder correctly updates numComputedPartitions metric with multiple" +
+    " partitions") {
+    // Sets the number of partitions that will be computed to 3
+    sqlContext.sparkContext.conf.set("spark.default.parallelism", "3")
+
+    val sourceDataFrame = sqlContext.sparkSession.createDataFrame(Seq(
+      ("1", "2"),
+      ("3", "4"),
+      ("5", "6"),
+      ("7", "8"),
+      ("9", "0")))
+    val cachedPlan = sourceDataFrame.queryExecution.executedPlan
+    val cacheBuilder = createCachedRDDBuilder(cachedPlan)
+
+    cacheBuilder.metrics("numComputedPartitions").value shouldBe 0
+    cacheBuilder.cachedColumnBuffers.collect()
+    cacheBuilder.metrics("numComputedPartitions").value shouldBe 3
+    cacheBuilder.cachedColumnBuffers.collect()
+    cacheBuilder.metrics("numComputedPartitions").value shouldBe 3
+  }
+
+  test("CachedRDDBuilder correctly updates numComputedRows metric") {
+    val sourceDataFrame = sqlContext.sparkSession.createDataFrame(Seq(("1", "2")))
+    val cachedPlan = sourceDataFrame.queryExecution.executedPlan
+    val cacheBuilder = createCachedRDDBuilder(cachedPlan)
+
+    cacheBuilder.metrics("numComputedRows").value shouldBe 0
+    cacheBuilder.cachedColumnBuffers.collect()
+    cacheBuilder.metrics("numComputedRows").value shouldBe 1
+    cacheBuilder.cachedColumnBuffers.collect()
+    cacheBuilder.metrics("numComputedRows").value shouldBe 1
+  }
+
+  test("CachedRDDBuilder correctly updates numComputedRows metric with batchSize less than" +
+    " rows computed") {
+    val sourceDataFrame = sqlContext.sparkSession.createDataFrame(Seq(
+      ("1", "2"),
+      ("3", "4"),
+      ("5", "6")))
+    val cachedPlan = sourceDataFrame.queryExecution.executedPlan
+    val cacheBuilder = createCachedRDDBuilder(cachedPlan, 1)
+
+    cacheBuilder.metrics("numComputedRows").value shouldBe 0
+    cacheBuilder.cachedColumnBuffers.collect()
+    cacheBuilder.metrics("numComputedRows").value shouldBe 3
+    cacheBuilder.cachedColumnBuffers.collect()
+    cacheBuilder.metrics("numComputedRows").value shouldBe 3
+  }
+
+  test("Copied CachedRDDBuilder nulls out buffers") {
+    val sourceDataFrame = sqlContext.sparkSession.createDataFrame(Seq(("1", "2")))
+    val cachedPlan = sourceDataFrame.queryExecution.executedPlan
+    val cacheBuilder1 = createCachedRDDBuilder(cachedPlan)
+    val output1 = cacheBuilder1.cachedColumnBuffers
+    val cacheBuilder2 = cacheBuilder1.copy()
+
+    cacheBuilder1.isCachedColumnBuffersLoaded shouldBe true
+    cacheBuilder2.isCachedColumnBuffersLoaded shouldBe false
+
+    val output2 = cacheBuilder2.cachedColumnBuffers
+
+    output1 should not be output2
+  }
+
+  private def createCachedRDDBuilder(cachedPlan: SparkPlan = NamedDummyLeafNode(),
+                                     batchSize: Int = 10): CachedRDDBuilder = {
+    CachedRDDBuilder(useCompression = false, batchSize, StorageLevel.MEMORY_ONLY, cachedPlan, None)
+  }
+}
+
+private case class NamedDummyLeafNode(override val nodeName: String = "") extends LeafExecNode {
+  override protected def doExecute(): RDD[InternalRow] = throw new UnsupportedOperationException
+  override def output: Seq[Attribute] = Seq.empty
+}
+
+private class emptyPartitionsRDD[T: ClassTag](numPartitions: Int, sc: SparkContext)
+  extends RDD[T](sc, Seq.empty) {
+
+  override def getPartitions: Array[Partition] = {
+    (0 until numPartitions).map(index => new emptyPartition(index)).toArray
+  }
+
+  override def compute(split: Partition, context: TaskContext): Iterator[T] = {
+    Seq().iterator
+  }
+}
+
+private class emptyPartition(val index: Int) extends Partition

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsTestUtils.scala
@@ -184,7 +184,7 @@ trait SQLMetricsTestUtils extends SQLTestUtils {
       // If we can track all jobs, check the metric values
       val metricValues = statusStore.executionMetrics(executionId)
       val metrics = SparkPlanGraph(SparkPlanInfo.fromSparkPlan(
-        df.queryExecution.executedPlan)).allNodes.filter { node =>
+        df.queryExecution.executedPlan), sparkContext.conf).allNodes.filter { node =>
         expectedNodeIds.contains(node.id)
       }.map { node =>
         val nodeMetrics = node.metrics.map { metric =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
@@ -165,7 +165,7 @@ class SQLAppStatusListenerSuite extends SharedSparkSession with JsonTestUtils
     val executionId = 0
     val df = createTestDataFrame
     val accumulatorIds =
-      SparkPlanGraph(SparkPlanInfo.fromSparkPlan(df.queryExecution.executedPlan))
+      SparkPlanGraph(SparkPlanInfo.fromSparkPlan(df.queryExecution.executedPlan), sparkConf)
         .allNodes.flatMap(_.metrics.map(_.accumulatorId))
     // Assume all accumulators are long
     var accumulatorValue = 0L

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SparkPlanGraphNodeTransformersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SparkPlanGraphNodeTransformersSuite.scala
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.ui
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.scalatest.Matchers._
+
+import org.apache.spark.SparkFunSuite
+
+class SparkPlanGraphNodeTransformersSuite extends SparkFunSuite {
+
+  test("getIsHiddenNode output identifies children of cached InMemoryRelation as hidden") {
+    val nodes = createNodesWithAscendingId("Parent", "InMemoryRelation", "child")
+    val edges = Seq((2L, 1L), (1L, 0L)).map(createEdge)
+    val graph = SparkPlanGraph(nodes, edges)
+
+    val metrics = Map(0L -> "0")
+
+    val transformers = new SparkPlanGraphNodeTransformers
+    val isHiddenNode = transformers.getIsHiddenNode(graph, metrics)
+
+    graph.nodes.map(node => isHiddenNode(node.id)) should contain theSameElementsInOrderAs
+      Seq(false, false, true)
+  }
+
+  test("getIsHiddenNode output identifies children of non-cached InMemoryRelation as not hidden") {
+    val nodes = createNodesWithAscendingId("Parent", "InMemoryRelation", "child")
+    val edges = Seq((2L, 1L), (1L, 0L)).map(createEdge)
+    val graph = SparkPlanGraph(nodes, edges)
+
+    val metrics = Map(0L -> "1")
+
+    val transformers = new SparkPlanGraphNodeTransformers
+    val isHiddenNode = transformers.getIsHiddenNode(graph, metrics)
+
+    graph.nodes.map(node => isHiddenNode(node.id)) should contain theSameElementsInOrderAs
+      Seq(false, false, false)
+  }
+
+  test("getIsHiddenNode output identifies children of InMemoryRelation with no " +
+    "numComputedPartitions metric as not hidden") {
+    val nodes = Seq(createNode(0, "Parent"), createInMemoryRelationWithoutNumComputedPartitions(1),
+      createNode(2, "child"))
+    val edges = Seq((2L, 1L), (1L, 0L)).map(createEdge)
+    val graph = SparkPlanGraph(nodes, edges)
+
+    val metrics = Map.empty[Long, String]
+
+    val transformers = new SparkPlanGraphNodeTransformers
+    val isHiddenNode = transformers.getIsHiddenNode(graph, metrics)
+
+    graph.nodes.map(node => isHiddenNode(node.id)) should contain theSameElementsInOrderAs
+      Seq(false, false, false)
+  }
+
+  test("getIsHiddenNode output identifies children of InMemoryRelation with its " +
+    "numComputedPartitions metric missing from metricValues as not hidden") {
+    val nodes = createNodesWithAscendingId("Parent", "InMemoryRelation", "child")
+    val edges = Seq((2L, 1L), (1L, 0L)).map(createEdge)
+    val graph = SparkPlanGraph(nodes, edges)
+
+    val metrics = Map.empty[Long, String]
+
+    val transformers = new SparkPlanGraphNodeTransformers
+    val isHiddenNode = transformers.getIsHiddenNode(graph, metrics)
+
+    graph.nodes.map(node => isHiddenNode(node.id)) should contain theSameElementsInOrderAs
+      Seq(false, false, false)
+  }
+
+  test("getIsHiddenNode output does not identify empty WholeStageCodegen as hidden") {
+    val cluster = createWholeStageCodegen(0, Seq.empty)
+    val graph = SparkPlanGraph(Seq(cluster), Seq.empty)
+
+    val transformers = new SparkPlanGraphNodeTransformers
+    val isHiddenNode = transformers.getIsHiddenNode(graph, Map.empty)
+
+    isHiddenNode(cluster.id) shouldBe false
+  }
+
+  test("getIsHiddenNode output identifies child of cached InMemoryRelation nested inside " +
+    "WholeStageCodegen cluster and the cluster itself as hidden") {
+    val nodes = Seq(createNode(0, "InMemoryRelation"),
+      createWholeStageCodegen(1, Seq(createNode(2, "child"))))
+    val edges = Seq(createEdge((2L, 0L)))
+    val graph = SparkPlanGraph(nodes, edges)
+
+    val metrics = Map(0L -> "0")
+
+    val transformers = new SparkPlanGraphNodeTransformers
+    val isHiddenNode = transformers.getIsHiddenNode(graph, metrics)
+
+    graph.nodes.map(node => isHiddenNode(node.id)) should contain theSameElementsInOrderAs
+      Seq(false, true)
+
+    val clusterSubNodes = graph.nodes.collect {
+      case cluster: SparkPlanGraphCluster => cluster.nodes
+    }.flatten
+    clusterSubNodes.map(node => isHiddenNode(node.id)) should contain only true
+  }
+
+  test("GetFilterHiddenMetricsForNode output filters empty numComputedPartitions metric for" +
+    " InMemoryRelation") {
+    val node = createNode(0, "InMemoryRelation", Seq(createNumComputedPartitionsMetric(0)))
+    val metrics = Map(0L -> "0")
+
+    val transformers = new SparkPlanGraphNodeTransformers
+    val filterHiddenMetricsForNode = transformers.getFilterHiddenMetricsForNode(metrics)
+
+    filterHiddenMetricsForNode(node).metrics shouldBe empty
+  }
+
+  test("GetFilterHiddenMetricsForNode output filters out numComputedPartitions metric") {
+    val numComputedPartitionsMetric = createNumComputedPartitionsMetric(0)
+    val numComputedRowsMetric = SQLPlanMetric("numComputedRows", 1, "sum")
+    val node = createNode(0, "InMemoryRelation",
+      Seq(numComputedPartitionsMetric, numComputedRowsMetric))
+    val metrics = Map(0L -> "1", 1L -> "0")
+
+    val transformers = new SparkPlanGraphNodeTransformers
+    val filterHiddenMetricsForNode = transformers.getFilterHiddenMetricsForNode(metrics)
+
+    filterHiddenMetricsForNode(node).metrics should contain only numComputedRowsMetric
+  }
+
+  test("GetFilterHiddenMetrics output does not filter out empty numComputedPartitions not of " +
+    "metricType \"sum\" and other metrics for non-InMemoryRelation") {
+    val numComputedPartitionsMetric = SQLPlanMetric("numComputedPartitions", 0, "size")
+    val numComputedRowsMetric = SQLPlanMetric("numComputedRows", 1, "sum")
+    val node = createNode(0, "InMemoryRelation",
+      Seq(numComputedPartitionsMetric, numComputedRowsMetric))
+    val metrics = Map(0L -> "0", 1L -> "0")
+
+    val transformers = new SparkPlanGraphNodeTransformers
+    val filterHiddenMetricsForNode = transformers.getFilterHiddenMetricsForNode(metrics)
+
+    filterHiddenMetricsForNode(node).metrics should contain only
+      (numComputedPartitionsMetric, numComputedRowsMetric)
+  }
+
+  test("GetFilterHiddenMetrics output does not filter out empty numComputedPartitions and other " +
+    "metrics for non-InMemoryRelation") {
+    val numComputedPartitionsMetric = createNumComputedPartitionsMetric(0)
+    val numComputedRowsMetric = SQLPlanMetric("numComputedRows", 1, "sum")
+    val node = createNode(0, "NotInMemoryRelation",
+      Seq(numComputedPartitionsMetric, numComputedRowsMetric))
+    val metrics = Map(0L -> "0", 1L -> "0")
+
+    val transformers = new SparkPlanGraphNodeTransformers
+    val filterHiddenMetricsForNode = transformers.getFilterHiddenMetricsForNode(metrics)
+
+    filterHiddenMetricsForNode(node).metrics should contain only
+      (numComputedPartitionsMetric, numComputedRowsMetric)
+  }
+
+  test("getNodeIdReassigner creates 0 to n reassignment with graph with discontinuous ids") {
+    val nodes = createNodes(("one", 0L), ("two", 2L), ("three", 3L))
+    val edges = Seq((3L, 2L), (2L, 0L)).map(createEdge)
+    val graph = SparkPlanGraph(nodes, edges)
+
+    val transformers = new SparkPlanGraphNodeTransformers
+    val reassigner = transformers.getNodeIdReassigner(graph)
+
+    Seq(0L, 2L, 3L).map(reassigner) should contain theSameElementsInOrderAs Seq(0L, 1L, 2L)
+  }
+
+  test("getNodeIdReassigner creates 0 to n reassignment with graph where ids are continuous but" +
+    " do not start at 0") {
+    val nodes = createNodes(("one", 1L), ("two", 2L), ("three", 3L))
+    val edges = Seq((3L, 2L), (2L, 1L)).map(createEdge)
+    val graph = SparkPlanGraph(nodes, edges)
+
+    val transformers = new SparkPlanGraphNodeTransformers
+    val reassigner = transformers.getNodeIdReassigner(graph)
+
+    Seq(1L, 2L, 3L).map(reassigner) should contain theSameElementsInOrderAs Seq(0L, 1L, 2L)
+  }
+
+  test("getNodeIdReassigner output throws exception when provided a node id not in the provided" +
+    " graph") {
+    val nodes = createNodes(("one", 0L), ("two", 2L), ("three", 3L))
+    val edges = Seq((3L, 2L), (2L, 0L)).map(createEdge)
+    val graph = SparkPlanGraph(nodes, edges)
+
+    val transformers = new SparkPlanGraphNodeTransformers
+    val reassigner = transformers.getNodeIdReassigner(graph)
+
+    an [IllegalArgumentException] should be thrownBy reassigner(1L)
+  }
+
+  test("getNodeIdReassigner existing 0 to n assignment in preorder gives identity assignment") {
+    val nodes = createNodes(("one", 0L), ("two", 1L), ("three", 2L))
+    val edges = Seq((2L, 1L), (1L, 0L)).map(createEdge)
+    val graph = SparkPlanGraph(nodes, edges)
+
+    val transformers = new SparkPlanGraphNodeTransformers
+    val reassigner = transformers.getNodeIdReassigner(graph)
+
+    Seq(0L, 1L, 2L).map(reassigner) should contain theSameElementsInOrderAs Seq(0L, 1L, 2L)
+  }
+
+  private def createNodesWithAscendingId(nodeNames: String*): Seq[SparkPlanGraphNode] = {
+    nodeNames.zipWithIndex.map {
+      case (name, index) => createNode(index, name)
+    }
+  }
+
+  private def createNodes(nodeNameAndIds: (String, Long)*): Seq[SparkPlanGraphNode] = {
+    nodeNameAndIds.map{ case (name, id) => createNode(id, name) }
+  }
+
+  private def createNode(id: Long,
+                         name: String,
+                         metrics: Seq[SQLPlanMetric] = null): SparkPlanGraphNode = {
+    val resultMetrics = metrics match {
+      case null => name match {
+        case "InMemoryRelation" => Seq(createNumComputedPartitionsMetric(0))
+        case _ => Seq.empty
+      }
+      case metrics: Seq[SQLPlanMetric] => metrics
+    }
+    new SparkPlanGraphNode(id, name, "", resultMetrics)
+  }
+
+  private def createInMemoryRelationWithoutNumComputedPartitions(id: Long) =
+    new SparkPlanGraphNode(id, "InMemoryRelation", "", Seq.empty)
+
+  private def createWholeStageCodegen(id: Long,
+                                      subNodes: Seq[SparkPlanGraphNode]): SparkPlanGraphCluster = {
+    val buffer = new ArrayBuffer[SparkPlanGraphNode]()
+    buffer ++= subNodes
+    new SparkPlanGraphCluster(id, "WholeStageCodegen", "", buffer, Seq.empty)
+  }
+
+  private def createNumComputedPartitionsMetric(accumulatorId: Long): SQLPlanMetric =
+    SQLPlanMetric("numComputedPartitions", accumulatorId, "sum")
+
+  private def createEdge(edge: (Long, Long)): SparkPlanGraphEdge = edge match {
+    case (from, to) => SparkPlanGraphEdge(from, to)
+  }
+
+}
+

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SparkPlanGraphSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SparkPlanGraphSuite.scala
@@ -1,0 +1,399 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.ui
+
+import java.util.NoSuchElementException
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.scalatest.Matchers._
+
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.sql.execution.SparkPlanInfo
+import org.apache.spark.sql.internal.SQLConf.UI_EXTENDED_INFO
+import org.apache.spark.sql.test.SharedSparkSession
+
+class SparkPlanGraphSuite extends SparkFunSuite with SharedSparkSession {
+
+  private val confWithExtendedUIEnabled: SparkConf = new SparkConf()
+    .set(UI_EXTENDED_INFO.key, "true")
+
+  private val confWithExtendedUIDisabled: SparkConf = new SparkConf()
+    .set(UI_EXTENDED_INFO.key, "false")
+
+  test("SparkPlanInfo with nodename InMemoryTableScan has child InMemoryRelation processed with " +
+    UI_EXTENDED_INFO.key + " enabled") {
+      val inMemoryTableScanInfo =
+        createStemInfo("InMemoryTableScan", createInMemoryRelationInfo())
+      val graph = SparkPlanGraph(inMemoryTableScanInfo, confWithExtendedUIEnabled)
+
+      graph.nodes.map(_.name) should contain only("InMemoryTableScan", "InMemoryRelation")
+      graph.getEdgesAsTuples should contain theSameElementsAs Seq(
+        ((1, "InMemoryRelation"), (0, "InMemoryTableScan")))
+  }
+
+  test("SparkPlanInfo with nodename InMemoryTableScan does not have child InMemoryRelation " +
+    "processed with " + UI_EXTENDED_INFO.key + " disabled") {
+      val inMemoryTableScanInfo = createStemInfo("InMemoryTableScan", createInMemoryRelationInfo())
+      val graph = SparkPlanGraph(inMemoryTableScanInfo, confWithExtendedUIDisabled)
+
+      graph.nodes.map(_.name) should contain only "InMemoryTableScan"
+      graph.getEdgesAsTuples shouldBe empty
+  }
+
+  test("SparkPlanInfo with nodename InMemoryTableScan has child with nodename Subquery processed " +
+    "with " + UI_EXTENDED_INFO.key + " enabled") {
+    val inMemoryTableScanInfo = createStemInfo("InMemoryTableScan", createLeafInfo("Subquery"))
+    val graph = SparkPlanGraph(inMemoryTableScanInfo, confWithExtendedUIEnabled)
+
+    graph.nodes.map(_.name) should contain only ("InMemoryTableScan", "Subquery")
+    graph.getEdgesAsTuples should contain theSameElementsAs Seq(
+      ((1, "Subquery"), (0, "InMemoryTableScan")))
+  }
+
+  test("SparkPlanInfo with nodename InMemoryTableScan has child with nodename Subquery " +
+    "processed with " + UI_EXTENDED_INFO.key + " disabled") {
+    val inMemoryTableScanInfo = createStemInfo("InMemoryTableScan", createLeafInfo("Subquery"))
+    val graph = SparkPlanGraph(inMemoryTableScanInfo, confWithExtendedUIDisabled)
+
+    graph.nodes.map(_.name) should contain only ("InMemoryTableScan", "Subquery")
+    graph.getEdgesAsTuples should contain theSameElementsAs Seq(
+      ((1, "Subquery"), (0, "InMemoryTableScan")))
+  }
+
+  test("SparkPlanInfo with nodename InMemoryTableScan has child with nodename GenerateBloomFilter" +
+    " processed with " + UI_EXTENDED_INFO.key + " enabled") {
+    val generateBloomFilterInfo = createLeafInfo("GenerateBloomFilter")
+    val inMemoryTableScanInfo = createStemInfo("InMemoryTableScan", generateBloomFilterInfo)
+    val graph = SparkPlanGraph(inMemoryTableScanInfo, confWithExtendedUIEnabled)
+
+    graph.nodes.map(_.name) should contain only ("InMemoryTableScan", "GenerateBloomFilter")
+    graph.getEdgesAsTuples should contain theSameElementsAs Seq(
+      ((1, "GenerateBloomFilter"), (0, "InMemoryTableScan")))
+  }
+
+  test("SparkPlanInfo with nodename InMemoryTableScan has child with nodename GenerateBloomFilter" +
+    " processed with " + UI_EXTENDED_INFO.key + " disabled") {
+    val generateBloomFilterInfo = createLeafInfo("GenerateBloomFilter")
+    val inMemoryTableScanInfo = createStemInfo("InMemoryTableScan", generateBloomFilterInfo)
+    val graph = SparkPlanGraph(inMemoryTableScanInfo, confWithExtendedUIDisabled)
+
+    graph.nodes.map(_.name) should contain only ("InMemoryTableScan", "GenerateBloomFilter")
+    graph.getEdgesAsTuples should contain theSameElementsAs Seq(
+      ((1, "GenerateBloomFilter"), (0, "InMemoryTableScan")))
+  }
+
+  test("InMemoryTableScan inside WholeStageCodegen does not include the child InMemoryRelation" +
+    " inside the WholeStageCodegen") {
+      val children = Seq(createLeafInfo("child"))
+      val inMemoryRelationInfo = createInMemoryRelationInfo(children = children)
+      val inMemoryTableScanInfo = createStemInfo("InMemoryTableScan", inMemoryRelationInfo)
+      val wholeStageCodegenInfo = createStemInfo("WholeStageCodegen", inMemoryTableScanInfo)
+      val graph = SparkPlanGraph(wholeStageCodegenInfo, confWithExtendedUIEnabled)
+
+      val clusters = graph.nodes collect { case cluster: SparkPlanGraphCluster => cluster }
+      clusters.length shouldBe 1
+
+      val codegenNodes = clusters.head.nodes
+      codegenNodes.map(_.name) should contain only "InMemoryTableScan"
+
+      val nonCodegenNodes = graph.nodes diff clusters
+      nonCodegenNodes.map(_.name) should contain only("InMemoryRelation", "child")
+
+      graph.getEdgesAsTuples should contain theSameElementsAs Seq(
+        ((3, "child"), (2, "InMemoryRelation")),
+        ((2, "InMemoryRelation"), (1, "InMemoryTableScan"))
+      )
+  }
+
+  test("InMemoryRelation keeps simpleString after being processed into SparkPlanGraph") {
+    val info = createInMemoryRelationInfo(simpleStringSuffix = "_a")
+    val graph = SparkPlanGraph(info, confWithExtendedUIDisabled)
+
+    graph.nodes.map(_.name) should contain only "InMemoryRelation"
+    graph.nodes.map(_.desc) should contain only "InMemoryRelation_a"
+  }
+
+  test("SparkPlanInfo with 2 InMemoryRelation children with same cacheBuilderId and simpleString" +
+    " are merged") {
+    val inMemoryRelationInfoOne = createInMemoryRelationInfo(1)
+    val inMemoryRelationInfoTwo = createInMemoryRelationInfo(1)
+    val parentInfo = createStemInfo("Parent", inMemoryRelationInfoOne, inMemoryRelationInfoTwo)
+    val graph = SparkPlanGraph(parentInfo, confWithExtendedUIDisabled)
+
+    graph.nodes.map(_.name) should contain only ("Parent", "InMemoryRelation")
+
+    graph.getEdgesAsTuples should contain theSameElementsAs Seq(
+      ((1, "InMemoryRelation"), (0, "Parent")),
+      ((1, "InMemoryRelation"), (0, "Parent"))
+    )
+  }
+
+  test("SparkPlanInfo with 2 InMemoryRelation children with different cacheBuilderId are not" +
+    " merged") {
+    val inMemoryRelationInfoOne = createInMemoryRelationInfo(1)
+    val inMemoryRelationInfoTwo = createInMemoryRelationInfo(2)
+    val parentInfo = createStemInfo("Parent", inMemoryRelationInfoOne, inMemoryRelationInfoTwo)
+    val graph = SparkPlanGraph(parentInfo, confWithExtendedUIDisabled)
+
+    graph.nodes.map(_.name) should contain theSameElementsAs
+      Seq("Parent", "InMemoryRelation", "InMemoryRelation")
+
+    graph.getEdgesAsTuples should contain theSameElementsAs Seq(
+      ((1, "InMemoryRelation"), (0, "Parent")),
+      ((2, "InMemoryRelation"), (0, "Parent"))
+    )
+  }
+
+  test("SparkPlanInfo with 2 InMemoryRelation children with same cacheBuilderId and simpleString" +
+    " but different children are not merged") {
+    val childrenOne = Seq(createLeafInfo("child1"))
+    val childrenTwo = Seq(createLeafInfo("child2"))
+    val inMemoryRelationInfoOne = createInMemoryRelationInfo(1, children = childrenOne)
+    val inMemoryRelationInfoTwo = createInMemoryRelationInfo(1, children = childrenTwo)
+    val parentInfo = createStemInfo("Parent", inMemoryRelationInfoOne, inMemoryRelationInfoTwo)
+    val graph = SparkPlanGraph(parentInfo, confWithExtendedUIDisabled)
+
+    graph.nodes.map(_.name) should contain theSameElementsAs
+      Seq("Parent", "InMemoryRelation", "InMemoryRelation", "child1", "child2")
+
+    graph.getEdgesAsTuples should contain theSameElementsAs Seq(
+      ((1, "InMemoryRelation"), (0, "Parent")),
+      ((3, "InMemoryRelation"), (0, "Parent")),
+      ((2, "child1"), (1, "InMemoryRelation")),
+      ((4, "child2"), (3, "InMemoryRelation"))
+    )
+  }
+
+  test("SparkPlanInfo with 2 InMemoryRelation children with same cacheBuilderId and children " +
+    "but different simpleStrings are merged and desc of InMemoryRelation node reflects the " +
+    "simpleString of first InMemoryRelation info in preorder") {
+    val childrenOne = Seq(createLeafInfo("child"))
+    val childrenTwo = Seq(createLeafInfo("child"))
+    val inMemoryRelationInfoOne = createInMemoryRelationInfo(1, "_a", childrenOne)
+    val inMemoryRelationInfoTwo = createInMemoryRelationInfo(1, "_b", childrenTwo)
+    val parentInfo = createStemInfo("Parent", inMemoryRelationInfoOne, inMemoryRelationInfoTwo)
+    val graph = SparkPlanGraph(parentInfo, confWithExtendedUIDisabled)
+
+    graph.nodes.map(_.name) should contain theSameElementsAs
+      Seq("Parent", "InMemoryRelation", "child")
+
+    graph.nodes.filter(_.name == "InMemoryRelation").map(_.desc) should contain only
+      inMemoryRelationInfoOne.simpleString
+
+    graph.getEdgesAsTuples should contain theSameElementsAs Seq(
+      ((1, "InMemoryRelation"), (0, "Parent")),
+      ((1, "InMemoryRelation"), (0, "Parent")),
+      ((2, "child"), (1, "InMemoryRelation"))
+    )
+  }
+
+  test("SparkPlanInfo with 2 InMemoryRelation children with different cacheBuilderId and" +
+    " simpleStrings but same children are not merged") {
+    val childrenOne = Seq(createLeafInfo("child"))
+    val childrenTwo = Seq(createLeafInfo("child"))
+    val inMemoryRelationInfoOne = createInMemoryRelationInfo(1, "_a", childrenOne)
+    val inMemoryRelationInfoTwo = createInMemoryRelationInfo(2, "_b", childrenTwo)
+    val parentInfo = createStemInfo("Parent", inMemoryRelationInfoOne, inMemoryRelationInfoTwo)
+    val graph = SparkPlanGraph(parentInfo, confWithExtendedUIDisabled)
+
+    graph.nodes.map(_.name) should contain theSameElementsAs Seq("Parent", "InMemoryRelation",
+      "InMemoryRelation", "child", "child")
+
+    graph.getEdgesAsTuples should contain theSameElementsAs Seq(
+      ((1, "InMemoryRelation"), (0, "Parent")),
+      ((3, "InMemoryRelation"), (0, "Parent")),
+      ((2, "child"), (1, "InMemoryRelation")),
+      ((4, "child"), (3, "InMemoryRelation"))
+    )
+  }
+
+  test("SparkPlanInfo with 2 InMemoryRelation children with same cacheBuilderId but different" +
+    " simpleStrings and different children are not merged") {
+    val childrenOne = Seq(createLeafInfo("child1"))
+    val childrenTwo = Seq(createLeafInfo("child2"))
+    val inMemoryRelationInfoOne = createInMemoryRelationInfo(1, "_a", childrenOne)
+    val inMemoryRelationInfoTwo = createInMemoryRelationInfo(1, "_b", childrenTwo)
+    val parentInfo = createStemInfo("Parent", inMemoryRelationInfoOne, inMemoryRelationInfoTwo)
+    val graph = SparkPlanGraph(parentInfo, confWithExtendedUIDisabled)
+
+    graph.nodes.map(_.name) should contain theSameElementsAs Seq("Parent", "InMemoryRelation",
+      "InMemoryRelation", "child1", "child2")
+
+    graph.getEdgesAsTuples should contain theSameElementsAs Seq(
+      ((1, "InMemoryRelation"), (0, "Parent")),
+      ((3, "InMemoryRelation"), (0, "Parent")),
+      ((2, "child1"), (1, "InMemoryRelation")),
+      ((4, "child2"), (3, "InMemoryRelation"))
+    )
+  }
+
+  test("Graph with no nodes or edges has childrenForEachNode return empty Map") {
+    val graph = SparkPlanGraph(Seq.empty, Seq.empty)
+
+    graph.childrenForEachNode shouldBe Map.empty
+  }
+
+  test("Graph with one node and no edges has childrenForEachNode return empty Map with a default" +
+    " value of empty set for the node") {
+    val node = createNode(0)
+    val graph = SparkPlanGraph(Seq(node), Seq.empty)
+
+    graph.childrenForEachNode should have size 1
+    graph.childrenForEachNode(node.id) shouldBe Set.empty
+  }
+
+  test("Graph with no nodes or edges has childrenForEachNode throw exception for node id not" +
+    " in graph node set") {
+    val node = createNode(0)
+    val graph = SparkPlanGraph(Seq.empty, Seq.empty)
+
+    graph.childrenForEachNode shouldBe Map.empty
+    a [NoSuchElementException] should be thrownBy graph.childrenForEachNode(node.id)
+  }
+
+  test("Graph with two nodes and one edge has childrenForEachNode return Map with one entry") {
+    val nodes = Seq(0L, 1L).map(createNode)
+    val edges = Seq(SparkPlanGraphEdge(1L, 0L))
+    val graph = SparkPlanGraph(nodes, edges)
+
+    graph.childrenForEachNode should have size 2
+    graph.childrenForEachNode(0L) should contain only 1L
+    graph.childrenForEachNode(1L) shouldBe Set.empty
+  }
+
+  test("Graph with multiple nodes and edges has childrenForEachNode give expected result") {
+    val nodes = Seq(0L, 1L, 2L, 3L).map(createNode)
+    val edges = Seq((1L, 0L), (2L, 0L), (3L, 2L), (0L, 3L))
+      .map{ case (x, y) => SparkPlanGraphEdge(x, y) }
+    val graph = SparkPlanGraph(nodes, edges)
+
+    graph.childrenForEachNode should have size 4
+    graph.childrenForEachNode(0L) should contain only (1L, 2L)
+    graph.childrenForEachNode(1L) shouldBe Set.empty
+    graph.childrenForEachNode(2L) should contain only 3L
+    graph.childrenForEachNode(3L) should contain only 0L
+  }
+
+  test("Graph with sub-node inside a SparkPlanGraphCluster has childrenForEachNode give" +
+    " entry for subnode") {
+    val subnode = createNode(1L)
+    val cluster = createCluster(0L, Seq(subnode))
+    val graph = SparkPlanGraph(Seq(cluster), Seq.empty)
+
+    graph.childrenForEachNode should have size 2
+    graph.childrenForEachNode(0L) shouldBe Set.empty
+    graph.childrenForEachNode(1L) shouldBe Set.empty
+  }
+
+  test("Graph with subnode inside a SparkPlanGraphCluster connected to a non-subnode" +
+    " has childrenForEachNode give expected result") {
+    val subnode = createNode(1L)
+    val cluster = createCluster(0L, Seq(subnode))
+    val node = createNode(2L)
+    val edges = Seq(SparkPlanGraphEdge(2L, 1L))
+    val graph = SparkPlanGraph(Seq(cluster, node), edges)
+
+    graph.childrenForEachNode should have size 3
+    graph.childrenForEachNode(0L) shouldBe Set.empty
+    graph.childrenForEachNode(1L) should contain only 2L
+    graph.childrenForEachNode(2L) shouldBe Set.empty
+  }
+
+  test("Graph with 0 nodes has idsAreConsecutiveFromZero return true") {
+    val graph = SparkPlanGraph(Seq.empty, Seq.empty)
+
+    graph.idsAreConsecutiveFromZero shouldBe true
+  }
+
+  test("Graph with one node with id = 0 has idsAreConsecutiveFromZero return true") {
+    val nodes = Seq(0L).map(createNode)
+    val graph = SparkPlanGraph(nodes, Seq.empty)
+
+    graph.idsAreConsecutiveFromZero shouldBe true
+  }
+
+  test("Graph with one node with id != 0 has idsAreConsecutiveFromZero return false") {
+    val nodes = Seq(1L).map(createNode)
+    val graph = SparkPlanGraph(nodes, Seq.empty)
+
+    graph.idsAreConsecutiveFromZero shouldBe false
+  }
+
+  test("Graph with consecutive ids has idsAreConsecutiveFromZero return true") {
+    val nodes = Seq(0L, 1L, 2L, 3L).map(createNode)
+    val graph = SparkPlanGraph(nodes, Seq.empty)
+
+    graph.idsAreConsecutiveFromZero shouldBe true
+  }
+
+  test("Graph with consecutive ids (but not given in consecutive order) has " +
+    "idsAreConsecutiveFromZero return true") {
+    val nodes = Seq(0L, 2L, 1L, 3L).map(createNode)
+    val graph = SparkPlanGraph(nodes, Seq.empty)
+
+    graph.idsAreConsecutiveFromZero shouldBe true
+  }
+
+  test("Graph with non-consecutive ids has idsAreConsecutiveFromZero return false") {
+    val nodes = Seq(0L, 2L, 3L).map(createNode)
+    val graph = SparkPlanGraph(nodes, Seq.empty)
+
+    graph.idsAreConsecutiveFromZero shouldBe false
+  }
+
+  test("Graph with ids not starting at 0 has idsAreConsecutiveFromZero return false") {
+    val nodes = Seq(1L, 2L, 3L).map(createNode)
+    val graph = SparkPlanGraph(nodes, Seq.empty)
+
+    graph.idsAreConsecutiveFromZero shouldBe false
+  }
+
+  private implicit class SparkPlanGraphAdditions(graph: SparkPlanGraph) {
+    def getEdgesAsTuples: Seq[((Long, String), (Long, String))] = {
+      val nodeIdsToNames = graph.allNodes.map(node => node.id -> node.name).toMap
+      graph.edges collect {
+        case SparkPlanGraphEdge(from, to) =>
+          ((from, nodeIdsToNames(from)), (to, nodeIdsToNames(to)))
+      }
+    }
+  }
+
+  private def createInMemoryRelationInfo(id: Long = 0,
+                                         simpleStringSuffix: String = "",
+                                         children: Seq[SparkPlanInfo] = Nil): SparkPlanInfo = {
+    new SparkPlanInfo("InMemoryRelation", "InMemoryRelation" + simpleStringSuffix,
+      children, Map("cacheBuilderId" -> id.toString), Nil)
+    }
+
+  private def createStemInfo(name: String, children: SparkPlanInfo*): SparkPlanInfo =
+    new SparkPlanInfo(name, name, children, Map.empty, Nil)
+
+  private def createLeafInfo(name: String): SparkPlanInfo =
+    new SparkPlanInfo(name, name, Nil, Map.empty, Nil)
+
+  private def createNode(id: Long): SparkPlanGraphNode =
+    new SparkPlanGraphNode(id, "", "", Nil)
+
+  private def createCluster(id: Long, subNodes: Seq[SparkPlanGraphNode]): SparkPlanGraphCluster = {
+    val subNodeBuffer = new ArrayBuffer[SparkPlanGraphNode]
+    subNodeBuffer ++= subNodes
+    new SparkPlanGraphCluster(id, "", "", subNodeBuffer, Nil)
+  }
+}
+

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SparkPlanGraphUpdaterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SparkPlanGraphUpdaterSuite.scala
@@ -1,0 +1,291 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.ui
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.scalatest.Matchers._
+
+import org.apache.spark.SparkFunSuite
+
+class SparkPlanGraphUpdaterSuite extends SparkFunSuite {
+
+  test("pruneHiddenNodes returns empty graph when empty graph is given") {
+    val graph = SparkPlanGraph(Seq.empty, Seq.empty)
+
+    val transformers = new SparkPlanGraphNodeTransformers {
+      override def getIsHiddenNode(graph: SparkPlanGraph,
+                                   metricValues: Map[Long, String]): Long => Boolean =
+        _ == 1
+    }
+    val updater = new SparkPlanGraphUpdater(Map.empty, transformers)
+    val prunedGraph = updater.pruneHiddenNodes(graph)
+
+    prunedGraph.nodes shouldBe empty
+    prunedGraph.edges shouldBe empty
+  }
+
+  test("pruneHiddenNodes prunes hidden nodes identified by input function") {
+    val nodes = createNodes(0, 1, 2, 3)
+    val edges = Seq((3L, 2L), (2L, 1L), (1L, 0L)).map(createEdge)
+    val graph = SparkPlanGraph(nodes, edges)
+
+    val transformers = new SparkPlanGraphNodeTransformers {
+      override def getIsHiddenNode(graph: SparkPlanGraph,
+                                   metricValues: Map[Long, String]): Long => Boolean =
+        _ > 1
+    }
+    val updater = new SparkPlanGraphUpdater(Map.empty, transformers)
+    val prunedGraph = updater.pruneHiddenNodes(graph)
+
+    prunedGraph.nodes.map(_.id) should contain only (0, 1)
+    prunedGraph.getEdgesAsTuples should contain theSameElementsAs Seq((1L, 0L))
+  }
+
+  test("pruneHiddenNodes prunes hidden nodes identified by input function that are" +
+    " in separate branches on graph") {
+    val nodes = createNodes(0, 1, 2, 3)
+    val edges = Seq((3L, 1L), (2L, 1L), (1L, 0L)).map(createEdge)
+    val graph = SparkPlanGraph(nodes, edges)
+
+    val transformers = new SparkPlanGraphNodeTransformers {
+      override def getIsHiddenNode(graph: SparkPlanGraph,
+                                   metricValues: Map[Long, String]): Long => Boolean =
+        _ > 1
+    }
+    val updater = new SparkPlanGraphUpdater(Map.empty, transformers)
+    val prunedGraph = updater.pruneHiddenNodes(graph)
+
+    prunedGraph.nodes.map(_.id) should contain only (0, 1)
+    prunedGraph.getEdgesAsTuples should contain theSameElementsAs Seq((1L, 0L))
+  }
+
+  test("pruneHiddenNodes prunes every node in graph if every node is hidden") {
+    val nodes = createNodes(0, 1, 2, 3)
+    val edges = Seq((3L, 2L), (2L, 1L), (1L, 0L)).map(createEdge)
+    val graph = SparkPlanGraph(nodes, edges)
+
+    val transformers = new SparkPlanGraphNodeTransformers {
+      override def getIsHiddenNode(graph: SparkPlanGraph,
+                                   metricValues: Map[Long, String]): Long => Boolean =
+        _ => true
+    }
+    val updater = new SparkPlanGraphUpdater(Map.empty, transformers)
+    val prunedGraph = updater.pruneHiddenNodes(graph)
+
+    prunedGraph.nodes.map(_.id) shouldBe empty
+    prunedGraph.getEdgesAsTuples shouldBe empty
+  }
+
+  test("pruneHiddenNodes prunes no nodes in graph if no nodes are hidden") {
+    val nodes = createNodes(0, 1, 2, 3)
+    val edges = Seq((3L, 2L), (2L, 1L), (1L, 0L)).map(createEdge)
+    val graph = SparkPlanGraph(nodes, edges)
+
+    val transformers = new SparkPlanGraphNodeTransformers {
+      override def getIsHiddenNode(graph: SparkPlanGraph,
+                                   metricValues: Map[Long, String]): Long => Boolean =
+        _ => false
+    }
+    val updater = new SparkPlanGraphUpdater(Map.empty, transformers)
+    val prunedGraph = updater.pruneHiddenNodes(graph)
+
+    prunedGraph.nodes.map(_.id) should contain only (0, 1, 2, 3)
+    prunedGraph.getEdgesAsTuples should contain theSameElementsAs Seq((3L, 2L), (2L, 1L), (1L, 0L))
+  }
+
+  test("pruneHiddenNodes prunes hidden cluster and its non-hidden subnodes identified by input " +
+    "function") {
+    val nodes = Seq(createNode(0), createCluster(1, createNodes(2, 3)))
+    val edges = Seq((3L, 2L), (2L, 0L)).map(createEdge)
+    val graph = SparkPlanGraph(nodes, edges)
+
+    val transformers = new SparkPlanGraphNodeTransformers {
+      override def getIsHiddenNode(graph: SparkPlanGraph,
+                                   metricValues: Map[Long, String]): Long => Boolean =
+        _ == 1
+    }
+    val updater = new SparkPlanGraphUpdater(Map.empty, transformers)
+    val prunedGraph = updater.pruneHiddenNodes(graph)
+
+    prunedGraph.nodes.map(_.id) should contain only 0
+    prunedGraph.getEdgesAsTuples shouldBe empty
+  }
+
+  test("pruneHiddenNodes doesn't prune cluster if all its subnodes are pruned") {
+    val nodes = Seq(createNode(0), createCluster(1, createNodes(2, 3)))
+    val edges = Seq((3L, 2L), (2L, 0L)).map(createEdge)
+    val graph = SparkPlanGraph(nodes, edges)
+
+    val transformers = new SparkPlanGraphNodeTransformers {
+      override def getIsHiddenNode(graph: SparkPlanGraph,
+                                   metricValues: Map[Long, String]): Long => Boolean =
+        _ > 1
+    }
+    val updater = new SparkPlanGraphUpdater(Map.empty, transformers)
+    val prunedGraph = updater.pruneHiddenNodes(graph)
+
+    prunedGraph.nodes.map(_.id) should contain only (0, 1)
+    prunedGraph.getEdgesAsTuples shouldBe empty
+  }
+
+  test("filterHiddenMetrics returns empty graph when empty graph is given") {
+    val graph = SparkPlanGraph(Seq.empty, Seq.empty)
+
+    val transformers = new SparkPlanGraphNodeTransformers {
+      override def getFilterHiddenMetricsForNode(metricValues: Map[Long, String]
+                                                ): SparkPlanGraphNode => SparkPlanGraphNode =
+        node => node.copy(newMetrics = node.metrics.filter(_.name != "a"))
+    }
+    val updater = new SparkPlanGraphUpdater(Map.empty, transformers)
+    val filteredGraph = updater.filterHiddenMetrics(graph)
+
+    filteredGraph.nodes shouldBe empty
+    filteredGraph.edges shouldBe empty
+  }
+
+  test("filterHiddenMetrics filters out node metrics identified by input function") {
+    val metricA = createMetric("a")
+    val metricB = createMetric("b")
+    val metricC = createMetric("c")
+
+    val nodes = Seq(createNode(0, Seq(metricA)),
+      createNode(1, Seq(metricB)),
+      createNode(2, Seq(metricC, metricA)))
+    val edges = Seq((2L, 1L), (1L, 0L)).map(createEdge)
+    val graph = SparkPlanGraph(nodes, edges)
+
+    val transformers = new SparkPlanGraphNodeTransformers {
+      override def getFilterHiddenMetricsForNode(metricValues: Map[Long, String]
+                                                ): SparkPlanGraphNode => SparkPlanGraphNode =
+        node => node.copy(newMetrics = node.metrics.filter(_.name != "a"))
+    }
+    val updater = new SparkPlanGraphUpdater(Map.empty, transformers)
+    val filteredGraph = updater.filterHiddenMetrics(graph)
+
+    filteredGraph.nodes.map(_.metrics) should contain theSameElementsInOrderAs
+      Seq(Seq.empty, Seq(metricB), Seq(metricC))
+  }
+
+  test("filterHiddenMetrics filters out node and cluster metrics identified by input function") {
+    val metricA = createMetric("a")
+    val metricB = createMetric("b")
+    val metricC = createMetric("c")
+
+    val nodes = Seq(createNode(0, Seq(metricA)),
+      createCluster(1, Seq(createNode(2, Seq(metricB))), Seq(metricC, metricA)))
+    val edges = Seq((2L, 0L)).map(createEdge)
+    val graph = SparkPlanGraph(nodes, edges)
+
+    val transformers = new SparkPlanGraphNodeTransformers {
+      override def getFilterHiddenMetricsForNode(metricValues: Map[Long, String]
+                                                ): SparkPlanGraphNode => SparkPlanGraphNode =
+        node => node.copy(newMetrics = node.metrics.filter(_.name != "a"))
+    }
+    val updater = new SparkPlanGraphUpdater(Map.empty, transformers)
+    val filteredGraph = updater.filterHiddenMetrics(graph)
+
+    filteredGraph.allNodes.map(_.metrics) should contain theSameElementsInOrderAs
+      Seq(Seq.empty, Seq(metricB), Seq(metricC))
+  }
+
+  test("reassignNodeIds returns empty graph when empty graph is given") {
+    val graph = SparkPlanGraph(Seq.empty, Seq.empty)
+
+    val transformers = new SparkPlanGraphNodeTransformers {
+      override def getNodeIdReassigner(graph: SparkPlanGraph): Long => Long = {
+        case 0 => 1
+      }
+    }
+
+    val updater = new SparkPlanGraphUpdater(Map.empty, transformers)
+    val updatedGraph = updater.reassignNodeIds(graph)
+
+    updatedGraph.nodes shouldBe empty
+    updatedGraph.edges shouldBe empty
+  }
+
+  test("reassignNodeIds reassigns node ids according to input function") {
+    val nodes = createNodes(20, 300, 1)
+    val edges = Seq((20L, 300L), (300L, 1L)).map(createEdge)
+    val graph = SparkPlanGraph(nodes, edges)
+
+    val transformers = new SparkPlanGraphNodeTransformers {
+      override def getNodeIdReassigner(graph: SparkPlanGraph): Long => Long = {
+        case 20 => 0
+        case 300 => 1
+        case 1 => 2
+      }
+    }
+
+    val updater = new SparkPlanGraphUpdater(Map.empty, transformers)
+    val updatedGraph = updater.reassignNodeIds(graph)
+
+    updatedGraph.nodes.map(_.id) should contain theSameElementsInOrderAs Seq(0, 1, 2)
+    updatedGraph.getEdgesAsTuples should contain theSameElementsAs Seq((0, 1), (1, 2))
+  }
+
+  test("reassignNodeIds reassigns node and cluster ids according to input function") {
+    val nodes = Seq(createNode(20), createCluster(300, createNodes(1)))
+    val edges = Seq((20L, 1L)).map(createEdge)
+    val graph = SparkPlanGraph(nodes, edges)
+
+    val transformers = new SparkPlanGraphNodeTransformers {
+      override def getNodeIdReassigner(graph: SparkPlanGraph): Long => Long = {
+        case 20 => 0
+        case 300 => 1
+        case 1 => 2
+      }
+    }
+
+    val updater = new SparkPlanGraphUpdater(Map.empty, transformers)
+    val updatedGraph = updater.reassignNodeIds(graph)
+
+    updatedGraph.allNodes.map(_.id) should contain theSameElementsAs Seq(0, 1, 2)
+    updatedGraph.getEdgesAsTuples should contain theSameElementsAs Seq((0, 2))
+  }
+
+  private def createNodes(nodeIds: Long*): Seq[SparkPlanGraphNode] = {
+    nodeIds.map(id => createNode(id))
+  }
+
+  private def createNode(id: Long,
+                         metrics: Seq[SQLPlanMetric] = Seq.empty): SparkPlanGraphNode = {
+    new SparkPlanGraphNode(id, "", "", metrics)
+  }
+
+  private def createCluster(id: Long,
+                            subNodes: Seq[SparkPlanGraphNode],
+                            metrics: Seq[SQLPlanMetric] = Seq.empty): SparkPlanGraphCluster = {
+    val buffer = new ArrayBuffer[SparkPlanGraphNode]()
+    buffer ++= subNodes
+    new SparkPlanGraphCluster(id, "", "", buffer, metrics)
+  }
+
+  private def createEdge(edge: (Long, Long)): SparkPlanGraphEdge = edge match {
+    case (from, to) => SparkPlanGraphEdge(from, to)
+  }
+
+  private def createMetric(name: String): SQLPlanMetric = SQLPlanMetric(name, 0L, "")
+
+  private implicit class SparkPlanGraphAdditions(graph: SparkPlanGraph) {
+    def getEdgesAsTuples: Seq[(Long, Long)] = graph.edges.map {
+      case SparkPlanGraphEdge(from, to) => (from, to)
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
1. Adds a InMemoryRelation node and its cachedPlan as a child node of InMemoryTableScan ([SPARK-29431](https://issues.apache.org/jira/browse/SPARK-29431)).
2. De-duplicate identical subplans shared by InMemoryTableScan operators within the same query ([SPARK-30367](https://issues.apache.org/jira/browse/SPARK-30367)).
3. Add computed rows metric to InMemoryRelation operators ([SPARK-30368](https://issues.apache.org/jira/browse/SPARK-30368)).
4. Prune the cached subplan if it was not actually computed ([SPARK-30369](https://issues.apache.org/jira/browse/SPARK-30369)).
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Currently, if a user caches a dataframe as part of the query, it introduces an InMemoryTableScan operator into the query plan when the cached data is read again. The InMemoryTableScan operator does not have child operators and thus doesn't show the subplan of the query that is run before caching the dataframe.

However, simply showing the subplan as a child of InMemoryTableScan can lead to some confusion for the user. It is possible for the cached dataframe to be read multiple times within the query, which will cause multiple InMemoryTableScan operators to be shown within the plan and thus cause the subplan to be shown multiple times across the query plan even though it is computed only once. 

Additionally, it is possible for the cached dataframe to be read in another query. This will cause the subplan to be shown in a query it was not actually computed in, which is misleading, so we should remove it in this case. However, It is also possible for the dataframe to be partially cached, meaning some partitions are cached whereas some need to be recomputed. In this case, we should still show the subplan in the query as it is will still be computed for some partitions of the dataframe. A "num computed rows" metric is added to InMemoryRelation (the child node of InMemoryTableScan which has the subplan as its child) to make it more clear when only some partitions of the cached data are recomputed.

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce any user-facing change?
Yes, in the SQL tab of the WebUI. See the JIRA for examples of the WebUI with and without the changes.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->


### How was this patch tested?
* Added unit tests in SparkPlanInfoSuite, CachedRDDBuilderSuite, SparkPlanGraphSuite, SparkPlanGraphUpdaterSuite, and SparkPlanGraphNodeTransformersSuite.
* Integration tests using the spark shell to show the desired behavior change in the UI is achieved.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
