### PR TITLE
[SPARK-30667][CORE] Add allGather method to BarrierTaskContext

### DIFF
--- a/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
+++ b/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
@@ -25,10 +25,6 @@ import java.util.function.Consumer
 
 import scala.collection.mutable.ArrayBuffer
 
-import org.json4s.JsonAST._
-import org.json4s.JsonDSL._
-import org.json4s.jackson.JsonMethods.{compact, render}
-
 import org.apache.spark.internal.Logging
 import org.apache.spark.rpc.{RpcCallContext, RpcEnv, ThreadSafeRpcEndpoint}
 import org.apache.spark.scheduler.{LiveListenerBus, SparkListener, SparkListenerStageCompleted}

--- a/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
+++ b/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
@@ -196,7 +196,6 @@ private[spark] class BarrierCoordinator(
             s"tasks, finished successfully.")
           barrierEpoch += 1
           requesters.clear()
-          allGatherMessages.clear()
           cancelTimerTask()
         }
       }
@@ -227,7 +226,6 @@ private[spark] class BarrierCoordinator(
       // messages come from current stage attempt shall fail.
       barrierEpoch = -1
       requesters.clear()
-      allGatherMessages.clear()
       cancelTimerTask()
     }
   }

--- a/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
+++ b/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
@@ -291,6 +291,15 @@ private[spark] class BarrierCoordinator(
 
 private[spark] sealed trait BarrierCoordinatorMessage extends Serializable
 
+private[spark] sealed trait RequestToSync extends BarrierCoordinatorMessage {
+  def numTasks: Int
+  def stageId: Int
+  def stageAttemptId: Int
+  def taskAttemptId: Long
+  def barrierEpoch: Int
+  def requestMethod: RequestMethod.Value
+}
+
 /**
  * A global sync request message from BarrierTaskContext, by `barrier()` call. Each request is
  * identified by stageId + stageAttemptId + barrierEpoch.
@@ -301,27 +310,7 @@ private[spark] sealed trait BarrierCoordinatorMessage extends Serializable
  * @param taskAttemptId Unique ID of current task
  * @param barrierEpoch ID of the `barrier()` call, a task may consist multiple `barrier()` calls.
  * @param requestMethod The BarrierTaskContext method that was called to trigger BarrierCoordinator
- * @param allGatherMessage Message sent from the BarrierTaskContext if requestMethod is ALL_GATHER
  */
-// private[spark] case class RequestToSync(
-//     numTasks: Int,
-//     stageId: Int,
-//     stageAttemptId: Int,
-//     taskAttemptId: Long,
-//     barrierEpoch: Int,
-//     requestMethod: RequestMethod.Value,
-//     allGatherMessage: Array[Byte]) extends BarrierCoordinatorMessage
-
-private[spark] sealed trait RequestToSync extends BarrierCoordinatorMessage {
-  def numTasks: Int
-  def stageId: Int
-  def stageAttemptId: Int
-  def taskAttemptId: Long
-  def barrierEpoch: Int
-  def requestMethod: RequestMethod.Value
-  // def allGatherMessage: Array[Byte]
-}
-
 private[spark] case class BarrierRequestToSync(
   numTasks: Int,
   stageId: Int,
@@ -331,6 +320,18 @@ private[spark] case class BarrierRequestToSync(
   requestMethod: RequestMethod.Value
 ) extends RequestToSync
 
+/**
+ * A global sync request message from BarrierTaskContext, by `allGather()` call. Each request is
+ * identified by stageId + stageAttemptId + barrierEpoch.
+ *
+ * @param numTasks The number of global sync requests the BarrierCoordinator shall receive
+ * @param stageId ID of current stage
+ * @param stageAttemptId ID of current stage attempt
+ * @param taskAttemptId Unique ID of current task
+ * @param barrierEpoch ID of the `barrier()` call, a task may consist multiple `barrier()` calls.
+ * @param requestMethod The BarrierTaskContext method that was called to trigger BarrierCoordinator
+ * @param allGatherMessage Message sent from the BarrierTaskContext if requestMethod is ALL_GATHER
+ */
 private[spark] case class AllGatherRequestToSync(
   numTasks: Int,
   stageId: Int,

--- a/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
+++ b/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
@@ -124,7 +124,7 @@ private[spark] class BarrierCoordinator(
           requesters.foreach(_.sendFailure(new SparkException("The coordinator didn't get all " +
             s"barrier sync requests for barrier epoch $barrierEpoch from $barrierId within " +
             s"$timeoutInSecs second(s).")))
-          cleanupBarrierStage(barrierId) 
+          cleanupBarrierStage(barrierId)
         }
       }
     }

--- a/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
+++ b/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
@@ -110,7 +110,7 @@ private[spark] class BarrierCoordinator(
     private val allGatherMessages: ArrayBuffer[Array[Byte]] = new ArrayBuffer[Array[Byte]](numTasks)
 
     // The blocking requestMethod called by tasks to sync up for this stage attempt
-    private var requestMethodToSync: Int = 0
+    private var requestMethodToSync: Int = RequestMethod.BARRIER
 
     // A timer task that ensures we may timeout for a barrier() call.
     private var timerTask: TimerTask = null

--- a/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
+++ b/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
@@ -124,7 +124,7 @@ private[spark] class BarrierCoordinator(
           requesters.foreach(_.sendFailure(new SparkException("The coordinator didn't get all " +
             s"barrier sync requests for barrier epoch $barrierEpoch from $barrierId within " +
             s"$timeoutInSecs second(s).")))
-          cleanupBarrierStage(barrierId)
+          cleanupBarrierStage(barrierId) 
         }
       }
     }

--- a/core/src/main/scala/org/apache/spark/BarrierTaskContext.scala
+++ b/core/src/main/scala/org/apache/spark/BarrierTaskContext.scala
@@ -17,11 +17,19 @@
 
 package org.apache.spark
 
+import java.nio.charset.StandardCharsets.UTF_8
 import java.util.{Properties, Timer, TimerTask}
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.TimeoutException
 import scala.concurrent.duration._
+import scala.language.postfixOps
+
+import org.json4s.DefaultFormats
+import org.json4s.JsonAST._
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods.parse
 
 import org.apache.spark.annotation.{Experimental, Since}
 import org.apache.spark.executor.TaskMetrics
@@ -58,6 +66,77 @@ class BarrierTaskContext private[spark] (
   // Number of tasks of the current barrier stage, a barrier() call must collect enough requests
   // from different tasks within the same barrier stage attempt to succeed.
   private lazy val numTasks = getTaskInfos().size
+
+  private def runBarrier(
+    requestMethod: Int,
+    allGatherMessage: Array[Byte] = Array[Byte]()
+  ): Array[Byte] = {
+
+    logInfo(s"Task $taskAttemptId from Stage $stageId(Attempt $stageAttemptNumber) has entered " +
+      s"the global sync, current barrier epoch is $barrierEpoch.")
+    logTrace("Current callSite: " + Utils.getCallSite())
+
+    val startTime = System.currentTimeMillis()
+    val timerTask = new TimerTask {
+      override def run(): Unit = {
+        logInfo(s"Task $taskAttemptId from Stage $stageId(Attempt $stageAttemptNumber) waiting " +
+          s"under the global sync since $startTime, has been waiting for " +
+          s"${MILLISECONDS.toSeconds(System.currentTimeMillis() - startTime)} seconds, " +
+          s"current barrier epoch is $barrierEpoch.")
+      }
+    }
+    // Log the update of global sync every 60 seconds.
+    timer.schedule(timerTask, 60000, 60000)
+
+    var messages: Array[Byte] = Array[Byte]()
+
+    try {
+      val abortableRpcFuture = barrierCoordinator.askAbortable[Array[Byte]](
+        message = RequestToSync(numTasks, stageId, stageAttemptNumber, taskAttemptId,
+          barrierEpoch, requestMethod, allGatherMessage),
+        // Set a fixed timeout for RPC here, so users shall get a SparkException thrown by
+        // BarrierCoordinator on timeout, instead of RPCTimeoutException from the RPC framework.
+        timeout = new RpcTimeout(31536000 /* = 3600 * 24 * 365 */ seconds, "barrierTimeout"))
+
+      // Wait the RPC future to be completed, but every 1 second it will jump out waiting
+      // and check whether current spark task is killed. If killed, then throw
+      // a `TaskKilledException`, otherwise continue wait RPC until it completes.
+      try {
+        while (!abortableRpcFuture.toFuture.isCompleted) {
+          // wait RPC future for at most 1 second
+          try {
+            messages = ThreadUtils.awaitResult(abortableRpcFuture.toFuture, 1.second)
+          } catch {
+            case _: TimeoutException | _: InterruptedException =>
+              // If `TimeoutException` thrown, waiting RPC future reach 1 second.
+              // If `InterruptedException` thrown, it is possible this task is killed.
+              // So in this two cases, we should check whether task is killed and then
+              // throw `TaskKilledException`
+              taskContext.killTaskIfInterrupted()
+          }
+        }
+      } finally {
+        abortableRpcFuture.abort(taskContext.getKillReason().getOrElse("Unknown reason."))
+      }
+
+      barrierEpoch += 1
+      logInfo(s"Task $taskAttemptId from Stage $stageId(Attempt $stageAttemptNumber) finished " +
+        "global sync successfully, waited for " +
+        s"${MILLISECONDS.toSeconds(System.currentTimeMillis() - startTime)} seconds, " +
+        s"current barrier epoch is $barrierEpoch.")
+    } catch {
+      case e: SparkException =>
+        logInfo(s"Task $taskAttemptId from Stage $stageId(Attempt $stageAttemptNumber) failed " +
+          "to perform global sync, waited for " +
+          s"${MILLISECONDS.toSeconds(System.currentTimeMillis() - startTime)} seconds, " +
+          s"current barrier epoch is $barrierEpoch.")
+        throw e
+    } finally {
+      timerTask.cancel()
+      timer.purge()
+    }
+    messages
+  }
 
   /**
    * :: Experimental ::
@@ -102,67 +181,17 @@ class BarrierTaskContext private[spark] (
   @Experimental
   @Since("2.4.0")
   def barrier(): Unit = {
-    logInfo(s"Task $taskAttemptId from Stage $stageId(Attempt $stageAttemptNumber) has entered " +
-      s"the global sync, current barrier epoch is $barrierEpoch.")
-    logTrace("Current callSite: " + Utils.getCallSite())
+    runBarrier(RequestMethod.BARRIER)
+    ()
+  }
 
-    val startTime = System.currentTimeMillis()
-    val timerTask = new TimerTask {
-      override def run(): Unit = {
-        logInfo(s"Task $taskAttemptId from Stage $stageId(Attempt $stageAttemptNumber) waiting " +
-          s"under the global sync since $startTime, has been waiting for " +
-          s"${MILLISECONDS.toSeconds(System.currentTimeMillis() - startTime)} seconds, " +
-          s"current barrier epoch is $barrierEpoch.")
-      }
-    }
-    // Log the update of global sync every 60 seconds.
-    timer.schedule(timerTask, 60000, 60000)
-
-    try {
-      val abortableRpcFuture = barrierCoordinator.askAbortable[Unit](
-        message = RequestToSync(numTasks, stageId, stageAttemptNumber, taskAttemptId,
-          barrierEpoch),
-        // Set a fixed timeout for RPC here, so users shall get a SparkException thrown by
-        // BarrierCoordinator on timeout, instead of RPCTimeoutException from the RPC framework.
-        timeout = new RpcTimeout(365.days, "barrierTimeout"))
-
-      // Wait the RPC future to be completed, but every 1 second it will jump out waiting
-      // and check whether current spark task is killed. If killed, then throw
-      // a `TaskKilledException`, otherwise continue wait RPC until it completes.
-      try {
-        while (!abortableRpcFuture.toFuture.isCompleted) {
-          // wait RPC future for at most 1 second
-          try {
-            ThreadUtils.awaitResult(abortableRpcFuture.toFuture, 1.second)
-          } catch {
-            case _: TimeoutException | _: InterruptedException =>
-              // If `TimeoutException` thrown, waiting RPC future reach 1 second.
-              // If `InterruptedException` thrown, it is possible this task is killed.
-              // So in this two cases, we should check whether task is killed and then
-              // throw `TaskKilledException`
-              taskContext.killTaskIfInterrupted()
-          }
-        }
-      } finally {
-        abortableRpcFuture.abort(taskContext.getKillReason().getOrElse("Unknown reason."))
-      }
-
-      barrierEpoch += 1
-      logInfo(s"Task $taskAttemptId from Stage $stageId(Attempt $stageAttemptNumber) finished " +
-        "global sync successfully, waited for " +
-        s"${MILLISECONDS.toSeconds(System.currentTimeMillis() - startTime)} seconds, " +
-        s"current barrier epoch is $barrierEpoch.")
-    } catch {
-      case e: SparkException =>
-        logInfo(s"Task $taskAttemptId from Stage $stageId(Attempt $stageAttemptNumber) failed " +
-          "to perform global sync, waited for " +
-          s"${MILLISECONDS.toSeconds(System.currentTimeMillis() - startTime)} seconds, " +
-          s"current barrier epoch is $barrierEpoch.")
-        throw e
-    } finally {
-      timerTask.cancel()
-      timer.purge()
-    }
+  @Experimental
+  @Since("3.0.0")
+  def allGather(message: String): ArrayBuffer[String] = {
+    val bytes = runBarrier(RequestMethod.ALL_GATHER, message.getBytes(UTF_8))
+    val jsonArray = parse(new String(bytes, UTF_8))
+    implicit val formats = DefaultFormats
+    ArrayBuffer(jsonArray.extract[Array[String]]: _*)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/BarrierTaskContext.scala
+++ b/core/src/main/scala/org/apache/spark/BarrierTaskContext.scala
@@ -92,7 +92,7 @@ class BarrierTaskContext private[spark] (
           barrierEpoch, requestMethod, allGatherMessage),
         // Set a fixed timeout for RPC here, so users shall get a SparkException thrown by
         // BarrierCoordinator on timeout, instead of RPCTimeoutException from the RPC framework.
-        timeout = new RpcTimeout(31536000 /* = 3600 * 24 * 365 */ seconds, "barrierTimeout"))
+        timeout = new RpcTimeout(365.days, "barrierTimeout"))
 
       // Wait the RPC future to be completed, but every 1 second it will jump out waiting
       // and check whether current spark task is killed. If killed, then throw

--- a/core/src/main/scala/org/apache/spark/BarrierTaskContext.scala
+++ b/core/src/main/scala/org/apache/spark/BarrierTaskContext.scala
@@ -27,11 +27,6 @@ import scala.concurrent.TimeoutException
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-import org.json4s.DefaultFormats
-import org.json4s.JsonAST._
-import org.json4s.JsonDSL._
-import org.json4s.jackson.JsonMethods.parse
-
 import org.apache.spark.annotation.{Experimental, Since}
 import org.apache.spark.executor.TaskMetrics
 import org.apache.spark.internal.Logging
@@ -186,6 +181,13 @@ class BarrierTaskContext private[spark] (
     ()
   }
 
+  /**
+   * :: Experimental ::
+   * Blocks until all tasks in the same stage have reached this routine.  Each task passes in
+   * a message and returns with a list of all the messages passed in by each of those tasks.
+   *
+   * CAUTION! The allGather method requires the same precautions as the barrier method
+   */
   @Experimental
   @Since("3.0.0")
   def allGather(message: Array[Byte]): ArrayBuffer[Array[Byte]] = {

--- a/core/src/main/scala/org/apache/spark/BarrierTaskContext.scala
+++ b/core/src/main/scala/org/apache/spark/BarrierTaskContext.scala
@@ -79,10 +79,10 @@ class BarrierTaskContext private[spark] (
   ): RequestToSync = {
     requestMethod match {
       case RequestMethod.BARRIER =>
-        return BarrierRequestToSync(numTasks, stageId, stageAttemptNumber, taskAttemptId,
+        BarrierRequestToSync(numTasks, stageId, stageAttemptNumber, taskAttemptId,
           barrierEpoch, partitionId, requestMethod)
       case RequestMethod.ALL_GATHER =>
-        return AllGatherRequestToSync(numTasks, stageId, stageAttemptNumber, taskAttemptId,
+        AllGatherRequestToSync(numTasks, stageId, stageAttemptNumber, taskAttemptId,
           barrierEpoch, partitionId, requestMethod, allGatherMessage)
     }
   }

--- a/core/src/main/scala/org/apache/spark/BarrierTaskContext.scala
+++ b/core/src/main/scala/org/apache/spark/BarrierTaskContext.scala
@@ -77,12 +77,14 @@ class BarrierTaskContext private[spark] (
     requestMethod: RequestMethod.Value,
     allGatherMessage: String
   ): RequestToSync = {
-    if (requestMethod == RequestMethod.BARRIER) {
-      return BarrierRequestToSync(numTasks, stageId, stageAttemptNumber, taskAttemptId,
-        barrierEpoch, partitionId, requestMethod)
+    requestMethod match {
+      case RequestMethod.BARRIER =>
+        return BarrierRequestToSync(numTasks, stageId, stageAttemptNumber, taskAttemptId,
+          barrierEpoch, partitionId, requestMethod)
+      case RequestMethod.ALL_GATHER =>
+        return AllGatherRequestToSync(numTasks, stageId, stageAttemptNumber, taskAttemptId,
+          barrierEpoch, partitionId, requestMethod, allGatherMessage)
     }
-    AllGatherRequestToSync(numTasks, stageId, stageAttemptNumber, taskAttemptId,
-      barrierEpoch, partitionId, requestMethod, allGatherMessage)
   }
 
   private def runBarrier(

--- a/core/src/main/scala/org/apache/spark/BarrierTaskContext.scala
+++ b/core/src/main/scala/org/apache/spark/BarrierTaskContext.scala
@@ -190,12 +190,13 @@ class BarrierTaskContext private[spark] (
    */
   @Experimental
   @Since("3.0.0")
-  def allGather(message: Array[Byte]): ArrayBuffer[Array[Byte]] = {
-    val messagesSerialized = runBarrier(RequestMethod.ALL_GATHER, message)
+  def allGather(message: String): ArrayBuffer[String] = {
+    val messagesSerialized = runBarrier(RequestMethod.ALL_GATHER, message.getBytes(UTF_8))
     val ois = new ObjectInputStream(new ByteArrayInputStream(messagesSerialized))
     val messages = ois.readObject.asInstanceOf[Array[Array[Byte]]]
     ois.close()
-    ArrayBuffer(messages: _*)
+    ArrayBuffer(messages: _*).map(msg => new String(msg, UTF_8))
+
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
@@ -244,15 +244,13 @@ private[spark] abstract class BasePythonRunner[IN, OUT](
                   authHelper.authClient(sock)
                   val input = new DataInputStream(sock.getInputStream())
                   val requestMethod = input.readInt()
+                  // The BarrierTaskContext function may wait infinitely, socket shall not timeout
+                  // before the function finishes.
                   sock.setSoTimeout(0)
                   requestMethod match {
                     case BarrierTaskContextMessageProtocol.BARRIER_FUNCTION =>
-                      // The barrier() function may wait infinitely, socket shall not timeout
-                      // before the function finishes.
                       barrierAndServe(requestMethod, sock)
                     case BarrierTaskContextMessageProtocol.ALL_GATHER_FUNCTION =>
-                      // The allGather() function may wait infinitely, socket shall not timeout
-                      // before the function finishes.
                       val length = input.readInt()
                       val message = new Array[Byte](length)
                       input.readFully(message)

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
@@ -244,20 +244,19 @@ private[spark] abstract class BasePythonRunner[IN, OUT](
                   authHelper.authClient(sock)
                   val input = new DataInputStream(sock.getInputStream())
                   val requestMethod = input.readInt()
+                  sock.setSoTimeout(0)
                   requestMethod match {
-                    case requestMethod @ BarrierTaskContextMessageProtocol.BARRIER_FUNCTION =>
+                    case BarrierTaskContextMessageProtocol.BARRIER_FUNCTION =>
                       // The barrier() function may wait infinitely, socket shall not timeout
                       // before the function finishes.
-                      sock.setSoTimeout(0)
                       barrierAndServe(requestMethod, sock)
-                    case requestMethod @ BarrierTaskContextMessageProtocol.ALL_GATHER_FUNCTION =>
+                    case BarrierTaskContextMessageProtocol.ALL_GATHER_FUNCTION =>
                       // The allGather() function may wait infinitely, socket shall not timeout
                       // before the function finishes.
-                      sock.setSoTimeout(0)
                       val length = input.readInt()
                       val message = new Array[Byte](length)
                       input.readFully(message)
-                     barrierAndServe(requestMethod, sock, new String(message, UTF_8))
+                      barrierAndServe(requestMethod, sock, new String(message, UTF_8))
                     case _ =>
                       val out = new DataOutputStream(new BufferedOutputStream(
                         sock.getOutputStream))

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
@@ -435,12 +435,12 @@ private[spark] abstract class BasePythonRunner[IN, OUT](
 
       val out = new DataOutputStream(new BufferedOutputStream(sock.getOutputStream))
       try {
-        val msgs: ArrayBuffer[Array[Byte]] = context.asInstanceOf[BarrierTaskContext].allGather(
-          message
+        val msgs: ArrayBuffer[String] = context.asInstanceOf[BarrierTaskContext].allGather(
+          new String(message, UTF_8)
         )
         val json: String = compact(render(JArray(
           msgs.map(
-            (message) => JString(new String(message, UTF_8))
+            (message) => JString(message)
           ).toList
         )))
         writeUTF(json, out)

--- a/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
@@ -64,8 +64,8 @@ class BarrierTaskContextSuite extends SparkFunSuite with LocalSparkContext {
       // Sleep for a random time before global sync.
       Thread.sleep(Random.nextInt(1000))
       // Pass partitionId message in
-      val message: String = context.partitionId().toString
-      val messages: ArrayBuffer<String> = context.allGather(message)
+      val message = context.partitionId().toString
+      val messages = context.allGather(message)
       messages.toList.iterator
     }
     // Take a sorted list of all the partitionId messages

--- a/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
@@ -65,12 +65,12 @@ class BarrierTaskContextSuite extends SparkFunSuite with LocalSparkContext {
       // Sleep for a random time before global sync.
       Thread.sleep(Random.nextInt(1000))
       // Pass partitionId message in
-      val message = context.partitionId().toString.getBytes(UTF_8)
+      val message: Array[Byte] = context.partitionId().toString.getBytes(UTF_8)
       val messages = context.allGather(message)
       messages.toList.iterator
     }
     // Take a list of all the partitionId messages
-    val output: Array[Array[Byte]] = rdd2.collect().head
+    val output: Array[Array[Byte]] = rdd2.collect().slice(0, 4)
     val messages = new Array[String](output.length)
     for (i <- 0 to output.length - 1) {
       messages(i) = new String(output(i), UTF_8)

--- a/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
@@ -69,13 +69,14 @@ class BarrierTaskContextSuite extends SparkFunSuite with LocalSparkContext {
       val messages = context.allGather(message)
       messages.toList.iterator
     }
-    // Take a sorted list of all the partitionId messages
+    // Take a list of all the partitionId messages
     val output = rdd2.collect().head
-    val messages = output.map(
-      (bytes) => new String(bytes, UTF_8)
-    ).sorted
+    val messages = Array[String](output.length)
+    for ((x, i) <- output.view.zipWithIndex)) {
+      messages(i) = new String(x, UTF_8)
+    }
     // All the task partitionIds are shared
-    for((x, i) <- messages.view.zipWithIndex) assert(x == i.toString)
+    for((x, i) <- messages.sorted.view.zipWithIndex) assert(x == i.toString)
   }
 
   test("support multiple barrier() call within a single task") {

--- a/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
@@ -71,10 +71,11 @@ class BarrierTaskContextSuite extends SparkFunSuite with LocalSparkContext {
       messages.toList.iterator
     }
     // Take a sorted list of all the partitionId messages
-    val messages = stableSort(rdd2.collect().head)
-    messages.foreach(
+    val output = rdd2.collect().head
+    output.foreach(
       (bytes) => new String(bytes, UTF_8)
     )
+    val messages = stableSort(output)
     // All the task partitionIds are shared
     for((x, i) <- messages.view.zipWithIndex) assert(x == i.toString)
   }

--- a/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
@@ -22,7 +22,6 @@ import java.nio.charset.StandardCharsets.UTF_8
 
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
-import scala.util.Sorting.stableSort
 
 import org.apache.spark._
 import org.apache.spark.internal.config.Tests.TEST_NO_STAGE_RETRY
@@ -72,10 +71,9 @@ class BarrierTaskContextSuite extends SparkFunSuite with LocalSparkContext {
     }
     // Take a sorted list of all the partitionId messages
     val output = rdd2.collect().head
-    output.foreach(
+    val messages = output.map(
       (bytes) => new String(bytes, UTF_8)
-    )
-    val messages = stableSort(output)
+    ).sorted
     // All the task partitionIds are shared
     for((x, i) <- messages.view.zipWithIndex) assert(x == i.toString)
   }

--- a/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
@@ -72,7 +72,7 @@ class BarrierTaskContextSuite extends SparkFunSuite with LocalSparkContext {
     // Take a sorted list of all the partitionId messages
     val messages = stableSort(rdd2.collect().head)
     // All the task partitionIds are shared
-    for((x,i) <- messages.view.zipWithIndex) assert(x == i.toString)
+    for((x, i) <- messages.view.zipWithIndex) assert(x == i.toString)
   }
 
   test("support multiple barrier() call within a single task") {

--- a/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.scheduler
 
 import java.io.File
+import java.nio.charset.StandardCharsets.UTF_8
 
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
@@ -65,12 +66,15 @@ class BarrierTaskContextSuite extends SparkFunSuite with LocalSparkContext {
       // Sleep for a random time before global sync.
       Thread.sleep(Random.nextInt(1000))
       // Pass partitionId message in
-      val message = context.partitionId().toString
+      val message = context.partitionId().toString.getBytes(UTF_8)
       val messages = context.allGather(message)
       messages.toList.iterator
     }
     // Take a sorted list of all the partitionId messages
     val messages = stableSort(rdd2.collect().head)
+    messages.foreach(
+      (bytes) => new String(bytes, UTF_8)
+    )
     // All the task partitionIds are shared
     for((x, i) <- messages.view.zipWithIndex) assert(x == i.toString)
   }

--- a/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
@@ -70,8 +70,8 @@ class BarrierTaskContextSuite extends SparkFunSuite with LocalSparkContext {
       messages.toList.iterator
     }
     // Take a list of all the partitionId messages
-    val output: List[Byte] = rdd2.collect().head
-    val messages = Array[String](output.length)
+    val output: Array[Byte] = rdd2.collect().head
+    val messages = new Array[String](output.length)
     for (i <- 0 to output.length - 1) {
       messages(i) = new String(output(i), UTF_8)
     }

--- a/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.scheduler
 
 import java.io.File
 
+import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
 
 import org.apache.spark._
@@ -68,7 +69,7 @@ class BarrierTaskContextSuite extends SparkFunSuite with LocalSparkContext {
       messages.toList.iterator
     }
     // Take a sorted list of all the partitionId messages
-    val messages = stableSort(rdd2.first())
+    val messages = stableSort(rdd2.collect().head)
     // All the task partitionIds are shared
     for((x,i) <- messages.view.zipWithIndex) assert(x == i.toString)
   }

--- a/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
@@ -70,10 +70,10 @@ class BarrierTaskContextSuite extends SparkFunSuite with LocalSparkContext {
       messages.toList.iterator
     }
     // Take a list of all the partitionId messages
-    val output = rdd2.collect().head
+    val output: List[Byte] = rdd2.collect().head
     val messages = Array[String](output.length)
-    for ((x, i) <- output.view.zipWithIndex)) {
-      messages(i) = new String(x, UTF_8)
+    for (i <- 0 to output.length - 1) {
+      messages(i) = new String(output(i), UTF_8)
     }
     // All the task partitionIds are shared
     for((x, i) <- messages.sorted.view.zipWithIndex) assert(x == i.toString)

--- a/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
@@ -73,7 +73,7 @@ class BarrierTaskContextSuite extends SparkFunSuite with LocalSparkContext {
     val output: Array[Byte] = rdd2.collect().head
     val messages = new Array[String](output.length)
     for (i <- 0 to output.length - 1) {
-      messages(i) = new String(output(i), UTF_8)
+      messages(i) = String(output(i), UTF_8)
     }
     // All the task partitionIds are shared
     for((x, i) <- messages.sorted.view.zipWithIndex) assert(x == i.toString)

--- a/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
@@ -21,6 +21,7 @@ import java.io.File
 
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
+import scala.util.Sorting.stableSort
 
 import org.apache.spark._
 import org.apache.spark.internal.config.Tests.TEST_NO_STAGE_RETRY

--- a/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
@@ -70,10 +70,10 @@ class BarrierTaskContextSuite extends SparkFunSuite with LocalSparkContext {
       messages.toList.iterator
     }
     // Take a list of all the partitionId messages
-    val output: Array[Byte] = rdd2.collect().head
+    val output: Array[Array[Byte]] = rdd2.collect().head
     val messages = new Array[String](output.length)
     for (i <- 0 to output.length - 1) {
-      messages(i) = String(output(i), UTF_8)
+      messages(i) = new String(output(i), UTF_8)
     }
     // All the task partitionIds are shared
     for((x, i) <- messages.sorted.view.zipWithIndex) assert(x == i.toString)

--- a/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
@@ -88,6 +88,7 @@ class BarrierTaskContextSuite extends SparkFunSuite with LocalSparkContext {
       } else {
         context.allGather(partitionId.toString)
       }
+      Seq(null).iterator
     }
     val error = intercept[SparkException] {
       rdd2.collect()

--- a/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
@@ -18,10 +18,10 @@
 package org.apache.spark.scheduler
 
 import java.io.File
-import java.nio.charset.StandardCharsets.UTF_8
 
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
+import scala.util.Sorting.stableSort
 
 import org.apache.spark._
 import org.apache.spark.internal.config.Tests.TEST_NO_STAGE_RETRY
@@ -65,14 +65,14 @@ class BarrierTaskContextSuite extends SparkFunSuite with LocalSparkContext {
       // Sleep for a random time before global sync.
       Thread.sleep(Random.nextInt(1000))
       // Pass partitionId message in
-      val message: String = context.partitionId().toString
+      val message = context.partitionId().toString
       val messages = context.allGather(message)
       messages.toList.iterator
     }
-    // Take a list of all the partitionId messages
-    val messages: Array[String] = rdd2.collect().slice(0, 4)
+    // Take a sorted list of all the partitionId messages
+    val messages = stableSort(rdd2.collect().head)
     // All the task partitionIds are shared
-    for((x, i) <- messages.sorted.view.zipWithIndex) assert(x == i.toString)
+    for((x, i) <- messages.view.zipWithIndex) assert(x == i.toString)
   }
 
   test("support multiple barrier() call within a single task") {

--- a/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
@@ -65,16 +65,12 @@ class BarrierTaskContextSuite extends SparkFunSuite with LocalSparkContext {
       // Sleep for a random time before global sync.
       Thread.sleep(Random.nextInt(1000))
       // Pass partitionId message in
-      val message: Array[Byte] = context.partitionId().toString.getBytes(UTF_8)
+      val message: String = context.partitionId().toString
       val messages = context.allGather(message)
       messages.toList.iterator
     }
     // Take a list of all the partitionId messages
-    val output: Array[Array[Byte]] = rdd2.collect().slice(0, 4)
-    val messages = new Array[String](output.length)
-    for (i <- 0 to output.length - 1) {
-      messages(i) = new String(output(i), UTF_8)
-    }
+    val messages: Array[String] = rdd2.collect().slice(0, 4)
     // All the task partitionIds are shared
     for((x, i) <- messages.sorted.view.zipWithIndex) assert(x == i.toString)
   }

--- a/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
@@ -21,7 +21,6 @@ import java.io.File
 
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
-import scala.util.Sorting.stableSort
 
 import org.apache.spark._
 import org.apache.spark.internal.config.Tests.TEST_NO_STAGE_RETRY
@@ -70,9 +69,60 @@ class BarrierTaskContextSuite extends SparkFunSuite with LocalSparkContext {
       messages.toList.iterator
     }
     // Take a sorted list of all the partitionId messages
-    val messages = stableSort(rdd2.collect().head)
+    val messages = rdd2.collect().head
     // All the task partitionIds are shared
     for((x, i) <- messages.view.zipWithIndex) assert(x == i.toString)
+  }
+
+  test("throw exception if we attempt to synchronize with different blocking calls") {
+    val conf = new SparkConf()
+      .setMaster("local-cluster[4, 1, 1024]")
+      .setAppName("test-cluster")
+    sc = new SparkContext(conf)
+    val rdd = sc.makeRDD(1 to 10, 4)
+    val rdd2 = rdd.barrier().mapPartitions { it =>
+      val context = BarrierTaskContext.get()
+      val partitionId = context.partitionId
+      if (partitionId == 0) {
+        context.barrier()
+      } else {
+        context.allGather(partitionId.toString)
+      }
+    }
+    val error = intercept[SparkException] {
+      rdd2.collect()
+    }.getMessage
+    assert(error.contains("does not match the current synchronized requestMethod"))
+  }
+
+  test("successively sync with allGather and barrier") {
+    val conf = new SparkConf()
+      .setMaster("local-cluster[4, 1, 1024]")
+      .setAppName("test-cluster")
+    sc = new SparkContext(conf)
+    val rdd = sc.makeRDD(1 to 10, 4)
+    val rdd2 = rdd.barrier().mapPartitions { it =>
+      val context = BarrierTaskContext.get()
+      // Sleep for a random time before global sync.
+      Thread.sleep(Random.nextInt(1000))
+      context.barrier()
+      val time1 = System.currentTimeMillis()
+      // Sleep for a random time before global sync.
+      Thread.sleep(Random.nextInt(1000))
+      // Pass partitionId message in
+      val message = context.partitionId().toString
+      val messages = context.allGather(message)
+      val time2 = System.currentTimeMillis()
+      Seq((time1, time2)).iterator
+    }
+    val times = rdd2.collect()
+    // All the tasks shall finish the first round of global sync within a short time slot.
+    val times1 = times.map(_._1)
+    assert(times1.max - times1.min <= 1000)
+
+    // All the tasks shall finish the second round of global sync within a short time slot.
+    val times2 = times.map(_._2)
+    assert(times2.max - times2.min <= 1000)
   }
 
   test("support multiple barrier() call within a single task") {

--- a/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
@@ -64,14 +64,14 @@ class BarrierTaskContextSuite extends SparkFunSuite with LocalSparkContext {
       // Sleep for a random time before global sync.
       Thread.sleep(Random.nextInt(1000))
       // Pass partitionId message in
-      val message = context.partitionId().toString
-      val messages = context.allGather(message)
+      val message: String = context.partitionId().toString
+      val messages: ArrayBuffer[String] = context.allGather(message)
       messages.toList.iterator
     }
     // Take a sorted list of all the partitionId messages
     val messages = rdd2.collect().head
     // All the task partitionIds are shared
-    for((x, i) <- messages.view.zipWithIndex) assert(x == i.toString)
+    for((x, i) <- messages.view.zipWithIndex) assert(x.toString == i.toString)
   }
 
   test("throw exception if we attempt to synchronize with different blocking calls") {

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -493,6 +493,9 @@ object MimaExcludes {
 
     // [SPARK-29543][SS][UI] Init structured streaming ui
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.streaming.StreamingQueryListener#QueryStartedEvent.this")
+
+    // [SPARK-30667][CORE] Add allGather method to BarrierTaskContext
+    ProblemFilters.exclude[IncompatibleTemplateDefProblem]("org.apache.spark.RequestToSync")
   )
 
   // Exclude rules for 2.4.x

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -492,7 +492,7 @@ object MimaExcludes {
     ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.spark.ml.regression.AFTSurvivalRegression.setPredictionCol"),
 
     // [SPARK-29543][SS][UI] Init structured streaming ui
-    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.streaming.StreamingQueryListener#QueryStartedEvent.this")
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.streaming.StreamingQueryListener#QueryStartedEvent.this"),
 
     // [SPARK-30667][CORE] Add allGather method to BarrierTaskContext
     ProblemFilters.exclude[IncompatibleTemplateDefProblem]("org.apache.spark.RequestToSync")

--- a/python/pyspark/taskcontext.py
+++ b/python/pyspark/taskcontext.py
@@ -127,7 +127,7 @@ def _load_from_socket(port, auth_secret, function, all_gather_message=None):
     elif function == ALL_GATHER_FUNCTION:
         # Make a all_gather() function call.
         write_int(function, sockfile)
-        write_with_length(all_gather_message.encode("utf-8"), sockfile)
+        write_with_length(all_gather_message, sockfile)
     else:
         raise ValueError("Unrecognized function type")
     sockfile.flush()
@@ -212,7 +212,7 @@ class BarrierTaskContext(TaskContext):
         else:
             _load_from_socket(self._port, self._secret, BARRIER_FUNCTION)
 
-    def allGather(self, message=""):
+    def allGather(self, message=b""):
         """
         .. note:: Experimental
 
@@ -224,8 +224,8 @@ class BarrierTaskContext(TaskContext):
             calls, in all possible code branches.
             Otherwise, you may get the job hanging or a SparkException after timeout.
         """
-        if not isinstance(message, str):
-            raise ValueError("Argument `message` must be of type `str`")
+        if not isinstance(message, bytes):
+            raise ValueError("Argument `message` must be of type `bytes`")
         elif self._port is None or self._secret is None:
             raise Exception("Not supported to call barrier() before initialize " +
                             "BarrierTaskContext.")
@@ -236,7 +236,7 @@ class BarrierTaskContext(TaskContext):
                 ALL_GATHER_FUNCTION,
                 message,
             )
-            return [e for e in json.loads(gathered_items)]
+            return [e.encode("utf-8") for e in json.loads(gathered_items)]
 
     def getTaskInfos(self):
         """

--- a/python/pyspark/taskcontext.py
+++ b/python/pyspark/taskcontext.py
@@ -227,7 +227,7 @@ class BarrierTaskContext(TaskContext):
         if not isinstance(message, bytes):
             raise ValueError("Argument `message` must be of type `bytes`")
         elif self._port is None or self._secret is None:
-            raise Exception("Not supported to call barrier() before initialize " +
+            raise Exception("Not supported to call allGather() before initialize " +
                             "BarrierTaskContext.")
         else:
             gathered_items = _load_from_socket(

--- a/python/pyspark/taskcontext.py
+++ b/python/pyspark/taskcontext.py
@@ -216,12 +216,11 @@ class BarrierTaskContext(TaskContext):
         """
         .. note:: Experimental
 
-        Sets a global barrier and waits until all tasks in this stage hit this barrier.
-        Similar to `MPI_Barrier` function in MPI, this function blocks until all tasks
-        in the same stage have reached this routine. Each task passes in a message and
-        returns with a list of all the messages passed in by each of those tasks.        
+        This function blocks until all tasks in the same stage have reached this routine.
+        Each task passes in a message and returns with a list of all the messages passed in
+        by each of those tasks.
 
-        .. warning:: In a barrier stage, each task much have the same number of `all_gather()`
+        .. warning:: In a barrier stage, each task much have the same number of `allGather()`
             calls, in all possible code branches.
             Otherwise, you may get the job hanging or a SparkException after timeout.
         """

--- a/python/pyspark/taskcontext.py
+++ b/python/pyspark/taskcontext.py
@@ -212,7 +212,7 @@ class BarrierTaskContext(TaskContext):
         else:
             _load_from_socket(self._port, self._secret, BARRIER_FUNCTION)
 
-    def all_gather(self, message=""):
+    def allGather(self, message=""):
         """
         .. note:: Experimental
 

--- a/python/pyspark/taskcontext.py
+++ b/python/pyspark/taskcontext.py
@@ -16,9 +16,10 @@
 #
 
 from __future__ import print_function
+import json
 
 from pyspark.java_gateway import local_connect_and_auth
-from pyspark.serializers import write_int, UTF8Deserializer
+from pyspark.serializers import write_int, write_with_length, UTF8Deserializer
 
 
 class TaskContext(object):
@@ -107,18 +108,28 @@ class TaskContext(object):
 
 
 BARRIER_FUNCTION = 1
+ALL_GATHER_FUNCTION = 2
 
 
-def _load_from_socket(port, auth_secret):
+def _load_from_socket(port, auth_secret, function, all_gather_message=None):
     """
     Load data from a given socket, this is a blocking method thus only return when the socket
     connection has been closed.
     """
     (sockfile, sock) = local_connect_and_auth(port, auth_secret)
-    # The barrier() call may block forever, so no timeout
+
+    # The call may block forever, so no timeout
     sock.settimeout(None)
-    # Make a barrier() function call.
-    write_int(BARRIER_FUNCTION, sockfile)
+
+    if function == BARRIER_FUNCTION:
+        # Make a barrier() function call.
+        write_int(function, sockfile)
+    elif function == ALL_GATHER_FUNCTION:
+        # Make a all_gather() function call.
+        write_int(function, sockfile)
+        write_with_length(all_gather_message.encode("utf-8"), sockfile)
+    else:
+        raise ValueError("Unrecognized function type")
     sockfile.flush()
 
     # Collect result.
@@ -199,7 +210,29 @@ class BarrierTaskContext(TaskContext):
             raise Exception("Not supported to call barrier() before initialize " +
                             "BarrierTaskContext.")
         else:
-            _load_from_socket(self._port, self._secret)
+            _load_from_socket(self._port, self._secret, BARRIER_FUNCTION)
+
+    def all_gather(self, message=""):
+        """
+        .. note:: Experimental
+
+        Sets a global barrier and waits until all tasks in this stage hit this barrier.
+        Similar to `MPI_Barrier` function in MPI, this function blocks until all tasks
+        in the same stage have reached this routine. Each task passes in a message and
+        returns with a list of all the messages passed in by each of those tasks.        
+
+        .. warning:: In a barrier stage, each task much have the same number of `all_gather()`
+            calls, in all possible code branches.
+            Otherwise, you may get the job hanging or a SparkException after timeout.
+        """
+        if not isinstance(message, str):
+            raise ValueError("Argument `message` must be of type `str`")
+        elif self._port is None or self._secret is None:
+            raise Exception("Not supported to call barrier() before initialize " +
+                            "BarrierTaskContext.")
+        else:
+            gathered_items = _load_from_socket(self._port, self._secret, ALL_GATHER_FUNCTION, message)
+            return [e for e in json.loads(gathered_items)]
 
     def getTaskInfos(self):
         """

--- a/python/pyspark/taskcontext.py
+++ b/python/pyspark/taskcontext.py
@@ -230,7 +230,12 @@ class BarrierTaskContext(TaskContext):
             raise Exception("Not supported to call barrier() before initialize " +
                             "BarrierTaskContext.")
         else:
-            gathered_items = _load_from_socket(self._port, self._secret, ALL_GATHER_FUNCTION, message)
+            gathered_items = _load_from_socket(
+                self._port,
+                self._secret,
+                ALL_GATHER_FUNCTION,
+                message,
+            )
             return [e for e in json.loads(gathered_items)]
 
     def getTaskInfos(self):

--- a/python/pyspark/taskcontext.py
+++ b/python/pyspark/taskcontext.py
@@ -125,9 +125,9 @@ def _load_from_socket(port, auth_secret, function, all_gather_message=None):
         # Make a barrier() function call.
         write_int(function, sockfile)
     elif function == ALL_GATHER_FUNCTION:
-        # Make a all_gather() function call.
+        # Make a allGather() function call.
         write_int(function, sockfile)
-        write_with_length(all_gather_message, sockfile)
+        write_with_length(all_gather_message.encode("utf-8"), sockfile)
     else:
         raise ValueError("Unrecognized function type")
     sockfile.flush()
@@ -212,7 +212,7 @@ class BarrierTaskContext(TaskContext):
         else:
             _load_from_socket(self._port, self._secret, BARRIER_FUNCTION)
 
-    def allGather(self, message=b""):
+    def allGather(self, message=""):
         """
         .. note:: Experimental
 
@@ -224,8 +224,8 @@ class BarrierTaskContext(TaskContext):
             calls, in all possible code branches.
             Otherwise, you may get the job hanging or a SparkException after timeout.
         """
-        if not isinstance(message, bytes):
-            raise ValueError("Argument `message` must be of type `bytes`")
+        if not isinstance(message, str):
+            raise ValueError("Argument `message` must be of type `str`")
         elif self._port is None or self._secret is None:
             raise Exception("Not supported to call allGather() before initialize " +
                             "BarrierTaskContext.")
@@ -236,7 +236,7 @@ class BarrierTaskContext(TaskContext):
                 ALL_GATHER_FUNCTION,
                 message,
             )
-            return [e.encode("utf-8") for e in json.loads(gathered_items)]
+            return json.loads(gathered_items)
 
     def getTaskInfos(self):
         """

--- a/python/pyspark/taskcontext.py
+++ b/python/pyspark/taskcontext.py
@@ -125,7 +125,7 @@ def _load_from_socket(port, auth_secret, function, all_gather_message=None):
         # Make a barrier() function call.
         write_int(function, sockfile)
     elif function == ALL_GATHER_FUNCTION:
-        # Make a allGather() function call.
+        # Make a all_gather() function call.
         write_int(function, sockfile)
         write_with_length(all_gather_message.encode("utf-8"), sockfile)
     else:
@@ -227,7 +227,7 @@ class BarrierTaskContext(TaskContext):
         if not isinstance(message, str):
             raise ValueError("Argument `message` must be of type `str`")
         elif self._port is None or self._secret is None:
-            raise Exception("Not supported to call allGather() before initialize " +
+            raise Exception("Not supported to call barrier() before initialize " +
                             "BarrierTaskContext.")
         else:
             gathered_items = _load_from_socket(
@@ -236,7 +236,7 @@ class BarrierTaskContext(TaskContext):
                 ALL_GATHER_FUNCTION,
                 message,
             )
-            return json.loads(gathered_items)
+            return [e for e in json.loads(gathered_items)]
 
     def getTaskInfos(self):
         """

--- a/python/pyspark/tests/test_taskcontext.py
+++ b/python/pyspark/tests/test_taskcontext.py
@@ -152,7 +152,7 @@ class TaskContextTests(PySparkTestCase):
             return [pids]
 
         pids = rdd.barrier().mapPartitions(f).map(context_barrier).collect()[0]
-        self.assertTrue(sorted(pids) = [0, 1, 2, 3])
+        self.assertTrue(sorted(pids) == [0, 1, 2, 3])
 
     def test_barrier_infos(self):
         """

--- a/python/pyspark/tests/test_taskcontext.py
+++ b/python/pyspark/tests/test_taskcontext.py
@@ -147,7 +147,7 @@ class TaskContextTests(PySparkTestCase):
         def context_barrier(x):
             tc = BarrierTaskContext.get()
             time.sleep(random.randint(1, 10))
-            out = tc.allGather(str(context.partitionId()))  
+            out = tc.allGather(str(context.partitionId()))
             pids = [int(e) for e in out]
             return [pids]
 

--- a/python/pyspark/tests/test_taskcontext.py
+++ b/python/pyspark/tests/test_taskcontext.py
@@ -149,10 +149,10 @@ class TaskContextTests(PySparkTestCase):
             time.sleep(random.randint(1, 10))
             out = tc.allGather(str(tc.partitionId()))
             pids = [int(e) for e in out]
-            return [pids]
+            return pids
 
         pids = rdd.barrier().mapPartitions(f).map(context_barrier).collect()[0]
-        self.assertTrue(pids == [0, 1, 2, 3])
+        self.assertEqual(pids, [0, 1, 2, 3])
 
     def test_barrier_infos(self):
         """

--- a/python/pyspark/tests/test_taskcontext.py
+++ b/python/pyspark/tests/test_taskcontext.py
@@ -147,8 +147,8 @@ class TaskContextTests(PySparkTestCase):
         def context_barrier(x):
             tc = BarrierTaskContext.get()
             time.sleep(random.randint(1, 10))
-            out = tc.allGather(str(context.partitionId()).encode("utf-8"))
-            pids = [int(e.decode("utf-8")) for e in out]
+            out = tc.allGather(str(context.partitionId()))  
+            pids = [int(e) for e in out]
             return [pids]
 
         pids = rdd.barrier().mapPartitions(f).map(context_barrier).collect()[0]

--- a/python/pyspark/tests/test_taskcontext.py
+++ b/python/pyspark/tests/test_taskcontext.py
@@ -152,7 +152,7 @@ class TaskContextTests(PySparkTestCase):
             return [pids]
 
         pids = rdd.barrier().mapPartitions(f).map(context_barrier).collect()[0]
-        self.assertTrue(sorted(pids) == [0, 1, 2, 3])
+        self.assertTrue(pids == [0, 1, 2, 3])
 
     def test_barrier_infos(self):
         """

--- a/python/pyspark/tests/test_taskcontext.py
+++ b/python/pyspark/tests/test_taskcontext.py
@@ -147,7 +147,7 @@ class TaskContextTests(PySparkTestCase):
         def context_barrier(x):
             tc = BarrierTaskContext.get()
             time.sleep(random.randint(1, 10))
-            out = tc.allGather(str(context.partitionId()))
+            out = tc.allGather(str(tc.partitionId()))
             pids = [int(e) for e in out]
             return [pids]
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

The `allGather` method is added to the `BarrierTaskContext`. This method contains the same functionality as the `BarrierTaskContext.barrier` method; it blocks the task until all tasks make the call, at which time they may continue execution. In addition, the `allGather` method takes an input message. Upon returning from the `allGather` the task receives a list of all the messages sent by all the tasks that made the `allGather` call.

### Why are the changes needed?

There are many situations where having the tasks communicate in a synchronized way is useful. One simple example is if each task needs to start a server to serve requests from one another; first the tasks must find a free port (the result of which is undetermined beforehand) and then start making requests, but to do so they each must know the port chosen by the other task. An `allGather` method would allow them to inform each other of the port they will run on.

### Does this PR introduce any user-facing change?

Yes, an `BarrierTaskContext.allGather` method will be available through the Scala, Java, and Python APIs.

### How was this patch tested?

Most of the code path is already covered by tests to the `barrier` method, since this PR includes a refactor so that much code is shared by the `barrier` and `allGather` methods. However, a test is added to assert that an all gather on each tasks partition ID will return a list of every partition ID.

An example through the Python API:
```python
>>> from pyspark import BarrierTaskContext
>>>
>>> def f(iterator):
...     context = BarrierTaskContext.get()
...     return [context.allGather('{}'.format(context.partitionId()))]
...
>>> sc.parallelize(range(4), 4).barrier().mapPartitions(f).collect()[0]
[u'3', u'1', u'0', u'2']
```
