### PR TITLE
[SPARK-30481][DOCS][FOLLOWUP] Document event log compaction into new section of monitoring.md

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -98,7 +98,7 @@ The history server can be configured as follows:
 ### Applying compaction of old event log files
 
 A long-running streaming application can bring a huge single event log file which may cost a lot to maintain and
-also requires bunch of resource to replay per each update in Spark History Server.
+also requires a bunch of resource to replay per each update in Spark History Server.
 
 Enabling <code>spark.eventLog.rolling.enabled</code> and <code>spark.eventLog.rolling.maxFileSize</code> would
 let you have multiple event log files instead of single huge event log file which may help some scenarios on its own,
@@ -108,7 +108,7 @@ Spark History Server can apply 'compaction' on the rolling event log files to re
 logs, via setting the configuration <code>spark.history.fs.eventLog.rolling.maxFilesToRetain</code> on the
 Spark History Server.
 
-When the compaction happens, History Server lists the all available event log files, and considers the event log files older than
+When the compaction happens, History Server lists all the available event log files, and considers the event log files older than
 retained log files as a target of compaction. For example, if the application A has 5 event log files and
 <code>spark.history.fs.eventLog.rolling.maxFilesToRetain</code> is set to 2, first 3 log files will be selected to be compacted.
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -129,6 +129,10 @@ would be reduced during compaction. For streaming query (including Structured St
 will run as each micro-batch will trigger one or more jobs which will be finished shortly, but compaction won't run
 in many cases for batch query.
 
+Please also note that this is a new feature introduced in Spark 3.0, and may not be completely stable. In some circumstance,
+the compaction may exclude more events than you expect, leading some UI issues on History Server for the application.
+Use with caution.
+
 ### Spark History Server Configuration Options
 
 Security options for the Spark History Server are covered more detail in the

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -104,12 +104,12 @@ Enabling <code>spark.eventLog.rolling.enabled</code> and <code>spark.eventLog.ro
 let you have rolling event log files instead of single huge event log file which may help some scenarios on its own,
 but it still doesn't help you reducing the overall size of logs.
 
-Spark History Server can apply 'compaction' on the rolling event log files to reduce the overall size of
+Spark History Server can apply compaction on the rolling event log files to reduce the overall size of
 logs, via setting the configuration <code>spark.history.fs.eventLog.rolling.maxFilesToRetain</code> on the
 Spark History Server.
 
-Details will be described below, but please note in prior that 'compaction' is LOSSY operation.
-'Compaction' will discard some events which will be no longer seen on UI - you may want to check which events will be discarded
+Details will be described below, but please note in prior that compaction is LOSSY operation.
+Compaction will discard some events which will be no longer seen on UI - you may want to check which events will be discarded
 before enabling the option.
 
 When the compaction happens, the History Server lists all the available event log files for the application, and considers
@@ -119,8 +119,7 @@ For example, if the application A has 5 event log files and <code>spark.history.
 Once it selects the target, it analyzes them to figure out which events can be excluded, and rewrites them
 into one compact file with discarding events which are decided to exclude.
 
-The compaction tries to exclude the events which point to the outdated things like jobs, and so on. As of now, below describes
-the candidates of events to be excluded:
+The compaction tries to exclude the events which point to the outdated data. As of now, below describes the candidates of events to be excluded:
 
 * Events for the job which is finished, and related stage/tasks events
 * Events for the executor which is terminated


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a FOLLOW-UP PR for review comment on #27208 : https://github.com/apache/spark/pull/27208#pullrequestreview-347451714

This PR documents a new feature `Eventlog Compaction` into the new section of `monitoring.md`, as it only has one configuration on the SHS side and it's hard to explain everything on the description on the single configuration.

### Why are the changes needed?

Event log compaction lacks the documentation for what it is and how it helps. This PR will explain it.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Built docs via jekyll.

> change on the new section

<img width="951" alt="Screen Shot 2020-02-16 at 2 23 18 PM" src="https://user-images.githubusercontent.com/1317309/74599587-eb9efa80-50c7-11ea-942c-f7744268e40b.png">

> change on the table

<img width="1126" alt="Screen Shot 2020-01-30 at 5 08 12 PM" src="https://user-images.githubusercontent.com/1317309/73431190-2e9c6680-4383-11ea-8ce0-815f10917ddd.png">
