### PR TITLE
[SPARK-30684][WEBUI] Show the descripton of metrics for WholeStageCodegen in DAG viz

### DIFF
--- a/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.css
+++ b/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.css
@@ -32,8 +32,13 @@
   stroke-width: 1px;
 }
 
+/* This declaration is needed to define the width of rectangles */
+#plan-viz-graph svg text :first-child {
+  font-weight: bold;
+}
+
 /* Highlight the SparkPlan node name */
-#plan-viz-graph svg text :first-child, #plan-viz-graph svg text :nth-child(2) {
+#plan-viz-graph svg text .operator-name {
   font-weight: bold;
 }
 

--- a/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.css
+++ b/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.css
@@ -33,7 +33,7 @@
 }
 
 /* Highlight the SparkPlan node name */
-#plan-viz-graph svg text :first-child {
+#plan-viz-graph svg text :first-child, #plan-viz-graph svg text :nth-child(2) {
   font-weight: bold;
 }
 

--- a/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
+++ b/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
@@ -83,7 +83,6 @@ function setupTooltipForSparkPlanNode(nodeId) {
 function preprocessGraphLayout(g) {
   g.graph().ranksep = "90";
   var nodes = g.nodes();
-
   for (var i = 0; i < nodes.length; i++) {
       var node = g.node(nodes[i]);
       node.padding = "5";

--- a/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
+++ b/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
@@ -81,7 +81,9 @@ function setupTooltipForSparkPlanNode(nodeId) {
  * and sizes of graph elements, e.g. padding, font style, shape.
  */
 function preprocessGraphLayout(g) {
+  g.graph().ranksep = "90";
   var nodes = g.nodes();
+
   for (var i = 0; i < nodes.length; i++) {
       var node = g.node(nodes[i]);
       node.padding = "5";

--- a/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
+++ b/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
@@ -34,6 +34,7 @@ function renderPlanViz() {
   preprocessGraphLayout(g);
   var renderer = new dagreD3.render();
   renderer(graph, g);
+  adjustPositionOfOperationName();
 
   // Round corners on rectangles
   svg
@@ -126,6 +127,34 @@ function resizeSvg(svg) {
   svg.attr("viewBox", startX + " " + startY + " " + width + " " + height)
      .attr("width", width)
      .attr("height", height);
+}
+
+
+/* Helper function to adjust the position of operation name and mark as a operation-name class. */
+function adjustPositionOfOperationName() {
+  $("#plan-viz-graph svg text")
+      .each(function() {
+        var tspans = $(this).find("tspan");
+
+        if (tspans[0].textContent.trim() !== "") {
+          var isOperationNameOnly =
+              $(tspans).filter(function(i, n) {
+                return i !== 0 && n.textContent.trim() !== "";
+              }).length === 0;
+
+          if (isOperationNameOnly) {
+            // If the only text in a node is operation name,
+            // vertically centering the position of operation name.
+            var operationName = tspans[0].textContent;
+            var half = parseInt(tspans.length / 2);
+            tspans[0].textContent = tspans[half].textContent;
+            tspans[half].textContent = operationName;
+            $(tspans[half]).addClass("operator-name");
+          } else {
+            tspans.first().addClass("operator-name");
+          }
+        }
+      });
 }
 
 /* Helper function to convert attributes to numeric values. */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
@@ -179,7 +179,7 @@ private[ui] class SparkPlanGraphNode(
     } else {
       // A certain level of height is needed for a rect as a node in a sub-graph
       // to avoid layout collapse for sub-graphs.
-      builder ++= " \n"
+      builder.insert(0, " \n")
     }
 
     s"""  $id [label="${StringEscapeUtils.escapeJava(builder.toString())}"];"""

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
@@ -169,12 +169,17 @@ private[ui] class SparkPlanGraphNode(
       metric.name + ": " + value
     }
 
+    // If there are metrics, display each entry in a separate line.
+    // Note: whitespace between two "\n"s is to create an empty line between the name of
+    // SparkPlan and metrics. If removing it, it won't display the empty line in UI.
+    builder ++= "\n \n"
+
     if (values.nonEmpty) {
-      // If there are metrics, display each entry in a separate line.
-      // Note: whitespace between two "\n"s is to create an empty line between the name of
-      // SparkPlan and metrics. If removing it, it won't display the empty line in UI.
-      builder ++= "\n \n"
       builder ++= values.mkString("\n")
+    } else {
+      // A certain level of height is needed for a rect as a node in a sub-graph
+      // to avoid layout collapse for sub-graphs.
+      builder ++= " \n"
     }
 
     s"""  $id [label="${StringEscapeUtils.escapeJava(builder.toString())}"];"""

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
@@ -202,7 +202,7 @@ private[ui] class SparkPlanGraphCluster(
     val labelStr = if (duration.nonEmpty) {
       require(duration.length == 1)
       val id = duration(0).accumulatorId
-      if (metricsValue.contains(duration(0).accumulatorId)) {
+      if (metricsValue.contains(id)) {
         name + "\n \n" + duration(0).name + ": " + metricsValue(id)
       } else {
         name

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
@@ -179,7 +179,7 @@ private[ui] class SparkPlanGraphNode(
     } else {
       // A certain level of height is needed for a rect as a node in a sub-graph
       // to avoid layout collapse for sub-graphs.
-      builder.insert(0, " \n")
+      builder ++= " "
     }
 
     s"""  $id [label="${StringEscapeUtils.escapeJava(builder.toString())}"];"""

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
@@ -198,7 +198,7 @@ private[ui] class SparkPlanGraphCluster(
       require(duration.length == 1)
       val id = duration(0).accumulatorId
       if (metricsValue.contains(duration(0).accumulatorId)) {
-        name + "\n\n" + metricsValue(id)
+        name + "\n \n" + duration(0).name + ": " + metricsValue(id)
       } else {
         name
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Added description for metrics shown in the WholeStageCodegen-node in DAG viz.

This is before the change is applied.
![before-changed](https://user-images.githubusercontent.com/4736016/73469870-5cf16480-43ca-11ea-9a13-714083508a3b.png)

And following is after change.
![after-fixing-layout](https://user-images.githubusercontent.com/4736016/73469364-983f6380-43c9-11ea-8b7e-ddab030d0270.png)

For this change, I also modify the layout of DAG viz.
Actually, I noticed  it's not enough to just added the description.
Following is without changing the layout.
![layout-is-broken](https://user-images.githubusercontent.com/4736016/73470178-cffadb00-43ca-11ea-86d7-aed109b105e6.png)


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Users can't understand what those metrics mean.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
Yes. The layout is a little bit changed. 

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I confirm the result of DAG viz with following 3 operations.

`sc.parallelize(1 to 10).toDF.sort("value").filter("value > 1").selectExpr("value * 2").show`
`sc.parallelize(1 to 10).toDF.sort("value").filter("value > 1").selectExpr("value * 2").write.format("json").mode("overwrite").save("/tmp/test_output")`
`sc.parallelize(1 to 10).toDF.write.format("json").mode("append").save("/tmp/test_output")`