### PR TITLE
[SPARK-30481][CORE][FOLLOWUP] Execute log compaction only when merge application listing is successful

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -840,7 +840,12 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
         case None => // This is not applied to single event log file.
       }
     } catch {
-      case e: Exception => logError(s"Exception while compacting log for $rootPath", e)
+      case e: InterruptedException =>
+        throw e
+      case e: AccessControlException =>
+        logWarning(s"Insufficient permission while compacting log for $rootPath", e)
+      case e: Exception =>
+        logError(s"Exception while compacting log for $rootPath", e)
     } finally {
       endProcessing(rootPath)
     }

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -656,6 +656,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
       scanTime: Long,
       enableOptimizations: Boolean): Unit = {
     val rootPath = reader.rootPath
+    var succeeded = false
     try {
       val lastEvaluatedForCompaction: Option[Long] = try {
         listing.read(classOf[LogInfo], rootPath.toString).lastEvaluatedForCompaction
@@ -668,6 +669,8 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
       if (conf.get(CLEANER_ENABLED)) {
         checkAndCleanLog(rootPath.toString)
       }
+
+      succeeded = true
     } catch {
       case e: InterruptedException =>
         throw e
@@ -684,8 +687,10 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
       endProcessing(rootPath)
       pendingReplayTasksCount.decrementAndGet()
 
-      // triggering another task for compaction task
-      submitLogProcessTask(rootPath) { () => compact(reader) }
+      // triggering another task for compaction task only if it succeeds
+      if (succeeded) {
+        submitLogProcessTask(rootPath) { () => compact(reader) }
+      }
     }
   }
 
@@ -834,6 +839,8 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
 
         case None => // This is not applied to single event log file.
       }
+    } catch {
+      case e: Exception => logError(s"Exception while compacting log for $rootPath", e)
     } finally {
       endProcessing(rootPath)
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes a couple of minor issues on SPARK-30481:

* SHS runs "compaction" regardless of the result of "merge application listing". 

If "merge application listing" fails, most likely the application log will have some issue and "compaction" won't work properly then. We can just skip trying compaction when "merge application listing" fails.

* When "compaction" throws exception we don't handle it.

It's expected to swallow exception, but we don't even log the exception for now. It should be logged properly.

### Why are the changes needed?

Described in above section.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Existing UTs.
