### PR TITLE
[WIP][SPARK-30694][SHUFFLE]If exception occured while fetching blocks by ExternalBlockClient, fail early when External Shuffle Service is not alive

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
@@ -103,14 +103,22 @@ public class ExternalBlockStoreClient extends BlockStoreClient {
     try {
       RetryingBlockFetcher.BlockFetchStarter blockFetchStarter =
           (blockIds1, listener1) -> {
-            // Unless this client is closed.
-            if (clientFactory != null) {
-              TransportClient client = clientFactory.createClient(host, port);
-              new OneForOneBlockFetcher(client, appId, execId,
-                blockIds1, listener1, conf, downloadFileManager).start();
-            } else {
-              logger.info("This clientFactory was closed. Skipping further block fetch retries.");
-            }
+           try{
+             // Unless this client is closed.
+             if (clientFactory != null) {
+               TransportClient client = clientFactory.createClient(host, port);
+               new OneForOneBlockFetcher(client, appId, execId,
+                   blockIds1, listener1, conf, downloadFileManager).start();
+             } else {
+               logger.info("This clientFactory was closed. Skipping further block fetch retries.");
+             }
+           } catch (IOException e) {
+             logger.info("The relative remote external shuffle service (host: " + host + "," +
+                 "port: "+ port + "), which maintains the block data can't been connected.");
+             throw e;
+           } catch (Exception e) {
+             throw e;
+           }
           };
 
       int maxRetries = conf.maxIORetries();

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
@@ -103,22 +103,26 @@ public class ExternalBlockStoreClient extends BlockStoreClient {
     try {
       RetryingBlockFetcher.BlockFetchStarter blockFetchStarter =
           (blockIds1, listener1) -> {
-           try{
-             // Unless this client is closed.
-             if (clientFactory != null) {
-               TransportClient client = clientFactory.createClient(host, port);
-               new OneForOneBlockFetcher(client, appId, execId,
-                   blockIds1, listener1, conf, downloadFileManager).start();
-             } else {
-               logger.info("This clientFactory was closed. Skipping further block fetch retries.");
-             }
-           } catch (IOException e) {
-             logger.info("The relative remote external shuffle service (host: " + host + "," +
-                 "port: "+ port + "), which maintains the block data can't been connected.");
-             throw e;
-           } catch (Exception e) {
-             throw e;
-           }
+
+            // Unless this client is closed.
+            if (clientFactory != null) {
+              TransportClient client = null;
+              try {
+                client = clientFactory.createClient(host, port);
+              } catch (Exception e) {
+                // throw ExternalShuffleServiceLostException exception then we won't retry to connect
+                // un-connected External Shuffle Service.
+                String msg = "The relative remote external shuffle service (host: " + host + "," +
+                    "port: " + port + "), which maintains the block data can't been connected.";
+                logger.info(msg);
+                throw new ExternalShuffleServiceLostException(msg);
+              }
+              new OneForOneBlockFetcher(client, appId, execId,
+                  blockIds1, listener1, conf, downloadFileManager).start();
+            } else {
+              logger.info("This clientFactory was closed. Skipping further block fetch retries.");
+            }
+
           };
 
       int maxRetries = conf.maxIORetries();

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
@@ -103,7 +103,6 @@ public class ExternalBlockStoreClient extends BlockStoreClient {
     try {
       RetryingBlockFetcher.BlockFetchStarter blockFetchStarter =
           (blockIds1, listener1) -> {
-
             // Unless this client is closed.
             if (clientFactory != null) {
               TransportClient client = null;
@@ -113,16 +112,15 @@ public class ExternalBlockStoreClient extends BlockStoreClient {
                 // throw ExternalShuffleServiceLostException exception then we won't retry to connect
                 // un-connected External Shuffle Service.
                 String msg = "The relative remote external shuffle service (host: " + host + "," +
-                    "port: " + port + "), which maintains the block data can't been connected.";
+                  "port: " + port + "), which maintains the block data can't been connected.";
                 logger.info(msg);
                 throw new ExternalShuffleServiceLostException(msg);
               }
               new OneForOneBlockFetcher(client, appId, execId,
-                  blockIds1, listener1, conf, downloadFileManager).start();
+                blockIds1, listener1, conf, downloadFileManager).start();
             } else {
               logger.info("This clientFactory was closed. Skipping further block fetch retries.");
             }
-
           };
 
       int maxRetries = conf.maxIORetries();

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleServiceLostException.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleServiceLostException.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.shuffle;
+
+/**
+ * Exception throw when we can't connect to external shuffle service to sto unnecessary
+ * retry in ExternalShuffleStoreClient.fetchBlocks()
+ */
+public class ExternalShuffleServiceLostException extends Exception {
+
+  ExternalShuffleServiceLostException(String message) {
+    super(message);
+  }
+}

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RetryingBlockFetcher.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RetryingBlockFetcher.java
@@ -58,7 +58,7 @@ public class RetryingBlockFetcher {
      * issues.
      */
     void createAndStart(String[] blockIds, BlockFetchingListener listener)
-         throws IOException, InterruptedException;
+        throws IOException, InterruptedException, ExternalShuffleServiceLostException;
   }
 
   /** Shared executor service used for waiting and retrying. */

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RetryingBlockFetcherSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RetryingBlockFetcherSuite.java
@@ -291,7 +291,11 @@ public class RetryingBlockFetcherSuite {
     }
 
     assertNotNull(stub);
-    stub.when(fetchStarter).createAndStart(any(), any());
+    try {
+      stub.when(fetchStarter).createAndStart(any(), any());
+    } catch (ExternalShuffleServiceLostException e) {
+      throw new IOException(e);
+    }
     String[] blockIdArray = blockIds.toArray(new String[blockIds.size()]);
     new RetryingBlockFetcher(conf, fetchStarter, blockIdArray, listener).start();
   }


### PR DESCRIPTION

### What changes were proposed in this pull request?
Like [SPARK-27637](https://github.com/apache/spark/pull/25469), 
When we fetch data use External Shuffle Service, we use ExternalBlockStoreClient to fetch blocks
from External Shuffle Service, in real huge cluster, we always need to offline some bad machine, and remote External Shuffle Service will down and we will can't create TransportClient to connect.
It will throw IOException, but in current way, we will only retry until run out of retry times. 

I think we should throw this error early like  [SPARK-27637](https://github.com/apache/spark/pull/25469)


### Why are the changes needed?
Old solution not comprehensive. Throw exception early and reduce unnecessary retry.


### Does this PR introduce any user-facing change?
NO

### How was this patch tested?
WIP
