### PR TITLE
[SPARK-30695][BUILD] Upgrade Apache ORC to 1.5.9

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -469,6 +469,7 @@ xmlenc:xmlenc
 net.sf.py4j:py4j
 org.jpmml:pmml-model
 org.jpmml:pmml-schema
+org.threeten:threeten-extra
 
 python/lib/py4j-*-src.zip
 python/pyspark/cloudpickle.py

--- a/dev/deps/spark-deps-hadoop-2.7-hive-1.2
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-1.2
@@ -160,9 +160,9 @@ objenesis/2.5.1//objenesis-2.5.1.jar
 okhttp/3.12.6//okhttp-3.12.6.jar
 okio/1.15.0//okio-1.15.0.jar
 opencsv/2.3//opencsv-2.3.jar
-orc-core/1.5.8/nohive/orc-core-1.5.8-nohive.jar
-orc-mapreduce/1.5.8/nohive/orc-mapreduce-1.5.8-nohive.jar
-orc-shims/1.5.8//orc-shims-1.5.8.jar
+orc-core/1.5.9/nohive/orc-core-1.5.9-nohive.jar
+orc-mapreduce/1.5.9/nohive/orc-mapreduce-1.5.9-nohive.jar
+orc-shims/1.5.9//orc-shims-1.5.9.jar
 oro/2.0.8//oro-2.0.8.jar
 osgi-resource-locator/1.0.3//osgi-resource-locator-1.0.3.jar
 paranamer/2.8//paranamer-2.8.jar
@@ -198,6 +198,7 @@ stax-api/1.0.1//stax-api-1.0.1.jar
 stream/2.9.6//stream-2.9.6.jar
 stringtemplate/3.2.1//stringtemplate-3.2.1.jar
 super-csv/2.2.0//super-csv-2.2.0.jar
+threeten-extra/1.5.0//threeten-extra-1.5.0.jar
 univocity-parsers/2.8.3//univocity-parsers-2.8.3.jar
 xbean-asm7-shaded/4.15//xbean-asm7-shaded-4.15.jar
 xercesImpl/2.9.1//xercesImpl-2.9.1.jar

--- a/dev/deps/spark-deps-hadoop-2.7-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-2.3
@@ -92,7 +92,7 @@ hive-shims-0.23/2.3.6//hive-shims-0.23-2.3.6.jar
 hive-shims-common/2.3.6//hive-shims-common-2.3.6.jar
 hive-shims-scheduler/2.3.6//hive-shims-scheduler-2.3.6.jar
 hive-shims/2.3.6//hive-shims-2.3.6.jar
-hive-storage-api/2.6.0//hive-storage-api-2.6.0.jar
+hive-storage-api/2.7.1//hive-storage-api-2.7.1.jar
 hive-vector-code-gen/2.3.6//hive-vector-code-gen-2.3.6.jar
 hk2-api/2.6.1//hk2-api-2.6.1.jar
 hk2-locator/2.6.1//hk2-locator-2.6.1.jar
@@ -176,9 +176,9 @@ objenesis/2.5.1//objenesis-2.5.1.jar
 okhttp/3.12.6//okhttp-3.12.6.jar
 okio/1.15.0//okio-1.15.0.jar
 opencsv/2.3//opencsv-2.3.jar
-orc-core/1.5.8//orc-core-1.5.8.jar
-orc-mapreduce/1.5.8//orc-mapreduce-1.5.8.jar
-orc-shims/1.5.8//orc-shims-1.5.8.jar
+orc-core/1.5.9//orc-core-1.5.9.jar
+orc-mapreduce/1.5.9//orc-mapreduce-1.5.9.jar
+orc-shims/1.5.9//orc-shims-1.5.9.jar
 oro/2.0.8//oro-2.0.8.jar
 osgi-resource-locator/1.0.3//osgi-resource-locator-1.0.3.jar
 paranamer/2.8//paranamer-2.8.jar
@@ -211,6 +211,7 @@ stax-api/1.0-2//stax-api-1.0-2.jar
 stax-api/1.0.1//stax-api-1.0.1.jar
 stream/2.9.6//stream-2.9.6.jar
 super-csv/2.2.0//super-csv-2.2.0.jar
+threeten-extra/1.5.0//threeten-extra-1.5.0.jar
 transaction-api/1.1//transaction-api-1.1.jar
 univocity-parsers/2.8.3//univocity-parsers-2.8.3.jar
 velocity/1.5//velocity-1.5.jar

--- a/dev/deps/spark-deps-hadoop-3.2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3.2-hive-2.3
@@ -91,7 +91,7 @@ hive-shims-0.23/2.3.6//hive-shims-0.23-2.3.6.jar
 hive-shims-common/2.3.6//hive-shims-common-2.3.6.jar
 hive-shims-scheduler/2.3.6//hive-shims-scheduler-2.3.6.jar
 hive-shims/2.3.6//hive-shims-2.3.6.jar
-hive-storage-api/2.6.0//hive-storage-api-2.6.0.jar
+hive-storage-api/2.7.1//hive-storage-api-2.7.1.jar
 hive-vector-code-gen/2.3.6//hive-vector-code-gen-2.3.6.jar
 hk2-api/2.6.1//hk2-api-2.6.1.jar
 hk2-locator/2.6.1//hk2-locator-2.6.1.jar
@@ -191,9 +191,9 @@ okhttp/2.7.5//okhttp-2.7.5.jar
 okhttp/3.12.6//okhttp-3.12.6.jar
 okio/1.15.0//okio-1.15.0.jar
 opencsv/2.3//opencsv-2.3.jar
-orc-core/1.5.8//orc-core-1.5.8.jar
-orc-mapreduce/1.5.8//orc-mapreduce-1.5.8.jar
-orc-shims/1.5.8//orc-shims-1.5.8.jar
+orc-core/1.5.9//orc-core-1.5.9.jar
+orc-mapreduce/1.5.9//orc-mapreduce-1.5.9.jar
+orc-shims/1.5.9//orc-shims-1.5.9.jar
 oro/2.0.8//oro-2.0.8.jar
 osgi-resource-locator/1.0.3//osgi-resource-locator-1.0.3.jar
 paranamer/2.8//paranamer-2.8.jar
@@ -227,6 +227,7 @@ stax-api/1.0.1//stax-api-1.0.1.jar
 stax2-api/3.1.4//stax2-api-3.1.4.jar
 stream/2.9.6//stream-2.9.6.jar
 super-csv/2.2.0//super-csv-2.2.0.jar
+threeten-extra/1.5.0//threeten-extra-1.5.0.jar
 token-provider/1.0.1//token-provider-1.0.1.jar
 transaction-api/1.1//transaction-api-1.1.jar
 univocity-parsers/2.8.3//univocity-parsers-2.8.3.jar

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
     <kafka.version>2.4.0</kafka.version>
     <derby.version>10.12.1.1</derby.version>
     <parquet.version>1.10.1</parquet.version>
-    <orc.version>1.5.8</orc.version>
+    <orc.version>1.5.9</orc.version>
     <orc.classifier></orc.classifier>
     <hive.parquet.group>com.twitter</hive.parquet.group>
     <hive.parquet.version>1.6.0</hive.parquet.version>
@@ -227,6 +227,7 @@
     <hadoop.deps.scope>compile</hadoop.deps.scope>
     <hive.deps.scope>compile</hive.deps.scope>
     <hive.parquet.scope>provided</hive.parquet.scope>
+    <hive.storage.version>2.7.1</hive.storage.version>
     <hive.storage.scope>compile</hive.storage.scope>
     <hive.common.scope>compile</hive.common.scope>
     <hive.llap.scope>compile</hive.llap.scope>
@@ -2244,7 +2245,7 @@
       <dependency>
         <groupId>org.apache.hive</groupId>
         <artifactId>hive-storage-api</artifactId>
-        <version>2.6.0</version>
+        <version>${hive.storage.version}</version>
         <scope>${hive.storage.scope}</scope>
         <exclusions>
           <exclusion>
@@ -3006,6 +3007,7 @@
         <!-- Version used for internal directory structure -->
         <hive.version.short>1.2</hive.version.short>
         <hive.parquet.scope>${hive.deps.scope}</hive.parquet.scope>
+        <hive.storage.version>2.6.0</hive.storage.version>
         <hive.storage.scope>provided</hive.storage.scope>
         <hive.common.scope>provided</hive.common.scope>
         <hive.llap.scope>provided</hive.llap.scope>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade to Apache ORC 1.5.9.
- For `hive-2.3` profile, we need to upgrade `hive-storage-api` from `2.6.0` to `2.7.1`.
- For `hive-1.2` profile, ORC library with classifier `nohive` already shaded it. So, there is no change.

### Why are the changes needed?

This will bring the latest bug fixes. The following is the full release note.
- https://issues.apache.org/jira/projects/ORC/versions/12346546

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Pass the Jenkins with the existing tests.

Here is the summary.
1. `Hive 1.2 + Hadoop 2.7` passed. ([here](https://github.com/apache/spark/pull/27421#issuecomment-580924552))
2. `Hive 2.3 + Hadoop 2.7` passed. ([here](https://github.com/apache/spark/pull/27421#issuecomment-580973391))