### PR TITLE
[SPARK-30698][BUILD] Bumps checkstyle from 8.25 to 8.29.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2836,7 +2836,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.25</version>
+            <version>8.29</version>
           </dependency>
         </dependencies>
         <executions>


### PR DESCRIPTION
### What changes were proposed in this pull request?
I found checkstyle have a new release https://checkstyle.org/releasenotes.html#Release_8.29
Bumps checkstyle from 8.25 to 8.29.

### Why are the changes needed?
I have bump  checkstyle from 8.25 to 8.29 on my fork branch and test to build.
It's OK

8.29 added some new features：

- New Check: AvoidNoArgumentSuperConstructorCall.

- New Check NoEnumTrailingComma.

- ENUM_DEF token support in RightCurlyCheck.

- FallThrough module does not support the spelling "fall-through" by default.

8.29 fix some bugs:

- Java 8 Grammar: annotations on varargs parameters.

- Sonar violation: Disable XML external entity (XXE) processing.

- Disable instantiation of modules with private ctor.

- Sonar violation: "ThreadLocal" variables should be cleaned up when no longer used.

- Indentation incorrect level for chained method with bracket on new line.

- InvalidJavadocPosition: false positive when comment is between javadoc and package.

### Does this PR introduce any user-facing change?
No


### How was this patch tested?
No UT