### PR TITLE
[MINOR][SQL][DOCS][2.4] Fix the timestamp pattern in the example for `to_timestamp`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -1370,7 +1370,7 @@ case class ParseToDate(left: Expression, format: Option[Expression], child: Expr
 }
 
 /**
- * Parses a column to a timestamp based on the supplied format.
+ * Parses a column to a timestamp in the seconds precision based on the supplied format.
  */
 @ExpressionDescription(
   usage = """

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -1370,7 +1370,7 @@ case class ParseToDate(left: Expression, format: Option[Expression], child: Expr
 }
 
 /**
- * Parses a column to a timestamp in the seconds precision based on the supplied format.
+ * Parses a column to a timestamp based on the supplied format.
  */
 @ExpressionDescription(
   usage = """

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -2949,10 +2949,10 @@ object functions {
   def unix_timestamp(s: Column, p: String): Column = withExpr { UnixTimestamp(s.expr, Literal(p)) }
 
   /**
-   * Converts to a timestamp by casting rules to `TimestampType`.
+   * Converts to a timestamp by casting rules to `TimestampType` in the seconds precision.
    *
    * @param s A date, timestamp or string. If a string, the data must be in a format that can be
-   *          cast to a timestamp, such as `yyyy-MM-dd` or `yyyy-MM-dd HH:mm:ss.SSSS`
+   *          cast to a timestamp, such as `yyyy-MM-dd` or `yyyy-MM-dd HH:mm:ss`
    * @return A timestamp, or null if the input was a string that could not be cast to a timestamp
    * @group datetime_funcs
    * @since 2.2.0
@@ -2962,12 +2962,12 @@ object functions {
   }
 
   /**
-   * Converts time string with the given pattern to timestamp.
+   * Converts time string with the given pattern to timestamp in the seconds precision.
    *
    * See [[java.text.SimpleDateFormat]] for valid date and time format patterns
    *
    * @param s   A date, timestamp or string. If a string, the data must be in a format that can be
-   *            cast to a timestamp, such as `yyyy-MM-dd` or `yyyy-MM-dd HH:mm:ss.SSSS`
+   *            cast to a timestamp, such as `yyyy-MM-dd` or `yyyy-MM-dd HH:mm:ss`
    * @param fmt A date time pattern detailing the format of `s` when `s` is a string
    * @return A timestamp, or null if `s` was a string that could not be cast to a timestamp or
    *         `fmt` was an invalid format

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -2949,10 +2949,10 @@ object functions {
   def unix_timestamp(s: Column, p: String): Column = withExpr { UnixTimestamp(s.expr, Literal(p)) }
 
   /**
-   * Converts to a timestamp by casting rules to `TimestampType` in the seconds precision.
+   * Converts to a timestamp by casting rules to `TimestampType`.
    *
    * @param s A date, timestamp or string. If a string, the data must be in a format that can be
-   *          cast to a timestamp, such as `yyyy-MM-dd` or `yyyy-MM-dd HH:mm:ss`
+   *          cast to a timestamp, such as `yyyy-MM-dd` or `yyyy-MM-dd HH:mm:ss.SSSS`
    * @return A timestamp, or null if the input was a string that could not be cast to a timestamp
    * @group datetime_funcs
    * @since 2.2.0
@@ -2962,7 +2962,7 @@ object functions {
   }
 
   /**
-   * Converts time string with the given pattern to timestamp in the seconds precision.
+   * Converts time string with the given pattern to timestamp.
    *
    * See [[java.text.SimpleDateFormat]] for valid date and time format patterns
    *


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to change the description of the `to_timestamp()` function, and change the pattern in the example. 

### Why are the changes needed?
To inform users about valid patterns for `to_timestamp` function.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
N/A