### PR TITLE
[SPARK-29587][DOC][FOLLOWUP] Add `SQL` tab in the `Data Types` page

### DIFF
--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -333,6 +333,8 @@ license: |
   - Since Spark 3.0, we upgraded the built-in Hive from 1.2 to 2.3. This may need to set `spark.sql.hive.metastore.version` and `spark.sql.hive.metastore.jars` according to the version of the Hive metastore.
   For example: set `spark.sql.hive.metastore.version` to `1.2.1` and `spark.sql.hive.metastore.jars` to `maven` if your Hive metastore version is 1.2.1.
 
+  - Since Spark 3.0, for the compatibility with ANSI SQL standard, the type `REAL` and `NUMERIC` have been added, which are aliases for `FLOAT` and `DECIMAL`.
+
 ## Upgrading from Spark SQL 2.4.4 to 2.4.5
 
   - Since Spark 2.4.5, `TRUNCATE TABLE` command tries to set back original permission and ACLs during re-creating the table/partition paths. To restore the behaviour of earlier versions, set `spark.sql.truncateTable.ignorePermissionAcl.enabled` to `true`.

--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -333,8 +333,6 @@ license: |
   - Since Spark 3.0, we upgraded the built-in Hive from 1.2 to 2.3. This may need to set `spark.sql.hive.metastore.version` and `spark.sql.hive.metastore.jars` according to the version of the Hive metastore.
   For example: set `spark.sql.hive.metastore.version` to `1.2.1` and `spark.sql.hive.metastore.jars` to `maven` if your Hive metastore version is 1.2.1.
 
-  - Since Spark 3.0, for the compatibility with ANSI SQL standard, the type `REAL` and `NUMERIC` have been added, which are aliases for `FLOAT` and `DECIMAL`.
-
 ## Upgrading from Spark SQL 2.4.4 to 2.4.5
 
   - Since Spark 2.4.5, `TRUNCATE TABLE` command tries to set back original permission and ACLs during re-creating the table/partition paths. To restore the behaviour of earlier versions, set `spark.sql.truncateTable.ignorePermissionAcl.enabled` to `true`.

--- a/docs/sql-ref-datatypes.md
+++ b/docs/sql-ref-datatypes.md
@@ -642,59 +642,55 @@ The following table shows the type names as well as aliases used in Spark SQL pa
   <th>SQL name</th></tr>
 <tr>
   <td> <b>BooleanType</b> </td>
-  <td> boolean </td>
+  <td> BOOLEAN </td>
 </tr>
 <tr>
   <td> <b>ByteType</b> </td>
-  <td> byte, tinyint </td>
+  <td> BYTE, TINYINT </td>
 </tr>
 <tr>
   <td> <b>ShortType</b> </td>
-  <td> shot, smallint </td>
+  <td> SHORT, SMALLINT </td>
 </tr>
 <tr>
   <td> <b>IntegerType</b> </td>
-  <td> int, integer </td>
+  <td> INT, INTEGER </td>
 </tr>
 <tr>
   <td> <b>LongType</b> </td>
-  <td> long, bigint </td>
+  <td> LONG, BIGINT </td>
 </tr>
 <tr>
   <td> <b>FloatType</b> </td>
-  <td> float, real </td>
+  <td> FLOAT, REAL </td>
 </tr>
 <tr>
   <td> <b>DoubleType</b> </td>
-  <td> double </td>
+  <td> DOUBLE </td>
 </tr>
 <tr>
   <td> <b>DateType</b> </td>
-  <td> date </td>
+  <td> DATE </td>
 </tr>
 <tr>
   <td> <b>TimestampType</b> </td>
-  <td> timestamp </td>
+  <td> TIMESTAMP </td>
 </tr>
 <tr>
   <td> <b>StringType</b> </td>
-  <td> string </td>
+  <td> STRING </td>
 </tr>
 <tr>
   <td> <b>BinaryType</b> </td>
-  <td> string </td>
-</tr>
-<tr>
-  <td> <b>BinaryType</b> </td>
-  <td> string </td>
+  <td> BINARY </td>
 </tr>
 <tr>
   <td> <b>DecimalType</b> </td>
-  <td> decimal, desc, numeric </td>
+  <td> DECIMAL, DEC, NUMERIC </td>
 </tr>
 <tr>
   <td> <b>CalendarIntervalType</b> </td>
-  <td> interval </td>
+  <td> INTERVAL </td>
 </tr>
 </table>
 </div>

--- a/docs/sql-ref-datatypes.md
+++ b/docs/sql-ref-datatypes.md
@@ -638,7 +638,7 @@ The following table shows the type names as well as aliases used in Spark SQL pa
 
 <table class="table">
 <tr>
-  <th style="width:50%">Data type</th>
+  <th style="width:40%">Data type</th>
   <th>SQL name</th></tr>
 <tr>
   <td> <b>BooleanType</b> </td>
@@ -691,6 +691,18 @@ The following table shows the type names as well as aliases used in Spark SQL pa
 <tr>
   <td> <b>CalendarIntervalType</b> </td>
   <td> INTERVAL </td>
+</tr>
+<tr>
+  <td> <b>ArrayType</b> </td>
+  <td> ARRAY&lt;element_type&gt; </td>
+</tr>
+<tr>
+  <td> <b>StructType</b> </td>
+  <td> STRUCT&lt;field1_name: field1_type, field2_name: field2_type, ...&gt; </td>
+</tr>
+<tr>
+  <td> <b>MapType</b> </td>
+  <td> MAP&lt;key_type, value_type&gt; </td>
 </tr>
 </table>
 </div>

--- a/docs/sql-ref-datatypes.md
+++ b/docs/sql-ref-datatypes.md
@@ -632,3 +632,84 @@ from pyspark.sql.types import *
 </table>
 </div>
 </div>
+
+## Type Names in Parser
+
+The following table shows the type names used in Spark SQL parser for each data type, the alternative names listed in the "Aliases" columns.
+
+<table class="table">
+<tr>
+  <th style="width:40%">Data type</th>
+  <th style="width:30%">Name</th>
+  <th>Aliases</th></tr>
+<tr>
+  <td> <b>BooleanType</b> </td>
+  <td> boolean </td>
+  <td></td>
+</tr>
+<tr>
+  <td> <b>ByteType</b> </td>
+  <td> byte </td>
+  <td> tinyint </td>
+</tr>
+<tr>
+  <td> <b>ShortType</b> </td>
+  <td> shot </td>
+  <td> smallint </td>
+</tr>
+<tr>
+  <td> <b>IntegerType</b> </td>
+  <td> int </td>
+  <td> integer </td>
+</tr>
+<tr>
+  <td> <b>LongType</b> </td>
+  <td> long </td>
+  <td> bigint </td>
+</tr>
+<tr>
+  <td> <b>FloatType</b> </td>
+  <td> float </td>
+  <td> real </td>
+</tr>
+<tr>
+  <td> <b>DoubleType</b> </td>
+  <td> double </td>
+  <td></td>
+</tr>
+<tr>
+  <td> <b>DateType</b> </td>
+  <td> date </td>
+  <td></td>
+</tr>
+<tr>
+  <td> <b>TimestampType</b> </td>
+  <td> timestamp </td>
+  <td></td>
+</tr>
+<tr>
+  <td> <b>StringType</b> </td>
+  <td> string </td>
+  <td></td>
+</tr>
+<tr>
+  <td> <b>BinaryType</b> </td>
+  <td> string </td>
+  <td></td>
+</tr>
+<tr>
+  <td> <b>BinaryType</b> </td>
+  <td> string </td>
+  <td></td>
+</tr>
+<tr>
+  <td> <b>DecimalType</b> </td>
+  <td> decimal </td>
+  <td> desc, numeric </td>
+</tr>
+<tr>
+  <td> <b>CalendarIntervalType</b> </td>
+  <td> interval </td>
+  <td></td>
+</tr>
+</table>

--- a/docs/sql-ref-datatypes.md
+++ b/docs/sql-ref-datatypes.md
@@ -631,85 +631,71 @@ from pyspark.sql.types import *
 </tr>
 </table>
 </div>
-</div>
 
-## Type Names in Parser
+<div data-lang="sql"  markdown="1">
 
-The following table shows the type names used in Spark SQL parser for each data type, the alternative names listed in the "Aliases" columns.
+The following table shows the type names as well as aliases used in Spark SQL parser for each data type.
 
 <table class="table">
 <tr>
-  <th style="width:40%">Data type</th>
-  <th style="width:30%">Name</th>
-  <th>Aliases</th></tr>
+  <th style="width:50%">Data type</th>
+  <th>SQL name</th></tr>
 <tr>
   <td> <b>BooleanType</b> </td>
   <td> boolean </td>
-  <td></td>
 </tr>
 <tr>
   <td> <b>ByteType</b> </td>
-  <td> byte </td>
-  <td> tinyint </td>
+  <td> byte, tinyint </td>
 </tr>
 <tr>
   <td> <b>ShortType</b> </td>
-  <td> shot </td>
-  <td> smallint </td>
+  <td> shot, smallint </td>
 </tr>
 <tr>
   <td> <b>IntegerType</b> </td>
-  <td> int </td>
-  <td> integer </td>
+  <td> int, integer </td>
 </tr>
 <tr>
   <td> <b>LongType</b> </td>
-  <td> long </td>
-  <td> bigint </td>
+  <td> long, bigint </td>
 </tr>
 <tr>
   <td> <b>FloatType</b> </td>
-  <td> float </td>
-  <td> real </td>
+  <td> float, real </td>
 </tr>
 <tr>
   <td> <b>DoubleType</b> </td>
   <td> double </td>
-  <td></td>
 </tr>
 <tr>
   <td> <b>DateType</b> </td>
   <td> date </td>
-  <td></td>
 </tr>
 <tr>
   <td> <b>TimestampType</b> </td>
   <td> timestamp </td>
-  <td></td>
 </tr>
 <tr>
   <td> <b>StringType</b> </td>
   <td> string </td>
-  <td></td>
 </tr>
 <tr>
   <td> <b>BinaryType</b> </td>
   <td> string </td>
-  <td></td>
 </tr>
 <tr>
   <td> <b>BinaryType</b> </td>
   <td> string </td>
-  <td></td>
 </tr>
 <tr>
   <td> <b>DecimalType</b> </td>
-  <td> decimal </td>
-  <td> desc, numeric </td>
+  <td> decimal, desc, numeric </td>
 </tr>
 <tr>
   <td> <b>CalendarIntervalType</b> </td>
   <td> interval </td>
-  <td></td>
 </tr>
 </table>
+</div>
+</div>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add the new tab `SQL` in the `Data Types` page.

### Why are the changes needed?
New type added in SPARK-29587.

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
Locally test by Jekyll.
![image](https://user-images.githubusercontent.com/4833765/73908593-2e511d80-48e5-11ea-85a7-6ee451e6b727.png)

