### PR TITLE
[SPARK-24914][SQL] Introduce new statistic to improve data size estimate for columnar storage formats (part 1)

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1443,6 +1443,14 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val DESERIALIZATION_FACTOR_EXTRA_DISTORTION =
+    buildConf("spark.sql.statistics.deserFactor.distortion")
+      .doc("Distortion value used as an extra multiplier at the application of the " +
+        "deserialization factor making one capable to modify the computed table size even after " +
+        "the deserialization factor is saved in the metastore.")
+      .doubleConf
+      .createWithDefault(1.0)
+
   val CBO_ENABLED =
     buildConf("spark.sql.cbo.enabled")
       .doc("Enables CBO for estimation of plan statistics when set true.")
@@ -2605,6 +2613,8 @@ class SQLConf extends Serializable with Logging {
   def planStatsEnabled: Boolean = getConf(SQLConf.PLAN_STATS_ENABLED)
 
   def autoSizeUpdateEnabled: Boolean = getConf(SQLConf.AUTO_SIZE_UPDATE_ENABLED)
+
+  def deserFactorDistortion: Double = getConf(SQLConf.DESERIALIZATION_FACTOR_EXTRA_DISTORTION)
 
   def joinReorderEnabled: Boolean = getConf(SQLConf.JOIN_REORDER_ENABLED)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/AnalyzeColumnCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/AnalyzeColumnCommand.scala
@@ -127,6 +127,7 @@ case class AnalyzeColumnCommand(
       // We also update table-level stats in order to keep them consistent with column-level stats.
       val statistics = CatalogStatistics(
         sizeInBytes = sizeInBytes,
+        deserFactor = tableMeta.stats.flatMap(_.deserFactor),
         rowCount = Some(rowCount),
         // Newly computed column stats should override the existing ones.
         colStats = tableMeta.stats.map(_.colStats).getOrElse(Map.empty) ++ newColCatalogStats)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -489,7 +489,9 @@ case class AlterTableAddPartitionCommand(
         val addedSize = CommandUtils.calculateMultipleLocationSizes(sparkSession, table.identifier,
           parts.map(_.storage.locationUri)).sum
         if (addedSize > 0) {
-          val newStats = CatalogStatistics(sizeInBytes = table.stats.get.sizeInBytes + addedSize)
+          val newStats = CatalogStatistics(
+            sizeInBytes = table.stats.get.sizeInBytes + addedSize,
+            deserFactor = table.stats.flatMap(_.deserFactor))
           catalog.alterTableStats(table.identifier, Some(newStats))
         }
       } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -569,7 +569,9 @@ case class TruncateTableCommand(
 
     if (table.stats.nonEmpty) {
       // empty table after truncation
-      val newStats = CatalogStatistics(sizeInBytes = 0, rowCount = Some(0))
+      val newStats = CatalogStatistics(sizeInBytes = 0,
+        deserFactor = table.stats.flatMap(_.deserFactor),
+        rowCount = Some(0))
       catalog.alterTableStats(tableName, Some(newStats))
     }
     Seq.empty[Row]

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/LogicalRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/LogicalRelation.scala
@@ -40,8 +40,9 @@ case class LogicalRelation(
     catalogTable = None)
 
   override def computeStats(): Statistics = {
+    val planStatsEnabled = conf.cboEnabled || conf.planStatsEnabled
     catalogTable
-      .flatMap(_.stats.map(_.toPlanStats(output, conf.cboEnabled || conf.planStatsEnabled)))
+      .flatMap(_.stats.map(_.toPlanStats(output, planStatsEnabled, conf.deserFactorDistortion)))
       .getOrElse(Statistics(sizeInBytes = relation.sizeInBytes))
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
@@ -81,8 +81,12 @@ private[sql] object PruneFileSourcePartitions extends Rule[LogicalPlan] {
         val prunedFsRelation =
           fsRelation.copy(location = prunedFileIndex)(fsRelation.sparkSession)
         // Change table stats based on the sizeInBytes of pruned files
-        val withStats = logicalRelation.catalogTable.map(_.copy(
-          stats = Some(CatalogStatistics(sizeInBytes = BigInt(prunedFileIndex.sizeInBytes)))))
+        val withStats = logicalRelation.catalogTable.map { catalogTable =>
+          catalogTable.copy(
+            stats = Some(CatalogStatistics(
+              sizeInBytes = BigInt(prunedFileIndex.sizeInBytes),
+              deserFactor = catalogTable.stats.flatMap(_.deserFactor))))
+        }
         val prunedLogicalRelation = logicalRelation.copy(
           relation = prunedFsRelation, catalogTable = withStats)
         // Keep partition-pruning predicates so that they are visible in physical planning

--- a/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionTestBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionTestBase.scala
@@ -378,12 +378,12 @@ abstract class StatisticsCollectionTestBase extends QueryTest with SQLTestUtils 
   }
 
   def checkNumBroadcastHashJoins(df: DataFrame, expectedNumBhj: Int, clue: String): Unit = {
-    val plan = EnsureRequirements(spark.sessionState.conf).apply(df.queryExecution.sparkPlan)
-    assert(plan.collect { case p: BroadcastHashJoinExec => p }.size === expectedNumBhj, clue)
+    val numNumBhj = df.queryExecution.sparkPlan.collect { case _: BroadcastHashJoinExec => }.size
+    assert(numNumBhj === expectedNumBhj, clue)
   }
 
   def checkNumSortMergeJoins(df: DataFrame, expectedNumSmj: Int, clue: String): Unit = {
-    val plan = EnsureRequirements(spark.sessionState.conf).apply(df.queryExecution.sparkPlan)
-    assert(plan.collect { case p: SortMergeJoinExec => p }.size === expectedNumSmj, clue)
+    val numNumSmj = df.queryExecution.sparkPlan.collect { case _: SortMergeJoinExec => }.size
+    assert(numNumSmj === expectedNumSmj, clue)
   }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -56,7 +56,7 @@ import org.apache.spark.sql.catalyst.parser.{CatalystSqlParser, ParseException}
 import org.apache.spark.sql.connector.catalog.SupportsNamespaces._
 import org.apache.spark.sql.execution.QueryExecutionException
 import org.apache.spark.sql.hive.HiveExternalCatalog
-import org.apache.spark.sql.hive.HiveExternalCatalog.{DATASOURCE_SCHEMA, DATASOURCE_SCHEMA_NUMPARTS, DATASOURCE_SCHEMA_PART_PREFIX}
+import org.apache.spark.sql.hive.HiveExternalCatalog.{DATASOURCE_SCHEMA, DATASOURCE_SCHEMA_NUMPARTS, DATASOURCE_SCHEMA_PART_PREFIX, DESER_FACTOR}
 import org.apache.spark.sql.hive.HiveUtils
 import org.apache.spark.sql.hive.client.HiveClientImpl._
 import org.apache.spark.sql.internal.SQLConf
@@ -1200,10 +1200,17 @@ private[hive] object HiveClientImpl {
     // return None.
     // In Hive, when statistics gathering is disabled, `rawDataSize` and `numRows` is always
     // zero after INSERT command. So they are used here only if they are larger than zero.
+    val deserFactor = properties.get(DESER_FACTOR).map(_.toInt)
     if (totalSize.isDefined && totalSize.get > 0L) {
-      Some(CatalogStatistics(sizeInBytes = totalSize.get, rowCount = rowCount.filter(_ > 0)))
+      Some(CatalogStatistics(
+        sizeInBytes = totalSize.get,
+        deserFactor = deserFactor,
+        rowCount = rowCount.filter(_ > 0)))
     } else if (rawDataSize.isDefined && rawDataSize.get > 0) {
-      Some(CatalogStatistics(sizeInBytes = rawDataSize.get, rowCount = rowCount.filter(_ > 0)))
+      Some(CatalogStatistics(
+        sizeInBytes = rawDataSize.get,
+        deserFactor = None,
+        rowCount = rowCount.filter(_ > 0)))
     } else {
       // TODO: still fill the rowCount even if sizeInBytes is empty. Might break anything?
       None


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR introduces a new statistic called `deserFactor` which can be set manualy as a table property 'spark.deserFactor' and intended to be used for columnar file formats as a ratio of actual data size (raw data size) to file size to scale up the file size to improve the estimate of in-memory data size and having a better query optimization (i.e., join strategy decision).

### Why are the changes needed?

Before this change Spark estimated the table size as the sum of all the file sizes. This estimate can be way too low at columnar file formats where huge data can be compressed into a very small file because of serialization (like dictionary encoding) and compression. 
With the `deserFactor` OOM error raised as a result of a wrongly chosen broadcast join strategy can be avoided.

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

The StatisticsSuite is extended with a new test: `SPARK-24914 - test deserialization factor`.