### PR TITLE
[SPARK-30736][ML] One-Pass ChiSquareTest

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/stat/test/ChiSqTest.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/stat/test/ChiSqTest.scala
@@ -120,7 +120,7 @@ private[spark] object ChiSqTest extends Logging {
       }
       val result = chiSquaredMatrix(contingency, methodName)
       (col, result)
-    }.collectAsMap().toArray.sortBy(_._1).map(_._2)
+    }.collect().sortBy(_._1).map(_._2)
   }
 
   /*

--- a/mllib/src/main/scala/org/apache/spark/mllib/stat/test/ChiSqTest.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/stat/test/ChiSqTest.scala
@@ -195,10 +195,16 @@ private[spark] object ChiSqTest extends Logging {
         contingency.update(i, j, c)
       }
       if (numInstances != nnz) {
+        val nnz = count.iterator
+          .map { case ((_, label), c) => (label, c) }
+          .toArray
+          .groupBy(_._1)
+          .mapValues(_.map(_._2).sum)
         val i = value2Index(0.0)
         label2Index.foreach { case (label, j) =>
           val countByLabel = labelCounts(label)
-          val nzByLabel = countByLabel - count.iterator.filter(_._1._2 == label).map(_._2).sum
+          val nnzByLabel = nnz.getOrElse(label, 0L)
+          val nzByLabel = countByLabel - nnzByLabel
           require(nzByLabel >= 0)
           if (nzByLabel != 0) contingency.update(i, j, nzByLabel)
         }

--- a/mllib/src/main/scala/org/apache/spark/mllib/stat/test/ChiSqTest.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/stat/test/ChiSqTest.scala
@@ -48,7 +48,7 @@ private[spark] object ChiSqTest extends Logging {
   case class Method(name: String, chiSqFunc: (Double, Double) => Double)
 
   // Pearson's chi-squared test: http://en.wikipedia.org/wiki/Pearson%27s_chi-squared_test
-  val PEARSON = new Method("pearson", (observed: Double, expected: Double) => {
+  val PEARSON = Method("pearson", (observed: Double, expected: Double) => {
     val dev = observed - expected
     dev * dev / expected
   })
@@ -114,12 +114,12 @@ private[spark] object ChiSqTest extends Logging {
 
       val contingency = new DenseMatrix(numFeatures, numLabels,
         Array.ofDim[Double](numFeatures * numLabels))
-      count.iterator.foreach { case ((feature, label), count) =>
+      count.iterator.foreach { case ((feature, label), c) =>
         val i = features(feature)
         val j = labels(label)
-        contingency.update(i, j, count)
+        contingency.update(i, j, c)
       }
-      val result = chiSquaredMatrix(contingency, methodName)
+      val result = ChiSqTest.chiSquaredMatrix(contingency, methodName)
       (col, result)
     }.collect().sortBy(_._1).map(_._2)
   }

--- a/mllib/src/main/scala/org/apache/spark/mllib/stat/test/ChiSqTest.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/stat/test/ChiSqTest.scala
@@ -120,8 +120,11 @@ private[spark] object ChiSqTest extends Logging {
         contingency.update(i, j, c)
       }
       val result = ChiSqTest.chiSquaredMatrix(contingency, methodName)
-      (col, result)
-    }.collect().sortBy(_._1).map(_._2)
+      (col, result.pValue, result.degreesOfFreedom, result.statistic, result.nullHypothesis)
+    }.collect().sortBy(_._1).map {
+      case (_, pValue, degreesOfFreedom, statistic, nullHypothesis) =>
+        new ChiSqTestResult(pValue, degreesOfFreedom, statistic, methodName, nullHypothesis)
+    }
   }
 
   /*

--- a/mllib/src/main/scala/org/apache/spark/mllib/stat/test/TestResult.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/stat/test/TestResult.scala
@@ -24,7 +24,7 @@ import org.apache.spark.annotation.Since
  * @tparam DF Return type of `degreesOfFreedom`.
  */
 @Since("1.1.0")
-trait TestResult[DF] {
+trait TestResult[DF] extends Serializable {
 
   /**
    * The probability of obtaining a test statistic result at least as extreme as the one that was

--- a/mllib/src/main/scala/org/apache/spark/mllib/stat/test/TestResult.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/stat/test/TestResult.scala
@@ -24,7 +24,7 @@ import org.apache.spark.annotation.Since
  * @tparam DF Return type of `degreesOfFreedom`.
  */
 @Since("1.1.0")
-trait TestResult[DF] extends Serializable {
+trait TestResult[DF] {
 
   /**
    * The probability of obtaining a test statistic result at least as extreme as the one that was

--- a/mllib/src/test/scala/org/apache/spark/ml/stat/ChiSquareTestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/stat/ChiSquareTestSuite.scala
@@ -53,19 +53,39 @@ class ChiSquareTestSuite
       assert(degreesOfFreedom === Array(2, 3))
       assert(statistics ~== Vectors.dense(0.75, 1.5) relTol 1e-4)
     }
+  }
 
-    val sparseData = data.map { case LabeledPoint(label, features) =>
+  test("test DataFrame of sparse points") {
+    val data = Seq(
+      LabeledPoint(0.0, Vectors.dense(0.5, 10.0, 0.0, 0.0, 0.0)),
+      LabeledPoint(0.0, Vectors.dense(1.5, 20.0, 0.0, 1.0, 0.0)),
+      LabeledPoint(1.0, Vectors.dense(1.5, 30.0, 0.0, 5.0, 0.0)),
+      LabeledPoint(0.0, Vectors.dense(3.5, 30.0, 0.0, 3.6, 0.0)),
+      LabeledPoint(0.0, Vectors.dense(3.5, 40.0, 0.0, 4.5, 0.0)),
+      LabeledPoint(1.0, Vectors.dense(3.5, 40.0, 0.0, 4.0, 0.0)))
+    val data2 = data.map { case LabeledPoint(label, features) =>
       LabeledPoint(label, features.toSparse)
     }
+
     for (numParts <- List(2, 4, 6, 8)) {
-      val df = spark.createDataFrame(sc.parallelize(sparseData, numParts))
+      val df = spark.createDataFrame(sc.parallelize(data, numParts))
       val chi = ChiSquareTest.test(df, "features", "label")
-      val (pValues: Vector, degreesOfFreedom: Array[Int], statistics: Vector) =
-        chi.select("pValues", "degreesOfFreedom", "statistics")
-          .as[(Vector, Array[Int], Vector)].head()
-      assert(pValues ~== Vectors.dense(0.6873, 0.6823) relTol 1e-4)
-      assert(degreesOfFreedom === Array(2, 3))
-      assert(statistics ~== Vectors.dense(0.75, 1.5) relTol 1e-4)
+      val res = chi.select("pValues", "degreesOfFreedom", "statistics")
+        .as[(Vector, Array[Int], Vector)]
+        .collect()
+
+      val df2 = spark.createDataFrame(sc.parallelize(data2, numParts))
+      val chi2 = ChiSquareTest.test(df2, "features", "label")
+      val res2 = chi2.select("pValues", "degreesOfFreedom", "statistics")
+        .as[(Vector, Array[Int], Vector)]
+        .collect()
+
+      assert(res.length === res2.length)
+      res.zip(res2).foreach { case (r, r2) =>
+        assert(r._1 ~== r2._1 relTol 1e-6)
+        assert(r._2 === r2._2)
+        assert(r._3 ~== r2._3 relTol 1e-6)
+      }
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
1, distributedly gather matrix `contingency` of each feature
2, distributedly compute the results and then collect them back to the driver

### Why are the changes needed?
existing impl is not efficient:
1, it directly collect matrix `contingency` of partial featues to driver and compute the corresponding result on one pass;
2, a matrix  `contingency` of a featues is of size numDistinctValues X numDistinctLabels, so only 1000 matrices can be collected at a time;


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
existing testsuites
