### PR TITLE
[MINOR][INFRA][3.0] Enable GitHub Action in branch-3.0

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -3,10 +3,10 @@ name: master
 on:
   push:
     branches:
-    - master
+    - branch-3.0
   pull_request:
     branches:
-    - master
+    - branch-3.0
 
 jobs:
   build:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This aims to enable `GitHub Action` in `branch-3.0`.

### Why are the changes needed?

Currently, it's not enabled.
<img width="731" alt="commitlog" src="https://user-images.githubusercontent.com/9700541/73978595-871eb700-48e1-11ea-87d4-f41ee5c8fe3a.png">

This will protect `branch-3.0` by monitoring every commits and PR against `branch-3.0`.

### Does this PR introduce any user-facing change?

No. This is a dev-only infra.

### How was this patch tested?

See the GitHub Action triggering in this PR.