### PR TITLE
[SPARK-30245][SQL][FOLLOWUP] Improve regex expression when pattern not changed

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
@@ -59,7 +59,7 @@ trait StringRegexExpression extends Expression
 
   def nullSafeMatch(input1: Any, input2: Any): Any = {
     val patternStr = input2.asInstanceOf[UTF8String].toString
-    val regex = if (cache == null || !(patternStr).equals(lastPatternStr)) {
+    val regex = if (cache == null) {
       if (!(patternStr).equals(lastPatternStr)) {
         compiledPattern = compile(patternStr)
         lastPatternStr = patternStr

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
@@ -54,9 +54,20 @@ trait StringRegexExpression extends Expression
     Pattern.compile(escape(str))
   }
 
+  var lastPatternStr: String = null
+  var compiledPattern: Pattern = null
+
   def nullSafeMatch(input1: Any, input2: Any): Any = {
-    val s = input2.asInstanceOf[UTF8String].toString
-    val regex = if (cache == null) compile(s) else cache
+    val patternStr = input2.asInstanceOf[UTF8String].toString
+    val regex = if (cache == null || !(patternStr).equals(lastPatternStr)) {
+      if (!(patternStr).equals(lastPatternStr)) {
+        compiledPattern = compile(patternStr)
+        lastPatternStr = patternStr
+      }
+      compiledPattern
+    } else {
+      cache
+    }
     if(regex == null) {
       null
     } else {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR follows up https://github.com/apache/spark/pull/26875.


### Why are the changes needed?
When pattern is not static, we should avoid compile pattern every time if some pattern is same.


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
Exists UT.