### PR TITLE
[SPARK-30762] Add dtype=float32 support to vector_to_array UDF

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/functions.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/functions.scala
@@ -55,9 +55,9 @@ object functions {
 
   /**
    * Converts a column of MLlib sparse/dense vectors into a column of dense arrays.
-   * @param v:
-   * @param dtype:
-   * @return
+   * @param v: the column of MLlib sparse/dense vectors
+   * @param dtype: the desired underlying data type in the returned array
+   * @return an array<float> if dtype is float32, or array<double> if dtype is float64
    * @since 3.0.0
    */
   def vector_to_array(v: Column, dtype: String = "float64"): Column = {

--- a/mllib/src/main/scala/org/apache/spark/ml/functions.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/functions.scala
@@ -57,7 +57,7 @@ object functions {
    * Converts a column of MLlib sparse/dense vectors into a column of dense arrays.
    * @param v: the column of MLlib sparse/dense vectors
    * @param dtype: the desired underlying data type in the returned array
-   * @return an array<float> if dtype is float32, or array<double> if dtype is float64
+   * @return an array&lt;float&gt; if dtype is float32, or array&lt;double&gt; if dtype is float64
    * @since 3.0.0
    */
   def vector_to_array(v: Column, dtype: String = "float64"): Column = {

--- a/mllib/src/main/scala/org/apache/spark/ml/functions.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/functions.scala
@@ -55,7 +55,9 @@ object functions {
 
   /**
    * Converts a column of MLlib sparse/dense vectors into a column of dense arrays.
-   *
+   * @param v:
+   * @param dtype:
+   * @return
    * @since 3.0.0
    */
   def vector_to_array(v: Column, dtype: String = "float64"): Column = {

--- a/mllib/src/main/scala/org/apache/spark/ml/functions.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/functions.scala
@@ -33,8 +33,8 @@ object functions {
       case v: OldVector => v.toArray
       case v => throw new IllegalArgumentException(
         "function vector_to_array requires a non-null input argument and input type must be " +
-          "`org.apache.spark.ml.linalg.Vector` or `org.apache.spark.mllib.linalg.Vector`, " +
-          s"but got ${ if (v == null) "null" else v.getClass.getName }.")
+        "`org.apache.spark.ml.linalg.Vector` or `org.apache.spark.mllib.linalg.Vector`, " +
+        s"but got ${ if (v == null) "null" else v.getClass.getName }.")
     }
   }.asNonNullable()
 
@@ -48,8 +48,8 @@ object functions {
       case v: OldVector => v.toArray.map(_.toFloat)
       case v => throw new IllegalArgumentException(
         "function vector_to_array requires a non-null input argument and input type must be " +
-          "`org.apache.spark.ml.linalg.Vector` or `org.apache.spark.mllib.linalg.Vector`, " +
-          s"but got ${ if (v == null) "null" else v.getClass.getName }.")
+        "`org.apache.spark.ml.linalg.Vector` or `org.apache.spark.mllib.linalg.Vector`, " +
+        s"but got ${ if (v == null) "null" else v.getClass.getName }.")
     }
   }.asNonNullable()
 

--- a/mllib/src/main/scala/org/apache/spark/ml/functions.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/functions.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.ml
 
 import org.apache.spark.annotation.Since
-import org.apache.spark.ml.linalg.Vector
+import org.apache.spark.ml.linalg.{SparseVector, Vector}
 import org.apache.spark.mllib.linalg.{Vector => OldVector}
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.functions.lit
@@ -30,23 +30,27 @@ object functions {
 // scalastyle:on
 
   private val vectorToArrayUdf = udf { (vec: Any, dtype: String) => {
-      val new_vec =
-        vec match {
-          case v: Vector => v.toArray
-          case v: OldVector => v.toArray
-          case v => throw new IllegalArgumentException(
-            "function vector_to_array requires a non-null input argument and input type must be " +
-              "`org.apache.spark.ml.linalg.Vector` or `org.apache.spark.mllib.linalg.Vector`, " +
-              s"but got ${ if (v == null) "null" else v.getClass.getName }.")
-        }
-      if (dtype == "float64") {
-        new_vec
-      } else if (dtype == "float32") {
-        new_vec.map(_.toFloat)
-      } else {
+      if (dtype != "float64" && dtype != "float32") {
         throw new IllegalArgumentException(
           s"Unsupported dtype: $dtype. Valid values: float64, float32."
         )
+      }
+
+      vec match {
+        case v: SparseVector =>
+          if (dtype == "float32") {
+            val data = new Array[Float](v.size)
+            v.foreachActive { (index, value) => data(index) = value.toFloat }
+            data
+          } else {
+            v.toArray
+          }
+        case v: Vector => if (dtype == "float64") v.toArray else v.toArray.map(_.toFloat)
+        case v: OldVector => if (dtype == "float64") v.toArray else v.toArray.map(_.toFloat)
+        case v => throw new IllegalArgumentException(
+          "function vector_to_array requires a non-null input argument and input type must be " +
+            "`org.apache.spark.ml.linalg.Vector` or `org.apache.spark.mllib.linalg.Vector`, " +
+            s"but got ${ if (v == null) "null" else v.getClass.getName }.")
       }
     }
   }.asNonNullable()

--- a/mllib/src/test/scala/org/apache/spark/ml/FunctionsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/FunctionsSuite.scala
@@ -86,7 +86,7 @@ class FunctionsSuite extends MLTest {
       df3.select(
         vector_to_array('vec, dtype = "float16"), vector_to_array('oldVec, dtype = "float16"))
     }
-    assert(thrown2.getCause.getMessage.contains(
+    assert(thrown2.getMessage.contains(
       s"Unsupported dtype: float16. Valid values: float64, float32."))
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/FunctionsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/FunctionsSuite.scala
@@ -61,5 +61,20 @@ class FunctionsSuite extends MLTest {
         "`org.apache.spark.ml.linalg.Vector` or `org.apache.spark.mllib.linalg.Vector`, " +
         s"but got ${valType}"))
     }
+
+    val df3 = Seq(
+      (Vectors.dense(1.0, 2.0, 3.0), OldVectors.dense(10.0, 20.0, 30.0)),
+      (Vectors.sparse(3, Seq((0, 2.0), (2, 3.0))), OldVectors.sparse(3, Seq((0, 20.0), (2, 30.0))))
+    ).toDF("vec", "oldVec")
+
+    val result3 = df3.select(
+      vector_to_array('vec, dtype = "float32"), vector_to_array('oldVec, dtype = "float32"))
+      .collect().toSeq
+
+    val expected3 = Seq(
+      (Seq(1.0, 2.0, 3.0), Seq(10.0, 20.0, 30.0)),
+      (Seq(2.0, 0.0, 3.0), Seq(20.0, 0.0, 30.0))
+    )
+    assert(result3 === expected3)
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/FunctionsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/FunctionsSuite.scala
@@ -82,7 +82,7 @@ class FunctionsSuite extends MLTest {
     df_array_float.schema.fields(0).dataType.simpleString == "array<float>"
     df_array_float.schema.fields(1).dataType.simpleString == "array<float>"
 
-    val thrown2 = intercept[SparkException] {
+    val thrown2 = intercept[IllegalArgumentException] {
       df3.select(
         vector_to_array('vec, dtype = "float16"), vector_to_array('oldVec, dtype = "float16"))
     }

--- a/mllib/src/test/scala/org/apache/spark/ml/FunctionsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/FunctionsSuite.scala
@@ -34,9 +34,8 @@ class FunctionsSuite extends MLTest {
       (Vectors.sparse(3, Seq((0, 2.0), (2, 3.0))), OldVectors.sparse(3, Seq((0, 20.0), (2, 30.0))))
     ).toDF("vec", "oldVec")
 
-      val result = df.select(vector_to_array('vec), vector_to_array('oldVec))
-      .as[(Seq[Double], Seq[Double])]
-      .collect().toSeq
+    val df_array_double = df.select(vector_to_array('vec), vector_to_array('oldVec))
+    val result = df_array_double.as[(Seq[Double], Seq[Double])].collect().toSeq
 
     val expected = Seq(
       (Seq(1.0, 2.0, 3.0), Seq(10.0, 20.0, 30.0)),
@@ -67,14 +66,19 @@ class FunctionsSuite extends MLTest {
       (Vectors.sparse(3, Seq((0, 2.0), (2, 3.0))), OldVectors.sparse(3, Seq((0, 20.0), (2, 30.0))))
     ).toDF("vec", "oldVec")
 
-    val result3 = df3.select(
+    val df_array_float = df3.select(
       vector_to_array('vec, dtype = "float32"), vector_to_array('oldVec, dtype = "float32"))
-      .collect().toSeq
+    val result3 = df_array_float.collect().toSeq
 
     val expected3 = Seq(
       (Seq(1.0, 2.0, 3.0), Seq(10.0, 20.0, 30.0)),
       (Seq(2.0, 0.0, 3.0), Seq(20.0, 0.0, 30.0))
     )
     assert(result3 === expected3)
+
+    df_array_double.schema.fields(0).dataType.simpleString == "array<double>"
+    df_array_double.schema.fields(1).dataType.simpleString == "array<double>"
+    df_array_float.schema.fields(0).dataType.simpleString == "array<float>"
+    df_array_float.schema.fields(1).dataType.simpleString == "array<float>"
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/FunctionsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/FunctionsSuite.scala
@@ -34,8 +34,8 @@ class FunctionsSuite extends MLTest {
       (Vectors.sparse(3, Seq((0, 2.0), (2, 3.0))), OldVectors.sparse(3, Seq((0, 20.0), (2, 30.0))))
     ).toDF("vec", "oldVec")
 
-    val df_array_double = df.select(vector_to_array('vec), vector_to_array('oldVec))
-    val result = df_array_double.as[(Seq[Double], Seq[Double])].collect().toSeq
+    val result = df.select(vector_to_array('vec), vector_to_array('oldVec))
+                   .as[(Seq[Double], Seq[Double])].collect().toSeq
 
     val expected = Seq(
       (Seq(1.0, 2.0, 3.0), Seq(10.0, 20.0, 30.0)),
@@ -64,11 +64,11 @@ class FunctionsSuite extends MLTest {
       (Vectors.dense(1.0, 2.0, 3.0), OldVectors.dense(10.0, 20.0, 30.0)),
       (Vectors.sparse(3, Seq((0, 2.0), (2, 3.0))), OldVectors.sparse(3, Seq((0, 20.0), (2, 30.0))))
     ).toDF("vec", "oldVec")
-    val df_array_float = df3.select(
+    val dfArrayFloat = df3.select(
       vector_to_array('vec, dtype = "float32"), vector_to_array('oldVec, dtype = "float32"))
 
     // Check values are correct
-    val result3 = df_array_float.as[(Seq[Float], Seq[Float])].collect().toSeq
+    val result3 = dfArrayFloat.as[(Seq[Float], Seq[Float])].collect().toSeq
 
     val expected3 = Seq(
       (Seq(1.0, 2.0, 3.0), Seq(10.0, 20.0, 30.0)),
@@ -77,10 +77,7 @@ class FunctionsSuite extends MLTest {
     assert(result3 === expected3)
 
     // Check data types are correct
-    df_array_double.schema.fields(0).dataType.simpleString == "array<double>"
-    df_array_double.schema.fields(1).dataType.simpleString == "array<double>"
-    df_array_float.schema.fields(0).dataType.simpleString == "array<float>"
-    df_array_float.schema.fields(1).dataType.simpleString == "array<float>"
+    dfArrayFloat.schema.simpleString == "struct<UDF(vec):array<float>,UDF(oldVec):array<float>>"
 
     val thrown2 = intercept[IllegalArgumentException] {
       df3.select(

--- a/mllib/src/test/scala/org/apache/spark/ml/FunctionsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/FunctionsSuite.scala
@@ -77,7 +77,8 @@ class FunctionsSuite extends MLTest {
     assert(result3 === expected3)
 
     // Check data types are correct
-    dfArrayFloat.schema.simpleString == "struct<UDF(vec):array<float>,UDF(oldVec):array<float>>"
+    assert(dfArrayFloat.schema.simpleString ===
+      "struct<UDF(vec):array<float>,UDF(oldVec):array<float>>")
 
     val thrown2 = intercept[IllegalArgumentException] {
       df3.select(

--- a/python/pyspark/ml/functions.py
+++ b/python/pyspark/ml/functions.py
@@ -32,10 +32,25 @@ def vector_to_array(col, dtype="float64"):
     ...     (Vectors.sparse(3, [(0, 2.0), (2, 3.0)]),
     ...      OldVectors.sparse(3, [(0, 20.0), (2, 30.0)]))],
     ...     ["vec", "oldVec"])
-    >>> df.select(vector_to_array("vec").alias("vec"),
-    ...           vector_to_array("oldVec").alias("oldVec")).collect()
+    >>> df1 = df.select(vector_to_array("vec").alias("vec"),
+    ...                 vector_to_array("oldVec").alias("oldVec"))
+    >>> df1.collect()
     [Row(vec=[1.0, 2.0, 3.0], oldVec=[10.0, 20.0, 30.0]),
      Row(vec=[2.0, 0.0, 3.0], oldVec=[20.0, 0.0, 30.0])]
+    >>> df2 = df.select(vector_to_array("vec", "float32").alias("vec"),
+    ...                 vector_to_array("oldVec", "float32").alias("oldVec"))
+    >>> df2.collect()
+    [Row(vec=[1.0, 2.0, 3.0], oldVec=[10.0, 20.0, 30.0]),
+     Row(vec=[2.0, 0.0, 3.0], oldVec=[20.0, 0.0, 30.0])]
+    >>> df1.schema.fields
+    [StructField(vec,ArrayType(DoubleType,false),false), StructField(oldVec,ArrayType(DoubleType,false),false)]
+    >>> df2.schema.fields
+    [StructField(vec,ArrayType(FloatType,false),false), StructField(oldVec,ArrayType(FloatType,false),false)]
+    >>> df.select(vector_to_array("vec", "float16").alias("vec"),
+    ...           vector_to_array("oldVec", "float16").alias("oldVec")).collect()
+    Traceback (most recent call last):
+        ...
+    pyspark.sql.utils.IllegalArgumentException: Unsupported dtype: float16. Valid values: float64, float32.
     """
     sc = SparkContext._active_spark_context
     return Column(

--- a/python/pyspark/ml/functions.py
+++ b/python/pyspark/ml/functions.py
@@ -43,14 +43,17 @@ def vector_to_array(col, dtype="float64"):
     [Row(vec=[1.0, 2.0, 3.0], oldVec=[10.0, 20.0, 30.0]),
      Row(vec=[2.0, 0.0, 3.0], oldVec=[20.0, 0.0, 30.0])]
     >>> df1.schema.fields
-    [StructField(vec,ArrayType(DoubleType,false),false), StructField(oldVec,ArrayType(DoubleType,false),false)]
+    [StructField(vec,ArrayType(DoubleType,false),false),
+    StructField(oldVec,ArrayType(DoubleType,false),false)]
     >>> df2.schema.fields
-    [StructField(vec,ArrayType(FloatType,false),false), StructField(oldVec,ArrayType(FloatType,false),false)]
+    [StructField(vec,ArrayType(FloatType,false),false),
+    StructField(oldVec,ArrayType(FloatType,false),false)]
     >>> df.select(vector_to_array("vec", "float16").alias("vec"),
     ...           vector_to_array("oldVec", "float16").alias("oldVec")).collect()
     Traceback (most recent call last):
         ...
-    pyspark.sql.utils.IllegalArgumentException: Unsupported dtype: float16. Valid values: float64, float32.
+    pyspark.sql.utils.IllegalArgumentException:
+    Unsupported dtype: float16. Valid values: float64, float32.
     """
     sc = SparkContext._active_spark_context
     return Column(

--- a/python/pyspark/ml/functions.py
+++ b/python/pyspark/ml/functions.py
@@ -48,12 +48,6 @@ def vector_to_array(col, dtype="float64"):
     >>> df2.schema.fields
     [StructField(vec,ArrayType(FloatType,false),false),
     StructField(oldVec,ArrayType(FloatType,false),false)]
-    >>> df.select(vector_to_array("vec", "float16").alias("vec"),
-    ...           vector_to_array("oldVec", "float16").alias("oldVec")).collect()
-    Traceback (most recent call last):
-        ...
-    pyspark.sql.utils.IllegalArgumentException:
-    Unsupported dtype: float16. Valid values: float64, float32.
     """
     sc = SparkContext._active_spark_context
     return Column(

--- a/python/pyspark/ml/functions.py
+++ b/python/pyspark/ml/functions.py
@@ -19,7 +19,7 @@ from pyspark import since, SparkContext
 from pyspark.sql.column import Column, _to_java_column
 
 
-@since(3.0)
+@since("3.0.0")
 def vector_to_array(col, dtype="float64"):
     """
     Converts a column of MLlib sparse/dense vectors into a column of dense arrays.

--- a/python/pyspark/ml/functions.py
+++ b/python/pyspark/ml/functions.py
@@ -23,6 +23,11 @@ from pyspark.sql.column import Column, _to_java_column
 def vector_to_array(col, dtype="float64"):
     """
     Converts a column of MLlib sparse/dense vectors into a column of dense arrays.
+    :param col: A string of the column name or a Column
+    :param dtype: The data type of the output array. Valid values: "float64" or "float32".
+    :return: The converted column of dense arrays.
+
+    .. versionadded:: 3.0.0
 
     >>> from pyspark.ml.linalg import Vectors
     >>> from pyspark.ml.functions import vector_to_array

--- a/python/pyspark/ml/functions.py
+++ b/python/pyspark/ml/functions.py
@@ -20,7 +20,7 @@ from pyspark.sql.column import Column, _to_java_column
 
 
 @since(3.0)
-def vector_to_array(col):
+def vector_to_array(col, dtype="float64"):
     """
     Converts a column of MLlib sparse/dense vectors into a column of dense arrays.
 
@@ -39,7 +39,7 @@ def vector_to_array(col):
     """
     sc = SparkContext._active_spark_context
     return Column(
-        sc._jvm.org.apache.spark.ml.functions.vector_to_array(_to_java_column(col)))
+        sc._jvm.org.apache.spark.ml.functions.vector_to_array(_to_java_column(col), dtype))
 
 
 def _test():


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this PR, we add a parameter in the python function vector_to_array(col) that allows converting to a column of arrays of Float (32bits) in scala, which would be mapped to a numpy array of dtype=float32.

### Why are the changes needed?
In the downstream ML training, using float32 instead of float64 (default) would allow a larger batch size, i.e., allow more data to fit in the memory.

### Does this PR introduce any user-facing change?
Yes.
Old: `vector_to_array()` only take one param
```
df.select(vector_to_array("colA"), ...)
```
New: `vector_to_array()` can take an additional optional param: `dtype` = "float32" (or "float64")
```
df.select(vector_to_array("colA", "float32"), ...)
```

### How was this patch tested?
Unit test in scala.
doctest in python.
