### PR TITLE
[MINOR] update dstream.py with more accurate exceptions

### DIFF
--- a/python/pyspark/streaming/dstream.py
+++ b/python/pyspark/streaming/dstream.py
@@ -418,10 +418,12 @@ class DStream(object):
     def _validate_window_param(self, window, slide):
         duration = self._jdstream.dstream().slideDuration().milliseconds()
         if int(window * 1000) % duration != 0:
-            raise ValueError("windowDuration must be multiple of the slide duration (%d ms)"
+            raise ValueError("windowDuration must be multiple of the parent " \
+                             "dstream's slide (batch) duration (%d ms)"
                              % duration)
         if slide and int(slide * 1000) % duration != 0:
-            raise ValueError("slideDuration must be multiple of the slide duration (%d ms)"
+            raise ValueError("slideDuration must be multiple of the parent " \
+                             "dstream's slide (batch) duration (%d ms)"
                              % duration)
 
     def window(self, windowDuration, slideDuration=None):


### PR DESCRIPTION


### What changes were proposed in this pull request?

The exception messages for dstream.py when using windows were improved to be specific about what sliding duration is important.


### Why are the changes needed?

The batch interval of dstreams are improperly named as sliding windows. The term sliding window is also used to reference the new window of a dstream collected over a window of rdds in a parent dstream. We should probably fix the naming convention of sliding window used in the dstream class, but for now more this more explicit exception message may reduce confusion.


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
It wasn't since this is only a change of the exception message
