### PR TITLE
[SPARK-30785][SQL] Create table like should keep tracksPartitionsInCatalog same with source table

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -123,7 +123,8 @@ case class CreateTableLikeCommand(
         provider = newProvider,
         partitionColumnNames = sourceTableDesc.partitionColumnNames,
         bucketSpec = sourceTableDesc.bucketSpec,
-        properties = properties)
+        properties = properties,
+        tracksPartitionsInCatalog = sourceTableDesc.tracksPartitionsInCatalog)
 
     catalog.createTable(newTableDesc, ifNotExists)
     Seq.empty[Row]

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -2742,6 +2742,7 @@ class HiveDDLSuite
       assert(sourceTable.tracksPartitionsInCatalog == targetTable.tracksPartitionsInCatalog)
       assert(targetTable.partitionColumnNames == Seq("ts"))
       sql("ALTER TABLE ta_part ADD PARTITION (ts=10)") // no exception
+      checkAnswer(sql("SHOW PARTITIONS ta_part"), Row("ts=10") :: Nil)
     }
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -2739,7 +2739,7 @@ class HiveDDLSuite
       val sourceTable = catalog.getTableMetadata(TableIdentifier("sc_part", Some("default")))
       val targetTable = catalog.getTableMetadata(TableIdentifier("ta_part", Some("default")))
       assert(sourceTable.tracksPartitionsInCatalog)
-      assert(sourceTable.tracksPartitionsInCatalog == targetTable.tracksPartitionsInCatalog)
+      assert(targetTable.tracksPartitionsInCatalog)
       assert(targetTable.partitionColumnNames == Seq("ts"))
       sql("ALTER TABLE ta_part ADD PARTITION (ts=10)") // no exception
       checkAnswer(sql("SHOW PARTITIONS ta_part"), Row("ts=10") :: Nil)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -1580,6 +1580,8 @@ class HiveDDLSuite
         "source table/view path should be different from target table path")
     }
 
+    assert(targetTable.tracksPartitionsInCatalog == sourceTable.tracksPartitionsInCatalog)
+
     // The source table contents should not been seen in the target table.
     assert(spark.table(sourceTable.identifier).count() != 0, "the source table should be nonempty")
     assert(spark.table(targetTable.identifier).count() == 0, "the target table should be empty")
@@ -2722,6 +2724,20 @@ class HiveDDLSuite
         val table = catalog.getTableMetadata(TableIdentifier("s"))
         assert(table.provider === Some("hive"))
       }
+    }
+  }
+
+  test("SPARK-30785: create table like a partitioned table") {
+    val catalog = spark.sessionState.catalog
+    withTable("sc_part", "ta_part") {
+      sql("CREATE TABLE sc_part (key string, ts int) USING parquet PARTITIONED BY (ts)")
+      sql("CREATE TABLE ta_part like sc_part")
+      val sourceTable = catalog.getTableMetadata(TableIdentifier("sc_part", Some("default")))
+      val targetTable = catalog.getTableMetadata(TableIdentifier("ta_part", Some("default")))
+      assert(sourceTable.tracksPartitionsInCatalog)
+      assert(sourceTable.tracksPartitionsInCatalog == targetTable.tracksPartitionsInCatalog)
+      assert(targetTable.partitionColumnNames == Seq("ts"))
+      sql("ALTER TABLE ta_part ADD PARTITION (ts=10)") // no exception
     }
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -1580,7 +1580,11 @@ class HiveDDLSuite
         "source table/view path should be different from target table path")
     }
 
-    assert(targetTable.tracksPartitionsInCatalog == sourceTable.tracksPartitionsInCatalog)
+    if (DDLUtils.isHiveTable(targetTable)) {
+      assert(targetTable.tracksPartitionsInCatalog)
+    } else {
+      assert(targetTable.tracksPartitionsInCatalog == sourceTable.tracksPartitionsInCatalog)
+    }
 
     // The source table contents should not been seen in the target table.
     assert(spark.table(sourceTable.identifier).count() != 0, "the source table should be nonempty")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Table generated by `CREATE TABLE LIKE` a partitioned table is a partitioned table. But when run `ALTER TABLE ADD PARTITION`, it will throw `AnalysisException: ALTER TABLE ADD PARTITION is not allowed`. That's because the default value of `tracksPartitionsInCatalog` from `CREATE TABLE LIKE` always is false.


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
Add a unit test.