### PR TITLE
[SPARK-30811][SQL][2.4] CTE should not cause stack overflow when it refers to non-existent table with same name

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -215,7 +215,7 @@ class Analyzer(
     }
 
     def substituteCTE(plan: LogicalPlan, cteRelations: Seq[(String, LogicalPlan)]): LogicalPlan = {
-      plan resolveOperatorsUp {
+      plan resolveOperatorsDown {
         case u: UnresolvedRelation if u.tableIdentifier.database.isEmpty =>
           cteRelations.find(x => resolver(x._1, u.tableIdentifier.table))
             .map(_._2).getOrElse(u)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -215,8 +215,8 @@ class Analyzer(
     }
 
     def substituteCTE(plan: LogicalPlan, cteRelations: Seq[(String, LogicalPlan)]): LogicalPlan = {
-      plan resolveOperatorsDown {
-        case u: UnresolvedRelation =>
+      plan resolveOperatorsUp {
+        case u: UnresolvedRelation if u.tableIdentifier.database.isEmpty =>
           cteRelations.find(x => resolver(x._1, u.tableIdentifier.table))
             .map(_._2).getOrElse(u)
         case other =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2641,4 +2641,12 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     val idTuples = sampled.collect().map(row => row.getLong(0) -> row.getLong(1))
     assert(idTuples.length == idTuples.toSet.size)
   }
+
+  test("SPARK-30811: CTE should not cause stack overflow when " +
+    "it refers to non-existent table with same name") {
+    val e = intercept[AnalysisException] {
+      sql("WITH t AS (SELECT 1 FROM nonexist.t) SELECT * FROM t")
+    }
+    assert(e.getMessage.contains("Table or view not found:"))
+  }
 }


### PR DESCRIPTION
### Why are the changes needed?
A query with Common Table Expressions can cause a stack overflow when it contains a CTE that refers a non-existing table with the same name. The name of the table need to have a database qualifier. This is caused by a couple of things:
- `CTESubstitution` runs analysis on the CTE, but this does not throw an exception because the table has a database qualifier. The reason is that we don't fail is because we re-attempt to resolve the relation in a later rule;
- `CTESubstitution` replace logic does not check if the table it is replacing has a database, it shouldn't replace the relation if it does. So now we will happily replace `nonexist.t` with `t`;

Note that this **not** an issue for master or the spark-3.0 branch.

This PR fixes this by checking whether the relation name does not have a database, and it also reverses the transformation order.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Added regression test to `DataFrameSuite`.