### PR TITLE
[SPARK-30791][SQL][PYTHON] Add 'sameSemantics' and 'sementicHash' methods in Dataset

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2153,21 +2153,28 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
                                               "should have been DataFrame." % type(result)
         return result
 
-    @since(3.0)
+    @since(3.1)
     def sameSemantics(self, other):
         """
         Return true when the query plan of the given :class:`DataFrame` will return the same
         results as this :class:`DataFrame`.
-        """
-        return self._jdf.sameSemantics(other)
 
-    @since(3.0)
+        >>> df = spark.createDataFrame([(1, 2),(4, 5)], ["col1", "col2"])
+        >>> df.sameSemantics(df)
+        True
+        """
+        return self._jdf.sameSemantics(other._jdf)
+
+    @since(3.1)
     def semanticHash(self):
         """
+        Returns a `hashCode` for the calculation performed by the query plan of this Dataset.
 
-        :return:
+        >>> df = spark.createDataFrame([(1, 2),(4, 5)], ["col1", "col2"])
+        >>> df.semanticHash()
+        ...
         """
-        return self._jdf.semanticHash(None)
+        return self._jdf.semanticHash()
 
     where = copy_func(
         filter,

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2156,8 +2156,15 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
     @since(3.1)
     def sameSemantics(self, other):
         """
-        Return true when the query plan of the given :class:`DataFrame` will return the same
-        results as this :class:`DataFrame`.
+        Returns `True` when the logical query plans inside both :class:`DataFrame`\\s are equal and
+        therefore return same results.
+
+        .. note:: The equality comparison here is simplified by tolerating the cosmetic differences
+            such as attribute names.
+
+        .. note::This API can compare both :class:`DataFrame`\\s very fast but can still return
+            `False` on the :class:`DataFrame` that return the same results, for instance, from
+            different plans. Such false negative semantic can be useful when caching as an example.
 
         >>> df1 = spark.createDataFrame([(1, 2),(4, 5)], ["col1", "col2"])
         >>> df2 = spark.createDataFrame([(1, 2),(4, 5)], ["col0", "col2"])
@@ -2180,7 +2187,10 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
     @since(3.1)
     def semanticHash(self):
         """
-        Returns a `hashCode` for the calculation performed by the query plan of this Dataset.
+        Returns a hash code of the logical query plan against this :class:`DataFrame`.
+
+        .. note:: Unlike the standard hash code, the hash is calculated against the query plan
+            simplified by tolerating the cosmetic differences such as attribute names.
 
         >>> df1 = spark.createDataFrame([(1, 2),(4, 5)], ["col1", "col2"])
         >>> df2 = spark.createDataFrame([(1, 2),(4, 5)], ["col0", "col2"])

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2153,6 +2153,22 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
                                               "should have been DataFrame." % type(result)
         return result
 
+    @since(3.0)
+    def sameSemantics(self, other):
+        """
+        Return true when the query plan of the given :class:`DataFrame` will return the same
+        results as this :class:`DataFrame`.
+        """
+        return self._jdf.sameSemantics(other)
+
+    @since(3.0)
+    def semanticHash(self):
+        """
+
+        :return:
+        """
+        return self._jdf.semanticHash(None)
+
     where = copy_func(
         filter,
         sinceversion=1.3,

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2199,7 +2199,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         True
         >>> df1.withColumn("col1", df1.id * 2).semanticHash() == \
             df3.withColumn("col1", df3.id + 2).semanticHash()
-        True
+        False
         >>> df1.withColumn("col1", df1.id * 2).semanticHash() == \
             df4.withColumn("col0", df4.id * 2).semanticHash()
         True

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2166,15 +2166,15 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
             `False` on the :class:`DataFrame` that return the same results, for instance, from
             different plans. Such false negative semantic can be useful when caching as an example.
 
-        >>> df1 = spark.range(100)
-        >>> df2 = spark.range(100)
-        >>> df3 = spark.range(100)
-        >>> df4 = spark.range(100)
+        .. note:: DeveloperApi
+
+        >>> df1 = spark.range(10)
+        >>> df2 = spark.range(10)
         >>> df1.withColumn("col1", df1.id * 2).sameSemantics(df2.withColumn("col1", df2.id * 2))
         True
-        >>> df1.withColumn("col1", df1.id * 2).sameSemantics(df3.withColumn("col1", df3.id + 2))
+        >>> df1.withColumn("col1", df1.id * 2).sameSemantics(df2.withColumn("col1", df2.id + 2))
         False
-        >>> df1.withColumn("col1", df1.id * 2).sameSemantics(df4.withColumn("col0", df4.id * 2))
+        >>> df1.withColumn("col1", df1.id * 2).sameSemantics(df2.withColumn("col0", df2.id * 2))
         True
         """
         if not isinstance(other, DataFrame):
@@ -2190,18 +2190,12 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         .. note:: Unlike the standard hash code, the hash is calculated against the query plan
             simplified by tolerating the cosmetic differences such as attribute names.
 
-        >>> df1 = spark.range(100)
-        >>> df2 = spark.range(100)
-        >>> df3 = spark.range(100)
-        >>> df4 = spark.range(100)
-        >>> df1.withColumn("col1", df1.id * 2).semanticHash() == \
-            df2.withColumn("col1", df2.id * 2).semanticHash()
-        True
-        >>> # df1.withColumn("col1", df1.id * 2).semanticHash() == \
-            df3.withColumn("col1", df3.id + 2).semanticHash()  # False
-        >>> df1.withColumn("col1", df1.id * 2).semanticHash() == \
-            df4.withColumn("col0", df4.id * 2).semanticHash()
-        True
+        .. note:: DeveloperApi
+
+        >>> spark.range(10).selectExpr("id as col0").semanticHash()  # doctest: +SKIP
+        1855039936
+        >>> spark.range(10).selectExpr("id as col1").semanticHash()  # doctest: +SKIP
+        1855039936
         """
         return self._jdf.semanticHash()
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2159,8 +2159,15 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         Return true when the query plan of the given :class:`DataFrame` will return the same
         results as this :class:`DataFrame`.
 
-        >>> df = spark.createDataFrame([(1, 2),(4, 5)], ["col1", "col2"])
-        >>> df.sameSemantics(df)
+        >>> df1 = spark.createDataFrame([(1, 2),(4, 5)], ["col1", "col2"])
+        >>> df2 = spark.createDataFrame([(1, 2),(4, 5)], ["col0", "col2"])
+        >>> df3 = spark.createDataFrame([(0, 2),(4, 5)], ["col1", "col2"])
+        >>> df4 = spark.createDataFrame([(1, 2),(4, 5)], ["col1", "col2"])
+        >>> df1.sameSemantics(df2)
+        False
+        >>> df1.sameSemantics(df3)
+        False
+        >>> df1.sameSemantics(df4)
         True
         """
         if not isinstance(other, DataFrame):
@@ -2172,9 +2179,16 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         """
         Returns a `hashCode` for the calculation performed by the query plan of this Dataset.
 
-        >>> df = spark.createDataFrame([(1, 2),(4, 5)], ["col1", "col2"])
-        >>> df.semanticHash()
-        ...
+        >>> df1 = spark.createDataFrame([(1, 2),(4, 5)], ["col1", "col2"])
+        >>> df2 = spark.createDataFrame([(1, 2),(4, 5)], ["col0", "col2"])
+        >>> df3 = spark.createDataFrame([(0, 2),(4, 5)], ["col1", "col2"])
+        >>> df4 = spark.createDataFrame([(1, 2),(4, 5)], ["col1", "col2"])
+        >>> df1.semanticHash() == df2.semanticHash()
+        False
+        >>> df1.semanticHash() == df3.semanticHash()
+        False
+        >>> df1.semanticHash() == df4.semanticHash()
+        True
         """
         return self._jdf.semanticHash()
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2166,15 +2166,15 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
             `False` on the :class:`DataFrame` that return the same results, for instance, from
             different plans. Such false negative semantic can be useful when caching as an example.
 
-        >>> df1 = spark.range(100).withColumn("col1", df1.id * 2)
-        >>> df2 = spark.range(100).withColumn("col1", df1.id * 2)
-        >>> df3 = spark.range(100).withColumn("col1", df1.id + 2)
-        >>> df4 = spark.range(100).withColumn("col0", df1.id * 2)
-        >>> df1.sameSemantics(df2)
+        >>> df1 = spark.range(100)
+        >>> df2 = spark.range(100)
+        >>> df3 = spark.range(100)
+        >>> df4 = spark.range(100)
+        >>> df1.withColumn("col1", df1.id * 2).sameSemantics(df2.withColumn("col1", df2.id * 2))
         True
-        >>> df1.sameSemantics(df3)
+        >>> df1.withColumn("col1", df1.id * 2).sameSemantics(df3.withColumn("col1", df3.id + 2))
         False
-        >>> df1.sameSemantics(df4)
+        >>> df1.withColumn("col1", df1.id * 2).sameSemantics(df4.withColumn("col0", df4.id * 2))
         True
         """
         if not isinstance(other, DataFrame):
@@ -2190,15 +2190,18 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         .. note:: Unlike the standard hash code, the hash is calculated against the query plan
             simplified by tolerating the cosmetic differences such as attribute names.
 
-        >>> df1 = spark.range(100).withColumn("col1", df1.id * 2)
-        >>> df2 = spark.range(100).withColumn("col1", df1.id * 2)
-        >>> df3 = spark.range(100).withColumn("col1", df1.id + 2)
-        >>> df4 = spark.range(100).withColumn("col0", df1.id * 2)
-        >>> df1.semanticHash() == df2.semanticHash()
+        >>> df1 = spark.range(100)
+        >>> df2 = spark.range(100)
+        >>> df3 = spark.range(100)
+        >>> df4 = spark.range(100)
+        >>> df1.withColumn("col1", df1.id * 2).semanticHash() == \
+            df2.withColumn("col1", df2.id * 2).semanticHash()
         True
-        >>> df1.semanticHash() == df3.semanticHash()
-        False
-        >>> df1.semanticHash() == df4.semanticHash()
+        >>> df1.withColumn("col1", df1.id * 2).semanticHash() == \
+            df3.withColumn("col1", df3.id + 2).semanticHash()
+        True
+        >>> df1.withColumn("col1", df1.id * 2).semanticHash() == \
+            df4.withColumn("col0", df4.id * 2).semanticHash()
         True
         """
         return self._jdf.semanticHash()

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2169,9 +2169,12 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         False
         >>> df1.sameSemantics(df4)
         True
+        >>> df1.sameSemantics(df1)
+        True
         """
         if not isinstance(other, DataFrame):
-            raise ValueError("other parameter should be of DataFrame; however, got %s" % type(other))
+            raise ValueError("other parameter should be of DataFrame; however, got %s"
+                             % type(other))
         return self._jdf.sameSemantics(other._jdf)
 
     @since(3.1)
@@ -2188,6 +2191,8 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         >>> df1.semanticHash() == df3.semanticHash()
         False
         >>> df1.semanticHash() == df4.semanticHash()
+        True
+        >>> df1.semanticHash() == df1.semanticHash()
         True
         """
         return self._jdf.semanticHash()

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2166,17 +2166,15 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
             `False` on the :class:`DataFrame` that return the same results, for instance, from
             different plans. Such false negative semantic can be useful when caching as an example.
 
-        >>> df1 = spark.createDataFrame([(1, 2),(4, 5)], ["col1", "col2"])
-        >>> df2 = spark.createDataFrame([(1, 2),(4, 5)], ["col0", "col2"])
-        >>> df3 = spark.createDataFrame([(0, 2),(4, 5)], ["col1", "col2"])
-        >>> df4 = spark.createDataFrame([(1, 2),(4, 5)], ["col1", "col2"])
+        >>> df1 = spark.range(100).withColumn("col1", df1.id * 2)
+        >>> df2 = spark.range(100).withColumn("col1", df1.id * 2)
+        >>> df3 = spark.range(100).withColumn("col1", df1.id + 2)
+        >>> df4 = spark.range(100).withColumn("col0", df1.id * 2)
         >>> df1.sameSemantics(df2)
-        False
+        True
         >>> df1.sameSemantics(df3)
         False
         >>> df1.sameSemantics(df4)
-        True
-        >>> df1.sameSemantics(df1)
         True
         """
         if not isinstance(other, DataFrame):
@@ -2192,17 +2190,15 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         .. note:: Unlike the standard hash code, the hash is calculated against the query plan
             simplified by tolerating the cosmetic differences such as attribute names.
 
-        >>> df1 = spark.createDataFrame([(1, 2),(4, 5)], ["col1", "col2"])
-        >>> df2 = spark.createDataFrame([(1, 2),(4, 5)], ["col0", "col2"])
-        >>> df3 = spark.createDataFrame([(0, 2),(4, 5)], ["col1", "col2"])
-        >>> df4 = spark.createDataFrame([(1, 2),(4, 5)], ["col1", "col2"])
+        >>> df1 = spark.range(100).withColumn("col1", df1.id * 2)
+        >>> df2 = spark.range(100).withColumn("col1", df1.id * 2)
+        >>> df3 = spark.range(100).withColumn("col1", df1.id + 2)
+        >>> df4 = spark.range(100).withColumn("col0", df1.id * 2)
         >>> df1.semanticHash() == df2.semanticHash()
-        False
+        True
         >>> df1.semanticHash() == df3.semanticHash()
         False
         >>> df1.semanticHash() == df4.semanticHash()
-        True
-        >>> df1.semanticHash() == df1.semanticHash()
         True
         """
         return self._jdf.semanticHash()

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2162,7 +2162,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         .. note:: The equality comparison here is simplified by tolerating the cosmetic differences
             such as attribute names.
 
-        .. note::This API can compare both :class:`DataFrame`\\s very fast but can still return
+        .. note:: This API can compare both :class:`DataFrame`\\s very fast but can still return
             `False` on the :class:`DataFrame` that return the same results, for instance, from
             different plans. Such false negative semantic can be useful when caching as an example.
 
@@ -2197,9 +2197,8 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         >>> df1.withColumn("col1", df1.id * 2).semanticHash() == \
             df2.withColumn("col1", df2.id * 2).semanticHash()
         True
-        >>> df1.withColumn("col1", df1.id * 2).semanticHash() == \
-            df3.withColumn("col1", df3.id + 2).semanticHash()
-        False
+        >>> # df1.withColumn("col1", df1.id * 2).semanticHash() == \
+            df3.withColumn("col1", df3.id + 2).semanticHash()  # False
         >>> df1.withColumn("col1", df1.id * 2).semanticHash() == \
             df4.withColumn("col0", df4.id * 2).semanticHash()
         True

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2163,6 +2163,8 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         >>> df.sameSemantics(df)
         True
         """
+        if not isinstance(other, DataFrame):
+            raise ValueError("other parameter should be of DataFrame; however, got %s" % type(other))
         return self._jdf.sameSemantics(other._jdf)
 
     @since(3.1)

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -782,6 +782,11 @@ class DataFrameTests(ReusedSQLTestCase):
                     break
             self.assertEqual(df.take(8), result)
 
+    def test_same_semantics_error(self):
+        with QuietTest(self.sc):
+            with self.assertRaisesRegexp(ValueError, "should be of DataFrame.*int"):
+                self.spark.range(10).sameSemantics(1)
+
 
 class QueryExecutionListenerTests(unittest.TestCase, SQLTestUtils):
     # These tests are separate because it uses 'spark.sql.queryExecutionListeners' which is

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -3323,8 +3323,9 @@ class Dataset[T] private[sql](
    * This function performs a modified version of equality that is tolerant of cosmetic
    * differences like attribute naming and or expression id differences.
    *
-   * @since 3.0.0
+   * @since 3.1.0
    */
+  @DeveloperApi
   def sameSemantics(other: Dataset[T]): Boolean = {
     queryExecution.analyzed.sameResult(other.queryExecution.analyzed)
   }
@@ -3332,8 +3333,13 @@ class Dataset[T] private[sql](
   /**
    * Returns a `hashCode` for the calculation performed by the query plan of this Dataset. Unlike
    * the standard `hashCode`, an attempt has been made to eliminate cosmetic differences.
+   *
+   * @since 3.1.0
    */
-  def semanticHash: Int = queryExecution.analyzed.semanticHash()
+  @DeveloperApi
+  def semanticHash(): Int = {
+    queryExecution.analyzed.semanticHash()
+  }
 
   ////////////////////////////////////////////////////////////////////////////
   // For Python API

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -3325,7 +3325,6 @@ class Dataset[T] private[sql](
    *
    * @since 3.0.0
    */
-  @DeveloperApi
   def sameSemantics(other: Dataset[T]): Boolean = {
     queryExecution.analyzed.sameResult(other.queryExecution.analyzed)
   }
@@ -3334,7 +3333,6 @@ class Dataset[T] private[sql](
    * Returns a `hashCode` for the calculation performed by the query plan of this Dataset. Unlike
    * the standard `hashCode`, an attempt has been made to eliminate cosmetic differences.
    */
-  @DeveloperApi
   def semanticHash: Int = queryExecution.analyzed.semanticHash()
 
   ////////////////////////////////////////////////////////////////////////////

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -3310,6 +3310,33 @@ class Dataset[T] private[sql](
     files.toSet.toArray
   }
 
+  /**
+   * Returns true when the query plan of the given Dataset will return the same results as this
+   * Dataset.
+   *
+   * Since its likely undecidable to generally determine if two given plans will produce the same
+   * results, it is okay for this function to return false, even if the results are actually
+   * the same.  Such behavior will not affect correctness, only the application of performance
+   * enhancements like caching.  However, it is not acceptable to return true if the results could
+   * possibly be different.
+   *
+   * This function performs a modified version of equality that is tolerant of cosmetic
+   * differences like attribute naming and or expression id differences.
+   *
+   * @since 3.0.0
+   */
+  @DeveloperApi
+  def sameSemantics(other: Dataset[T]): Boolean = {
+    queryExecution.analyzed.sameResult(other.queryExecution.analyzed)
+  }
+
+  /**
+   * Returns a `hashCode` for the calculation performed by the query plan of this Dataset. Unlike
+   * the standard `hashCode`, an attempt has been made to eliminate cosmetic differences.
+   */
+  @DeveloperApi
+  def semanticHash: Int = queryExecution.analyzed.semanticHash()
+
   ////////////////////////////////////////////////////////////////////////////
   // For Python API
   ////////////////////////////////////////////////////////////////////////////

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -3311,18 +3311,14 @@ class Dataset[T] private[sql](
   }
 
   /**
-   * Returns true when the query plan of the given Dataset will return the same results as this
-   * Dataset.
+   * Returns `true` when the logical query plans inside both [[Dataset]]s are equal and
+   * therefore return same results.
    *
-   * Since its likely undecidable to generally determine if two given plans will produce the same
-   * results, it is okay for this function to return false, even if the results are actually
-   * the same.  Such behavior will not affect correctness, only the application of performance
-   * enhancements like caching.  However, it is not acceptable to return true if the results could
-   * possibly be different.
-   *
-   * This function performs a modified version of equality that is tolerant of cosmetic
-   * differences like attribute naming and or expression id differences.
-   *
+   * @note The equality comparison here is simplified by tolerating the cosmetic differences
+   *       such as attribute names.
+   * @note This API can compare both [[Dataset]]s very fast but can still return `false` on
+   *       the [[Dataset]] that return the same results, for instance, from different plans. Such
+   *       false negative semantic can be useful when caching as an example.
    * @since 3.1.0
    */
   @DeveloperApi
@@ -3331,9 +3327,10 @@ class Dataset[T] private[sql](
   }
 
   /**
-   * Returns a `hashCode` for the calculation performed by the query plan of this Dataset. Unlike
-   * the standard `hashCode`, an attempt has been made to eliminate cosmetic differences.
+   * Returns a `hashCode` of the logical query plan against this [[Dataset]].
    *
+   * @note Unlike the standard `hashCode`, the hash is calculated against the query plan
+   *       simplified by tolerating the cosmetic differences such as attribute names.
    * @since 3.1.0
    */
   @DeveloperApi

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1908,8 +1908,9 @@ class DatasetSuite extends QueryTest
     ds.queryExecution.analyzed
 
     assert(active eq SparkSession.getActiveSession.get)
+  }
 
-  test("sameSemantics and semanticHash work") {
+  test("SPARK-30791: sameSemantics and semanticHash work") {
     val df1 = Seq((1, 2), (4, 5)).toDF("col1", "col2")
     val df2 = Seq((1, 2), (4, 5)).toDF("col1", "col2")
     val df3 = Seq((0, 2), (4, 5)).toDF("col1", "col2")

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1908,6 +1908,20 @@ class DatasetSuite extends QueryTest
     ds.queryExecution.analyzed
 
     assert(active eq SparkSession.getActiveSession.get)
+
+  test("sameSemantics and semanticHash work") {
+    val df1 = Seq((1, 2), (4, 5)).toDF("col1", "col2")
+    val df2 = Seq((1, 2), (4, 5)).toDF("col1", "col2")
+    val df3 = Seq((0, 2), (4, 5)).toDF("col1", "col2")
+    val df4 = Seq((0, 2), (4, 5)).toDF("col0", "col2")
+
+    assert(df1.sameSemantics(df2) === true)
+    assert(df1.sameSemantics(df3) === false)
+    assert(df3.sameSemantics(df4) === true)
+
+    assert(df1.semanticHash === df2.semanticHash)
+    assert(df1.semanticHash !== df3.semanticHash)
+    assert(df3.semanticHash === df4.semanticHash)
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR added two DeveloperApis to the Dataset[T] class. Both methods are just exposing lower-level methods to the Dataset[T] class.

### Why are the changes needed?
They are useful for checking whether two dataframes are the same when implementing dataframe caching in python, and also get a unique ID. It's easier to use if we wrap the lower-level APIs.

### Does this PR introduce any user-facing change?
```
scala> val df1 = Seq((1,2),(4,5)).toDF("col1", "col2")
df1: org.apache.spark.sql.DataFrame = [col1: int, col2: int]

scala> val df2 = Seq((1,2),(4,5)).toDF("col1", "col2")
df2: org.apache.spark.sql.DataFrame = [col1: int, col2: int]

scala> val df3 = Seq((0,2),(4,5)).toDF("col1", "col2")
df3: org.apache.spark.sql.DataFrame = [col1: int, col2: int]

scala> val df4 = Seq((0,2),(4,5)).toDF("col0", "col2")
df4: org.apache.spark.sql.DataFrame = [col0: int, col2: int]

scala> df1.semanticHash
res0: Int = 594427822

scala> df2.semanticHash
res1: Int = 594427822

scala> df1.sameSemantics(df2)
res2: Boolean = true

scala> df1.sameSemantics(df3)
res3: Boolean = false

scala> df3.semanticHash
res4: Int = -1592702048

scala> df4.semanticHash
res5: Int = -1592702048

scala> df4.sameSemantics(df3)
res6: Boolean = true
```

### How was this patch tested?
Unit test in scala and doctest in python.

Note: comments are copied from the corresponding lower-level APIs.
Note: There are some issues to be fixed that would improve the hash collision rate: https://github.com/apache/spark/pull/27565#discussion_r379881028