### PR TITLE
[SPARK-30816][K8S][TESTS] Fix dev-run-integration-tests.sh to ignore empty params

### DIFF
--- a/resource-managers/kubernetes/integration-tests/dev/dev-run-integration-tests.sh
+++ b/resource-managers/kubernetes/integration-tests/dev/dev-run-integration-tests.sh
@@ -130,27 +130,27 @@ then
   properties=( ${properties[@]} -Dspark.kubernetes.test.javaImageTag=$JAVA_IMAGE_TAG )
 fi
 
-if [ -n $NAMESPACE ];
+if [ -n "$NAMESPACE" ];
 then
   properties=( ${properties[@]} -Dspark.kubernetes.test.namespace=$NAMESPACE )
 fi
 
-if [ -n $SERVICE_ACCOUNT ];
+if [ -n "$SERVICE_ACCOUNT" ];
 then
   properties=( ${properties[@]} -Dspark.kubernetes.test.serviceAccountName=$SERVICE_ACCOUNT )
 fi
 
-if [ -n $CONTEXT ];
+if [ -n "$CONTEXT" ];
 then
   properties=( ${properties[@]} -Dspark.kubernetes.test.kubeConfigContext=$CONTEXT )
 fi
 
-if [ -n $SPARK_MASTER ];
+if [ -n "$SPARK_MASTER" ];
 then
   properties=( ${properties[@]} -Dspark.kubernetes.test.master=$SPARK_MASTER )
 fi
 
-if [ -n $EXCLUDE_TAGS ];
+if [ -n "$EXCLUDE_TAGS" ];
 then
   properties=( ${properties[@]} -Dtest.exclude.tags=$EXCLUDE_TAGS )
 fi


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `dev-run-integration-tests.sh` to ignore empty params correctly.

### Why are the changes needed?

The following script runs `mvn` integration test like the following.
```
$ resource-managers/kubernetes/integration-tests/dev/dev-run-integration-tests.sh
...
build/mvn integration-test 
-f /Users/dongjoon/APACHE/spark/pom.xml 
-pl resource-managers/kubernetes/integration-tests 
-am
-Pscala-2.12
-Pkubernetes
-Pkubernetes-integration-tests 
-Djava.version=8 
-Dspark.kubernetes.test.sparkTgz=N/A 
-Dspark.kubernetes.test.imageTag=N/A 
-Dspark.kubernetes.test.imageRepo=docker.io/kubespark 
-Dspark.kubernetes.test.deployMode=minikube 
-Dtest.include.tags=k8s 
-Dspark.kubernetes.test.namespace= 
-Dspark.kubernetes.test.serviceAccountName= 
-Dspark.kubernetes.test.kubeConfigContext= 
-Dspark.kubernetes.test.master= 
-Dtest.exclude.tags= 
-Dspark.kubernetes.test.jvmImage=spark 
-Dspark.kubernetes.test.pythonImage=spark-py 
-Dspark.kubernetes.test.rImage=spark-r
```

After this PR, the empty parameters like the followings will be skipped like the original design.
```
-Dspark.kubernetes.test.namespace= 
-Dspark.kubernetes.test.serviceAccountName= 
-Dspark.kubernetes.test.kubeConfigContext= 
-Dspark.kubernetes.test.master= 
-Dtest.exclude.tags= 
```

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Pass the Jenkins K8S integration test.