### PR TITLE
[SPARK-30828][SQL] Improving insertInto behaviour

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -1379,6 +1379,25 @@ class DataFrameSuite extends QueryTest
     }
   }
 
+  test("insert into checks that the columns name of the query match the target table") {
+
+    val df = Seq((7, 9), (5, 57)).toDF("id", "p1")
+    val df1 = Seq(7, 8).toDF("p2")
+    val df2 = Seq((9, 8)).toDF("id", "p2")
+    df.write.mode("overwrite").saveAsTable("table")
+
+    val e1 = intercept[AnalysisException] {
+      df1.write.mode("overwrite").insertInto("table")
+    }
+    assert(e1.getMessage.contains("cannot resolve 'p2' given input columns: [id, p1];"))
+
+    val e2 = intercept[AnalysisException] {
+      df2.write.mode("overwrite").insertInto("table")
+    }
+    assert(e2.getMessage.contains("cannot resolve 'p2' given input columns: [id, p1];"))
+
+  }
+
   test("SPARK-8608: call `show` on local DataFrame with random columns should return same value") {
     val df = testData.select(rand(33))
     assert(df.showString(5) == df.showString(5))


### PR DESCRIPTION

### What changes were proposed in this pull request?
The only change is that I've added a column check when using insertInto. Now it checks that the query dataFrame has the same column names as the target table.


### Why are the changes needed?
They are needed because it helps a lot when you have a lot of columns, and if you have one missing the current message doesn't tell you which one. 
Also insertInto just check that the number of columns of both are the same, but not the order or anything.


### Does this PR introduce any user-facing change?
No

### How was this patch tested?
I added a test case just to show the new behaviour, obviously there will be more test added depending on the comments

Jira -> https://issues.apache.org/jira/browse/SPARK-30828
