### PR TITLE
[SPARK-30832][DOCS] SQL function doc headers should link to anchors

### DIFF
--- a/sql/mkdocs.yml
+++ b/sql/mkdocs.yml
@@ -17,3 +17,6 @@ site_name: Spark SQL, Built-in Functions
 theme: readthedocs
 pages:
   - 'Functions': 'index.md'
+markdown_extensions:
+  - toc:
+      anchorlink: True


### PR DESCRIPTION
### Why are the changes needed?

In most of our docs, you can click on a heading to immediately get an anchor link to that specific section of the docs. This is very handy when you are reading the docs and want to share a link to a specific part.

The SQL function docs are lacking this. This PR adds this convenience to the SQL function docs.

Here's the impact on the generated HTML.

Before this PR:

```html
<h3 id="array_join">array_join</h3>
```

After this PR:

```html
<h3 id="array_join"><a class="toclink" href="#array_join">array_join</a></h3>
```

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

I built the docs manually and reviewed the results in my browser.