### PR TITLE
[SPARK-30844][SQL]Static partition should also follow StoreAssignmentPolicy when insert into table

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -107,7 +107,7 @@ case class DataSourceAnalysis(conf: SQLConf) extends Rule[LogicalPlan] with Cast
         val partValue = potentialSpecs.head._2
         conf.storeAssignmentPolicy match {
           // SPARK-30844: try our best to follow StoreAssignmentPolicy for static partition
-          // values but not completely follow because we can't use`DataType.canWrite` due to
+          // values but not completely follow because we can't do static type checking due to
           // the reason that the parser has erased the type info of static partition values
           // and converted them to string.
           case StoreAssignmentPolicy.ANSI | StoreAssignmentPolicy.STRICT =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -60,8 +60,7 @@ case class DataSourceAnalysis(conf: SQLConf) extends Rule[LogicalPlan] with Cast
       sourceAttributes: Seq[Attribute],
       providedPartitions: Map[String, Option[String]],
       targetAttributes: Seq[Attribute],
-      targetPartitionSchema: StructType,
-      conf: SQLConf): Seq[NamedExpression] = {
+      targetPartitionSchema: StructType): Seq[NamedExpression] = {
 
     assert(providedPartitions.exists(_._2.isDefined))
 
@@ -184,8 +183,7 @@ case class DataSourceAnalysis(conf: SQLConf) extends Rule[LogicalPlan] with Cast
           sourceAttributes = query.output,
           providedPartitions = parts,
           targetAttributes = l.output,
-          targetPartitionSchema = t.partitionSchema,
-          conf)
+          targetPartitionSchema = t.partitionSchema)
         Project(projectList, query)
       } else {
         query

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -106,6 +106,10 @@ case class DataSourceAnalysis(conf: SQLConf) extends Rule[LogicalPlan] with Cast
       } else if (potentialSpecs.size == 1) {
         val partValue = potentialSpecs.head._2
         conf.storeAssignmentPolicy match {
+          // SPARK-30844: try our best to follow StoreAssignmentPolicy for static partition
+          // values but not completely follow because we can't use`DataType.canWrite` due to
+          // the reason that the parser has erased the type info of static partition values
+          // and converted them to string.
           case StoreAssignmentPolicy.ANSI | StoreAssignmentPolicy.STRICT =>
             Some(Alias(AnsiCast(Literal(partValue), field.dataType,
               Option(conf.sessionLocalTimeZone)), field.name)())

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/DataSourceAnalysisSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/DataSourceAnalysisSuite.scala
@@ -69,8 +69,7 @@ class DataSourceAnalysisSuite extends SparkFunSuite with BeforeAndAfterAll {
           sourceAttributes = Seq('e.int, 'f.int),
           providedPartitions = Map("b" -> None, "c" -> None),
           targetAttributes = targetAttributes,
-          targetPartitionSchema = targetPartitionSchema,
-          conf)
+          targetPartitionSchema = targetPartitionSchema)
       }
     }
 
@@ -81,8 +80,7 @@ class DataSourceAnalysisSuite extends SparkFunSuite with BeforeAndAfterAll {
           sourceAttributes = Seq('e.int),
           providedPartitions = Map("b" -> Some("1"), "c" -> None),
           targetAttributes = targetAttributes,
-          targetPartitionSchema = targetPartitionSchema,
-          conf)
+          targetPartitionSchema = targetPartitionSchema)
       }
     }
 
@@ -93,8 +91,7 @@ class DataSourceAnalysisSuite extends SparkFunSuite with BeforeAndAfterAll {
           sourceAttributes = Seq('e.int, 'f.int),
           providedPartitions = Map("b" -> Some("1")),
           targetAttributes = targetAttributes,
-          targetPartitionSchema = targetPartitionSchema,
-          conf)
+          targetPartitionSchema = targetPartitionSchema)
       }
 
       // Missing partitioning columns.
@@ -103,8 +100,7 @@ class DataSourceAnalysisSuite extends SparkFunSuite with BeforeAndAfterAll {
           sourceAttributes = Seq('e.int, 'f.int, 'g.int),
           providedPartitions = Map("b" -> Some("1")),
           targetAttributes = targetAttributes,
-          targetPartitionSchema = targetPartitionSchema,
-          conf)
+          targetPartitionSchema = targetPartitionSchema)
       }
 
       // Wrong partitioning columns.
@@ -113,8 +109,7 @@ class DataSourceAnalysisSuite extends SparkFunSuite with BeforeAndAfterAll {
           sourceAttributes = Seq('e.int, 'f.int),
           providedPartitions = Map("b" -> Some("1"), "d" -> None),
           targetAttributes = targetAttributes,
-          targetPartitionSchema = targetPartitionSchema,
-          conf)
+          targetPartitionSchema = targetPartitionSchema)
       }
     }
 
@@ -125,8 +120,7 @@ class DataSourceAnalysisSuite extends SparkFunSuite with BeforeAndAfterAll {
           sourceAttributes = Seq('e.int, 'f.int),
           providedPartitions = Map("b" -> Some("1"), "d" -> Some("2")),
           targetAttributes = targetAttributes,
-          targetPartitionSchema = targetPartitionSchema,
-          conf)
+          targetPartitionSchema = targetPartitionSchema)
       }
 
       // Wrong partitioning columns.
@@ -135,8 +129,7 @@ class DataSourceAnalysisSuite extends SparkFunSuite with BeforeAndAfterAll {
           sourceAttributes = Seq('e.int),
           providedPartitions = Map("b" -> Some("1"), "c" -> Some("3"), "d" -> Some("2")),
           targetAttributes = targetAttributes,
-          targetPartitionSchema = targetPartitionSchema,
-          conf)
+          targetPartitionSchema = targetPartitionSchema)
       }
 
       if (caseSensitive) {
@@ -146,8 +139,7 @@ class DataSourceAnalysisSuite extends SparkFunSuite with BeforeAndAfterAll {
             sourceAttributes = Seq('e.int, 'f.int),
             providedPartitions = Map("b" -> Some("1"), "C" -> Some("3")),
             targetAttributes = targetAttributes,
-            targetPartitionSchema = targetPartitionSchema,
-            conf)
+            targetPartitionSchema = targetPartitionSchema)
         }
       }
     }
@@ -161,8 +153,7 @@ class DataSourceAnalysisSuite extends SparkFunSuite with BeforeAndAfterAll {
           sourceAttributes = Seq('e.int, 'f.int),
           providedPartitions = Map("b" -> None, "c" -> Some("3")),
           targetAttributes = targetAttributes,
-          targetPartitionSchema = targetPartitionSchema,
-          conf)
+          targetPartitionSchema = targetPartitionSchema)
       }
     }
 
@@ -175,8 +166,7 @@ class DataSourceAnalysisSuite extends SparkFunSuite with BeforeAndAfterAll {
           sourceAttributes = nonPartitionedAttributes,
           providedPartitions = Map("b" -> Some("1"), "C" -> Some("3")),
           targetAttributes = targetAttributes,
-          targetPartitionSchema = targetPartitionSchema,
-          conf)
+          targetPartitionSchema = targetPartitionSchema)
         checkProjectList(actual, expected)
       }
 
@@ -188,8 +178,7 @@ class DataSourceAnalysisSuite extends SparkFunSuite with BeforeAndAfterAll {
           sourceAttributes = nonPartitionedAttributes,
           providedPartitions = Map("b" -> Some("1"), "c" -> Some("3")),
           targetAttributes = targetAttributes,
-          targetPartitionSchema = targetPartitionSchema,
-          conf)
+          targetPartitionSchema = targetPartitionSchema)
         checkProjectList(actual, expected)
       }
 
@@ -201,8 +190,7 @@ class DataSourceAnalysisSuite extends SparkFunSuite with BeforeAndAfterAll {
           sourceAttributes = nonPartitionedAttributes,
           providedPartitions = Map("b" -> Some("1")),
           targetAttributes = Seq('a.int, 'd.int, 'b.int),
-          targetPartitionSchema = new StructType().add("b", IntegerType),
-          conf)
+          targetPartitionSchema = new StructType().add("b", IntegerType))
         checkProjectList(actual, expected)
       }
     }
@@ -218,8 +206,7 @@ class DataSourceAnalysisSuite extends SparkFunSuite with BeforeAndAfterAll {
         sourceAttributes = nonPartitionedAttributes ++ dynamicPartitionAttributes,
         providedPartitions = Map("b" -> Some("1"), "c" -> None),
         targetAttributes = targetAttributes,
-        targetPartitionSchema = targetPartitionSchema,
-        conf)
+        targetPartitionSchema = targetPartitionSchema)
       checkProjectList(actual, expected)
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Make static partition also follows `StoreAssignmentPolicy` when insert into table:

if `StoreAssignmentPolicy=LEGACY`, using `Cast`;
if `StoreAssignmentPolicy=ANSI | STRIC`, using `AnsiCast`;

E.g., for the table `t` created by:

```
create table t(a int, b string) using parquet partitioned by (a)
```
and insert values with `StoreAssignmentPolicy=ANSI` using:
```
insert into t partition(a='ansi') values('ansi')
```

Before this PR:

```
+----+----+
|   b|   a|
+----+----+
|ansi|null|
+----+----+
```

After this PR, insert will fail by:
```
java.lang.NumberFormatException: invalid input syntax for type numeric: ansi
```

(It should be better if we could use `TableOutputResolver.checkField` to fully follow `StoreAssignmentPolicy`. But since we lost the data type of static partition's value at first place, it's hard to use `TableOutputResolver.checkField`.)


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

I think we should follow `StoreAssignmentPolicy` when insert into table for any columns, including static partition.


### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Added new test.