### PR TITLE
[SPARK-30846][CORE] Add AccumulatorV2 API in JavaSparkContext

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
@@ -36,6 +36,7 @@ import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.input.PortableDataStream
 import org.apache.spark.rdd.{EmptyRDD, HadoopRDD, NewHadoopRDD}
 import org.apache.spark.resource.ResourceInformation
+import org.apache.spark.util.{AccumulatorV2, CollectionAccumulator, DoubleAccumulator, LongAccumulator}
 
 /**
  * A Java-friendly version of [[org.apache.spark.SparkContext]] that returns
@@ -142,6 +143,79 @@ class JavaSparkContext(val sc: SparkContext) extends Closeable {
     JavaRDD.fromRDD(new EmptyRDD[T](sc))
   }
 
+  /**
+   * Register the given accumulator.
+   *
+   * @note Accumulators must be registered before use, or it will throw exception.
+   */
+  def register(acc: AccumulatorV2[_, _]): Unit = {
+    sc.register(acc)
+  }
+
+  /**
+   * Register the given accumulator with given name.
+   *
+   * @note Accumulators must be registered before use, or it will throw exception.
+   */
+  def register(acc: AccumulatorV2[_, _], name: String): Unit = {
+    sc.register(acc, name)
+  }
+
+  /**
+   * Create and register a long accumulator, which starts with 0 and accumulates inputs by `add`.
+   */
+  def longAccumulator: LongAccumulator = {
+    val acc = new LongAccumulator
+    register(acc)
+    acc
+  }
+
+  /**
+   * Create and register a long accumulator, which starts with 0 and accumulates inputs by `add`.
+   */
+  def longAccumulator(name: String): LongAccumulator = {
+    val acc = new LongAccumulator
+    register(acc, name)
+    acc
+  }
+
+  /**
+   * Create and register a double accumulator, which starts with 0 and accumulates inputs by `add`.
+   */
+  def doubleAccumulator: DoubleAccumulator = {
+    val acc = new DoubleAccumulator
+    register(acc)
+    acc
+  }
+
+  /**
+   * Create and register a double accumulator, which starts with 0 and accumulates inputs by `add`.
+   */
+  def doubleAccumulator(name: String): DoubleAccumulator = {
+    val acc = new DoubleAccumulator
+    register(acc, name)
+    acc
+  }
+
+  /**
+   * Create and register a `CollectionAccumulator`, which starts with empty list and accumulates
+   * inputs by adding them into the list.
+   */
+  def collectionAccumulator[T]: CollectionAccumulator[T] = {
+    val acc = new CollectionAccumulator[T]
+    register(acc)
+    acc
+  }
+
+  /**
+   * Create and register a `CollectionAccumulator`, which starts with empty list and accumulates
+   * inputs by adding them into the list.
+   */
+  def collectionAccumulator[T](name: String): CollectionAccumulator[T] = {
+    val acc = new CollectionAccumulator[T]
+    register(acc, name)
+    acc
+  }
 
   /** Distribute a local Scala collection to form an RDD. */
   def parallelize[T](list: java.util.List[T]): JavaRDD[T] =

--- a/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
@@ -165,36 +165,28 @@ class JavaSparkContext(val sc: SparkContext) extends Closeable {
    * Create and register a long accumulator, which starts with 0 and accumulates inputs by `add`.
    */
   def longAccumulator: LongAccumulator = {
-    val acc = new LongAccumulator
-    register(acc)
-    acc
+    sc.longAccumulator
   }
 
   /**
    * Create and register a long accumulator, which starts with 0 and accumulates inputs by `add`.
    */
   def longAccumulator(name: String): LongAccumulator = {
-    val acc = new LongAccumulator
-    register(acc, name)
-    acc
+    sc.longAccumulator(name)
   }
 
   /**
    * Create and register a double accumulator, which starts with 0 and accumulates inputs by `add`.
    */
   def doubleAccumulator: DoubleAccumulator = {
-    val acc = new DoubleAccumulator
-    register(acc)
-    acc
+    sc.doubleAccumulator
   }
 
   /**
    * Create and register a double accumulator, which starts with 0 and accumulates inputs by `add`.
    */
   def doubleAccumulator(name: String): DoubleAccumulator = {
-    val acc = new DoubleAccumulator
-    register(acc, name)
-    acc
+    sc.doubleAccumulator(name)
   }
 
   /**
@@ -202,9 +194,7 @@ class JavaSparkContext(val sc: SparkContext) extends Closeable {
    * inputs by adding them into the list.
    */
   def collectionAccumulator[T]: CollectionAccumulator[T] = {
-    val acc = new CollectionAccumulator[T]
-    register(acc)
-    acc
+    sc.collectionAccumulator
   }
 
   /**
@@ -212,9 +202,7 @@ class JavaSparkContext(val sc: SparkContext) extends Closeable {
    * inputs by adding them into the list.
    */
   def collectionAccumulator[T](name: String): CollectionAccumulator[T] = {
-    val acc = new CollectionAccumulator[T]
-    register(acc, name)
-    acc
+    sc.collectionAccumulator(name)
   }
 
   /** Distribute a local Scala collection to form an RDD. */

--- a/core/src/test/java/test/org/apache/spark/JavaAPISuite.java
+++ b/core/src/test/java/test/org/apache/spark/JavaAPISuite.java
@@ -280,7 +280,7 @@ public class JavaAPISuite implements Serializable {
 
   @Test
   public void foreach() {
-    LongAccumulator accum = sc.sc().longAccumulator();
+    LongAccumulator accum = sc.longAccumulator();
     JavaRDD<String> rdd = sc.parallelize(Arrays.asList("Hello", "World"));
     rdd.foreach(s -> accum.add(1));
     assertEquals(2, accum.value().intValue());
@@ -288,7 +288,7 @@ public class JavaAPISuite implements Serializable {
 
   @Test
   public void foreachPartition() {
-    LongAccumulator accum = sc.sc().longAccumulator();
+    LongAccumulator accum = sc.longAccumulator();
     JavaRDD<String> rdd = sc.parallelize(Arrays.asList("Hello", "World"));
     rdd.foreachPartition(iter -> {
       while (iter.hasNext()) {

--- a/docs/rdd-programming-guide.md
+++ b/docs/rdd-programming-guide.md
@@ -1446,7 +1446,7 @@ using its `value` method.
 The code below shows an accumulator being used to add up the elements of an array:
 
 {% highlight java %}
-LongAccumulator accum = jsc.sc().longAccumulator();
+LongAccumulator accum = jsc.longAccumulator();
 
 sc.parallelize(Arrays.asList(1, 2, 3, 4)).foreach(x -> accum.add(x));
 // ...
@@ -1555,7 +1555,7 @@ data.map { x => accum.add(x); x }
 
 <div data-lang="java"  markdown="1">
 {% highlight java %}
-LongAccumulator accum = jsc.sc().longAccumulator();
+LongAccumulator accum = jsc.longAccumulator();
 data.map(x -> { accum.add(x); return f(x); });
 // Here, accum is still 0 because no actions have caused the `map` to be computed.
 {% endhighlight %}

--- a/docs/streaming-programming-guide.md
+++ b/docs/streaming-programming-guide.md
@@ -1904,7 +1904,7 @@ class JavaDroppedWordsCounter {
     if (instance == null) {
       synchronized (JavaDroppedWordsCounter.class) {
         if (instance == null) {
-          instance = jsc.sc().longAccumulator("WordsInBlacklistCounter");
+          instance = jsc.longAccumulator("WordsInBlacklistCounter");
         }
       }
     }

--- a/examples/src/main/java/org/apache/spark/examples/streaming/JavaRecoverableNetworkWordCount.java
+++ b/examples/src/main/java/org/apache/spark/examples/streaming/JavaRecoverableNetworkWordCount.java
@@ -69,7 +69,7 @@ class JavaDroppedWordsCounter {
     if (instance == null) {
       synchronized (JavaDroppedWordsCounter.class) {
         if (instance == null) {
-          instance = jsc.sc().longAccumulator("WordsInBlacklistCounter");
+          instance = jsc.longAccumulator("WordsInBlacklistCounter");
         }
       }
     }

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -498,7 +498,10 @@ object MimaExcludes {
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.streaming.StreamingQueryListener#QueryStartedEvent.this"),
 
     // [SPARK-30667][CORE] Add allGather method to BarrierTaskContext
-    ProblemFilters.exclude[IncompatibleTemplateDefProblem]("org.apache.spark.RequestToSync")
+    ProblemFilters.exclude[IncompatibleTemplateDefProblem]("org.apache.spark.RequestToSync"),
+
+    // [SPARK-30846][CORE] Add AccumulatorV2 API in JavaSparkContext
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.spark.api.java.JavaSparkContext.doubleAccumulator")
   )
 
   // Exclude rules for 2.4.x

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
@@ -142,7 +142,7 @@ public class JavaDatasetSuite implements Serializable {
 
   @Test
   public void testForeach() {
-    LongAccumulator accum = jsc.sc().longAccumulator();
+    LongAccumulator accum = jsc.longAccumulator();
     List<String> data = Arrays.asList("a", "b", "c");
     Dataset<String> ds = spark.createDataset(data, Encoders.STRING());
 

--- a/streaming/src/test/java/test/org/apache/spark/streaming/JavaAPISuite.java
+++ b/streaming/src/test/java/test/org/apache/spark/streaming/JavaAPISuite.java
@@ -618,8 +618,8 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
   @SuppressWarnings("unchecked")
   @Test
   public void testForeachRDD() {
-    final LongAccumulator accumRdd = ssc.sparkContext().sc().longAccumulator();
-    final LongAccumulator accumEle = ssc.sparkContext().sc().longAccumulator();
+    final LongAccumulator accumRdd = ssc.sparkContext().longAccumulator();
+    final LongAccumulator accumEle = ssc.sparkContext().longAccumulator();
     List<List<Integer>> inputData = Arrays.asList(
         Arrays.asList(1,1,1),
         Arrays.asList(1,1,1));


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Add `AccumulatorV2` API in `JavaSparkContext` and replace old usage of AccumulatorV2 in Java with the new API.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Officially, we should add any APIs in `SparkContext` to `JavaSparkContext`. And with the API, Java user could directly use `AccumulatorV2`, e.g. `JavaSparkContext.longAccumulator`,  comparing to current way, `JavaSparkContext.sc().longAccumulator`.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

Yes. Java user could directly use `AccumulatorV2`.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Updated exist tests.
