### PR TITLE
[SPARK-30851][ML] Add 'path' field to the 'LoadInstanceEnd' ML listener event

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/events.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/events.scala
@@ -89,7 +89,7 @@ case class LoadInstanceStart[T](path: String) extends MLEvent {
  * Event fired after `MLReader.load`.
  */
 @Unstable
-case class LoadInstanceEnd[T]() extends MLEvent {
+case class LoadInstanceEnd[T](path: String) extends MLEvent {
   @JsonIgnore var reader: MLReader[T] = _
   @JsonIgnore var instance: T = _
 }
@@ -160,7 +160,7 @@ private[ml] trait MLEvents extends Logging {
     logEvent(startEvent)
     listenerBus.post(startEvent)
     val instance: T = func
-    val endEvent = LoadInstanceEnd[T]()
+    val endEvent = LoadInstanceEnd[T](path)
     endEvent.reader = reader
     endEvent.instance = instance
     logEvent(endEvent)

--- a/mllib/src/test/scala/org/apache/spark/ml/MLEventsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/MLEventsSuite.scala
@@ -252,6 +252,7 @@ class MLEventsSuite
           case e: LoadInstanceEnd[_]
               if e.reader.isInstanceOf[DefaultParamsReader[_]] =>
             assert(e.instance.isInstanceOf[PipelineStage])
+            assert(e.path.endsWith("writableStage"))
           case e: LoadInstanceStart[_] =>
             assert(e.reader === pipelineReader)
           case e: LoadInstanceEnd[_] =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add 'path' field to the 'LoadInstanceEnd' ML listener event.


### Why are the changes needed?
The [LoadInstanceEnd](https://github.com/apache/spark/blob/master/mllib/src/main/scala/org/apache/spark/ml/events.scala#L92) ML listener event that is added on the scope of SPARK-23674 has no 'path' field which makes it impossible to determine from what path an ML instance was loaded as well as there is no way to get instance's 'uid' via [LoadInstanceStart](https://github.com/apache/spark/blob/master/mllib/src/main/scala/org/apache/spark/ml/events.scala#L84) event.

The [LoadInstanceEnd](https://github.com/apache/spark/blob/master/mllib/src/main/scala/org/apache/spark/ml/events.scala#L92) must be changed to include 'path' field. Please, refer [SaveInstanceStart](https://github.com/apache/spark/blob/master/mllib/src/main/scala/org/apache/spark/ml/events.scala#L101) and [SaveInstanceEnd](https://github.com/apache/spark/blob/master/mllib/src/main/scala/org/apache/spark/ml/events.scala#L109) events. Both of them have `path` but [LoadInstanceStart](https://github.com/apache/spark/blob/master/mllib/src/main/scala/org/apache/spark/ml/events.scala#L84) and [LoadInstanceEnd](https://github.com/apache/spark/blob/master/mllib/src/main/scala/org/apache/spark/ml/events.scala#L92) are not.

### Does this PR introduce any user-facing change?
No.


### How was this patch tested?
Manually tested and existing unit test modified.
