### PR TITLE
[SPARK-30849][CORE][SHUFFLE]Fix application failed due to failed to get MapStatuses broadcast block

### DIFF
--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -805,8 +805,8 @@ private[spark] class MapOutputTrackerWorker(conf: SparkConf) extends MapOutputTr
       endPartition: Int)
     : Iterator[(BlockManagerId, Seq[(BlockId, Long, Int)])] = {
     logDebug(s"Fetching outputs for shuffle $shuffleId, partitions $startPartition-$endPartition")
-    val statuses = getStatuses(shuffleId, conf)
     try {
+      val statuses = getStatuses(shuffleId, conf)
       MapOutputTracker.convertMapStatuses(
         shuffleId, startPartition, endPartition, statuses, 0, statuses.length)
     } catch {

--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -857,7 +857,7 @@ private[spark] class MapOutputTrackerWorker(conf: SparkConf) extends MapOutputTr
             fetchedStatuses = MapOutputTracker.deserializeMapStatuses(fetchedBytes, conf)
           } catch {
             case e: IOException if
-            Throwables.getCausalChain(e).asScala.exists(_.isInstanceOf[BlockNotFoundException]) =>
+              Throwables.getCausalChain(e).asScala.exists(_.isInstanceOf[BlockNotFoundException]) =>
               mapStatuses.clear()
               throw new MetadataFetchFailedException(
                 shuffleId, -1, Throwables.getStackTraceAsString(e))

--- a/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
@@ -186,7 +186,7 @@ private[spark] class TorrentBroadcast[T: ClassTag](obj: T, id: Long)
               }
               blocks(pid) = new ByteBufferBlockData(b, true)
             case None =>
-              throw new SparkException(s"Failed to get $pieceId of $broadcastId")
+              throw new BlockNotFoundException(pieceId.toString)
           }
       }
     }

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -374,7 +374,8 @@ class MapOutputTrackerSuite extends SparkFunSuite {
         .askSync(ArgumentMatchers.eq(GetMapOutputStatuses(20)))(any())
 
       // Should throw MetadataFetchFailedException because the block is missing.
-      val exception = intercept[MetadataFetchFailedException](workerTracker.getMapSizesByExecutorId(20, 0))
+      val exception = intercept[MetadataFetchFailedException](
+        workerTracker.getMapSizesByExecutorId(20, 0))
       assert(Utils.exceptionString(exception)
         .contains(classOf[BlockNotFoundException].getSimpleName))
     }


### PR DESCRIPTION


### What changes were proposed in this pull request?

As described in [SPARK-30849](https://issues.apache.org/jira/browse/SPARK-30849), spark application will sometimes failed due to failed to get mapStatuses broadcast block. 
```
Job aborted due to stage failure: Task 18 in stage 2.0 failed 4 times, most recent failure: Lost task 18.3 in stage 2.0 (TID 13819, xxxx , executor 8): java.io.IOException: org.apache.spark.SparkException: Failed to get broadcast_9_piece1 of broadcast_9
java.io.IOException: org.apache.spark.SparkException: Failed to get broadcast_9_piece1 of broadcast_9
	at org.apache.spark.util.Utils$.tryOrIOException(Utils.scala:1287)
	at org.apache.spark.broadcast.TorrentBroadcast.readBroadcastBlock(TorrentBroadcast.scala:206)
	at org.apache.spark.broadcast.TorrentBroadcast._value$lzycompute(TorrentBroadcast.scala:66)
	at org.apache.spark.broadcast.TorrentBroadcast._value(TorrentBroadcast.scala:66)
	at org.apache.spark.broadcast.TorrentBroadcast.getValue(TorrentBroadcast.scala:96)
	at org.apache.spark.broadcast.Broadcast.value(Broadcast.scala:70)
	at org.apache.spark.MapOutputTracker$$anonfun$deserializeMapStatuses$1.apply(MapOutputTracker.scala:775)
	at org.apache.spark.MapOutputTracker$$anonfun$deserializeMapStatuses$1.apply(MapOutputTracker.scala:775)
	at org.apache.spark.internal.Logging$class.logInfo(Logging.scala:54)
	at org.apache.spark.MapOutputTracker$.logInfo(MapOutputTracker.scala:712)
	at org.apache.spark.MapOutputTracker$.deserializeMapStatuses(MapOutputTracker.scala:774)
	at org.apache.spark.MapOutputTrackerWorker.getStatuses(MapOutputTracker.scala:665)
	at org.apache.spark.MapOutputTrackerWorker.getMapSizesByExecutorId(MapOutputTracker.scala:603)
	at org.apache.spark.shuffle.BlockStoreShuffleReader.read(BlockStoreShuffleReader.scala:57)
	at org.apache.spark.rdd.ShuffledRDD.compute(ShuffledRDD.scala:109)
```
This is caused by the mapStatuses broadcast id is sent to executor, but was invalidated immediately by the driver before the real fetching of the broadcast.

This PR will try to fix this issue.


### Why are the changes needed?
Bugfix


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
UT
