### PR TITLE
[SPARK-30857][SQL][2.4] Fix truncations of timestamps before the epoch to hours and days

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -1019,11 +1019,11 @@ object DateTimeUtils {
       case TRUNC_TO_DAY =>
         val offset = timeZone.getOffset(millis)
         millis += offset
-        millis - millis % (MILLIS_PER_SECOND * SECONDS_PER_DAY) - offset
+        millis - Math.floorMod(millis, MILLIS_PER_SECOND * SECONDS_PER_DAY) - offset
       case TRUNC_TO_HOUR =>
         val offset = timeZone.getOffset(millis)
         millis += offset
-        millis - millis % (60 * 60 * MILLIS_PER_SECOND) - offset
+        millis - Math.floorMod(millis, 60 * 60 * MILLIS_PER_SECOND) - offset
       case TRUNC_TO_MINUTE =>
         millis - millis % (60 * MILLIS_PER_SECOND)
       case TRUNC_TO_SECOND =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
@@ -730,7 +730,7 @@ class DateFunctionsSuite extends QueryTest with SharedSQLContext {
         Row(Timestamp.valueOf("2015-07-24 22:00:00"))))
   }
 
-  test("SPARK-30793: truncate timestamps before the epoch to seconds and minutes") {
+  test("SPARK-30793, SPARK-30857: truncate timestamps before the epoch") {
     def checkTrunc(level: String, expected: String): Unit = {
       val df = Seq("1961-04-12 00:01:02.345")
         .toDF()
@@ -741,17 +741,6 @@ class DateFunctionsSuite extends QueryTest with SharedSQLContext {
 
     checkTrunc("SECOND", "1961-04-12 00:01:02")
     checkTrunc("MINUTE", "1961-04-12 00:01:00")
-  }
-
-  test("SPARK-30857: truncate timestamps before the epoch to hours and days") {
-    def checkTrunc(level: String, expected: String): Unit = {
-      val df = Seq("1961-04-12 00:01:02.345")
-        .toDF()
-        .select($"value".cast("timestamp").as("ts"))
-        .select(date_trunc(level, $"ts").cast("string"))
-      checkAnswer(df, Row(expected))
-    }
-
     checkTrunc("HOUR", "1961-04-12 00:00:00")
     checkTrunc("DAY", "1961-04-12 00:00:00")
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
@@ -729,4 +729,17 @@ class DateFunctionsSuite extends QueryTest with SharedSQLContext {
         Row(Timestamp.valueOf("2015-07-24 07:00:00")),
         Row(Timestamp.valueOf("2015-07-24 22:00:00"))))
   }
+
+  test("SPARK-30857: truncate timestamps before the epoch to hours and days") {
+    def checkTrunc(level: String, expected: String): Unit = {
+      val df = Seq("1961-04-12 00:01:02.345")
+        .toDF()
+        .select($"value".cast("timestamp").as("ts"))
+        .select(date_trunc(level, $"ts").cast("string"))
+      checkAnswer(df, Row(expected))
+    }
+
+    checkTrunc("HOUR", "1961-04-12 00:00:00")
+    checkTrunc("DAY", "1961-04-12 00:00:00")
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to replace `%` by `Math.floorMod` in `DateTimeUtils.truncTimestamp` for the `HOUR` and `DAY` levels.

### Why are the changes needed?
This fixes the issue of incorrect truncation of timestamps before the epoch `1970-01-01T00:00:00.000000Z` to the `HOUR` and `DAY` levels. For example, timestamps after the epoch are truncated by cutting off the rest part of the timestamp:
```sql
spark-sql> select date_trunc('HOUR', '2020-02-11 00:01:02.123'), date_trunc('HOUR', '2020-02-11 00:01:02.789');
2020-02-11 00:00:00	2020-02-11 00:00:00
```
but hours in the truncated timestamp before the epoch are increased by 1:
```sql
spark-sql> select date_trunc('HOUR', '1960-02-11 00:01:02.123'), date_trunc('HOUR', '1960-02-11 00:01:02.789');
1960-02-11 01:00:00	1960-02-11 01:00:00
```

### Does this PR introduce any user-facing change?
Yes. After the changes, the example above outputs correct result:
```sql
spark-sql> select date_trunc('HOUR', '1960-02-11 00:01:02.123');
1960-02-11 00:00:00
```

### How was this patch tested?
Added new tests to `DateFunctionsSuite`.