### PR TITLE
[SPARK-30731] Update deprecated Mkdocs option

### DIFF
--- a/sql/mkdocs.yml
+++ b/sql/mkdocs.yml
@@ -15,7 +15,7 @@
 
 site_name: Spark SQL, Built-in Functions
 theme: readthedocs
-pages:
+nav:
   - 'Functions': 'index.md'
 markdown_extensions:
   - toc:


### PR DESCRIPTION
Split from #27534.

### What changes were proposed in this pull request?

This PR updates a deprecated Mkdocs option to use the new name.

### Why are the changes needed?

This change will prevent the docs from failing to build when we update to a version of Mkdocs that no longer supports the deprecated option.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

I built the docs locally and reviewed them in my browser.