### PR TITLE
[SPARK-30874][SQL] Support Postgres Kerberos login in JDBC connector

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/SecurityUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/SecurityUtils.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util
+
+import org.apache.spark.internal.Logging
+
+/**
+ * Various utility methods used by Spark Security.
+ */
+private[spark] object SecurityUtils extends Logging {
+  private val JAVA_VENDOR = "java.vendor"
+  private val IBM_KRB_DEBUG_CONFIG = "com.ibm.security.krb5.Krb5Debug"
+  private val SUN_KRB_DEBUG_CONFIG = "sun.security.krb5.debug"
+
+  def setGlobalKrbDebug(enabled: Boolean): Unit = {
+    if (enabled) {
+      if (isIBMVendor()) {
+        System.setProperty(IBM_KRB_DEBUG_CONFIG, "all")
+      } else {
+        System.setProperty(SUN_KRB_DEBUG_CONFIG, "true")
+      }
+    } else {
+      if (isIBMVendor()) {
+        System.clearProperty(IBM_KRB_DEBUG_CONFIG)
+      } else {
+        System.clearProperty(SUN_KRB_DEBUG_CONFIG)
+      }
+    }
+  }
+
+  def isGlobalKrbDebugEnabled(): Boolean = {
+    if (isIBMVendor()) {
+      val debug = System.getenv(IBM_KRB_DEBUG_CONFIG)
+      debug != null && debug.equalsIgnoreCase("all")
+    } else {
+      val debug = System.getenv(SUN_KRB_DEBUG_CONFIG)
+      debug != null && debug.equalsIgnoreCase("true")
+    }
+  }
+
+  /**
+   * Krb5LoginModule package vary in different JVMs.
+   * Please see Hadoop UserGroupInformation for further details.
+   */
+  def getKrb5LoginModuleName(): String = {
+    if (isIBMVendor()) {
+      "com.ibm.security.auth.module.Krb5LoginModule"
+    } else {
+      "com.sun.security.auth.module.Krb5LoginModule"
+    }
+  }
+
+  private def isIBMVendor(): Boolean = {
+    System.getProperty(JAVA_VENDOR).contains("IBM")
+  }
+}

--- a/core/src/main/scala/org/apache/spark/util/SecurityUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/SecurityUtils.scala
@@ -17,12 +17,10 @@
 
 package org.apache.spark.util
 
-import org.apache.spark.internal.Logging
-
 /**
  * Various utility methods used by Spark Security.
  */
-private[spark] object SecurityUtils extends Logging {
+private[spark] object SecurityUtils {
   private val JAVA_VENDOR = "java.vendor"
   private val IBM_KRB_DEBUG_CONFIG = "com.ibm.security.krb5.Krb5Debug"
   private val SUN_KRB_DEBUG_CONFIG = "sun.security.krb5.debug"

--- a/core/src/main/scala/org/apache/spark/util/SecurityUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/SecurityUtils.scala
@@ -54,7 +54,7 @@ private[spark] object SecurityUtils extends Logging {
   }
 
   /**
-   * Krb5LoginModule package vary in different JVMs.
+   * Krb5LoginModule package varies in different JVMs.
    * Please see Hadoop UserGroupInformation for further details.
    */
   def getKrb5LoginModuleName(): String = {

--- a/docs/sql-data-sources-jdbc.md
+++ b/docs/sql-data-sources-jdbc.md
@@ -201,7 +201,7 @@ the following case-insensitive options:
   <tr>
     <td><code>keytab</code></td>
     <td>
-     Location of the kerberos keytab file (which must be pre-uploaded to all nodes either by <code>--files</code> option of spark-submit or manually) for the JDBC client. If both <code>keytab</code> and <code>principal</code> are defined then Spark tries to do kerberos authentication.
+     Location of the kerberos keytab file (which must be pre-uploaded to all nodes either by <code>--files</code> option of spark-submit or manually) for the JDBC client. When path information found then Spark considers the keytab distributed manually, otherwise <code>--files</code> assumed. If both <code>keytab</code> and <code>principal</code> are defined then Spark tries to do kerberos authentication.
     </td>
   </tr>
 

--- a/docs/sql-data-sources-jdbc.md
+++ b/docs/sql-data-sources-jdbc.md
@@ -201,14 +201,14 @@ the following case-insensitive options:
   <tr>
     <td><code>keytab</code></td>
     <td>
-     Location of the kerberos keytab file (which must be pre-uploaded to all nodes either by <code>--files</code> option of spark-submit or manually) for the JDBC client. If both <code>keytab</code> and <code>principal</code> defined then Spark tries to do kerberos authentication.
+     Location of the kerberos keytab file (which must be pre-uploaded to all nodes either by <code>--files</code> option of spark-submit or manually) for the JDBC client. If both <code>keytab</code> and <code>principal</code> are defined then Spark tries to do kerberos authentication.
     </td>
   </tr>
 
   <tr>
     <td><code>principal</code></td>
     <td>
-     Specifies kerberos principal name for the JDBC client. If both <code>keytab</code> and <code>principal</code> defined then Spark tries to do kerberos authentication.
+     Specifies kerberos principal name for the JDBC client. If both <code>keytab</code> and <code>principal</code> are defined then Spark tries to do kerberos authentication.
     </td>
   </tr>
 </table>

--- a/docs/sql-data-sources-jdbc.md
+++ b/docs/sql-data-sources-jdbc.md
@@ -197,6 +197,20 @@ the following case-insensitive options:
      The option to enable or disable predicate push-down into the JDBC data source. The default value is true, in which case Spark will push down filters to the JDBC data source as much as possible. Otherwise, if set to false, no filter will be pushed down to the JDBC data source and thus all filters will be handled by Spark. Predicate push-down is usually turned off when the predicate filtering is performed faster by Spark than by the JDBC data source.
     </td>
   </tr>
+
+  <tr>
+    <td><code>keytab</code></td>
+    <td>
+     Location of the kerberos keytab file (which must be pre-uploaded to all nodes either by <code>--files</code> option of spark-submit or manually) for the JDBC client. If both <code>keytab</code> and <code>principal</code> defined then Spark tries to do kerberos authentication.
+    </td>
+  </tr>
+
+  <tr>
+    <td><code>principal</code></td>
+    <td>
+     Specifies kerberos principal name for the JDBC client. If both <code>keytab</code> and <code>principal</code> defined then Spark tries to do kerberos authentication.
+    </td>
+  </tr>
 </table>
 
 <div class="codetabs">

--- a/external/docker-integration-tests/pom.xml
+++ b/external/docker-integration-tests/pom.xml
@@ -106,6 +106,11 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-minikdc</artifactId>
+      <scope>test</scope>
+    </dependency>
     <!-- Although SPARK-28737 upgraded Jersey to 2.29 for JDK11, 'com.spotify.docker-client' still
       uses this repackaged 'jersey-guava'. We add this back for JDK8/JDK11 testing. -->
     <dependency>

--- a/external/docker-integration-tests/src/test/resources/log4j.properties
+++ b/external/docker-integration-tests/src/test/resources/log4j.properties
@@ -1,0 +1,36 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set everything to be logged to the file target/unit-tests.log
+test.appender=file
+log4j.rootCategory=INFO, ${test.appender}
+log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file.append=true
+log4j.appender.file.file=target/unit-tests.log
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n
+
+# Tests that launch java subprocesses can set the "test.appender" system property to
+# "console" to avoid having the child process's logs overwrite the unit test's
+# log file.
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n
+
+# Ignore messages below warning level from Jetty, because it's a bit verbose
+log4j.logger.org.sparkproject.jetty=WARN

--- a/external/docker-integration-tests/src/test/resources/postgres_krb_setup.sh
+++ b/external/docker-integration-tests/src/test/resources/postgres_krb_setup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+sed -i 's/host all all all md5/host all all all gss/g' /var/lib/postgresql/data/pg_hba.conf
+echo "krb_server_keyfile='/docker-entrypoint-initdb.d/postgres.keytab'" >> /var/lib/postgresql/data/postgresql.conf
+psql -U postgres -c "CREATE ROLE \"postgres/__IP_ADDRESS_REPLACE_ME__@EXAMPLE.COM\" LOGIN SUPERUSER"

--- a/external/docker-integration-tests/src/test/resources/postgres_krb_setup.sh
+++ b/external/docker-integration-tests/src/test/resources/postgres_krb_setup.sh
@@ -1,5 +1,21 @@
 #!/usr/bin/env bash
 
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 sed -i 's/host all all all md5/host all all all gss/g' /var/lib/postgresql/data/pg_hba.conf
 echo "krb_server_keyfile='/docker-entrypoint-initdb.d/postgres.keytab'" >> /var/lib/postgresql/data/postgresql.conf
 psql -U postgres -c "CREATE ROLE \"postgres/__IP_ADDRESS_REPLACE_ME__@EXAMPLE.COM\" LOGIN SUPERUSER"

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
@@ -62,10 +62,17 @@ abstract class DatabaseOnDocker {
    * Optional process to run when container starts
    */
   def getStartupProcessName: Option[String]
+
+  /**
+   * Optional step before container starts
+   */
+  def beforeContainerStart(hostConfigBuilder: HostConfig.Builder,
+      containerConfigBuilder: ContainerConfig.Builder): Unit = {}
 }
 
 abstract class DockerJDBCIntegrationSuite extends SharedSparkSession with Eventually {
 
+  protected val dockerIp = DockerUtils.getDockerIp()
   val db: DatabaseOnDocker
 
   private var docker: DockerClient = _
@@ -99,24 +106,23 @@ abstract class DockerJDBCIntegrationSuite extends SharedSparkSession with Eventu
         sock.close()
         port
       }
-      val dockerIp = DockerUtils.getDockerIp()
-      val hostConfig: HostConfig = HostConfig.builder()
+      val hostConfigBuilder = HostConfig.builder()
         .networkMode("bridge")
         .ipcMode(if (db.usesIpc) "host" else "")
         .portBindings(
           Map(s"${db.jdbcPort}/tcp" -> List(PortBinding.of(dockerIp, externalPort)).asJava).asJava)
-        .build()
       // Create the database container:
       val containerConfigBuilder = ContainerConfig.builder()
         .image(db.imageName)
         .networkDisabled(false)
         .env(db.env.map { case (k, v) => s"$k=$v" }.toSeq.asJava)
-        .hostConfig(hostConfig)
         .exposedPorts(s"${db.jdbcPort}/tcp")
       if(db.getStartupProcessName.isDefined) {
         containerConfigBuilder
         .cmd(db.getStartupProcessName.get)
       }
+      db.beforeContainerStart(hostConfigBuilder, containerConfigBuilder)
+      containerConfigBuilder.hostConfig(hostConfigBuilder.build())
       val config = containerConfigBuilder.build()
       // Create the database container:
       containerId = docker.createContainer(config).id

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
@@ -66,7 +66,8 @@ abstract class DatabaseOnDocker {
   /**
    * Optional step before container starts
    */
-  def beforeContainerStart(hostConfigBuilder: HostConfig.Builder,
+  def beforeContainerStart(
+      hostConfigBuilder: HostConfig.Builder,
       containerConfigBuilder: ContainerConfig.Builder): Unit = {}
 }
 

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerKrbJDBCIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerKrbJDBCIntegrationSuite.scala
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.jdbc
+
+import java.io.{File, FileInputStream, FileOutputStream}
+import javax.security.auth.login.Configuration
+
+import scala.io.Source
+
+import org.apache.hadoop.minikdc.MiniKdc
+
+import org.apache.spark.sql.execution.datasources.jdbc.connection.PostgresConnectionProvider
+import org.apache.spark.util.{SecurityUtils, Utils}
+
+abstract class DockerKrbJDBCIntegrationSuite extends DockerJDBCIntegrationSuite {
+  private var kdc: MiniKdc = _
+  protected var workDir: File = _
+  protected val userName: String
+  protected var principal: String = _
+  protected val keytabFileName: String
+  protected var keytabFile: File = _
+
+  override def beforeAll(): Unit = {
+    SecurityUtils.setGlobalKrbDebug(true)
+
+    val kdcDir = Utils.createTempDir()
+    val kdcConf = MiniKdc.createConf()
+    kdcConf.setProperty(MiniKdc.DEBUG, "true")
+    kdc = new MiniKdc(kdcConf, kdcDir)
+    kdc.start()
+
+    principal = s"$userName@${kdc.getRealm}"
+
+    workDir = Utils.createTempDir()
+    keytabFile = new File(workDir, keytabFileName)
+    kdc.createPrincipal(keytabFile, userName)
+    logInfo(s"Created keytab file: ${keytabFile.getAbsolutePath}")
+
+    val config = new PostgresConnectionProvider.PGJDBCConfiguration(
+      Configuration.getConfiguration, keytabFile.getAbsolutePath, principal)
+    Configuration.setConfiguration(config)
+
+    // This must be executed intentionally later
+    super.beforeAll()
+  }
+
+  override def afterAll(): Unit = {
+    try {
+      if (kdc != null) {
+        kdc.stop()
+      }
+      Configuration.setConfiguration(null)
+      SecurityUtils.setGlobalKrbDebug(false)
+    } finally {
+      super.afterAll()
+    }
+  }
+
+  protected def copyExecutableResource(
+      fileName: String, dir: File, processLine: String => String) = {
+    val newEntry = new File(dir.getAbsolutePath, fileName)
+    newEntry.createNewFile()
+    val inputStream = new FileInputStream(getClass.getClassLoader.getResource(fileName).getFile)
+    val outputStream = new FileOutputStream(newEntry)
+    for (line <- Source.fromInputStream(inputStream).getLines()) {
+      val processedLine = processLine(line) + System.lineSeparator()
+      outputStream.write(processedLine.getBytes)
+    }
+    newEntry.setExecutable(true, false)
+    logInfo(s"Created executable resource file: ${newEntry.getAbsolutePath}")
+    newEntry
+  }
+}

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresKrbIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresKrbIntegrationSuite.scala
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.jdbc
+
+import com.spotify.docker.client.messages.{ContainerConfig, HostConfig}
+import java.io.{File, FileInputStream, FileOutputStream}
+import java.sql.Connection
+import java.util.Properties
+import javax.security.auth.login.Configuration
+import org.apache.hadoop.minikdc.MiniKdc
+import scala.io.Source
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.execution.datasources.jdbc.connection.PostgresConnectionProvider
+import org.apache.spark.sql.types.StringType
+import org.apache.spark.tags.DockerTest
+import org.apache.spark.util.{SecurityUtils, Utils}
+
+@DockerTest
+class PostgresKrbIntegrationSuite extends DockerJDBCIntegrationSuite {
+  private var kdc: MiniKdc = _
+  private var workDir: File = _
+  private val postgresUser = s"postgres/$dockerIp"
+  private var postgresPrincipal: String = _
+  private var keytabFile: File = _
+
+  override val db = new DatabaseOnDocker {
+    override val imageName = "postgres:12.0"
+    override val env = Map(
+      "POSTGRES_PASSWORD" -> "rootpass"
+    )
+    override val usesIpc = false
+    override val jdbcPort = 5432
+
+    override def getJdbcUrl(ip: String, port: Int): String =
+      s"jdbc:postgresql://$ip:$port/postgres?user=$postgresPrincipal&gsslib=gssapi"
+
+    override def getStartupProcessName: Option[String] = None
+
+    override def beforeContainerStart(hostConfigBuilder: HostConfig.Builder,
+        containerConfigBuilder: ContainerConfig.Builder): Unit = {
+      def replaceIp(s: String): String = s.replace("__IP_ADDRESS_REPLACE_ME__", dockerIp)
+      copyExecutableResource("postgres_krb_setup.sh", workDir, replaceIp)
+
+      hostConfigBuilder.appendBinds(
+        HostConfig.Bind.from(workDir.getAbsolutePath)
+          .to("/docker-entrypoint-initdb.d").readOnly(true).build()
+      )
+    }
+  }
+
+  override def dataPreparation(conn: Connection): Unit = {
+    conn.prepareStatement("CREATE DATABASE foo").executeUpdate()
+    conn.setCatalog("foo")
+    conn.prepareStatement("CREATE TABLE bar (c0 text)").executeUpdate()
+    conn.prepareStatement("INSERT INTO bar VALUES ('hello')").executeUpdate()
+  }
+
+  private def copyExecutableResource(fileName: String, dir: File, processLine: String => String) = {
+    val newEntry = new File(dir.getAbsolutePath, fileName)
+    newEntry.createNewFile()
+    val inputStream = new FileInputStream(getClass.getClassLoader.getResource(fileName).getFile)
+    val outputStream = new FileOutputStream(newEntry)
+    for (line <- Source.fromInputStream(inputStream).getLines()) {
+      val processedLine = processLine(line) + System.lineSeparator()
+      outputStream.write(processedLine.getBytes)
+    }
+    newEntry.setExecutable(true, false)
+    logInfo(s"Created executable resource file: ${newEntry.getAbsolutePath}")
+    newEntry
+  }
+
+  override def beforeAll(): Unit = {
+    SecurityUtils.setGlobalKrbDebug(true)
+
+    val kdcDir = Utils.createTempDir()
+    val kdcConf = MiniKdc.createConf()
+    kdcConf.setProperty(MiniKdc.DEBUG, "true")
+    kdc = new MiniKdc(kdcConf, kdcDir)
+    kdc.start()
+
+    postgresPrincipal = s"$postgresUser@${kdc.getRealm}"
+
+    workDir = Utils.createTempDir()
+    keytabFile = new File(workDir, "postgres.keytab")
+    kdc.createPrincipal(keytabFile, postgresUser)
+    logInfo(s"Created keytab file: ${keytabFile.getAbsolutePath}")
+
+    val config = new PostgresConnectionProvider.PGJDBCConfiguration(
+      Configuration.getConfiguration, keytabFile.getAbsolutePath, postgresPrincipal)
+    Configuration.setConfiguration(config)
+
+    // This must be executed intentionally later
+    super.beforeAll()
+  }
+
+  override def afterAll(): Unit = {
+    try {
+      if (kdc != null) {
+        kdc.stop()
+      }
+      Configuration.setConfiguration(null)
+      SecurityUtils.setGlobalKrbDebug(false)
+    } finally {
+      super.afterAll()
+    }
+  }
+
+  test("Basic read test") {
+    // This makes sure Spark must do authentication
+    Configuration.setConfiguration(null)
+
+    val expectedResult = Set("hello").map(Row(_))
+
+    val query = "SELECT c0 FROM bar"
+    // query option to pass on the query string.
+    val df = spark.read.format("jdbc")
+      .option("url", jdbcUrl)
+      .option("keytab", keytabFile.getAbsolutePath)
+      .option("principal", postgresPrincipal)
+      .option("query", query)
+      .load()
+    assert(df.collect().toSet === expectedResult)
+
+    // query option in the create table path.
+    sql(
+      s"""
+         |CREATE OR REPLACE TEMPORARY VIEW queryOption
+         |USING org.apache.spark.sql.jdbc
+         |OPTIONS (url '$jdbcUrl', query '$query')
+       """.stripMargin.replaceAll("\n", " "))
+    assert(sql("select c0 from queryOption").collect().toSet === expectedResult)
+  }
+
+  test("Basic write test") {
+    // This makes sure Spark must do authentication
+    Configuration.setConfiguration(null)
+
+    val props = new Properties
+    props.setProperty("keytab", keytabFile.getAbsolutePath)
+    props.setProperty("principal", postgresPrincipal)
+
+    val tableName = "write_test"
+    sqlContext.createDataFrame(Seq(("foo", "bar")))
+      .write.jdbc(jdbcUrl, tableName, props)
+    val df = sqlContext.read.jdbc(jdbcUrl, tableName, props)
+
+    val schema = df.schema
+    assert(schema.head.dataType == StringType)
+    assert(schema(1).dataType == StringType)
+    val rows = df.collect()
+    assert(rows.length === 1)
+    assert(rows(0).getString(0) === "foo")
+    assert(rows(0).getString(1) === "bar")
+  }
+}

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresKrbIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresKrbIntegrationSuite.scala
@@ -61,7 +61,7 @@ class PostgresKrbIntegrationSuite extends DockerKrbJDBCIntegrationSuite {
 
   override protected def setAuthentication(keytabFile: String, principal: String): Unit = {
     val config = new PostgresConnectionProvider.PGJDBCConfiguration(
-      Configuration.getConfiguration, keytabFile, principal)
+      Configuration.getConfiguration, "pgjdbc", keytabFile, principal)
     Configuration.setConfiguration(config)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -197,7 +197,7 @@ class JDBCOptions(
     val keytabParam = parameters.getOrElse(JDBC_KEYTAB, null)
     if (keytabParam != null && FilenameUtils.getPath(keytabParam).isEmpty) {
       val result = SparkFiles.get(keytabParam)
-      logDebug(s"Keytab path found, assuming --files, file name used on executor: $result")
+      logDebug(s"Keytab path not found, assuming --files, file name used on executor: $result")
       result
     } else {
       logDebug("No keytab path found, assuming manual upload")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -200,7 +200,7 @@ class JDBCOptions(
       logDebug(s"Keytab path not found, assuming --files, file name used on executor: $result")
       result
     } else {
-      logDebug("No keytab path found, assuming manual upload")
+      logDebug("Keytab path found, assuming manual upload")
       keytabParam
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -187,6 +187,12 @@ class JDBCOptions(
 
   // An option to allow/disallow pushing down predicate into JDBC data source
   val pushDownPredicate = parameters.getOrElse(JDBC_PUSHDOWN_PREDICATE, "true").toBoolean
+
+  // The local path of user's keytab file, which is assumed to be pre-uploaded to all nodes either
+  // by --files option of spark-submit or manually
+  val keytab = parameters.getOrElse(JDBC_KEYTAB, null)
+  // The principal name of user's keytab file
+  val principal = parameters.getOrElse(JDBC_PRINCIPAL, null)
 }
 
 class JdbcOptionsInWrite(
@@ -239,4 +245,6 @@ object JDBCOptions {
   val JDBC_TXN_ISOLATION_LEVEL = newOption("isolationLevel")
   val JDBC_SESSION_INIT_STATEMENT = newOption("sessionInitStatement")
   val JDBC_PUSHDOWN_PREDICATE = newOption("pushDownPredicate")
+  val JDBC_KEYTAB = newOption("keytab")
+  val JDBC_PRINCIPAL = newOption("principal")
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -34,6 +34,7 @@ import org.apache.spark.sql.catalyst.encoders.RowEncoder
 import org.apache.spark.sql.catalyst.expressions.SpecificInternalRow
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, DateTimeUtils, GenericArrayData}
+import org.apache.spark.sql.execution.datasources.jdbc.connection.ConnectionProvider
 import org.apache.spark.sql.jdbc.{JdbcDialect, JdbcDialects, JdbcType}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.SchemaUtils
@@ -61,7 +62,7 @@ object JdbcUtils extends Logging {
         throw new IllegalStateException(
           s"Did not find registered driver with class $driverClass")
       }
-      val connection: Connection = driver.connect(options.url, options.asConnectionProperties)
+      val connection = ConnectionProvider.create(driver, options).getConnection()
       require(connection != null,
         s"The driver could not open a JDBC connection. Check the URL: ${options.url}")
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/BasicConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/BasicConnectionProvider.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.jdbc.connection
+
+import java.sql.{Connection, Driver}
+
+import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
+
+private[jdbc] class BasicConnectionProvider(driver: Driver, options: JDBCOptions)
+    extends ConnectionProvider {
+  def getConnection(): Connection = {
+    driver.connect(options.url, options.asConnectionProperties)
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProvider.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.jdbc.connection
+
+import java.sql.{Connection, Driver}
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
+
+/**
+ * Connection provider which opens connection toward various databases (database specific instance
+ * needed). If authentication required then it's the provider's responsibility to set all the
+ * parameters.
+ */
+private[jdbc] trait ConnectionProvider {
+  def getConnection(): Connection
+}
+
+private[jdbc] object ConnectionProvider extends Logging {
+  def create(driver: Driver, options: JDBCOptions): ConnectionProvider = {
+    if (options.keytab == null || options.principal == null) {
+      logInfo("No authentication configuration found, using basic connection provider")
+      new BasicConnectionProvider(driver, options)
+    } else {
+      logInfo("Authentication configuration found, using database specific connection provider")
+      options.driverClass match {
+        case PostgresConnectionProvider.driverClass =>
+          logInfo("Postgres connection provider found")
+          new PostgresConnectionProvider(driver, options)
+
+        case _ =>
+          throw new IllegalArgumentException(s"Driver ${options.driverClass} does not support " +
+            "secure connection")
+      }
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProvider.scala
@@ -24,8 +24,8 @@ import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 
 /**
  * Connection provider which opens connection toward various databases (database specific instance
- * needed). If authentication required then it's the provider's responsibility to set all the
- * parameters.
+ * needed). If kerberos authentication required then it's the provider's responsibility to set all
+ * the parameters.
  */
 private[jdbc] trait ConnectionProvider {
   def getConnection(): Connection
@@ -45,7 +45,7 @@ private[jdbc] object ConnectionProvider extends Logging {
 
         case _ =>
           throw new IllegalArgumentException(s"Driver ${options.driverClass} does not support " +
-            "secure connection")
+            "Kerberos authentication")
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProvider.scala
@@ -34,13 +34,13 @@ private[jdbc] trait ConnectionProvider {
 private[jdbc] object ConnectionProvider extends Logging {
   def create(driver: Driver, options: JDBCOptions): ConnectionProvider = {
     if (options.keytab == null || options.principal == null) {
-      logInfo("No authentication configuration found, using basic connection provider")
+      logDebug("No authentication configuration found, using basic connection provider")
       new BasicConnectionProvider(driver, options)
     } else {
-      logInfo("Authentication configuration found, using database specific connection provider")
+      logDebug("Authentication configuration found, using database specific connection provider")
       options.driverClass match {
         case PostgresConnectionProvider.driverClass =>
-          logInfo("Postgres connection provider found")
+          logDebug("Postgres connection provider found")
           new PostgresConnectionProvider(driver, options)
 
         case _ =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProvider.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.jdbc.connection
+
+import java.sql.{Connection, Driver}
+import javax.security.auth.login.{AppConfigurationEntry, Configuration}
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
+import org.apache.spark.sql.execution.datasources.jdbc.connection.PostgresConnectionProvider.PGJDBCConfiguration
+import org.apache.spark.util.SecurityUtils
+
+private[jdbc] class PostgresConnectionProvider(driver: Driver, options: JDBCOptions)
+    extends BasicConnectionProvider(driver, options) {
+  def setAuthenticationConfigIfNeeded(): Unit = {
+    val parent = Configuration.getConfiguration
+    val configEntry = parent.getAppConfigurationEntry(PostgresConnectionProvider.appEntry)
+    if (configEntry == null || (configEntry != null && configEntry.isEmpty)) {
+      val config = new PGJDBCConfiguration(parent, options.keytab, options.principal)
+      Configuration.setConfiguration(config)
+    }
+  }
+
+  override def getConnection(): Connection = {
+    setAuthenticationConfigIfNeeded()
+    super.getConnection()
+  }
+}
+
+private[sql] object PostgresConnectionProvider {
+  class PGJDBCConfiguration(
+      parent: Configuration, keytab: String, principal: String) extends Configuration {
+    val entry =
+      new AppConfigurationEntry(
+        SecurityUtils.getKrb5LoginModuleName(),
+        AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
+        Map[String, Object](
+          "useTicketCache" -> "false",
+          "useKeyTab" -> "true",
+          "keyTab" -> keytab,
+          "principal" -> principal,
+          "debug" -> "true"
+        ).asJava
+      )
+
+    override def getAppConfigurationEntry(name: String): Array[AppConfigurationEntry] = {
+      if (name.equals(appEntry)) {
+        Array(entry)
+      } else {
+        parent.getAppConfigurationEntry(name)
+      }
+    }
+  }
+
+  val driverClass = "org.postgresql.Driver"
+  val appEntry = "pgjdbc"
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProvider.scala
@@ -45,8 +45,9 @@ private[jdbc] class PostgresConnectionProvider(driver: Driver, options: JDBCOpti
 
 private[sql] object PostgresConnectionProvider {
   class PGJDBCConfiguration(
-      parent: Configuration, keytab: String, principal: String) extends Configuration {
-    val entry =
+      parent: Configuration,
+      keytab: String, principal: String) extends Configuration {
+    private val entry =
       new AppConfigurationEntry(
         SecurityUtils.getKrb5LoginModuleName(),
         AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProvider.scala
@@ -31,7 +31,7 @@ private[jdbc] class PostgresConnectionProvider(driver: Driver, options: JDBCOpti
   def setAuthenticationConfigIfNeeded(): Unit = {
     val parent = Configuration.getConfiguration
     val configEntry = parent.getAppConfigurationEntry(PostgresConnectionProvider.appEntry)
-    if (configEntry == null || (configEntry != null && configEntry.isEmpty)) {
+    if (configEntry == null || configEntry.isEmpty) {
       val config = new PGJDBCConfiguration(parent, options.keytab, options.principal)
       Configuration.setConfiguration(config)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProvider.scala
@@ -45,7 +45,7 @@ private[jdbc] class PostgresConnectionProvider(driver: Driver, options: JDBCOpti
 
   def appEntry: String = {
     val parseURL = driver.getClass.getMethod("parseURL", classOf[String], classOf[Properties])
-    val properties: Properties = parseURL.invoke(driver, options.url, null).asInstanceOf[Properties]
+    val properties = parseURL.invoke(driver, options.url, null).asInstanceOf[Properties]
     properties.getProperty("jaasApplicationName", "pgjdbc")
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProvider.scala
@@ -29,6 +29,12 @@ import org.apache.spark.util.SecurityUtils
 
 private[jdbc] class PostgresConnectionProvider(driver: Driver, options: JDBCOptions)
     extends BasicConnectionProvider(driver, options) {
+  val appEntry: String = {
+    val parseURL = driver.getClass.getMethod("parseURL", classOf[String], classOf[Properties])
+    val properties = parseURL.invoke(driver, options.url, null).asInstanceOf[Properties]
+    properties.getProperty("jaasApplicationName", "pgjdbc")
+  }
+
   def setAuthenticationConfigIfNeeded(): Unit = {
     val parent = Configuration.getConfiguration
     val configEntry = parent.getAppConfigurationEntry(appEntry)
@@ -41,12 +47,6 @@ private[jdbc] class PostgresConnectionProvider(driver: Driver, options: JDBCOpti
   override def getConnection(): Connection = {
     setAuthenticationConfigIfNeeded()
     super.getConnection()
-  }
-
-  def appEntry: String = {
-    val parseURL = driver.getClass.getMethod("parseURL", classOf[String], classOf[Properties])
-    val properties = parseURL.invoke(driver, options.url, null).asInstanceOf[Properties]
-    properties.getProperty("jaasApplicationName", "pgjdbc")
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProviderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProviderSuite.scala
@@ -28,7 +28,7 @@ class PostgresConnectionProviderSuite extends SparkFunSuite with BeforeAndAfterE
   private val options = new JDBCOptions(Map[String, String](
     JDBCOptions.JDBC_URL -> "jdbc:postgresql://localhost/postgres",
     JDBCOptions.JDBC_TABLE_NAME -> "table",
-    JDBCOptions.JDBC_KEYTAB -> "keytab",
+    JDBCOptions.JDBC_KEYTAB -> "/path/to/keytab",
     JDBCOptions.JDBC_PRINCIPAL -> "principal"
   ))
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProviderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProviderSuite.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.jdbc.connection
+
+import javax.security.auth.login.Configuration
+
+import org.scalatest.BeforeAndAfterEach
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
+
+class PostgresConnectionProviderSuite extends SparkFunSuite with BeforeAndAfterEach {
+  private val options = new JDBCOptions(Map[String, String](
+    JDBCOptions.JDBC_URL -> "jdbc:postgresql://localhost/postgres",
+    JDBCOptions.JDBC_TABLE_NAME -> "table",
+    JDBCOptions.JDBC_KEYTAB -> "keytab",
+    JDBCOptions.JDBC_PRINCIPAL -> "prinipal"
+  ))
+
+  var provider: PostgresConnectionProvider = _
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+
+    provider = new PostgresConnectionProvider(null, options)
+  }
+
+  override def afterEach(): Unit = {
+    try {
+      Configuration.setConfiguration(null)
+    } finally {
+      super.afterEach()
+    }
+  }
+
+  test("setAuthenticationConfigIfNeeded must set authentication if not set") {
+    // Make sure no authentication for postgres set
+    assert(Configuration.getConfiguration.getAppConfigurationEntry(
+      PostgresConnectionProvider.appEntry) == null)
+
+    // Make sure the first call sets authentication properly
+    val savedConfig = Configuration.getConfiguration
+    provider.setAuthenticationConfigIfNeeded()
+    val postgresConfig = Configuration.getConfiguration
+    assert(savedConfig != postgresConfig)
+    assert(postgresConfig.getAppConfigurationEntry(PostgresConnectionProvider.appEntry) != null)
+
+    // Make sure a second call is not modifying the already changed authentication
+    provider.setAuthenticationConfigIfNeeded()
+    assert(postgresConfig == Configuration.getConfiguration)
+    assert(postgresConfig.getAppConfigurationEntry(PostgresConnectionProvider.appEntry) != null)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProviderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProviderSuite.scala
@@ -17,28 +17,23 @@
 
 package org.apache.spark.sql.execution.datasources.jdbc.connection
 
+import java.sql.{Driver, DriverManager}
 import javax.security.auth.login.Configuration
+
+import scala.collection.JavaConverters._
 
 import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
+import org.apache.spark.sql.execution.datasources.jdbc.{DriverRegistry, JDBCOptions}
 
 class PostgresConnectionProviderSuite extends SparkFunSuite with BeforeAndAfterEach {
-  private val options = new JDBCOptions(Map[String, String](
-    JDBCOptions.JDBC_URL -> "jdbc:postgresql://localhost/postgres",
+  private def options(url: String) = new JDBCOptions(Map[String, String](
+    JDBCOptions.JDBC_URL -> url,
     JDBCOptions.JDBC_TABLE_NAME -> "table",
     JDBCOptions.JDBC_KEYTAB -> "/path/to/keytab",
     JDBCOptions.JDBC_PRINCIPAL -> "principal"
   ))
-
-  var provider: PostgresConnectionProvider = _
-
-  override def beforeEach(): Unit = {
-    super.beforeEach()
-
-    provider = new PostgresConnectionProvider(null, options)
-  }
 
   override def afterEach(): Unit = {
     try {
@@ -49,23 +44,42 @@ class PostgresConnectionProviderSuite extends SparkFunSuite with BeforeAndAfterE
   }
 
   test("setAuthenticationConfigIfNeeded must set authentication if not set") {
+    DriverRegistry.register(PostgresConnectionProvider.driverClass)
+    val driver = DriverManager.getDrivers.asScala.collectFirst {
+      case d if d.getClass.getCanonicalName == PostgresConnectionProvider.driverClass => d
+    }.get
+    val defaultProvider = new PostgresConnectionProvider(
+      driver, options("jdbc:postgresql://localhost/postgres"))
+    val customProvider = new PostgresConnectionProvider(
+      driver, options(s"jdbc:postgresql://localhost/postgres?jaasApplicationName=custompgjdbc"))
+
+    assert(defaultProvider.appEntry !== customProvider.appEntry)
+
     // Make sure no authentication for postgres is set
     assert(Configuration.getConfiguration.getAppConfigurationEntry(
-      PostgresConnectionProvider.appEntry) == null)
+      defaultProvider.appEntry) == null)
+    assert(Configuration.getConfiguration.getAppConfigurationEntry(
+      customProvider.appEntry) == null)
 
     // Make sure the first call sets authentication properly
     val savedConfig = Configuration.getConfiguration
-    provider.setAuthenticationConfigIfNeeded()
-    val postgresConfig = Configuration.getConfiguration
-    assert(savedConfig != postgresConfig)
-    val postgresAppEntry = postgresConfig.getAppConfigurationEntry(
-      PostgresConnectionProvider.appEntry)
-    assert(postgresAppEntry != null)
+    defaultProvider.setAuthenticationConfigIfNeeded()
+    val defaultConfig = Configuration.getConfiguration
+    assert(savedConfig != defaultConfig)
+    val defaultAppEntry = defaultConfig.getAppConfigurationEntry(defaultProvider.appEntry)
+    assert(defaultAppEntry != null)
+    customProvider.setAuthenticationConfigIfNeeded()
+    val customConfig = Configuration.getConfiguration
+    assert(savedConfig != customConfig)
+    assert(defaultConfig != customConfig)
+    val customAppEntry = customConfig.getAppConfigurationEntry(customProvider.appEntry)
+    assert(customAppEntry != null)
 
     // Make sure a second call is not modifying the existing authentication
-    provider.setAuthenticationConfigIfNeeded()
-    assert(postgresConfig == Configuration.getConfiguration)
-    assert(postgresConfig.getAppConfigurationEntry(PostgresConnectionProvider.appEntry) ===
-      postgresAppEntry)
+    defaultProvider.setAuthenticationConfigIfNeeded()
+    customProvider.setAuthenticationConfigIfNeeded()
+    assert(customConfig == Configuration.getConfiguration)
+    assert(defaultConfig.getAppConfigurationEntry(defaultProvider.appEntry) === defaultAppEntry)
+    assert(customConfig.getAppConfigurationEntry(customProvider.appEntry) === customAppEntry)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProviderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProviderSuite.scala
@@ -29,7 +29,7 @@ class PostgresConnectionProviderSuite extends SparkFunSuite with BeforeAndAfterE
     JDBCOptions.JDBC_URL -> "jdbc:postgresql://localhost/postgres",
     JDBCOptions.JDBC_TABLE_NAME -> "table",
     JDBCOptions.JDBC_KEYTAB -> "keytab",
-    JDBCOptions.JDBC_PRINCIPAL -> "prinipal"
+    JDBCOptions.JDBC_PRINCIPAL -> "principal"
   ))
 
   var provider: PostgresConnectionProvider = _
@@ -49,7 +49,7 @@ class PostgresConnectionProviderSuite extends SparkFunSuite with BeforeAndAfterE
   }
 
   test("setAuthenticationConfigIfNeeded must set authentication if not set") {
-    // Make sure no authentication for postgres set
+    // Make sure no authentication for postgres is set
     assert(Configuration.getConfiguration.getAppConfigurationEntry(
       PostgresConnectionProvider.appEntry) == null)
 
@@ -58,11 +58,14 @@ class PostgresConnectionProviderSuite extends SparkFunSuite with BeforeAndAfterE
     provider.setAuthenticationConfigIfNeeded()
     val postgresConfig = Configuration.getConfiguration
     assert(savedConfig != postgresConfig)
-    assert(postgresConfig.getAppConfigurationEntry(PostgresConnectionProvider.appEntry) != null)
+    val postgresAppEntry = postgresConfig.getAppConfigurationEntry(
+      PostgresConnectionProvider.appEntry)
+    assert(postgresAppEntry != null)
 
-    // Make sure a second call is not modifying the already changed authentication
+    // Make sure a second call is not modifying the existing authentication
     provider.setAuthenticationConfigIfNeeded()
     assert(postgresConfig == Configuration.getConfiguration)
-    assert(postgresConfig.getAppConfigurationEntry(PostgresConnectionProvider.appEntry) != null)
+    assert(postgresConfig.getAppConfigurationEntry(PostgresConnectionProvider.appEntry) ===
+      postgresAppEntry)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
When loading DataFrames from JDBC datasource with Kerberos authentication, remote executors (yarn-client/cluster etc. modes) fail to establish a connection due to lack of Kerberos ticket or ability to generate it.

This is a real issue when trying to ingest data from kerberized data sources (SQL Server, Oracle) in enterprise environment where exposing simple authentication access is not an option due to IT policy issues.

In this PR I've added Postgres support (other supported databases will come in later PRs).

What this PR contains:
* Added `keytab` and `principal` JDBC options
* Added `ConnectionProvider` trait and it's impementations:
  * `BasicConnectionProvider` => unsecure connection
  * `PostgresConnectionProvider` => postgres secure connection
* Added `ConnectionProvider` tests
* Added `PostgresKrbIntegrationSuite` docker integration test
* Created `SecurityUtils` to concentrate re-usable security related functionalities
* Documentation

### Why are the changes needed?
Missing JDBC kerberos support.

### Does this PR introduce any user-facing change?
Yes, 2 additional JDBC options added:
* keytab
* principal

If both provided then Spark does kerberos authentication.

### How was this patch tested?
To demonstrate the functionality with a standalone application I've created this repository: https://github.com/gaborgsomogyi/docker-kerberos

* Additional + existing unit tests
* Additional docker integration test
* Test on cluster manually
* `SKIP_API=1 jekyll build`
