### PR TITLE
[SPARK-30886][SQL] Deprecate two-parameter TRIM/LTRIM/RTRIM functions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1844,10 +1844,11 @@ class Analyzer(
                 case other if (isDistinct || filter.isDefined) =>
                   failAnalysis("DISTINCT or FILTER specified, " +
                     s"but ${other.prettyName} is not an aggregate function")
-                case e: StringTrim if arguments.size == 2 =>
+                case e: String2TrimExpression if arguments.size == 2 =>
                   if (trimWarningEnabled.get) {
-                    log.warn("Two-parameter TRIM function signature is deprecated." +
-                      " Use SQL syntax `TRIM(trimStr FROM str)` instead.")
+                    log.warn("Two-parameter TRIM/LTRIM/RTRIM function signatures are deprecated." +
+                      " Use SQL syntax `TRIM((BOTH | LEADING | TRAILING)? trimStr FROM str)`" +
+                      " instead.")
                     trimWarningEnabled.set(false)
                   }
                   e

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1796,7 +1796,6 @@ class Analyzer(
    * Replaces [[UnresolvedFunction]]s with concrete [[Expression]]s.
    */
   object ResolveFunctions extends Rule[LogicalPlan] {
-    val ltrimAndRtrimWarningEnabled = new AtomicBoolean(true)
     val trimWarningEnabled = new AtomicBoolean(true)
     def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsUp {
       case q: LogicalPlan =>
@@ -1845,13 +1844,6 @@ class Analyzer(
                 case other if (isDistinct || filter.isDefined) =>
                   failAnalysis("DISTINCT or FILTER specified, " +
                     s"but ${other.prettyName} is not an aggregate function")
-                case e @ (_: StringTrimLeft | _: StringTrimRight) =>
-                  if (ltrimAndRtrimWarningEnabled.get) {
-                    log.warn("LTRIM and RTRIM functions are deprecated. Use SQL syntax " +
-                      "`TRIM((BOTH | LEADING | TRAILING)? trimStr FROM str)` instead.")
-                    ltrimAndRtrimWarningEnabled.set(false)
-                  }
-                  e
                 case e: StringTrim if arguments.size == 2 =>
                   if (trimWarningEnabled.get) {
                     log.warn("Two-parameter TRIM function signature is deprecated." +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.catalyst.analysis
 
 import java.util
 import java.util.Locale
+import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -1795,6 +1796,7 @@ class Analyzer(
    * Replaces [[UnresolvedFunction]]s with concrete [[Expression]]s.
    */
   object ResolveFunctions extends Rule[LogicalPlan] {
+    val trimWarningEnabled = new AtomicBoolean(true)
     def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsUp {
       case q: LogicalPlan =>
         q transformExpressions {
@@ -1839,13 +1841,19 @@ class Analyzer(
                   }
                   AggregateExpression(agg, Complete, isDistinct, filter)
                 // This function is not an aggregate function, just return the resolved one.
-                case other =>
-                  if (isDistinct || filter.isDefined) {
-                    failAnalysis("DISTINCT or FILTER specified, " +
-                      s"but ${other.prettyName} is not an aggregate function")
-                  } else {
-                    other
+                case other if (isDistinct || filter.isDefined) =>
+                  failAnalysis("DISTINCT or FILTER specified, " +
+                    s"but ${other.prettyName} is not an aggregate function")
+                case e: String2TrimExpression if arguments.size == 2 =>
+                  if (trimWarningEnabled.get) {
+                    log.warn("Two-parameter TRIM/LTRIM/RTRIM function signatures are deprecated." +
+                      s" Use SQL syntax `${e.prettyName.toUpperCase(Locale.ROOT)}(trimStr" +
+                      s" FROM str)` instead of `${e.prettyName}`. Please refer SPARK-28093.")
+                    trimWarningEnabled.set(false)
                   }
+                  e
+                case other =>
+                  other
               }
             }
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -853,10 +853,7 @@ object StringTrimLeft {
       > SELECT _FUNC_('    SparkSQL   ');
        SparkSQL
   """,
-  since = "1.5.0",
-  deprecated = """
-    Deprecated since 3.0.0. Use SQL syntax `TRIM(LEADING trimStr FROM str)` instead.
-  """)
+  since = "1.5.0")
 case class StringTrimLeft(
     srcStr: Expression,
     trimStr: Option[Expression] = None)
@@ -954,10 +951,7 @@ object StringTrimRight {
       > SELECT _FUNC_('    SparkSQL   ');
        SparkSQL
   """,
-  since = "1.5.0",
-  deprecated = """
-    Deprecated since 3.0.0. Use SQL syntax `TRIM(TRAILING trimStr FROM str)` instead.
-  """)
+  since = "1.5.0")
 // scalastyle:on line.size.limit
 case class StringTrimRight(
     srcStr: Expression,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -853,7 +853,10 @@ object StringTrimLeft {
       > SELECT _FUNC_('    SparkSQL   ');
        SparkSQL
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  deprecated = """
+    Deprecated since 3.0.0. Use SQL syntax `TRIM(LEADING trimStr FROM str)` instead.
+  """)
 case class StringTrimLeft(
     srcStr: Expression,
     trimStr: Option[Expression] = None)
@@ -951,7 +954,10 @@ object StringTrimRight {
       > SELECT _FUNC_('    SparkSQL   ');
        SparkSQL
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  deprecated = """
+    Deprecated since 3.0.0. Use SQL syntax `TRIM(TRAILING trimStr FROM str)` instead.
+  """)
 // scalastyle:on line.size.limit
 case class StringTrimRight(
     srcStr: Expression,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -773,7 +773,8 @@ class AnalysisSuite extends AnalysisTest with Matchers {
   test("SPARK-30886 Deprecate two-parameter TRIM/LTRIM/RTRIM") {
     Seq("trim", "ltrim", "rtrim").foreach { f =>
       val logAppender = new LogAppender("deprecated two-parameter TRIM/LTRIM/RTRIM functions")
-      def check(count: Int, message: String): Unit = {
+      def check(count: Int): Unit = {
+        val message = "Two-parameter TRIM/LTRIM/RTRIM function signatures are deprecated."
         assert(logAppender.loggingEvents.size == count)
         assert(logAppender.loggingEvents.exists(
           e => e.getLevel == Level.WARN &&
@@ -794,13 +795,13 @@ class AnalysisSuite extends AnalysisTest with Matchers {
           UnresolvedFunction(f, $"a" :: $"b" :: Nil, isDistinct = false))
         testAnalyzer1.execute(plan2)
         // Deprecation warning is printed out once.
-        check(1, "Two-parameter TRIM/LTRIM/RTRIM function signatures are deprecated.")
+        check(1)
 
         val plan3 = testRelation2.select(
           UnresolvedFunction(f, $"b" :: $"a" :: Nil, isDistinct = false))
         testAnalyzer1.execute(plan3)
         // There is no change in the log.
-        check(1, "Two-parameter TRIM/LTRIM/RTRIM function signatures are deprecated.")
+        check(1)
 
         // New analyzer from new SessionState
         val testAnalyzer2 = new Analyzer(
@@ -809,13 +810,13 @@ class AnalysisSuite extends AnalysisTest with Matchers {
           UnresolvedFunction(f, $"c" :: $"d" :: Nil, isDistinct = false))
         testAnalyzer2.execute(plan4)
         // Additional deprecation warning from new analyzer
-        check(2, "Two-parameter TRIM/LTRIM/RTRIM function signatures are deprecated.")
+        check(2)
 
         val plan5 = testRelation2.select(
           UnresolvedFunction(f, $"c" :: $"d" :: Nil, isDistinct = false))
         testAnalyzer2.execute(plan5)
         // There is no change in the log.
-        check(2, "Two-parameter TRIM/LTRIM/RTRIM function signatures are deprecated.")
+        check(2)
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to show a deprecation warning on two-parameter TRIM/LTRIM/RTRIM function usages based on the community decision.
- https://lists.apache.org/thread.html/r48b6c2596ab06206b7b7fd4bbafd4099dccd4e2cf9801aaa9034c418%40%3Cdev.spark.apache.org%3E

### Why are the changes needed?

For backward compatibility, SPARK-28093 is reverted. However, from Apache Spark 3.0.0, we should give a safe guideline to use SQL syntax instead of the esoteric function signatures.

### Does this PR introduce any user-facing change?

Yes. This shows a directional warning.

### How was this patch tested?

Pass the Jenkins with a newly added test case.