### PR TITLE
[SPARK-30868][SQL] Throw Exception if runHive(sql) failed

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -839,7 +839,7 @@ private[hive] class HiveClientImpl(
             state.out.println(tokens(0) + " " + cmd_1)
             // scalastyle:on println
           }
-          val response: CommandProcessorResponse = proc.run(cmd)
+          val response: CommandProcessorResponse = proc.run(cmd_1)
           // Throw an exception if there is an error in query processing.
           if (response.getResponseCode != 0) {
             throw new QueryExecutionException(response.getErrorMessage)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -839,7 +839,12 @@ private[hive] class HiveClientImpl(
             state.out.println(tokens(0) + " " + cmd_1)
             // scalastyle:on println
           }
-          Seq(proc.run(cmd_1).getResponseCode.toString)
+          val response: CommandProcessorResponse = proc.run(cmd)
+          // Throw an exception if there is an error in query processing.
+          if (response.getResponseCode != 0) {
+            throw new QueryExecutionException(response.getErrorMessage)
+          }
+          Seq(response.getResponseCode.toString)
       }
     } catch {
       case e: Exception =>

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
@@ -170,7 +170,7 @@ class HiveExternalCatalogSuite extends ExternalCatalogSuite {
     assertThrows[QueryExecutionException](externalCatalog.client.runSqlHive(
       s"CREATE TABLE $tblName(n into)"))
 
-    // test describe table failed
+    // test desc table failed
     assertThrows[QueryExecutionException](externalCatalog.client.runSqlHive(
       s"DESC FORMATED $tblName"))
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
@@ -174,7 +174,7 @@ class HiveExternalCatalogSuite extends ExternalCatalogSuite {
     assertThrows[QueryExecutionException](externalCatalog.client.runSqlHive(
       s"DESC FORMATED $tblName"))
 
-    // test wrong insert queries
+    // test wrong insert query
     assertThrows[QueryExecutionException](externalCatalog.client.runSqlHive(
       "INSERT overwrite directory \"fs://localhost/tmp\" select 1 as a"))
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
@@ -168,7 +168,7 @@ class HiveExternalCatalogSuite extends ExternalCatalogSuite {
     // test create hive table failed
     val tblName = "table_not_exists"
     assertThrows[QueryExecutionException](externalCatalog.client.runSqlHive(
-      s"CREATE TABLE $tblName(s into)"))
+      s"CREATE TABLE $tblName(n into)"))
 
     // test describe table failed
     assertThrows[QueryExecutionException](externalCatalog.client.runSqlHive(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
@@ -157,24 +157,25 @@ class HiveExternalCatalogSuite extends ExternalCatalogSuite {
   }
 
   test("SPARK-30868 throw an exception if HiveClient#runSqlHive fails") {
+    val client = externalCatalog.client
     // test add jars which not exists
     val jarPath = "file:///tmp/not_exists.jar"
-    assertThrows[QueryExecutionException](externalCatalog.client.runSqlHive(s"ADD JAR $jarPath"))
+    assertThrows[QueryExecutionException](client.runSqlHive(s"ADD JAR $jarPath"))
 
     // test change to the database which doesn't exists
-    assertThrows[QueryExecutionException](externalCatalog.client.runSqlHive(
+    assertThrows[QueryExecutionException](client.runSqlHive(
       s"use db_not_exists"))
 
-    // test create hive table failed
-    assertThrows[QueryExecutionException](externalCatalog.client.runSqlHive(
-      s"CREATE TABLE table_not_exists(n into)"))
+    // test create hive table failed with unsupported into type
+    assertThrows[QueryExecutionException](client.runSqlHive(
+      s"CREATE TABLE t(n into)"))
 
     // test desc table failed with wrong `FORMATED` keyword
-    assertThrows[QueryExecutionException](externalCatalog.client.runSqlHive(
+    assertThrows[QueryExecutionException](client.runSqlHive(
       s"DESC FORMATED t"))
 
     // test wrong insert query
-    assertThrows[QueryExecutionException](externalCatalog.client.runSqlHive(
+    assertThrows[QueryExecutionException](client.runSqlHive(
       "INSERT overwrite directory \"fs://localhost/tmp\" select 1 as a"))
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
@@ -166,20 +166,15 @@ class HiveExternalCatalogSuite extends ExternalCatalogSuite {
       s"use db_not_exists"))
 
     // test create hive table failed
-    val tblName = "table_not_exists"
     assertThrows[QueryExecutionException](externalCatalog.client.runSqlHive(
-      s"CREATE TABLE $tblName(n into)"))
+      s"CREATE TABLE table_not_exists(n into)"))
 
-    // test desc table failed
+    // test desc table failed with wrong `FORMATED` keyword
     assertThrows[QueryExecutionException](externalCatalog.client.runSqlHive(
-      s"DESC FORMATED $tblName"))
+      s"DESC FORMATED t"))
 
     // test wrong insert query
     assertThrows[QueryExecutionException](externalCatalog.client.runSqlHive(
       "INSERT overwrite directory \"fs://localhost/tmp\" select 1 as a"))
-
-    // test drop hive table which doesn't exists
-    assertThrows[QueryExecutionException](externalCatalog.client.runSqlHive(
-      s"DROP TABLE $tblName"))
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
@@ -156,28 +156,27 @@ class HiveExternalCatalogSuite extends ExternalCatalogSuite {
     assert(catalog.getTable("db1", "spark_29498").owner === owner)
   }
 
-  test("SPARK-30868 throw QueryExectionException if run hive query failed") {
+  test("SPARK-30868 throw an exception if HiveClient#runSqlHive fails") {
     // test add jars which not exists
     val jarPath = "file:///tmp/not_exists.jar"
     assertThrows[QueryExecutionException](externalCatalog.client.runSqlHive(s"ADD JAR $jarPath"))
 
     // test change to the database which not exists
-    val dbName = "db_not_exists"
     assertThrows[QueryExecutionException](externalCatalog.client.runSqlHive(
-      s"use $dbName"))
+      s"use db_not_exists"))
 
     // test create hive table failed
     val tblName = "table_not_exists"
     assertThrows[QueryExecutionException](externalCatalog.client.runSqlHive(
-      s"CREATE TABLE $tblName(n int)"))
+      s"CREATE TABLE $tblName(n into)"))
 
-    // test describe hive table which not exists
+    // test describe table failed
     assertThrows[QueryExecutionException](externalCatalog.client.runSqlHive(
       s"DESC FORMATED $tblName"))
 
-    // test insert hive table which not exists
+    // test wrong insert queries
     assertThrows[QueryExecutionException](externalCatalog.client.runSqlHive(
-      s"INSERT into table $tblName values(1)"))
+      s"INSERT into directory /tmp/test select 1 as a"))
 
     // test drop hive table which not exists
     assertThrows[QueryExecutionException](externalCatalog.client.runSqlHive(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
@@ -161,7 +161,7 @@ class HiveExternalCatalogSuite extends ExternalCatalogSuite {
     val jarPath = "file:///tmp/not_exists.jar"
     assertThrows[QueryExecutionException](externalCatalog.client.runSqlHive(s"ADD JAR $jarPath"))
 
-    // test change to the database which not exists
+    // test change to the database which doesn't exists
     assertThrows[QueryExecutionException](externalCatalog.client.runSqlHive(
       s"use db_not_exists"))
 
@@ -178,7 +178,7 @@ class HiveExternalCatalogSuite extends ExternalCatalogSuite {
     assertThrows[QueryExecutionException](externalCatalog.client.runSqlHive(
       "INSERT overwrite directory \"fs://localhost/tmp\" select 1 as a"))
 
-    // test drop hive table which not exists
+    // test drop hive table which doesn't exists
     assertThrows[QueryExecutionException](externalCatalog.client.runSqlHive(
       s"DROP TABLE $tblName"))
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
@@ -168,7 +168,7 @@ class HiveExternalCatalogSuite extends ExternalCatalogSuite {
     // test create hive table failed
     val tblName = "table_not_exists"
     assertThrows[QueryExecutionException](externalCatalog.client.runSqlHive(
-      s"CREATE TABLE $tblName(n into)"))
+      s"CREATE TABLE $tblName(s into)"))
 
     // test describe table failed
     assertThrows[QueryExecutionException](externalCatalog.client.runSqlHive(
@@ -176,7 +176,7 @@ class HiveExternalCatalogSuite extends ExternalCatalogSuite {
 
     // test wrong insert queries
     assertThrows[QueryExecutionException](externalCatalog.client.runSqlHive(
-      s"INSERT into directory /tmp/test select 1 as a"))
+      s"INSERT overwrite directory \"fs://localhost/tmp\" select 1 as a"))
 
     // test drop hive table which not exists
     assertThrows[QueryExecutionException](externalCatalog.client.runSqlHive(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
@@ -158,7 +158,7 @@ class HiveExternalCatalogSuite extends ExternalCatalogSuite {
 
   test("SPARK-30868 throw an exception if HiveClient#runSqlHive fails") {
     val client = externalCatalog.client
-    // test add jars which not exists
+    // test add jars which doesn't exists
     val jarPath = "file:///tmp/not_exists.jar"
     assertThrows[QueryExecutionException](client.runSqlHive(s"ADD JAR $jarPath"))
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
@@ -176,7 +176,7 @@ class HiveExternalCatalogSuite extends ExternalCatalogSuite {
 
     // test wrong insert queries
     assertThrows[QueryExecutionException](externalCatalog.client.runSqlHive(
-      s"INSERT overwrite directory \"fs://localhost/tmp\" select 1 as a"))
+      "INSERT overwrite directory \"fs://localhost/tmp\" select 1 as a"))
 
     // test drop hive table which not exists
     assertThrows[QueryExecutionException](externalCatalog.client.runSqlHive(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -33,7 +33,6 @@ import org.apache.spark.sql.{AnalysisException, DataFrame, Row, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.Cast
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.logical.Project
-import org.apache.spark.sql.execution.QueryExecutionException
 import org.apache.spark.sql.execution.joins.BroadcastNestedLoopJoinExec
 import org.apache.spark.sql.hive._
 import org.apache.spark.sql.hive.test.{HiveTestJars, TestHive}

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -848,11 +848,6 @@ class HiveQuerySuite extends HiveComparisonTest with SQLTestUtils with BeforeAnd
     sql("DROP TEMPORARY FUNCTION udtf_count2")
   }
 
-  test("SPARK-30868 ADD JAR command failed") {
-    val jarPath = "file:///tmp/not_exists.jar"
-    assertThrows[QueryExecutionException](sql(s"ADD JAR $jarPath"))
-  }
-
   test("ADD FILE command") {
     val testFile = TestHive.getHiveFile("data/files/v1.txt").toURI
     sql(s"ADD FILE $testFile")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.{AnalysisException, DataFrame, Row, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.Cast
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.logical.Project
+import org.apache.spark.sql.execution.QueryExecutionException
 import org.apache.spark.sql.execution.joins.BroadcastNestedLoopJoinExec
 import org.apache.spark.sql.hive._
 import org.apache.spark.sql.hive.test.{HiveTestJars, TestHive}
@@ -845,6 +846,11 @@ class HiveQuerySuite extends HiveComparisonTest with SQLTestUtils with BeforeAnd
       """.stripMargin)
     assert(sql("DESCRIBE FUNCTION udtf_count2").count > 1)
     sql("DROP TEMPORARY FUNCTION udtf_count2")
+  }
+
+  test("SPARK-30868 ADD JAR command failed") {
+    val jarPath = "file:///tmp/not_exists.jar"
+    assertThrows[QueryExecutionException](sql(s"ADD JAR $jarPath"))
   }
 
   test("ADD FILE command") {


### PR DESCRIPTION
### Why are the changes needed?
At present, HiveClientImpl.runHive will not throw an exception when it runs incorrectly, which will cause it to fail to feedback error information normally.
Example
```scala
spark.sql("add jar file:///tmp/not_exists.jar")
spark.sql("show databases").show()
```
/tmp/not_exists.jar doesn't exist, thus add jar is failed. However this code will run completely without causing application failure.


### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
add new suite tests