### PR TITLE
[SPARK-30883][TEST] Cancel the tests when setReadable and setExecutable don't work

### DIFF
--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -185,6 +185,7 @@ class FsHistoryProviderSuite extends SparkFunSuite with Matchers with Logging {
       SparkListenerApplicationEnd(2L)
       )
     logFile2.setReadable(false, false)
+    assume(!logFile2.canRead, "Cancel the case for root can read any files.")
 
     updateAndCheck(provider) { list =>
       list.size should be (1)

--- a/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
@@ -119,6 +119,8 @@ class DiskBlockManagerSuite extends SparkFunSuite with BeforeAndAfterEach with B
 
       // all disks damaged
       rootDir1.setExecutable(false)
+      assume(!rootDir1.canExecute, "Cancel the case for root can execute any files.")
+      
       val tempShuffleFile3 = diskBlockManager.createTempShuffleBlock()._2
       val tempLocalFile3 = diskBlockManager.createTempLocalBlock()._2
       assert(!tempShuffleFile3.exists(),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
@@ -324,6 +324,7 @@ class BinaryFileFormatSuite extends QueryTest with SharedSparkSession {
       val content = "abc".getBytes
       Files.write(file.toPath, content, StandardOpenOption.CREATE, StandardOpenOption.WRITE)
       file.setReadable(false)
+      assume(!file.canRead, "Cancel the case for root can read any files.")
 
       // If content is selected, it throws an exception because it's not readable.
       intercept[IOException] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
@@ -84,6 +84,7 @@ class CreateTableAsSelectSuite extends DataSourceTest with SharedSparkSession {
     val childPath = new File(path.toString, "child")
     path.mkdir()
     path.setWritable(false)
+    assume(!path.canWrite, "Cancel the case for root can write any files.")
 
     val e = intercept[SparkException] {
       sql(


### PR DESCRIPTION
### What changes were proposed in this pull request?
The java api setWritable,setReadable and setExecutable dosen't work well because root can read / write or execute every files. Maybe, we could cancel these tests or fast failure when the mvn test is starting.


### Why are the changes needed?
When we run the test in root role, the test will fail.
```
SPARK-3697: ignore files that cannot be read. *** FAILED ***
  2 was not equal to 1 (FsHistoryProviderSuite.scala:187)

temporary shuffle/local file should be able to handle disk failures *** FAILED ***
  tempShuffleFile3.exists() was true All disks are broken, so there should be no temp shuffle file created (DiskBlockManagerSuite.scala:124)
```


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
UT
