### PR TITLE
[SPARK-24994][SQL] : Support filter pushdown for short and byte without explicit casting

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -443,30 +443,62 @@ object DataSourceStrategy {
     case expressions.EqualTo(Literal(v, t), a: Attribute) =>
       Some(sources.EqualTo(a.name, convertToScala(v, t)))
 
+    case expressions.EqualTo(Cast(c, dt, tz), Literal(v, t)) if c.isInstanceOf[Attribute] =>
+      Some(sources.EqualTo(c.asInstanceOf[Attribute].name, convertToScala(v, t)))
+    case expressions.EqualTo(Literal(v, t), Cast(c, dt, tz)) if c.isInstanceOf[Attribute] =>
+      Some(sources.EqualTo(c.asInstanceOf[Attribute].name, convertToScala(v, t)))
+
     case expressions.EqualNullSafe(a: Attribute, Literal(v, t)) =>
       Some(sources.EqualNullSafe(a.name, convertToScala(v, t)))
     case expressions.EqualNullSafe(Literal(v, t), a: Attribute) =>
       Some(sources.EqualNullSafe(a.name, convertToScala(v, t)))
+
+    case expressions.EqualNullSafe(Cast(c, dt, tz), Literal(v, t)) if c.isInstanceOf[Attribute] =>
+      Some(sources.EqualNullSafe(c.asInstanceOf[Attribute].name, convertToScala(v, t)))
+    case expressions.EqualNullSafe(Literal(v, t), Cast(c, dt, tz)) if c.isInstanceOf[Attribute] =>
+      Some(sources.EqualNullSafe(c.asInstanceOf[Attribute].name, convertToScala(v, t)))
 
     case expressions.GreaterThan(a: Attribute, Literal(v, t)) =>
       Some(sources.GreaterThan(a.name, convertToScala(v, t)))
     case expressions.GreaterThan(Literal(v, t), a: Attribute) =>
       Some(sources.LessThan(a.name, convertToScala(v, t)))
 
+    case expressions.GreaterThan(Cast(c, dt, tz), Literal(v, t)) if c.isInstanceOf[Attribute] =>
+      Some(sources.GreaterThan(c.asInstanceOf[Attribute].name, convertToScala(v, t)))
+    case expressions.GreaterThan(Literal(v, t), Cast(c, dt, tz)) if c.isInstanceOf[Attribute] =>
+      Some(sources.LessThan(c.asInstanceOf[Attribute].name, convertToScala(v, t)))
+
     case expressions.LessThan(a: Attribute, Literal(v, t)) =>
       Some(sources.LessThan(a.name, convertToScala(v, t)))
     case expressions.LessThan(Literal(v, t), a: Attribute) =>
       Some(sources.GreaterThan(a.name, convertToScala(v, t)))
+
+    case expressions.LessThan(Cast(c, dt, tz), Literal(v, t)) if c.isInstanceOf[Attribute] =>
+      Some(sources.LessThan(c.asInstanceOf[Attribute].name, convertToScala(v, t)))
+    case expressions.LessThan(Literal(v, t), Cast(c, dt, tz)) if c.isInstanceOf[Attribute] =>
+      Some(sources.GreaterThan(c.asInstanceOf[Attribute].name, convertToScala(v, t)))
 
     case expressions.GreaterThanOrEqual(a: Attribute, Literal(v, t)) =>
       Some(sources.GreaterThanOrEqual(a.name, convertToScala(v, t)))
     case expressions.GreaterThanOrEqual(Literal(v, t), a: Attribute) =>
       Some(sources.LessThanOrEqual(a.name, convertToScala(v, t)))
 
+    case expressions.GreaterThanOrEqual(Cast(c, dt, tz), Literal(v, t))
+      if c.isInstanceOf[Attribute] =>
+      Some(sources.GreaterThanOrEqual(c.asInstanceOf[Attribute].name, convertToScala(v, t)))
+    case expressions.GreaterThanOrEqual(Literal(v, t), Cast(c, dt, tz))
+      if c.isInstanceOf[Attribute] =>
+      Some(sources.LessThanOrEqual(c.asInstanceOf[Attribute].name, convertToScala(v, t)))
+
     case expressions.LessThanOrEqual(a: Attribute, Literal(v, t)) =>
       Some(sources.LessThanOrEqual(a.name, convertToScala(v, t)))
     case expressions.LessThanOrEqual(Literal(v, t), a: Attribute) =>
       Some(sources.GreaterThanOrEqual(a.name, convertToScala(v, t)))
+
+    case expressions.LessThanOrEqual(Cast(c, dt, tz), Literal(v, t)) if c.isInstanceOf[Attribute] =>
+      Some(sources.LessThanOrEqual(c.asInstanceOf[Attribute].name, convertToScala(v, t)))
+    case expressions.LessThanOrEqual(Literal(v, t), Cast(c, dt, tz)) if c.isInstanceOf[Attribute] =>
+      Some(sources.GreaterThanOrEqual(c.asInstanceOf[Attribute].name, convertToScala(v, t)))
 
     case expressions.InSet(a: Attribute, set) =>
       val toScala = CatalystTypeConverters.createToScalaConverter(a.dataType)
@@ -479,6 +511,11 @@ object DataSourceStrategy {
       val hSet = list.map(_.eval(EmptyRow))
       val toScala = CatalystTypeConverters.createToScalaConverter(a.dataType)
       Some(sources.In(a.name, hSet.toArray.map(toScala)))
+
+    case expressions.In(Cast(c, dt, tz), list) if list.forall(_.isInstanceOf[Literal]) =>
+      val hSet = list.map(_.eval(EmptyRow))
+      val toScala = CatalystTypeConverters.createToScalaConverter(dt)
+      Some(sources.In(c.asInstanceOf[Attribute].name, hSet.toArray.map(toScala)))
 
     case expressions.IsNull(a: Attribute) =>
       Some(sources.IsNull(a.name))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -443,62 +443,30 @@ object DataSourceStrategy {
     case expressions.EqualTo(Literal(v, t), a: Attribute) =>
       Some(sources.EqualTo(a.name, convertToScala(v, t)))
 
-    case expressions.EqualTo(Cast(c, dt, tz), Literal(v, t)) if c.isInstanceOf[Attribute] =>
-      Some(sources.EqualTo(c.asInstanceOf[Attribute].name, convertToScala(v, t)))
-    case expressions.EqualTo(Literal(v, t), Cast(c, dt, tz)) if c.isInstanceOf[Attribute] =>
-      Some(sources.EqualTo(c.asInstanceOf[Attribute].name, convertToScala(v, t)))
-
     case expressions.EqualNullSafe(a: Attribute, Literal(v, t)) =>
       Some(sources.EqualNullSafe(a.name, convertToScala(v, t)))
     case expressions.EqualNullSafe(Literal(v, t), a: Attribute) =>
       Some(sources.EqualNullSafe(a.name, convertToScala(v, t)))
-
-    case expressions.EqualNullSafe(Cast(c, dt, tz), Literal(v, t)) if c.isInstanceOf[Attribute] =>
-      Some(sources.EqualNullSafe(c.asInstanceOf[Attribute].name, convertToScala(v, t)))
-    case expressions.EqualNullSafe(Literal(v, t), Cast(c, dt, tz)) if c.isInstanceOf[Attribute] =>
-      Some(sources.EqualNullSafe(c.asInstanceOf[Attribute].name, convertToScala(v, t)))
 
     case expressions.GreaterThan(a: Attribute, Literal(v, t)) =>
       Some(sources.GreaterThan(a.name, convertToScala(v, t)))
     case expressions.GreaterThan(Literal(v, t), a: Attribute) =>
       Some(sources.LessThan(a.name, convertToScala(v, t)))
 
-    case expressions.GreaterThan(Cast(c, dt, tz), Literal(v, t)) if c.isInstanceOf[Attribute] =>
-      Some(sources.GreaterThan(c.asInstanceOf[Attribute].name, convertToScala(v, t)))
-    case expressions.GreaterThan(Literal(v, t), Cast(c, dt, tz)) if c.isInstanceOf[Attribute] =>
-      Some(sources.LessThan(c.asInstanceOf[Attribute].name, convertToScala(v, t)))
-
     case expressions.LessThan(a: Attribute, Literal(v, t)) =>
       Some(sources.LessThan(a.name, convertToScala(v, t)))
     case expressions.LessThan(Literal(v, t), a: Attribute) =>
       Some(sources.GreaterThan(a.name, convertToScala(v, t)))
-
-    case expressions.LessThan(Cast(c, dt, tz), Literal(v, t)) if c.isInstanceOf[Attribute] =>
-      Some(sources.LessThan(c.asInstanceOf[Attribute].name, convertToScala(v, t)))
-    case expressions.LessThan(Literal(v, t), Cast(c, dt, tz)) if c.isInstanceOf[Attribute] =>
-      Some(sources.GreaterThan(c.asInstanceOf[Attribute].name, convertToScala(v, t)))
 
     case expressions.GreaterThanOrEqual(a: Attribute, Literal(v, t)) =>
       Some(sources.GreaterThanOrEqual(a.name, convertToScala(v, t)))
     case expressions.GreaterThanOrEqual(Literal(v, t), a: Attribute) =>
       Some(sources.LessThanOrEqual(a.name, convertToScala(v, t)))
 
-    case expressions.GreaterThanOrEqual(Cast(c, dt, tz), Literal(v, t))
-      if c.isInstanceOf[Attribute] =>
-      Some(sources.GreaterThanOrEqual(c.asInstanceOf[Attribute].name, convertToScala(v, t)))
-    case expressions.GreaterThanOrEqual(Literal(v, t), Cast(c, dt, tz))
-      if c.isInstanceOf[Attribute] =>
-      Some(sources.LessThanOrEqual(c.asInstanceOf[Attribute].name, convertToScala(v, t)))
-
     case expressions.LessThanOrEqual(a: Attribute, Literal(v, t)) =>
       Some(sources.LessThanOrEqual(a.name, convertToScala(v, t)))
     case expressions.LessThanOrEqual(Literal(v, t), a: Attribute) =>
       Some(sources.GreaterThanOrEqual(a.name, convertToScala(v, t)))
-
-    case expressions.LessThanOrEqual(Cast(c, dt, tz), Literal(v, t)) if c.isInstanceOf[Attribute] =>
-      Some(sources.LessThanOrEqual(c.asInstanceOf[Attribute].name, convertToScala(v, t)))
-    case expressions.LessThanOrEqual(Literal(v, t), Cast(c, dt, tz)) if c.isInstanceOf[Attribute] =>
-      Some(sources.GreaterThanOrEqual(c.asInstanceOf[Attribute].name, convertToScala(v, t)))
 
     case expressions.InSet(a: Attribute, set) =>
       val toScala = CatalystTypeConverters.createToScalaConverter(a.dataType)
@@ -511,11 +479,6 @@ object DataSourceStrategy {
       val hSet = list.map(_.eval(EmptyRow))
       val toScala = CatalystTypeConverters.createToScalaConverter(a.dataType)
       Some(sources.In(a.name, hSet.toArray.map(toScala)))
-
-    case expressions.In(Cast(c, dt, tz), list) if list.forall(_.isInstanceOf[Literal]) =>
-      val hSet = list.map(_.eval(EmptyRow))
-      val toScala = CatalystTypeConverters.createToScalaConverter(dt)
-      Some(sources.In(c.asInstanceOf[Attribute].name, hSet.toArray.map(toScala)))
 
     case expressions.IsNull(a: Attribute) =>
       Some(sources.IsNull(a.name))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilters.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources.parquet
 
-import java.lang.{Boolean => JBoolean, Double => JDouble, Float => JFloat, Long => JLong}
+import java.lang.{Boolean => JBoolean, Byte => JByte, Double => JDouble, Float => JFloat, Integer => JInteger, Long => JLong, Short => JShort}
 import java.math.{BigDecimal => JBigDecimal}
 import java.sql.{Date, Timestamp}
 import java.util.Locale
@@ -439,7 +439,13 @@ class ParquetFilters(
   private def valueCanMakeFilterOn(name: String, value: Any): Boolean = {
     value == null || (nameToParquetField(name).fieldType match {
       case ParquetBooleanType => value.isInstanceOf[JBoolean]
-      case ParquetByteType | ParquetShortType | ParquetIntegerType => value.isInstanceOf[Number]
+      case ParquetByteType => value.isInstanceOf[JByte] ||
+        (value.isInstanceOf[JInteger] && value.asInstanceOf[JInteger].toByte.toInt ==
+          value.asInstanceOf[JInteger])
+      case ParquetShortType => value.isInstanceOf[JShort] ||
+        (value.isInstanceOf[JInteger] && value.asInstanceOf[JInteger].toShort.toInt ==
+          value.asInstanceOf[JInteger])
+      case ParquetIntegerType => value.isInstanceOf[Number]
       case ParquetLongType => value.isInstanceOf[JLong]
       case ParquetFloatType => value.isInstanceOf[JFloat]
       case ParquetDoubleType => value.isInstanceOf[JDouble]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
If we have a shortType column in our table, filter will not be pushed down for the following query:
`select * from t where id = 2;`
pushed filter ->
`PushedFilters: [IsNotNull(id)], ReadSchema: struct<id:smallint>`

2 is within short range still filter is not pushed down. 
But it pushes filter if we cast the literal to smallint: 
`select * from t where id = cast(2 as smallint) ; `
pushed filter ->
` PushedFilters: [IsNotNull(id), EqualTo(id,2)], ReadSchema: struct<id:smallint>`

After these changes, there is no need to explicitly convert literals to short/byte for filter pushdown:

`Select * from t where id = 2;`
pushed filter ->
`PushedFilters: [IsNotNull(id), EqualTo(id,2)], ReadSchema: struct<id:smallint>`

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
These changes are needed because whenever we want to pushdown filters for short/byte value we have to explicitly cast them to short/byte even if the value is well within short/byte range.

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce any user-facing change?
Yes, now users dont need to explicitly cast literals to short/byte for filter pushdown.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->


### How was this patch tested?
Manually. UT will be added soon.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
