### PR TITLE
[MINOR][SQL] Add a comment for `removedSQLConfigs`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2254,6 +2254,14 @@ object SQLConf {
    * The map contains info about removed SQL configs. Keys are SQL config names,
    * map values contain extra information like the version in which the config was removed,
    * config's default value and a comment.
+   *
+   * Removed SQL config should be added to the map iff its non-default value changed
+   * the behavior. Any removed config of `removedSQLConfigs` which set to a non-default
+   * value raises an exception propagated to user's app. For example, the SQL config
+   * `spark.sql.variable.substitute.depth` was deprecated since Spark 2.1 and not
+   * used in Spark 2.4, so, it should not be placed here because any of its values
+   * does not impact on the behavior of Spark 3.0. And this makes migrations to new
+   * Spark versions painless.
    */
   val removedSQLConfigs: Map[String, RemovedConfig] = {
     val configs = Seq(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2259,9 +2259,8 @@ object SQLConf {
    * the behavior. Any removed config of `removedSQLConfigs` which set to a non-default
    * value raises an exception propagated to user's app. For example, the SQL config
    * `spark.sql.variable.substitute.depth` was deprecated since Spark 2.1 and not
-   * used in Spark 2.4, so, it should not be placed here because any of its values
-   * does not impact on the behavior of Spark 3.0. And this makes migrations to new
-   * Spark versions painless.
+   * used in Spark 2.4, so, it should not be placed here because the config
+   * is no-op technically. And this makes migrations to new Spark versions painless.
    */
   val removedSQLConfigs: Map[String, RemovedConfig] = {
     val configs = Seq(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2255,12 +2255,9 @@ object SQLConf {
    * map values contain extra information like the version in which the config was removed,
    * config's default value and a comment.
    *
-   * Removed SQL config should be added to the map iff its non-default value changed
-   * the behavior. Any removed config of `removedSQLConfigs` which set to a non-default
-   * value raises an exception propagated to user's app. For example, the SQL config
-   * `spark.sql.variable.substitute.depth` was deprecated since Spark 2.1 and not
-   * used in Spark 2.4, so, it should not be placed here because the config
-   * is no-op technically. And this makes migrations to new Spark versions painless.
+   * Please, add a removed SQL configuration property here only when it affects behaviours.
+   * For example, `spark.sql.variable.substitute.depth` was not added as it virtually
+   * became no-op later. By this, it makes migrations to new Spark versions painless.
    */
   val removedSQLConfigs: Map[String, RemovedConfig] = {
     val configs = Seq(


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to explain in the description of `removedSQLConfigs` when removed SQL configs should NOT be placed to the map.

### Why are the changes needed?
To make the cases when SQL configs should be added to `removedSQLConfigs` more clear. Recently, `spark.sql.variable.substitute.depth` was removed from the map by #27646 because it contradicts to the condition described by the PR.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
By `./dev/scalastyle`