### PR TITLE
[SPARK-30895]:The behavior of CsvToStructs should not depend on SQLConf.get

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/csvExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/csvExpressions.scala
@@ -139,7 +139,7 @@ case class CsvToStructs(
   override def prettyName: String = "from_csv"
 }
 
-object CsvToStructs{
+object CsvToStructs {
   def apply(
              schema: StructType,
              options: Map[String, String],

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/csvExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/csvExpressions.scala
@@ -64,11 +64,11 @@ case class CsvToStructs(
   // of the user-provided schema to avoid data corruptions.
   val nullableSchema: StructType = schema.asNullable
 
+  // Used in `FunctionRegistry`
   def this(schema: StructType, options: Map[String, String], child: Expression,
-           timeZoneId: Option[String]) = this(schema, options, child, timeZoneId,
+      timeZoneId: Option[String]) = this(schema, options, child, timeZoneId,
     SQLConf.get.columnNameOfCorruptRecord)
 
-  // Used in `FunctionRegistry`
   def this(child: Expression, schema: Expression, options: Map[String, String]) =
     this(
       schema = ExprUtils.evalSchemaExpr(schema),
@@ -140,17 +140,12 @@ case class CsvToStructs(
 }
 
 object CsvToStructs {
-  def apply(
-      schema: StructType,
-      options: Map[String, String],
-      child: Expression,
+  def apply(schema: StructType, options: Map[String, String], child: Expression,
       timeZoneId: Option[String]): CsvToStructs =
     new CsvToStructs(schema, options, child, timeZoneId)
 
-  def apply(
-      schema: StructType,
-      options: Map[String, String],
-      child: Expression): CsvToStructs = new CsvToStructs(schema, options, child, None)
+  def apply(schema: StructType, options: Map[String, String], child: Expression): CsvToStructs =
+    new CsvToStructs(schema, options, child, None)
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/csvExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/csvExpressions.scala
@@ -141,17 +141,16 @@ case class CsvToStructs(
 
 object CsvToStructs {
   def apply(
-             schema: StructType,
-             options: Map[String, String],
-             child: Expression,
-             timeZoneId: Option[String]): CsvToStructs =
+      schema: StructType,
+      options: Map[String, String],
+      child: Expression,
+      timeZoneId: Option[String]): CsvToStructs =
     new CsvToStructs(schema, options, child, timeZoneId)
 
   def apply(
-             schema: StructType,
-             options: Map[String, String],
-             child: Expression): CsvToStructs =
-    new CsvToStructs(schema, options, child, None)
+      schema: StructType,
+      options: Map[String, String],
+      child: Expression): CsvToStructs = new CsvToStructs(schema, options, child, None)
 }
 
 /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I add the `nameOfCorruptRecord` parameter to the `CsvToStructs` expression.

### Why are the changes needed?
This allows to avoid the issue when the configuration change between different phases of planning, and this can silently break a query plan which can lead to crashes or data corruption.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
By CsvExpressionsSuite.
