### PR TITLE
[SPARK-30915][SS] CompactibleFileStreamLog: Avoid reading the metadata log file when finding the latest batch ID

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/CompactibleFileStreamLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/CompactibleFileStreamLog.scala
@@ -213,7 +213,7 @@ abstract class CompactibleFileStreamLog[T <: AnyRef : ClassTag](
    * Returns all files except the deleted ones.
    */
   def allFiles(): Array[T] = {
-    var latestId = getLatest().map(_._1).getOrElse(-1L)
+    var latestId = getLatestBatchId().getOrElse(-1L)
     // There is a race condition when `FileStreamSink` is deleting old files and `StreamFileIndex`
     // is calling this method. This loop will retry the reading to deal with the
     // race condition.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/CompactibleFileStreamLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/CompactibleFileStreamLog.scala
@@ -163,26 +163,6 @@ abstract class CompactibleFileStreamLog[T <: AnyRef : ClassTag](
   }
 
   /**
-   * Return the latest batch Id.
-   *
-   * This method is a complement of getLatest() - while metadata log file per batch tends to be
-   * small, it doesn't apply to the compacted log file. This method only checks for existence of
-   * file to avoid huge cost on reading and deserializing compacted log file.
-   */
-  def getLatestBatchId(): Option[Long] = {
-    val batchIds = fileManager.list(metadataPath, batchFilesFilter)
-      .map(f => pathToBatchId(f.getPath))
-      .sorted(Ordering.Long.reverse)
-    for (batchId <- batchIds) {
-      val batchMetadataFile = batchIdToPath(batchId)
-      if (fileManager.exists(batchMetadataFile)) {
-        return Some(batchId)
-      }
-    }
-    None
-  }
-
-  /**
    * CompactibleFileStreamLog maintains logs by itself, and manual purging might break internal
    * state, specifically which latest compaction batch is purged.
    *

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/CompactibleFileStreamLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/CompactibleFileStreamLog.scala
@@ -163,6 +163,26 @@ abstract class CompactibleFileStreamLog[T <: AnyRef : ClassTag](
   }
 
   /**
+   * Return the latest batch Id.
+   *
+   * This method is a complement of getLatest() - while metadata log file per batch tends to be
+   * small, it doesn't apply to the compacted log file. This method only checks for existence of
+   * file to avoid huge cost on reading and deserializing compacted log file.
+   */
+  def getLatestBatchId(): Option[Long] = {
+    val batchIds = fileManager.list(metadataPath, batchFilesFilter)
+      .map(f => pathToBatchId(f.getPath))
+      .sorted(Ordering.Long.reverse)
+    for (batchId <- batchIds) {
+      val batchMetadataFile = batchIdToPath(batchId)
+      if (fileManager.exists(batchMetadataFile)) {
+        return Some(batchId)
+      }
+    }
+    None
+  }
+
+  /**
    * CompactibleFileStreamLog maintains logs by itself, and manual purging might break internal
    * state, specifically which latest compaction batch is purged.
    *

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSink.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSink.scala
@@ -142,7 +142,7 @@ class FileStreamSink(
   }
 
   override def addBatch(batchId: Long, data: DataFrame): Unit = {
-    if (batchId <= fileLog.getLatest().map(_._1).getOrElse(-1L)) {
+    if (batchId <= fileLog.getLatestBatchId().getOrElse(-1L)) {
       logInfo(s"Skipping already committed batch $batchId")
     } else {
       val committer = FileCommitProtocol.instantiate(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSourceLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSourceLog.scala
@@ -96,7 +96,7 @@ class FileStreamSourceLog(
     val searchKeys = removedBatches.map(_._1)
     val retrievedBatches = if (searchKeys.nonEmpty) {
       logWarning(s"Get batches from removed files, this is unexpected in the current code path!!!")
-      val latestBatchId = getLatest().map(_._1).getOrElse(-1L)
+      val latestBatchId = getLatestBatchId().getOrElse(-1L)
       if (latestBatchId < 0) {
         Map.empty[Long, Option[Array[FileEntry]]]
       } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/HDFSMetadataLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/HDFSMetadataLog.scala
@@ -202,8 +202,8 @@ class HDFSMetadataLog[T <: AnyRef : ClassTag](sparkSession: SparkSession, path: 
   override def getLatest(): Option[(Long, T)] = {
     getLatestBatchId().map { batchId =>
       val content = get(batchId).getOrElse {
-        // This only happens in odd case where the file exists when getLatestBatchId() is called,
-        // but get() doesn't find it.
+        // If we find the last batch file, we must read that file, other than failing back to
+        // old batches.
         throw new IllegalStateException(s"failed to read log file for batch $batchId")
       }
       (batchId, content)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/HDFSMetadataLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/HDFSMetadataLog.scala
@@ -187,16 +187,10 @@ class HDFSMetadataLog[T <: AnyRef : ClassTag](sparkSession: SparkSession, path: 
    * file to avoid cost on reading and deserializing log file.
    */
   def getLatestBatchId(): Option[Long] = {
-    val batchIds = fileManager.list(metadataPath, batchFilesFilter)
+    fileManager.list(metadataPath, batchFilesFilter)
       .map(f => pathToBatchId(f.getPath))
       .sorted(Ordering.Long.reverse)
-    for (batchId <- batchIds) {
-      val batchMetadataFile = batchIdToPath(batchId)
-      if (fileManager.exists(batchMetadataFile)) {
-        return Some(batchId)
-      }
-    }
-    None
+      .headOption
   }
 
   override def getLatest(): Option[(Long, T)] = {
@@ -207,7 +201,7 @@ class HDFSMetadataLog[T <: AnyRef : ClassTag](sparkSession: SparkSession, path: 
         throw new IllegalStateException(s"failed to read log file for batch $batchId")
       }
       (batchId, content)
-    }.orElse(None)
+    }
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/FileStreamSinkLogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/FileStreamSinkLogSuite.scala
@@ -254,7 +254,7 @@ class FileStreamSinkLogSuite extends SparkFunSuite with SharedSparkSession {
         withTempDir { dir =>
           val sinkLog = new FileStreamSinkLog(FileStreamSinkLog.VERSION, spark,
             s"$scheme:///${dir.getCanonicalPath}")
-          for (batchId <- 0 to 2) {
+          for (batchId <- 0L to 2L) {
             sinkLog.add(
               batchId,
               Array(newFakeSinkFileStatus("/a/b/" + batchId, FileStreamSinkLog.ADD_ACTION)))
@@ -262,7 +262,7 @@ class FileStreamSinkLogSuite extends SparkFunSuite with SharedSparkSession {
 
           def getCountForOpenOnMetadataFile(batchId: Long): Long = {
             val path = sinkLog.batchIdToPath(batchId).toUri.getPath
-            CountOpenLocalFileSystem.pathToNumOpenCalled.get(path).map(_.get()).getOrElse(0)
+            CountOpenLocalFileSystem.pathToNumOpenCalled.get(path).map(_.get()).getOrElse(0L)
           }
 
           CountOpenLocalFileSystem.resetCount()
@@ -270,16 +270,16 @@ class FileStreamSinkLogSuite extends SparkFunSuite with SharedSparkSession {
           assert(sinkLog.getLatestBatchId() === Some(2L))
           // getLatestBatchId doesn't open the latest metadata log file
           (0L to 2L).foreach { batchId =>
-            assert(getCountForOpenOnMetadataFile(batchId) === 0)
+            assert(getCountForOpenOnMetadataFile(batchId) === 0L)
           }
 
           assert(sinkLog.getLatest().map(_._1).getOrElse(-1L) === 2L)
           (0L to 1L).foreach { batchId =>
-            assert(getCountForOpenOnMetadataFile(batchId) === 0)
+            assert(getCountForOpenOnMetadataFile(batchId) === 0L)
           }
           // getLatest opens the latest metadata log file, which explains the needs on
           // having "getLatestBatchId".
-          assert(getCountForOpenOnMetadataFile(2L) === 1)
+          assert(getCountForOpenOnMetadataFile(2L) === 1L)
         }
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This patch adds the new method `getLatestBatchId()` in CompactibleFileStreamLog in complement of getLatest() which doesn't read the content of the latest batch metadata log file, and apply to both FileStreamSource and FileStreamSink to avoid unnecessary latency on reading log file.

### Why are the changes needed?

Once compacted metadata log file becomes huge, writing outputs for the compact + 1 batch is also affected due to unnecessarily reading the compacted metadata log file. This unnecessary latency can be simply avoided.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

New UT. Also manually tested under query which has huge metadata log on file stream sink:

> before applying the patch

![Screen Shot 2020-02-21 at 4 20 19 PM](https://user-images.githubusercontent.com/1317309/75016223-d3ffb180-54cd-11ea-9063-49405943049d.png)

> after applying the patch

![Screen Shot 2020-02-21 at 4 06 18 PM](https://user-images.githubusercontent.com/1317309/75016220-d235ee00-54cd-11ea-81a7-7c03a43c4db4.png)

Peaks are compact batches - please compare the next batch after compact batches, especially the area of "light brown".