### PR TITLE
[SPARK-30776][ML] Support FValueSelector for continuous features and continuous labels

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
@@ -21,7 +21,7 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml._
-import org.apache.spark.ml.attribute.{AttributeGroup, _}
+import org.apache.spark.ml.attribute._
 import org.apache.spark.ml.linalg._
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared._

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/FValueSelector.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/FValueSelector.scala
@@ -1,0 +1,448 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.feature
+
+import scala.collection.mutable.ArrayBuilder
+
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.annotation.Since
+import org.apache.spark.ml._
+import org.apache.spark.ml.attribute.{AttributeGroup, _}
+import org.apache.spark.ml.linalg._
+import org.apache.spark.ml.param._
+import org.apache.spark.ml.param.shared._
+import org.apache.spark.ml.stat.{FValueTest, SelectionTestResult}
+import org.apache.spark.ml.util._
+import org.apache.spark.sql._
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.{DoubleType, StructField, StructType}
+
+
+/**
+ * Params for [[FValueSelector]] and [[FValueSelectorModel]].
+ */
+private[feature] trait FValueSelectorParams extends Params
+  with HasFeaturesCol with HasOutputCol with HasLabelCol {
+
+  /**
+   * Number of features that selector will select, ordered by ascending p-value. If the
+   * number of features is less than numTopFeatures, then this will select all features.
+   * Only applicable when selectorType = "numTopFeatures".
+   * The default value of numTopFeatures is 50.
+   *
+   * @group param
+   */
+  @Since("3.1.0")
+  final val numTopFeatures = new IntParam(this, "numTopFeatures",
+    "Number of features that selector will select, ordered by ascending p-value. If the" +
+      " number of features is < numTopFeatures, then this will select all features.",
+    ParamValidators.gtEq(1))
+  setDefault(numTopFeatures -> 50)
+
+  /** @group getParam */
+  @Since("3.1.0")
+  def getNumTopFeatures: Int = $(numTopFeatures)
+
+  /**
+   * Percentile of features that selector will select, ordered by ascending p-value.
+   * Only applicable when selectorType = "percentile".
+   * Default value is 0.1.
+   * @group param
+   */
+  @Since("3.1.0")
+  final val percentile = new DoubleParam(this, "percentile",
+    "Percentile of features that selector will select, ordered by ascending p-value.",
+    ParamValidators.inRange(0, 1))
+  setDefault(percentile -> 0.1)
+
+  /** @group getParam */
+  @Since("3.1.0")
+  def getPercentile: Double = $(percentile)
+
+  /**
+   * The lowest p-value for features to be kept.
+   * Only applicable when selectorType = "fpr".
+   * Default value is 0.05.
+   * @group param
+   */
+  @Since("3.1.0")
+  final val fpr = new DoubleParam(this, "fpr", "The lowest p-value for features to be kept.",
+    ParamValidators.inRange(0, 1))
+  setDefault(fpr -> 0.05)
+
+  /** @group getParam */
+  @Since("3.1.0")
+  def getFpr: Double = $(fpr)
+
+  /**
+   * The upper bound of the expected false discovery rate.
+   * Only applicable when selectorType = "fdr".
+   * Default value is 0.05.
+   * @group param
+   */
+  @Since("3.1.0")
+  final val fdr = new DoubleParam(this, "fdr",
+    "The upper bound of the expected false discovery rate.", ParamValidators.inRange(0, 1))
+  setDefault(fdr -> 0.05)
+
+  /** @group getParam */
+  def getFdr: Double = $(fdr)
+
+  /**
+   * The upper bound of the expected family-wise error rate.
+   * Only applicable when selectorType = "fwe".
+   * Default value is 0.05.
+   * @group param
+   */
+  @Since("3.1.0")
+  final val fwe = new DoubleParam(this, "fwe",
+    "The upper bound of the expected family-wise error rate.", ParamValidators.inRange(0, 1))
+  setDefault(fwe -> 0.05)
+
+  /** @group getParam */
+  def getFwe: Double = $(fwe)
+
+  /**
+   * The selector type.
+   * Supported options: "numTopFeatures" (default), "percentile", "fpr", "fdr", "fwe"
+   * @group param
+   */
+  @Since("3.1.0")
+  final val selectorType = new Param[String](this, "selectorType",
+    "The selector type. Supported options: numTopFeatures, percentile, fpr, fdr, fwe",
+    ParamValidators.inArray(Array("numTopFeatures", "percentile", "fpr", "fdr",
+      "fwe")))
+  setDefault(selectorType -> "numTopFeatures")
+
+  /** @group getParam */
+  @Since("3.1.0")
+  def getSelectorType: String = $(selectorType)
+}
+
+/**
+ * F Value Regression feature selector, which selects continuous features to use for predicting a
+ * continuous label.
+ * The selector supports different selection methods: `numTopFeatures`, `percentile`, `fpr`,
+ * `fdr`, `fwe`.
+ *  - `numTopFeatures` chooses a fixed number of top features according to a F value regression
+ *  test.
+ *  - `percentile` is similar but chooses a fraction of all features instead of a fixed number.
+ *  - `fpr` chooses all features whose p-value are below a threshold, thus controlling the false
+ *    positive rate of selection.
+ *  - `fdr` uses the [Benjamini-Hochberg procedure]
+ *    (https://en.wikipedia.org/wiki/False_discovery_rate#Benjamini.E2.80.93Hochberg_procedure)
+ *    to choose all features whose false discovery rate is below a threshold.
+ *  - `fwe` chooses all features whose p-values are below a threshold. The threshold is scaled by
+ *    1/numFeatures, thus controlling the family-wise error rate of selection.
+ * By default, the selection method is `numTopFeatures`, with the default number of top features
+ * set to 50.
+ */
+@Since("3.1.0")
+final class FValueSelector @Since("3.1.0") (override val uid: String)
+  extends Estimator[FValueSelectorModel] with FValueSelectorParams
+    with DefaultParamsWritable {
+
+  @Since("3.1.0")
+  def this() = this(Identifiable.randomUID("FValueSelector"))
+
+  /** @group setParam */
+  @Since("3.1.0")
+  def setNumTopFeatures(value: Int): this.type = set(numTopFeatures, value)
+
+  /** @group setParam */
+  @Since("3.1.0")
+  def setPercentile(value: Double): this.type = set(percentile, value)
+
+  /** @group setParam */
+  @Since("3.1.0")
+  def setFpr(value: Double): this.type = set(fpr, value)
+
+  /** @group setParam */
+  @Since("3.1.0")
+  def setFdr(value: Double): this.type = set(fdr, value)
+
+  /** @group setParam */
+  @Since("3.1.0")
+  def setFwe(value: Double): this.type = set(fwe, value)
+
+  /** @group setParam */
+  @Since("3.1.0")
+  def setSelectorType(value: String): this.type = set(selectorType, value)
+
+  /** @group setParam */
+  @Since("3.1.0")
+  def setFeaturesCol(value: String): this.type = set(featuresCol, value)
+
+  /** @group setParam */
+  @Since("3.1.0")
+  def setOutputCol(value: String): this.type = set(outputCol, value)
+
+  /** @group setParam */
+  @Since("3.1.0")
+  def setLabelCol(value: String): this.type = set(labelCol, value)
+
+  @Since("3.1.0")
+  override def fit(dataset: Dataset[_]): FValueSelectorModel = {
+    transformSchema(dataset.schema, logging = true)
+    dataset.select(col($(labelCol)).cast(DoubleType), col($(featuresCol))).rdd.map {
+      case Row(label: Double, features: Vector) =>
+        LabeledPoint(label, features)
+    }
+
+    val testResult = FValueTest.testRegression(dataset, getFeaturesCol, getLabelCol)
+      .zipWithIndex
+    val features = $(selectorType) match {
+      case "numTopFeatures" =>
+        testResult
+          .sortBy { case (res, _) => res.pValue }
+          .take(getNumTopFeatures)
+      case "percentile" =>
+        testResult
+          .sortBy { case (res, _) => res.pValue }
+          .take((testResult.length * getPercentile).toInt)
+      case "fpr" =>
+        testResult
+          .filter { case (res, _) => res.pValue < getFpr }
+      case "fdr" =>
+        // This uses the Benjamini-Hochberg procedure.
+        // https://en.wikipedia.org/wiki/False_discovery_rate#Benjamini.E2.80.93Hochberg_procedure
+        val tempRes = testResult
+          .sortBy { case (res, _) => res.pValue }
+        val selected = tempRes
+          .zipWithIndex
+          .filter { case ((res, _), index) =>
+            res.pValue <= getFdr * (index + 1) / testResult.length }
+        if (selected.isEmpty) {
+          Array.empty[(SelectionTestResult, Int)]
+        } else {
+          val maxIndex = selected.map(_._2).max
+          tempRes.take(maxIndex + 1)
+        }
+      case "fwe" =>
+        testResult
+          .filter { case (res, _) => res.pValue < getFwe / testResult.length }
+      case errorType =>
+        throw new IllegalStateException(s"Unknown Selector Type: $errorType")
+    }
+    val indices = features.map { case (_, index) => index }
+    val pValues = features.map(_._1.pValue)
+    val statistic = features.map(_._1.statistic)
+    copyValues(new FValueSelectorModel(uid, indices.sorted, pValues, statistic)
+      .setParent(this))
+  }
+
+  @Since("3.1.0")
+  override def transformSchema(schema: StructType): StructType = {
+    SchemaUtils.checkColumnType(schema, $(featuresCol), new VectorUDT)
+    SchemaUtils.checkNumericType(schema, $(labelCol))
+    SchemaUtils.appendColumn(schema, $(outputCol), new VectorUDT)
+  }
+
+  @Since("3.1.0")
+  override def copy(extra: ParamMap): FValueSelector = defaultCopy(extra)
+}
+
+@Since("3.1.0")
+object FValueSelector extends DefaultParamsReadable[FValueSelector] {
+
+  @Since("3.1.0")
+  override def load(path: String): FValueSelector = super.load(path)
+}
+
+/**
+ * Model fitted by [[FValueSelector]].
+ */
+@Since("3.1.0")
+class FValueSelectorModel private[ml](
+    override val uid: String,
+    val selectedFeatures: Array[Int],
+    val pValues: Array[Double],
+    val statistic: Array[Double])
+  extends Model[FValueSelectorModel] with FValueSelectorParams with MLWritable {
+
+  var prev = -1
+  selectedFeatures.foreach { i =>
+    require(prev < i, s"Index $i follows $prev and is not strictly increasing")
+    prev = i
+  }
+
+  /** @group setParam */
+  @Since("3.1.0")
+  def setFeaturesCol(value: String): this.type = set(featuresCol, value)
+
+  /** @group setParam */
+  @Since("3.1.0")
+  def setOutputCol(value: String): this.type = set(outputCol, value)
+
+  @Since("3.1.0")
+  override def transform(dataset: Dataset[_]): DataFrame = {
+    val outputSchema = transformSchema(dataset.schema, logging = true)
+
+    val newSize = selectedFeatures.length
+    val func = { vector: Vector =>
+      vector match {
+        case SparseVector(_, indices, values) =>
+          val (newIndices, newValues) = compressSparse(indices, values)
+          Vectors.sparse(newSize, newIndices, newValues)
+        case DenseVector(values) =>
+          Vectors.dense(selectedFeatures.map(i => values(i)))
+        case other =>
+          throw new UnsupportedOperationException(
+            s"Only sparse and dense vectors are supported but got ${other.getClass}.")
+      }
+    }
+
+    val transformer = udf(func)
+    dataset.withColumn($(outputCol), transformer(col($(featuresCol))),
+      outputSchema($(outputCol)).metadata)
+  }
+
+  @Since("3.1.0")
+  override def transformSchema(schema: StructType): StructType = {
+    SchemaUtils.checkColumnType(schema, $(featuresCol), new VectorUDT)
+    val newField = prepOutputField(schema)
+    SchemaUtils.appendColumn(schema, newField)
+  }
+
+  /**
+   * Prepare the output column field, including per-feature metadata.
+   */
+  private def prepOutputField(schema: StructType): StructField = {
+    val selector = selectedFeatures.toSet
+    val origAttrGroup = AttributeGroup.fromStructField(schema($(featuresCol)))
+    val featureAttributes: Array[Attribute] = if (origAttrGroup.attributes.nonEmpty) {
+      origAttrGroup.attributes.get.zipWithIndex.filter(x => selector.contains(x._2)).map(_._1)
+    } else {
+      Array.fill[Attribute](selector.size)(NominalAttribute.defaultAttr)
+    }
+    val newAttributeGroup = new AttributeGroup($(outputCol), featureAttributes)
+    newAttributeGroup.toStructField()
+  }
+
+  @Since("3.1.0")
+  override def copy(extra: ParamMap): FValueSelectorModel = {
+    val copied = new FValueSelectorModel(uid, selectedFeatures, pValues, statistic)
+      .setParent(parent)
+    copyValues(copied, extra)
+  }
+
+  @Since("3.1.0")
+  override def write: MLWriter = new FValueSelectorModel.
+  FValueSelectorModelWriter(this)
+
+  @Since("3.1.0")
+  override def toString: String = {
+    s"FValueSelectorModel: uid=$uid, numSelectedFeatures=${selectedFeatures.length}"
+  }
+
+  private[spark] def compressSparse(
+      indices: Array[Int],
+      values: Array[Double]): (Array[Int], Array[Double]) = {
+    val newValues = new ArrayBuilder.ofDouble
+    val newIndices = new ArrayBuilder.ofInt
+    var i = 0
+    var j = 0
+    var indicesIdx = 0
+    var filterIndicesIdx = 0
+    while (i < indices.length && j < selectedFeatures.length) {
+      indicesIdx = indices(i)
+      filterIndicesIdx = selectedFeatures(j)
+      if (indicesIdx == filterIndicesIdx) {
+        newIndices += j
+        newValues += values(i)
+        j += 1
+        i += 1
+      } else {
+        if (indicesIdx > filterIndicesIdx) {
+          j += 1
+        } else {
+          i += 1
+        }
+      }
+    }
+    // TODO: Sparse representation might be ineffective if (newSize ~= newValues.size)
+    (newIndices.result(), newValues.result())
+  }
+}
+
+@Since("3.1.0")
+object FValueSelectorModel extends MLReadable[FValueSelectorModel] {
+
+  @Since("3.1.0")
+  override def read: MLReader[FValueSelectorModel] =
+    new FValueSelectorModelReader
+
+  @Since("3.1.0")
+  override def load(path: String): FValueSelectorModel = super.load(path)
+
+  private[FValueSelectorModel] class FValueSelectorModelWriter(
+      instance:
+      FValueSelectorModel) extends MLWriter {
+
+    private case class Data(selectedFeatures: Seq[Int],
+                            pValue: Seq[Double],
+                            statistics: Seq[Double])
+
+    override protected def saveImpl(path: String): Unit = {
+      DefaultParamsWriter.saveMetadata(instance, path, sc)
+      val data = Data(instance.selectedFeatures.toSeq, instance.pValues.toSeq,
+        instance.statistic.toSeq)
+      val dataPath = new Path(path, "data").toString
+      sparkSession.createDataFrame(Seq(data)).repartition(1).write.parquet(dataPath)
+    }
+  }
+
+  private class FValueSelectorModelReader extends
+    MLReader[FValueSelectorModel] {
+
+    /** Checked against metadata when loading model */
+    private val className = classOf[FValueSelectorModel].getName
+
+    override def load(path: String): FValueSelectorModel = {
+      val metadata = DefaultParamsReader.loadMetadata(path, sc, className)
+      val dataPath = new Path(path, "data").toString
+      val data = sparkSession.read.parquet(dataPath)
+        .select("selectedFeatures", "pValue", "statistics").head()
+      val selectedFeatures = data.getAs[Seq[Int]](0).toArray
+      val pValue = data.getAs[Seq[Double]](1).toArray
+      val statistics = data.getAs[Seq[Double]](2).toArray
+      val model = new FValueSelectorModel(metadata.uid, selectedFeatures,
+        pValue, statistics)
+      metadata.getAndSetParams(model)
+      model
+    }
+  }
+}

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/FValueSelector.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/FValueSelector.scala
@@ -15,23 +15,6 @@
  * limitations under the License.
  */
 
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.apache.spark.ml.feature
 
 import scala.collection.mutable.ArrayBuilder
@@ -40,7 +23,7 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml._
-import org.apache.spark.ml.attribute.{AttributeGroup, _}
+import org.apache.spark.ml.attribute._
 import org.apache.spark.ml.linalg._
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared._
@@ -412,9 +395,10 @@ object FValueSelectorModel extends MLReadable[FValueSelectorModel] {
       instance:
       FValueSelectorModel) extends MLWriter {
 
-    private case class Data(selectedFeatures: Seq[Int],
-                            pValue: Seq[Double],
-                            statistics: Seq[Double])
+    private case class Data(
+        selectedFeatures: Seq[Int],
+        pValue: Seq[Double],
+        statistics: Seq[Double])
 
     override protected def saveImpl(path: String): Unit = {
       DefaultParamsWriter.saveMetadata(instance, path, sc)

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/FValueTest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/FValueTest.scala
@@ -122,7 +122,7 @@ object FValueTest {
       val corr = covariance / (yStd * xStd(i))
       val fValue = corr * corr / (1 - corr * corr) * degreesOfFreedom
       val pValue = 1.0 - fd.cumulativeProbability(fValue)
-      fTestResultArray(i) = new FValueRegressionTestResult(pValue, degreesOfFreedom, fValue)
+      fTestResultArray(i) = new FValueTestResult(pValue, degreesOfFreedom, fValue)
     }
     fTestResultArray
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/FValueTest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/FValueTest.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.functions._
 object FValueTest {
 
   /** Used to construct output schema of tests */
-  case class FValueResult(
+  private  case class FValueResult(
       pValues: Vector,
       degreesOfFreedom: Array[Long],
       fValues: Vector)

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/FValueTest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/FValueTest.scala
@@ -22,9 +22,8 @@ import org.apache.commons.math3.distribution.FDistribution
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml.linalg.{Vector, Vectors, VectorUDT}
 import org.apache.spark.ml.util.SchemaUtils
-import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.{DataFrame, Dataset, Row}
 import org.apache.spark.sql.functions._
-
 
 /**
  * FValue test for continuous data.
@@ -33,10 +32,10 @@ import org.apache.spark.sql.functions._
 object FValueTest {
 
   /** Used to construct output schema of tests */
-  private case class FValueResult(
-      pValues: Vector,
-      degreesOfFreedom: Array[Long],
-      fValues: Vector)
+  case class FValueResult(
+                           pValues: Vector,
+                           degreesOfFreedom: Array[Long],
+                           fValues: Vector)
 
   /**
    * @param dataset  DataFrame of continuous labels and continuous features.
@@ -51,6 +50,24 @@ object FValueTest {
    */
   @Since("3.1.0")
   def test(dataset: DataFrame, featuresCol: String, labelCol: String): DataFrame = {
+    val spark = dataset.sparkSession
+    val testResults = testRegression(dataset, featuresCol, labelCol)
+    val pValues: Vector = Vectors.dense(testResults.map(_.pValue))
+    val degreesOfFreedom: Array[Long] = testResults.map(_.degreesOfFreedom)
+    val fValues: Vector = Vectors.dense(testResults.map(_.statistic))
+    spark.createDataFrame(
+      Seq(new FValueResult(pValues, degreesOfFreedom, fValues)))
+  }
+
+  /**
+   * @param dataset  DataFrame of continuous labels and continuous features.
+   * @param featuresCol  Name of features column in dataset, of type `Vector` (`VectorUDT`)
+   * @param labelCol  Name of label column in dataset, of any numerical type
+   * @return Array containing the FRegressionTestResult for every feature against the label.
+   */
+  @Since("3.1.0")
+  private[ml] def testRegression(dataset: Dataset[_], featuresCol: String, labelCol: String):
+  Array[SelectionTestResult] = {
 
     val spark = dataset.sparkSession
     import spark.implicits._
@@ -96,10 +113,7 @@ object FValueTest {
       }
       array1
     }
-
-    val pValues = Array.ofDim[Double](numFeatures)
-    val degreesOfFreedoms = Array.fill(numFeatures)(degreesOfFreedom)
-    val fValues = Array.ofDim[Double](numFeatures)
+    var fTestResultArray = new Array[SelectionTestResult](numFeatures)
 
     val fd = new FDistribution(1, degreesOfFreedom)
     for (i <- 0 until numFeatures) {
@@ -107,11 +121,9 @@ object FValueTest {
       val covariance = sumForCov (i) / (numSamples - 1)
       val corr = covariance / (yStd * xStd(i))
       val fValue = corr * corr / (1 - corr * corr) * degreesOfFreedom
-      pValues(i) = 1.0 - fd.cumulativeProbability(fValue)
-      fValues(i) = fValue
+      val pValue = 1.0 - fd.cumulativeProbability(fValue)
+      fTestResultArray(i) = new FValueRegressionTestResult(pValue, degreesOfFreedom, fValue)
     }
-
-    spark.createDataFrame(
-      Seq(FValueResult(Vectors.dense(pValues), degreesOfFreedoms, Vectors.dense(fValues))))
+    fTestResultArray
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/FValueTest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/FValueTest.scala
@@ -33,9 +33,9 @@ object FValueTest {
 
   /** Used to construct output schema of tests */
   case class FValueResult(
-                           pValues: Vector,
-                           degreesOfFreedom: Array[Long],
-                           fValues: Vector)
+      pValues: Vector,
+      degreesOfFreedom: Array[Long],
+      fValues: Vector)
 
   /**
    * @param dataset  DataFrame of continuous labels and continuous features.

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/SelectionTestResult.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/SelectionTestResult.scala
@@ -115,5 +115,3 @@ class ANOVAClassificationTestResult private[stat] (
       s"F Value = $statistic \n"
   }
 }
-
-

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/SelectionTestResult.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/SelectionTestResult.scala
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.stat
+
+import org.apache.spark.annotation.Since
+
+/**
+ * Trait for selection test results.
+ */
+@Since("3.1.0")
+trait SelectionTestResult {
+
+  /**
+   * The probability of obtaining a test statistic result at least as extreme as the one that was
+   * actually observed, assuming that the null hypothesis is true.
+   */
+  @Since("3.1.0")
+  def pValue: Double
+
+  /**
+   * Test statistic.
+   * In ChiSqSelector, this is chi square statistic
+   * In ANOVASelector and FValueSelector, this is F Value
+   */
+  @Since("3.1.0")
+  def statistic: Double
+
+  /**
+   * Returns the degrees of freedom of the hypothesis test.
+   */
+  @Since("3.1.0")
+  def degreesOfFreedom: Long
+
+  /**
+   * String explaining the hypothesis test result.
+   * Specific classes implementing this trait should override this method to output test-specific
+   * information.
+   */
+  override def toString: String = {
+
+    // String explaining what the p-value indicates.
+    val pValueExplain = if (pValue <= 0.01) {
+      s"Very strong presumption against null hypothesis."
+    } else if (0.01 < pValue && pValue <= 0.05) {
+      s"Strong presumption against null hypothesis."
+    } else if (0.05 < pValue && pValue <= 0.1) {
+      s"Low presumption against null hypothesis."
+    } else {
+      s"No presumption against null hypothesis."
+    }
+
+    s"degrees of freedom = ${degreesOfFreedom.toString} \n" + s"pValue = $pValue \n" + pValueExplain
+  }
+}
+
+/**
+ * Object containing the test results for the chi-squared hypothesis test.
+ */
+@Since("3.1.0")
+class ChiSqTestResult private[stat] (
+    override val pValue: Double,
+    override val degreesOfFreedom: Long,
+    override val statistic: Double) extends SelectionTestResult {
+
+  override def toString: String = {
+    "Chi square test summary:\n" +
+      super.toString +
+      s"Chi square statistic = $statistic \n"
+  }
+}
+
+/**
+ * Object containing the test results for the FValue regression test.
+ */
+@Since("3.1.0")
+class FValueRegressionTestResult private[stat] (
+    override val pValue: Double,
+    override val degreesOfFreedom: Long,
+    override val statistic: Double) extends SelectionTestResult {
+
+  override def toString: String = {
+    "FValue Regression test summary:\n" +
+      super.toString +
+      s"F Value = $statistic \n"
+  }
+}
+
+/**
+ * Object containing the test results for the ANOVA classification test.
+ */
+@Since("3.1.0")
+class ANOVAClassificationTestResult private[stat] (
+    override val pValue: Double,
+    override val degreesOfFreedom: Long,
+    override val statistic: Double) extends SelectionTestResult {
+
+  override def toString: String = {
+    "ANOVA Regression test summary:\n" +
+      super.toString +
+      s"F Value = $statistic \n"
+  }
+}
+
+

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/SelectionTestResult.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/SelectionTestResult.scala
@@ -88,7 +88,7 @@ class ChiSqTestResult private[stat] (
  * Object containing the test results for the FValue regression test.
  */
 @Since("3.1.0")
-class FValueRegressionTestResult private[stat] (
+class FValueTestResult private[stat] (
     override val pValue: Double,
     override val degreesOfFreedom: Long,
     override val statistic: Double) extends SelectionTestResult {

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/SelectionTestResult.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/SelectionTestResult.scala
@@ -99,19 +99,3 @@ class FValueRegressionTestResult private[stat] (
       s"F Value = $statistic \n"
   }
 }
-
-/**
- * Object containing the test results for the ANOVA classification test.
- */
-@Since("3.1.0")
-class ANOVAClassificationTestResult private[stat] (
-    override val pValue: Double,
-    override val degreesOfFreedom: Long,
-    override val statistic: Double) extends SelectionTestResult {
-
-  override def toString: String = {
-    "ANOVA Regression test summary:\n" +
-      super.toString +
-      s"F Value = $statistic \n"
-  }
-}

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/FValueSelectorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/FValueSelectorSuite.scala
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.feature
+
+import org.apache.spark.ml.linalg.{Vector, Vectors}
+import org.apache.spark.ml.param.ParamsSuite
+import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTest}
+import org.apache.spark.ml.util.TestingUtils._
+import org.apache.spark.sql.{Dataset, Row}
+
+class FValueSelectorSuite extends MLTest with DefaultReadWriteTest {
+
+  import testImplicits._
+
+  @transient var dataset: Dataset[_] = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    // scalastyle:off
+    /*
+    FValue REGRESSION
+     X (features) =
+     [[1.67318514e-01, 1.78398028e-01, 4.36846538e-01, 5.24003164e-01, 1.80915415e-01, 1.98030859e-01],
+     [3.71836586e-01, 6.13453963e-01, 7.15269190e-01, 9.33623792e-03, 5.36095674e-01, 2.74223333e-01],
+     [3.68988949e-01, 5.34104018e-01, 5.24858744e-01, 6.86815853e-01, 3.26534757e-01, 6.92699400e-01],
+     [4.87748505e-02, 3.07080315e-01, 7.82955385e-01, 6.90167375e-01, 6.44077919e-01, 4.23739024e-01],
+     [6.50153455e-01, 8.32746110e-01, 6.88029140e-03, 1.27859556e-01, 6.80223767e-01, 6.25825675e-01],
+
+     [9.47343271e-01, 2.13193978e-01, 3.71342472e-01, 8.21291956e-01, 4.38195693e-01, 5.76569439e-01],
+     [9.96499254e-01, 8.45833297e-01, 6.56086922e-02, 5.90029174e-01, 1.68954572e-01, 7.19792823e-02],
+     [1.85926914e-01, 9.60329804e-01, 3.13487406e-01, 9.59549928e-01, 6.89093311e-01, 6.94999427e-01],
+     [9.40164576e-01, 2.69042714e-02, 5.39491321e-01, 5.74068666e-01, 1.10935343e-01, 2.17519760e-01],
+     [2.97951848e-02, 1.06592106e-01, 5.74931856e-01, 8.80801522e-01, 8.60445070e-01, 9.22757966e-01],
+
+     [9.80970473e-01, 3.05909353e-01, 4.96401766e-01, 2.44342697e-01, 6.90559227e-01, 5.64858704e-01],
+     [1.55939260e-01, 2.18626853e-01, 5.01834270e-01, 1.86694987e-01, 9.15411148e-01, 6.40527848e-01],
+     [3.16107608e-01, 9.25906358e-01, 5.47327167e-01, 4.83712979e-01, 8.42305220e-01, 7.58488462e-01],
+     [4.14393503e-01, 1.30817883e-01, 5.62034942e-01, 1.05150633e-01, 5.35632795e-01, 9.47594074e-04],
+     [5.26233981e-01, 7.63781419e-02, 3.19188240e-01, 5.16528633e-02, 5.28416724e-01, 6.47050470e-03],
+
+     [2.73404764e-01, 7.17070744e-01, 3.12889595e-01, 8.39271965e-01, 9.67650889e-01, 8.50098873e-01],
+     [4.63289495e-01, 3.57055416e-02, 5.43528596e-01, 4.44840919e-01, 9.36845855e-02, 7.81595037e-01],
+     [3.21784993e-01, 3.15622454e-01, 7.58870408e-01, 5.18198558e-01, 2.28151905e-01, 4.42460325e-01],
+     [3.72428352e-01, 1.44447969e-01, 8.40274188e-01, 5.86308041e-01, 6.09893953e-01, 3.97006473e-01],
+     [3.12776786e-01, 9.33630195e-01, 2.29328749e-01, 4.32807208e-01, 1.51703470e-02, 1.51589320e-01]]
+
+     y (labels) =
+     [0.33997803, 0.71456716, 0.58676766, 0.52894227, 0.53158463,
+     0.55515181, 0.67008744, 0.5966537 , 0.56255674, 0.33904133,
+     0.66485577, 0.38514965, 0.73885841, 0.45766267, 0.34801557,
+     0.52529452, 0.42503336, 0.60221968, 0.58964479, 0.58194949]
+
+     Note that y = X @ w, where w = [0.3, 0.4, 0.5, 0. , 0. , 0. ]
+
+    Sklearn results:
+    F values per feature: [2.76445780e+00, 1.05267800e+01, 4.43399092e-02, 2.04580501e-02,
+     3.13208557e-02, 1.35248025e-03]
+    p values per feature: [0.11369388, 0.0044996 , 0.83558782, 0.88785417, 0.86150261, 0.97106833]
+    */
+    // scalastyle:on
+
+    val data = Seq(
+      (0.33997803, Vectors.dense(1.67318514e-01, 1.78398028e-01, 4.36846538e-01,
+        5.24003164e-01, 1.80915415e-01, 1.98030859e-01), Vectors.dense(1.78398028e-01)),
+      (0.71456716, Vectors.dense(3.71836586e-01, 6.13453963e-01, 7.15269190e-01,
+        9.33623792e-03, 5.36095674e-01, 2.74223333e-01), Vectors.dense(6.13453963e-01)),
+      (0.58676766, Vectors.dense(3.68988949e-01, 5.34104018e-01, 5.24858744e-01,
+        6.86815853e-01, 3.26534757e-01, 6.92699400e-01), Vectors.dense(5.34104018e-01)),
+      (0.52894227, Vectors.dense(4.87748505e-02, 3.07080315e-01, 7.82955385e-01,
+        6.90167375e-01, 6.44077919e-01, 4.23739024e-01), Vectors.dense(3.07080315e-01)),
+      (0.53158463, Vectors.dense(6.50153455e-01, 8.32746110e-01, 6.88029140e-03,
+        1.27859556e-01, 6.80223767e-01, 6.25825675e-01), Vectors.dense(8.32746110e-01)),
+      (0.55515181, Vectors.dense(9.47343271e-01, 2.13193978e-01, 3.71342472e-01,
+        8.21291956e-01, 4.38195693e-01, 5.76569439e-01), Vectors.dense(2.13193978e-01)),
+      (0.67008744, Vectors.dense(9.96499254e-01, 8.45833297e-01, 6.56086922e-02,
+        5.90029174e-01, 1.68954572e-01, 7.19792823e-02), Vectors.dense(8.45833297e-01)),
+      (0.5966537, Vectors.dense(1.85926914e-01, 9.60329804e-01, 3.13487406e-01,
+        9.59549928e-01, 6.89093311e-01, 6.94999427e-01), Vectors.dense(9.60329804e-01)),
+      (0.56255674, Vectors.dense(9.40164576e-01, 2.69042714e-02, 5.39491321e-01,
+        5.74068666e-01, 1.10935343e-01, 2.17519760e-01), Vectors.dense(2.69042714e-02)),
+      (0.33904133, Vectors.dense(2.97951848e-02, 1.06592106e-01, 5.74931856e-01,
+        8.80801522e-01, 8.60445070e-01, 9.22757966e-01), Vectors.dense(1.06592106e-01)),
+      (0.66485577, Vectors.dense(9.80970473e-01, 3.05909353e-01, 4.96401766e-01,
+        2.44342697e-01, 6.90559227e-01, 5.64858704e-01), Vectors.dense(3.05909353e-01)),
+      (0.38514965, Vectors.dense(1.55939260e-01, 2.18626853e-01, 5.01834270e-01,
+        1.86694987e-01, 9.15411148e-01, 6.40527848e-01), Vectors.dense(2.18626853e-01)),
+      (0.73885841, Vectors.dense(3.16107608e-01, 9.25906358e-01, 5.47327167e-01,
+        4.83712979e-01, 8.42305220e-01, 7.58488462e-01), Vectors.dense(9.25906358e-01)),
+      (0.45766267, Vectors.dense(4.14393503e-01, 1.30817883e-01, 5.62034942e-01,
+        1.05150633e-01, 5.35632795e-01, 9.47594074e-04), Vectors.dense(1.30817883e-01)),
+      (0.34801557, Vectors.dense(5.26233981e-01, 7.63781419e-02, 3.19188240e-01,
+        5.16528633e-02, 5.28416724e-01, 6.47050470e-03), Vectors.dense(7.63781419e-02)),
+      (0.52529452, Vectors.dense(2.73404764e-01, 7.17070744e-01, 3.12889595e-01,
+        8.39271965e-01, 9.67650889e-01, 8.50098873e-01), Vectors.dense(7.17070744e-01)),
+      (0.42503336, Vectors.dense(4.63289495e-01, 3.57055416e-02, 5.43528596e-01,
+        4.44840919e-01, 9.36845855e-02, 7.81595037e-01), Vectors.dense(3.57055416e-02)),
+      (0.60221968, Vectors.dense(3.21784993e-01, 3.15622454e-01, 7.58870408e-01,
+        5.18198558e-01, 2.28151905e-01, 4.42460325e-01), Vectors.dense(3.15622454e-01)),
+      (0.58964479, Vectors.dense(3.72428352e-01, 1.44447969e-01, 8.40274188e-01,
+        5.86308041e-01, 6.09893953e-01, 3.97006473e-01), Vectors.dense(1.44447969e-01)),
+      (0.58194949, Vectors.dense(3.12776786e-01, 9.33630195e-01, 2.29328749e-01,
+        4.32807208e-01, 1.51703470e-02, 1.51589320e-01), Vectors.dense(9.33630195e-01)))
+
+    dataset = spark.createDataFrame(data).toDF("label", "features", "topFeature")
+  }
+
+  test("params") {
+    ParamsSuite.checkParams(new FValueSelector)
+  }
+
+  test("Test FValue selector: numTopFeatures") {
+    val selector = new FValueSelector()
+      .setOutputCol("filtered").setSelectorType("numTopFeatures").setNumTopFeatures(1)
+    val model = selector.fit(dataset)
+    testSelector(selector, dataset)
+  }
+
+  test("Test F Value selector: percentile") {
+    val selector = new FValueSelector()
+      .setOutputCol("filtered").setSelectorType("percentile").setPercentile(0.17)
+    val model = selector.fit(dataset)
+    testSelector(selector, dataset)
+  }
+
+  test("Test F Value selector: fpr") {
+    val selector = new FValueSelector()
+      .setOutputCol("filtered").setSelectorType("fpr").setFpr(0.01)
+    val model = selector.fit(dataset)
+    testSelector(selector, dataset)
+  }
+
+  test("Test F Value selector: fdr") {
+    val selector = new FValueSelector()
+      .setOutputCol("filtered").setSelectorType("fdr").setFdr(0.03)
+    testSelector(selector, dataset)
+  }
+
+  test("Test F Value selector: fwe") {
+    val selector = new FValueSelector()
+      .setOutputCol("filtered").setSelectorType("fwe").setFwe(0.03)
+    testSelector(selector, dataset)
+  }
+
+  test("Test FValue selector with sparse vector") {
+    val df = spark.createDataFrame(Seq(
+      (4.6, Vectors.sparse(6, Array((0, 6.0), (1, 7.0), (3, 7.0), (4, 6.0))), Vectors.dense(0.0)),
+      (6.6, Vectors.sparse(6, Array((1, 9.0), (2, 6.0), (4, 5.0), (5, 9.0))), Vectors.dense(6.0)),
+      (5.1, Vectors.sparse(6, Array((1, 9.0), (2, 3.0), (4, 5.0), (5, 5.0))), Vectors.dense(3.0)),
+      (7.6, Vectors.dense(Array(0.0, 9.0, 8.0, 5.0, 6.0, 4.0)), Vectors.dense(8.0)),
+      (9.0, Vectors.dense(Array(8.0, 9.0, 6.0, 5.0, 4.0, 4.0)), Vectors.dense(6.0)),
+      (9.0, Vectors.dense(Array(8.0, 9.0, 6.0, 4.0, 0.0, 0.0)), Vectors.dense(6.0))
+    )).toDF("label", "features", "topFeature")
+
+    val selector = new FValueSelector()
+      .setOutputCol("filtered").setSelectorType("numTopFeatures").setNumTopFeatures(1)
+    val model = selector.fit(df)
+    testSelector(selector, df)
+  }
+
+  test("read/write") {
+    def checkModelData(model: FValueSelectorModel, model2:
+      FValueSelectorModel): Unit = {
+      assert(model.selectedFeatures === model2.selectedFeatures)
+    }
+    val fSelector = new FValueSelector
+    testEstimatorAndModelReadWrite(fSelector, dataset,
+      FValueSelectorSuite.allParamSettings,
+      FValueSelectorSuite.allParamSettings, checkModelData)
+  }
+
+  private def testSelector(selector: FValueSelector, data: Dataset[_]):
+      FValueSelectorModel = {
+    val selectorModel = selector.fit(data)
+    testTransformer[(Double, Vector, Vector)](data.toDF(), selectorModel,
+      "filtered", "topFeature") {
+      case Row(vec1: Vector, vec2: Vector) =>
+        assert(vec1 ~== vec2 absTol 1e-6)
+    }
+    selectorModel
+  }
+}
+
+object FValueSelectorSuite {
+
+  /**
+   * Mapping from all Params to valid settings which differ from the defaults.
+   * This is useful for tests which need to exercise all Params, such as save/load.
+   * This excludes input columns to simplify some tests.
+   */
+  val allParamSettings: Map[String, Any] = Map(
+    "selectorType" -> "percentile",
+    "numTopFeatures" -> 1,
+    "percentile" -> 0.12,
+    "outputCol" -> "myOutput"
+  )
+}
+
+
+

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/FValueSelectorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/FValueSelectorSuite.scala
@@ -210,6 +210,3 @@ object FValueSelectorSuite {
     "outputCol" -> "myOutput"
   )
 }
-
-
-


### PR DESCRIPTION


### What changes were proposed in this pull request?
Add FValueRegressionSelector for continuous features and continuous labels.


### Why are the changes needed?
Currently Spark only supports selection of categorical features, while there are many requirements for the selection of continuous distribution features.

This PR adds FValueSelector for continuous features and continuous labels.
ANOVASelector for continuous features and categorical labels will be added later using a separate PR.


### Does this PR introduce any user-facing change?
Yes.
Add a new Selector


### How was this patch tested?
Add new tests
