### PR TITLE
[WIP][DO-NOT-MERGE] Test the -Yrepl-class-based changes

### DIFF
--- a/build/mvn
+++ b/build/mvn
@@ -126,7 +126,7 @@ install_zinc() {
 install_scala() {
   # determine the Scala version used in Spark
   local scala_binary_version=`grep "scala.binary.version" "${_DIR}/../pom.xml" | head -n1 | awk -F '[<>]' '{print $3}'`
-  local scala_version=`grep "scala.version" "${_DIR}/../pom.xml" | grep ${scala_binary_version} | head -n1 | awk -F '[<>]' '{print $3}'`
+  local scala_version=2.12.10
   local scala_bin="${_DIR}/scala-${scala_version}/bin/scala"
   local TYPESAFE_MIRROR=${TYPESAFE_MIRROR:-https://downloads.lightbend.com}
 

--- a/dev/deps/spark-deps-hadoop-2.7-hive-1.2
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-1.2
@@ -177,10 +177,10 @@ protobuf-java/2.5.0//protobuf-java-2.5.0.jar
 py4j/0.10.8.1//py4j-0.10.8.1.jar
 pyrolite/4.30//pyrolite-4.30.jar
 scala-collection-compat_2.12/2.1.1//scala-collection-compat_2.12-2.1.1.jar
-scala-compiler/2.12.10//scala-compiler-2.12.10.jar
-scala-library/2.12.10//scala-library-2.12.10.jar
+scala-compiler/2.12.11-bin-4c726db//scala-compiler-2.12.11-bin-4c726db.jar
+scala-library/2.12.11-bin-4c726db//scala-library-2.12.11-bin-4c726db.jar
 scala-parser-combinators_2.12/1.1.2//scala-parser-combinators_2.12-1.1.2.jar
-scala-reflect/2.12.10//scala-reflect-2.12.10.jar
+scala-reflect/2.12.11-bin-4c726db//scala-reflect-2.12.11-bin-4c726db.jar
 scala-xml_2.12/1.2.0//scala-xml_2.12-1.2.0.jar
 shapeless_2.12/2.3.3//shapeless_2.12-2.3.3.jar
 shims/0.7.45//shims-0.7.45.jar

--- a/dev/deps/spark-deps-hadoop-2.7-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-2.3
@@ -191,10 +191,10 @@ protobuf-java/2.5.0//protobuf-java-2.5.0.jar
 py4j/0.10.8.1//py4j-0.10.8.1.jar
 pyrolite/4.30//pyrolite-4.30.jar
 scala-collection-compat_2.12/2.1.1//scala-collection-compat_2.12-2.1.1.jar
-scala-compiler/2.12.10//scala-compiler-2.12.10.jar
-scala-library/2.12.10//scala-library-2.12.10.jar
+scala-compiler/2.12.11-bin-4c726db//scala-compiler-2.12.11-bin-4c726db.jar
+scala-library/2.12.11-bin-4c726db//scala-library-2.12.11-bin-4c726db.jar
 scala-parser-combinators_2.12/1.1.2//scala-parser-combinators_2.12-1.1.2.jar
-scala-reflect/2.12.10//scala-reflect-2.12.10.jar
+scala-reflect/2.12.11-bin-4c726db//scala-reflect-2.12.11-bin-4c726db.jar
 scala-xml_2.12/1.2.0//scala-xml_2.12-1.2.0.jar
 shapeless_2.12/2.3.3//shapeless_2.12-2.3.3.jar
 shims/0.7.45//shims-0.7.45.jar

--- a/dev/deps/spark-deps-hadoop-3.2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3.2-hive-2.3
@@ -207,10 +207,10 @@ py4j/0.10.8.1//py4j-0.10.8.1.jar
 pyrolite/4.30//pyrolite-4.30.jar
 re2j/1.1//re2j-1.1.jar
 scala-collection-compat_2.12/2.1.1//scala-collection-compat_2.12-2.1.1.jar
-scala-compiler/2.12.10//scala-compiler-2.12.10.jar
-scala-library/2.12.10//scala-library-2.12.10.jar
+scala-compiler/2.12.11-bin-4c726db//scala-compiler-2.12.11-bin-4c726db.jar
+scala-library/2.12.11-bin-4c726db//scala-library-2.12.11-bin-4c726db.jar
 scala-parser-combinators_2.12/1.1.2//scala-parser-combinators_2.12-1.1.2.jar
-scala-reflect/2.12.10//scala-reflect-2.12.10.jar
+scala-reflect/2.12.11-bin-4c726db//scala-reflect-2.12.11-bin-4c726db.jar
 scala-xml_2.12/1.2.0//scala-xml_2.12-1.2.0.jar
 shapeless_2.12/2.3.3//shapeless_2.12-2.3.3.jar
 shims/0.7.45//shims-0.7.45.jar

--- a/pom.xml
+++ b/pom.xml
@@ -275,6 +275,16 @@
         <enabled>false</enabled>
       </snapshots>
     </repository>
+    <repository>
+       <id>scala-integration</id>
+       <url>https://scala-ci.typesafe.com/artifactory/scala-integration</url>
+       <releases>
+         <enabled>true</enabled>
+       </releases>
+       <snapshots>
+         <enabled>false</enabled>
+       </snapshots>
+     </repository>
   </repositories>
   <pluginRepositories>
     <pluginRepository>
@@ -3178,20 +3188,7 @@
 
     <profile>
       <id>scala-integration</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
       <repositories>
-       <repository>
-          <id>scala-integration</id>
-          <url>https://scala-ci.typesafe.com/artifactory/scala-integration</url>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
-          <releases>
-            <enabled>true</enabled>
-          </releases>
-        </repository>
       </repositories>
     </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
     <commons.math3.version>3.4.1</commons.math3.version>
     <!-- managed up from 3.2.1 for SPARK-11652 -->
     <commons.collections.version>3.2.2</commons.collections.version>
-    <scala.version>2.12.10</scala.version>
+    <scala.version>2.12.11-bin-4c726db</scala.version>
     <scala.binary.version>2.12</scala.binary.version>
     <scalafmt.parameters>--test</scalafmt.parameters>
     <!-- for now, not running scalafmt as part of default verify pipeline -->
@@ -3171,6 +3171,25 @@
           </snapshots>
           <releases>
             <enabled>false</enabled>
+          </releases>
+        </repository>
+      </repositories>
+    </profile>
+
+    <profile>
+      <id>scala-integration</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <repositories>
+       <repository>
+          <id>scala-integration</id>
+          <url>https://scala-ci.typesafe.com/artifactory/scala-integration</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
           </releases>
         </repository>
       </repositories>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -228,6 +228,7 @@ object SparkBuild extends PomBuild {
       // See https://storage-download.googleapis.com/maven-central/index.html for more info.
       "gcs-maven-central-mirror" at "https://maven-central.storage-download.googleapis.com/repos/central/data/",
       DefaultMavenRepository,
+      "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/",
       Resolver.mavenLocal,
       Resolver.file("local", file(Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns)
     ),


### PR DESCRIPTION
Hi!  This PR is to test the change to the scala compiler's `-Yrepl-class-based` option (which the Spark REPL uses) that landed in https://github.com/scala/scala/pull/8712.

I don't expect it to be merged. :)

I tested this locally with:

    ./build/mvn -P scala-integration -Dscala.version=2.12.11-bin-4c726db -pl :spark-repl_2.12 -Dtest=none -DwildcardSuites='org.apache.spark.repl.ReplSuite,org.apache.spark.repl.SingletonReplSuite,org.apache.spark.repl.ExecutorClassLoaderSuite' test

and that subset passed for me.  I'm interested to see if those or any other tests fail in CI.