### PR TITLE
[SPARK-30940][SQL] Remove attributeId in auto-generated arguments when Explain SQL query

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -266,19 +266,20 @@ abstract class Expression extends TreeNode[Expression] {
     case single => single :: Nil
   }
 
-  protected def flatArgumentStrings: Iterator[String] = flatArguments.map {
-    case e: Expression => e.argumentString
-    case arg => s"$arg"
-  }
-
   // Marks this as final, Expression.verboseString should never be called, and thus shouldn't be
   // overridden by concrete classes.
   final override def verboseString(maxFields: Int): String = simpleString(maxFields)
 
   override def simpleString(maxFields: Int): String = toString
 
-  override def toString: String = prettyName + truncatedString(
-    flatArgumentStrings.toSeq, "(", ", ", ")", SQLConf.get.maxToStringFields)
+  override def toString: String = {
+    val argumentStrings = flatArguments.map {
+      case e: Expression => e.argumentString
+      case arg => s"$arg"
+    }
+    prettyName + truncatedString(
+      argumentStrings.toSeq, "(", ", ", ")", SQLConf.get.maxToStringFields)
+  }
 
   def argumentString: String = toString
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -268,7 +268,7 @@ abstract class Expression extends TreeNode[Expression] {
 
   protected def flatArgumentStrings: Iterator[String] = flatArguments.map {
     case e: Expression => e.argumentString
-    case arg: Any => arg.toString
+    case arg => s"$arg"
   }
 
   // Marks this as final, Expression.verboseString should never be called, and thus shouldn't be

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -263,8 +263,12 @@ abstract class Expression extends TreeNode[Expression] {
 
   protected def flatArguments: Iterator[Any] = stringArgs.flatMap {
     case t: Iterable[_] => t
-    case e: Expression => e.argumentString :: Nil
     case single => single :: Nil
+  }
+
+  protected def flatArgumentStrings: Iterator[String] = flatArguments.map {
+    case e: Expression => e.argumentString
+    case arg: Any => arg.toString
   }
 
   // Marks this as final, Expression.verboseString should never be called, and thus shouldn't be
@@ -274,7 +278,7 @@ abstract class Expression extends TreeNode[Expression] {
   override def simpleString(maxFields: Int): String = toString
 
   override def toString: String = prettyName + truncatedString(
-    flatArguments.toSeq, "(", ", ", ")", SQLConf.get.maxToStringFields)
+    flatArgumentStrings.toSeq, "(", ", ", ")", SQLConf.get.maxToStringFields)
 
   def argumentString: String = toString
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -263,6 +263,7 @@ abstract class Expression extends TreeNode[Expression] {
 
   protected def flatArguments: Iterator[Any] = stringArgs.flatMap {
     case t: Iterable[_] => t
+    case e: Expression => e.argumentString :: Nil
     case single => single :: Nil
   }
 
@@ -274,6 +275,8 @@ abstract class Expression extends TreeNode[Expression] {
 
   override def toString: String = prettyName + truncatedString(
     flatArguments.toSeq, "(", ", ", ")", SQLConf.get.maxToStringFields)
+
+  def argumentString: String = toString
 
   /**
    * Returns SQL representation of this expression.  For expressions extending [[NonSQLExpression]],

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
@@ -234,8 +234,11 @@ abstract class AggregateFunction extends Expression {
 
   /** String representation used in explain plans. */
   def toAggString(isDistinct: Boolean): String = {
-    val start = if (isDistinct) "(distinct " else "("
-    prettyName + flatArgumentStrings.mkString(start, ", ", ")")
+    if (isDistinct) {
+      toString.patch(prettyName.size + 1, "distinct ", 0)
+    } else {
+      toString
+    }
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
@@ -235,7 +235,7 @@ abstract class AggregateFunction extends Expression {
   /** String representation used in explain plans. */
   def toAggString(isDistinct: Boolean): String = {
     val start = if (isDistinct) "(distinct " else "("
-    prettyName + flatArguments.mkString(start, ", ", ")")
+    prettyName + flatArgumentStrings.mkString(start, ", ", ")")
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
@@ -327,6 +327,15 @@ case class AttributeReference(
 
   override def toString: String = s"$name#${exprId.id}$typeSuffix$delaySuffix"
 
+  override def argumentString: String = {
+    val endingMsg = s"$typeSuffix$delaySuffix"
+    if (endingMsg.nonEmpty) {
+      s"${name}#$endingMsg"
+    } else {
+      name
+    }
+  }
+
   // Since the expression id is not in the first constructor it is missing from the default
   // tree string.
   override def simpleString(maxFields: Int): String = {

--- a/sql/core/src/test/resources/sql-tests/results/explain.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain.sql.out
@@ -91,7 +91,7 @@ Results [2]: [key#x, max#x]
      
 (6) Exchange 
 Input [2]: [key#x, max#x]
-Arguments: hashpartitioning(key#x, 4), true, [id=#x]
+Arguments: hashpartitioning(key, 4), true, [id=#x]
       
 (7) HashAggregate [codegen id : 2]
 Input [2]: [key#x, max#x]
@@ -158,7 +158,7 @@ Results [2]: [key#x, max#x]
      
 (6) Exchange 
 Input [2]: [key#x, max#x]
-Arguments: hashpartitioning(key#x, 4), true, [id=#x]
+Arguments: hashpartitioning(key, 4), true, [id=#x]
       
 (7) HashAggregate [codegen id : 2]
 Input [2]: [key#x, max#x]
@@ -246,7 +246,7 @@ Results [2]: [key#x, val#x]
      
 (11) Exchange 
 Input [2]: [key#x, val#x]
-Arguments: hashpartitioning(key#x, val#x, 4), true, [id=#x]
+Arguments: hashpartitioning(key, val, 4), true, [id=#x]
       
 (12) HashAggregate [codegen id : 4]
 Input [2]: [key#x, val#x]
@@ -832,7 +832,7 @@ Results [2]: [key#x, max#x]
      
 (6) Exchange 
 Input [2]: [key#x, max#x]
-Arguments: hashpartitioning(key#x, 4), true, [id=#x]
+Arguments: hashpartitioning(key, 4), true, [id=#x]
       
 (7) HashAggregate [codegen id : 4]
 Input [2]: [key#x, max#x]
@@ -917,7 +917,7 @@ Input [2]: [key#x, val#x]
 (3) HashAggregate 
 Input [2]: [key#x, val#x]
 Keys: []
-Functions [3]: [partial_count(val#x), partial_sum(cast(key#x as bigint)), partial_count(key#x) FILTER (WHERE (val#x > 1))]
+Functions [3]: [partial_count(val), partial_sum(cast(key#x as bigint)), partial_count(key) FILTER (WHERE (val#x > 1))]
 Aggregate Attributes [3]: [count#xL, sum#xL, count#xL]
 Results [3]: [count#xL, sum#xL, count#xL]
      
@@ -928,9 +928,9 @@ Arguments: SinglePartition, true, [id=#x]
 (5) HashAggregate [codegen id : 2]
 Input [3]: [count#xL, sum#xL, count#xL]
 Keys: []
-Functions [3]: [count(val#x), sum(cast(key#x as bigint)), count(key#x)]
-Aggregate Attributes [3]: [count(val#x)#xL, sum(cast(key#x as bigint))#xL, count(key#x)#xL]
-Results [2]: [(count(val#x)#xL + sum(cast(key#x as bigint))#xL) AS TOTAL#xL, count(key#x)#xL AS count(key) FILTER (WHERE (val > 1))#xL]
+Functions [3]: [count(val), sum(cast(key#x as bigint)), count(key)]
+Aggregate Attributes [3]: [count(val)#xL, sum(cast(key#x as bigint))#xL, count(key)#xL]
+Results [2]: [(count(val)#xL + sum(cast(key#x as bigint))#xL) AS TOTAL#xL, count(key)#xL AS count(key) FILTER (WHERE (val > 1))#xL]
 
 
 -- !query
@@ -967,7 +967,7 @@ Results [2]: [key#x, buf#x]
      
 (4) Exchange 
 Input [2]: [key#x, buf#x]
-Arguments: hashpartitioning(key#x, 4), true, [id=#x]
+Arguments: hashpartitioning(key, 4), true, [id=#x]
       
 (5) ObjectHashAggregate 
 Input [2]: [key#x, buf#x]
@@ -1017,7 +1017,7 @@ Results [2]: [key#x, min#x]
      
 (5) Exchange 
 Input [2]: [key#x, min#x]
-Arguments: hashpartitioning(key#x, 4), true, [id=#x]
+Arguments: hashpartitioning(key, 4), true, [id=#x]
       
 (6) Sort [codegen id : 2]
 Input [2]: [key#x, min#x]

--- a/sql/core/src/test/resources/sql-tests/results/explain.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain.sql.out
@@ -76,7 +76,7 @@ Input [2]: [key#x, val#x]
       
 (3) Filter [codegen id : 1]
 Input [2]: [key#x, val#x]
-Condition : (isnotnull(key#x) AND (key#x > 0))
+Condition : (isnotnull(key) AND (key#x > 0))
      
 (4) Project [codegen id : 1]
 Output [2]: [key#x, val#x]
@@ -85,7 +85,7 @@ Input [2]: [key#x, val#x]
 (5) HashAggregate [codegen id : 1]
 Input [2]: [key#x, val#x]
 Keys [1]: [key#x]
-Functions [1]: [partial_max(val#x)]
+Functions [1]: [partial_max(val)]
 Aggregate Attributes [1]: [max#x]
 Results [2]: [key#x, max#x]
      
@@ -96,9 +96,9 @@ Arguments: hashpartitioning(key#x, 4), true, [id=#x]
 (7) HashAggregate [codegen id : 2]
 Input [2]: [key#x, max#x]
 Keys [1]: [key#x]
-Functions [1]: [max(val#x)]
-Aggregate Attributes [1]: [max(val#x)#x]
-Results [2]: [key#x, max(val#x)#x AS max(val)#x]
+Functions [1]: [max(val)]
+Aggregate Attributes [1]: [max(val)#x]
+Results [2]: [key#x, max(val)#x AS max(val)#x]
      
 (8) Exchange 
 Input [2]: [key#x, max(val)#x]
@@ -143,7 +143,7 @@ Input [2]: [key#x, val#x]
       
 (3) Filter [codegen id : 1]
 Input [2]: [key#x, val#x]
-Condition : (isnotnull(key#x) AND (key#x > 0))
+Condition : (isnotnull(key) AND (key#x > 0))
      
 (4) Project [codegen id : 1]
 Output [2]: [key#x, val#x]
@@ -152,7 +152,7 @@ Input [2]: [key#x, val#x]
 (5) HashAggregate [codegen id : 1]
 Input [2]: [key#x, val#x]
 Keys [1]: [key#x]
-Functions [1]: [partial_max(val#x)]
+Functions [1]: [partial_max(val)]
 Aggregate Attributes [1]: [max#x]
 Results [2]: [key#x, max#x]
      
@@ -163,17 +163,17 @@ Arguments: hashpartitioning(key#x, 4), true, [id=#x]
 (7) HashAggregate [codegen id : 2]
 Input [2]: [key#x, max#x]
 Keys [1]: [key#x]
-Functions [1]: [max(val#x)]
-Aggregate Attributes [1]: [max(val#x)#x]
-Results [3]: [key#x, max(val#x)#x AS max(val)#x, max(val#x)#x AS max(val#x)#x]
+Functions [1]: [max(val)]
+Aggregate Attributes [1]: [max(val)#x]
+Results [3]: [key#x, max(val)#x AS max(val)#x, max(val)#x AS max(val)#x]
      
 (8) Filter [codegen id : 2]
-Input [3]: [key#x, max(val)#x, max(val#x)#x]
-Condition : (isnotnull(max(val#x)#x) AND (max(val#x)#x > 0))
+Input [3]: [key#x, max(val)#x, max(val)#x]
+Condition : (isnotnull(max(val)) AND (max(val)#x > 0))
      
 (9) Project [codegen id : 2]
 Output [2]: [key#x, max(val)#x]
-Input [3]: [key#x, max(val)#x, max(val#x)#x]
+Input [3]: [key#x, max(val)#x, max(val)#x]
 
 
 -- !query
@@ -211,7 +211,7 @@ Input [2]: [key#x, val#x]
       
 (3) Filter [codegen id : 1]
 Input [2]: [key#x, val#x]
-Condition : (isnotnull(key#x) AND (key#x > 0))
+Condition : (isnotnull(key) AND (key#x > 0))
      
 (4) Project [codegen id : 1]
 Output [2]: [key#x, val#x]
@@ -229,7 +229,7 @@ Input [2]: [key#x, val#x]
       
 (7) Filter [codegen id : 2]
 Input [2]: [key#x, val#x]
-Condition : (isnotnull(key#x) AND (key#x > 0))
+Condition : (isnotnull(key) AND (key#x > 0))
      
 (8) Project [codegen id : 2]
 Output [2]: [key#x, val#x]
@@ -290,7 +290,7 @@ Input [2]: [key#x, val#x]
       
 (3) Filter [codegen id : 2]
 Input [2]: [key#x, val#x]
-Condition : isnotnull(key#x)
+Condition : isnotnull(key)
      
 (4) Project [codegen id : 2]
 Output [2]: [key#x, val#x]
@@ -308,7 +308,7 @@ Input [2]: [key#x, val#x]
       
 (7) Filter [codegen id : 1]
 Input [2]: [key#x, val#x]
-Condition : isnotnull(key#x)
+Condition : isnotnull(key)
      
 (8) Project [codegen id : 1]
 Output [2]: [key#x, val#x]
@@ -365,7 +365,7 @@ Input [2]: [key#x, val#x]
       
 (5) Filter [codegen id : 1]
 Input [2]: [key#x, val#x]
-Condition : isnotnull(key#x)
+Condition : isnotnull(key)
      
 (6) Project [codegen id : 1]
 Output [2]: [key#x, val#x]
@@ -414,7 +414,7 @@ Input [2]: [key#x, val#x]
       
 (3) Filter [codegen id : 1]
 Input [2]: [key#x, val#x]
-Condition : (((isnotnull(key#x) AND isnotnull(val#x)) AND (key#x = Subquery scalar-subquery#x, [id=#x])) AND (val#x > 3))
+Condition : (((isnotnull(key) AND isnotnull(val)) AND (key#x = Subquery scalar-subquery#x, [id=#x])) AND (val#x > 3))
      
 (4) Project [codegen id : 1]
 Output [2]: [key#x, val#x]
@@ -444,7 +444,7 @@ Input [2]: [key#x, val#x]
       
 (7) Filter [codegen id : 1]
 Input [2]: [key#x, val#x]
-Condition : (((isnotnull(key#x) AND isnotnull(val#x)) AND (key#x = Subquery scalar-subquery#x, [id=#x])) AND (val#x = 2))
+Condition : (((isnotnull(key) AND isnotnull(val)) AND (key#x = Subquery scalar-subquery#x, [id=#x])) AND (val#x = 2))
      
 (8) Project [codegen id : 1]
 Output [1]: [key#x]
@@ -453,7 +453,7 @@ Input [2]: [key#x, val#x]
 (9) HashAggregate [codegen id : 1]
 Input [1]: [key#x]
 Keys: []
-Functions [1]: [partial_max(key#x)]
+Functions [1]: [partial_max(key)]
 Aggregate Attributes [1]: [max#x]
 Results [1]: [max#x]
      
@@ -464,9 +464,9 @@ Arguments: SinglePartition, true, [id=#x]
 (11) HashAggregate [codegen id : 2]
 Input [1]: [max#x]
 Keys: []
-Functions [1]: [max(key#x)]
-Aggregate Attributes [1]: [max(key#x)#x]
-Results [1]: [max(key#x)#x AS max(key)#x]
+Functions [1]: [max(key)]
+Aggregate Attributes [1]: [max(key)#x]
+Results [1]: [max(key)#x AS max(key)#x]
      
 Subquery:2 Hosting operator id = 7 Hosting Expression = Subquery scalar-subquery#x, [id=#x]
 * HashAggregate (18)
@@ -490,7 +490,7 @@ Input [2]: [key#x, val#x]
       
 (14) Filter [codegen id : 1]
 Input [2]: [key#x, val#x]
-Condition : (isnotnull(val#x) AND (val#x > 0))
+Condition : (isnotnull(val) AND (val#x > 0))
      
 (15) Project [codegen id : 1]
 Output [1]: [key#x]
@@ -499,7 +499,7 @@ Input [2]: [key#x, val#x]
 (16) HashAggregate [codegen id : 1]
 Input [1]: [key#x]
 Keys: []
-Functions [1]: [partial_max(key#x)]
+Functions [1]: [partial_max(key)]
 Aggregate Attributes [1]: [max#x]
 Results [1]: [max#x]
      
@@ -510,9 +510,9 @@ Arguments: SinglePartition, true, [id=#x]
 (18) HashAggregate [codegen id : 2]
 Input [1]: [max#x]
 Keys: []
-Functions [1]: [max(key#x)]
-Aggregate Attributes [1]: [max(key#x)#x]
-Results [1]: [max(key#x)#x AS max(key)#x]
+Functions [1]: [max(key)]
+Aggregate Attributes [1]: [max(key)#x]
+Results [1]: [max(key)#x AS max(key)#x]
 
 
 -- !query
@@ -572,7 +572,7 @@ Input [2]: [key#x, val#x]
       
 (6) Filter [codegen id : 1]
 Input [2]: [key#x, val#x]
-Condition : (isnotnull(val#x) AND (val#x > 0))
+Condition : (isnotnull(val) AND (val#x > 0))
      
 (7) Project [codegen id : 1]
 Output [1]: [key#x]
@@ -581,7 +581,7 @@ Input [2]: [key#x, val#x]
 (8) HashAggregate [codegen id : 1]
 Input [1]: [key#x]
 Keys: []
-Functions [1]: [partial_max(key#x)]
+Functions [1]: [partial_max(key)]
 Aggregate Attributes [1]: [max#x]
 Results [1]: [max#x]
      
@@ -592,9 +592,9 @@ Arguments: SinglePartition, true, [id=#x]
 (10) HashAggregate [codegen id : 2]
 Input [1]: [max#x]
 Keys: []
-Functions [1]: [max(key#x)]
-Aggregate Attributes [1]: [max(key#x)#x]
-Results [1]: [max(key#x)#x AS max(key)#x]
+Functions [1]: [max(key)]
+Aggregate Attributes [1]: [max(key)#x]
+Results [1]: [max(key)#x AS max(key)#x]
      
 Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#x, [id=#x]
 * HashAggregate (17)
@@ -618,7 +618,7 @@ Input [2]: [key#x, val#x]
       
 (13) Filter [codegen id : 1]
 Input [2]: [key#x, val#x]
-Condition : (isnotnull(val#x) AND (val#x > 0))
+Condition : (isnotnull(val) AND (val#x > 0))
      
 (14) Project [codegen id : 1]
 Output [1]: [key#x]
@@ -745,7 +745,7 @@ Input [2]: [key#x, val#x]
       
 (3) Filter [codegen id : 2]
 Input [2]: [key#x, val#x]
-Condition : (isnotnull(key#x) AND (key#x > 10))
+Condition : (isnotnull(key) AND (key#x > 10))
      
 (4) Project [codegen id : 2]
 Output [2]: [key#x, val#x]
@@ -763,7 +763,7 @@ Input [2]: [key#x, val#x]
       
 (7) Filter [codegen id : 1]
 Input [2]: [key#x, val#x]
-Condition : (isnotnull(key#x) AND (key#x > 10))
+Condition : (isnotnull(key) AND (key#x > 10))
      
 (8) Project [codegen id : 1]
 Output [2]: [key#x, val#x]
@@ -817,7 +817,7 @@ Input [2]: [key#x, val#x]
       
 (3) Filter [codegen id : 1]
 Input [2]: [key#x, val#x]
-Condition : (isnotnull(key#x) AND (key#x > 10))
+Condition : (isnotnull(key) AND (key#x > 10))
      
 (4) Project [codegen id : 1]
 Output [2]: [key#x, val#x]
@@ -826,7 +826,7 @@ Input [2]: [key#x, val#x]
 (5) HashAggregate [codegen id : 1]
 Input [2]: [key#x, val#x]
 Keys [1]: [key#x]
-Functions [1]: [partial_max(val#x)]
+Functions [1]: [partial_max(val)]
 Aggregate Attributes [1]: [max#x]
 Results [2]: [key#x, max#x]
      
@@ -837,9 +837,9 @@ Arguments: hashpartitioning(key#x, 4), true, [id=#x]
 (7) HashAggregate [codegen id : 4]
 Input [2]: [key#x, max#x]
 Keys [1]: [key#x]
-Functions [1]: [max(val#x)]
-Aggregate Attributes [1]: [max(val#x)#x]
-Results [2]: [key#x, max(val#x)#x AS max(val)#x]
+Functions [1]: [max(val)]
+Aggregate Attributes [1]: [max(val)#x]
+Results [2]: [key#x, max(val)#x AS max(val)#x]
      
 (8) ReusedExchange  [Reuses operator id: 6]
 Output [2]: [key#x, max#x]
@@ -847,9 +847,9 @@ Output [2]: [key#x, max#x]
 (9) HashAggregate [codegen id : 3]
 Input [2]: [key#x, max#x]
 Keys [1]: [key#x]
-Functions [1]: [max(val#x)]
-Aggregate Attributes [1]: [max(val#x)#x]
-Results [2]: [key#x, max(val#x)#x AS max(val)#x]
+Functions [1]: [max(val)]
+Aggregate Attributes [1]: [max(val)#x]
+Results [2]: [key#x, max(val)#x AS max(val)#x]
      
 (10) BroadcastExchange 
 Input [2]: [key#x, max(val)#x]
@@ -961,7 +961,7 @@ Input [2]: [key#x, val#x]
 (3) ObjectHashAggregate 
 Input [2]: [key#x, val#x]
 Keys [1]: [key#x]
-Functions [1]: [partial_collect_set(val#x, 0, 0)]
+Functions [1]: [partial_collect_set(val, 0, 0)]
 Aggregate Attributes [1]: [buf#x]
 Results [2]: [key#x, buf#x]
      
@@ -972,9 +972,9 @@ Arguments: hashpartitioning(key#x, 4), true, [id=#x]
 (5) ObjectHashAggregate 
 Input [2]: [key#x, buf#x]
 Keys [1]: [key#x]
-Functions [1]: [collect_set(val#x, 0, 0)]
-Aggregate Attributes [1]: [collect_set(val#x, 0, 0)#x]
-Results [2]: [key#x, sort_array(collect_set(val#x, 0, 0)#x, true)[0] AS sort_array(collect_set(val), true)[0]#x]
+Functions [1]: [collect_set(val, 0, 0)]
+Aggregate Attributes [1]: [collect_set(val, 0, 0)#x]
+Results [2]: [key#x, sort_array(collect_set(val, 0, 0), true)[0] AS sort_array(collect_set(val), true)[0]#x]
 
 
 -- !query
@@ -1011,7 +1011,7 @@ Arguments: [key#x ASC NULLS FIRST], false, 0
 (4) SortAggregate 
 Input [2]: [key#x, val#x]
 Keys [1]: [key#x]
-Functions [1]: [partial_min(val#x)]
+Functions [1]: [partial_min(val)]
 Aggregate Attributes [1]: [min#x]
 Results [2]: [key#x, min#x]
      
@@ -1026,9 +1026,9 @@ Arguments: [key#x ASC NULLS FIRST], false, 0
 (7) SortAggregate 
 Input [2]: [key#x, min#x]
 Keys [1]: [key#x]
-Functions [1]: [min(val#x)]
-Aggregate Attributes [1]: [min(val#x)#x]
-Results [2]: [key#x, min(val#x)#x AS min(val)#x]
+Functions [1]: [min(val)]
+Aggregate Attributes [1]: [min(val)#x]
+Results [2]: [key#x, min(val)#x AS min(val)#x]
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/group-by-filter.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-by-filter.sql.out
@@ -366,9 +366,9 @@ GROUP BY dept_id
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, avg(salary#x) AS avg(salary)#x, avg(salary#x) FILTER (WHERE exists#x [dept_id#x]) AS avg(salary) FILTER (WHERE exists(dept_id))#x]
+IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, avg(salary) AS avg(salary)#x, avg(salary) FILTER (WHERE exists#x [dept_id#x]) AS avg(salary) FILTER (WHERE exists(dept_id))#x]
 :  +- Project [state#x]
-:     +- Filter (dept_id#x = outer(dept_id#x))
+:     +- Filter (dept_id#x = outer(dept_id))
 :        +- SubqueryAlias dept
 :           +- Project [dept_id#x, dept_name#x, state#x]
 :              +- SubqueryAlias DEPT
@@ -392,9 +392,9 @@ GROUP BY dept_id
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, sum(salary#x) AS sum(salary)#x, sum(salary#x) FILTER (WHERE NOT exists#x [dept_id#x]) AS sum(salary) FILTER (WHERE (NOT exists(dept_id)))#x]
+IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, sum(salary) AS sum(salary)#x, sum(salary) FILTER (WHERE NOT exists#x [dept_id#x]) AS sum(salary) FILTER (WHERE (NOT exists(dept_id)))#x]
 :  +- Project [state#x]
-:     +- Filter (dept_id#x = outer(dept_id#x))
+:     +- Filter (dept_id#x = outer(dept_id))
 :        +- SubqueryAlias dept
 :           +- Project [dept_id#x, dept_name#x, state#x]
 :              +- SubqueryAlias DEPT
@@ -417,7 +417,7 @@ GROUP BY dept_id
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, avg(salary#x) AS avg(salary)#x, avg(salary#x) FILTER (WHERE dept_id#x IN (list#x [])) AS avg(salary) FILTER (WHERE (dept_id IN (listquery())))#x]
+IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, avg(salary) AS avg(salary)#x, avg(salary) FILTER (WHERE dept_id#x IN (list#x [])) AS avg(salary) FILTER (WHERE (dept_id IN (listquery())))#x]
 :  +- Distinct
 :     +- Project [dept_id#x]
 :        +- SubqueryAlias dept
@@ -442,7 +442,7 @@ GROUP BY dept_id
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, sum(salary#x) AS sum(salary)#x, sum(salary#x) FILTER (WHERE NOT dept_id#x IN (list#x [])) AS sum(salary) FILTER (WHERE (NOT (dept_id IN (listquery()))))#x]
+IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate [dept_id#x], [dept_id#x, sum(salary) AS sum(salary)#x, sum(salary) FILTER (WHERE NOT dept_id#x IN (list#x [])) AS sum(salary) FILTER (WHERE (NOT (dept_id IN (listquery()))))#x]
 :  +- Distinct
 :     +- Project [dept_id#x]
 :        +- SubqueryAlias dept

--- a/sql/core/src/test/resources/sql-tests/results/pivot.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pivot.sql.out
@@ -475,7 +475,7 @@ PIVOT (
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-Invalid pivot column 'named_struct(course, course#x, m, m#x)'. Pivot columns must be comparable.;
+Invalid pivot column 'named_struct(course, course, m, m)'. Pivot columns must be comparable.;
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/select_having.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/select_having.sql.out
@@ -143,7 +143,7 @@ SELECT a FROM test_having HAVING min(a) < max(a)
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-grouping expressions sequence is empty, and 'spark_catalog.default.test_having.`a`' is not an aggregate function. Wrap '(min(spark_catalog.default.test_having.`a`) AS `min(a#x)`, max(spark_catalog.default.test_having.`a`) AS `max(a#x)`)' in windowing function(s) or wrap 'spark_catalog.default.test_having.`a`' in first() (or first_value) if you don't care which value you get.;
+grouping expressions sequence is empty, and 'spark_catalog.default.test_having.`a`' is not an aggregate function. Wrap '(min(spark_catalog.default.test_having.`a`) AS `min(a)`, max(spark_catalog.default.test_having.`a`) AS `max(a)`)' in windowing function(s) or wrap 'spark_catalog.default.test_having.`a`' in first() (or first_value) if you don't care which value you get.;
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/subquery/negative-cases/invalid-correlation.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/negative-cases/invalid-correlation.sql.out
@@ -109,7 +109,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 Expressions referencing the outer query are not supported outside of WHERE/HAVING clauses:
-Aggregate [min(outer(t2a#x)) AS min(outer(t2.`t2a`))#x]
+Aggregate [min(outer(t2a)) AS min(outer(t2.`t2a`))#x]
 +- SubqueryAlias t3
    +- Project [t3a#x, t3b#x, t3c#x]
       +- SubqueryAlias t3

--- a/sql/core/src/test/resources/sql-tests/results/udf/postgreSQL/udf-select_having.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/postgreSQL/udf-select_having.sql.out
@@ -143,7 +143,7 @@ SELECT udf(a) FROM test_having HAVING udf(min(a)) < udf(max(a))
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-grouping expressions sequence is empty, and 'spark_catalog.default.test_having.`a`' is not an aggregate function. Wrap '(min(spark_catalog.default.test_having.`a`) AS `min(a#x)`, max(spark_catalog.default.test_having.`a`) AS `max(a#x)`)' in windowing function(s) or wrap 'spark_catalog.default.test_having.`a`' in first() (or first_value) if you don't care which value you get.;
+grouping expressions sequence is empty, and 'spark_catalog.default.test_having.`a`' is not an aggregate function. Wrap '(min(spark_catalog.default.test_having.`a`) AS `min(a)`, max(spark_catalog.default.test_having.`a`) AS `max(a)`)' in windowing function(s) or wrap 'spark_catalog.default.test_having.`a`' in first() (or first_value) if you don't care which value you get.;
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/udf/udf-pivot.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/udf-pivot.sql.out
@@ -441,7 +441,7 @@ PIVOT (
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-Invalid pivot column 'named_struct(course, course#x, m, m#x)'. Pivot columns must be comparable.;
+Invalid pivot column 'named_struct(course, course, m, m)'. Pivot columns must be comparable.;
 
 
 -- !query

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
@@ -116,8 +116,8 @@ class ExplainSuite extends QueryTest with SharedSparkSession {
       // plan should show the rewritten aggregate expression.
       val df = sql("SELECT k, every(v), some(v), any(v) FROM test_agg GROUP BY k")
       checkKeywordsExistsInExplain(df,
-        "Aggregate [k#x], [k#x, every(v#x) AS every(v)#x, some(v#x) AS some(v)#x, " +
-          "any(v#x) AS any(v)#x]")
+        "Aggregate [k#x], [k#x, every(v) AS every(v)#x, some(v) AS some(v)#x, " +
+          "any(v) AS any(v)#x]")
     }
   }
 
@@ -266,7 +266,7 @@ class ExplainSuite extends QueryTest with SharedSparkSession {
           val expected_pattern1 =
             "Subquery:1 Hosting operator id = 1 Hosting Expression = k#xL IN subquery#x"
           val expected_pattern2 =
-            "PartitionFilters: \\[isnotnull\\(k#xL\\), dynamicpruningexpression\\(k#xL " +
+            "PartitionFilters: \\[isnotnull\\(k#L\\), dynamicpruningexpression\\(k#xL " +
               "IN subquery#x\\)\\]"
           val expected_pattern3 =
             "Location: InMemoryFileIndex \\[.*org.apache.spark.sql.ExplainSuite" +


### PR DESCRIPTION
### What changes were proposed in this pull request?
When EXPLAIN sql query, the auto-generated argument alias shouldn't include expr/attribute id. This will provide better readability of Explain results. This is a follow-up to address #27368 (comment). 

**Before**
```
(7) HashAggregate [codegen id : 2]
Input [2]: [key#x, max#x]
Keys [1]: [key#x]
Functions [1]: [max(val#x)]
Aggregate Attributes [1]: [max(val#x)#x]
Results [2]: [key#x, max(val#x)#x AS max(val)#x]
```
**After**
```
(7) HashAggregate [codegen id : 2]
Input [2]: [key#x, max#x]
Keys [1]: [key#x]
Functions [1]: [max(val)]
Aggregate Attributes [1]: [max(val)#x]
Results [2]: [key#x, max(val)#x AS max(val)#x]
```



### Why are the changes needed?
Provide better readability for Explain result


### Does this PR introduce any user-facing change?
Update Explain result to a better format 


### How was this patch tested?
Update existing tests
