### PR TITLE
[SPARK-30945][CORE] Preserve JVM information when executor heartbeat …

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -36,6 +36,7 @@ import org.apache.spark._
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.internal.Logging
 import org.apache.spark.memory.{SparkOutOfMemoryError, TaskMemoryManager}
+import org.apache.spark.monitor.JVMQuake
 import org.apache.spark.rpc.RpcTimeout
 import org.apache.spark.scheduler.{DirectTaskResult, IndirectTaskResult, Task, TaskDescription}
 import org.apache.spark.shuffle.FetchFailedException
@@ -167,6 +168,9 @@ private[spark] class Executor(
    */
   private var heartbeatFailures = 0
 
+  private val jvmQuake = JVMQuake.create(conf)
+  jvmQuake.start()
+
   startDriverHeartbeater()
 
   private[executor] def numRunningTasks: Int = runningTasks.size()
@@ -216,6 +220,7 @@ private[spark] class Executor(
 
   def stop(): Unit = {
     env.metricsSystem.report()
+    jvmQuake.stop()
     heartbeater.shutdown()
     heartbeater.awaitTermination(10, TimeUnit.SECONDS)
     threadPool.shutdown()

--- a/core/src/main/scala/org/apache/spark/monitor/JVMQuake.scala
+++ b/core/src/main/scala/org/apache/spark/monitor/JVMQuake.scala
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.monitor
+
+import java.io.File
+import java.lang.management.ManagementFactory
+import java.nio.file.Files
+import java.util.concurrent.{ScheduledExecutorService, TimeUnit}
+
+import com.sun.management.HotSpotDiagnosticMXBean
+import org.apache.commons.lang3.SystemUtils
+import scala.concurrent.duration._
+import sun.jvmstat.monitor._
+
+import org.apache.spark.SparkConf
+import org.apache.spark.internal.Logging
+import org.apache.spark.util.{ThreadUtils, Utils}
+
+class JVMQuake(conf: SparkConf) extends Logging {
+
+  import JVMQuake._
+
+  private[this] val appId = conf.get("spark.app.id", "test-app-id").stripPrefix("application_")
+  private[this] val threshold = conf.getTimeAsMs("spark.jvmQuake.threshold", "100s").millis.toNanos
+  private[this] val jvmQuakeEnabled = conf.getBoolean("spark.jvmQuake.enabled", false)
+  private[this] val checkInterval = conf.getTimeAsMs("spark.jvmQuake.checkInterval", "1s")
+  private[this] val runTimeWeight = conf.getDouble("spark.jvmQuake.runTimeWeight", 1)
+
+  private[this] var lastExitTime = getLastExitTime
+  private[this] var lastGCTime = getLastGCTime
+  private[this] var bucket = 0L
+  private[monitor] var heapExist = false
+
+  val scheduler: ScheduledExecutorService =
+    ThreadUtils.newDaemonSingleThreadScheduledExecutor("jvm-quake")
+
+  def run(): Unit = {
+    val currentExitTime = getLastExitTime
+    val currentGcTime = getLastGCTime
+    val gcTime = currentGcTime - lastGCTime
+    val runTime = currentExitTime - lastExitTime - gcTime
+
+    bucket = Math.max(0, bucket + gcTime - BigDecimal(runTime * runTimeWeight).toLong)
+    logDebug(s"Time: (gcTime: $gcTime, runTime: $runTime)")
+    logDebug(s"Capacity: (bucket: $bucket, threshold: ${threshold})")
+
+    if (bucket > threshold) {
+      logError(s"JVM GC has reached the threshold!!! (bucket: $bucket, threshold: $threshold)")
+      if (shouldDumpHeap) {
+        val savePath = getHeapDumpSavePath(appId)
+        val linkPath = getHeapDumpLinkPath(appId)
+        saveHeap(savePath, linkPath)
+      }
+    }
+
+    lastExitTime = currentExitTime
+    lastGCTime = currentGcTime
+  }
+
+  def start(): Unit = {
+    if (jvmQuakeEnabled) {
+      scheduler.scheduleAtFixedRate(new Runnable() {
+        override def run(): Unit = {
+          JVMQuake.this.run()
+        }
+      }, 0, checkInterval, TimeUnit.MILLISECONDS)
+    }
+  }
+
+  def stop(): Unit = {
+    scheduler.shutdown()
+  }
+
+  def shouldDumpHeap: Boolean = {
+    !heapExist
+  }
+
+  def getHeapDumpSavePath(appId: String): String = {
+    s"${Utils.getLocalDir(conf).stripSuffix("/")}/$appId"
+  }
+
+  def getHeapDumpLinkPath(appId: String): String = {
+    s"/tmp/spark-debug/apps/$appId"
+  }
+
+  def saveHeap(savePath: String, linkPath: String, live: Boolean = false): Unit = {
+    val saveDir = new File(savePath)
+    if (!saveDir.exists()) {
+      saveDir.mkdirs()
+    }
+    val heapDumpFile = new File(saveDir, s"spark-quake-heapdump.hprof")
+    if (heapDumpFile.exists()) {
+      logInfo(s"Heap exits $heapDumpFile")
+      heapExist = true
+      return
+    }
+    logInfo(s"Starting heap dump at $heapDumpFile.")
+    val server = ManagementFactory.getPlatformMBeanServer
+    val mxBean = ManagementFactory.newPlatformMXBeanProxy(server,
+      "com.sun.management:type=HotSpotDiagnostic", classOf[HotSpotDiagnosticMXBean])
+    mxBean.dumpHeap(heapDumpFile.getAbsolutePath, live)
+    // link
+    val linkDir = new File(linkPath)
+    if (linkDir.exists()) {
+      logInfo(s"Soft link exists $linkPath.")
+    } else if (!linkDir.getParentFile.exists()) {
+      linkDir.getParentFile.mkdirs()
+    }
+    try {
+      Files.createSymbolicLink(linkDir.toPath, saveDir.toPath)
+      logInfo(s"Create soft link at $linkPath.")
+    } catch {
+      case e: Exception =>
+        logError(s"Link failed ", e)
+    } finally {
+      heapExist = true
+    }
+  }
+}
+
+object JVMQuake {
+
+  private[this] var monitor: JVMQuake = _
+
+  def create(sparkConf: SparkConf): JVMQuake = {
+    set(new JVMQuake(sparkConf))
+    monitor
+  }
+
+  def get: JVMQuake = {
+    monitor
+  }
+
+  def set(monitor: JVMQuake): Unit = {
+    this.monitor = monitor
+  }
+
+  implicit def timeToTick(value: Long): Tick = {
+    new Tick(value)
+  }
+
+  private[this] val pid = ManagementFactory.getRuntimeMXBean.getName.split("@")(0).toLong
+
+  private[this] val monitoredVm: MonitoredVm = {
+    val host = MonitoredHost.getMonitoredHost(new HostIdentifier("localhost"))
+    host.getMonitoredVm(new VmIdentifier("local://%s@localhost".format(pid)))
+  }
+
+  val youngGCExitTimeMonitor: Monitor =
+    monitoredVm.findByName("sun.gc.collector.0.lastExitTime")
+  val fullGCExitTimeMonitor: Monitor =
+    monitoredVm.findByName("sun.gc.collector.1.lastExitTime")
+  val youngGCTimeMonitor: Monitor =
+    monitoredVm.findByName("sun.gc.collector.0.time")
+  val fullGCTimeMonitor: Monitor =
+    monitoredVm.findByName("sun.gc.collector.1.time")
+
+  def getLastExitTime: Long = {
+    Math.max(youngGCExitTimeMonitor.getValue.asInstanceOf[Long],
+      fullGCExitTimeMonitor.getValue.asInstanceOf[Long])
+  }
+
+  def getLastGCTime: Long = {
+    youngGCTimeMonitor.getValue.asInstanceOf[Long] +
+      fullGCTimeMonitor.getValue.asInstanceOf[Long]
+  }
+}
+
+private[monitor] class Tick(value: Long) {
+  // Convert tick to nanos according to jdk version
+  def toNanos: Long = {
+    val javaVersion = SystemUtils.JAVA_SPECIFICATION_VERSION
+    if (javaVersion < "1.8") {
+      value * 1.micros.toNanos
+    } else {
+      // already nanos, so just return
+      value
+    }
+  }
+}

--- a/core/src/test/scala/org/apache/spark/monitor/JVMQuakeSuite.scala
+++ b/core/src/test/scala/org/apache/spark/monitor/JVMQuakeSuite.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.monitor
+
+import java.io.File
+
+import org.scalatest.BeforeAndAfterEach
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.internal.Logging
+import org.apache.spark.util.Utils
+
+class JVMQuakeSuite extends SparkFunSuite with BeforeAndAfterEach with Logging {
+
+  val alloc = new ArrayBuffer[Array[Byte]]()
+
+  override def afterEach(): Unit = {
+    alloc.clear()
+    System.gc()
+  }
+
+  def easyNonOOM(alloc: ArrayBuffer[Array[Byte]], monitor: JVMQuake): Unit = {
+    val goodZone = 0.5 * Runtime.getRuntime.maxMemory
+    logInfo(s"Not triggering OutOfMemory by only allocating $goodZone bytes")
+
+    val capacity = 1024 * 1024 * 100
+    while (alloc.size * capacity < goodZone) {
+      val bytes = new Array[Byte](capacity)
+      alloc.append(bytes)
+    }
+
+    while (monitor.shouldDumpHeap) {
+      for (i <- alloc.indices) {
+        val bytes = new Array[Byte](capacity)
+        alloc(i) = bytes
+      }
+    }
+  }
+
+  test("check jvm quake status") {
+    val conf = new SparkConf
+    conf.set("spark.jvmQuake.threshold", "1s")
+    conf.set("spark.jvmQuake.enabled", "true")
+    conf.set("spark.jvmQuake.checkInterval", "1s")
+    conf.set("spark.jvmQuake.runTimeWeight", "1")
+
+    val monitor = new JVMQuake(conf)
+    monitor.start()
+    easyNonOOM(alloc, monitor)
+    monitor.stop()
+    assert(monitor.heapExist === true)
+    val savePath = s"${monitor.getHeapDumpSavePath("test-app-id")}/spark-quake-heapdump.hprof"
+    val linkPath = monitor.getHeapDumpLinkPath("test-app-id")
+    assert(new File(savePath).exists())
+    Utils.deleteRecursively(new File(linkPath))
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
I added GC detection to generate heap when appropriate

### Why are the changes needed?
In practice, it was found that executor has a gc loop state, which will cause gc to spend a lot of time. Usually, this situation does not cause OOM, but causes the connection driver to timeout.

### Does this PR introduce any user-facing change?
Users can start the detection process via "spark.jvmQuake.enabled=true"

### How was this patch tested?
Unit test
