### PR TITLE
[SPARK-30947][CORE] Log better message when accelerate resource is empty

### DIFF
--- a/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala
+++ b/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala
@@ -194,9 +194,8 @@ class ResourceProfile(
       throw new SparkException("No executor resource configs were not specified for the " +
         s"following task configs: ${taskResourcesToCheck.keys.mkString(",")}")
     }
-    if (limitingResource.nonEmpty) {
-      logInfo(s"Limiting resource is $limitingResource at $taskLimit tasks per executor")
-    }
+    val limiting = if (taskLimit == -1) "None" else limitingResource
+    logInfo(s"Limiting resource is $limiting at $taskLimit tasks per executor")
     _executorResourceSlotsPerAddr = Some(numPartsPerResourceMap.toMap)
     _maxTasksPerExecutor = if (taskLimit == -1) Some(1) else Some(taskLimit)
     _limitingResource = Some(limitingResource)

--- a/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala
+++ b/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala
@@ -194,8 +194,9 @@ class ResourceProfile(
       throw new SparkException("No executor resource configs were not specified for the " +
         s"following task configs: ${taskResourcesToCheck.keys.mkString(",")}")
     }
-    val limiting = if (taskLimit == -1) "None" else limitingResource
-    logInfo(s"Limiting resource is $limiting at $taskLimit tasks per executor")
+    val limiting =
+      if (taskLimit == -1) "cpu" else s"$limitingResource at $taskLimit tasks per executor"
+    logInfo(s"Limiting resource is $limiting")
     _executorResourceSlotsPerAddr = Some(numPartsPerResourceMap.toMap)
     _maxTasksPerExecutor = if (taskLimit == -1) Some(1) else Some(taskLimit)
     _limitingResource = Some(limitingResource)

--- a/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala
+++ b/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala
@@ -194,7 +194,9 @@ class ResourceProfile(
       throw new SparkException("No executor resource configs were not specified for the " +
         s"following task configs: ${taskResourcesToCheck.keys.mkString(",")}")
     }
-    logInfo(s"Limiting resource is $limitingResource at $taskLimit tasks per executor")
+    if (limitingResource.nonEmpty) {
+      logInfo(s"Limiting resource is $limitingResource at $taskLimit tasks per executor")
+    }
     _executorResourceSlotsPerAddr = Some(numPartsPerResourceMap.toMap)
     _maxTasksPerExecutor = if (taskLimit == -1) Some(1) else Some(taskLimit)
     _limitingResource = Some(limitingResource)

--- a/core/src/main/scala/org/apache/spark/resource/ResourceUtils.scala
+++ b/core/src/main/scala/org/apache/spark/resource/ResourceUtils.scala
@@ -363,9 +363,9 @@ private[spark] object ResourceUtils extends Logging {
   def logResourceInfo(componentName: String, resources: Map[String, ResourceInformation])
     : Unit = {
     val resourceInfo = if (resources.isEmpty) {
-      s"No extra accelerate resources configured for $componentName."
+      s"No extra custom resources configured for $componentName."
     } else {
-      s"Accelerate Resources for $componentName:\n${resources.mkString("\n")}"
+      s"Custom resources for $componentName:\n${resources.mkString("\n")}"
     }
     logInfo("==============================================================")
     logInfo(resourceInfo)

--- a/core/src/main/scala/org/apache/spark/resource/ResourceUtils.scala
+++ b/core/src/main/scala/org/apache/spark/resource/ResourceUtils.scala
@@ -362,9 +362,13 @@ private[spark] object ResourceUtils extends Logging {
 
   def logResourceInfo(componentName: String, resources: Map[String, ResourceInformation])
     : Unit = {
-    if (resources.isEmpty) return
+    val resourceInfo = if (resources.isEmpty) {
+      s"No extra accelerate resources configured for $componentName."
+    } else {
+      s"Accelerate Resources for $componentName:\n${resources.mkString("\n")}"
+    }
     logInfo("==============================================================")
-    logInfo(s"Accelerate Resources for $componentName:\n${resources.mkString("\n")}")
+    logInfo(resourceInfo)
     logInfo("==============================================================")
   }
 

--- a/core/src/main/scala/org/apache/spark/resource/ResourceUtils.scala
+++ b/core/src/main/scala/org/apache/spark/resource/ResourceUtils.scala
@@ -363,7 +363,7 @@ private[spark] object ResourceUtils extends Logging {
   def logResourceInfo(componentName: String, resources: Map[String, ResourceInformation])
     : Unit = {
     val resourceInfo = if (resources.isEmpty) {
-      s"No extra custom resources configured for $componentName."
+      s"No custom resources configured for $componentName."
     } else {
       s"Custom resources for $componentName:\n${resources.mkString("\n")}"
     }

--- a/core/src/main/scala/org/apache/spark/resource/ResourceUtils.scala
+++ b/core/src/main/scala/org/apache/spark/resource/ResourceUtils.scala
@@ -362,8 +362,9 @@ private[spark] object ResourceUtils extends Logging {
 
   def logResourceInfo(componentName: String, resources: Map[String, ResourceInformation])
     : Unit = {
+    if (resources.isEmpty) return
     logInfo("==============================================================")
-    logInfo(s"Resources for $componentName:\n${resources.mkString("\n")}")
+    logInfo(s"Accelerate Resources for $componentName:\n${resources.mkString("\n")}")
     logInfo("==============================================================")
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Try to log better message when accelerate resource is empty.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Otherwise, it's weird to see cpu/memory resources after logging **that** resources is empty:

```
20/02/25 21:47:55 INFO ResourceUtils: ==============================================================
20/02/25 21:47:55 INFO ResourceUtils: Resources for spark.driver:

20/02/25 21:47:55 INFO ResourceUtils: ==============================================================
20/02/25 21:47:55 INFO SparkContext: Submitted application: Spark shell
20/02/25 21:47:55 INFO ResourceProfile: Default ResourceProfile created, executor resources: Map(cores -> name: cores, amount: 1, script: , vendor: , memory -> name: memory, amount: 1024, script: , vendor: ), task resources: Map(cpus -> name: cpus, amount: 1.0)
20/02/25 21:47:55 INFO ResourceProfile: Limiting resource is  at -1 tasks per executor
```

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

NO.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Tested manually.