### PR TITLE
[SPARK-30946][SS] Serde entry via DataInputStream/DataOutputStream with LZ4 compression on FileStream(Source/Sink)Log

### DIFF
--- a/core/src/main/scala/org/apache/spark/io/CompressionCodec.scala
+++ b/core/src/main/scala/org/apache/spark/io/CompressionCodec.scala
@@ -135,8 +135,11 @@ class LZ4CompressionCodec(conf: SparkConf) extends CompressionCodec {
   private[this] val defaultSeed: Int = 0x9747b28c // LZ4BlockOutputStream.DEFAULT_SEED
 
   override def compressedOutputStream(s: OutputStream): OutputStream = {
+    compressedOutputStream(s, syncFlush = false)
+  }
+
+  def compressedOutputStream(s: OutputStream, syncFlush: Boolean): OutputStream = {
     val blockSize = conf.get(IO_COMPRESSION_LZ4_BLOCKSIZE).toInt
-    val syncFlush = false
     new LZ4BlockOutputStream(
       s,
       blockSize,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1464,6 +1464,21 @@ object SQLConf {
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefault(TimeUnit.MINUTES.toMillis(10)) // 10 minutes
 
+  val FILE_SINK_LOG_WRITE_METADATA_VERSION =
+    buildConf("spark.sql.streaming.fileSink.log.writeMetadataVersion")
+      .doc("The version of file stream sink log metadata. By default the version is set to " +
+        "the highest version current Spark handles, as higher version tends to be better in " +
+        "some aspects. You may want to set this to lower value when the outputs should be " +
+        "readable from lower version of Spark. " +
+        "Note that it doesn't 'rewrite' the old batch files: to ensure the metadata to be " +
+        "read by lower version of Spark, the metadata log should be written from the scratch, " +
+        "or at least one compact batch should be written with configured version. " +
+        "Available metadata versions: 1 (all versions) 2 (3.1.0+)")
+      .version("3.1.0")
+      .intConf
+      .checkValue(v => Set(1, 2).contains(v), "Valid versions are 1 and 2")
+      .createOptional
+
   val FILE_SOURCE_LOG_DELETION = buildConf("spark.sql.streaming.fileSource.log.deletion")
     .internal()
     .doc("Whether to delete the expired log files in file stream source.")
@@ -2807,6 +2822,8 @@ class SQLConf extends Serializable with Logging {
   def fileSinkLogCompactInterval: Int = getConf(FILE_SINK_LOG_COMPACT_INTERVAL)
 
   def fileSinkLogCleanupDelay: Long = getConf(FILE_SINK_LOG_CLEANUP_DELAY)
+
+  def fileSinkWriteMetadataLogVersion: Option[Int] = getConf(FILE_SINK_LOG_WRITE_METADATA_VERSION)
 
   def fileSourceLogDeletion: Boolean = getConf(FILE_SOURCE_LOG_DELETION)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/HDFSMetadataLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/HDFSMetadataLog.scala
@@ -249,6 +249,16 @@ class HDFSMetadataLog[T <: AnyRef : ClassTag](sparkSession: SparkSession, path: 
    * "v123xyz" etc.)
    */
   private[sql] def validateVersion(text: String, maxSupportedVersion: Int): Int = {
+    val version = parseVersion(text)
+    if (version > maxSupportedVersion) {
+      throw new IllegalStateException(s"UnsupportedLogVersion: maximum supported log version " +
+        s"is v${maxSupportedVersion}, but encountered v$version. The log file was produced " +
+        s"by a newer version of Spark and cannot be read by this version. Please upgrade.")
+    }
+    version
+  }
+
+  private[sql] def parseVersion(text: String): Int = {
     if (text.length > 0 && text(0) == 'v') {
       val version =
         try {
@@ -258,15 +268,8 @@ class HDFSMetadataLog[T <: AnyRef : ClassTag](sparkSession: SparkSession, path: 
             throw new IllegalStateException(s"Log file was malformed: failed to read correct log " +
               s"version from $text.")
         }
-      if (version > 0) {
-        if (version > maxSupportedVersion) {
-          throw new IllegalStateException(s"UnsupportedLogVersion: maximum supported log version " +
-            s"is v${maxSupportedVersion}, but encountered v$version. The log file was produced " +
-            s"by a newer version of Spark and cannot be read by this version. Please upgrade.")
-        } else {
-          return version
-        }
-      }
+
+      if (version > 0) return version
     }
 
     // reaching here means we failed to read the correct log version

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/CompactibleFileStreamLogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/CompactibleFileStreamLogSuite.scala
@@ -109,45 +109,49 @@ class CompactibleFileStreamLogSuite extends SharedSparkSession {
       })
   }
 
-  test("serialize") {
+  test("serialize & deserialize") {
     withFakeCompactibleFileStreamLog(
       fileCleanupDelayMs = Long.MaxValue,
       defaultCompactInterval = 3,
       defaultMinBatchesToRetain = 1,
       compactibleLog => {
         val logs = Array("entry_1", "entry_2", "entry_3")
-        val expected = s"""v${FakeCompactibleFileStreamLog.VERSION}
-            |"entry_1"
-            |"entry_2"
-            |"entry_3"""".stripMargin
+
         val baos = new ByteArrayOutputStream()
         compactibleLog.serialize(logs, baos)
-        assert(expected === baos.toString(UTF_8.name()))
+
+        val actualLogs = compactibleLog.deserialize(new ByteArrayInputStream(baos.toByteArray))
+        assert(actualLogs === logs)
 
         baos.reset()
         compactibleLog.serialize(Array(), baos)
-        assert(s"v${FakeCompactibleFileStreamLog.VERSION}" === baos.toString(UTF_8.name()))
+        val actualLogs2 = compactibleLog.deserialize(new ByteArrayInputStream(baos.toByteArray))
+        assert(actualLogs2.isEmpty)
       })
   }
 
-  test("deserialize") {
-    withFakeCompactibleFileStreamLog(
-      fileCleanupDelayMs = Long.MaxValue,
-      defaultCompactInterval = 3,
-      defaultMinBatchesToRetain = 1,
-      compactibleLog => {
-        val logs = s"""v${FakeCompactibleFileStreamLog.VERSION}
-            |"entry_1"
-            |"entry_2"
-            |"entry_3"""".stripMargin
-        val expected = Array("entry_1", "entry_2", "entry_3")
-        assert(expected ===
-          compactibleLog.deserialize(new ByteArrayInputStream(logs.getBytes(UTF_8))))
+  test("write older version of metadata for compatibility") {
+    withTempDir { dir =>
+      def newFakeCompactibleFileStreamLog(
+          readVersion: Int,
+          writeVersion: Option[Int]): FakeCompactibleFileStreamLog =
+        new FakeCompactibleFileStreamLog(
+          readVersion,
+          writeVersion,
+          _fileCleanupDelayMs = Long.MaxValue, // this param does not matter here in this test case
+          _defaultCompactInterval = 3,         // this param does not matter here in this test case
+          _defaultMinBatchesToRetain = 1,      // this param does not matter here in this test case
+          spark,
+          dir.getCanonicalPath)
 
-        assert(Nil ===
-          compactibleLog.deserialize(
-            new ByteArrayInputStream(s"v${FakeCompactibleFileStreamLog.VERSION}".getBytes(UTF_8))))
-      })
+      // writer understands version 2 but to ensure compatibility it sets the write version to 1
+      val writer = newFakeCompactibleFileStreamLog(2, Some(1))
+      // suppose a reader only understand version 1
+      val reader = newFakeCompactibleFileStreamLog(1, None)
+      writer.add(0, Array("entry"))
+      // reader can read the metadata log writer just wrote
+      assert(Array("entry") === reader.get(0).get)
+    }
   }
 
   test("deserialization log written by future version") {
@@ -155,6 +159,7 @@ class CompactibleFileStreamLogSuite extends SharedSparkSession {
       def newFakeCompactibleFileStreamLog(version: Int): FakeCompactibleFileStreamLog =
         new FakeCompactibleFileStreamLog(
           version,
+          None,
           _fileCleanupDelayMs = Long.MaxValue, // this param does not matter here in this test case
           _defaultCompactInterval = 3,         // this param does not matter here in this test case
           _defaultMinBatchesToRetain = 1,      // this param does not matter here in this test case
@@ -263,6 +268,7 @@ class CompactibleFileStreamLogSuite extends SharedSparkSession {
     withTempDir { file =>
       val compactibleLog = new FakeCompactibleFileStreamLog(
         FakeCompactibleFileStreamLog.VERSION,
+        None,
         fileCleanupDelayMs,
         defaultCompactInterval,
         defaultMinBatchesToRetain,
@@ -274,11 +280,12 @@ class CompactibleFileStreamLogSuite extends SharedSparkSession {
 }
 
 object FakeCompactibleFileStreamLog {
-  val VERSION = 1
+  val VERSION = 2
 }
 
 class FakeCompactibleFileStreamLog(
     metadataLogVersion: Int,
+    _writeMetadataLogVersion: Option[Int],
     _fileCleanupDelayMs: Long,
     _defaultCompactInterval: Int,
     _defaultMinBatchesToRetain: Int,
@@ -296,7 +303,17 @@ class FakeCompactibleFileStreamLog(
 
   override protected def defaultCompactInterval: Int = _defaultCompactInterval
 
+  override protected def writeMetadataLogVersion: Option[Int] = _writeMetadataLogVersion
+
   override protected val minBatchesToRetain: Int = _defaultMinBatchesToRetain
 
   override def compactLogs(logs: Seq[String]): Seq[String] = logs
+
+  override protected def serializeEntryToV2(data: String): Array[Byte] = {
+    data.getBytes(UTF_8)
+  }
+
+  override protected def deserializeEntryFromV2(serialized: Array[Byte]): String = {
+    new String(serialized, UTF_8)
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This patch uses DataInputStream / DataOutputStream to serialize/deserialize entry on FileStream(Source/Sink)Log, as well as applying LZ4 compression on serde.

The ground idea is that both FileEntry and SinkFileStatus haven't been changed for 3 years but we have been simply taking JSON serde to prepare with possible change and spending bunch of overhead on JSON format. CompactibleFileStreamLog has the metadata version information but it has been just version 1.

This patch introduces metadata version 2 of CompactibleFileStreamLog as leveraging DataInputStream / DataOutputStream & LZ4 compression. While we introduce version 2 for CompactibleFileStreamLog, CompactibleFileStreamLog is still compatible with version 1 for both serialization and deserialization, so we can read from version 2 and write to version 2 in normal, and also we can read from version 1 and write to version 2 for smooth migration.

There's some exceptional case on file stream sink, which outputs are possibly read by older version of Spark. To support such case, a new configuration (`spark.sql.streaming.fileSink.log.writeMetadataVersion`) is introduced to specify the write version of the metadata on file stream sink. If specified, further batch log files will be written via the write version. This doesn't rewrite the existing batch log files, so if the query is started from existing metadata, the query should be run at least for next compact batch so that the metadata log of compact batch can be written via the write version.

### Why are the changes needed?

Multiple JIRA issues have been filed to report that huge metadata logs make their queries very slow. While this patch won't make their metadata log stop growing, this patch may heavily reduce down their metadata log and time to process compaction.

* [SPARK-24295](https://issues.apache.org/jira/browse/SPARK-24295)
* [SPARK-29995](https://issues.apache.org/jira/browse/SPARK-29995)

Please find the numbers in the section "How was this patch tested?".

As this also reduces the latency to read all files from file stream sink metadata, it also helps to speed up the query for both batch and streaming if the input path is pointing to the output of file stream sink.

### Does this PR introduce any user-facing change?

Further metadata log files will be written by configured write version for file stream sink. For other compatible metadata logs, further metadata log files will be written by version 2.

### How was this patch tested?

* Existing UTs (UTs for checking with 2.1.0 compatibility is basically the checking with V1 compatibility, as I don't find any change)
* Manually done simple perf. test

Note that the version 4 in the experiment is now taken as version 2 in this patch.

This is the experiment branch: https://github.com/HeartSaVioR/spark/tree/SPARK-30946-experiments

> Version 3 is only applying compaction (LZ4) on existing format. See below commit:

https://github.com/HeartSaVioR/spark/commit/406670aa4910c4bec847a590ef37f2f0bd130902

> Version 4 is serializing/deserializing entry via DataInputStream / DataOutputStream

https://github.com/HeartSaVioR/spark/commit/7c665163bdd1930fb8812d46a7f8cdd599b1cafb

I've also implemented simple apps to 1) prepare metadata (so that we can experiment on the specific batch) and 2) run simple test with various versions:

https://github.com/HeartSaVioR/spark-delegation-token-experiment/commit/bea7680e4c588f455f8c3181a96c9eff5002fa1a

The numbers are recorded below:

https://docs.google.com/spreadsheets/d/1D5P103F_sKOjkDpNr9PaCC8Ehk4Y4dRtH3oEdytM4_c/edit?usp=sharing

version | elapsed time | elapsed time (ratio of v1) | size | size (ratio of v1)
------- | -------------- | ------------------------- | ----- | -----------------
1  | 10628.75 | 100.00% | 57265744 | 100.00%
2 | 939.25 | 8.84% | 16655736 | 29.08%
3 | 10116 | 95.18% | 17259852 | 30.14%
**4** | 837 | 7.87% | 15285626 | 26.69%