### PR TITLE
[SPARK-30815][SQL] Add function to format timestamp with time zone

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -394,6 +394,7 @@ object FunctionRegistry {
     expression[DateDiff]("datediff"),
     expression[DateAdd]("date_add"),
     expression[DateFormatClass]("date_format"),
+    expression[DateFormatTzClass]("date_format_tz"),
     expression[DateSub]("date_sub"),
     expression[DayOfMonth]("day", true),
     expression[DayOfYear]("dayofyear"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -691,9 +691,9 @@ case class DateFormatClass(left: Expression, right: Expression, timeZoneId: Opti
       * timeZone - The time zone to format the timestamp for.
   """,
   examples = """
-    Examples:
-      > SELECT _FUNC_('2016-04-08', 'y', 'Europe/Berlin');
-       2016
+    Examples (with spark.sql.session.timeZone='America/Los_Angeles'):
+      > SELECT _FUNC_('2016-04-08 12:34:56', 'HH:mm:ss Z', 'Europe/Berlin');
+       21:34:56 +0200
   """,
   since = "3.1.0")
 // scalastyle:on line.size.limit

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -2769,17 +2769,17 @@ object functions {
 
   /**
    * Converts a date/timestamp/string to a value of string in the format specified by the date
-   * format given by the second argument.
+   * format given by the second argument and time zone given by the third argument.
    *
    * See [[java.time.format.DateTimeFormatter]] for valid date and time format patterns
    *
    * @param dateExpr A date, timestamp or string. If a string, the data must be in a format that
    *                 can be cast to a timestamp, such as `yyyy-MM-dd` or `yyyy-MM-dd HH:mm:ss.SSSS`
-   * @param format A pattern `dd.MM.yyyy` would return a string like `18.03.1993`
+   * @param format A pattern `HH:mm:ss Z` would return a string like `22:34:56 +0200`
    * @param tz A string detailing the time zone that the input should be adjusted to, such as
-   *           `Europe/London`, `PST` or `GMT+5`
+   *           `Europe/Berlin`, `PST` or `GMT+5`
    * @return A string, or null if `dateExpr` was a string that could not be cast to a timestamp
-   * @note Use specialized functions like [[year]] whenever possible as they benefit from a
+   * @note Use specialized functions like [[hour]] whenever possible as they benefit from a
    * specialized implementation.
    * @throws IllegalArgumentException if the `format` pattern is invalid
    * @group datetime_funcs

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -2768,6 +2768,28 @@ object functions {
   }
 
   /**
+   * Converts a date/timestamp/string to a value of string in the format specified by the date
+   * format given by the second argument.
+   *
+   * See [[java.time.format.DateTimeFormatter]] for valid date and time format patterns
+   *
+   * @param dateExpr A date, timestamp or string. If a string, the data must be in a format that
+   *                 can be cast to a timestamp, such as `yyyy-MM-dd` or `yyyy-MM-dd HH:mm:ss.SSSS`
+   * @param format A pattern `dd.MM.yyyy` would return a string like `18.03.1993`
+   * @param tz A string detailing the time zone that the input should be adjusted to, such as
+   *           `Europe/London`, `PST` or `GMT+5`
+   * @return A string, or null if `dateExpr` was a string that could not be cast to a timestamp
+   * @note Use specialized functions like [[year]] whenever possible as they benefit from a
+   * specialized implementation.
+   * @throws IllegalArgumentException if the `format` pattern is invalid
+   * @group datetime_funcs
+   * @since 3.1.0
+   */
+  def date_format_tz(dateExpr: Column, format: String, tz: String): Column = withExpr {
+    DateFormatTzClass(dateExpr.expr, Literal(format), Literal(tz))
+  }
+
+  /**
    * Returns the date that is `days` days after `start`
    *
    * @param start A date, timestamp or string. If a string, the data must be in a format that

--- a/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
@@ -113,6 +113,20 @@ class DateFunctionsSuite extends QueryTest with SharedSparkSession {
     }
   }
 
+  test("date format with timezone") {
+    val df = Seq(ts).toDF("a")
+
+    checkAnswer(
+      df.select(date_format_tz($"a", "yyyy-MM-dd HH:mm:ss ZZZZZ", "Europe/Berlin")),
+      Row("2013-04-08 22:10:15 +02:00")
+    )
+
+    checkAnswer(
+      df.selectExpr("date_format_tz(a, 'yyyy-MM-dd HH:mm:ss ZZZZZ', 'Europe/Berlin')"),
+      Row("2013-04-08 22:10:15 +02:00")
+    )
+  }
+
   test("year") {
     val df = Seq((d, sdfDate.format(d), ts)).toDF("a", "b", "c")
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
@@ -137,6 +137,10 @@ object DateTimeBenchmark extends SqlBasedBenchmark {
           run(N, "format date", s"date_format($dateExpr, 'MMM yyyy')")
         }
         runBenchmark("Formatting timestamps") {
+          val timeExpr = "cast(id as timestamp)"
+          val tz = "Europe/Berlin"
+          run(N, "format date", s"date_format($timeExpr, 'yyyy-MM-dd HH:mm:ss')")
+          run(N, "format date tz", s"date_format_tz($timeExpr, 'yyyy-MM-dd HH:mm:ss ZZZZZ', '$tz')")
           run(N, "from_unixtime", "from_unixtime(id, 'yyyy-MM-dd HH:mm:ss.SSSSSS')")
         }
         runBenchmark("Convert timestamps") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Whenever timestamps are turned into strings (`Column.cast(StringType)`, `date_format(timestamp, format)`, `Dataset.show()`) the default time zone is used to format the string. This default time zone is either the java default zone `user.timezone`, the Spark default zone `spark.sql.session.timeZone` or the default DataFrameWriter zone `timeZone`. Currently there is no way to format a single column in a different timezone.

```
scala> spark.conf.set("spark.sql.session.timeZone", "Europe/London")
scala> spark.range(10). \
         select(concat(lit("2020-02-01 0"), $"id", lit(":00:00")).cast(TimestampType).as("time")). \
         select(
           $"time",
           date_format($"time", "uuuu-MM-dd HH:mm:ss ZZZZZ").as("local"),
           date_format_tz($"time", "uuuu-MM-dd HH:mm:ss ZZZZZ", "Europe/Berlin").as("Berlin")
         ). \
         show(false)
+-------------------+---------------------+--------------------------+
|time               |local                |Berlin                    |
+-------------------+---------------------+--------------------------+
|2020-02-01 00:00:00|2020-02-01 00:00:00 Z|2020-02-01 01:00:00 +01:00|
|2020-02-01 01:00:00|2020-02-01 01:00:00 Z|2020-02-01 02:00:00 +01:00|
|2020-02-01 02:00:00|2020-02-01 02:00:00 Z|2020-02-01 03:00:00 +01:00|
|2020-02-01 03:00:00|2020-02-01 03:00:00 Z|2020-02-01 04:00:00 +01:00|
|2020-02-01 04:00:00|2020-02-01 04:00:00 Z|2020-02-01 05:00:00 +01:00|
|2020-02-01 05:00:00|2020-02-01 05:00:00 Z|2020-02-01 06:00:00 +01:00|
|2020-02-01 06:00:00|2020-02-01 06:00:00 Z|2020-02-01 07:00:00 +01:00|
|2020-02-01 07:00:00|2020-02-01 07:00:00 Z|2020-02-01 08:00:00 +01:00|
|2020-02-01 08:00:00|2020-02-01 08:00:00 Z|2020-02-01 09:00:00 +01:00|
|2020-02-01 09:00:00|2020-02-01 09:00:00 Z|2020-02-01 10:00:00 +01:00|
+-------------------+---------------------+--------------------------+
```

### Why are the changes needed?
Formatting timestamps in timezones other than the default one requires a laborious UDF while a very similar operation `date_format` with all the code exists already.

### Does this PR introduce any user-facing change?
Yes, it introduces a new SQL operation `date_format_tz`. I could not get the existing `date_format` take an optional third `tz` argument.

### How was this patch tested?
Unit tests.