### PR TITLE
[SPARK-30964][Core][WebUI] Accelerate InMemoryStore with a new index

### DIFF
--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
@@ -384,9 +384,9 @@ public class InMemoryStore implements KVStore {
       if (parent != null) {
         Comparable<Object> parentKey = asKey(parent);
         if (hasNaturalParentIndex && naturalParentIndexName.equals(ti.getParentIndexName(index))) {
-          // If there is a parent index for the natural index and the parent of `index` happens to be
-          // it, Spark can use the `parentToChildrenMap` to get the related natural keys, and then
-          // copy them from `data`.
+          // If there is a parent index for the natural index and the parent of `index` happens to
+          // be it, Spark can use the `parentToChildrenMap` to get the related natural keys, and
+          // then copy them from `data`.
           NaturalKeys children = parentToChildrenMap.getOrDefault(parentKey, new NaturalKeys());
           ArrayList<T> elements = new ArrayList<>();
           for (Comparable<Object> naturalKey : children.keySet()) {

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
@@ -373,7 +373,10 @@ public class InMemoryStore implements KVStore {
             parentToChildrenMap.computeIfAbsent(parentKey, k -> new ConcurrentHashMap<>());
           ArrayList<T> elements = new ArrayList<>();
           for (Comparable<Object> naturalKey : children.keySet()) {
-            data.computeIfPresent(naturalKey, (k, v) -> {elements.add(v); return v;});
+            data.computeIfPresent(naturalKey, (k, v) -> {
+              elements.add(v);
+              return v;
+            });
           }
           return elements;
         } else {

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
@@ -226,7 +226,8 @@ public class InMemoryStore implements KVStore {
       if (!naturalParentIndexName.isEmpty() && naturalParentIndexName.equals(index)) {
         for (Object indexValue : indexValues) {
           Comparable<Object> parentKey = asKey(indexValue);
-          NaturalKeys children = parentToChildrenMap.computeIfAbsent(parentKey, k -> new NaturalKeys());
+          NaturalKeys children =
+            parentToChildrenMap.computeIfAbsent(parentKey, k -> new NaturalKeys());
           int count = 0;
           for (Object key : children.keySet()) {
             data.remove(asKey(key));
@@ -253,7 +254,8 @@ public class InMemoryStore implements KVStore {
       data.put(asKey(naturalKey.get(value)), value);
       if (!naturalParentIndexName.isEmpty()) {
         Comparable<Object> parentKey = asKey(getIndexAccessor(naturalParentIndexName).get(value));
-        NaturalKeys children = parentToChildrenMap.computeIfAbsent(parentKey, k -> new NaturalKeys());
+        NaturalKeys children =
+          parentToChildrenMap.computeIfAbsent(parentKey, k -> new NaturalKeys());
         children.put(asKey(naturalKey.get(value)), true);
       }
     }
@@ -366,7 +368,8 @@ public class InMemoryStore implements KVStore {
         Comparable<Object> parentKey = asKey(parent);
         if (!naturalParentIndexName.isEmpty() &&
           naturalParentIndexName.equals(ti.getParentIndexName(index))) {
-          NaturalKeys children = parentToChildrenMap.computeIfAbsent(parentKey, k -> new NaturalKeys());
+          NaturalKeys children =
+            parentToChildrenMap.computeIfAbsent(parentKey, k -> new NaturalKeys());
           ArrayList<T> elements = new ArrayList<>();
           for (Comparable<Object> naturalKey : children.keySet()) {
             data.computeIfPresent(naturalKey, (k, v) -> {

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
@@ -163,6 +163,10 @@ public class InMemoryStore implements KVStore {
     }
   }
 
+  /**
+   * An alias class for the type "ConcurrentHashMap<Comparable<Object>, Boolean>", which is used
+   * as a concurrent hashset for storing natural keys.
+   */
   private static class NaturalKeys extends ConcurrentHashMap<Comparable<Object>, Boolean> {}
 
   private static class InstanceList<T> {
@@ -316,10 +320,10 @@ public class InMemoryStore implements KVStore {
     private final String naturalParentIndexName;
 
     InMemoryView(
-      ConcurrentMap<Comparable<Object>, T> data,
-      KVTypeInfo ti,
-      String naturalParentIndexName,
-      ConcurrentMap<Comparable<Object>, NaturalKeys> parentToChildrenMap) {
+        ConcurrentMap<Comparable<Object>, T> data,
+        KVTypeInfo ti,
+        String naturalParentIndexName,
+        ConcurrentMap<Comparable<Object>, NaturalKeys> parentToChildrenMap) {
       this.data = data;
       this.ti = ti;
       this.natural = ti != null ? ti.getAccessor(KVIndex.NATURAL_INDEX_NAME) : null;

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
@@ -165,7 +165,7 @@ public class InMemoryStore implements KVStore {
 
   /**
    * An alias class for the type "ConcurrentHashMap<Comparable<Object>, Boolean>", which is used
-   * as a concurrent hashset for storing natural keys.
+   * as a concurrent hashset for storing natural keys and the boolean value doesn't matter.
    */
   private static class NaturalKeys extends ConcurrentHashMap<Comparable<Object>, Boolean> {}
 
@@ -233,8 +233,7 @@ public class InMemoryStore implements KVStore {
         int count = 0;
         for (Object indexValue : indexValues) {
           Comparable<Object> parentKey = asKey(indexValue);
-          NaturalKeys children =
-            parentToChildrenMap.computeIfAbsent(parentKey, k -> new NaturalKeys());
+          NaturalKeys children = parentToChildrenMap.getOrDefault(parentKey, new NaturalKeys());
           for (Comparable<Object> naturalKey : children.keySet()) {
             data.remove(naturalKey);
             count ++;
@@ -373,8 +372,7 @@ public class InMemoryStore implements KVStore {
         Comparable<Object> parentKey = asKey(parent);
         if (!naturalParentIndexName.isEmpty() &&
           naturalParentIndexName.equals(ti.getParentIndexName(index))) {
-          NaturalKeys children =
-            parentToChildrenMap.computeIfAbsent(parentKey, k -> new NaturalKeys());
+          NaturalKeys children = parentToChildrenMap.getOrDefault(parentKey, new NaturalKeys());
           ArrayList<T> elements = new ArrayList<>();
           for (Comparable<Object> naturalKey : children.keySet()) {
             data.computeIfPresent(naturalKey, (k, v) -> {

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
@@ -223,7 +223,7 @@ public class InMemoryStore implements KVStore {
       this.data = new ConcurrentHashMap<>();
       this.naturalParentIndexName = ti.getParentIndexName(KVIndex.NATURAL_INDEX_NAME);
       this.parentToChildrenMap = new ConcurrentHashMap<>();
-      this.hasNaturalParentIndex = naturalParentIndexName.isEmpty();
+      this.hasNaturalParentIndex = !naturalParentIndexName.isEmpty();
     }
 
     KVTypeInfo.Accessor getIndexAccessor(String indexName) {

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVTypeInfo.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVTypeInfo.java
@@ -68,8 +68,6 @@ public class KVTypeInfo {
 
     Preconditions.checkArgument(indices.containsKey(KVIndex.NATURAL_INDEX_NAME),
         "No natural index defined for type %s.", type.getName());
-    Preconditions.checkArgument(indices.get(KVIndex.NATURAL_INDEX_NAME).parent().isEmpty(),
-        "Natural index of %s cannot have a parent.", type.getName());
 
     for (KVIndex idx : indices.values()) {
       if (!idx.parent().isEmpty()) {
@@ -115,6 +113,11 @@ public class KVTypeInfo {
   Accessor getParentAccessor(String indexName) {
     KVIndex index = indices.get(indexName);
     return index.parent().isEmpty() ? null : getAccessor(index.parent());
+  }
+
+  String getParentIndexName(String indexName) {
+    KVIndex index = indices.get(indexName);
+    return index.parent();
   }
 
   /**

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBTypeInfo.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBTypeInfo.java
@@ -133,12 +133,13 @@ class LevelDBTypeInfo {
 
     // First create the parent indices, then the child indices.
     ti.indices().forEach(idx -> {
-      if (idx.parent().isEmpty()) {
+      // In LevelDB, there is no parent index for the NUTURAL INDEX.
+      if (idx.parent().isEmpty() || idx.value().equals(KVIndex.NATURAL_INDEX_NAME)) {
         indices.put(idx.value(), new Index(idx, ti.getAccessor(idx.value()), null));
       }
     });
     ti.indices().forEach(idx -> {
-      if (!idx.parent().isEmpty()) {
+      if (!idx.parent().isEmpty() && !idx.value().equals(KVIndex.NATURAL_INDEX_NAME)) {
         indices.put(idx.value(), new Index(idx, ti.getAccessor(idx.value()),
           indices.get(idx.parent())));
       }

--- a/core/src/main/scala/org/apache/spark/status/storeTypes.scala
+++ b/core/src/main/scala/org/apache/spark/status/storeTypes.scala
@@ -154,7 +154,7 @@ private[spark] object TaskIndexNames {
 private[spark] class TaskDataWrapper(
     // Storing this as an object actually saves memory; it's also used as the key in the in-memory
     // store, so in that case you'd save the extra copy of the value here.
-    @KVIndexParam
+    @KVIndexParam(parent = TaskIndexNames.STAGE)
     val taskId: JLong,
     @KVIndexParam(value = TaskIndexNames.TASK_INDEX, parent = TaskIndexNames.STAGE)
     val index: Int,

--- a/core/src/test/scala/org/apache/spark/status/AppStatusStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/AppStatusStoreSuite.scala
@@ -176,8 +176,10 @@ class AppStatusStoreSuite extends SparkFunSuite with TimeLimits {
     }
   }
 
-  private def newTaskData(i: Int, status: String = "SUCCESS",
-                          sId: Int = stageId): TaskDataWrapper = {
+  private def newTaskData(
+      i: Int,
+      status: String = "SUCCESS",
+      sId: Int = stageId): TaskDataWrapper = {
     new TaskDataWrapper(
       i.toLong, i, i, i, i, i, i.toString, i.toString, status, i.toString, false, Nil, None, true,
       i, i, i, i, i, i, i, i, i, i,

--- a/core/src/test/scala/org/apache/spark/status/AppStatusStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/AppStatusStoreSuite.scala
@@ -17,13 +17,17 @@
 
 package org.apache.spark.status
 
+import org.scalatest.concurrent.TimeLimits
+import org.scalatest.time.{Millis, Span}
+import scala.collection.JavaConverters._
+
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.executor.TaskMetrics
 import org.apache.spark.scheduler.{TaskInfo, TaskLocality}
 import org.apache.spark.util.{Distribution, Utils}
 import org.apache.spark.util.kvstore._
 
-class AppStatusStoreSuite extends SparkFunSuite {
+class AppStatusStoreSuite extends SparkFunSuite with TimeLimits {
 
   private val uiQuantiles = Array(0.0, 0.25, 0.5, 0.75, 1.0)
   private val stageId = 1
@@ -76,6 +80,26 @@ class AppStatusStoreSuite extends SparkFunSuite {
     }
 
     assert(store.count(classOf[CachedQuantile]) === 2)
+  }
+
+  test("InMemoryStore should build index from Stage ID to Task data") {
+    val store = new InMemoryStore()
+    (0 until 1000).map { sId =>
+       (0 until 1000).map { taskId =>
+         val task = newTaskData(sId * 1000 + taskId, "SUCCESS", sId)
+         store.write(task)
+       }
+    }
+    val appStatusStore = new AppStatusStore(store)
+    failAfter(Span(200, Millis)) {
+      appStatusStore.taskSummary(1, attemptId, Array(0, 0.25, 0.5, 0.75, 1))
+    }
+    val stageIds = Seq(1, 11, 66, 88)
+    val stageKeys = stageIds.map(Array(_, attemptId))
+    failAfter(Span(10, Millis)) {
+      store.removeAllByIndexValues(classOf[TaskDataWrapper], TaskIndexNames.STAGE,
+       stageKeys.asJavaCollection)
+    }
   }
 
   private def createAppStore(disk: Boolean, live: Boolean): AppStatusStore = {
@@ -152,12 +176,13 @@ class AppStatusStoreSuite extends SparkFunSuite {
     }
   }
 
-  private def newTaskData(i: Int, status: String = "SUCCESS"): TaskDataWrapper = {
+  private def newTaskData(i: Int, status: String = "SUCCESS",
+                          sId: Int = stageId): TaskDataWrapper = {
     new TaskDataWrapper(
       i.toLong, i, i, i, i, i, i.toString, i.toString, status, i.toString, false, Nil, None, true,
       i, i, i, i, i, i, i, i, i, i,
       i, i, i, i, i, i, i, i, i, i,
-      i, i, i, i, stageId, attemptId)
+      i, i, i, i, sId, attemptId)
   }
 
   private def writeTaskDataToStore(i: Int, store: KVStore, status: String): Unit = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Spark uses the class `InMemoryStore` as the KV storage for live UI and history server(by default if no LevelDB file path is provided).
In `InMemoryStore`, all the task data in one application is stored in a hashmap, which key is the task ID and the value is the task data. This fine for getting or deleting with a provided task ID.
However, Spark stage UI always shows all the task data in one stage and the current implementation is to look up all the values in the hashmap. The time complexity is O(numOfTasks).
Also, when there are too many stages (>spark.ui.retainedStages), Spark will linearly try to look up all the task data of the stages to be deleted as well.

This can be very bad for a large application with many stages and tasks. We can improve it by allowing the natural key of an entity to have a real parent index. So that on each lookup with parent node provided, Spark can look up all the natural keys(in our case, the task IDs) first, and then find the data with the natural keys in the hashmap.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The in-memory KV store becomes really slow for large applications. We can improve it with a new index. The performance can be 10 times, 100 times, even 1000 times faster.
This is also possible to make the Spark driver more stable for large applications.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Existing unit tests.
Also, I run a benchmark with the following code
```
  val store = new InMemoryStore()
  val numberOfTasksPerStage = 10000
   (0 until 1000).map { sId =>
     (0 until numberOfTasksPerStage).map { taskId =>
       val task = newTaskData(sId * numberOfTasksPerStage + taskId, "SUCCESS", sId)
       store.write(task)
     }
   }
  val appStatusStore = new AppStatusStore(store)
  var start = System.nanoTime()
  appStatusStore.taskSummary(2, attemptId, Array(0, 0.25, 0.5, 0.75, 1))
  println("task summary run time: " + ((System.nanoTime() - start) / 1000000))
  val stageIds = Seq(1, 11, 66, 88)
  val stageKeys = stageIds.map(Array(_, attemptId))
  start = System.nanoTime()
  store.removeAllByIndexValues(classOf[TaskDataWrapper], TaskIndexNames.STAGE,
    stageKeys.asJavaCollection)
   println("clean up tasks run time: " + ((System.nanoTime() - start) / 1000000))
```

Task summary before the changes: 98642ms
Task summary after the changes: 120ms

Task clean up before the changes:  4900ms
Task clean up before the changes: 4ms

It's 800x faster after the changes in the micro-benchmark.