### PR TITLE
SPARK-30975: rename config spark memoryOverhead

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -689,9 +689,9 @@ private[spark] object SparkConf extends Logging {
     LISTENER_BUS_EVENT_QUEUE_CAPACITY.key -> Seq(
       AlternateConfig("spark.scheduler.listenerbus.eventqueue.size", "2.3")),
     DRIVER_MEMORY_OVERHEAD.key -> Seq(
-      AlternateConfig("spark.yarn.driver.memoryOverhead", "2.3")),
+      AlternateConfig("spark.driver.memoryOverhead", "2.3")),
     EXECUTOR_MEMORY_OVERHEAD.key -> Seq(
-      AlternateConfig("spark.yarn.executor.memoryOverhead", "2.3")),
+      AlternateConfig("spark.executor.memoryOverhead", "2.3")),
     KEYTAB.key -> Seq(
       AlternateConfig("spark.yarn.keytab", "3.0")),
     PRINCIPAL.key -> Seq(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Rename spark config to the new one for memoryOverhead

### Why are the changes needed?
Remove old name in the configuration, it will be deprecated


### Does this PR introduce any user-facing change?
Yes, we change the config parameter name


### How was this patch tested?
No need
