### PR TITLE
[SPARK-30985][k8s] Support propagating SPARK_CONF_DIR files to driver and executor pods.

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Constants.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Constants.scala
@@ -66,7 +66,8 @@ private[spark] object Constants {
   val ENV_SPARK_USER = "SPARK_USER"
   val ENV_RESOURCE_PROFILE_ID = "SPARK_RESOURCE_PROFILE_ID"
   // Spark app configs for containers
-  val SPARK_CONF_VOLUME = "spark-conf-volume"
+  val SPARK_CONF_VOLUME_DRIVER = "spark-conf-volume-driver"
+  val SPARK_CONF_VOLUME_EXEC = "spark-conf-volume-exec"
   val SPARK_CONF_DIR_INTERNAL = "/opt/spark/conf"
   val SPARK_CONF_FILE_NAME = "spark.properties"
   val SPARK_CONF_PATH = s"$SPARK_CONF_DIR_INTERNAL/$SPARK_CONF_FILE_NAME"

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
@@ -16,10 +16,9 @@
  */
 package org.apache.spark.deploy.k8s.submit
 
-import java.io.StringWriter
-import java.util.{Collections, UUID}
-import java.util.Properties
+import java.util.UUID
 
+import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.util.control.Breaks._
 import scala.util.control.NonFatal
@@ -105,8 +104,11 @@ private[spark] class Client(
 
   def run(): Unit = {
     val resolvedDriverSpec = builder.buildFromFeatures(conf, kubernetesClient)
-    val configMapName = s"${conf.resourceNamePrefix}-driver-conf-map"
-    val configMap = buildConfigMap(configMapName, resolvedDriverSpec.systemProperties)
+    val configMapName = KubernetesClientUtils.configMapNameDriver
+    val confFilesMap = KubernetesClientUtils.buildSparkConfDirFilesMap(configMapName,
+      conf.sparkConf, resolvedDriverSpec.systemProperties)
+    val configMap = KubernetesClientUtils.buildConfigMap(configMapName, confFilesMap)
+
     // The include of the ENV_VAR for "SPARK_CONF_DIR" is to allow for the
     // Spark command builder to pickup on the Java Options present in the ConfigMap
     val resolvedDriverContainer = new ContainerBuilder(resolvedDriverSpec.pod.container)
@@ -115,7 +117,7 @@ private[spark] class Client(
         .withValue(SPARK_CONF_DIR_INTERNAL)
         .endEnv()
       .addNewVolumeMount()
-        .withName(SPARK_CONF_VOLUME)
+        .withName(SPARK_CONF_VOLUME_DRIVER)
         .withMountPath(SPARK_CONF_DIR_INTERNAL)
         .endVolumeMount()
       .build()
@@ -123,8 +125,9 @@ private[spark] class Client(
       .editSpec()
         .addToContainers(resolvedDriverContainer)
         .addNewVolume()
-          .withName(SPARK_CONF_VOLUME)
+          .withName(SPARK_CONF_VOLUME_DRIVER)
           .withNewConfigMap()
+            .withItems(KubernetesClientUtils.buildKeyToPathObjects(confFilesMap).asJava)
             .withName(configMapName)
             .endConfigMap()
           .endVolume()
@@ -163,23 +166,6 @@ private[spark] class Client(
         }
       }
     }
-  }
-
-  // Build a Config Map that will house spark conf properties in a single file for spark-submit
-  private def buildConfigMap(configMapName: String, conf: Map[String, String]): ConfigMap = {
-    val properties = new Properties()
-    conf.foreach { case (k, v) =>
-      properties.setProperty(k, v)
-    }
-    val propertiesWriter = new StringWriter()
-    properties.store(propertiesWriter,
-      s"Java properties built from Kubernetes config map with name: $configMapName")
-    new ConfigMapBuilder()
-      .withNewMetadata()
-        .withName(configMapName)
-        .endMetadata()
-      .addToData(SPARK_CONF_FILE_NAME, propertiesWriter.toString)
-      .build()
   }
 }
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.k8s.submit
+
+import java.io.{File, StringWriter}
+import java.util.Properties
+
+import scala.collection.JavaConverters._
+import scala.io.{Codec, Source}
+
+import io.fabric8.kubernetes.api.model.{ConfigMap, ConfigMapBuilder, KeyToPath}
+
+import org.apache.spark.SparkConf
+import org.apache.spark.deploy.k8s.{Constants, KubernetesUtils}
+import org.apache.spark.deploy.k8s.Constants.ENV_SPARK_CONF_DIR
+import org.apache.spark.internal.Logging
+
+private[spark] object KubernetesClientUtils extends Logging {
+
+  // Config map name can be 63 chars at max.
+  def configMapName(prefix: String): String = s"${prefix.take(54)}-conf-map"
+
+  val configMapNameExecutor: String = configMapName(s"spark-exec-${KubernetesUtils.uniqueID()}")
+
+  val configMapNameDriver: String = configMapName(s"spark-drv-${KubernetesUtils.uniqueID()}")
+
+  private def buildStringFromPropertiesMap(configMapName: String,
+      propertiesMap: Map[String, String]): String = {
+    val properties = new Properties()
+    propertiesMap.foreach { case (k, v) =>
+      properties.setProperty(k, v)
+    }
+    val propertiesWriter = new StringWriter()
+    properties.store(propertiesWriter,
+      s"Java properties built from Kubernetes config map with name: $configMapName")
+    propertiesWriter.toString
+  }
+
+  /**
+   * Build, file -> 'file's content' map of all the selected files in SPARK_CONF_DIR.
+   */
+  def buildSparkConfDirFilesMap(configMapName: String,
+      sparkConf: SparkConf, resolvedPropertiesMap: Map[String, String]): Map[String, String] = {
+    val loadedConfFilesMap = KubernetesClientUtils.loadSparkConfDirFiles(sparkConf)
+    // Add resolved spark conf to the loaded configuration files map.
+    if (resolvedPropertiesMap.nonEmpty) {
+      val resolvedProperties: String = KubernetesClientUtils
+        .buildStringFromPropertiesMap(configMapName, resolvedPropertiesMap)
+      loadedConfFilesMap ++ Map(Constants.SPARK_CONF_FILE_NAME -> resolvedProperties)
+    } else {
+      loadedConfFilesMap
+    }
+  }
+
+  def buildKeyToPathObjects(confFilesMap: Map[String, String]): Seq[KeyToPath] = {
+    confFilesMap.map {
+      case (fileName: String, _: String) =>
+        val filePermissionMode = 420  // 420 is decimal for octal literal 0644.
+        new KeyToPath(fileName, filePermissionMode, fileName)
+    }.toList.sortBy(x => x.getKey) // List is sorted to make mocking based tests work
+  }
+
+  /**
+   * Build a Config Map that will hold the content for environment variable SPARK_CONF_DIR
+   * on remote pods.
+   */
+  def buildConfigMap(configMapName: String, confFileMap: Map[String, String],
+      withLabels: Map[String, String] = Map()): ConfigMap = {
+    new ConfigMapBuilder()
+      .withNewMetadata()
+        .withName(configMapName)
+        .withLabels(withLabels.asJava)
+        .endMetadata()
+      .addToData(confFileMap.asJava)
+      .build()
+  }
+
+  private def loadSparkConfDirFiles(conf: SparkConf): Map[String, String] = {
+    val confDir = Option(conf.getenv(ENV_SPARK_CONF_DIR)).orElse(
+      conf.getOption("spark.home").map(dir => s"$dir/conf"))
+    if (confDir.isDefined) {
+      val confFiles = listConfFiles(confDir.get)
+      logInfo(s"Spark configuration files loaded from $confDir : ${confFiles.mkString(",")}")
+      confFiles.map { file =>
+        val source = Source.fromFile(file)(Codec.UTF8)
+        val mapping = (file.getName -> source.mkString)
+        source.close()
+        mapping
+      }.toMap
+    } else {
+      Map.empty[String, String]
+    }
+  }
+
+  private def listConfFiles(confDir: String): Seq[File] = {
+    // We exclude all the template files and user provided spark conf or properties.
+    // As spark properties are resolved in a different step.
+    val fileFilter = (f: File) => {
+      f.isFile && !(f.getName.endsWith("template") ||
+        f.getName.matches("spark.*(conf|properties)"))
+    }
+    val confFiles: Seq[File] = {
+      val dir = new File(confDir)
+      if (dir.isDirectory) {
+        dir.listFiles.filter(x => fileFilter(x)).toSeq
+      } else {
+        Nil
+      }
+    }
+    confFiles
+  }
+}

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/Fabric8Aliases.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/Fabric8Aliases.scala
@@ -16,14 +16,18 @@
  */
 package org.apache.spark.deploy.k8s
 
-import io.fabric8.kubernetes.api.model.{DoneablePod, HasMetadata, Pod, PodList}
+import io.fabric8.kubernetes.api.model.{ConfigMap, ConfigMapList, DoneableConfigMap, DoneablePod, HasMetadata, Pod, PodList}
 import io.fabric8.kubernetes.client.{Watch, Watcher}
-import io.fabric8.kubernetes.client.dsl.{FilterWatchListDeletable, MixedOperation, NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable, PodResource}
+import io.fabric8.kubernetes.client.dsl.{FilterWatchListDeletable, MixedOperation, NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable, PodResource, Resource}
 
 object Fabric8Aliases {
   type PODS = MixedOperation[Pod, PodList, DoneablePod, PodResource[Pod, DoneablePod]]
+  type CONFIG_MAPS = MixedOperation[
+    ConfigMap, ConfigMapList, DoneableConfigMap, Resource[ConfigMap, DoneableConfigMap]]
   type LABELED_PODS = FilterWatchListDeletable[
     Pod, PodList, java.lang.Boolean, Watch, Watcher[Pod]]
+  type LABELED_CONFIG_MAPS = FilterWatchListDeletable[
+    ConfigMap, ConfigMapList, java.lang.Boolean, Watch, Watcher[ConfigMap]]
   type SINGLE_POD = PodResource[Pod, DoneablePod]
   type RESOURCE_LIST = NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable[
     HasMetadata, Boolean]

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/ClientSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/ClientSuite.scala
@@ -16,6 +16,12 @@
  */
 package org.apache.spark.deploy.k8s.submit
 
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+
+import scala.collection.JavaConverters._
+
 import io.fabric8.kubernetes.api.model._
 import io.fabric8.kubernetes.client.{KubernetesClient, Watch}
 import io.fabric8.kubernetes.client.dsl.PodResource
@@ -24,10 +30,11 @@ import org.mockito.Mockito.{verify, when}
 import org.scalatest.BeforeAndAfter
 import org.scalatestplus.mockito.MockitoSugar._
 
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.deploy.k8s._
 import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.deploy.k8s.Fabric8Aliases._
+import org.apache.spark.util.Utils
 
 class ClientSuite extends SparkFunSuite with BeforeAndAfter {
 
@@ -66,27 +73,36 @@ class ClientSuite extends SparkFunSuite with BeforeAndAfter {
       .withValue(SPARK_CONF_DIR_INTERNAL)
       .endEnv()
     .addNewVolumeMount()
-      .withName(SPARK_CONF_VOLUME)
+      .withName(SPARK_CONF_VOLUME_DRIVER)
       .withMountPath(SPARK_CONF_DIR_INTERNAL)
       .endVolumeMount()
     .build()
-  private val FULL_EXPECTED_POD = new PodBuilder(BUILT_DRIVER_POD)
-    .editSpec()
-      .addToContainers(FULL_EXPECTED_CONTAINER)
-      .addNewVolume()
-        .withName(SPARK_CONF_VOLUME)
-        .withNewConfigMap().withName(s"$KUBERNETES_RESOURCE_PREFIX-driver-conf-map").endConfigMap()
-        .endVolume()
-      .endSpec()
-    .build()
 
-  private val POD_WITH_OWNER_REFERENCE = new PodBuilder(FULL_EXPECTED_POD)
-    .editMetadata()
-      .withUid(DRIVER_POD_UID)
-      .endMetadata()
-    .withApiVersion(DRIVER_POD_API_VERSION)
-    .withKind(DRIVER_POD_KIND)
-    .build()
+  private val KEY_TO_PATH =
+    new KeyToPath(SPARK_CONF_FILE_NAME, 420, SPARK_CONF_FILE_NAME)
+
+  private def fullExpectedPod(keyToPaths: List[KeyToPath] = List(KEY_TO_PATH)) =
+    new PodBuilder(BUILT_DRIVER_POD)
+      .editSpec()
+        .addToContainers(FULL_EXPECTED_CONTAINER)
+        .addNewVolume()
+          .withName(SPARK_CONF_VOLUME_DRIVER)
+          .withNewConfigMap()
+            .withItems(keyToPaths.asJava)
+            .withName(KubernetesClientUtils.configMapNameDriver)
+            .endConfigMap()
+          .endVolume()
+        .endSpec()
+      .build()
+
+  private def podWithOwnerReference(keyToPaths: List[KeyToPath] = List(KEY_TO_PATH)) =
+    new PodBuilder(fullExpectedPod(keyToPaths))
+      .editMetadata()
+        .withUid(DRIVER_POD_UID)
+        .endMetadata()
+      .withApiVersion(DRIVER_POD_API_VERSION)
+      .withKind(DRIVER_POD_KIND)
+      .build()
 
   private val ADDITIONAL_RESOURCES_WITH_OWNER_REFERENCES = ADDITIONAL_RESOURCES.map { secret =>
     new SecretBuilder(secret)
@@ -134,7 +150,7 @@ class ClientSuite extends SparkFunSuite with BeforeAndAfter {
 
     createdPodArgumentCaptor = ArgumentCaptor.forClass(classOf[Pod])
     createdResourcesArgumentCaptor = ArgumentCaptor.forClass(classOf[HasMetadata])
-    when(podOperations.create(FULL_EXPECTED_POD)).thenReturn(POD_WITH_OWNER_REFERENCE)
+    when(podOperations.create(fullExpectedPod())).thenReturn(podWithOwnerReference())
     when(namedPods.watch(loggingPodStatusWatcher)).thenReturn(mock[Watch])
     when(loggingPodStatusWatcher.watchOrStop(kconf.namespace + ":" + POD_NAME)).thenReturn(true)
     doReturn(resourceList)
@@ -149,7 +165,7 @@ class ClientSuite extends SparkFunSuite with BeforeAndAfter {
       kubernetesClient,
       loggingPodStatusWatcher)
     submissionClient.run()
-    verify(podOperations).create(FULL_EXPECTED_POD)
+    verify(podOperations).create(fullExpectedPod())
   }
 
   test("The client should create Kubernetes resources") {
@@ -169,10 +185,69 @@ class ClientSuite extends SparkFunSuite with BeforeAndAfter {
     assert(configMaps.nonEmpty)
     val configMap = configMaps.head
     assert(configMap.getMetadata.getName ===
-      s"$KUBERNETES_RESOURCE_PREFIX-driver-conf-map")
+      KubernetesClientUtils.configMapNameDriver)
     assert(configMap.getData.containsKey(SPARK_CONF_FILE_NAME))
     assert(configMap.getData.get(SPARK_CONF_FILE_NAME).contains("conf1key=conf1value"))
     assert(configMap.getData.get(SPARK_CONF_FILE_NAME).contains("conf2key=conf2value"))
+  }
+
+  test("All files from SPARK_CONF_DIR, except templates and spark config " +
+    "should be populated to pod's configMap.") {
+    def testSetup: (SparkConf, Seq[String]) = {
+      val tempDir = Utils.createTempDir()
+      val sparkConf = new SparkConf(loadDefaults = false).setSparkHome(tempDir.getAbsolutePath)
+
+      val tempConfDir = new File(s"${tempDir.getAbsolutePath}/conf")
+      tempConfDir.mkdir()
+      // File names - which should not get mounted on the resultant config map.
+      val filteredConfFileNames =
+        Set("spark-env.sh.template", "spark.properties", "spark-defaults.conf")
+      val confFileNames = for (i <- 1 to 5) yield s"testConf.$i" ++
+        List("spark-env.sh") ++ filteredConfFileNames
+
+      val testConfFiles = for (i <- confFileNames) yield {
+        val file = new File(s"${tempConfDir.getAbsolutePath}/$i")
+        Files.write(file.toPath, "conf1key=conf1value".getBytes(StandardCharsets.UTF_8))
+        file.getName
+      }
+      assert(tempConfDir.listFiles().length == confFileNames.length)
+      val expectedConfFiles: Seq[String] = testConfFiles.filterNot(filteredConfFileNames.contains)
+      (sparkConf, expectedConfFiles)
+    }
+
+    val (sparkConf: SparkConf, expectedConfFiles: Seq[String]) = testSetup
+
+    val expectedKeyToPaths = (expectedConfFiles.map(x => new KeyToPath(x, 420, x)).toList ++
+      List(KEY_TO_PATH)).sortBy(x => x.getKey)
+
+    when(podOperations.create(fullExpectedPod(expectedKeyToPaths)))
+      .thenReturn(podWithOwnerReference(expectedKeyToPaths))
+
+    kconf = KubernetesTestConf.createDriverConf(sparkConf = sparkConf,
+      resourceNamePrefix = Some(KUBERNETES_RESOURCE_PREFIX))
+
+    assert(kconf.sparkConf.getOption("spark.home").isDefined)
+    when(driverBuilder.buildFromFeatures(kconf, kubernetesClient)).thenReturn(BUILT_KUBERNETES_SPEC)
+
+    val submissionClient = new Client(
+      kconf,
+      driverBuilder,
+      kubernetesClient,
+      loggingPodStatusWatcher)
+    submissionClient.run()
+    val otherCreatedResources = createdResourcesArgumentCaptor.getAllValues
+
+    val configMaps = otherCreatedResources.toArray
+      .filter(_.isInstanceOf[ConfigMap]).map(_.asInstanceOf[ConfigMap])
+    assert(configMaps.nonEmpty)
+    val configMapName = KubernetesClientUtils.configMapNameDriver
+    val configMap: ConfigMap = configMaps.head
+    assert(configMap.getMetadata.getName == configMapName)
+    val configMapLoadedFiles = configMap.getData.keySet().asScala.toSet
+    assert(configMapLoadedFiles === expectedConfFiles.toSet ++ Set(SPARK_CONF_FILE_NAME))
+    for (f <- configMapLoadedFiles) {
+      assert(configMap.getData.get(f).contains("conf1key=conf1value"))
+    }
   }
 
   test("Waiting for app completion should stall on the watcher") {

--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
@@ -61,6 +61,12 @@ if ! [ -z ${HADOOP_CONF_DIR+x} ]; then
   SPARK_CLASSPATH="$HADOOP_CONF_DIR:$SPARK_CLASSPATH";
 fi
 
+if ! [ -z ${SPARK_CONF_DIR+x} ]; then
+  SPARK_CLASSPATH="$SPARK_CONF_DIR:$SPARK_CLASSPATH";
+elif ! [ -z ${SPARK_HOME+x} ]; then
+  SPARK_CLASSPATH="$SPARK_HOME/conf:$SPARK_CLASSPATH";
+fi
+
 case "$1" in
   driver)
     shift 1


### PR DESCRIPTION
### What changes were proposed in this pull request?
This is an improvement, we mount all the user specific configuration files(except the templates and spark properties files) from `SPARK_CONF_DIR` at the point of spark-submit, to both executor and driver pods. Currently, only `spark.properties` is mounted, only on driver.

### Why are the changes needed?

`SPARK_CONF_DIR` hosts several configuration files, for example, 
1) `spark-defaults.conf` - containing all the spark properties.
2) `log4j.properties` - Logger configuration.
3) `core-site.xml` - Hadoop related configuration.
4) `fairscheduler.xml` - Spark's fair scheduling policy at the job level.
5) `metrics.properties` - Spark metrics.
6) Any user specific - library or framework specific configuration file.

At the moment, we can cannot propagate these files to the driver and executor configuration directory.

There is a design doc, with more details, and this patch is currently providing a reference implementation. Please take a look at the doc and comment, how we can improve. [google docs link to the doc](https://bit.ly/spark-30985)

### Further scope
Support user defined configMaps.

### Does this PR introduce any user-facing change?
Yes, previously the user configuration files(e.g. hdfs-site.xml, log4j.properties etc...) were not propagated by default, now after this patch it is propagated to driver and executor pods' `SPARK_CONF_DIR`.

### How was this patch tested?
Added tests.

Also manually tested, by deploying it to a minikube cluster and observing the additional configuration files were present, and taking effect. For example, changes to log4j.properties was properly applied to executors.

