### PR TITLE
[SPARK-30912][CORE][DOC] Add version information to the configuration of Streaming.scala

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/Streaming.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Streaming.scala
@@ -23,16 +23,19 @@ private[spark] object Streaming {
 
   private[spark] val STREAMING_DYN_ALLOCATION_ENABLED =
     ConfigBuilder("spark.streaming.dynamicAllocation.enabled")
+      .version("3.0.0")
       .booleanConf
       .createWithDefault(false)
 
   private[spark] val STREAMING_DYN_ALLOCATION_TESTING =
     ConfigBuilder("spark.streaming.dynamicAllocation.testing")
+      .version("3.0.0")
       .booleanConf
       .createWithDefault(false)
 
   private[spark] val STREAMING_DYN_ALLOCATION_MIN_EXECUTORS =
     ConfigBuilder("spark.streaming.dynamicAllocation.minExecutors")
+      .version("3.0.0")
       .intConf
       .checkValue(_ > 0, "The min executor number of streaming dynamic " +
         "allocation must be positive.")
@@ -40,6 +43,7 @@ private[spark] object Streaming {
 
   private[spark] val STREAMING_DYN_ALLOCATION_MAX_EXECUTORS =
     ConfigBuilder("spark.streaming.dynamicAllocation.maxExecutors")
+      .version("3.0.0")
       .intConf
       .checkValue(_ > 0, "The max executor number of streaming dynamic " +
         "allocation must be positive.")
@@ -47,6 +51,7 @@ private[spark] object Streaming {
 
   private[spark] val STREAMING_DYN_ALLOCATION_SCALING_INTERVAL =
     ConfigBuilder("spark.streaming.dynamicAllocation.scalingInterval")
+      .version("3.0.0")
       .timeConf(TimeUnit.SECONDS)
       .checkValue(_ > 0, "The scaling interval of streaming dynamic " +
         "allocation must be positive.")
@@ -54,6 +59,7 @@ private[spark] object Streaming {
 
   private[spark] val STREAMING_DYN_ALLOCATION_SCALING_UP_RATIO =
     ConfigBuilder("spark.streaming.dynamicAllocation.scalingUpRatio")
+      .version("3.0.0")
       .doubleConf
       .checkValue(_ > 0, "The scaling up ratio of streaming dynamic " +
         "allocation must be positive.")
@@ -61,6 +67,7 @@ private[spark] object Streaming {
 
   private[spark] val STREAMING_DYN_ALLOCATION_SCALING_DOWN_RATIO =
     ConfigBuilder("spark.streaming.dynamicAllocation.scalingDownRatio")
+      .version("3.0.0")
       .doubleConf
       .checkValue(_ > 0, "The scaling down ratio of streaming dynamic " +
         "allocation must be positive.")


### PR DESCRIPTION
### What changes were proposed in this pull request?
1.Add version information to the configuration of `Streaming`.
2.Update the docs of `Streaming`.

I sorted out some information show below.

Item name | Since version | JIRA ID | Commit ID | Note
-- | -- | -- | -- | --
spark.streaming.dynamicAllocation.enabled | 3.0.0 | SPARK-26941 | cad475dcc9376557f882859856286e858002389a#diff-335c3bbf4ca27cf65a6f850b1a7c89dd | 
spark.streaming.dynamicAllocation.testing | 3.0.0 | SPARK-26941 | cad475dcc9376557f882859856286e858002389a#diff-335c3bbf4ca27cf65a6f850b1a7c89dd | 
spark.streaming.dynamicAllocation.minExecutors | 3.0.0 | SPARK-26941 | cad475dcc9376557f882859856286e858002389a#diff-335c3bbf4ca27cf65a6f850b1a7c89dd | 
spark.streaming.dynamicAllocation.maxExecutors | 3.0.0 | SPARK-26941 | cad475dcc9376557f882859856286e858002389a#diff-335c3bbf4ca27cf65a6f850b1a7c89dd | 
spark.streaming.dynamicAllocation.scalingInterval | 3.0.0 | SPARK-26941 | cad475dcc9376557f882859856286e858002389a#diff-335c3bbf4ca27cf65a6f850b1a7c89dd | 
spark.streaming.dynamicAllocation.scalingUpRatio | 3.0.0 | SPARK-26941 | cad475dcc9376557f882859856286e858002389a#diff-335c3bbf4ca27cf65a6f850b1a7c89dd | 
spark.streaming.dynamicAllocation.scalingDownRatio | 3.0.0 | SPARK-26941 | cad475dcc9376557f882859856286e858002389a#diff-335c3bbf4ca27cf65a6f850b1a7c89dd | 


### Why are the changes needed?
Supplemental configuration version information.


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
Exists UT
