### PR TITLE
[SPARK-31007][ML] KMeans optimization based on triangle-inequality

### DIFF
--- a/mllib-local/src/main/scala/org/apache/spark/ml/impl/Utils.scala
+++ b/mllib-local/src/main/scala/org/apache/spark/ml/impl/Utils.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.ml.impl
 
 
-private[ml] object Utils {
+private[spark] object Utils {
 
   lazy val EPSILON = {
     var eps = 1.0
@@ -26,5 +26,56 @@ private[ml] object Utils {
       eps /= 2.0
     }
     eps
+  }
+
+  /**
+   * Convert an n * (n + 1) / 2 dimension array representing the upper triangular part of a matrix
+   * into an n * n array representing the full symmetric matrix (column major).
+   *
+   * @param n The order of the n by n matrix.
+   * @param triangularValues The upper triangular part of the matrix packed in an array
+   *                         (column major).
+   * @return A dense matrix which represents the symmetric matrix in column major.
+   */
+  def unpackUpperTriangular(
+      n: Int,
+      triangularValues: Array[Double]): Array[Double] = {
+    val symmetricValues = new Array[Double](n * n)
+    var r = 0
+    var i = 0
+    while (i < n) {
+      var j = 0
+      while (j <= i) {
+        symmetricValues(i * n + j) = triangularValues(r)
+        symmetricValues(j * n + i) = triangularValues(r)
+        r += 1
+        j += 1
+      }
+      i += 1
+    }
+    symmetricValues
+  }
+
+  /**
+   * Indexing in an array representing the upper triangular part of a matrix
+   * into an n * n array representing the full symmetric matrix (column major).
+   *    val symmetricValues = unpackUpperTriangularMatrix(n, triangularValues)
+   *    val matrix = new DenseMatrix(n, n, symmetricValues)
+   *    val index = indexUpperTriangularMatrix(n, i, j)
+   *    then: symmetricValues(index) == matrix(i, j)
+   *
+   * @param n The order of the n by n matrix.
+   */
+  def indexUpperTriangular(
+      n: Int,
+      i: Int,
+      j: Int): Int = {
+    require(i >= 0 && i < n, s"Expected 0 <= i < $n, got i = $i.")
+    require(j >= 0 && j < n, s"Expected 0 <= j < $n, got j = $j.")
+    if (i <= j) {
+      j * (j + 1) / 2 + i
+    } else {
+      i * (i + 1) / 2 + j
+    }
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
@@ -22,7 +22,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.annotation.Since
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.ml.{Estimator, Model}
-import org.apache.spark.ml.impl.Utils.EPSILON
+import org.apache.spark.ml.impl.Utils.{unpackUpperTriangular, EPSILON}
 import org.apache.spark.ml.linalg._
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared._
@@ -583,19 +583,7 @@ object GaussianMixture extends DefaultParamsReadable[GaussianMixture] {
   private[clustering] def unpackUpperTriangularMatrix(
       n: Int,
       triangularValues: Array[Double]): DenseMatrix = {
-    val symmetricValues = new Array[Double](n * n)
-    var r = 0
-    var i = 0
-    while (i < n) {
-      var j = 0
-      while (j <= i) {
-        symmetricValues(i * n + j) = triangularValues(r)
-        symmetricValues(j * n + i) = triangularValues(r)
-        r += 1
-        j += 1
-      }
-      i += 1
-    }
+    val symmetricValues = unpackUpperTriangular(n, triangularValues)
     new DenseMatrix(n, n, symmetricValues)
   }
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/DistanceMeasure.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/DistanceMeasure.scala
@@ -100,7 +100,7 @@ private[spark] abstract class DistanceMeasure extends Serializable {
             } else Iterator.empty
           }
         }.filterNot(_._2 == 0)
-      }.foreach { case (i, j, s) =>
+      }.collect.foreach { case (i, j, s) =>
         val index = indexUpperTriangular(k, i, j)
         packedValues(index) = s
         if (s < diagValues(i)) diagValues(i) = s

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/DistanceMeasure.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/DistanceMeasure.scala
@@ -99,7 +99,7 @@ private[spark] abstract class DistanceMeasure extends Serializable {
               Iterator.single((i, j, s))
             } else Iterator.empty
           }
-        }.filterNot(_._2 == 0)
+        }
       }.collect.foreach { case (i, j, s) =>
         val index = indexUpperTriangular(k, i, j)
         packedValues(index) = s

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeansModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeansModel.scala
@@ -48,11 +48,11 @@ class KMeansModel (@Since("1.0.0") val clusterCenters: Array[Vector],
   @transient private lazy val clusterCentersWithNorm =
     if (clusterCenters == null) null else clusterCenters.map(new VectorWithNorm(_))
 
-  // TODO: computation of radii may take seconds, so save it to KMeansModel in training
-  @transient private lazy val radii = if (clusterCenters == null) {
+  // TODO: computation of statistics may take seconds, so save it to KMeansModel in training
+  @transient private lazy val statistics = if (clusterCenters == null) {
     null
   } else {
-    distanceMeasureInstance.computeRadii(clusterCentersWithNorm)
+    distanceMeasureInstance.computeStatistics(clusterCentersWithNorm)
   }
 
   @Since("2.4.0")
@@ -80,7 +80,7 @@ class KMeansModel (@Since("1.0.0") val clusterCenters: Array[Vector],
    */
   @Since("0.8.0")
   def predict(point: Vector): Int = {
-    distanceMeasureInstance.findClosest(clusterCentersWithNorm, radii,
+    distanceMeasureInstance.findClosest(clusterCentersWithNorm, statistics,
       new VectorWithNorm(point))._1
   }
 
@@ -90,7 +90,7 @@ class KMeansModel (@Since("1.0.0") val clusterCenters: Array[Vector],
   @Since("1.0.0")
   def predict(points: RDD[Vector]): RDD[Int] = {
     val bcCentersWithNorm = points.context.broadcast(clusterCentersWithNorm)
-    val bcRadii = points.context.broadcast(radii)
+    val bcRadii = points.context.broadcast(statistics)
     points.map(p =>
       distanceMeasureInstance.findClosest(bcCentersWithNorm.value,
         bcRadii.value, new VectorWithNorm(p))._1)

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeansModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeansModel.scala
@@ -90,10 +90,10 @@ class KMeansModel (@Since("1.0.0") val clusterCenters: Array[Vector],
   @Since("1.0.0")
   def predict(points: RDD[Vector]): RDD[Int] = {
     val bcCentersWithNorm = points.context.broadcast(clusterCentersWithNorm)
-    val bcRadii = points.context.broadcast(statistics)
+    val bcStatistics = points.context.broadcast(statistics)
     points.map(p =>
       distanceMeasureInstance.findClosest(bcCentersWithNorm.value,
-        bcRadii.value, new VectorWithNorm(p))._1)
+        bcStatistics.value, new VectorWithNorm(p))._1)
   }
 
   /**

--- a/mllib/src/test/scala/org/apache/spark/mllib/clustering/DistanceMeasureSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/clustering/DistanceMeasureSuite.scala
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.mllib.clustering
+
+import scala.util.Random
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.mllib.linalg.Vectors
+import org.apache.spark.mllib.util.MLlibTestSparkContext
+import org.apache.spark.mllib.util.TestingUtils._
+
+class DistanceMeasureSuite extends SparkFunSuite with MLlibTestSparkContext {
+
+  private val seed = 42
+  private val k = 10
+  private val dim = 8
+
+  private var centers: Array[VectorWithNorm] = _
+
+  private var data: Array[VectorWithNorm] = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    val rng = new Random(seed)
+
+    centers = Array.tabulate(k) { i =>
+      val values = Array.fill(dim)(rng.nextGaussian)
+      new VectorWithNorm(Vectors.dense(values))
+    }
+
+    data = Array.tabulate(1000) { i =>
+      val values = Array.fill(dim)(rng.nextGaussian)
+      new VectorWithNorm(Vectors.dense(values))
+    }
+  }
+
+  test("predict with statistics") {
+    Seq(DistanceMeasure.COSINE, DistanceMeasure.EUCLIDEAN).foreach { distanceMeasure =>
+      val distance = DistanceMeasure.decodeFromString(distanceMeasure)
+      val statistics = distance.computeStatistics(centers)
+      data.foreach { point =>
+        val (index1, cost1) = distance.findClosest(centers, point)
+        val (index2, cost2) = distance.findClosest(centers, statistics, point)
+        assert(index1 == index2)
+        assert(cost1 ~== cost2 relTol 1E-10)
+      }
+    }
+  }
+
+  test("compute statistics distributedly") {
+    Seq(DistanceMeasure.COSINE, DistanceMeasure.EUCLIDEAN).foreach { distanceMeasure =>
+      val distance = DistanceMeasure.decodeFromString(distanceMeasure)
+      val statistics1 = distance.computeStatistics(centers)
+      val sc = spark.sparkContext
+      val bcCenters = sc.broadcast(centers)
+      val statistics2 = distance.computeStatisticsDistributedly(sc, bcCenters)
+      bcCenters.destroy()
+      assert(Vectors.dense(statistics1) ~== Vectors.dense(statistics2) relTol 1E-10)
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
apply Lemma 1 in [Using the Triangle Inequality to Accelerate K-Means](https://www.aaai.org/Papers/ICML/2003/ICML03-022.pdf):
 
> Let x be a point, and let b and c be centers. If d(b,c)>=2d(x,b) then d(x,c) >= d(x,b);

It can be directly applied in EuclideanDistance, but not in CosineDistance.
However,  for CosineDistance we can luckily get a variant in the space of radian/angle.


### Why are the changes needed?
It help improving the performance of prediction and training (mostly)


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
existing testsuites