### PR TITLE
[SPARK-31006][DOC][DSTREAM] Add Spark streaming deprecation notice.

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -88,7 +88,7 @@ jobs:
       run: ./dev/lint-java
     - name: Python
       run: |
-        pip install flake8 sphinx numpy
+        pip install flake8 sphinx numpy deprecation
         ./dev/lint-python
     - name: License
       run: ./dev/check-license

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -3,3 +3,4 @@ jira==1.0.3
 PyGithub==1.26.0
 Unidecode==0.04.19
 sphinx
+deprecation

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,7 +58,7 @@ Note: Other versions of roxygen2 might work in SparkR documentation generation b
 To generate API docs for any language, you'll need to install these libraries:
 
 ```sh
-$ sudo pip install sphinx mkdocs numpy
+$ sudo pip install sphinx mkdocs numpy deprecation
 ```
 
 ## Generating the Documentation HTML

--- a/docs/streaming-custom-receivers.md
+++ b/docs/streaming-custom-receivers.md
@@ -18,6 +18,14 @@ license: |
   limitations under the License.
 ---
 
+***************************************************************************************************
+## Deprecation notice.
+Spark Streaming is deprecated in favor of 
+[Spark structured streaming](structured-streaming-programming-guide.md).
+ This component is no longer actively maintained.
+ 
+***************************************************************************************************
+
 Spark Streaming can receive streaming data from any arbitrary data source beyond
 the ones for which it has built-in support (that is, beyond Kafka, Kinesis, files, sockets, etc.).
 This requires the developer to implement a *receiver* that is customized for receiving data from

--- a/docs/streaming-kafka-0-10-integration.md
+++ b/docs/streaming-kafka-0-10-integration.md
@@ -18,6 +18,14 @@ license: |
   limitations under the License.
 ---
 
+***************************************************************************************************
+## Deprecation notice.
+Spark Streaming is deprecated in favor of 
+[Spark structured streaming](structured-streaming-programming-guide.md).
+ This component is no longer actively maintained.
+ 
+***************************************************************************************************
+
 The Spark Streaming integration for Kafka 0.10 provides simple parallelism, 1:1 correspondence between Kafka 
 partitions and Spark partitions, and access to offsets and metadata. However, because the newer integration uses 
 the [new Kafka consumer API](https://kafka.apache.org/documentation.html#newconsumerapi) instead of the simple API, 

--- a/docs/streaming-kafka-integration.md
+++ b/docs/streaming-kafka-integration.md
@@ -18,6 +18,14 @@ license: |
   limitations under the License.
 ---
 
+***************************************************************************************************
+## Deprecation notice.
+Spark Streaming is deprecated in favor of 
+[Spark structured streaming](structured-streaming-programming-guide.md).
+ This component is no longer actively maintained.
+ 
+***************************************************************************************************
+
 [Apache Kafka](https://kafka.apache.org/) is publish-subscribe messaging rethought as a distributed, partitioned, 
 replicated commit log service.  Please read the [Kafka documentation](https://kafka.apache.org/documentation.html) 
 thoroughly before starting an integration using Spark.

--- a/docs/streaming-kinesis-integration.md
+++ b/docs/streaming-kinesis-integration.md
@@ -17,6 +17,17 @@ license: |
   See the License for the specific language governing permissions and
   limitations under the License.
 ---
+
+
+***************************************************************************************************
+## Deprecation notice.
+Spark Streaming is deprecated in favor of 
+[Spark structured streaming](structured-streaming-programming-guide.md).
+ This component is no longer actively maintained.
+ 
+***************************************************************************************************
+
+
 [Amazon Kinesis](http://aws.amazon.com/kinesis/) is a fully managed service for real-time processing of streaming data at massive scale.
 The Kinesis receiver creates an input DStream using the Kinesis Client Library (KCL) provided by Amazon under the Amazon Software License (ASL).
 The KCL builds on top of the Apache 2.0 licensed AWS Java SDK and provides load-balancing, fault-tolerance, checkpointing through the concepts of Workers, Checkpoints, and Shard Leases.

--- a/docs/streaming-programming-guide.md
+++ b/docs/streaming-programming-guide.md
@@ -20,10 +20,20 @@ license: |
   limitations under the License.
 ---
 
+***************************************************************************************************
+## Deprecation notice.
+Spark Streaming is deprecated in favor of 
+[Spark structured streaming](structured-streaming-programming-guide.md).
+ This component is no longer actively maintained.
+ 
+***************************************************************************************************
+
+
 * This will become a table of contents (this text will be scraped).
 {:toc}
 
 # Overview
+
 Spark Streaming is an extension of the core Spark API that enables scalable, high-throughput,
 fault-tolerant stream processing of live data streams. Data can be ingested from many sources
 like Kafka, Kinesis, or TCP sockets, and can be processed using complex

--- a/python/pyspark/streaming/context.py
+++ b/python/pyspark/streaming/context.py
@@ -18,6 +18,7 @@
 from __future__ import print_function
 
 from py4j.java_gateway import java_import
+from deprecation import deprecated
 
 from pyspark import RDD, SparkConf
 from pyspark.serializers import NoOpSerializer, UTF8Deserializer, CloudPickleSerializer
@@ -28,7 +29,8 @@ from pyspark.streaming.util import TransformFunction, TransformFunctionSerialize
 
 __all__ = ["StreamingContext"]
 
-
+@deprecated(deprecated_in="3.0.0",
+            details="Spark Streaming is deprecated in favor of Structured Streaming.")
 class StreamingContext(object):
     """
     Main entry point for Spark Streaming functionality. A StreamingContext

--- a/python/pyspark/streaming/context.py
+++ b/python/pyspark/streaming/context.py
@@ -27,7 +27,9 @@ from pyspark.storagelevel import StorageLevel
 from pyspark.streaming.dstream import DStream
 from pyspark.streaming.util import TransformFunction, TransformFunctionSerializer
 
+
 __all__ = ["StreamingContext"]
+
 
 @deprecated(deprecated_in="3.0.0",
             details="Spark Streaming is deprecated in favor of Structured Streaming.")

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -60,6 +60,7 @@ import org.apache.spark.util.{CallSite, ShutdownHookManager, ThreadUtils, Utils}
  * `context.awaitTermination()` allows the current thread to wait for the termination
  * of the context by `stop()` or by an exception.
  */
+@deprecated("Spark Streaming is deprecated in favor of Structured Streaming.", since = "3.0.0")
 class StreamingContext private[streaming] (
     _sc: SparkContext,
     _cp: Checkpoint,
@@ -130,6 +131,9 @@ class StreamingContext private[streaming] (
 
   require(_sc != null || _cp != null,
     "Spark Streaming cannot be initialized with both SparkContext and checkpoint as null")
+
+  logWarning("Spark Streaming is deprecated in favor of Structured Streaming and is" +
+    " not under active development.")
 
   private[streaming] val isCheckpointPresent: Boolean = _cp != null
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaStreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaStreamingContext.scala
@@ -51,6 +51,7 @@ import org.apache.spark.streaming.scheduler.StreamingListener
  * respectively. `context.awaitTermination()` allows the current thread to wait for the
  * termination of a context by `stop()` or by an exception.
  */
+@deprecated("Spark Streaming is deprecated in favor of Structured Streaming.", since = "3.0.0")
 class JavaStreamingContext(val ssc: StreamingContext) extends Closeable {
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add clear deprecation warning so that a user is not at all confused about it's current state.

### Why are the changes needed?
To save the consumers of Apache spark from accidentally thinking that Spark streaming is the currently supported form of Streaming in Apache Spark.


### Does this PR introduce any user-facing change?
Yes, it adds deprecation warnings.


### How was this patch tested?
Tested by building docs and manually checking out rendered docs. Both API docs for scala, java and python and markdown renderings using `jekyll serve` for streaming programming guide.

---
<img width="1203" alt="Screenshot 2020-03-02 at 5 26 16 PM" src="https://user-images.githubusercontent.com/992952/75674607-7298c900-5cab-11ea-9ef2-5d203c91f914.png">

---
<img width="1203" alt="Screenshot 2020-03-02 at 5 17 36 PM" src="https://user-images.githubusercontent.com/992952/75674612-762c5000-5cab-11ea-9a3f-ee7a830f9cf6.png">

---
<img width="1203" alt="Screenshot 2020-03-02 at 5 30 57 PM" src="https://user-images.githubusercontent.com/992952/75674694-a2e06780-5cab-11ea-853e-31ec72d93916.png">
