### PR TITLE
[SPARK-31013][Core][WebUI] InMemoryStore: improve removeAllByIndexValues over natural key index

### DIFF
--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
@@ -231,11 +231,16 @@ public class InMemoryStore implements KVStore {
     }
 
     int countingRemoveAllByIndexValues(String index, Collection<?> indexValues) {
-      if (hasNaturalParentIndex && naturalParentIndexName.equals(index)) {
+      int count = 0;
+      if (KVIndex.NATURAL_INDEX_NAME.equals(index)) {
+        for (Object naturalKey : indexValues) {
+          count += delete(asKey(naturalKey)) ? 1 : 0;
+        }
+        return count;
+      } else if (hasNaturalParentIndex && naturalParentIndexName.equals(index)) {
         // If there is a parent index for the natural index and `index` happens to be it,
         // Spark can use the `parentToChildrenMap` to get the related natural keys, and then
         // delete them from `data`.
-        int count = 0;
         for (Object indexValue : indexValues) {
           Comparable<Object> parentKey = asKey(indexValue);
           NaturalKeys children = parentToChildrenMap.getOrDefault(parentKey, new NaturalKeys());
@@ -271,9 +276,9 @@ public class InMemoryStore implements KVStore {
       }
     }
 
-    public void delete(Object key) {
-      data.remove(asKey(key));
-      if (hasNaturalParentIndex) {
+    public Boolean delete(Object key) {
+      Boolean entryExists = data.remove(asKey(key)) != null;
+      if (entryExists && hasNaturalParentIndex) {
         for (NaturalKeys v : parentToChildrenMap.values()) {
           if (v.remove(asKey(key))) {
             // `v` can be empty after removing the natural key and we can remove it from
@@ -284,6 +289,7 @@ public class InMemoryStore implements KVStore {
           }
         }
       }
+      return entryExists;
     }
 
     public int size() {

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
@@ -276,8 +276,8 @@ public class InMemoryStore implements KVStore {
       }
     }
 
-    public Boolean delete(Object key) {
-      Boolean entryExists = data.remove(asKey(key)) != null;
+    public boolean delete(Object key) {
+      boolean entryExists = data.remove(asKey(key)) != null;
       if (entryExists && hasNaturalParentIndex) {
         for (NaturalKeys v : parentToChildrenMap.values()) {
           if (v.remove(asKey(key))) {

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/InMemoryStoreSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/InMemoryStoreSuite.java
@@ -158,23 +158,29 @@ public class InMemoryStoreSuite {
 
     assertEquals(9, store.count(ArrayKeyIndexType.class));
 
-
-    store.removeAllByIndexValues(
+    // Try removing non-existing keys
+    assert(!store.removeAllByIndexValues(
       ArrayKeyIndexType.class,
       KVIndex.NATURAL_INDEX_NAME,
-      ImmutableSet.of(new int[] {0, 0, 0}, new int[] { 2, 2, 2 }));
+      ImmutableSet.of(new int[] {10, 10, 10}, new int[] { 3, 3, 3 })));
+    assertEquals(9, store.count(ArrayKeyIndexType.class));
+
+    assert(store.removeAllByIndexValues(
+      ArrayKeyIndexType.class,
+      KVIndex.NATURAL_INDEX_NAME,
+      ImmutableSet.of(new int[] {0, 0, 0}, new int[] { 2, 2, 2 })));
     assertEquals(7, store.count(ArrayKeyIndexType.class));
 
-    store.removeAllByIndexValues(
+    assert(store.removeAllByIndexValues(
       ArrayKeyIndexType.class,
       "id",
-      ImmutableSet.of(new String [] { "things" }));
+      ImmutableSet.of(new String [] { "things" })));
     assertEquals(4, store.count(ArrayKeyIndexType.class));
 
-    store.removeAllByIndexValues(
+    assert(store.removeAllByIndexValues(
       ArrayKeyIndexType.class,
       "id",
-      ImmutableSet.of(new String [] { "more things" }));
+      ImmutableSet.of(new String [] { "more things" })));
     assertEquals(0, store.count(ArrayKeyIndexType.class));
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
The method `removeAllByIndexValues` in KVStore is to delete all the objects which have certain values in the given index.
However, in the current implementation of `InMemoryStore`, when the given index is the natural key index, there is no special handling for it and a linear search over all the task data is performed.

We can improve it by deleting the natural keys directly from the internal hashmap.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Better performance if the given index for `removeAllByIndexValues` is the natural key index in 
`InMemoryStore`
### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Enhance the existing test.