### PR TITLE
[SPARK-31017][TEST][CORE] Test for shuffle requests packaging with different size and numBlocks limit

### DIFF
--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -254,60 +254,69 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
     intercept[FetchFailedException] { iterator.next() }
   }
 
-  test("SPARK-31017: Hit maxBytesInFlight limitation before maxBlocksInFlightPerAddress") {
+  test("Hit maxBytesInFlight limitation before maxBlocksInFlightPerAddress") {
     val blockManager = mock(classOf[BlockManager])
     val localBmId = BlockManagerId("test-client", "test-local-host", 1)
     doReturn(localBmId).when(blockManager).blockManagerId
 
     val remoteBmId1 = BlockManagerId("test-remote-client-1", "test-remote-host1", 1)
     val remoteBmId2 = BlockManagerId("test-remote-client-2", "test-remote-host2", 2)
-    val remoteBmId3 = BlockManagerId("test-remote-client-3", "test-remote-host2", 3)
-    // set maxBlocksInFlightPerAddress to Int.MaxValue,
-    // and there will be 3 FetchRequests after initialize and 1000 bytes per request.
+    val blockId1 = ShuffleBlockId(0, 1, 0)
+    val blockId2 = ShuffleBlockId(1, 1, 0)
     val blocksByAddress = Seq(
-      (remoteBmId1, Seq((ShuffleBlockId(0, 1, 0), 1000L, 0))),
-      (remoteBmId2, Seq((ShuffleBlockId(1, 1, 0), 1000L, 0))),
-      (remoteBmId3, Seq((ShuffleBlockId(2, 1, 0), 1000L, 0)))).toIterator
-    // give empty data to make sure the sent request is aways in flight
-    val transfer = createMockTransfer(Map())
+      (remoteBmId1, Seq((blockId1, 1000L, 0))),
+      (remoteBmId2, Seq((blockId2, 1000L, 0)))).toIterator
+    val transfer = createMockTransfer(Map(
+      blockId1 -> createMockManagedBuffer(1000),
+      blockId2 -> createMockManagedBuffer(1000)))
     val taskContext = TaskContext.empty()
     val metrics = taskContext.taskMetrics.createTempShuffleReadMetrics()
-    new ShuffleBlockFetcherIterator(
+    val iterator = new ShuffleBlockFetcherIterator(
       taskContext,
       transfer,
       blockManager,
       blocksByAddress,
       (_, in) => in,
-      2500L, // allow 2 FetchRequests at most at the same time
+      1000L, // allow 1 FetchRequests at most at the same time
       Int.MaxValue,
       Int.MaxValue, // set maxBlocksInFlightPerAddress to Int.MaxValue
       Int.MaxValue,
       true,
       false,
       metrics,
-      true)
-    // only the first 2 FetchRequests can be sent, but the last one will
-    // hit maxBytesInFlight so it won't be sent.
+      false)
+    // After initialize() we'll have 2 FetchRequests and each is 1000 bytes. So only the
+    // first FetchRequests can be sent, and the second one will hit maxBytesInFlight so
+    // it won't be sent.
+    verify(transfer, times(1)).fetchBlocks(any(), any(), any(), any(), any(), any())
+    assert(iterator.hasNext)
+    // next() will trigger off sending deferred request
+    iterator.next()
+    // the second FetchRequest should be sent at this time
     verify(transfer, times(2)).fetchBlocks(any(), any(), any(), any(), any(), any())
+    assert(iterator.hasNext)
+    iterator.next()
+    assert(!iterator.hasNext)
   }
 
-  test("SPARK-31017: Hit maxBlocksInFlightPerAddress limitation before maxBytesInFlight") {
+  test("Hit maxBlocksInFlightPerAddress limitation before maxBytesInFlight") {
     val blockManager = mock(classOf[BlockManager])
     val localBmId = BlockManagerId("test-client", "test-local-host", 1)
     doReturn(localBmId).when(blockManager).blockManagerId
 
     val remoteBmId = BlockManagerId("test-remote-client-1", "test-remote-host", 2)
-    // set maxBlocksInFlightPerAddress to 2, so there will be 2 FetchRequests after initialize.
-    // One has 2 blocks inside and another one has only one block.
+    val blockId1 = ShuffleBlockId(0, 1, 0)
+    val blockId2 = ShuffleBlockId(0, 2, 0)
+    val blockId3 = ShuffleBlockId(0, 3, 0)
     val blocksByAddress = Seq((remoteBmId,
-      Seq((ShuffleBlockId(0, 1, 0), 1000L, 0),
-        (ShuffleBlockId(0, 2, 0), 1000L, 0),
-        (ShuffleBlockId(0, 3, 0), 1000L, 0)))).toIterator
-    // give empty data to make sure the sent request is aways in flight
-    val transfer = createMockTransfer(Map())
+      Seq((blockId1, 1000L, 0), (blockId2, 1000L, 0), (blockId3, 1000L, 0)))).toIterator
+    val transfer = createMockTransfer(Map(
+      blockId1 -> createMockManagedBuffer(),
+      blockId2 -> createMockManagedBuffer(),
+      blockId3 -> createMockManagedBuffer()))
     val taskContext = TaskContext.empty()
     val metrics = taskContext.taskMetrics.createTempShuffleReadMetrics()
-    new ShuffleBlockFetcherIterator(
+    val iterator = new ShuffleBlockFetcherIterator(
       taskContext,
       transfer,
       blockManager,
@@ -315,15 +324,26 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       (_, in) => in,
       Int.MaxValue, // set maxBytesInFlight to Int.MaxValue
       Int.MaxValue,
-      2,
+      2, // set maxBlocksInFlightPerAddress to 2
       Int.MaxValue,
       true,
       false,
       metrics,
-      true)
-    // only the first FetchRequest can be sent. The second FetchRequest will
+      false)
+    // After initialize(), we'll have 2 FetchRequests that one has 2 blocks inside and another one
+    // has only one block. So only the first FetchRequest can be sent. The second FetchRequest will
     // hit maxBlocksInFlightPerAddress so it won't be sent.
     verify(transfer, times(1)).fetchBlocks(any(), any(), any(), any(), any(), any())
+    // the first request packaged 2 blocks, so we also need to
+    // call next() for 2 times to exhaust the iterator.
+    assert(iterator.hasNext)
+    iterator.next()
+    assert(iterator.hasNext)
+    iterator.next()
+    verify(transfer, times(2)).fetchBlocks(any(), any(), any(), any(), any(), any())
+    assert(iterator.hasNext)
+    iterator.next()
+    assert(!iterator.hasNext)
   }
 
   test("fetch continuous blocks in batch successful 3 local + 4 host local + 2 remote reads") {
@@ -413,31 +433,28 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
     assert(blockManager.hostLocalDirManager.get.getCachedHostLocalDirs().size === 1)
   }
 
-  test("fetch continuous blocks in batch respects maxSize and maxBlocks") {
+  test("fetch continuous blocks in batch should respects maxBytesInFlight") {
     val blockManager = mock(classOf[BlockManager])
     val localBmId = BlockManagerId("test-client", "test-local-host", 1)
     doReturn(localBmId).when(blockManager).blockManagerId
 
     // Make sure remote blocks would return the merged block
-    val remoteBmId = BlockManagerId("test-client-1", "test-client-1", 2)
-    val remoteBlocks = Seq[BlockId](
-      ShuffleBlockId(0, 3, 0),
-      ShuffleBlockId(0, 3, 1),
-      ShuffleBlockId(0, 3, 2),
-      ShuffleBlockId(0, 4, 0),
-      ShuffleBlockId(0, 4, 1),
-      ShuffleBlockId(0, 5, 0),
-      ShuffleBlockId(0, 5, 1),
-      ShuffleBlockId(0, 5, 2))
+    val remoteBmId1 = BlockManagerId("test-client-1", "test-client-1", 1)
+    val remoteBmId2 = BlockManagerId("test-client-2", "test-client-2", 2)
+    val remoteBlocks1 = (0 until 15).map(ShuffleBlockId(0, 3, _))
+    val remoteBlocks2 = Seq[BlockId](ShuffleBlockId(0, 4, 0), ShuffleBlockId(0, 4, 1))
     val mergedRemoteBlocks = Map[BlockId, ManagedBuffer](
       ShuffleBlockBatchId(0, 3, 0, 3) -> createMockManagedBuffer(),
-      ShuffleBlockBatchId(0, 4, 0, 2) -> createMockManagedBuffer(),
-      ShuffleBlockBatchId(0, 5, 0, 3) -> createMockManagedBuffer())
+      ShuffleBlockBatchId(0, 3, 3, 6) -> createMockManagedBuffer(),
+      ShuffleBlockBatchId(0, 3, 6, 9) -> createMockManagedBuffer(),
+      ShuffleBlockBatchId(0, 3, 9, 12) -> createMockManagedBuffer(),
+      ShuffleBlockBatchId(0, 3, 12, 15) -> createMockManagedBuffer(),
+      ShuffleBlockBatchId(0, 4, 0, 2) -> createMockManagedBuffer())
     val transfer = createMockTransfer(mergedRemoteBlocks)
 
     val blocksByAddress = Seq[(BlockManagerId, Seq[(BlockId, Long, Int)])](
-      (remoteBmId, remoteBlocks.map(blockId => (blockId, 1L, 1)))
-    ).toIterator
+      (remoteBmId1, remoteBlocks1.map(blockId => (blockId, 100L, 1))),
+      (remoteBmId2, remoteBlocks2.map(blockId => (blockId, 100L, 1)))).toIterator
 
     val taskContext = TaskContext.empty()
     val metrics = taskContext.taskMetrics.createTempShuffleReadMetrics()
@@ -447,7 +464,64 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       blockManager,
       blocksByAddress,
       (_, in) => in,
-      35,
+      1500,
+      Int.MaxValue,
+      Int.MaxValue,
+      Int.MaxValue,
+      true,
+      false,
+      metrics,
+      true)
+
+    var numResults = 0
+    // After initialize(), there will be 6 FetchRequests, and the each of the first 5
+    // includes 3 merged blocks and the last one has 1 merged block. So, only the
+    // first 5 requests(5 * 3 * 100 >= 1500) can be sent.
+    verify(transfer, times(5)).fetchBlocks(any(), any(), any(), any(), any(), any())
+    while (iterator.hasNext) {
+      val (blockId, inputStream) = iterator.next()
+      // Make sure we release buffers when a wrapped input stream is closed.
+      val mockBuf = mergedRemoteBlocks(blockId)
+      verifyBufferRelease(mockBuf, inputStream)
+      numResults += 1
+    }
+    // The last request will be sent after next() is called.
+    verify(transfer, times(6)).fetchBlocks(any(), any(), any(), any(), any(), any())
+    assert(numResults == 6)
+  }
+
+  // TODO(wuyi) test this after the fix
+  ignore("fetch continuous blocks in batch should respects maxBlocksInFlightPerAddress") {
+    val blockManager = mock(classOf[BlockManager])
+    val localBmId = BlockManagerId("test-client", "test-local-host", 1)
+    doReturn(localBmId).when(blockManager).blockManagerId
+
+    // Make sure remote blocks would return the merged block
+    val remoteBmId = BlockManagerId("test-client-1", "test-client-1", 1)
+    val remoteBlocks = Seq(
+      ShuffleBlockId(0, 3, 0),
+      ShuffleBlockId(0, 3, 1),
+      ShuffleBlockId(0, 4, 0),
+      ShuffleBlockId(0, 4, 1),
+      ShuffleBlockId(0, 5, 0))
+    val mergedRemoteBlocks = Map[BlockId, ManagedBuffer](
+      ShuffleBlockBatchId(0, 3, 0, 2) -> createMockManagedBuffer(),
+      ShuffleBlockBatchId(0, 4, 0, 2) -> createMockManagedBuffer(),
+      ShuffleBlockBatchId(0, 5, 0, 1) -> createMockManagedBuffer())
+    val transfer = createMockTransfer(mergedRemoteBlocks)
+
+    val blocksByAddress = Seq[(BlockManagerId, Seq[(BlockId, Long, Int)])](
+      (remoteBmId, remoteBlocks.map(blockId => (blockId, 100L, 1)))).toIterator
+
+    val taskContext = TaskContext.empty()
+    val metrics = taskContext.taskMetrics.createTempShuffleReadMetrics()
+    val iterator = new ShuffleBlockFetcherIterator(
+      taskContext,
+      transfer,
+      blockManager,
+      blocksByAddress,
+      (_, in) => in,
+      Int.MaxValue,
       Int.MaxValue,
       2,
       Int.MaxValue,
@@ -457,6 +531,10 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       true)
 
     var numResults = 0
+    // After initialize(), there will be 2 FetchRequests that one has 2 merged blocks and another
+    // one has one merged blocks. So only the first FetchRequest can be sent. The second
+    // FetchRequest will hit maxBlocksInFlightPerAddress so it won't be sent.
+    verify(transfer, times(1)).fetchBlocks(any(), any(), any(), any(), any(), any())
     while (iterator.hasNext) {
       val (blockId, inputStream) = iterator.next()
       // Make sure we release buffers when a wrapped input stream is closed.
@@ -464,8 +542,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       verifyBufferRelease(mockBuf, inputStream)
       numResults += 1
     }
-    // The first 2 batch block ids are in the same fetch request as they don't exceed the max size
-    // and max blocks, so 2 requests in total.
+    // The second request will be sent after next() is called.
     verify(transfer, times(2)).fetchBlocks(any(), any(), any(), any(), any(), any())
     assert(numResults == 3)
   }

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -254,7 +254,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
     intercept[FetchFailedException] { iterator.next() }
   }
 
-  test("SPARK-31017: Hit maxBytesInFlight limit before maxBlocksInFlightPerAddress") {
+  test("SPARK-31017: Hit maxBytesInFlight limitation before maxBlocksInFlightPerAddress") {
     val blockManager = mock(classOf[BlockManager])
     val localBmId = BlockManagerId("test-client", "test-local-host", 1)
     doReturn(localBmId).when(blockManager).blockManagerId
@@ -291,7 +291,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
     verify(transfer, times(2)).fetchBlocks(any(), any(), any(), any(), any(), any())
   }
 
-  test("SPARK-31017: Hit maxBlocksInFlightPerAddress limit before maxBytesInFlight") {
+  test("SPARK-31017: Hit maxBlocksInFlightPerAddress limitation before maxBytesInFlight") {
     val blockManager = mock(classOf[BlockManager])
     val localBmId = BlockManagerId("test-client", "test-local-host", 1)
     doReturn(localBmId).when(blockManager).blockManagerId

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -254,7 +254,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
     intercept[FetchFailedException] { iterator.next() }
   }
 
-  test("Hit maxBytesInFlight limit before maxBlocksInFlightPerAddress") {
+  test("SPARK-31017: Hit maxBytesInFlight limit before maxBlocksInFlightPerAddress") {
     val blockManager = mock(classOf[BlockManager])
     val localBmId = BlockManagerId("test-client", "test-local-host", 1)
     doReturn(localBmId).when(blockManager).blockManagerId
@@ -291,7 +291,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
     verify(transfer, times(2)).fetchBlocks(any(), any(), any(), any(), any(), any())
   }
 
-  test("Hit maxBlocksInFlightPerAddress limit before maxBytesInFlight") {
+  test("SPARK-31017: Hit maxBlocksInFlightPerAddress limit before maxBytesInFlight") {
     val blockManager = mock(classOf[BlockManager])
     val localBmId = BlockManagerId("test-client", "test-local-host", 1)
     doReturn(localBmId).when(blockManager).blockManagerId


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Added 2 tests for `ShuffleBlockFetcherIteratorSuite`.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

When packaging shuffle fetch requests in `ShuffleBlockFetcherIterator`, there are two limitations: `maxBytesInFlight` and `maxBlocksInFlightPerAddress`. However, we don’t have test cases to test them both, e.g. the size limitation is hit before the numBlocks limitation.

We should add test cases in `ShuffleBlockFetcherIteratorSuite` to test:

1. the size limitation is hit before the numBlocks limitation
2. the numBlocks limitation is hit before the size limitation

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Added new tests.
