### PR TITLE
[SPARK-31018][CORE][DOCS] Deprecate support of multiple workers on the same host in Standalone

### DIFF
--- a/docs/core-migration-guide.md
+++ b/docs/core-migration-guide.md
@@ -38,3 +38,5 @@ license: |
 - Event log file will be written as UTF-8 encoding, and Spark History Server will replay event log files as UTF-8 encoding. Previously Spark wrote the event log file as default charset of driver JVM process, so Spark History Server of Spark 2.x is needed to read the old event log files in case of incompatible encoding.
 
 - A new protocol for fetching shuffle blocks is used. It's recommended that external shuffle services be upgraded when running Spark 3.0 apps. You can still use old external shuffle services by setting the configuration `spark.shuffle.useOldFetchProtocol` to `true`. Otherwise, Spark may run into errors with messages like `IllegalArgumentException: Unexpected message type: <number>`.
+
+- `SPARK_WORKER_INSTANCES` is deprecated. It's recommended to launch multiple executors in one worker and launch one worker per node instead of launching multiple workers per node and launching one executor per worker.

--- a/docs/core-migration-guide.md
+++ b/docs/core-migration-guide.md
@@ -39,4 +39,4 @@ license: |
 
 - A new protocol for fetching shuffle blocks is used. It's recommended that external shuffle services be upgraded when running Spark 3.0 apps. You can still use old external shuffle services by setting the configuration `spark.shuffle.useOldFetchProtocol` to `true`. Otherwise, Spark may run into errors with messages like `IllegalArgumentException: Unexpected message type: <number>`.
 
-- `SPARK_WORKER_INSTANCES` is deprecated. It's recommended to launch multiple executors in one worker and launch one worker per node instead of launching multiple workers per node and launching one executor per worker.
+- `SPARK_WORKER_INSTANCES` is deprecated in Standalone mode. It's recommended to launch multiple executors in one worker and launch one worker per node instead of launching multiple workers per node and launching one executor per worker.

--- a/docs/hardware-provisioning.md
+++ b/docs/hardware-provisioning.md
@@ -66,7 +66,8 @@ Finally, note that the Java VM does not always behave well with more than 200 Gi
 purchase machines with more RAM than this, you can run _multiple worker JVMs per node_. In
 Spark's [standalone mode](spark-standalone.html), you can set the number of workers per node
 with the `SPARK_WORKER_INSTANCES` variable in `conf/spark-env.sh`, and the number of cores
-per worker with `SPARK_WORKER_CORES`.
+per worker with `SPARK_WORKER_CORES`. But please note that support of multiple workers on the
+same host is deprecated in Spark 3.0 and is going to be removed in Spark 3.1.
 
 # Network
 

--- a/docs/hardware-provisioning.md
+++ b/docs/hardware-provisioning.md
@@ -63,11 +63,10 @@ Note that memory usage is greatly affected by storage level and serialization fo
 the [tuning guide](tuning.html) for tips on how to reduce it.
 
 Finally, note that the Java VM does not always behave well with more than 200 GiB of RAM. If you
-purchase machines with more RAM than this, you can run _multiple worker JVMs per node_. In
-Spark's [standalone mode](spark-standalone.html), you can set the number of workers per node
-with the `SPARK_WORKER_INSTANCES` variable in `conf/spark-env.sh`, and the number of cores
-per worker with `SPARK_WORKER_CORES`. But please note that support of multiple workers on the
-same host is deprecated in Spark 3.0 and is going to be removed in Spark 3.1.
+purchase machines with more RAM than this, you can launch multiple executors in a single node. In
+Spark's [standalone mode](spark-standalone.html), a worker is responsible for launching multiple
+executors according to its available memory and cores. And each executor will be launched in a
+separate Java VM.
 
 # Network
 

--- a/docs/hardware-provisioning.md
+++ b/docs/hardware-provisioning.md
@@ -65,7 +65,7 @@ the [tuning guide](tuning.html) for tips on how to reduce it.
 Finally, note that the Java VM does not always behave well with more than 200 GiB of RAM. If you
 purchase machines with more RAM than this, you can launch multiple executors in a single node. In
 Spark's [standalone mode](spark-standalone.html), a worker is responsible for launching multiple
-executors according to its available memory and cores. And each executor will be launched in a
+executors according to its available memory and cores, and each executor will be launched in a
 separate Java VM.
 
 # Network

--- a/sbin/decommission-slave.sh
+++ b/sbin/decommission-slave.sh
@@ -40,7 +40,6 @@ fi
 if [ "$SPARK_WORKER_INSTANCES" = "" ]; then
   "${SPARK_HOME}/sbin"/spark-daemon.sh decommission org.apache.spark.deploy.worker.Worker 1
 else
-  echo "WARNING: Support of multiple workers on the same host is deprecated in Spark 3.0 and is going to be removed in Spark 3.1."
   for ((i=0; i<$SPARK_WORKER_INSTANCES; i++)); do
     "${SPARK_HOME}/sbin"/spark-daemon.sh decommission org.apache.spark.deploy.worker.Worker $(( $i + 1 ))
   done

--- a/sbin/decommission-slave.sh
+++ b/sbin/decommission-slave.sh
@@ -40,6 +40,7 @@ fi
 if [ "$SPARK_WORKER_INSTANCES" = "" ]; then
   "${SPARK_HOME}/sbin"/spark-daemon.sh decommission org.apache.spark.deploy.worker.Worker 1
 else
+  echo "WARNING: Support of multiple workers on the same host is deprecated in Spark 3.0 and is going to be removed in Spark 3.1."
   for ((i=0; i<$SPARK_WORKER_INSTANCES; i++)); do
     "${SPARK_HOME}/sbin"/spark-daemon.sh decommission org.apache.spark.deploy.worker.Worker $(( $i + 1 ))
   done

--- a/sbin/start-slave.sh
+++ b/sbin/start-slave.sh
@@ -86,6 +86,7 @@ function start_instance {
 if [ "$SPARK_WORKER_INSTANCES" = "" ]; then
   start_instance 1 "$@"
 else
+  echo "WARNING: Support of multiple workers on the same host is deprecated in Spark 3.0 and is going to be removed in Spark 3.1."
   for ((i=0; i<$SPARK_WORKER_INSTANCES; i++)); do
     start_instance $(( 1 + $i )) "$@"
   done

--- a/sbin/start-slave.sh
+++ b/sbin/start-slave.sh
@@ -22,7 +22,7 @@
 # Environment Variables
 #
 #   SPARK_WORKER_INSTANCES  The number of worker instances to run on this
-#                           slave.  Default is 1.
+#                           slave.  Default is 1. Note it has been deprecate since Spark 3.0.
 #   SPARK_WORKER_PORT       The base port number for the first worker. If set,
 #                           subsequent workers will increment this number.  If
 #                           unset, Spark will find a valid port number, but
@@ -86,7 +86,6 @@ function start_instance {
 if [ "$SPARK_WORKER_INSTANCES" = "" ]; then
   start_instance 1 "$@"
 else
-  echo "WARNING: Support of multiple workers on the same host is deprecated in Spark 3.0 and is going to be removed in Spark 3.1."
   for ((i=0; i<$SPARK_WORKER_INSTANCES; i++)); do
     start_instance $(( 1 + $i )) "$@"
   done


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Update the document and shell script to warn user about the deprecation of multiple workers on the same host support.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This is a sub-task of [SPARK-30978](https://issues.apache.org/jira/browse/SPARK-30978), which plans to totally remove support of multiple workers in Spark 3.1. This PR makes the first step to deprecate it firstly in Spark 3.0. 

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

Yeah, user see warning when they run start worker script.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Tested manually.
