### PR TITLE
[SPARK-31020][SQL] Support foldable schemas by `from_csv`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExprUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExprUtils.scala
@@ -30,11 +30,11 @@ object ExprUtils {
   def evalSchemaExpr(exp: Expression): StructType = {
     val dataType = if (exp.foldable) {
       exp.eval() match {
-        case s: UTF8String =>
+        case s: UTF8String if s != null =>
           // Use `DataType.fromDDL` since the type string can be struct<...>.
           DataType.fromDDL(s.toString)
         case _ => throw new AnalysisException(
-          s"The expression ${exp.sql} must return a valid string.")
+          s"The expression '${exp.sql}' must be evaluated to a valid string.")
       }
     } else {
       throw new AnalysisException(

--- a/sql/core/src/test/resources/sql-tests/results/csv-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/csv-functions.sql.out
@@ -24,7 +24,7 @@ select from_csv('1', 1)
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-Schema should be specified in DDL format as a string literal or output of the schema_of_csv function instead of 1;; line 1 pos 7
+The expression '1' must be evaluated to a valid string.;; line 1 pos 7
 
 
 -- !query

--- a/sql/core/src/test/scala/org/apache/spark/sql/CsvFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CsvFunctionsSuite.scala
@@ -217,6 +217,6 @@ class CsvFunctionsSuite extends QueryTest with SharedSparkSession {
     val errMsg2 = intercept[AnalysisException] {
       Seq("1").toDF("csv").select(from_csv($"csv", lit(1), options)).collect()
     }.getMessage
-    assert(errMsg2.contains("must return a valid string"))
+    assert(errMsg2.contains("The expression '1' must be evaluated to a valid string"))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to replace matching by `Literal` in `ExprUtils.evalSchemaExpr()` to checking foldable property of the `schema` expression.

### Why are the changes needed?
This should improve Spark SQL UX for `from_csv`. Currently, Spark expects only literals:
```sql
spark-sql> select from_csv('1,Moscow', replace('dpt_org_id INT, dpt_org_city STRING', 'dpt_org_', ''));
Error in query: Schema should be specified in DDL format as a string literal or output of the schema_of_csv function instead of replace('dpt_org_id INT, dpt_org_city STRING', 'dpt_org_', '');; line 1 pos 7
```

### Does this PR introduce any user-facing change?
Yes, after the changes users can pass any foldable string expression as the `schema` parameter to `from_csv()`. For the example above:
```sql
spark-sql> select from_csv('1,Moscow', replace('dpt_org_id INT, dpt_org_city STRING', 'dpt_org_', ''));
{"id":1,"city":"Moscow"}
```

### How was this patch tested?
Added new test to `CsvFunctionsSuite`.
