### PR TITLE
[SPARK-31027] [SQL] Refactor DataSourceStrategy to be more extendable

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -478,8 +478,8 @@ object DataSourceStrategy {
     // Because we only convert In to InSet in Optimizer when there are more than certain
     // items. So it is possible we still get an In expression here that needs to be pushed
     // down.
-    case expressions.In(e, list) if list.forall(_.isInstanceOf[Literal]) => e match {
-      case PushableColumn(name) =>
+    case expressions.In(e, list) => e match {
+      case PushableColumn(name) if list.forall(_.isInstanceOf[Literal]) =>
         val hSet = list.map(_.eval(EmptyRow))
         val toScala = CatalystTypeConverters.createToScalaConverter(e.dataType)
         Some(sources.In(name, hSet.toArray.map(toScala)))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -468,7 +468,7 @@ object DataSourceStrategy {
     case expressions.LessThanOrEqual(Literal(v, t), PushableColumn(name)) =>
       Some(sources.GreaterThanOrEqual(name, convertToScala(v, t)))
 
-    case expressions.InSet(e: Expression, set) => e match {
+    case expressions.InSet(e, set) => e match {
       case PushableColumn(name) =>
         val toScala = CatalystTypeConverters.createToScalaConverter(e.dataType)
         Some(sources.In(name, set.toArray.map(toScala)))
@@ -645,7 +645,7 @@ object DataSourceStrategy {
 /**
  * Find the column name of an expression that can be pushed down.
  */
-private[sql] object PushableColumn {
+private[datasources] object PushableColumn {
   def unapply(e: Expression): Option[String] = {
     def helper(e: Expression) = e match {
       case a: Attribute => Some(a.name)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -437,76 +437,62 @@ object DataSourceStrategy {
     }
   }
 
-  /**
-   * Find the column name of an expression that can be pushed down.
-   */
-  private[sql] def pushDownColName(e: Expression): Option[String] = {
-    def helper(e: Expression) = e match {
-      case a: Attribute => Some(a.name)
-      case _ => None
-    }
-    helper(e)
-  }
-
   private def translateLeafNodeFilter(predicate: Expression): Option[Filter] = predicate match {
-    case expressions.EqualTo(e: Expression, Literal(v, t)) =>
-      pushDownColName(e).map(sources.EqualTo(_, convertToScala(v, t)))
-    case expressions.EqualTo(Literal(v, t), e: Expression) =>
-      pushDownColName(e).map(sources.EqualTo(_, convertToScala(v, t)))
+    case expressions.EqualTo(PushDownCol(col), Literal(v, t)) =>
+      Some(sources.EqualTo(col.name, convertToScala(v, t)))
+    case expressions.EqualTo(Literal(v, t), PushDownCol(col)) =>
+      Some(sources.EqualTo(col.name, convertToScala(v, t)))
 
-    case expressions.EqualNullSafe(e: Expression, Literal(v, t)) =>
-      pushDownColName(e).map(sources.EqualNullSafe(_, convertToScala(v, t)))
-    case expressions.EqualNullSafe(Literal(v, t), e: Expression) =>
-      pushDownColName(e).map(sources.EqualNullSafe(_, convertToScala(v, t)))
+    case expressions.EqualNullSafe(PushDownCol(col), Literal(v, t)) =>
+      Some(sources.EqualNullSafe(col.name, convertToScala(v, t)))
+    case expressions.EqualNullSafe(Literal(v, t), PushDownCol(col)) =>
+      Some(sources.EqualNullSafe(col.name, convertToScala(v, t)))
 
-    case expressions.GreaterThan(e: Expression, Literal(v, t)) =>
-      pushDownColName(e).map(sources.GreaterThan(_, convertToScala(v, t)))
-    case expressions.GreaterThan(Literal(v, t), e: Expression) =>
-      pushDownColName(e).map(sources.LessThan(_, convertToScala(v, t)))
+    case expressions.GreaterThan(PushDownCol(col), Literal(v, t)) =>
+      Some(sources.GreaterThan(col.name, convertToScala(v, t)))
+    case expressions.GreaterThan(Literal(v, t), PushDownCol(col)) =>
+      Some(sources.LessThan(col.name, convertToScala(v, t)))
 
-    case expressions.LessThan(e: Expression, Literal(v, t)) =>
-      pushDownColName(e).map(sources.LessThan(_, convertToScala(v, t)))
-    case expressions.LessThan(Literal(v, t), e: Expression) =>
-      pushDownColName(e).map(sources.GreaterThan(_, convertToScala(v, t)))
+    case expressions.LessThan(PushDownCol(col), Literal(v, t)) =>
+      Some(sources.LessThan(col.name, convertToScala(v, t)))
+    case expressions.LessThan(Literal(v, t), PushDownCol(col)) =>
+      Some(sources.GreaterThan(col.name, convertToScala(v, t)))
 
-    case expressions.GreaterThanOrEqual(e: Expression, Literal(v, t)) =>
-      pushDownColName(e).map(sources.GreaterThanOrEqual(_, convertToScala(v, t)))
-    case expressions.GreaterThanOrEqual(Literal(v, t), e: Expression) =>
-      pushDownColName(e).map(sources.LessThanOrEqual(_, convertToScala(v, t)))
+    case expressions.GreaterThanOrEqual(PushDownCol(col), Literal(v, t)) =>
+      Some(sources.GreaterThanOrEqual(col.name, convertToScala(v, t)))
+    case expressions.GreaterThanOrEqual(Literal(v, t), PushDownCol(col)) =>
+      Some(sources.LessThanOrEqual(col.name, convertToScala(v, t)))
 
-    case expressions.LessThanOrEqual(e: Expression, Literal(v, t)) =>
-      pushDownColName(e).map(sources.LessThanOrEqual(_, convertToScala(v, t)))
-    case expressions.LessThanOrEqual(Literal(v, t), e: Expression) =>
-      pushDownColName(e).map(sources.GreaterThanOrEqual(_, convertToScala(v, t)))
+    case expressions.LessThanOrEqual(PushDownCol(col), Literal(v, t)) =>
+      Some(sources.LessThanOrEqual(col.name, convertToScala(v, t)))
+    case expressions.LessThanOrEqual(Literal(v, t), PushDownCol(col)) =>
+      Some(sources.GreaterThanOrEqual(col.name, convertToScala(v, t)))
 
-    case expressions.InSet(e: Expression, set) =>
-      pushDownColName(e).map {
-        val toScala = CatalystTypeConverters.createToScalaConverter(e.dataType)
-        sources.In(_, set.toArray.map(toScala))
-      }
+    case expressions.InSet(PushDownCol(col), set) =>
+      val b: PushDownCol = col
+      val toScala = CatalystTypeConverters.createToScalaConverter(col.dataType)
+      Some(sources.In(col.name, set.toArray.map(toScala)))
 
     // Because we only convert In to InSet in Optimizer when there are more than certain
     // items. So it is possible we still get an In expression here that needs to be pushed
     // down.
-    case expressions.In(e: Expression, list) if list.forall(_.isInstanceOf[Literal]) =>
-      pushDownColName(e).map {
-        val hSet = list.map(_.eval(EmptyRow))
-        val toScala = CatalystTypeConverters.createToScalaConverter(e.dataType)
-        sources.In(_, hSet.toArray.map(toScala))
-      }
+    case expressions.In(PushDownCol(col), list) if list.forall(_.isInstanceOf[Literal]) =>
+      val hSet = list.map(_.eval(EmptyRow))
+      val toScala = CatalystTypeConverters.createToScalaConverter(col.dataType)
+      Some(sources.In(col.name, hSet.toArray.map(toScala)))
 
-    case expressions.IsNull(e: Expression) =>
-      pushDownColName(e).map(sources.IsNull)
-    case expressions.IsNotNull(e: Expression) =>
-      pushDownColName(e).map(sources.IsNotNull)
-    case expressions.StartsWith(e: Expression, Literal(v: UTF8String, StringType)) =>
-      pushDownColName(e).map(sources.StringStartsWith(_, v.toString))
+    case expressions.IsNull(PushDownCol(col)) =>
+      Some(sources.IsNull(col.name))
+    case expressions.IsNotNull(PushDownCol(col)) =>
+      Some(sources.IsNotNull(col.name))
+    case expressions.StartsWith(PushDownCol(col), Literal(v: UTF8String, StringType)) =>
+      Some(sources.StringStartsWith(col.name, v.toString))
 
-    case expressions.EndsWith(e: Expression, Literal(v: UTF8String, StringType)) =>
-      pushDownColName(e).map(sources.StringEndsWith(_, v.toString))
+    case expressions.EndsWith(PushDownCol(col), Literal(v: UTF8String, StringType)) =>
+      Some(sources.StringEndsWith(col.name, v.toString))
 
-    case expressions.Contains(e: Expression, Literal(v: UTF8String, StringType)) =>
-      pushDownColName(e).map(sources.StringContains(_, v.toString))
+    case expressions.Contains(PushDownCol(col), Literal(v: UTF8String, StringType)) =>
+      Some(sources.StringContains(col.name, v.toString))
 
     case expressions.Literal(true, BooleanType) =>
       Some(sources.AlwaysTrue)
@@ -648,5 +634,20 @@ object DataSourceStrategy {
     } else {
       rdd.asInstanceOf[RDD[InternalRow]]
     }
+  }
+}
+
+case class PushDownCol(name: String, dataType: DataType)
+
+/**
+ * Find the column name of an expression that can be pushed down.
+ */
+object PushDownCol {
+  def unapply(e: Expression): Option[PushDownCol] = {
+    def helper(e: Expression) = e match {
+      case a: Attribute => Some(a.name)
+      case _ => None
+    }
+    helper(e).map(PushDownCol(_, e.dataType))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -636,12 +636,12 @@ object DataSourceStrategy {
   }
 }
 
-case class PushDownColumn(name: String, dataType: DataType)
-
 /**
  * Find the column name of an expression that can be pushed down.
  */
-object PushableColumn {
+private[sql] object PushableColumn {
+  case class PushDownColumn(name: String, dataType: DataType)
+
   def unapply(e: Expression): Option[PushDownColumn] = {
     def helper(e: Expression) = e match {
       case a: Attribute => Some(a.name)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
@@ -243,14 +243,14 @@ class DataSourceStrategySuite extends PlanTest with SharedSparkSession {
   test("SPARK-31027 test `PushDownCol.unapply` that finds the column name of " +
     "an expression that can be pushed down") {
     attrInts.foreach { case (attrInt, colName) =>
-      assert(PushDownCol.unapply(attrInt) === Some(PushDownCol(colName, IntegerType)))
+      assert(PushableColumn.unapply(attrInt) === Some(PushDownColumn(colName, IntegerType)))
     }
     attrStrs.foreach { case (attrStr, colName) =>
-      assert(PushDownCol.unapply(attrStr) === Some(PushDownCol(colName, StringType)))
+      assert(PushableColumn.unapply(attrStr) === Some(PushDownColumn(colName, StringType)))
     }
 
     // `Abs(col)` can not be pushed down, so it returns `None`
-    assert(PushDownCol.unapply(Abs('col.int)) === None)
+    assert(PushableColumn.unapply(Abs('col.int)) === None)
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
@@ -243,10 +243,12 @@ class DataSourceStrategySuite extends PlanTest with SharedSparkSession {
   test("SPARK-31027 test `PushDownCol.unapply` that finds the column name of " +
     "an expression that can be pushed down") {
     attrInts.foreach { case (attrInt, colName) =>
-      assert(PushableColumn.unapply(attrInt) === Some(PushDownColumn(colName, IntegerType)))
+      assert(PushableColumn.unapply(attrInt) ===
+        Some(PushableColumn.PushDownColumn(colName, IntegerType)))
     }
     attrStrs.foreach { case (attrStr, colName) =>
-      assert(PushableColumn.unapply(attrStr) === Some(PushDownColumn(colName, StringType)))
+      assert(PushableColumn.unapply(attrStr) ===
+        Some(PushableColumn.PushDownColumn(colName, StringType)))
     }
 
     // `Abs(col)` can not be pushed down, so it returns `None`

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
@@ -26,15 +26,15 @@ import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructT
 
 class DataSourceStrategySuite extends PlanTest with SharedSparkSession {
   val attrInts = Seq(
-    'cint.int,
+    'cint.int
   ).zip(Seq(
-    "cint",
+    "cint"
   ))
 
   val attrStrs = Seq(
-    'cstr.int,
+    'cstr.int
   ).zip(Seq(
-    "cstr",
+    "cstr"
   ))
 
   test("translate simple expression") { attrInts.zip(attrStrs)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
@@ -32,7 +32,7 @@ class DataSourceStrategySuite extends PlanTest with SharedSparkSession {
   ))
 
   val attrStrs = Seq(
-    'cstr.int
+    'cstr.string
   ).zip(Seq(
     "cstr"
   ))
@@ -240,17 +240,17 @@ class DataSourceStrategySuite extends PlanTest with SharedSparkSession {
     }
   }
 
-  test("SPARK-31027 test `DataSourceStrategy.pushDownColName` that finds the column name of " +
+  test("SPARK-31027 test `PushDownCol.unapply` that finds the column name of " +
     "an expression that can be pushed down") {
     attrInts.foreach { case (attrInt, colName) =>
-      assert(DataSourceStrategy.pushDownColName(attrInt) === Some(colName))
+      assert(PushDownCol.unapply(attrInt) === Some(PushDownCol(colName, IntegerType)))
     }
     attrStrs.foreach { case (attrStr, colName) =>
-      assert(DataSourceStrategy.pushDownColName(attrStr) === Some(colName))
+      assert(PushDownCol.unapply(attrStr) === Some(PushDownCol(colName, StringType)))
     }
 
     // `Abs(col)` can not be pushed down, so it returns `None`
-    assert(DataSourceStrategy.pushDownColName(Abs('col.int)) === None)
+    assert(PushDownCol.unapply(Abs('col.int)) === None)
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
@@ -243,12 +243,10 @@ class DataSourceStrategySuite extends PlanTest with SharedSparkSession {
   test("SPARK-31027 test `PushDownCol.unapply` that finds the column name of " +
     "an expression that can be pushed down") {
     attrInts.foreach { case (attrInt, colName) =>
-      assert(PushableColumn.unapply(attrInt) ===
-        Some(PushableColumn.PushDownColumn(colName, IntegerType)))
+      assert(PushableColumn.unapply(attrInt) === Some(colName))
     }
     attrStrs.foreach { case (attrStr, colName) =>
-      assert(PushableColumn.unapply(attrStr) ===
-        Some(PushableColumn.PushDownColumn(colName, StringType)))
+      assert(PushableColumn.unapply(attrStr) === Some(colName))
     }
 
     // `Abs(col)` can not be pushed down, so it returns `None`

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
@@ -22,68 +22,82 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.sources
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
 class DataSourceStrategySuite extends PlanTest with SharedSparkSession {
+  val attrInts = Seq(
+    'cint.int,
+  ).zip(Seq(
+    "cint",
+  ))
 
-  test("translate simple expression") {
-    val attrInt = 'cint.int
-    val attrStr = 'cstr.string
+  val attrStrs = Seq(
+    'cstr.int,
+  ).zip(Seq(
+    "cstr",
+  ))
 
-    testTranslateFilter(EqualTo(attrInt, 1), Some(sources.EqualTo("cint", 1)))
-    testTranslateFilter(EqualTo(1, attrInt), Some(sources.EqualTo("cint", 1)))
+  test("translate simple expression") { attrInts.zip(attrStrs)
+    .foreach { case ((attrInt, intColName), (attrStr, strColName)) =>
+
+    testTranslateFilter(EqualTo(attrInt, 1), Some(sources.EqualTo(intColName, 1)))
+    testTranslateFilter(EqualTo(1, attrInt), Some(sources.EqualTo(intColName, 1)))
 
     testTranslateFilter(EqualNullSafe(attrStr, Literal(null)),
-      Some(sources.EqualNullSafe("cstr", null)))
+      Some(sources.EqualNullSafe(strColName, null)))
     testTranslateFilter(EqualNullSafe(Literal(null), attrStr),
-      Some(sources.EqualNullSafe("cstr", null)))
+      Some(sources.EqualNullSafe(strColName, null)))
 
-    testTranslateFilter(GreaterThan(attrInt, 1), Some(sources.GreaterThan("cint", 1)))
-    testTranslateFilter(GreaterThan(1, attrInt), Some(sources.LessThan("cint", 1)))
+    testTranslateFilter(GreaterThan(attrInt, 1), Some(sources.GreaterThan(intColName, 1)))
+    testTranslateFilter(GreaterThan(1, attrInt), Some(sources.LessThan(intColName, 1)))
 
-    testTranslateFilter(LessThan(attrInt, 1), Some(sources.LessThan("cint", 1)))
-    testTranslateFilter(LessThan(1, attrInt), Some(sources.GreaterThan("cint", 1)))
+    testTranslateFilter(LessThan(attrInt, 1), Some(sources.LessThan(intColName, 1)))
+    testTranslateFilter(LessThan(1, attrInt), Some(sources.GreaterThan(intColName, 1)))
 
-    testTranslateFilter(GreaterThanOrEqual(attrInt, 1), Some(sources.GreaterThanOrEqual("cint", 1)))
-    testTranslateFilter(GreaterThanOrEqual(1, attrInt), Some(sources.LessThanOrEqual("cint", 1)))
+    testTranslateFilter(GreaterThanOrEqual(attrInt, 1),
+      Some(sources.GreaterThanOrEqual(intColName, 1)))
+    testTranslateFilter(GreaterThanOrEqual(1, attrInt),
+      Some(sources.LessThanOrEqual(intColName, 1)))
 
-    testTranslateFilter(LessThanOrEqual(attrInt, 1), Some(sources.LessThanOrEqual("cint", 1)))
-    testTranslateFilter(LessThanOrEqual(1, attrInt), Some(sources.GreaterThanOrEqual("cint", 1)))
+    testTranslateFilter(LessThanOrEqual(attrInt, 1),
+      Some(sources.LessThanOrEqual(intColName, 1)))
+    testTranslateFilter(LessThanOrEqual(1, attrInt),
+      Some(sources.GreaterThanOrEqual(intColName, 1)))
 
-    testTranslateFilter(InSet(attrInt, Set(1, 2, 3)), Some(sources.In("cint", Array(1, 2, 3))))
+    testTranslateFilter(InSet(attrInt, Set(1, 2, 3)), Some(sources.In(intColName, Array(1, 2, 3))))
 
-    testTranslateFilter(In(attrInt, Seq(1, 2, 3)), Some(sources.In("cint", Array(1, 2, 3))))
+    testTranslateFilter(In(attrInt, Seq(1, 2, 3)), Some(sources.In(intColName, Array(1, 2, 3))))
 
-    testTranslateFilter(IsNull(attrInt), Some(sources.IsNull("cint")))
-    testTranslateFilter(IsNotNull(attrInt), Some(sources.IsNotNull("cint")))
+    testTranslateFilter(IsNull(attrInt), Some(sources.IsNull(intColName)))
+    testTranslateFilter(IsNotNull(attrInt), Some(sources.IsNotNull(intColName)))
 
     // cint > 1 AND cint < 10
     testTranslateFilter(And(
       GreaterThan(attrInt, 1),
       LessThan(attrInt, 10)),
       Some(sources.And(
-        sources.GreaterThan("cint", 1),
-        sources.LessThan("cint", 10))))
+        sources.GreaterThan(intColName, 1),
+        sources.LessThan(intColName, 10))))
 
     // cint >= 8 OR cint <= 2
     testTranslateFilter(Or(
       GreaterThanOrEqual(attrInt, 8),
       LessThanOrEqual(attrInt, 2)),
       Some(sources.Or(
-        sources.GreaterThanOrEqual("cint", 8),
-        sources.LessThanOrEqual("cint", 2))))
+        sources.GreaterThanOrEqual(intColName, 8),
+        sources.LessThanOrEqual(intColName, 2))))
 
     testTranslateFilter(Not(GreaterThanOrEqual(attrInt, 8)),
-      Some(sources.Not(sources.GreaterThanOrEqual("cint", 8))))
+      Some(sources.Not(sources.GreaterThanOrEqual(intColName, 8))))
 
-    testTranslateFilter(StartsWith(attrStr, "a"), Some(sources.StringStartsWith("cstr", "a")))
+    testTranslateFilter(StartsWith(attrStr, "a"), Some(sources.StringStartsWith(strColName, "a")))
 
-    testTranslateFilter(EndsWith(attrStr, "a"), Some(sources.StringEndsWith("cstr", "a")))
+    testTranslateFilter(EndsWith(attrStr, "a"), Some(sources.StringEndsWith(strColName, "a")))
 
-    testTranslateFilter(Contains(attrStr, "a"), Some(sources.StringContains("cstr", "a")))
-  }
+    testTranslateFilter(Contains(attrStr, "a"), Some(sources.StringContains(strColName, "a")))
+  }}
 
-  test("translate complex expression") {
-    val attrInt = 'cint.int
+  test("translate complex expression") { attrInts.foreach { case (attrInt, intColName) =>
 
     // ABS(cint) - 2 <= 1
     testTranslateFilter(LessThanOrEqual(
@@ -102,11 +116,11 @@ class DataSourceStrategySuite extends PlanTest with SharedSparkSession {
         LessThan(attrInt, 100))),
       Some(sources.Or(
         sources.And(
-          sources.GreaterThan("cint", 1),
-          sources.LessThan("cint", 10)),
+          sources.GreaterThan(intColName, 1),
+          sources.LessThan(intColName, 10)),
         sources.And(
-          sources.GreaterThan("cint", 50),
-          sources.LessThan("cint", 100)))))
+          sources.GreaterThan(intColName, 50),
+          sources.LessThan(intColName, 100)))))
 
     // SPARK-22548 Incorrect nested AND expression pushed down to JDBC data source
     // (cint > 1 AND ABS(cint) < 10) OR (cint < 50 AND cint > 100)
@@ -142,11 +156,11 @@ class DataSourceStrategySuite extends PlanTest with SharedSparkSession {
         LessThan(attrInt, -10))),
       Some(sources.Or(
         sources.Or(
-          sources.EqualTo("cint", 1),
-          sources.EqualTo("cint", 10)),
+          sources.EqualTo(intColName, 1),
+          sources.EqualTo(intColName, 10)),
         sources.Or(
-          sources.GreaterThan("cint", 0),
-          sources.LessThan("cint", -10)))))
+          sources.GreaterThan(intColName, 0),
+          sources.LessThan(intColName, -10)))))
 
     // (cint = 1 OR ABS(cint) = 10) OR (cint > 0 OR cint < -10)
     testTranslateFilter(Or(
@@ -173,11 +187,11 @@ class DataSourceStrategySuite extends PlanTest with SharedSparkSession {
         IsNotNull(attrInt))),
       Some(sources.And(
         sources.And(
-          sources.GreaterThan("cint", 1),
-          sources.LessThan("cint", 10)),
+          sources.GreaterThan(intColName, 1),
+          sources.LessThan(intColName, 10)),
         sources.And(
-          sources.EqualTo("cint", 6),
-          sources.IsNotNull("cint")))))
+          sources.EqualTo(intColName, 6),
+          sources.IsNotNull(intColName)))))
 
     // (cint > 1 AND cint < 10) AND (ABS(cint) = 6 AND cint IS NOT NULL)
     testTranslateFilter(And(
@@ -201,11 +215,11 @@ class DataSourceStrategySuite extends PlanTest with SharedSparkSession {
         IsNotNull(attrInt))),
       Some(sources.And(
         sources.Or(
-          sources.GreaterThan("cint", 1),
-          sources.LessThan("cint", 10)),
+          sources.GreaterThan(intColName, 1),
+          sources.LessThan(intColName, 10)),
         sources.Or(
-          sources.EqualTo("cint", 6),
-          sources.IsNotNull("cint")))))
+          sources.EqualTo(intColName, 6),
+          sources.IsNotNull(intColName)))))
 
     // (cint > 1 OR cint < 10) AND (cint = 6 OR cint IS NOT NULL)
     testTranslateFilter(And(
@@ -217,13 +231,26 @@ class DataSourceStrategySuite extends PlanTest with SharedSparkSession {
         // Functions such as 'Abs' are not supported
         EqualTo(Abs(attrInt), 6),
         IsNotNull(attrInt))), None)
-  }
+  }}
 
   test("SPARK-26865 DataSourceV2Strategy should push normalized filters") {
     val attrInt = 'cint.int
     assertResult(Seq(IsNotNull(attrInt))) {
       DataSourceStrategy.normalizeExprs(Seq(IsNotNull(attrInt.withName("CiNt"))), Seq(attrInt))
     }
+  }
+
+  test("SPARK-31027 test `DataSourceStrategy.pushDownColName` that finds the column name of " +
+    "an expression that can be pushed down") {
+    attrInts.foreach { case (attrInt, colName) =>
+      assert(DataSourceStrategy.pushDownColName(attrInt) === Some(colName))
+    }
+    attrStrs.foreach { case (attrStr, colName) =>
+      assert(DataSourceStrategy.pushDownColName(attrStr) === Some(colName))
+    }
+
+    // `Abs(col)` can not be pushed down, so it returns `None`
+    assert(DataSourceStrategy.pushDownColName(Abs('col.int)) === None)
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
@@ -240,7 +240,7 @@ class DataSourceStrategySuite extends PlanTest with SharedSparkSession {
     }
   }
 
-  test("SPARK-31027 test `PushDownCol.unapply` that finds the column name of " +
+  test("SPARK-31027 test `PushableColumn.unapply` that finds the column name of " +
     "an expression that can be pushed down") {
     attrInts.foreach { case (attrInt, colName) =>
       assert(PushableColumn.unapply(attrInt) === Some(colName))


### PR DESCRIPTION
### What changes were proposed in this pull request?
Refactor `DataSourceStrategy.scala` and `DataSourceStrategySuite.scala` so it's more extendable to implement nested predicate pushdown.

### Why are the changes needed?
To support nested predicate pushdown.

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
Existing tests and new tests.