### PR TITLE
[SPARK-31049][SQL] Support nested adjacent generators, e.g., explode(explode(v))

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2243,6 +2243,8 @@ class Analyzer(
         child)
     }
 
+    // This method extracts all generators from given expressions and then returns a sequence of
+    // pairs (a found generator, the generator is outer or not).
     private def collectAdjacentGenerators(children: Seq[Expression]): Seq[(Generator, Boolean)] = {
       // We've already checked that all the `Generator` has unary nodes only
       // in `hasUnsupportedNestedGenerator`.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2372,7 +2372,7 @@ class Analyzer(
                   resolvedGenerator = null
                   Nil
                 }
-              } else if (generator.childrenResolved) {
+              } else if (generator.resolved) {
                 resolvedGenerator = createGenerate(generator, outer, names, child)
                 resolvedGenerator.generatorOutput
               } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2196,9 +2196,8 @@ class Analyzer(
             })
       }
       def hasUnsupportedInnerGenerator(g: Generator): Boolean = g match {
-        // This is the case where we can support nested inner generators;
-        // inner generators have single input/output and they are adjacent between each other,
-        // e.g., `explode(explode(array(array(1, 2), array(3))))`.
+        // This is the case where we can support nested inner generators; inner generators are unary
+        // and adjacent with single output, e.g., `explode(explode(array(array(1, 2), array(3))))`.
         case g if hasAdjacentInnerGenerators(g) => false
         case _ =>
           g.children.exists { _.find {
@@ -2282,7 +2281,7 @@ class Analyzer(
       case Project(projectList, _) if projectList.exists(hasUnsupportedNestedGenerator) =>
         val nestedGenerator = projectList.find(hasUnsupportedNestedGenerator).get
         throw new AnalysisException("Nested generators are supported only when inner generators " +
-          "have single input/output and they are adjacent between each other, but got: " +
+          "are unary and adjacent with single output, but got: " +
           toPrettySQL(trimAlias(nestedGenerator)))
 
       case Project(projectList, _) if projectList.count(hasGenerator) > 1 =>
@@ -2293,7 +2292,7 @@ class Analyzer(
       case Aggregate(_, aggList, _) if aggList.exists(hasUnsupportedNestedGenerator) =>
         val nestedGenerator = aggList.find(hasUnsupportedNestedGenerator).get
         throw new AnalysisException("Nested generators are supported only when inner generators " +
-          "have single input/output and they are adjacent between each other, but got: " +
+          "are unary and adjacent with single output, but got: " +
           toPrettySQL(trimAlias(nestedGenerator)))
 
       case Aggregate(_, aggList, _) if aggList.count(hasGenerator) > 1 =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -429,29 +429,31 @@ class AnalysisErrorSuite extends AnalysisTest {
   errorTest(
     "generator nested in expressions",
     listRelation.select(Explode($"list") + 1),
-    "Generators are not supported when it's nested in expressions, but got: (explode(list) + 1)"
-      :: Nil
+    "Nested generators are supported only when inner generators have single input/output and " +
+      "they are adjacent between each other, but got: (explode(list) + 1)" :: Nil
   )
 
   errorTest(
     "SPARK-30998: unsupported nested inner generators",
     listRelation.select(Stack(Explode($"list") :: Nil)),
-    "Generators are not supported when it's nested in expressions, but got: " +
-      "stack(explode(list))" :: Nil
+    "Nested generators are supported only when inner generators have single input/output and " +
+      "they are adjacent between each other, but got: stack(explode(list))" :: Nil
   )
 
   errorTest(
     "SPARK-30998: unsupported nested inner generators for aggregates",
     testRelation.select(Stack(Explode(
       CreateArray(CreateArray(min($"a") :: max($"a") :: Nil) :: Nil)) :: Nil)),
-    "Generators are not supported when it's nested in expressions, but got: " +
+    "Nested generators are supported only when inner generators have single input/output and " +
+      "they are adjacent between each other, but got: " +
       "stack(explode(array(array(min(a), max(a)))))" :: Nil
   )
 
   errorTest(
     "generator nested in expressions for aggregates",
     testRelation.select(Explode(CreateArray(min($"a") :: max($"a") :: Nil)) + 1),
-    "Generators are not supported when it's nested in expressions, but got: " +
+    "Nested generators are supported only when inner generators have single input/output and " +
+      "they are adjacent between each other, but got: " +
       "(explode(array(min(a), max(a))) + 1)" :: Nil
   )
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -435,21 +435,17 @@ class AnalysisErrorSuite extends AnalysisTest {
 
   errorTest(
     "SPARK-30998: unsupported nested inner generators",
-    {
-      val nestedListRelation = LocalRelation(
-        AttributeReference("nestedList", ArrayType(ArrayType(IntegerType)))())
-      nestedListRelation.select(Explode(Explode($"nestedList")))
-    },
+    listRelation.select(Stack(Explode($"list") :: Nil)),
     "Generators are not supported when it's nested in expressions, but got: " +
-      "explode(explode(nestedList))" :: Nil
+      "stack(explode(list))" :: Nil
   )
 
   errorTest(
     "SPARK-30998: unsupported nested inner generators for aggregates",
-    testRelation.select(Explode(Explode(
-      CreateArray(CreateArray(min($"a") :: max($"a") :: Nil) :: Nil)))),
+    testRelation.select(Stack(Explode(
+      CreateArray(CreateArray(min($"a") :: max($"a") :: Nil) :: Nil)) :: Nil)),
     "Generators are not supported when it's nested in expressions, but got: " +
-      "explode(explode(array(array(min(a), max(a)))))" :: Nil
+      "stack(explode(array(array(min(a), max(a)))))" :: Nil
   )
 
   errorTest(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -425,8 +425,7 @@ class AnalysisErrorSuite extends AnalysisTest {
       TimeWindow(Literal("2016-01-01 01:01:01"), "1 second", "0 second", "0 second").as("window")),
       "The slide duration" :: " must be greater than 0." :: Nil
   )
-"Nested generators are supported only when inner generators " +
-          "are unary and adjacent with single output, but got: "
+
   errorTest(
     "generator nested in expressions",
     listRelation.select(Explode($"list") + 1),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -425,36 +425,35 @@ class AnalysisErrorSuite extends AnalysisTest {
       TimeWindow(Literal("2016-01-01 01:01:01"), "1 second", "0 second", "0 second").as("window")),
       "The slide duration" :: " must be greater than 0." :: Nil
   )
-
+"Nested generators are supported only when inner generators " +
+          "are unary and adjacent with single output, but got: "
   errorTest(
     "generator nested in expressions",
     listRelation.select(Explode($"list") + 1),
-    "Nested generators are supported only when inner generators have single input/output and " +
-      "they are adjacent between each other, but got: (explode(list) + 1)" :: Nil
+    "Nested generators are supported only when inner generators are unary and adjacent " +
+      "with single output, but got: (explode(list) + 1)" :: Nil
   )
 
   errorTest(
     "SPARK-30998: unsupported nested inner generators",
     listRelation.select(Stack(Explode($"list") :: Nil)),
-    "Nested generators are supported only when inner generators have single input/output and " +
-      "they are adjacent between each other, but got: stack(explode(list))" :: Nil
+    "Nested generators are supported only when inner generators are unary and adjacent " +
+      "with single output, but got: stack(explode(list))" :: Nil
   )
 
   errorTest(
     "SPARK-30998: unsupported nested inner generators for aggregates",
     testRelation.select(Stack(Explode(
       CreateArray(CreateArray(min($"a") :: max($"a") :: Nil) :: Nil)) :: Nil)),
-    "Nested generators are supported only when inner generators have single input/output and " +
-      "they are adjacent between each other, but got: " +
-      "stack(explode(array(array(min(a), max(a)))))" :: Nil
+    "Nested generators are supported only when inner generators are unary and adjacent " +
+      "with single output, but got: stack(explode(array(array(min(a), max(a)))))" :: Nil
   )
 
   errorTest(
     "generator nested in expressions for aggregates",
     testRelation.select(Explode(CreateArray(min($"a") :: max($"a") :: Nil)) + 1),
-    "Nested generators are supported only when inner generators have single input/output and " +
-      "they are adjacent between each other, but got: " +
-      "(explode(array(min(a), max(a))) + 1)" :: Nil
+    "Nested generators are supported only when inner generators are unary and adjacent " +
+      "with single output, but got: (explode(array(min(a), max(a))) + 1)" :: Nil
   )
 
   errorTest(

--- a/sql/core/src/test/scala/org/apache/spark/sql/GeneratorFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/GeneratorFunctionSuite.scala
@@ -345,7 +345,7 @@ class GeneratorFunctionSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("Supported nested inner generators") {
+  test("SPARK-31049: Supported nested inner generators") {
     // Project cases
     checkAnswer(
       sql("SELECT explode(explode(array(array(1, 2), array(3))))"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/GeneratorFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/GeneratorFunctionSuite.scala
@@ -362,6 +362,15 @@ class GeneratorFunctionSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       sql("SELECT inline(explode(array(array(struct(1, 'a'), struct(2, 'b')))))"),
       Row(1, "a") :: Row(2, "b") :: Nil)
+    // More nested explodes
+    checkAnswer(
+      sql("SELECT explode(explode(explode(explode(array(array(array(array(1, 2), " +
+        "array(3, 4))))))))"),
+      Row(1) :: Row(2) :: Row(3) :: Row(4) :: Nil)
+    checkAnswer(
+      sql("SELECT array(array(array(array(0, 4), array(6)))) v")
+        .select(explode_outer(explode(explode_outer(explode($"v"))))),
+      Row(0) :: Row(4) :: Row(6) :: Nil)
 
     // Aggregate cases
     checkAnswer(
@@ -370,6 +379,15 @@ class GeneratorFunctionSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       sql("SELECT array(array(min(v), max(v))) ar FROM VALUES 7, 9 t(v)")
         .select(explode(explode_outer($"ar"))),
+      Row(7) :: Row(9) :: Nil)
+    // More nested explodes
+    checkAnswer(
+      sql("SELECT explode(explode(explode(explode(array(array(array(array(min(v), max(v))))))))) " +
+        "FROM VALUES 1, 2, 3 t(v)"),
+      Row(1) :: Row(3) :: Nil)
+    checkAnswer(
+      sql("SELECT array(array(array(array(min(v), max(v))))) ar FROM VALUES 7, 9 t(v)")
+        .select(explode(explode_outer(explode(explode_outer($"ar"))))),
       Row(7) :: Row(9) :: Nil)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/GeneratorFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/GeneratorFunctionSuite.scala
@@ -331,7 +331,7 @@ class GeneratorFunctionSuite extends QueryTest with SharedSparkSession {
         sql("select 1 + explode(array(min(c2), max(c2))) from t1 group by c1")
       }.getMessage
       assert(msg1.contains("Nested generators are supported only when inner generators " +
-        "have single input/output and they are adjacent between each other"))
+        "are unary and adjacent with single output"))
 
       val msg2 = intercept[AnalysisException] {
         sql(
@@ -375,7 +375,7 @@ class GeneratorFunctionSuite extends QueryTest with SharedSparkSession {
 
   test("SPARK-30998: Unsupported nested inner generators") {
     val expectedErrMsg = "Nested generators are supported only when inner generators " +
-      "have single input/output and they are adjacent between each other"
+      "are unary and adjacent with single output"
 
     // Multiple input generator (e.g., stack) case
     val errMsg1 = intercept[AnalysisException] {


### PR DESCRIPTION
### What changes were proposed in this pull request?

In the master, we currently don't support any nested generators, but I think supporting limited nested cases is somewhat useful for users, e.g., explode(explode(v)). This PR intends to add some logics in `ExtractGenerator` for supporting the nested generators as follows;

```scala
// before this PR
scala> sql("select explode(explode(array(array(1, 2), array(3))))").show()
org.apache.spark.sql.AnalysisException: Generators are not supported when it's nested in expressions, but got: explode(explode(array(array(1, 2), array(3))));

// after this PR
scala> sql("select explode(explode(array(array(1, 2), array(3))))").show()
+---+
|col|
+---+
|  1|
|  2|
|  3|
+---+
```

### Why are the changes needed?

I saw some usecases on the web where users expand nested arrays by a `unnest` function in potgresql and google big query;
```
postgres=# select unnest(ARRAY[ARRAY[1,2],ARRAY[3,4]]);
 unnest 
--------
      1
      2
      3
      4
(4 rows)
```
Based on this, IMO extending the existing `explode` for nested arrays seems helpful for users.
FYI: we already have the [jira](https://issues.apache.org/jira/browse/SPARK-28382) for implementing the unnest function, but we've closed the jira because of our policy as you know.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Added tests.
