### PR TITLE
[SPARK-31054][REPL] Turn on deprecation in Scala REPL/SparkShell by default

### DIFF
--- a/repl/src/main/scala/org/apache/spark/repl/Main.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/Main.scala
@@ -66,6 +66,7 @@ object Main extends Logging {
       .map { x => if (x.startsWith("file:")) new File(new URI(x)).getPath else x }
       .mkString(File.pathSeparator)
     val interpArguments = List(
+      "-deprecation",
       "-Yrepl-class-based",
       "-Yrepl-outdir", s"${outputDir.getAbsolutePath}",
       "-classpath", jars


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
In this PR, I propose to turn on `-deprecation` in SparkShell by default.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Without `-deprecation`, user can not know details(why we deprecate, any alternatives to use) of the deprecation API and they even don't know the warning is from which deprecated API.

Though, Scala REPL will tell user to use `:setting -deprecation` or `:replay -deprecation` to enable deprecation. But we can not guarantee that user know exactly how to use it and they may even not willing to do it. So, I think show the details of deprecation explicitly by ourself will give user a chance to learn Spark's deprecated API.

Besides, there's always a warning. So, why don't we choose the detail and useful one?



### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

Yes. When using a deprecate API,

Before:

```
import org.apache.spark.sql._
scala> Row.merge(Row(1,2,3), Row(4,5,6))
warning: there was one deprecation warning (since 3.0.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
res0: org.apache.spark.sql.Row = [1,2,3,4,5,6]
```

After:

```
import org.apache.spark.sql._
scala> Row.merge(Row(1,2,3), Row(4,5,6))
<console>:28: warning: method merge in object Row is deprecated (since 3.0.0): This method is deprecated and will be removed in future versions.
       Row.merge(Row(1,2,3), Row(4,5,6))
           ^
res0: org.apache.spark.sql.Row = [1,2,3,4,5,6]
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Tested manually.
