### PR TITLE
[SPARK-31061][SQL] Provide ability to alter the provider of a table

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -634,10 +634,15 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
         k.startsWith(DATASOURCE_PREFIX) || k.startsWith(STATISTICS_PREFIX) ||
           k.startsWith(CREATED_SPARK_VERSION)
       }
-      val newFormatIfExists = tableDefinition.provider.map(p => Map(DATASOURCE_PROVIDER -> p))
-        .getOrElse(Map.empty)
-      val newTableProps = propsFromOldTable ++ tableDefinition.properties ++
-        newFormatIfExists + partitionProviderProp
+      val newFormatIfExists = tableDefinition.provider.flatMap { p =>
+        if (DDLUtils.isDatasourceTable(tableDefinition)) {
+          Some(DATASOURCE_PROVIDER -> p)
+        } else {
+          None
+        }
+      }
+      val newTableProps =
+        propsFromOldTable ++ tableDefinition.properties + partitionProviderProp ++ newFormatIfExists
 
       // // Add old table's owner if we need to restore
       val owner = Option(tableDefinition.owner).filter(_.nonEmpty).getOrElse(oldTableDef.owner)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -634,7 +634,10 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
         k.startsWith(DATASOURCE_PREFIX) || k.startsWith(STATISTICS_PREFIX) ||
           k.startsWith(CREATED_SPARK_VERSION)
       }
-      val newTableProps = propsFromOldTable ++ tableDefinition.properties + partitionProviderProp
+      val newFormatIfExists = tableDefinition.provider.map(p => Map(DATASOURCE_PROVIDER -> p))
+        .getOrElse(Map.empty)
+      val newTableProps = propsFromOldTable ++ tableDefinition.properties ++
+        newFormatIfExists + partitionProviderProp
 
       // // Add old table's owner if we need to restore
       val owner = Option(tableDefinition.owner).filter(_.nonEmpty).getOrElse(oldTableDef.owner)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.hive
 
+import java.net.URI
+
 import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.SparkConf
@@ -184,17 +186,36 @@ class HiveExternalCatalogSuite extends ExternalCatalogSuite {
     val parquetTable = CatalogTable(
       identifier = TableIdentifier("parq_tbl", Some("db1")),
       tableType = CatalogTableType.MANAGED,
-      storage = storageFormat,
+      storage = storageFormat.copy(locationUri = Some(new URI("file:/some/path"))),
       schema = new StructType().add("col1", "int").add("col2", "string"),
       provider = Some("parquet"))
     catalog.createTable(parquetTable, ignoreIfExists = false)
 
-    val rawTable = externalCatalog.client.getTable("db1", "parq_tbl")
+    val rawTable = externalCatalog.getTable("db1", "parq_tbl")
     assert(rawTable.provider === Some("parquet"))
 
     val fooTable = parquetTable.copy(provider = Some("foo"))
     catalog.alterTable(fooTable)
-    val alteredTable = externalCatalog.client.getTable("db1", "parq_tbl")
+    val alteredTable = externalCatalog.getTable("db1", "parq_tbl")
+    assert(alteredTable.provider === Some("foo"))
+  }
+
+  test("SPARK-31061: alterTable should be able to change table provider from hive") {
+    val catalog = newBasicCatalog()
+    val parquetTable = CatalogTable(
+      identifier = TableIdentifier("parq_tbl", Some("db1")),
+      tableType = CatalogTableType.MANAGED,
+      storage = storageFormat,
+      schema = new StructType().add("col1", "int").add("col2", "string"),
+      provider = Some("hive"))
+    catalog.createTable(parquetTable, ignoreIfExists = false)
+
+    val rawTable = externalCatalog.getTable("db1", "parq_tbl")
+    assert(rawTable.provider === Some("hive"))
+
+    val fooTable = rawTable.copy(provider = Some("foo"))
+    catalog.alterTable(fooTable)
+    val alteredTable = externalCatalog.getTable("db1", "parq_tbl")
     assert(alteredTable.provider === Some("foo"))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds functionality to HiveExternalCatalog to be able to change the provider of a table. 
### Why are the changes needed?

This is useful for catalogs in Spark 3.0 to be able to use alterTable to change the provider of a table as part of an atomic REPLACE TABLE function.

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

Unit tests