### PR TITLE
[SPARK-31045][SQL][FOLLOWUP][3.0] Fix build due to divergence between master and 3.0

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -382,7 +382,6 @@ object SQLConf {
     .internal()
     .doc("Configures the log level for adaptive execution logging of plan changes. The value " +
       "can be 'trace', 'debug', 'info', 'warn', or 'error'. The default log level is 'debug'.")
-    .version("3.0.0")
     .stringConf
     .transform(_.toUpperCase(Locale.ROOT))
     .checkValues(Set("TRACE", "DEBUG", "INFO", "WARN", "ERROR"))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This patch fixes the build failure in `branch-3.0` due to cherry-picking SPARK-31045 to branch-3.0, as `.version()` is not available in `branch-3.0` yet.

### Why are the changes needed?

The build is failing in `branch-3.0`.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Jenkins build will verify.