### PR TITLE
[SPARK-31069][CORE] high cpu caused by chunksBeingTransferred in external shuffle service

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/server/OneForOneStreamManager.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/OneForOneStreamManager.java
@@ -43,6 +43,7 @@ public class OneForOneStreamManager extends StreamManager {
 
   private final AtomicLong nextStreamId;
   private final ConcurrentHashMap<Long, StreamState> streams;
+  private final AtomicLong totalChunksBeingTransferred = new AtomicLong(0);
 
   /** State of a single stream. */
   private static class StreamState {
@@ -124,6 +125,7 @@ public class OneForOneStreamManager extends StreamManager {
       StreamState state = entry.getValue();
       if (state.associatedChannel == channel) {
         streams.remove(entry.getKey());
+        totalChunksBeingTransferred.addAndGet((-state.chunksBeingTransferred.get()));
 
         try {
           // Release all remaining buffers.
@@ -168,6 +170,7 @@ public class OneForOneStreamManager extends StreamManager {
     StreamState streamState = streams.get(streamId);
     if (streamState != null) {
       streamState.chunksBeingTransferred.incrementAndGet();
+      totalChunksBeingTransferred.incrementAndGet();
     }
 
   }
@@ -182,6 +185,7 @@ public class OneForOneStreamManager extends StreamManager {
     StreamState streamState = streams.get(streamId);
     if (streamState != null) {
       streamState.chunksBeingTransferred.decrementAndGet();
+      totalChunksBeingTransferred.decrementAndGet();
     }
   }
 
@@ -192,11 +196,7 @@ public class OneForOneStreamManager extends StreamManager {
 
   @Override
   public long chunksBeingTransferred() {
-    long sum = 0L;
-    for (StreamState streamState: streams.values()) {
-      sum += streamState.chunksBeingTransferred.get();
-    }
-    return sum;
+    return totalChunksBeingTransferred.get();
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
This change is targeted to speed up the calculation of chunksBeingTransferred to avoid high cpu when there are many stream requests.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
