### PR TITLE
[SPARK-31075] Add documentation for ALTER TABLE ... ADD PARTITION

### DIFF
--- a/docs/sql-ref-syntax-ddl-alter-table.md
+++ b/docs/sql-ref-syntax-ddl-alter-table.md
@@ -83,6 +83,37 @@ ALTER TABLE table_identifier ADD COLUMNS ( col_spec [ , col_spec ... ] )
 </dl>
 
 
+### ADD PARTITION
+
+`ALTER TABLE ADD PARTITION` adds a new partition to an existing, partitioned table.
+
+#### Syntax
+
+```sql
+ALTER TABLE <table_identifier> ADD [IF NOT EXISTS]
+  PARTITION <partition_spec> [LOCATION 'location']
+  [ PARTITION <partition_spec> [LOCATION 'location'] ...]
+;
+
+<table_identifier> ::=
+  [ database_name. ]table_name
+
+<partition_spec> ::=
+  (partition_column = partition_col_value, partition_column = partition_col_value, ...)
+```
+
+#### Examples
+
+```sql
+ALTER TABLE orders ADD PARTITION (date='2020-03-10');
+ALTER TABLE orders ADD PARTITION (date='2020-03-10') LOCATION 'data/orders/2020-03-10/';
+ALTER TABLE orders ADD
+  PARTITION (date='2020-03-11')
+  PARTITION (date='2020-03-12')
+  PARTITION (date='2020-03-13')
+;
+```
+
 ### SET AND UNSET
 
 #### SET TABLE PROPERTIES


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds documentation for `ALTER TABLE ... ADD PARTITION`.

Here's a screenshot:

![Screen Shot 2020-03-06 at 7 43 59 PM](https://user-images.githubusercontent.com/1039369/76132822-e1935c00-5fe2-11ea-9962-0cbfe3fbfd42.png)

### Why are the changes needed?

Every bit of major Spark SQL syntax should be documented so users know that it's there and how to use it.

### Does this PR introduce any user-facing change?

Yes, documentation only.

### How was this patch tested?

Built and reviewed the docs locally.