### PR TITLE
[SPARK-31071][SQL] Allow annotating non-null fields when encoding Java Beans

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SerializerBuildHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SerializerBuildHelper.scala
@@ -187,8 +187,12 @@ object SerializerBuildHelper {
     val nonNullOutput = CreateNamedStruct(fields.flatMap { case(fieldName, fieldExpr) =>
       argumentsForFieldSerializer(fieldName, fieldExpr)
     })
-    val nullOutput = expressions.Literal.create(null, nonNullOutput.dataType)
-    expressions.If(IsNull(inputObject), nullOutput, nonNullOutput)
+    if (inputObject.nullable) {
+      val nullOutput = expressions.Literal.create(null, nonNullOutput.dataType)
+      expressions.If(IsNull(inputObject), nullOutput, nonNullOutput)
+    } else {
+      nonNullOutput
+    }
   }
 
   def createSerializerForUserDefinedType(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoder.scala
@@ -203,6 +203,7 @@ case class ExpressionEncoder[T](
       }
       nullSafeSerializer match {
         case If(_: IsNull, _, s: CreateNamedStruct) => s
+        case s: CreateNamedStruct => s
         case _ =>
           throw new RuntimeException(s"class $clsName has unexpected serializer: $objSerializer")
       }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
@@ -24,6 +24,7 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.*;
+import javax.annotation.Nonnull;
 
 import org.apache.spark.sql.streaming.GroupStateTimeout;
 import org.apache.spark.sql.streaming.OutputMode;
@@ -823,6 +824,75 @@ public class JavaDatasetSuite implements Serializable {
     }
   }
 
+  public static class NestedSmallBeanWithNonNullField implements Serializable {
+    private SmallBean nonNull_f;
+    private SmallBean nullable_f;
+    private Map<String, SmallBean> childMap;
+
+    @Nonnull
+    public SmallBean getNonNull_f() {
+      return nonNull_f;
+    }
+
+    public void setNonNull_f(SmallBean f) {
+      this.nonNull_f = f;
+    }
+
+    public SmallBean getNullable_f() {
+      return nullable_f;
+    }
+
+    public void setNullable_f(SmallBean f) {
+      this.nullable_f = f;
+    }
+
+    @Nonnull
+    public Map<String, SmallBean> getChildMap() { return childMap; }
+    public void setChildMap(Map<String, SmallBean> childMap) {
+      this.childMap = childMap;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      NestedSmallBeanWithNonNullField that = (NestedSmallBeanWithNonNullField) o;
+      return Objects.equal(nullable_f, that.nullable_f) &&
+        Objects.equal(nonNull_f, that.nonNull_f) && Objects.equal(childMap, that.childMap);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(nullable_f, nonNull_f, childMap);
+    }
+  }
+
+  public static class NestedSmallBean2 implements Serializable {
+    private NestedSmallBeanWithNonNullField f;
+
+    @Nonnull
+    public NestedSmallBeanWithNonNullField getF() {
+      return f;
+    }
+
+    public void setF(NestedSmallBeanWithNonNullField f) {
+      this.f = f;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      NestedSmallBean2 that = (NestedSmallBean2) o;
+      return Objects.equal(f, that.f);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(f);
+    }
+  }
+
   @Rule
   public transient ExpectedException nullabilityCheck = ExpectedException.none();
 
@@ -1502,6 +1572,54 @@ public class JavaDatasetSuite implements Serializable {
     Dataset<NestedSmallBean> ds2 =
       ds1.map((MapFunction<NestedSmallBean, NestedSmallBean>) b -> b, encoder);
     Assert.assertEquals(beans, ds2.collectAsList());
+  }
+
+  @Test
+  public void testNonNullField() {
+    NestedSmallBeanWithNonNullField bean1 = new NestedSmallBeanWithNonNullField();
+    SmallBean smallBean = new SmallBean();
+    bean1.setNonNull_f(smallBean);
+    Map<String, SmallBean> map = new HashMap<>();
+    bean1.setChildMap(map);
+
+    Encoder<NestedSmallBeanWithNonNullField> encoder1 =
+            Encoders.bean(NestedSmallBeanWithNonNullField.class);
+    List<NestedSmallBeanWithNonNullField> beans1 = Arrays.asList(bean1);
+    Dataset<NestedSmallBeanWithNonNullField> ds1 = spark.createDataset(beans1, encoder1);
+
+    StructType schema = ds1.schema();
+    Assert.assertFalse(schema.fields()[schema.fieldIndex("nonNull_f")].nullable());
+    Assert.assertTrue(schema.fields()[schema.fieldIndex("nullable_f")].nullable());
+    Assert.assertFalse(schema.fields()[schema.fieldIndex("childMap")].nullable());
+
+    Assert.assertEquals(beans1, ds1.collectAsList());
+    Dataset<NestedSmallBeanWithNonNullField> ds2 = ds1.map(
+      (MapFunction<NestedSmallBeanWithNonNullField, NestedSmallBeanWithNonNullField>) b -> b,
+      encoder1);
+    Assert.assertEquals(beans1, ds2.collectAsList());
+
+    // Nonnull nested fields
+    NestedSmallBean2 bean2 = new NestedSmallBean2();
+    bean2.setF(bean1);
+
+    Encoder<NestedSmallBean2> encoder2 =
+            Encoders.bean(NestedSmallBean2.class);
+    List<NestedSmallBean2> beans2 = Arrays.asList(bean2);
+    Dataset<NestedSmallBean2> ds3 = spark.createDataset(beans2, encoder2);
+
+    StructType nestedSchema = (StructType) ds3.schema()
+      .fields()[ds3.schema().fieldIndex("f")]
+      .dataType();
+    Assert.assertFalse(nestedSchema.fields()[nestedSchema.fieldIndex("nonNull_f")].nullable());
+    Assert.assertTrue(nestedSchema.fields()[nestedSchema.fieldIndex("nullable_f")].nullable());
+    Assert.assertFalse(nestedSchema.fields()[nestedSchema.fieldIndex("childMap")].nullable());
+
+    Assert.assertEquals(beans2, ds3.collectAsList());
+
+    Dataset<NestedSmallBean2> ds4 = ds3.map(
+      (MapFunction<NestedSmallBean2, NestedSmallBean2>) b -> b,
+      encoder2);
+    Assert.assertEquals(beans2, ds4.collectAsList());
   }
 
   @Test

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
@@ -1588,9 +1588,9 @@ public class JavaDatasetSuite implements Serializable {
     Dataset<NestedSmallBeanWithNonNullField> ds1 = spark.createDataset(beans1, encoder1);
 
     StructType schema = ds1.schema();
-    Assert.assertFalse(schema.fields()[schema.fieldIndex("nonNull_f")].nullable());
-    Assert.assertTrue(schema.fields()[schema.fieldIndex("nullable_f")].nullable());
-    Assert.assertFalse(schema.fields()[schema.fieldIndex("childMap")].nullable());
+    Assert.assertFalse(schema.apply("nonNull_f").nullable());
+    Assert.assertTrue(schema.apply("nullable_f").nullable());
+    Assert.assertFalse(schema.apply("childMap").nullable());
 
     Assert.assertEquals(beans1, ds1.collectAsList());
     Dataset<NestedSmallBeanWithNonNullField> ds2 = ds1.map(
@@ -1610,9 +1610,9 @@ public class JavaDatasetSuite implements Serializable {
     StructType nestedSchema = (StructType) ds3.schema()
       .fields()[ds3.schema().fieldIndex("f")]
       .dataType();
-    Assert.assertFalse(nestedSchema.fields()[nestedSchema.fieldIndex("nonNull_f")].nullable());
-    Assert.assertTrue(nestedSchema.fields()[nestedSchema.fieldIndex("nullable_f")].nullable());
-    Assert.assertFalse(nestedSchema.fields()[nestedSchema.fieldIndex("childMap")].nullable());
+    Assert.assertFalse(nestedSchema.apply("nonNull_f").nullable());
+    Assert.assertTrue(nestedSchema.apply("nullable_f").nullable());
+    Assert.assertFalse(nestedSchema.apply("childMap").nullable());
 
     Assert.assertEquals(beans2, ds3.collectAsList());
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

When encoding Java Beans to Spark DataFrame, respecting `javax.annotation.Nonnull` and producing non-null fields.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

When encoding Java Beans to Spark DataFrame, non-primitive types are encoded as nullable fields. Although It works for most cases, it can be an issue under a few situations, e.g. the one described in the JIRA ticket when saving DataFrame to Avro format with non-null field.

We should allow Spark users more flexibility when creating Spark DataFrame from Java Beans. Currently, Spark users cannot create DataFrame with non-nullable fields in the schema from beans with non-nullable properties.

Although it is possible to project top-level columns with SQL expressions like `AssertNotNull` to make it non-null, for nested fields it is more tricky to do it similarly.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

Yes. After this change, Spark users can use `javax.annotation.Nonnull` to annotate non-null fields in Java Beans when encoding beans to Spark DataFrame.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Added unit test.
