### PR TITLE
[SPARK-31107][CORE]Extend FairScheduler to support pool level resource isolation

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/Pool.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Pool.scala
@@ -51,7 +51,7 @@ private[spark] class Pool(
   val name = poolName
   var parent: Pool = null
 
-  // A map that keeps the number of slots for each binded executor.
+  // A map that keeps the number of slots for each bound executor.
   val boundExecutors = new ConcurrentHashMap[String, Int]()
 
   private val taskSetSchedulingAlgorithm: SchedulingAlgorithm = {

--- a/core/src/main/scala/org/apache/spark/scheduler/Schedulable.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Schedulable.scala
@@ -34,6 +34,7 @@ private[spark] trait Schedulable {
   def schedulingMode: SchedulingMode
   def weight: Int
   def minShare: Int
+  def maxShare: Int
   def runningTasks: Int
   def priority: Int
   def stageId: Int

--- a/core/src/main/scala/org/apache/spark/scheduler/SchedulableBuilder.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SchedulableBuilder.scala
@@ -113,8 +113,9 @@ private[spark] class FairSchedulableBuilder(val rootPool: Pool, conf: SparkConf)
       val pool = new Pool(DEFAULT_POOL_NAME, DEFAULT_SCHEDULING_MODE,
         DEFAULT_MINIMUM_SHARE, DEFAULT_MAXIMUM_SHARE, DEFAULT_WEIGHT)
       rootPool.addSchedulable(pool)
-      logInfo("Created default pool: %s, schedulingMode: %s, minShare: %d, weight: %d".format(
-        DEFAULT_POOL_NAME, DEFAULT_SCHEDULING_MODE, DEFAULT_MINIMUM_SHARE, DEFAULT_WEIGHT))
+      logInfo(("Created default pool: %s, schedulingMode: %s, minShare: %d, maxShare: %d, " +
+        "weight: %d").format(DEFAULT_POOL_NAME, DEFAULT_SCHEDULING_MODE,
+        DEFAULT_MINIMUM_SHARE, DEFAULT_MAXIMUM_SHARE, DEFAULT_WEIGHT))
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -111,6 +111,7 @@ private[spark] class TaskSetManager(
 
   val weight = 1
   val minShare = 0
+  val maxShare = Int.MaxValue
   var priority = taskSet.priority
   var stageId = taskSet.stageId
   val name = "TaskSet_" + taskSet.id
@@ -924,7 +925,7 @@ private[spark] class TaskSetManager(
   }
 
   def canScheduleOn(executorId: String): Boolean = {
-    parent.bindedExecutors.contains(executorId)
+    parent.boundExecutors.contains(executorId)
   }
 
   override def getSchedulableByName(name: String): Schedulable = {

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -925,7 +925,7 @@ private[spark] class TaskSetManager(
   }
 
   def canScheduleOn(executorId: String): Boolean = {
-    parent.boundExecutors.contains(executorId)
+    parent.boundExecutors.containsKey(executorId)
   }
 
   override def getSchedulableByName(name: String): Schedulable = {

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -923,6 +923,10 @@ private[spark] class TaskSetManager(
     }
   }
 
+  def canScheduleOn(executorId: String): Boolean = {
+    parent.assignedExecutorIds.contains(executorId)
+  }
+
   override def getSchedulableByName(name: String): Schedulable = {
     null
   }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -924,7 +924,7 @@ private[spark] class TaskSetManager(
   }
 
   def canScheduleOn(executorId: String): Boolean = {
-    parent.assignedExecutorIds.contains(executorId)
+    parent.bindedExecutors.contains(executorId)
   }
 
   override def getSchedulableByName(name: String): Schedulable = {

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -389,7 +389,6 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
           }
           totalCoreCount.addAndGet(-executorInfo.totalCores)
           totalRegisteredExecutors.addAndGet(-1)
-          scheduler.rootPool.unbindExecutor(executorId)
           scheduler.executorLost(executorId, if (killed) ExecutorKilled else reason)
           listenerBus.post(
             SparkListenerExecutorRemoved(System.currentTimeMillis(), executorId, reason.toString))

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -389,6 +389,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
           }
           totalCoreCount.addAndGet(-executorInfo.totalCores)
           totalRegisteredExecutors.addAndGet(-1)
+          scheduler.rootPool.unbindExecutor(executorId)
           scheduler.executorLost(executorId, if (killed) ExecutorKilled else reason)
           listenerBus.post(
             SparkListenerExecutorRemoved(System.currentTimeMillis(), executorId, reason.toString))

--- a/core/src/main/scala/org/apache/spark/ui/jobs/PoolTable.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/PoolTable.scala
@@ -21,9 +21,10 @@ import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import javax.servlet.http.HttpServletRequest
 
+import scala.collection.JavaConverters._
 import scala.xml.Node
 
-import org.apache.spark.scheduler.Schedulable
+import org.apache.spark.scheduler.{Pool, Schedulable}
 import org.apache.spark.status.PoolData
 import org.apache.spark.ui.UIUtils
 
@@ -39,9 +40,15 @@ private[ui] class PoolTable(pools: Map[Schedulable, PoolData], parent: StagesTab
            cores">Minimum Share</span>
         </th>
         <th>
+          <span data-toggle="tooltip" data-placement="top" title="Pool's maximum share of CPU
+          cores">Maximum Share</span>
+        </th>
+        <th>
           <span data-toggle="tooltip" data-placement="top" title="Pool's share of cluster resources
            relative to others">Pool Weight</span>
         </th>
+        <th>Bound executors</th>
+        <th>Slots</th>
         <th>Active Stages</th>
         <th>Running Tasks</th>
         <th>Scheduling Mode</th>
@@ -57,12 +64,18 @@ private[ui] class PoolTable(pools: Map[Schedulable, PoolData], parent: StagesTab
     val href = "%s/stages/pool?poolname=%s"
       .format(UIUtils.prependBaseUri(request, parent.basePath),
         URLEncoder.encode(p.name, StandardCharsets.UTF_8.name()))
+    val pool = s.asInstanceOf[Pool]
+    val numBoundExecutors = pool.boundExecutors.size()
+    val numSlots = pool.boundExecutors.asScala.values.sum
     <tr>
       <td>
         <a href={href}>{p.name}</a>
       </td>
       <td>{s.minShare}</td>
+      <td>{s.maxShare}</td>
       <td>{s.weight}</td>
+      <td>{numBoundExecutors}</td>
+      <td>{numSlots}</td>
       <td>{activeStages}</td>
       <td>{s.runningTasks}</td>
       <td>{s.schedulingMode}</td>

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -138,7 +138,7 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
 
   val taskScheduler = new TaskScheduler() {
     override def schedulingMode: SchedulingMode = SchedulingMode.FIFO
-    override def rootPool: Pool = new Pool("", schedulingMode, 0, 0)
+    override def rootPool: Pool = new Pool("", schedulingMode, 0, Int.MaxValue, 0)
     override def start() = {}
     override def stop() = {}
     override def executorHeartbeatReceived(
@@ -681,7 +681,7 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     // doesn't implement killTask()
     val noKillTaskScheduler = new TaskScheduler() {
       override def schedulingMode: SchedulingMode = SchedulingMode.FIFO
-      override def rootPool: Pool = new Pool("", schedulingMode, 0, 0)
+      override def rootPool: Pool = new Pool("", schedulingMode, 0, Int.MaxValue, 0)
       override def start(): Unit = {}
       override def stop(): Unit = {}
       override def submitTasks(taskSet: TaskSet): Unit = {

--- a/core/src/test/scala/org/apache/spark/scheduler/ExternalClusterManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/ExternalClusterManagerSuite.scala
@@ -77,7 +77,7 @@ private class DummySchedulerBackend extends SchedulerBackend {
 private class DummyTaskScheduler extends TaskScheduler {
   var initialized = false
   override def schedulingMode: SchedulingMode = SchedulingMode.FIFO
-  override def rootPool: Pool = new Pool("", schedulingMode, 0, 0)
+  override def rootPool: Pool = new Pool("", schedulingMode, 0, Int.MaxValue, 0)
   override def start(): Unit = {}
   override def stop(): Unit = {}
   override def submitTasks(taskSet: TaskSet): Unit = {}

--- a/core/src/test/scala/org/apache/spark/scheduler/PoolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/PoolSuite.scala
@@ -55,7 +55,7 @@ class PoolSuite extends SparkFunSuite with LocalSparkContext {
     sc = new SparkContext(LOCAL, APP_NAME)
     val taskScheduler = new TaskSchedulerImpl(sc)
 
-    val rootPool = new Pool("", FIFO, 0, 0)
+    val rootPool = new Pool("", FIFO, 0, Int.MaxValue, 0)
     val schedulableBuilder = new FIFOSchedulableBuilder(rootPool)
 
     val taskSetManager0 = createTaskSetManager(0, 2, taskScheduler)
@@ -84,7 +84,7 @@ class PoolSuite extends SparkFunSuite with LocalSparkContext {
     sc = new SparkContext(LOCAL, APP_NAME, conf)
     val taskScheduler = new TaskSchedulerImpl(sc)
 
-    val rootPool = new Pool("", FAIR, 0, 0)
+    val rootPool = new Pool("", FAIR, 0, Int.MaxValue, 0)
     val schedulableBuilder = new FairSchedulableBuilder(rootPool, sc.conf)
     schedulableBuilder.buildPools()
 
@@ -137,19 +137,19 @@ class PoolSuite extends SparkFunSuite with LocalSparkContext {
     sc = new SparkContext(LOCAL, APP_NAME)
     val taskScheduler = new TaskSchedulerImpl(sc)
 
-    val rootPool = new Pool("", FAIR, 0, 0)
-    val pool0 = new Pool("0", FAIR, 3, 1)
-    val pool1 = new Pool("1", FAIR, 4, 1)
+    val rootPool = new Pool("", FAIR, 0, Int.MaxValue, 0)
+    val pool0 = new Pool("0", FAIR, 3, Int.MaxValue, 1)
+    val pool1 = new Pool("1", FAIR, 4, Int.MaxValue, 1)
     rootPool.addSchedulable(pool0)
     rootPool.addSchedulable(pool1)
 
-    val pool00 = new Pool("00", FAIR, 2, 2)
-    val pool01 = new Pool("01", FAIR, 1, 1)
+    val pool00 = new Pool("00", FAIR, 2, Int.MaxValue, 2)
+    val pool01 = new Pool("01", FAIR, 1, Int.MaxValue, 1)
     pool0.addSchedulable(pool00)
     pool0.addSchedulable(pool01)
 
-    val pool10 = new Pool("10", FAIR, 2, 2)
-    val pool11 = new Pool("11", FAIR, 2, 1)
+    val pool10 = new Pool("10", FAIR, 2, Int.MaxValue, 2)
+    val pool11 = new Pool("11", FAIR, 2, Int.MaxValue, 1)
     pool1.addSchedulable(pool10)
     pool1.addSchedulable(pool11)
 
@@ -184,7 +184,7 @@ class PoolSuite extends SparkFunSuite with LocalSparkContext {
       .getFile()
     val conf = new SparkConf().set(SCHEDULER_ALLOCATION_FILE, xmlPath)
 
-    val rootPool = new Pool("", FAIR, 0, 0)
+    val rootPool = new Pool("", FAIR, 0, Int.MaxValue, 0)
     val schedulableBuilder = new FairSchedulableBuilder(rootPool, conf)
     schedulableBuilder.buildPools()
 
@@ -211,7 +211,8 @@ class PoolSuite extends SparkFunSuite with LocalSparkContext {
     sc = new SparkContext("local", "PoolSuite")
     val taskScheduler = new TaskSchedulerImpl(sc)
 
-    val rootPool = new Pool("", SchedulingMode.FIFO, initMinShare = 0, initWeight = 0)
+    val rootPool = new Pool("", SchedulingMode.FIFO, initMinShare = 0,
+      initMaxShare = Int.MaxValue, initWeight = 0)
     val schedulableBuilder = new FIFOSchedulableBuilder(rootPool)
 
     val taskSetManager0 = createTaskSetManager(stageId = 0, numTasks = 1, taskScheduler)
@@ -236,7 +237,8 @@ class PoolSuite extends SparkFunSuite with LocalSparkContext {
     sc = new SparkContext("local", "PoolSuite")
     val taskScheduler = new TaskSchedulerImpl(sc)
 
-    val rootPool = new Pool("", SchedulingMode.FAIR, initMinShare = 0, initWeight = 0)
+    val rootPool = new Pool("", SchedulingMode.FAIR, initMinShare = 0,
+      initMaxShare = Int.MaxValue, initWeight = 0)
     val schedulableBuilder = new FairSchedulableBuilder(rootPool, sc.conf)
     schedulableBuilder.buildPools()
 
@@ -264,7 +266,8 @@ class PoolSuite extends SparkFunSuite with LocalSparkContext {
     sc = new SparkContext("local", "PoolSuite")
     val taskScheduler = new TaskSchedulerImpl(sc)
 
-    val rootPool = new Pool("", SchedulingMode.FAIR, initMinShare = 0, initWeight = 0)
+    val rootPool = new Pool("", SchedulingMode.FAIR, initMinShare = 0,
+      initMaxShare = Int.MaxValue, initWeight = 0)
     val schedulableBuilder = new FairSchedulableBuilder(rootPool, sc.conf)
     schedulableBuilder.buildPools()
 
@@ -289,7 +292,7 @@ class PoolSuite extends SparkFunSuite with LocalSparkContext {
 
   test("Pool should throw IllegalArgumentException when schedulingMode is not supported") {
     intercept[IllegalArgumentException] {
-      new Pool("TestPool", SchedulingMode.NONE, 0, 1)
+      new Pool("TestPool", SchedulingMode.NONE, 0, Int.MaxValue, 1)
     }
   }
 
@@ -299,7 +302,7 @@ class PoolSuite extends SparkFunSuite with LocalSparkContext {
     val conf = new SparkConf().set(SCHEDULER_ALLOCATION_FILE, xmlPath)
     sc = new SparkContext(LOCAL, APP_NAME, conf)
 
-    val rootPool = new Pool("", SchedulingMode.FAIR, 0, 0)
+    val rootPool = new Pool("", SchedulingMode.FAIR, 0, Int.MaxValue, 0)
     val schedulableBuilder = new FairSchedulableBuilder(rootPool, sc.conf)
     schedulableBuilder.buildPools()
 
@@ -314,7 +317,7 @@ class PoolSuite extends SparkFunSuite with LocalSparkContext {
     val conf = new SparkConf()
     sc = new SparkContext(LOCAL, APP_NAME, conf)
 
-    val rootPool = new Pool("", SchedulingMode.FAIR, 0, 0)
+    val rootPool = new Pool("", SchedulingMode.FAIR, 0, Int.MaxValue, 0)
     val schedulableBuilder = new FairSchedulableBuilder(rootPool, sc.conf)
     schedulableBuilder.buildPools()
 
@@ -329,7 +332,7 @@ class PoolSuite extends SparkFunSuite with LocalSparkContext {
     val conf = new SparkConf().set(SCHEDULER_ALLOCATION_FILE, "INVALID_FILE_PATH")
     sc = new SparkContext(LOCAL, APP_NAME, conf)
 
-    val rootPool = new Pool("", SchedulingMode.FAIR, 0, 0)
+    val rootPool = new Pool("", SchedulingMode.FAIR, 0, Int.MaxValue, 0)
     val schedulableBuilder = new FairSchedulableBuilder(rootPool, sc.conf)
     intercept[FileNotFoundException] {
       schedulableBuilder.buildPools()


### PR DESCRIPTION


### What changes were proposed in this pull request?
Currently, spark only provided two types of scheduler: FIFO & FAIR, but in sql high-concurrency scenarios, a few of drawbacks are exposed.

FIFO: it can easily causing congestion when large sql query occupies all the resources

FAIR: the taskSets of one pool may occupies all the resource due to there are no hard limit on the maximum usage for each pool. this case may be frequently met under high workloads.

So we propose to add a maxShare argument for FairScheduler to control the maximum running tasks for each pool.


### Why are the changes needed?
Improvements


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
existing UT
