### PR TITLE
[SPARK-31111][SQL][Tests] Fix interval output issue in ExtractBenchmark

### DIFF
--- a/sql/core/benchmarks/ExtractBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/ExtractBenchmark-jdk11-results.txt
@@ -2,118 +2,118 @@ Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke extract for timestamp:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp                                   207            232          39         48.3          20.7       1.0X
-MILLENNIUM of timestamp                             754            772          19         13.3          75.4       0.3X
-CENTURY of timestamp                                753            768          14         13.3          75.3       0.3X
-DECADE of timestamp                                 719            730           9         13.9          71.9       0.3X
-YEAR of timestamp                                   701            707           9         14.3          70.1       0.3X
-ISOYEAR of timestamp                                793            818          38         12.6          79.3       0.3X
-QUARTER of timestamp                                834            912          76         12.0          83.4       0.2X
-MONTH of timestamp                                  681            692          13         14.7          68.1       0.3X
-WEEK of timestamp                                  1198           1421         281          8.3         119.8       0.2X
-DAY of timestamp                                    699            716          23         14.3          69.9       0.3X
-DAYOFWEEK of timestamp                              819            833          22         12.2          81.9       0.3X
-DOW of timestamp                                    808            830          20         12.4          80.8       0.3X
-ISODOW of timestamp                                 846            854           7         11.8          84.6       0.2X
-DOY of timestamp                                    715            723           8         14.0          71.5       0.3X
-HOUR of timestamp                                   529            533           6         18.9          52.9       0.4X
-MINUTE of timestamp                                 531            545          17         18.8          53.1       0.4X
-SECOND of timestamp                                 619            627           7         16.2          61.9       0.3X
-MILLISECONDS of timestamp                           635            650          14         15.7          63.5       0.3X
-MICROSECONDS of timestamp                           545            555           9         18.3          54.5       0.4X
-EPOCH of timestamp                                  684            693           9         14.6          68.4       0.3X
+cast to timestamp                                   343            348           5         29.1          34.3       1.0X
+MILLENNIUM of timestamp                             888            899          14         11.3          88.8       0.4X
+CENTURY of timestamp                                835            846          15         12.0          83.5       0.4X
+DECADE of timestamp                                 824            834           9         12.1          82.4       0.4X
+YEAR of timestamp                                   818            824          10         12.2          81.8       0.4X
+ISOYEAR of timestamp                                879            890          17         11.4          87.9       0.4X
+QUARTER of timestamp                                965           1073          96         10.4          96.5       0.4X
+MONTH of timestamp                                  787            793           8         12.7          78.7       0.4X
+WEEK of timestamp                                  1277           1341          57          7.8         127.7       0.3X
+DAY of timestamp                                    780            785           8         12.8          78.0       0.4X
+DAYOFWEEK of timestamp                              956            962           7         10.5          95.6       0.4X
+DOW of timestamp                                    995           1034          36         10.1          99.5       0.3X
+ISODOW of timestamp                                 885            898          11         11.3          88.5       0.4X
+DOY of timestamp                                    808            810           3         12.4          80.8       0.4X
+HOUR of timestamp                                   622            627           7         16.1          62.2       0.6X
+MINUTE of timestamp                                 629            636           8         15.9          62.9       0.5X
+SECOND of timestamp                                 800            819          30         12.5          80.0       0.4X
+MILLISECONDS of timestamp                           743            755          21         13.5          74.3       0.5X
+MICROSECONDS of timestamp                           692            730          53         14.5          69.2       0.5X
+EPOCH of timestamp                                  773            798          40         12.9          77.3       0.4X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke date_part for timestamp:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp                                   184            190           5         54.4          18.4       1.0X
-MILLENNIUM of timestamp                             706            714           7         14.2          70.6       0.3X
-CENTURY of timestamp                                718            727          11         13.9          71.8       0.3X
-DECADE of timestamp                                 684            718          29         14.6          68.4       0.3X
-YEAR of timestamp                                   677            681           4         14.8          67.7       0.3X
-ISOYEAR of timestamp                                812            824          16         12.3          81.2       0.2X
-QUARTER of timestamp                                845            907          80         11.8          84.5       0.2X
-MONTH of timestamp                                  683            694          12         14.6          68.3       0.3X
-WEEK of timestamp                                  1114           1180          59          9.0         111.4       0.2X
-DAY of timestamp                                    676            691          25         14.8          67.6       0.3X
-DAYOFWEEK of timestamp                              898            928          27         11.1          89.8       0.2X
-DOW of timestamp                                    829            840          17         12.1          82.9       0.2X
-ISODOW of timestamp                                 872            936          57         11.5          87.2       0.2X
-DOY of timestamp                                    692            733          56         14.5          69.2       0.3X
-HOUR of timestamp                                   519            534          15         19.3          51.9       0.4X
-MINUTE of timestamp                                 538            566          40         18.6          53.8       0.3X
-SECOND of timestamp                                 634            662          27         15.8          63.4       0.3X
-MILLISECONDS of timestamp                           633            671          50         15.8          63.3       0.3X
-MICROSECONDS of timestamp                           546            605          53         18.3          54.6       0.3X
-EPOCH of timestamp                                  694            722          36         14.4          69.4       0.3X
+cast to timestamp                                   303            323          24         33.0          30.3       1.0X
+MILLENNIUM of timestamp                             841            852           9         11.9          84.1       0.4X
+CENTURY of timestamp                                818            821           4         12.2          81.8       0.4X
+DECADE of timestamp                                 821            836          15         12.2          82.1       0.4X
+YEAR of timestamp                                   858            928          61         11.7          85.8       0.4X
+ISOYEAR of timestamp                                933            939           6         10.7          93.3       0.3X
+QUARTER of timestamp                                979           1004          26         10.2          97.9       0.3X
+MONTH of timestamp                                  755            784          25         13.2          75.5       0.4X
+WEEK of timestamp                                  1189           1228          64          8.4         118.9       0.3X
+DAY of timestamp                                    768            770           4         13.0          76.8       0.4X
+DAYOFWEEK of timestamp                              918            948          27         10.9          91.8       0.3X
+DOW of timestamp                                    933            983          53         10.7          93.3       0.3X
+ISODOW of timestamp                                 884            928          61         11.3          88.4       0.3X
+DOY of timestamp                                    787            797          12         12.7          78.7       0.4X
+HOUR of timestamp                                   611            664          58         16.4          61.1       0.5X
+MINUTE of timestamp                                 616            622           5         16.2          61.6       0.5X
+SECOND of timestamp                                 732            748          14         13.7          73.2       0.4X
+MILLISECONDS of timestamp                           705            716          17         14.2          70.5       0.4X
+MICROSECONDS of timestamp                           642            664          33         15.6          64.2       0.5X
+EPOCH of timestamp                                  760            781          18         13.2          76.0       0.4X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke extract for date:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date                                        621            639          21         16.1          62.1       1.0X
-MILLENNIUM of date                                  793            864          62         12.6          79.3       0.8X
-CENTURY of date                                     801            823          22         12.5          80.1       0.8X
-DECADE of date                                      716            721           4         14.0          71.6       0.9X
-YEAR of date                                        765            868         108         13.1          76.5       0.8X
-ISOYEAR of date                                     849            863          13         11.8          84.9       0.7X
-QUARTER of date                                     913            934          18         11.0          91.3       0.7X
-MONTH of date                                       660            675          17         15.2          66.0       0.9X
-WEEK of date                                       1036           1086          78          9.7         103.6       0.6X
-DAY of date                                         653            665          16         15.3          65.3       1.0X
-DAYOFWEEK of date                                   816            824           7         12.3          81.6       0.8X
-DOW of date                                         798            813          26         12.5          79.8       0.8X
-ISODOW of date                                      808            825          24         12.4          80.8       0.8X
-DOY of date                                         677            703          33         14.8          67.7       0.9X
-HOUR of date                                       1418           1512         135          7.1         141.8       0.4X
-MINUTE of date                                     1431           1458          25          7.0         143.1       0.4X
-SECOND of date                                     1583           1673          97          6.3         158.3       0.4X
-MILLISECONDS of date                               1595           1649          53          6.3         159.5       0.4X
-MICROSECONDS of date                               1435           1461          23          7.0         143.5       0.4X
-EPOCH of date                                      1655           1669          22          6.0         165.5       0.4X
+cast to date                                        712            786         120         14.0          71.2       1.0X
+MILLENNIUM of date                                  846            888          73         11.8          84.6       0.8X
+CENTURY of date                                     781            792          11         12.8          78.1       0.9X
+DECADE of date                                      770            824          48         13.0          77.0       0.9X
+YEAR of date                                        804            832          27         12.4          80.4       0.9X
+ISOYEAR of date                                     909            931          24         11.0          90.9       0.8X
+QUARTER of date                                     957            975          22         10.4          95.7       0.7X
+MONTH of date                                       789            794           7         12.7          78.9       0.9X
+WEEK of date                                       1141           1165          29          8.8         114.1       0.6X
+DAY of date                                         784            800          22         12.8          78.4       0.9X
+DAYOFWEEK of date                                   907            916          14         11.0          90.7       0.8X
+DOW of date                                         931            958          25         10.7          93.1       0.8X
+ISODOW of date                                      852            857           7         11.7          85.2       0.8X
+DOY of date                                         831            870          45         12.0          83.1       0.9X
+HOUR of date                                       1574           1598          26          6.4         157.4       0.5X
+MINUTE of date                                     1525           1590          58          6.6         152.5       0.5X
+SECOND of date                                     1728           1739          10          5.8         172.8       0.4X
+MILLISECONDS of date                               1715           1727          10          5.8         171.5       0.4X
+MICROSECONDS of date                               1559           1669          95          6.4         155.9       0.5X
+EPOCH of date                                      1766           1774           9          5.7         176.6       0.4X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke date_part for date:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date                                        580            582           2         17.2          58.0       1.0X
-MILLENNIUM of date                                  697            703           8         14.3          69.7       0.8X
-CENTURY of date                                     680            683           3         14.7          68.0       0.9X
-DECADE of date                                      672            681           8         14.9          67.2       0.9X
-YEAR of date                                        654            663           9         15.3          65.4       0.9X
-ISOYEAR of date                                     829            843          15         12.1          82.9       0.7X
-QUARTER of date                                     850            864          12         11.8          85.0       0.7X
-MONTH of date                                       660            663           4         15.1          66.0       0.9X
-WEEK of date                                       1012           1037          44          9.9         101.2       0.6X
-DAY of date                                         699            710          12         14.3          69.9       0.8X
-DAYOFWEEK of date                                   824            833          10         12.1          82.4       0.7X
-DOW of date                                         821            917         134         12.2          82.1       0.7X
-ISODOW of date                                      809            812           5         12.4          80.9       0.7X
-DOY of date                                         679            684           8         14.7          67.9       0.9X
-HOUR of date                                       1410           1426          14          7.1         141.0       0.4X
-MINUTE of date                                     1424           1427           3          7.0         142.4       0.4X
-SECOND of date                                     1566           1585          22          6.4         156.6       0.4X
-MILLISECONDS of date                               1570           1579          15          6.4         157.0       0.4X
-MICROSECONDS of date                               1418           1424           9          7.1         141.8       0.4X
-EPOCH of date                                      1644           1668          32          6.1         164.4       0.4X
+cast to date                                        803            825          23         12.5          80.3       1.0X
+MILLENNIUM of date                                  918            924           8         10.9          91.8       0.9X
+CENTURY of date                                     855            879          25         11.7          85.5       0.9X
+DECADE of date                                      777            795          19         12.9          77.7       1.0X
+YEAR of date                                        772            779           9         13.0          77.2       1.0X
+ISOYEAR of date                                     903            927          21         11.1          90.3       0.9X
+QUARTER of date                                     983           1339         381         10.2          98.3       0.8X
+MONTH of date                                       764            780          20         13.1          76.4       1.1X
+WEEK of date                                       1239           1316         112          8.1         123.9       0.6X
+DAY of date                                         769            857          91         13.0          76.9       1.0X
+DAYOFWEEK of date                                   900            965          61         11.1          90.0       0.9X
+DOW of date                                         990           1041          62         10.1          99.0       0.8X
+ISODOW of date                                      974            977           5         10.3          97.4       0.8X
+DOY of date                                         862            918          50         11.6          86.2       0.9X
+HOUR of date                                       1491           1517          25          6.7         149.1       0.5X
+MINUTE of date                                     1514           1520           9          6.6         151.4       0.5X
+SECOND of date                                     1657           1677          27          6.0         165.7       0.5X
+MILLISECONDS of date                               1646           1669          26          6.1         164.6       0.5X
+MICROSECONDS of date                               1538           1556          23          6.5         153.8       0.5X
+EPOCH of date                                      1699           1718          28          5.9         169.9       0.5X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke date_part for interval:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to interval                                   3165           3185          20          3.2         316.5       1.0X
-MILLENNIUM of interval                              867            867           0         11.5          86.7       3.7X
-CENTURY of interval                                 882            891          10         11.3          88.2       3.6X
-DECADE of interval                                  883            888           8         11.3          88.3       3.6X
-YEAR of interval                                    887            896          14         11.3          88.7       3.6X
-QUARTER of interval                                 871            874           5         11.5          87.1       3.6X
-MONTH of interval                                   895            908          17         11.2          89.5       3.5X
-DAY of interval                                     881            882           1         11.4          88.1       3.6X
-HOUR of interval                                    863            873           9         11.6          86.3       3.7X
-MINUTE of interval                                  922            974          45         10.8          92.2       3.4X
-SECOND of interval                                  938            968          28         10.7          93.8       3.4X
-MILLISECONDS of interval                           1065           1092          30          9.4         106.5       3.0X
-MICROSECONDS of interval                           1020           1050          34          9.8         102.0       3.1X
-EPOCH of interval                                   971           1042         102         10.3          97.1       3.3X
+cast to interval                                    971            976           5         10.3          97.1       1.0X
+MILLENNIUM of interval                              983           1009          23         10.2          98.3       1.0X
+CENTURY of interval                                 972            984          12         10.3          97.2       1.0X
+DECADE of interval                                  954            962          10         10.5          95.4       1.0X
+YEAR of interval                                    954            973          17         10.5          95.4       1.0X
+QUARTER of interval                                1009           1020          11          9.9         100.9       1.0X
+MONTH of interval                                   946            963          16         10.6          94.6       1.0X
+DAY of interval                                     952            963          12         10.5          95.2       1.0X
+HOUR of interval                                    948            960          11         10.5          94.8       1.0X
+MINUTE of interval                                 1035           1040           4          9.7         103.5       0.9X
+SECOND of interval                                 1085           1105          31          9.2         108.5       0.9X
+MILLISECONDS of interval                           1065           1088          24          9.4         106.5       0.9X
+MICROSECONDS of interval                            992           1007          17         10.1          99.2       1.0X
+EPOCH of interval                                  1087           1103          25          9.2         108.7       0.9X
 

--- a/sql/core/benchmarks/ExtractBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/ExtractBenchmark-jdk11-results.txt
@@ -1,119 +1,119 @@
-OpenJDK 64-Bit Server VM 11.0.5+10-post-Ubuntu-0ubuntu1.118.04 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke extract for timestamp:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp                                   380            456          67         26.3          38.0       1.0X
-MILLENNIUM of timestamp                            1274           1361         138          7.9         127.4       0.3X
-CENTURY of timestamp                               1119           1132          19          8.9         111.9       0.3X
-DECADE of timestamp                                1076           1083           6          9.3         107.6       0.4X
-YEAR of timestamp                                  1066           1098          43          9.4         106.6       0.4X
-ISOYEAR of timestamp                               1190           1194           4          8.4         119.0       0.3X
-QUARTER of timestamp                               1269           1273           4          7.9         126.9       0.3X
-MONTH of timestamp                                 1060           1075          22          9.4         106.0       0.4X
-WEEK of timestamp                                  1560           1565           8          6.4         156.0       0.2X
-DAY of timestamp                                   1039           1046           8          9.6         103.9       0.4X
-DAYOFWEEK of timestamp                             1248           1274          24          8.0         124.8       0.3X
-DOW of timestamp                                   1252           1273          25          8.0         125.2       0.3X
-ISODOW of timestamp                                1195           1204           9          8.4         119.5       0.3X
-DOY of timestamp                                   1081           1086           6          9.3         108.1       0.4X
-HOUR of timestamp                                   778            781           5         12.9          77.8       0.5X
-MINUTE of timestamp                                 779            780           1         12.8          77.9       0.5X
-SECOND of timestamp                                 597            611          20         16.7          59.7       0.6X
-MILLISECONDS of timestamp                           636            642           6         15.7          63.6       0.6X
-MICROSECONDS of timestamp                           498            504           5         20.1          49.8       0.8X
-EPOCH of timestamp                                  946            956           9         10.6          94.6       0.4X
+cast to timestamp                                   207            222          23         48.4          20.7       1.0X
+MILLENNIUM of timestamp                             754            762           7         13.3          75.4       0.3X
+CENTURY of timestamp                                776            783           8         12.9          77.6       0.3X
+DECADE of timestamp                                 758            769          12         13.2          75.8       0.3X
+YEAR of timestamp                                   733            737           6         13.6          73.3       0.3X
+ISOYEAR of timestamp                                815            823           7         12.3          81.5       0.3X
+QUARTER of timestamp                                833            849          16         12.0          83.3       0.2X
+MONTH of timestamp                                  720            753          50         13.9          72.0       0.3X
+WEEK of timestamp                                   998           1017          22         10.0          99.8       0.2X
+DAY of timestamp                                    727            735          10         13.8          72.7       0.3X
+DAYOFWEEK of timestamp                              825            832           6         12.1          82.5       0.3X
+DOW of timestamp                                    825            854          26         12.1          82.5       0.3X
+ISODOW of timestamp                                 803            815          17         12.5          80.3       0.3X
+DOY of timestamp                                    743            762          16         13.5          74.3       0.3X
+HOUR of timestamp                                   551            557           6         18.1          55.1       0.4X
+MINUTE of timestamp                                 555            560           7         18.0          55.5       0.4X
+SECOND of timestamp                                 632            644          16         15.8          63.2       0.3X
+MILLISECONDS of timestamp                           631            660          31         15.8          63.1       0.3X
+MICROSECONDS of timestamp                           559            573          14         17.9          55.9       0.4X
+EPOCH of timestamp                                  648            653           6         15.4          64.8       0.3X
 
-OpenJDK 64-Bit Server VM 11.0.5+10-post-Ubuntu-0ubuntu1.118.04 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke date_part for timestamp:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp                                   356            362           9         28.1          35.6       1.0X
-MILLENNIUM of timestamp                            1260           1297          41          7.9         126.0       0.3X
-CENTURY of timestamp                               1082           1085           3          9.2         108.2       0.3X
-DECADE of timestamp                                1056           1068          19          9.5         105.6       0.3X
-YEAR of timestamp                                  1045           1053          13          9.6         104.5       0.3X
-ISOYEAR of timestamp                               1300           1316          25          7.7         130.0       0.3X
-QUARTER of timestamp                               1279           1280           2          7.8         127.9       0.3X
-MONTH of timestamp                                 1037           1046          11          9.6         103.7       0.3X
-WEEK of timestamp                                  1539           1557          28          6.5         153.9       0.2X
-DAY of timestamp                                   1032           1038           6          9.7         103.2       0.3X
-DAYOFWEEK of timestamp                             1241           1244           4          8.1         124.1       0.3X
-DOW of timestamp                                   1237           1241           7          8.1         123.7       0.3X
-ISODOW of timestamp                                1155           1158           3          8.7         115.5       0.3X
-DOY of timestamp                                   1075           1080           4          9.3         107.5       0.3X
-HOUR of timestamp                                   766            770           5         13.1          76.6       0.5X
-MINUTE of timestamp                                 764            769           4         13.1          76.4       0.5X
-SECOND of timestamp                                 590            592           2         16.9          59.0       0.6X
-MILLISECONDS of timestamp                           627            636          10         16.0          62.7       0.6X
-MICROSECONDS of timestamp                           493            505          15         20.3          49.3       0.7X
-EPOCH of timestamp                                  962            966           4         10.4          96.2       0.4X
+cast to timestamp                                   170            173           4         59.0          17.0       1.0X
+MILLENNIUM of timestamp                             747            763          20         13.4          74.7       0.2X
+CENTURY of timestamp                                731            750          17         13.7          73.1       0.2X
+DECADE of timestamp                                 750            763          11         13.3          75.0       0.2X
+YEAR of timestamp                                   716            725           8         14.0          71.6       0.2X
+ISOYEAR of timestamp                                883            892           9         11.3          88.3       0.2X
+QUARTER of timestamp                                866            880          22         11.5          86.6       0.2X
+MONTH of timestamp                                  733            739           6         13.6          73.3       0.2X
+WEEK of timestamp                                   994           1006          12         10.1          99.4       0.2X
+DAY of timestamp                                    760            807          56         13.2          76.0       0.2X
+DAYOFWEEK of timestamp                              833            842          10         12.0          83.3       0.2X
+DOW of timestamp                                    972            986          19         10.3          97.2       0.2X
+ISODOW of timestamp                                 807            809           2         12.4          80.7       0.2X
+DOY of timestamp                                    914            923          11         10.9          91.4       0.2X
+HOUR of timestamp                                   555            562          12         18.0          55.5       0.3X
+MINUTE of timestamp                                 550            567          24         18.2          55.0       0.3X
+SECOND of timestamp                                 624            628           5         16.0          62.4       0.3X
+MILLISECONDS of timestamp                           635            663          37         15.8          63.5       0.3X
+MICROSECONDS of timestamp                           555            608          46         18.0          55.5       0.3X
+EPOCH of timestamp                                  656            659           5         15.2          65.6       0.3X
 
-OpenJDK 64-Bit Server VM 11.0.5+10-post-Ubuntu-0ubuntu1.118.04 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke extract for date:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date                                        886            905          17         11.3          88.6       1.0X
-MILLENNIUM of date                                 1253           1261           7          8.0         125.3       0.7X
-CENTURY of date                                    1068           1079          10          9.4         106.8       0.8X
-DECADE of date                                     1040           1068          25          9.6         104.0       0.9X
-YEAR of date                                       1032           1043          11          9.7         103.2       0.9X
-ISOYEAR of date                                    1304           1313          12          7.7         130.4       0.7X
-QUARTER of date                                    1284           1301          16          7.8         128.4       0.7X
-MONTH of date                                      1033           1036           4          9.7         103.3       0.9X
-WEEK of date                                       1535           1545           8          6.5         153.5       0.6X
-DAY of date                                        1023           1033          11          9.8         102.3       0.9X
-DAYOFWEEK of date                                  1230           1236           6          8.1         123.0       0.7X
-DOW of date                                        1238           1247           9          8.1         123.8       0.7X
-ISODOW of date                                     1159           1169          17          8.6         115.9       0.8X
-DOY of date                                        1082           1084           3          9.2         108.2       0.8X
-HOUR of date                                       1879           1891          11          5.3         187.9       0.5X
-MINUTE of date                                     1881           1905          21          5.3         188.1       0.5X
-SECOND of date                                     1718           1724           5          5.8         171.8       0.5X
-MILLISECONDS of date                               1733           1737           6          5.8         173.3       0.5X
-MICROSECONDS of date                               1629           1644          23          6.1         162.9       0.5X
-EPOCH of date                                      2085           2090           5          4.8         208.5       0.4X
+cast to date                                        615            646          30         16.3          61.5       1.0X
+MILLENNIUM of date                                  728            751          30         13.7          72.8       0.8X
+CENTURY of date                                     750            756           8         13.3          75.0       0.8X
+DECADE of date                                      719            734          21         13.9          71.9       0.9X
+YEAR of date                                        738            765          35         13.5          73.8       0.8X
+ISOYEAR of date                                     870            876           5         11.5          87.0       0.7X
+QUARTER of date                                     885            911          25         11.3          88.5       0.7X
+MONTH of date                                       711            716           4         14.1          71.1       0.9X
+WEEK of date                                       1005           1071         111          9.9         100.5       0.6X
+DAY of date                                         716            721           7         14.0          71.6       0.9X
+DAYOFWEEK of date                                   832            856          21         12.0          83.2       0.7X
+DOW of date                                         839            850          12         11.9          83.9       0.7X
+ISODOW of date                                      800            819          18         12.5          80.0       0.8X
+DOY of date                                         750            756           7         13.3          75.0       0.8X
+HOUR of date                                       1517           1545          36          6.6         151.7       0.4X
+MINUTE of date                                     1531           1546          15          6.5         153.1       0.4X
+SECOND of date                                     1623           1629          11          6.2         162.3       0.4X
+MILLISECONDS of date                               1601           1626          25          6.2         160.1       0.4X
+MICROSECONDS of date                               1535           1547          14          6.5         153.5       0.4X
+EPOCH of date                                      1628           1648          24          6.1         162.8       0.4X
 
-OpenJDK 64-Bit Server VM 11.0.5+10-post-Ubuntu-0ubuntu1.118.04 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke date_part for date:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date                                        888            891           6         11.3          88.8       1.0X
-MILLENNIUM of date                                 1250           1260          17          8.0         125.0       0.7X
-CENTURY of date                                    1070           1076           6          9.3         107.0       0.8X
-DECADE of date                                     1036           1041           5          9.6         103.6       0.9X
-YEAR of date                                       1037           1038           1          9.6         103.7       0.9X
-ISOYEAR of date                                    1300           1307           9          7.7         130.0       0.7X
-QUARTER of date                                    1267           1277           9          7.9         126.7       0.7X
-MONTH of date                                      1034           1037           4          9.7         103.4       0.9X
-WEEK of date                                       1543           1554          10          6.5         154.3       0.6X
-DAY of date                                        1022           1030          12          9.8         102.2       0.9X
-DAYOFWEEK of date                                  1230           1232           4          8.1         123.0       0.7X
-DOW of date                                        1227           1242          15          8.1         122.7       0.7X
-ISODOW of date                                     1157           1173          20          8.6         115.7       0.8X
-DOY of date                                        1073           1083          18          9.3         107.3       0.8X
-HOUR of date                                       1873           1878           7          5.3         187.3       0.5X
-MINUTE of date                                     1861           1876          14          5.4         186.1       0.5X
-SECOND of date                                     1717           1724           6          5.8         171.7       0.5X
-MILLISECONDS of date                               1729           1736           7          5.8         172.9       0.5X
-MICROSECONDS of date                               1622           1627           5          6.2         162.2       0.5X
-EPOCH of date                                      2066           2079          19          4.8         206.6       0.4X
+cast to date                                        612            613           1         16.3          61.2       1.0X
+MILLENNIUM of date                                  736            749          18         13.6          73.6       0.8X
+CENTURY of date                                     741            755          13         13.5          74.1       0.8X
+DECADE of date                                      747            755           7         13.4          74.7       0.8X
+YEAR of date                                        718            724           7         13.9          71.8       0.9X
+ISOYEAR of date                                     890            902          11         11.2          89.0       0.7X
+QUARTER of date                                     889            901          16         11.3          88.9       0.7X
+MONTH of date                                       731            739          12         13.7          73.1       0.8X
+WEEK of date                                       1003           1007           7         10.0         100.3       0.6X
+DAY of date                                         722            736          12         13.8          72.2       0.8X
+DAYOFWEEK of date                                   830            837           8         12.0          83.0       0.7X
+DOW of date                                         830            846          14         12.0          83.0       0.7X
+ISODOW of date                                      790            803          14         12.7          79.0       0.8X
+DOY of date                                         765            773           6         13.1          76.5       0.8X
+HOUR of date                                       1525           1527           2          6.6         152.5       0.4X
+MINUTE of date                                     1526           1533           6          6.6         152.6       0.4X
+SECOND of date                                     1608           1627          26          6.2         160.8       0.4X
+MILLISECONDS of date                               1618           1643          22          6.2         161.8       0.4X
+MICROSECONDS of date                               1546           1565          30          6.5         154.6       0.4X
+EPOCH of date                                      1622           1641          17          6.2         162.2       0.4X
 
-OpenJDK 64-Bit Server VM 11.0.5+10-post-Ubuntu-0ubuntu1.118.04 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke date_part for interval:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to interval                                   1273           1279           6          7.9         127.3       1.0X
-MILLENNIUM of interval                             1323           1352          36          7.6         132.3       1.0X
-CENTURY of interval                                1353           1356           4          7.4         135.3       0.9X
-DECADE of interval                                 1326           1339          11          7.5         132.6       1.0X
-YEAR of interval                                   1341           1345           3          7.5         134.1       0.9X
-QUARTER of interval                                1368           1372           4          7.3         136.8       0.9X
-MONTH of interval                                  1320           1326           6          7.6         132.0       1.0X
-DAY of interval                                    1306           1310           4          7.7         130.6       1.0X
-HOUR of interval                                   1341           1347           8          7.5         134.1       0.9X
-MINUTE of interval                                 1337           1349          11          7.5         133.7       1.0X
-SECOND of interval                                 1450           1451           1          6.9         145.0       0.9X
-MILLISECONDS of interval                           1476           1490          23          6.8         147.6       0.9X
-MICROSECONDS of interval                           1316           1331          25          7.6         131.6       1.0X
-EPOCH of interval                                  1461           1462           1          6.8         146.1       0.9X
+cast to interval                                   3327           3337           9          3.0         332.7       1.0X
+MILLENNIUM of interval                             4037           4055          19          2.5         403.7       0.8X
+CENTURY of interval                                4020           4056          57          2.5         402.0       0.8X
+DECADE of interval                                 4019           4043          29          2.5         401.9       0.8X
+YEAR of interval                                   4071           4200         166          2.5         407.1       0.8X
+QUARTER of interval                                4060           4253         172          2.5         406.0       0.8X
+MONTH of interval                                  3995           4160         239          2.5         399.5       0.8X
+DAY of interval                                    4584           5542        1283          2.2         458.4       0.7X
+HOUR of interval                                   4419           4515         120          2.3         441.9       0.8X
+MINUTE of interval                                 4339           4403          55          2.3         433.9       0.8X
+SECOND of interval                                 4430           4444          16          2.3         443.0       0.8X
+MILLISECONDS of interval                           4420           4435          21          2.3         442.0       0.8X
+MICROSECONDS of interval                           4429           4456          24          2.3         442.9       0.8X
+EPOCH of interval                                  4442           4474          37          2.3         444.2       0.7X
 

--- a/sql/core/benchmarks/ExtractBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/ExtractBenchmark-jdk11-results.txt
@@ -2,118 +2,118 @@ Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke extract for timestamp:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp                                   207            222          23         48.4          20.7       1.0X
-MILLENNIUM of timestamp                             754            762           7         13.3          75.4       0.3X
-CENTURY of timestamp                                776            783           8         12.9          77.6       0.3X
-DECADE of timestamp                                 758            769          12         13.2          75.8       0.3X
-YEAR of timestamp                                   733            737           6         13.6          73.3       0.3X
-ISOYEAR of timestamp                                815            823           7         12.3          81.5       0.3X
-QUARTER of timestamp                                833            849          16         12.0          83.3       0.2X
-MONTH of timestamp                                  720            753          50         13.9          72.0       0.3X
-WEEK of timestamp                                   998           1017          22         10.0          99.8       0.2X
-DAY of timestamp                                    727            735          10         13.8          72.7       0.3X
-DAYOFWEEK of timestamp                              825            832           6         12.1          82.5       0.3X
-DOW of timestamp                                    825            854          26         12.1          82.5       0.3X
-ISODOW of timestamp                                 803            815          17         12.5          80.3       0.3X
-DOY of timestamp                                    743            762          16         13.5          74.3       0.3X
-HOUR of timestamp                                   551            557           6         18.1          55.1       0.4X
-MINUTE of timestamp                                 555            560           7         18.0          55.5       0.4X
-SECOND of timestamp                                 632            644          16         15.8          63.2       0.3X
-MILLISECONDS of timestamp                           631            660          31         15.8          63.1       0.3X
-MICROSECONDS of timestamp                           559            573          14         17.9          55.9       0.4X
-EPOCH of timestamp                                  648            653           6         15.4          64.8       0.3X
+cast to timestamp                                   207            232          39         48.3          20.7       1.0X
+MILLENNIUM of timestamp                             754            772          19         13.3          75.4       0.3X
+CENTURY of timestamp                                753            768          14         13.3          75.3       0.3X
+DECADE of timestamp                                 719            730           9         13.9          71.9       0.3X
+YEAR of timestamp                                   701            707           9         14.3          70.1       0.3X
+ISOYEAR of timestamp                                793            818          38         12.6          79.3       0.3X
+QUARTER of timestamp                                834            912          76         12.0          83.4       0.2X
+MONTH of timestamp                                  681            692          13         14.7          68.1       0.3X
+WEEK of timestamp                                  1198           1421         281          8.3         119.8       0.2X
+DAY of timestamp                                    699            716          23         14.3          69.9       0.3X
+DAYOFWEEK of timestamp                              819            833          22         12.2          81.9       0.3X
+DOW of timestamp                                    808            830          20         12.4          80.8       0.3X
+ISODOW of timestamp                                 846            854           7         11.8          84.6       0.2X
+DOY of timestamp                                    715            723           8         14.0          71.5       0.3X
+HOUR of timestamp                                   529            533           6         18.9          52.9       0.4X
+MINUTE of timestamp                                 531            545          17         18.8          53.1       0.4X
+SECOND of timestamp                                 619            627           7         16.2          61.9       0.3X
+MILLISECONDS of timestamp                           635            650          14         15.7          63.5       0.3X
+MICROSECONDS of timestamp                           545            555           9         18.3          54.5       0.4X
+EPOCH of timestamp                                  684            693           9         14.6          68.4       0.3X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke date_part for timestamp:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp                                   170            173           4         59.0          17.0       1.0X
-MILLENNIUM of timestamp                             747            763          20         13.4          74.7       0.2X
-CENTURY of timestamp                                731            750          17         13.7          73.1       0.2X
-DECADE of timestamp                                 750            763          11         13.3          75.0       0.2X
-YEAR of timestamp                                   716            725           8         14.0          71.6       0.2X
-ISOYEAR of timestamp                                883            892           9         11.3          88.3       0.2X
-QUARTER of timestamp                                866            880          22         11.5          86.6       0.2X
-MONTH of timestamp                                  733            739           6         13.6          73.3       0.2X
-WEEK of timestamp                                   994           1006          12         10.1          99.4       0.2X
-DAY of timestamp                                    760            807          56         13.2          76.0       0.2X
-DAYOFWEEK of timestamp                              833            842          10         12.0          83.3       0.2X
-DOW of timestamp                                    972            986          19         10.3          97.2       0.2X
-ISODOW of timestamp                                 807            809           2         12.4          80.7       0.2X
-DOY of timestamp                                    914            923          11         10.9          91.4       0.2X
-HOUR of timestamp                                   555            562          12         18.0          55.5       0.3X
-MINUTE of timestamp                                 550            567          24         18.2          55.0       0.3X
-SECOND of timestamp                                 624            628           5         16.0          62.4       0.3X
-MILLISECONDS of timestamp                           635            663          37         15.8          63.5       0.3X
-MICROSECONDS of timestamp                           555            608          46         18.0          55.5       0.3X
-EPOCH of timestamp                                  656            659           5         15.2          65.6       0.3X
+cast to timestamp                                   184            190           5         54.4          18.4       1.0X
+MILLENNIUM of timestamp                             706            714           7         14.2          70.6       0.3X
+CENTURY of timestamp                                718            727          11         13.9          71.8       0.3X
+DECADE of timestamp                                 684            718          29         14.6          68.4       0.3X
+YEAR of timestamp                                   677            681           4         14.8          67.7       0.3X
+ISOYEAR of timestamp                                812            824          16         12.3          81.2       0.2X
+QUARTER of timestamp                                845            907          80         11.8          84.5       0.2X
+MONTH of timestamp                                  683            694          12         14.6          68.3       0.3X
+WEEK of timestamp                                  1114           1180          59          9.0         111.4       0.2X
+DAY of timestamp                                    676            691          25         14.8          67.6       0.3X
+DAYOFWEEK of timestamp                              898            928          27         11.1          89.8       0.2X
+DOW of timestamp                                    829            840          17         12.1          82.9       0.2X
+ISODOW of timestamp                                 872            936          57         11.5          87.2       0.2X
+DOY of timestamp                                    692            733          56         14.5          69.2       0.3X
+HOUR of timestamp                                   519            534          15         19.3          51.9       0.4X
+MINUTE of timestamp                                 538            566          40         18.6          53.8       0.3X
+SECOND of timestamp                                 634            662          27         15.8          63.4       0.3X
+MILLISECONDS of timestamp                           633            671          50         15.8          63.3       0.3X
+MICROSECONDS of timestamp                           546            605          53         18.3          54.6       0.3X
+EPOCH of timestamp                                  694            722          36         14.4          69.4       0.3X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke extract for date:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date                                        615            646          30         16.3          61.5       1.0X
-MILLENNIUM of date                                  728            751          30         13.7          72.8       0.8X
-CENTURY of date                                     750            756           8         13.3          75.0       0.8X
-DECADE of date                                      719            734          21         13.9          71.9       0.9X
-YEAR of date                                        738            765          35         13.5          73.8       0.8X
-ISOYEAR of date                                     870            876           5         11.5          87.0       0.7X
-QUARTER of date                                     885            911          25         11.3          88.5       0.7X
-MONTH of date                                       711            716           4         14.1          71.1       0.9X
-WEEK of date                                       1005           1071         111          9.9         100.5       0.6X
-DAY of date                                         716            721           7         14.0          71.6       0.9X
-DAYOFWEEK of date                                   832            856          21         12.0          83.2       0.7X
-DOW of date                                         839            850          12         11.9          83.9       0.7X
-ISODOW of date                                      800            819          18         12.5          80.0       0.8X
-DOY of date                                         750            756           7         13.3          75.0       0.8X
-HOUR of date                                       1517           1545          36          6.6         151.7       0.4X
-MINUTE of date                                     1531           1546          15          6.5         153.1       0.4X
-SECOND of date                                     1623           1629          11          6.2         162.3       0.4X
-MILLISECONDS of date                               1601           1626          25          6.2         160.1       0.4X
-MICROSECONDS of date                               1535           1547          14          6.5         153.5       0.4X
-EPOCH of date                                      1628           1648          24          6.1         162.8       0.4X
+cast to date                                        621            639          21         16.1          62.1       1.0X
+MILLENNIUM of date                                  793            864          62         12.6          79.3       0.8X
+CENTURY of date                                     801            823          22         12.5          80.1       0.8X
+DECADE of date                                      716            721           4         14.0          71.6       0.9X
+YEAR of date                                        765            868         108         13.1          76.5       0.8X
+ISOYEAR of date                                     849            863          13         11.8          84.9       0.7X
+QUARTER of date                                     913            934          18         11.0          91.3       0.7X
+MONTH of date                                       660            675          17         15.2          66.0       0.9X
+WEEK of date                                       1036           1086          78          9.7         103.6       0.6X
+DAY of date                                         653            665          16         15.3          65.3       1.0X
+DAYOFWEEK of date                                   816            824           7         12.3          81.6       0.8X
+DOW of date                                         798            813          26         12.5          79.8       0.8X
+ISODOW of date                                      808            825          24         12.4          80.8       0.8X
+DOY of date                                         677            703          33         14.8          67.7       0.9X
+HOUR of date                                       1418           1512         135          7.1         141.8       0.4X
+MINUTE of date                                     1431           1458          25          7.0         143.1       0.4X
+SECOND of date                                     1583           1673          97          6.3         158.3       0.4X
+MILLISECONDS of date                               1595           1649          53          6.3         159.5       0.4X
+MICROSECONDS of date                               1435           1461          23          7.0         143.5       0.4X
+EPOCH of date                                      1655           1669          22          6.0         165.5       0.4X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke date_part for date:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date                                        612            613           1         16.3          61.2       1.0X
-MILLENNIUM of date                                  736            749          18         13.6          73.6       0.8X
-CENTURY of date                                     741            755          13         13.5          74.1       0.8X
-DECADE of date                                      747            755           7         13.4          74.7       0.8X
-YEAR of date                                        718            724           7         13.9          71.8       0.9X
-ISOYEAR of date                                     890            902          11         11.2          89.0       0.7X
-QUARTER of date                                     889            901          16         11.3          88.9       0.7X
-MONTH of date                                       731            739          12         13.7          73.1       0.8X
-WEEK of date                                       1003           1007           7         10.0         100.3       0.6X
-DAY of date                                         722            736          12         13.8          72.2       0.8X
-DAYOFWEEK of date                                   830            837           8         12.0          83.0       0.7X
-DOW of date                                         830            846          14         12.0          83.0       0.7X
-ISODOW of date                                      790            803          14         12.7          79.0       0.8X
-DOY of date                                         765            773           6         13.1          76.5       0.8X
-HOUR of date                                       1525           1527           2          6.6         152.5       0.4X
-MINUTE of date                                     1526           1533           6          6.6         152.6       0.4X
-SECOND of date                                     1608           1627          26          6.2         160.8       0.4X
-MILLISECONDS of date                               1618           1643          22          6.2         161.8       0.4X
-MICROSECONDS of date                               1546           1565          30          6.5         154.6       0.4X
-EPOCH of date                                      1622           1641          17          6.2         162.2       0.4X
+cast to date                                        580            582           2         17.2          58.0       1.0X
+MILLENNIUM of date                                  697            703           8         14.3          69.7       0.8X
+CENTURY of date                                     680            683           3         14.7          68.0       0.9X
+DECADE of date                                      672            681           8         14.9          67.2       0.9X
+YEAR of date                                        654            663           9         15.3          65.4       0.9X
+ISOYEAR of date                                     829            843          15         12.1          82.9       0.7X
+QUARTER of date                                     850            864          12         11.8          85.0       0.7X
+MONTH of date                                       660            663           4         15.1          66.0       0.9X
+WEEK of date                                       1012           1037          44          9.9         101.2       0.6X
+DAY of date                                         699            710          12         14.3          69.9       0.8X
+DAYOFWEEK of date                                   824            833          10         12.1          82.4       0.7X
+DOW of date                                         821            917         134         12.2          82.1       0.7X
+ISODOW of date                                      809            812           5         12.4          80.9       0.7X
+DOY of date                                         679            684           8         14.7          67.9       0.9X
+HOUR of date                                       1410           1426          14          7.1         141.0       0.4X
+MINUTE of date                                     1424           1427           3          7.0         142.4       0.4X
+SECOND of date                                     1566           1585          22          6.4         156.6       0.4X
+MILLISECONDS of date                               1570           1579          15          6.4         157.0       0.4X
+MICROSECONDS of date                               1418           1424           9          7.1         141.8       0.4X
+EPOCH of date                                      1644           1668          32          6.1         164.4       0.4X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke date_part for interval:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to interval                                   3327           3337           9          3.0         332.7       1.0X
-MILLENNIUM of interval                             4037           4055          19          2.5         403.7       0.8X
-CENTURY of interval                                4020           4056          57          2.5         402.0       0.8X
-DECADE of interval                                 4019           4043          29          2.5         401.9       0.8X
-YEAR of interval                                   4071           4200         166          2.5         407.1       0.8X
-QUARTER of interval                                4060           4253         172          2.5         406.0       0.8X
-MONTH of interval                                  3995           4160         239          2.5         399.5       0.8X
-DAY of interval                                    4584           5542        1283          2.2         458.4       0.7X
-HOUR of interval                                   4419           4515         120          2.3         441.9       0.8X
-MINUTE of interval                                 4339           4403          55          2.3         433.9       0.8X
-SECOND of interval                                 4430           4444          16          2.3         443.0       0.8X
-MILLISECONDS of interval                           4420           4435          21          2.3         442.0       0.8X
-MICROSECONDS of interval                           4429           4456          24          2.3         442.9       0.8X
-EPOCH of interval                                  4442           4474          37          2.3         444.2       0.7X
+cast to interval                                   3165           3185          20          3.2         316.5       1.0X
+MILLENNIUM of interval                              867            867           0         11.5          86.7       3.7X
+CENTURY of interval                                 882            891          10         11.3          88.2       3.6X
+DECADE of interval                                  883            888           8         11.3          88.3       3.6X
+YEAR of interval                                    887            896          14         11.3          88.7       3.6X
+QUARTER of interval                                 871            874           5         11.5          87.1       3.6X
+MONTH of interval                                   895            908          17         11.2          89.5       3.5X
+DAY of interval                                     881            882           1         11.4          88.1       3.6X
+HOUR of interval                                    863            873           9         11.6          86.3       3.7X
+MINUTE of interval                                  922            974          45         10.8          92.2       3.4X
+SECOND of interval                                  938            968          28         10.7          93.8       3.4X
+MILLISECONDS of interval                           1065           1092          30          9.4         106.5       3.0X
+MICROSECONDS of interval                           1020           1050          34          9.8         102.0       3.1X
+EPOCH of interval                                   971           1042         102         10.3          97.1       3.3X
 

--- a/sql/core/benchmarks/ExtractBenchmark-results.txt
+++ b/sql/core/benchmarks/ExtractBenchmark-results.txt
@@ -1,119 +1,119 @@
-OpenJDK 64-Bit Server VM 1.8.0_232-8u232-b09-0ubuntu1~18.04.1-b09 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke extract for timestamp:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp                                   409            457          45         24.5          40.9       1.0X
-MILLENNIUM of timestamp                            1240           1295          57          8.1         124.0       0.3X
-CENTURY of timestamp                               1186           1240          49          8.4         118.6       0.3X
-DECADE of timestamp                                1083           1104          20          9.2         108.3       0.4X
-YEAR of timestamp                                  1061           1073          15          9.4         106.1       0.4X
-ISOYEAR of timestamp                               1198           1213          25          8.3         119.8       0.3X
-QUARTER of timestamp                               1304           1322          23          7.7         130.4       0.3X
-MONTH of timestamp                                 1052           1067          19          9.5         105.2       0.4X
-WEEK of timestamp                                  1534           1558          25          6.5         153.4       0.3X
-DAY of timestamp                                   1038           1057          26          9.6         103.8       0.4X
-DAYOFWEEK of timestamp                             1226           1239          22          8.2         122.6       0.3X
-DOW of timestamp                                   1212           1224          13          8.3         121.2       0.3X
-ISODOW of timestamp                                1148           1165          24          8.7         114.8       0.4X
-DOY of timestamp                                   1066           1075          14          9.4         106.6       0.4X
-HOUR of timestamp                                   358            362           6         27.9          35.8       1.1X
-MINUTE of timestamp                                 364            369           4         27.4          36.4       1.1X
-SECOND of timestamp                                 453            471          26         22.1          45.3       0.9X
-MILLISECONDS of timestamp                           497            500           2         20.1          49.7       0.8X
-MICROSECONDS of timestamp                           360            363           4         27.8          36.0       1.1X
-EPOCH of timestamp                                 1100           1104           5          9.1         110.0       0.4X
+cast to timestamp                                   200            224          28         50.0          20.0       1.0X
+MILLENNIUM of timestamp                             741            750          14         13.5          74.1       0.3X
+CENTURY of timestamp                                768            781          15         13.0          76.8       0.3X
+DECADE of timestamp                                 671            680           7         14.9          67.1       0.3X
+YEAR of timestamp                                   659            680          30         15.2          65.9       0.3X
+ISOYEAR of timestamp                                732            753          22         13.7          73.2       0.3X
+QUARTER of timestamp                                772            789          20         12.9          77.2       0.3X
+MONTH of timestamp                                  643            673          47         15.6          64.3       0.3X
+WEEK of timestamp                                   965            971          10         10.4          96.5       0.2X
+DAY of timestamp                                    635            641           9         15.7          63.5       0.3X
+DAYOFWEEK of timestamp                              755            774          17         13.3          75.5       0.3X
+DOW of timestamp                                    768            798          39         13.0          76.8       0.3X
+ISODOW of timestamp                                 736            760          24         13.6          73.6       0.3X
+DOY of timestamp                                    688            696           6         14.5          68.8       0.3X
+HOUR of timestamp                                   490            498           7         20.4          49.0       0.4X
+MINUTE of timestamp                                 484            497          13         20.7          48.4       0.4X
+SECOND of timestamp                                 614            627          11         16.3          61.4       0.3X
+MILLISECONDS of timestamp                           610            631          24         16.4          61.0       0.3X
+MICROSECONDS of timestamp                           516            525           8         19.4          51.6       0.4X
+EPOCH of timestamp                                  665            670           7         15.0          66.5       0.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_232-8u232-b09-0ubuntu1~18.04.1-b09 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke date_part for timestamp:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp                                   315            317           2         31.8          31.5       1.0X
-MILLENNIUM of timestamp                            1155           1162           8          8.7         115.5       0.3X
-CENTURY of timestamp                               1146           1152           5          8.7         114.6       0.3X
-DECADE of timestamp                                1031           1043          11          9.7         103.1       0.3X
-YEAR of timestamp                                  1033           1041          10          9.7         103.3       0.3X
-ISOYEAR of timestamp                               1274           1278           5          7.8         127.4       0.2X
-QUARTER of timestamp                               1326           1346          30          7.5         132.6       0.2X
-MONTH of timestamp                                 1027           1031           7          9.7         102.7       0.3X
-WEEK of timestamp                                  1529           1535           6          6.5         152.9       0.2X
-DAY of timestamp                                   1024           1031           9          9.8         102.4       0.3X
-DAYOFWEEK of timestamp                             1197           1201           5          8.4         119.7       0.3X
-DOW of timestamp                                   1201           1218          15          8.3         120.1       0.3X
-ISODOW of timestamp                                1143           1149           6          8.8         114.3       0.3X
-DOY of timestamp                                   1074           1085           9          9.3         107.4       0.3X
-HOUR of timestamp                                   354            354           0         28.3          35.4       0.9X
-MINUTE of timestamp                                 358            361           5         27.9          35.8       0.9X
-SECOND of timestamp                                 445            456          17         22.5          44.5       0.7X
-MILLISECONDS of timestamp                           504            514          12         19.8          50.4       0.6X
-MICROSECONDS of timestamp                           361            370           8         27.7          36.1       0.9X
-EPOCH of timestamp                                 1111           1117           9          9.0         111.1       0.3X
+cast to timestamp                                   171            177           5         58.4          17.1       1.0X
+MILLENNIUM of timestamp                             744            758          15         13.4          74.4       0.2X
+CENTURY of timestamp                                721            742          23         13.9          72.1       0.2X
+DECADE of timestamp                                 650            657           6         15.4          65.0       0.3X
+YEAR of timestamp                                   634            640           7         15.8          63.4       0.3X
+ISOYEAR of timestamp                                793            803          13         12.6          79.3       0.2X
+QUARTER of timestamp                                811            844          31         12.3          81.1       0.2X
+MONTH of timestamp                                  642            652          13         15.6          64.2       0.3X
+WEEK of timestamp                                   944            955          10         10.6          94.4       0.2X
+DAY of timestamp                                    650            652           2         15.4          65.0       0.3X
+DAYOFWEEK of timestamp                              778            814          52         12.9          77.8       0.2X
+DOW of timestamp                                    769            772           3         13.0          76.9       0.2X
+ISODOW of timestamp                                 776            805          28         12.9          77.6       0.2X
+DOY of timestamp                                    675            685          10         14.8          67.5       0.3X
+HOUR of timestamp                                   552            573          22         18.1          55.2       0.3X
+MINUTE of timestamp                                 486            496           9         20.6          48.6       0.4X
+SECOND of timestamp                                 622            629           7         16.1          62.2       0.3X
+MILLISECONDS of timestamp                           685            720          35         14.6          68.5       0.2X
+MICROSECONDS of timestamp                           574            580           8         17.4          57.4       0.3X
+EPOCH of timestamp                                  669            689          24         15.0          66.9       0.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_232-8u232-b09-0ubuntu1~18.04.1-b09 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke extract for date:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date                                        849            851           3         11.8          84.9       1.0X
-MILLENNIUM of date                                 1129           1139          11          8.9         112.9       0.8X
-CENTURY of date                                    1136           1143           7          8.8         113.6       0.7X
-DECADE of date                                     1039           1043           5          9.6         103.9       0.8X
-YEAR of date                                       1030           1037          10          9.7         103.0       0.8X
-ISOYEAR of date                                    1269           1278           9          7.9         126.9       0.7X
-QUARTER of date                                    1323           1330           6          7.6         132.3       0.6X
-MONTH of date                                      1021           1023           2          9.8         102.1       0.8X
-WEEK of date                                       1541           1549           8          6.5         154.1       0.6X
-DAY of date                                        1021           1033          13          9.8         102.1       0.8X
-DAYOFWEEK of date                                  1196           1209          11          8.4         119.6       0.7X
-DOW of date                                        1214           1229          13          8.2         121.4       0.7X
-ISODOW of date                                     1148           1153           7          8.7         114.8       0.7X
-DOY of date                                        1073           1079           5          9.3         107.3       0.8X
-HOUR of date                                       1311           1314           4          7.6         131.1       0.6X
-MINUTE of date                                     1311           1311           1          7.6         131.1       0.6X
-SECOND of date                                     1420           1434          13          7.0         142.0       0.6X
-MILLISECONDS of date                               1426           1442          14          7.0         142.6       0.6X
-MICROSECONDS of date                               1312           1318           6          7.6         131.2       0.6X
-EPOCH of date                                      2034           2050          16          4.9         203.4       0.4X
+cast to date                                        551            555           5         18.1          55.1       1.0X
+MILLENNIUM of date                                  720            731           9         13.9          72.0       0.8X
+CENTURY of date                                     724            735          11         13.8          72.4       0.8X
+DECADE of date                                      666            725          55         15.0          66.6       0.8X
+YEAR of date                                        628            648          20         15.9          62.8       0.9X
+ISOYEAR of date                                     780            823          52         12.8          78.0       0.7X
+QUARTER of date                                     819            828          10         12.2          81.9       0.7X
+MONTH of date                                       653            714          56         15.3          65.3       0.8X
+WEEK of date                                        930            942          10         10.8          93.0       0.6X
+DAY of date                                         632            642          11         15.8          63.2       0.9X
+DAYOFWEEK of date                                   746            760          20         13.4          74.6       0.7X
+DOW of date                                         778            781           3         12.9          77.8       0.7X
+ISODOW of date                                      748            761          12         13.4          74.8       0.7X
+DOY of date                                         674            684          10         14.8          67.4       0.8X
+HOUR of date                                       1312           1329          17          7.6         131.2       0.4X
+MINUTE of date                                     1288           1308          29          7.8         128.8       0.4X
+SECOND of date                                     1438           1451          14          7.0         143.8       0.4X
+MILLISECONDS of date                               1440           1444           6          6.9         144.0       0.4X
+MICROSECONDS of date                               1353           1371          27          7.4         135.3       0.4X
+EPOCH of date                                      1495           1541          51          6.7         149.5       0.4X
 
-OpenJDK 64-Bit Server VM 1.8.0_232-8u232-b09-0ubuntu1~18.04.1-b09 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke date_part for date:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date                                        852            879          42         11.7          85.2       1.0X
-MILLENNIUM of date                                 1131           1136           7          8.8         113.1       0.8X
-CENTURY of date                                    1138           1145           6          8.8         113.8       0.7X
-DECADE of date                                     1030           1043          13          9.7         103.0       0.8X
-YEAR of date                                       1022           1028           8          9.8         102.2       0.8X
-ISOYEAR of date                                    1260           1265           6          7.9         126.0       0.7X
-QUARTER of date                                    1326           1330           7          7.5         132.6       0.6X
-MONTH of date                                      1014           1034          26          9.9         101.4       0.8X
-WEEK of date                                       1523           1526           5          6.6         152.3       0.6X
-DAY of date                                        1022           1023           2          9.8         102.2       0.8X
-DAYOFWEEK of date                                  1197           1203           9          8.4         119.7       0.7X
-DOW of date                                        1188           1198          16          8.4         118.8       0.7X
-ISODOW of date                                     1143           1153           9          8.8         114.3       0.7X
-DOY of date                                        1052           1058           7          9.5         105.2       0.8X
-HOUR of date                                       1309           1311           4          7.6         130.9       0.7X
-MINUTE of date                                     1302           1305           6          7.7         130.2       0.7X
-SECOND of date                                     1414           1432          16          7.1         141.4       0.6X
-MILLISECONDS of date                               1441           1450          11          6.9         144.1       0.6X
-MICROSECONDS of date                               1292           1301           8          7.7         129.2       0.7X
-EPOCH of date                                      2030           2036           8          4.9         203.0       0.4X
+cast to date                                        553            559           9         18.1          55.3       1.0X
+MILLENNIUM of date                                  735            752          18         13.6          73.5       0.8X
+CENTURY of date                                     719            726          12         13.9          71.9       0.8X
+DECADE of date                                      667            676           9         15.0          66.7       0.8X
+YEAR of date                                        628            650          20         15.9          62.8       0.9X
+ISOYEAR of date                                     815            815           1         12.3          81.5       0.7X
+QUARTER of date                                     801            822          22         12.5          80.1       0.7X
+MONTH of date                                       641            652          10         15.6          64.1       0.9X
+WEEK of date                                        939            956          17         10.6          93.9       0.6X
+DAY of date                                         630            661          44         15.9          63.0       0.9X
+DAYOFWEEK of date                                   770            780          10         13.0          77.0       0.7X
+DOW of date                                         763            792          38         13.1          76.3       0.7X
+ISODOW of date                                      785            807          24         12.7          78.5       0.7X
+DOY of date                                         681            694          14         14.7          68.1       0.8X
+HOUR of date                                       1359           1417          53          7.4         135.9       0.4X
+MINUTE of date                                     1338           1342           4          7.5         133.8       0.4X
+SECOND of date                                     1483           1498          20          6.7         148.3       0.4X
+MILLISECONDS of date                               1473           1503          28          6.8         147.3       0.4X
+MICROSECONDS of date                               1379           1393          22          7.3         137.9       0.4X
+EPOCH of date                                      1510           1546          60          6.6         151.0       0.4X
 
-OpenJDK 64-Bit Server VM 1.8.0_232-8u232-b09-0ubuntu1~18.04.1-b09 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke date_part for interval:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to interval                                   1249           1254           6          8.0         124.9       1.0X
-MILLENNIUM of interval                             1310           1316           9          7.6         131.0       1.0X
-CENTURY of interval                                1304           1315          10          7.7         130.4       1.0X
-DECADE of interval                                 1306           1313           7          7.7         130.6       1.0X
-YEAR of interval                                   1304           1313          11          7.7         130.4       1.0X
-QUARTER of interval                                1310           1317           7          7.6         131.0       1.0X
-MONTH of interval                                  1311           1319          12          7.6         131.1       1.0X
-DAY of interval                                    1295           1304          13          7.7         129.5       1.0X
-HOUR of interval                                   1301           1306           8          7.7         130.1       1.0X
-MINUTE of interval                                 1316           1319           3          7.6         131.6       0.9X
-SECOND of interval                                 1437           1440           3          7.0         143.7       0.9X
-MILLISECONDS of interval                           1435           1449          16          7.0         143.5       0.9X
-MICROSECONDS of interval                           1304           1314           9          7.7         130.4       1.0X
-EPOCH of interval                                  1440           1453          19          6.9         144.0       0.9X
+cast to interval                                   3984           4034          79          2.5         398.4       1.0X
+MILLENNIUM of interval                             4764           4817          75          2.1         476.4       0.8X
+CENTURY of interval                                4844           4857          23          2.1         484.4       0.8X
+DECADE of interval                                 4745           4785          46          2.1         474.5       0.8X
+YEAR of interval                                   4741           4744           2          2.1         474.1       0.8X
+QUARTER of interval                                4691           4708          15          2.1         469.1       0.8X
+MONTH of interval                                  4707           4746          36          2.1         470.7       0.8X
+DAY of interval                                    4715           4889         249          2.1         471.5       0.8X
+HOUR of interval                                   5237           5323          83          1.9         523.7       0.8X
+MINUTE of interval                                 5146           5376         222          1.9         514.6       0.8X
+SECOND of interval                                 5196           5345         229          1.9         519.6       0.8X
+MILLISECONDS of interval                           5567           5725         242          1.8         556.7       0.7X
+MICROSECONDS of interval                           5097           5119          21          2.0         509.7       0.8X
+EPOCH of interval                                  5222           5379         172          1.9         522.2       0.8X
 

--- a/sql/core/benchmarks/ExtractBenchmark-results.txt
+++ b/sql/core/benchmarks/ExtractBenchmark-results.txt
@@ -2,118 +2,118 @@ Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke extract for timestamp:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp                                   200            224          28         50.0          20.0       1.0X
-MILLENNIUM of timestamp                             741            750          14         13.5          74.1       0.3X
-CENTURY of timestamp                                768            781          15         13.0          76.8       0.3X
-DECADE of timestamp                                 671            680           7         14.9          67.1       0.3X
-YEAR of timestamp                                   659            680          30         15.2          65.9       0.3X
-ISOYEAR of timestamp                                732            753          22         13.7          73.2       0.3X
-QUARTER of timestamp                                772            789          20         12.9          77.2       0.3X
-MONTH of timestamp                                  643            673          47         15.6          64.3       0.3X
-WEEK of timestamp                                   965            971          10         10.4          96.5       0.2X
-DAY of timestamp                                    635            641           9         15.7          63.5       0.3X
-DAYOFWEEK of timestamp                              755            774          17         13.3          75.5       0.3X
-DOW of timestamp                                    768            798          39         13.0          76.8       0.3X
-ISODOW of timestamp                                 736            760          24         13.6          73.6       0.3X
-DOY of timestamp                                    688            696           6         14.5          68.8       0.3X
-HOUR of timestamp                                   490            498           7         20.4          49.0       0.4X
-MINUTE of timestamp                                 484            497          13         20.7          48.4       0.4X
-SECOND of timestamp                                 614            627          11         16.3          61.4       0.3X
-MILLISECONDS of timestamp                           610            631          24         16.4          61.0       0.3X
-MICROSECONDS of timestamp                           516            525           8         19.4          51.6       0.4X
-EPOCH of timestamp                                  665            670           7         15.0          66.5       0.3X
+cast to timestamp                                   204            225          26         49.0          20.4       1.0X
+MILLENNIUM of timestamp                             820            833          20         12.2          82.0       0.2X
+CENTURY of timestamp                                820            833          12         12.2          82.0       0.2X
+DECADE of timestamp                                 734            742           7         13.6          73.4       0.3X
+YEAR of timestamp                                   709            723          13         14.1          70.9       0.3X
+ISOYEAR of timestamp                                799            808          11         12.5          79.9       0.3X
+QUARTER of timestamp                                867            877           8         11.5          86.7       0.2X
+MONTH of timestamp                                  713            724          10         14.0          71.3       0.3X
+WEEK of timestamp                                  1018           1032          16          9.8         101.8       0.2X
+DAY of timestamp                                    707            716          14         14.1          70.7       0.3X
+DAYOFWEEK of timestamp                              812            822          17         12.3          81.2       0.3X
+DOW of timestamp                                    828            836           7         12.1          82.8       0.2X
+ISODOW of timestamp                                 791            803          12         12.6          79.1       0.3X
+DOY of timestamp                                    751            760           7         13.3          75.1       0.3X
+HOUR of timestamp                                   557            565          10         17.9          55.7       0.4X
+MINUTE of timestamp                                 535            553          25         18.7          53.5       0.4X
+SECOND of timestamp                                 658            669          16         15.2          65.8       0.3X
+MILLISECONDS of timestamp                           662            675          20         15.1          66.2       0.3X
+MICROSECONDS of timestamp                           550            556           9         18.2          55.0       0.4X
+EPOCH of timestamp                                  674            684          12         14.8          67.4       0.3X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke date_part for timestamp:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp                                   171            177           5         58.4          17.1       1.0X
-MILLENNIUM of timestamp                             744            758          15         13.4          74.4       0.2X
-CENTURY of timestamp                                721            742          23         13.9          72.1       0.2X
-DECADE of timestamp                                 650            657           6         15.4          65.0       0.3X
-YEAR of timestamp                                   634            640           7         15.8          63.4       0.3X
-ISOYEAR of timestamp                                793            803          13         12.6          79.3       0.2X
-QUARTER of timestamp                                811            844          31         12.3          81.1       0.2X
-MONTH of timestamp                                  642            652          13         15.6          64.2       0.3X
-WEEK of timestamp                                   944            955          10         10.6          94.4       0.2X
-DAY of timestamp                                    650            652           2         15.4          65.0       0.3X
-DAYOFWEEK of timestamp                              778            814          52         12.9          77.8       0.2X
-DOW of timestamp                                    769            772           3         13.0          76.9       0.2X
-ISODOW of timestamp                                 776            805          28         12.9          77.6       0.2X
-DOY of timestamp                                    675            685          10         14.8          67.5       0.3X
-HOUR of timestamp                                   552            573          22         18.1          55.2       0.3X
-MINUTE of timestamp                                 486            496           9         20.6          48.6       0.4X
-SECOND of timestamp                                 622            629           7         16.1          62.2       0.3X
-MILLISECONDS of timestamp                           685            720          35         14.6          68.5       0.2X
-MICROSECONDS of timestamp                           574            580           8         17.4          57.4       0.3X
-EPOCH of timestamp                                  669            689          24         15.0          66.9       0.3X
+cast to timestamp                                   166            170           3         60.1          16.6       1.0X
+MILLENNIUM of timestamp                             782            796          20         12.8          78.2       0.2X
+CENTURY of timestamp                                812            866          74         12.3          81.2       0.2X
+DECADE of timestamp                                 738            758          23         13.5          73.8       0.2X
+YEAR of timestamp                                   756            770          23         13.2          75.6       0.2X
+ISOYEAR of timestamp                                960            969          10         10.4          96.0       0.2X
+QUARTER of timestamp                                936            963          30         10.7          93.6       0.2X
+MONTH of timestamp                                  703            710           8         14.2          70.3       0.2X
+WEEK of timestamp                                  1090           1119          29          9.2         109.0       0.2X
+DAY of timestamp                                    793            819          34         12.6          79.3       0.2X
+DAYOFWEEK of timestamp                              990           1001          11         10.1          99.0       0.2X
+DOW of timestamp                                    866            923          98         11.5          86.6       0.2X
+ISODOW of timestamp                                 824            830           7         12.1          82.4       0.2X
+DOY of timestamp                                    763            805          62         13.1          76.3       0.2X
+HOUR of timestamp                                   549            556           6         18.2          54.9       0.3X
+MINUTE of timestamp                                 545            556           9         18.3          54.5       0.3X
+SECOND of timestamp                                 690            762         113         14.5          69.0       0.2X
+MILLISECONDS of timestamp                           683            695          12         14.6          68.3       0.2X
+MICROSECONDS of timestamp                           592            601           8         16.9          59.2       0.3X
+EPOCH of timestamp                                  698            754          76         14.3          69.8       0.2X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke extract for date:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date                                        551            555           5         18.1          55.1       1.0X
-MILLENNIUM of date                                  720            731           9         13.9          72.0       0.8X
-CENTURY of date                                     724            735          11         13.8          72.4       0.8X
-DECADE of date                                      666            725          55         15.0          66.6       0.8X
-YEAR of date                                        628            648          20         15.9          62.8       0.9X
-ISOYEAR of date                                     780            823          52         12.8          78.0       0.7X
-QUARTER of date                                     819            828          10         12.2          81.9       0.7X
-MONTH of date                                       653            714          56         15.3          65.3       0.8X
-WEEK of date                                        930            942          10         10.8          93.0       0.6X
-DAY of date                                         632            642          11         15.8          63.2       0.9X
-DAYOFWEEK of date                                   746            760          20         13.4          74.6       0.7X
-DOW of date                                         778            781           3         12.9          77.8       0.7X
-ISODOW of date                                      748            761          12         13.4          74.8       0.7X
-DOY of date                                         674            684          10         14.8          67.4       0.8X
-HOUR of date                                       1312           1329          17          7.6         131.2       0.4X
-MINUTE of date                                     1288           1308          29          7.8         128.8       0.4X
-SECOND of date                                     1438           1451          14          7.0         143.8       0.4X
-MILLISECONDS of date                               1440           1444           6          6.9         144.0       0.4X
-MICROSECONDS of date                               1353           1371          27          7.4         135.3       0.4X
-EPOCH of date                                      1495           1541          51          6.7         149.5       0.4X
+cast to date                                        638            646           7         15.7          63.8       1.0X
+MILLENNIUM of date                                  827            836           9         12.1          82.7       0.8X
+CENTURY of date                                     811            855          56         12.3          81.1       0.8X
+DECADE of date                                      746            765          25         13.4          74.6       0.9X
+YEAR of date                                        737            762          21         13.6          73.7       0.9X
+ISOYEAR of date                                     870            886          15         11.5          87.0       0.7X
+QUARTER of date                                     881            896          17         11.3          88.1       0.7X
+MONTH of date                                       693            716          22         14.4          69.3       0.9X
+WEEK of date                                       1012           1020           8          9.9         101.2       0.6X
+DAY of date                                         695            705           9         14.4          69.5       0.9X
+DAYOFWEEK of date                                   822            831           8         12.2          82.2       0.8X
+DOW of date                                         843            854          10         11.9          84.3       0.8X
+ISODOW of date                                      791            801          12         12.6          79.1       0.8X
+DOY of date                                         758            765           7         13.2          75.8       0.8X
+HOUR of date                                       1402           1422          18          7.1         140.2       0.5X
+MINUTE of date                                     1502           1509           7          6.7         150.2       0.4X
+SECOND of date                                     1589           1613          22          6.3         158.9       0.4X
+MILLISECONDS of date                               1598           1652          61          6.3         159.8       0.4X
+MICROSECONDS of date                               1468           1494          32          6.8         146.8       0.4X
+EPOCH of date                                      1621           1671          44          6.2         162.1       0.4X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke date_part for date:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date                                        553            559           9         18.1          55.3       1.0X
-MILLENNIUM of date                                  735            752          18         13.6          73.5       0.8X
-CENTURY of date                                     719            726          12         13.9          71.9       0.8X
-DECADE of date                                      667            676           9         15.0          66.7       0.8X
-YEAR of date                                        628            650          20         15.9          62.8       0.9X
-ISOYEAR of date                                     815            815           1         12.3          81.5       0.7X
-QUARTER of date                                     801            822          22         12.5          80.1       0.7X
-MONTH of date                                       641            652          10         15.6          64.1       0.9X
-WEEK of date                                        939            956          17         10.6          93.9       0.6X
-DAY of date                                         630            661          44         15.9          63.0       0.9X
-DAYOFWEEK of date                                   770            780          10         13.0          77.0       0.7X
-DOW of date                                         763            792          38         13.1          76.3       0.7X
-ISODOW of date                                      785            807          24         12.7          78.5       0.7X
-DOY of date                                         681            694          14         14.7          68.1       0.8X
-HOUR of date                                       1359           1417          53          7.4         135.9       0.4X
-MINUTE of date                                     1338           1342           4          7.5         133.8       0.4X
-SECOND of date                                     1483           1498          20          6.7         148.3       0.4X
-MILLISECONDS of date                               1473           1503          28          6.8         147.3       0.4X
-MICROSECONDS of date                               1379           1393          22          7.3         137.9       0.4X
-EPOCH of date                                      1510           1546          60          6.6         151.0       0.4X
+cast to date                                        619            652          29         16.1          61.9       1.0X
+MILLENNIUM of date                                  812            834          20         12.3          81.2       0.8X
+CENTURY of date                                     816            849          29         12.3          81.6       0.8X
+DECADE of date                                      738            756          16         13.5          73.8       0.8X
+YEAR of date                                        734            743           8         13.6          73.4       0.8X
+ISOYEAR of date                                     877            899          21         11.4          87.7       0.7X
+QUARTER of date                                     955            966          10         10.5          95.5       0.6X
+MONTH of date                                       719            723           7         13.9          71.9       0.9X
+WEEK of date                                       1014           1031          16          9.9         101.4       0.6X
+DAY of date                                         747            756          10         13.4          74.7       0.8X
+DAYOFWEEK of date                                   803            810           6         12.4          80.3       0.8X
+DOW of date                                         807            835          25         12.4          80.7       0.8X
+ISODOW of date                                      794            825          29         12.6          79.4       0.8X
+DOY of date                                         737            753          14         13.6          73.7       0.8X
+HOUR of date                                       1440           1457          15          6.9         144.0       0.4X
+MINUTE of date                                     1496           1520          31          6.7         149.6       0.4X
+SECOND of date                                     1648           1670          23          6.1         164.8       0.4X
+MILLISECONDS of date                               1577           1609          32          6.3         157.7       0.4X
+MICROSECONDS of date                               1469           1483          17          6.8         146.9       0.4X
+EPOCH of date                                      1581           1593          11          6.3         158.1       0.4X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke date_part for interval:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to interval                                   3984           4034          79          2.5         398.4       1.0X
-MILLENNIUM of interval                             4764           4817          75          2.1         476.4       0.8X
-CENTURY of interval                                4844           4857          23          2.1         484.4       0.8X
-DECADE of interval                                 4745           4785          46          2.1         474.5       0.8X
-YEAR of interval                                   4741           4744           2          2.1         474.1       0.8X
-QUARTER of interval                                4691           4708          15          2.1         469.1       0.8X
-MONTH of interval                                  4707           4746          36          2.1         470.7       0.8X
-DAY of interval                                    4715           4889         249          2.1         471.5       0.8X
-HOUR of interval                                   5237           5323          83          1.9         523.7       0.8X
-MINUTE of interval                                 5146           5376         222          1.9         514.6       0.8X
-SECOND of interval                                 5196           5345         229          1.9         519.6       0.8X
-MILLISECONDS of interval                           5567           5725         242          1.8         556.7       0.7X
-MICROSECONDS of interval                           5097           5119          21          2.0         509.7       0.8X
-EPOCH of interval                                  5222           5379         172          1.9         522.2       0.8X
+cast to interval                                   4195           4242          54          2.4         419.5       1.0X
+MILLENNIUM of interval                              895            913          19         11.2          89.5       4.7X
+CENTURY of interval                                 871            906          33         11.5          87.1       4.8X
+DECADE of interval                                  868            879          11         11.5          86.8       4.8X
+YEAR of interval                                    847            874          39         11.8          84.7       5.0X
+QUARTER of interval                                 898            914          14         11.1          89.8       4.7X
+MONTH of interval                                   868            882          21         11.5          86.8       4.8X
+DAY of interval                                     857            880          26         11.7          85.7       4.9X
+HOUR of interval                                    875            891          20         11.4          87.5       4.8X
+MINUTE of interval                                  874            922          54         11.4          87.4       4.8X
+SECOND of interval                                 1039           1073          36          9.6         103.9       4.0X
+MILLISECONDS of interval                            961            979          24         10.4          96.1       4.4X
+MICROSECONDS of interval                            885            900          14         11.3          88.5       4.7X
+EPOCH of interval                                   984           1003          17         10.2          98.4       4.3X
 

--- a/sql/core/benchmarks/ExtractBenchmark-results.txt
+++ b/sql/core/benchmarks/ExtractBenchmark-results.txt
@@ -2,118 +2,118 @@ Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke extract for timestamp:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp                                   204            225          26         49.0          20.4       1.0X
-MILLENNIUM of timestamp                             820            833          20         12.2          82.0       0.2X
-CENTURY of timestamp                                820            833          12         12.2          82.0       0.2X
-DECADE of timestamp                                 734            742           7         13.6          73.4       0.3X
-YEAR of timestamp                                   709            723          13         14.1          70.9       0.3X
-ISOYEAR of timestamp                                799            808          11         12.5          79.9       0.3X
-QUARTER of timestamp                                867            877           8         11.5          86.7       0.2X
-MONTH of timestamp                                  713            724          10         14.0          71.3       0.3X
-WEEK of timestamp                                  1018           1032          16          9.8         101.8       0.2X
-DAY of timestamp                                    707            716          14         14.1          70.7       0.3X
-DAYOFWEEK of timestamp                              812            822          17         12.3          81.2       0.3X
-DOW of timestamp                                    828            836           7         12.1          82.8       0.2X
-ISODOW of timestamp                                 791            803          12         12.6          79.1       0.3X
-DOY of timestamp                                    751            760           7         13.3          75.1       0.3X
-HOUR of timestamp                                   557            565          10         17.9          55.7       0.4X
-MINUTE of timestamp                                 535            553          25         18.7          53.5       0.4X
-SECOND of timestamp                                 658            669          16         15.2          65.8       0.3X
-MILLISECONDS of timestamp                           662            675          20         15.1          66.2       0.3X
-MICROSECONDS of timestamp                           550            556           9         18.2          55.0       0.4X
-EPOCH of timestamp                                  674            684          12         14.8          67.4       0.3X
+cast to timestamp                                   287            308          19         34.8          28.7       1.0X
+MILLENNIUM of timestamp                             896            918          20         11.2          89.6       0.3X
+CENTURY of timestamp                                849            856           7         11.8          84.9       0.3X
+DECADE of timestamp                                 765            777          17         13.1          76.5       0.4X
+YEAR of timestamp                                   754            756           2         13.3          75.4       0.4X
+ISOYEAR of timestamp                                843            849           5         11.9          84.3       0.3X
+QUARTER of timestamp                                867            873           9         11.5          86.7       0.3X
+MONTH of timestamp                                  758            762           4         13.2          75.8       0.4X
+WEEK of timestamp                                  1049           1054           6          9.5         104.9       0.3X
+DAY of timestamp                                    750            763          11         13.3          75.0       0.4X
+DAYOFWEEK of timestamp                              890            918          25         11.2          89.0       0.3X
+DOW of timestamp                                    879            887           8         11.4          87.9       0.3X
+ISODOW of timestamp                                 862            869          11         11.6          86.2       0.3X
+DOY of timestamp                                    811            868          55         12.3          81.1       0.4X
+HOUR of timestamp                                   627            638          11         16.0          62.7       0.5X
+MINUTE of timestamp                                 600            606           6         16.7          60.0       0.5X
+SECOND of timestamp                                 743            799          51         13.5          74.3       0.4X
+MILLISECONDS of timestamp                           723            737          22         13.8          72.3       0.4X
+MICROSECONDS of timestamp                           648            653           5         15.4          64.8       0.4X
+EPOCH of timestamp                                  780            800          17         12.8          78.0       0.4X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke date_part for timestamp:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp                                   166            170           3         60.1          16.6       1.0X
-MILLENNIUM of timestamp                             782            796          20         12.8          78.2       0.2X
-CENTURY of timestamp                                812            866          74         12.3          81.2       0.2X
-DECADE of timestamp                                 738            758          23         13.5          73.8       0.2X
-YEAR of timestamp                                   756            770          23         13.2          75.6       0.2X
-ISOYEAR of timestamp                                960            969          10         10.4          96.0       0.2X
-QUARTER of timestamp                                936            963          30         10.7          93.6       0.2X
-MONTH of timestamp                                  703            710           8         14.2          70.3       0.2X
-WEEK of timestamp                                  1090           1119          29          9.2         109.0       0.2X
-DAY of timestamp                                    793            819          34         12.6          79.3       0.2X
-DAYOFWEEK of timestamp                              990           1001          11         10.1          99.0       0.2X
-DOW of timestamp                                    866            923          98         11.5          86.6       0.2X
-ISODOW of timestamp                                 824            830           7         12.1          82.4       0.2X
-DOY of timestamp                                    763            805          62         13.1          76.3       0.2X
-HOUR of timestamp                                   549            556           6         18.2          54.9       0.3X
-MINUTE of timestamp                                 545            556           9         18.3          54.5       0.3X
-SECOND of timestamp                                 690            762         113         14.5          69.0       0.2X
-MILLISECONDS of timestamp                           683            695          12         14.6          68.3       0.2X
-MICROSECONDS of timestamp                           592            601           8         16.9          59.2       0.3X
-EPOCH of timestamp                                  698            754          76         14.3          69.8       0.2X
+cast to timestamp                                   238            248          12         42.0          23.8       1.0X
+MILLENNIUM of timestamp                             862            875          12         11.6          86.2       0.3X
+CENTURY of timestamp                                833            847          22         12.0          83.3       0.3X
+DECADE of timestamp                                 759            765           7         13.2          75.9       0.3X
+YEAR of timestamp                                   744            755          15         13.4          74.4       0.3X
+ISOYEAR of timestamp                                937           1019          73         10.7          93.7       0.3X
+QUARTER of timestamp                               1011           1091          69          9.9         101.1       0.2X
+MONTH of timestamp                                  846            888          40         11.8          84.6       0.3X
+WEEK of timestamp                                  1210           1239          41          8.3         121.0       0.2X
+DAY of timestamp                                    932            979          41         10.7          93.2       0.3X
+DAYOFWEEK of timestamp                             1174           1200          42          8.5         117.4       0.2X
+DOW of timestamp                                   1131           1172          37          8.8         113.1       0.2X
+ISODOW of timestamp                                 896            903           7         11.2          89.6       0.3X
+DOY of timestamp                                    805            818          12         12.4          80.5       0.3X
+HOUR of timestamp                                   596            597           2         16.8          59.6       0.4X
+MINUTE of timestamp                                 582            597          17         17.2          58.2       0.4X
+SECOND of timestamp                                 697            709          16         14.4          69.7       0.3X
+MILLISECONDS of timestamp                           700            710          10         14.3          70.0       0.3X
+MICROSECONDS of timestamp                           612            631          21         16.3          61.2       0.4X
+EPOCH of timestamp                                  755            760           7         13.2          75.5       0.3X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke extract for date:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date                                        638            646           7         15.7          63.8       1.0X
-MILLENNIUM of date                                  827            836           9         12.1          82.7       0.8X
-CENTURY of date                                     811            855          56         12.3          81.1       0.8X
-DECADE of date                                      746            765          25         13.4          74.6       0.9X
-YEAR of date                                        737            762          21         13.6          73.7       0.9X
-ISOYEAR of date                                     870            886          15         11.5          87.0       0.7X
-QUARTER of date                                     881            896          17         11.3          88.1       0.7X
-MONTH of date                                       693            716          22         14.4          69.3       0.9X
-WEEK of date                                       1012           1020           8          9.9         101.2       0.6X
-DAY of date                                         695            705           9         14.4          69.5       0.9X
-DAYOFWEEK of date                                   822            831           8         12.2          82.2       0.8X
-DOW of date                                         843            854          10         11.9          84.3       0.8X
-ISODOW of date                                      791            801          12         12.6          79.1       0.8X
-DOY of date                                         758            765           7         13.2          75.8       0.8X
-HOUR of date                                       1402           1422          18          7.1         140.2       0.5X
-MINUTE of date                                     1502           1509           7          6.7         150.2       0.4X
-SECOND of date                                     1589           1613          22          6.3         158.9       0.4X
-MILLISECONDS of date                               1598           1652          61          6.3         159.8       0.4X
-MICROSECONDS of date                               1468           1494          32          6.8         146.8       0.4X
-EPOCH of date                                      1621           1671          44          6.2         162.1       0.4X
+cast to date                                        633            641           7         15.8          63.3       1.0X
+MILLENNIUM of date                                  824            845          26         12.1          82.4       0.8X
+CENTURY of date                                     864            878          13         11.6          86.4       0.7X
+DECADE of date                                      746            763          17         13.4          74.6       0.8X
+YEAR of date                                        752            785          39         13.3          75.2       0.8X
+ISOYEAR of date                                     900            905           5         11.1          90.0       0.7X
+QUARTER of date                                     906            930          23         11.0          90.6       0.7X
+MONTH of date                                       747            752           6         13.4          74.7       0.8X
+WEEK of date                                       1089           1100          17          9.2         108.9       0.6X
+DAY of date                                         795            803          13         12.6          79.5       0.8X
+DAYOFWEEK of date                                   937            944          10         10.7          93.7       0.7X
+DOW of date                                         927           1003          66         10.8          92.7       0.7X
+ISODOW of date                                      977            980           7         10.2          97.7       0.6X
+DOY of date                                         827            877          45         12.1          82.7       0.8X
+HOUR of date                                       1525           1547          34          6.6         152.5       0.4X
+MINUTE of date                                     1473           1499          23          6.8         147.3       0.4X
+SECOND of date                                     1600           1615          15          6.2         160.0       0.4X
+MILLISECONDS of date                               1666           1765         156          6.0         166.6       0.4X
+MICROSECONDS of date                               1554           1627         127          6.4         155.4       0.4X
+EPOCH of date                                      1615           1646          27          6.2         161.5       0.4X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke date_part for date:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date                                        619            652          29         16.1          61.9       1.0X
-MILLENNIUM of date                                  812            834          20         12.3          81.2       0.8X
-CENTURY of date                                     816            849          29         12.3          81.6       0.8X
-DECADE of date                                      738            756          16         13.5          73.8       0.8X
-YEAR of date                                        734            743           8         13.6          73.4       0.8X
-ISOYEAR of date                                     877            899          21         11.4          87.7       0.7X
-QUARTER of date                                     955            966          10         10.5          95.5       0.6X
-MONTH of date                                       719            723           7         13.9          71.9       0.9X
-WEEK of date                                       1014           1031          16          9.9         101.4       0.6X
-DAY of date                                         747            756          10         13.4          74.7       0.8X
-DAYOFWEEK of date                                   803            810           6         12.4          80.3       0.8X
-DOW of date                                         807            835          25         12.4          80.7       0.8X
-ISODOW of date                                      794            825          29         12.6          79.4       0.8X
-DOY of date                                         737            753          14         13.6          73.7       0.8X
-HOUR of date                                       1440           1457          15          6.9         144.0       0.4X
-MINUTE of date                                     1496           1520          31          6.7         149.6       0.4X
-SECOND of date                                     1648           1670          23          6.1         164.8       0.4X
-MILLISECONDS of date                               1577           1609          32          6.3         157.7       0.4X
-MICROSECONDS of date                               1469           1483          17          6.8         146.9       0.4X
-EPOCH of date                                      1581           1593          11          6.3         158.1       0.4X
+cast to date                                        676            690          20         14.8          67.6       1.0X
+MILLENNIUM of date                                  868            882          16         11.5          86.8       0.8X
+CENTURY of date                                     875            880           8         11.4          87.5       0.8X
+DECADE of date                                      762            776          16         13.1          76.2       0.9X
+YEAR of date                                        788            800          11         12.7          78.8       0.9X
+ISOYEAR of date                                     903            917          12         11.1          90.3       0.7X
+QUARTER of date                                     983           1018          40         10.2          98.3       0.7X
+MONTH of date                                       836            857          19         12.0          83.6       0.8X
+WEEK of date                                       1137           1168          28          8.8         113.7       0.6X
+DAY of date                                         768            817          82         13.0          76.8       0.9X
+DAYOFWEEK of date                                   890            926          36         11.2          89.0       0.8X
+DOW of date                                        1007           1033          39          9.9         100.7       0.7X
+ISODOW of date                                      962            969           7         10.4          96.2       0.7X
+DOY of date                                         797            882          80         12.6          79.7       0.8X
+HOUR of date                                       1449           1482          29          6.9         144.9       0.5X
+MINUTE of date                                     1536           1610          69          6.5         153.6       0.4X
+SECOND of date                                     1675           1823         128          6.0         167.5       0.4X
+MILLISECONDS of date                               1605           1622          18          6.2         160.5       0.4X
+MICROSECONDS of date                               1481           1504          32          6.8         148.1       0.5X
+EPOCH of date                                      1656           1843         296          6.0         165.6       0.4X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke date_part for interval:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to interval                                   4195           4242          54          2.4         419.5       1.0X
-MILLENNIUM of interval                              895            913          19         11.2          89.5       4.7X
-CENTURY of interval                                 871            906          33         11.5          87.1       4.8X
-DECADE of interval                                  868            879          11         11.5          86.8       4.8X
-YEAR of interval                                    847            874          39         11.8          84.7       5.0X
-QUARTER of interval                                 898            914          14         11.1          89.8       4.7X
-MONTH of interval                                   868            882          21         11.5          86.8       4.8X
-DAY of interval                                     857            880          26         11.7          85.7       4.9X
-HOUR of interval                                    875            891          20         11.4          87.5       4.8X
-MINUTE of interval                                  874            922          54         11.4          87.4       4.8X
-SECOND of interval                                 1039           1073          36          9.6         103.9       4.0X
-MILLISECONDS of interval                            961            979          24         10.4          96.1       4.4X
-MICROSECONDS of interval                            885            900          14         11.3          88.5       4.7X
-EPOCH of interval                                   984           1003          17         10.2          98.4       4.3X
+cast to interval                                    919            959          45         10.9          91.9       1.0X
+MILLENNIUM of interval                              959           1001          36         10.4          95.9       1.0X
+CENTURY of interval                                 974            998          21         10.3          97.4       0.9X
+DECADE of interval                                  975            989          13         10.3          97.5       0.9X
+YEAR of interval                                    987           1012          24         10.1          98.7       0.9X
+QUARTER of interval                                1014           1031          25          9.9         101.4       0.9X
+MONTH of interval                                   978           1018          45         10.2          97.8       0.9X
+DAY of interval                                    1012           1095          92          9.9         101.2       0.9X
+HOUR of interval                                   1129           1143          14          8.9         112.9       0.8X
+MINUTE of interval                                 1038           1060          25          9.6         103.8       0.9X
+SECOND of interval                                 1062           1289         356          9.4         106.2       0.9X
+MILLISECONDS of interval                           1142           1226          83          8.8         114.2       0.8X
+MICROSECONDS of interval                           1038           1129          79          9.6         103.8       0.9X
+EPOCH of interval                                  1090           1127          34          9.2         109.0       0.8X
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ExtractBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ExtractBenchmark.scala
@@ -56,11 +56,13 @@ object ExtractBenchmark extends SqlBasedBenchmark {
     }
   }
 
-  private def castExpr(from: String): String = from match {
+  private def castExpr(from: String, toStr: Boolean = false): String = from match {
     case "timestamp" => "cast(id as timestamp)"
     case "date" => "cast(cast(id as timestamp) as date)"
-    case "interval" => "cast((cast(cast(id as timestamp) as date) - date'0001-01-01') + " +
+    case "interval" if toStr => "cast((cast(cast(id as timestamp) as date) - date'0001-01-01') + " +
       "(cast(id as timestamp) - timestamp'1000-01-01 01:02:03.123456') as string)"
+    case "interval" => "(cast(cast(id as timestamp) as date) - date'0001-01-01') + " +
+      "(cast(id as timestamp) - timestamp'1000-01-01 01:02:03.123456')"
     case other => throw new IllegalArgumentException(
       s"Unsupported column type $other. Valid column types are 'timestamp' and 'date'")
   }
@@ -108,7 +110,7 @@ object ExtractBenchmark extends SqlBasedBenchmark {
 
       val benchmark = new Benchmark(s"Invoke $func for $dataType", N, output = output)
 
-      run(benchmark, iterNum, s"cast to $dataType", castExpr(dataType))
+      run(benchmark, iterNum, s"cast to $dataType", castExpr(dataType, true))
       fields.foreach(run(benchmark, func, iterNum, _, dataType))
 
       benchmark.run()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ExtractBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ExtractBenchmark.scala
@@ -59,8 +59,8 @@ object ExtractBenchmark extends SqlBasedBenchmark {
   private def castExpr(from: String): String = from match {
     case "timestamp" => "cast(id as timestamp)"
     case "date" => "cast(cast(id as timestamp) as date)"
-    case "interval" => "(cast(cast(id as timestamp) as date) - date'0001-01-01') + " +
-      "(cast(id as timestamp) - timestamp'1000-01-01 01:02:03.123456')"
+    case "interval" => "cast((cast(cast(id as timestamp) as date) - date'0001-01-01') + " +
+      "(cast(id as timestamp) - timestamp'1000-01-01 01:02:03.123456') as string)"
     case other => throw new IllegalArgumentException(
       s"Unsupported column type $other. Valid column types are 'timestamp' and 'date'")
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

fix the error caused by interval output in ExtractBenchmark
### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
fix a bug in the test

```scala
[info]   Running case: cast to interval
[error] Exception in thread "main" org.apache.spark.sql.AnalysisException: Cannot use interval type in the table schema.;;
[error] OverwriteByExpression RelationV2[] noop-table, true, true
[error] +- Project [(subtractdates(cast(cast(id#0L as timestamp) as date), -719162) + subtracttimestamps(cast(id#0L as timestamp), -30610249419876544)) AS ((CAST(CAST(id AS TIMESTAMP) AS DATE) - DATE '0001-01-01') + (CAST(id AS TIMESTAMP) - TIMESTAMP '1000-01-01 01:02:03.123456'))#2]
[error]    +- Range (1262304000, 1272304000, step=1, splits=Some(1))
[error]
[error] 	at org.apache.spark.sql.catalyst.util.TypeUtils$.failWithIntervalType(TypeUtils.scala:106)
[error] 	at org.apache.spark.sql.catalyst.analysis.CheckAnalysis.$anonfun$checkAnalysis$25(CheckAnalysis.scala:389)
[error] 	at org.a
```
### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
re-run benchmark