### PR TITLE
[SPARK-31095][BUILD][2.4] Upgrade netty-all to 4.1.47.Final

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.6
+++ b/dev/deps/spark-deps-hadoop-2.6
@@ -147,7 +147,7 @@ metrics-graphite/3.1.5//metrics-graphite-3.1.5.jar
 metrics-json/3.1.5//metrics-json-3.1.5.jar
 metrics-jvm/3.1.5//metrics-jvm-3.1.5.jar
 minlog/1.3.0//minlog-1.3.0.jar
-netty-all/4.1.42.Final//netty-all-4.1.42.Final.jar
+netty-all/4.1.47.Final//netty-all-4.1.47.Final.jar
 netty/3.9.9.Final//netty-3.9.9.Final.jar
 objenesis/2.5.1//objenesis-2.5.1.jar
 okhttp/3.12.0//okhttp-3.12.0.jar

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -148,7 +148,7 @@ metrics-graphite/3.1.5//metrics-graphite-3.1.5.jar
 metrics-json/3.1.5//metrics-json-3.1.5.jar
 metrics-jvm/3.1.5//metrics-jvm-3.1.5.jar
 minlog/1.3.0//minlog-1.3.0.jar
-netty-all/4.1.42.Final//netty-all-4.1.42.Final.jar
+netty-all/4.1.47.Final//netty-all-4.1.47.Final.jar
 netty/3.9.9.Final//netty-3.9.9.Final.jar
 objenesis/2.5.1//objenesis-2.5.1.jar
 okhttp/3.12.0//okhttp-3.12.0.jar

--- a/dev/deps/spark-deps-hadoop-3.1
+++ b/dev/deps/spark-deps-hadoop-3.1
@@ -165,7 +165,7 @@ metrics-json/3.1.5//metrics-json-3.1.5.jar
 metrics-jvm/3.1.5//metrics-jvm-3.1.5.jar
 minlog/1.3.0//minlog-1.3.0.jar
 mssql-jdbc/6.2.1.jre7//mssql-jdbc-6.2.1.jre7.jar
-netty-all/4.1.42.Final//netty-all-4.1.42.Final.jar
+netty-all/4.1.47.Final//netty-all-4.1.47.Final.jar
 netty/3.9.9.Final//netty-3.9.9.Final.jar
 nimbus-jose-jwt/4.41.1//nimbus-jose-jwt-4.41.1.jar
 objenesis/2.5.1//objenesis-2.5.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -622,7 +622,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.1.42.Final</version>
+        <version>4.1.47.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a backport of https://github.com/apache/spark/pull/27869.

This PR aims to bring the bug fixes from the latest netty-all.

### Why are the changes needed?

- 4.1.47.Final: https://github.com/netty/netty/milestone/222?closed=1 (15 patches or issues)
- 4.1.46.Final: https://github.com/netty/netty/milestone/221?closed=1 (80 patches or issues)
- 4.1.45.Final: https://github.com/netty/netty/milestone/220?closed=1 (23 patches or issues)
- 4.1.44.Final: https://github.com/netty/netty/milestone/218?closed=1 (113 patches or issues)
- 4.1.43.Final: https://github.com/netty/netty/milestone/217?closed=1 (63 patches or issues)

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Pass the Jenkins with the existing tests.