### PR TITLE
[SPARK-31105][CORE]Respect sql execution id for FIFO scheduling mode

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/Pool.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Pool.scala
@@ -42,6 +42,7 @@ private[spark] class Pool(
   var runningTasks = 0
   val priority = 0
 
+  val jobId = -1
   // A pool's stage id is used to break the tie in scheduling.
   var stageId = -1
   val name = poolName

--- a/core/src/main/scala/org/apache/spark/scheduler/Schedulable.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Schedulable.scala
@@ -35,7 +35,8 @@ private[spark] trait Schedulable {
   def weight: Int
   def minShare: Int
   def runningTasks: Int
-  def priority: Int
+  def priority: Long
+  def jobId: Int
   def stageId: Int
   def name: String
 

--- a/core/src/main/scala/org/apache/spark/scheduler/SchedulingAlgorithm.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SchedulingAlgorithm.scala
@@ -32,9 +32,14 @@ private[spark] class FIFOSchedulingAlgorithm extends SchedulingAlgorithm {
     val priority2 = s2.priority
     var res = math.signum(priority1 - priority2)
     if (res == 0) {
-      val stageId1 = s1.stageId
-      val stageId2 = s2.stageId
-      res = math.signum(stageId1 - stageId2)
+      val jobId1 = s1.jobId
+      val jobId2 = s2.jobId
+      res = math.signum(jobId1 - jobId2)
+      if (res == 0) {
+        val stageId1 = s1.stageId
+        val stageId2 = s2.stageId
+        res = math.signum(stageId1 - stageId2)
+      }
     }
     res < 0
   }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -111,8 +111,11 @@ private[spark] class TaskSetManager(
 
   val weight = 1
   val minShare = 0
-  var priority = taskSet.priority
-  var stageId = taskSet.stageId
+  val priority = if (taskSet.properties != null) {
+    taskSet.properties.getProperty("spark.sql.execution.id", "0").toLong
+  } else 0L
+  val jobId = taskSet.priority
+  val stageId = taskSet.stageId
   val name = "TaskSet_" + taskSet.id
   var parent: Pool = null
   private var totalResultSize = 0L


### PR DESCRIPTION

### What changes were proposed in this pull request?

Currently, spark will sort taskSets by jobId and stageId and then schedule them in order for FIFO schedulingMode. In OLAP senerios, especially under high concurrency, the taskSets are always from different sql queries and several jobs can be submitted for execution at one time for one query, especailly for adaptive execution. But now we order those taskSets without considering the execution group, which may causes the query being delayed.

So I propose to consider the sql execution id when scheduling jobs.


### Why are the changes needed?

Improvements


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
existing UT & added UT
