### PR TITLE
[SPARK-31115][SQL] Detect known Janino bug janino-compiler/janino#113 and apply workaround automatically as a fail-back via avoid using switch statement in generated code

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -113,7 +113,7 @@ private[codegen] case class NewFunctionSpec(
  * A context for codegen, tracking a list of objects that could be passed into generated Java
  * function.
  */
-class CodegenContext extends Logging {
+class CodegenContext(val disallowSwitchStatement: Boolean = false) extends Logging {
 
   import CodeGenerator._
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -454,8 +454,7 @@ case class InSet(child: Expression, hset: Set[Any]) extends UnaryExpression with
   }
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
-    val sqlConf = SQLConf.get
-    if (canBeComputedUsingSwitch && hset.size <= sqlConf.optimizerInSetSwitchThreshold &&
+    if (canBeComputedUsingSwitch && hset.size <= SQLConf.get.optimizerInSetSwitchThreshold &&
       !ctx.disallowSwitchStatement) {
       genCodeWithSwitch(ctx, ev)
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -454,7 +454,9 @@ case class InSet(child: Expression, hset: Set[Any]) extends UnaryExpression with
   }
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
-    if (canBeComputedUsingSwitch && hset.size <= SQLConf.get.optimizerInSetSwitchThreshold) {
+    val sqlConf = SQLConf.get
+    if (canBeComputedUsingSwitch && hset.size <= sqlConf.optimizerInSetSwitchThreshold &&
+      sqlConf.codegenUseSwitchStatement) {
       genCodeWithSwitch(ctx, ev)
     } else {
       genCodeWithSet(ctx, ev)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -456,7 +456,7 @@ case class InSet(child: Expression, hset: Set[Any]) extends UnaryExpression with
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     val sqlConf = SQLConf.get
     if (canBeComputedUsingSwitch && hset.size <= sqlConf.optimizerInSetSwitchThreshold &&
-      sqlConf.codegenUseSwitchStatement) {
+      !ctx.disallowSwitchStatement) {
       genCodeWithSwitch(ctx, ev)
     } else {
       genCodeWithSet(ctx, ev)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1130,23 +1130,6 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
-  val CODEGEN_USE_SWITCH_STATEMENT =
-    buildConf("spark.sql.codegen.useSwitchStatement")
-      .internal()
-      .doc("When true, Spark leverages switch statement while generating code. Otherwise Spark " +
-        "will leverage if ~ else if ~ else statement as an alternative. In normal case, " +
-        "'switch' statement is preferred against if ~ else if ~ else. This configuration is " +
-        "required to avoid Janino bug (https://github.com/janino-compiler/janino/issues/113); " +
-        "If InternalCompilerException has been thrown and following conditions are met, you " +
-        "may want to turn this off and try executing the query again." +
-        "1) The generated code contains 'switch' statement." +
-        "2) Exception message contains 'Operand stack inconsistent at offset xxx: Previous size 1" +
-        ", now 0'." +
-        "The configuration will be no-op and maybe removed once Spark upgrades Janino containing" +
-        " the fix.")
-      .booleanConf
-      .createWithDefault(true)
-
   val FILES_MAX_PARTITION_BYTES = buildConf("spark.sql.files.maxPartitionBytes")
     .doc("The maximum number of bytes to pack into a single partition when reading files. " +
       "This configuration is effective only when using file-based sources such as Parquet, JSON " +
@@ -2780,8 +2763,6 @@ class SQLConf extends Serializable with Logging {
 
   def wholeStageSplitConsumeFuncByOperator: Boolean =
     getConf(WHOLESTAGE_SPLIT_CONSUME_FUNC_BY_OPERATOR)
-
-  def codegenUseSwitchStatement: Boolean = getConf(CODEGEN_USE_SWITCH_STATEMENT)
 
   def tableRelationCacheSize: Int =
     getConf(StaticSQLConf.FILESOURCE_TABLE_RELATION_CACHE_SIZE)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1130,6 +1130,23 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val CODEGEN_USE_SWITCH_STATEMENT =
+    buildConf("spark.sql.codegen.useSwitchStatement")
+      .internal()
+      .doc("When true, Spark leverages switch statement while generating code. Otherwise Spark " +
+        "will leverage if ~ else if ~ else statement as an alternative. In normal case, " +
+        "'switch' statement is preferred against if ~ else if ~ else. This configuration is " +
+        "required to avoid Janino bug (https://github.com/janino-compiler/janino/issues/113); " +
+        "If InternalCompilerException has been thrown and following conditions are met, you " +
+        "may want to turn this off and try executing the query again." +
+        "1) The generated code contains 'switch' statement." +
+        "2) Exception message contains 'Operand stack inconsistent at offset xxx: Previous size 1" +
+        ", now 0'." +
+        "The configuration will be no-op and maybe removed once Spark upgrades Janino containing" +
+        " the fix.")
+      .booleanConf
+      .createWithDefault(true)
+
   val FILES_MAX_PARTITION_BYTES = buildConf("spark.sql.files.maxPartitionBytes")
     .doc("The maximum number of bytes to pack into a single partition when reading files. " +
       "This configuration is effective only when using file-based sources such as Parquet, JSON " +
@@ -2763,6 +2780,8 @@ class SQLConf extends Serializable with Logging {
 
   def wholeStageSplitConsumeFuncByOperator: Boolean =
     getConf(WHOLESTAGE_SPLIT_CONSUME_FUNC_BY_OPERATOR)
+
+  def codegenUseSwitchStatement: Boolean = getConf(CODEGEN_USE_SWITCH_STATEMENT)
 
   def tableRelationCacheSize: Int =
     getConf(StaticSQLConf.FILESOURCE_TABLE_RELATION_CACHE_SIZE)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -1009,7 +1009,7 @@ class DataFrameAggregateSuite extends QueryTest
         .agg(aggExprs.head, aggExprs.tail: _*)
 
       // We are only interested in whether the code compilation fails or not, so skipping
-      // verificaion on outputs.
+      // verification on outputs.
       aggDf.collect()
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -978,8 +978,7 @@ class DataFrameAggregateSuite extends QueryTest
       (SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key, "true"),
       (SQLConf.WHOLESTAGE_MAX_NUM_FIELDS.key, "10000"),
       (SQLConf.CODEGEN_FALLBACK.key, "false"),
-      (SQLConf.CODEGEN_LOGGING_MAX_LINES.key, "-1"),
-      (SQLConf.CODEGEN_USE_SWITCH_STATEMENT.key, "false")
+      (SQLConf.CODEGEN_LOGGING_MAX_LINES.key, "-1")
     ) {
       var df = Seq(("1", "2", 1), ("1", "2", 2), ("2", "3", 3), ("2", "3", 4)).toDF("a", "b", "c")
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/ExecutorSideSQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/ExecutorSideSQLConfSuite.scala
@@ -107,7 +107,7 @@ class ExecutorSideSQLConfSuite extends SparkFunSuite with SQLTestUtils {
           .queryExecution.executedPlan)
         assert(res.length == 2)
         assert(res.forall { case (_, code, _) =>
-          (code.contains("* Codegend pipeline") == flag) &&
+          (code.contains("* Codegen pipeline") == flag) &&
             (code.contains("// input[") == flag)
         })
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This patch proposes to detect whether the generated code hits the known Janino bug janino-compiler/janino#113 from exception thrown in codegen compilation, and re-generate workaround code via not using `switch` statement, as a "fail-back".

The bug is triggered from some circumstance with using `switch` statement (please refer Janino issue for more details), but `switch` statement is still used first, as it makes the generated code more concise, and also more efficient in point of performance's view. So if the generated code doesn't hit the Janino bug, the behavior would be same with the state before the patch.

The conditions are below:

* The generated code contains 'switch' statement.
* Exception message contains 'Operand stack inconsistent at offset xxx: Previous size 1, now 0'.

From the new test, the generated code for `expand_doConsume` is following in normal path:

```
/* 491 */   private void expand_doConsume_0(UTF8String expand_expr_0_0, boolean expand_exprIsNull_0_0, UTF8String expand_expr_1_0, boolean expand_exprIsNull_1_0, int expand_expr_2_0, int expand_expr_3_0, int expand_expr_4_0, int expand_expr_5_0, int expand_expr_6_0, int expand_expr_7_0, int expand_expr_8_0, int expand_expr_9_0, int expand_expr_10_0, int expand_expr_11_0, int expand_expr_12_0, int expand_expr_13_0, int expand_expr_14_0, int expand_expr_15_0, int expand_expr_16_0, int expand_expr_17_0, int expand_expr_18_0, int expand_expr_19_0, int expand_expr_20_0, int expand_expr_21_0, int expand_expr_22_0, int expand_expr_23_0, int expand_expr_24_0, int expand_expr_25_0, int expand_expr_26_0, int expand_expr_27_0, int expand_expr_28_0, int expand_expr_29_0, int expand_expr_30_0, int expand_expr_31_0, int expand_expr_32_0, int expand_expr_33_0, int expand_expr_34_0, int expand_expr_35_0, int expand_expr_36_0, int expand_expr_37_0, int expand_expr_38_0, int expand_expr_39_0, int expand_expr_40_0, int expand_expr_41_0, int expand_expr_42_0, int expand_expr_43_0, int expand_expr_44_0, int expand_expr_45_0, int expand_expr_46_0, int expand_expr_47_0, int expand_expr_48_0, int expand_expr_49_0, int expand_expr_50_0, int expand_expr_51_0, int expand_expr_52_0, int expand_expr_53_0, int expand_expr_54_0, int expand_expr_55_0, int expand_expr_56_0, int expand_expr_57_0, int expand_expr_58_0, int expand_expr_59_0, int expand_expr_60_0, int expand_expr_61_0, int expand_expr_62_0, int expand_expr_63_0, int expand_expr_64_0, int expand_expr_65_0, int expand_expr_66_0, int expand_expr_67_0, int expand_expr_68_0, int expand_expr_69_0, int expand_expr_70_0, int expand_expr_71_0, int expand_expr_72_0, int expand_expr_73_0, int expand_expr_74_0, int expand_expr_75_0, int expand_expr_76_0, int expand_expr_77_0, int expand_expr_78_0, int expand_expr_79_0, int expand_expr_80_0, int expand_expr_81_0, int expand_expr_82_0, int expand_expr_83_0, int expand_expr_84_0, int expand_expr_85_0, int expand_expr_86_0, int expand_expr_87_0, int expand_expr_88_0, int expand_expr_89_0, int expand_expr_90_0, int expand_expr_91_0, int expand_expr_92_0, int expand_expr_93_0, int expand_expr_94_0, int expand_expr_95_0, int expand_expr_96_0, int expand_expr_97_0, int expand_expr_98_0, int expand_expr_99_0, int expand_expr_100_0) throws java.io.IOException {
/* 492 */     boolean expand_isNull_103 = true;
/* 493 */     int expand_value_103 =
/* 494 */     -1;
...
/* 792 */     for (int expand_i_0 = 0; expand_i_0 < 50; expand_i_0 ++) {
/* 793 */       switch (expand_i_0) {
/* 794 */       case 0:
/* 795 */         expand_isNull_103 = true;
/* 796 */         expand_value_103 = -1;
/* 797 */
...
/* 15592 */       case 49:
/* 15593 */         expand_isNull_103 = true;
/* 15594 */         expand_value_103 = -1;
/* 15595 */
...
/* 15892 */         break;
/* 15893 */       }
/* 15894 */
/* 15895 */       ((org.apache.spark.sql.execution.metric.SQLMetric) references[7] /* numOutputRows */).add(1);
/* 15896 */
/* 15897 */       agg_doConsume_0(expand_expr_0_0, expand_exprIsNull_0_0, expand_expr_1_0, expand_exprIsNull_1_0, expand_value_103, expand_isNull_103, expand_value_104, expand_isNull_104, expand_value_105, expand_isNull_105, expand_value_106, expand_isNull_106, expand_value_107, expand_isNull_107, expand_value_108, expand_isNull_108, expand_value_109, expand_isNull_109, expand_value_110, expand_isNull_110, expand_value_111, expand_isNull_111, expand_value_112, expand_isNull_112, expand_value_113, expand_isNull_113, expand_value_114, expand_isNull_114, expand_value_115, expand_isNull_115, expand_value_116, expand_isNull_116, expand_value_117, expand_isNull_117, expand_value_118, expand_isNull_118, expand_value_119, expand_isNull_119, expand_value_120, expand_isNull_120, expand_value_121, expand_isNull_121, expand_value_122, expand_isNull_122, expand_value_123, expand_isNull_123, expand_value_124, expand_isNull_124, expand_value_125, expand_isNull_125, expand_value_126, expand_isNull_126, expand_value_127, expand_isNull_127, expand_value_128, expand_isNull_128, expand_value_129, expand_isNull_129, expand_value_130, expand_isNull_130, expand_value_131, expand_isNull_131, expand_value_132, expand_isNull_132, expand_value_133, expand_isNull_133, expand_value_134, expand_isNull_134, expand_value_135, expand_isNull_135, expand_value_136, expand_isNull_136, expand_value_137, expand_isNull_137, expand_value_138, expand_isNull_138, expand_value_139, expand_isNull_139, expand_value_140, expand_isNull_140, expand_value_141, expand_isNull_141, expand_value_142, expand_isNull_142, expand_value_143, expand_isNull_143, expand_value_144, expand_isNull_144, expand_value_145, expand_isNull_145, expand_value_146, expand_isNull_146, expand_value_147, expand_isNull_147, expand_value_148, expand_isNull_148, expand_value_149, expand_isNull_149, expand_value_150, expand_isNull_150, expand_value_151, expand_isNull_151, expand_value_152, expand_value_153, expand_isNull_153, expand_value_154, expand_isNull_154, expand_value_155, expand_isNull_155, expand_value_156, expand_isNull_156, expand_value_157, expand_isNull_157, expand_value_158, expand_isNull_158, expand_value_159, expand_isNull_159, expand_value_160, expand_isNull_160, expand_value_161, expand_isNull_161, expand_value_162, expand_isNull_162, expand_value_163, expand_isNull_163, expand_value_164, expand_isNull_164, expand_value_165, expand_isNull_165, expand_value_166, expand_isNull_166, expand_value_167, expand_isNull_167, expand_value_168, expand_isNull_168, expand_value_169, expand_isNull_169, expand_value_170, expand_isNull_170, expand_value_171, expand_isNull_171, expand_value_172, expand_isNull_172, expand_value_173, expand_isNull_173, expand_value_174, expand_isNull_174, expand_value_175, expand_isNull_175, expand_value_176, expand_isNull_176, expand_value_177, expand_isNull_177, expand_value_178, expand_isNull_178, expand_value_179, expand_isNull_179, expand_value_180, expand_isNull_180, expand_value_181, expand_isNull_181, expand_value_182, expand_isNull_182, expand_value_183, expand_isNull_183, expand_value_184, expand_isNull_184, expand_value_185, expand_isNull_185, expand_value_186, expand_isNull_186, expand_value_187, expand_isNull_187, expand_value_188, expand_isNull_188, expand_value_189, expand_isNull_189, expand_value_190, expand_isNull_190, expand_value_191, expand_isNull_191, expand_value_192, expand_isNull_192, expand_value_193, expand_isNull_193, expand_value_194, expand_isNull_194, expand_value_195, expand_isNull_195, expand_value_196, expand_isNull_196, expand_value_197, expand_isNull_197, expand_value_198, expand_isNull_198, expand_value_199, expand_isNull_199, expand_value_200, expand_isNull_200, expand_value_201, expand_isNull_201, expand_value_202, expand_isNull_202);
/* 15898 */
/* 15899 */     }
```

and after applying the workaround automatically as a fail-back, the new generated code for `expand_doConsume` is following:

```
/* 491 */   private void expand_doConsume_0(UTF8String expand_expr_0_0, boolean expand_exprIsNull_0_0, UTF8String expand_expr_1_0, boolean expand_exprIsNull_1_0, int expand_expr_2_0, int expand_expr_3_0, int expand_expr_4_0, int expand_expr_5_0, int expand_expr_6_0, int expand_expr_7_0, int expand_expr_8_0, int expand_expr_9_0, int expand_expr_10_0, int expand_expr_11_0, int expand_expr_12_0, int expand_expr_13_0, int expand_expr_14_0, int expand_expr_15_0, int expand_expr_16_0, int expand_expr_17_0, int expand_expr_18_0, int expand_expr_19_0, int expand_expr_20_0, int expand_expr_21_0, int expand_expr_22_0, int expand_expr_23_0, int expand_expr_24_0, int expand_expr_25_0, int expand_expr_26_0, int expand_expr_27_0, int expand_expr_28_0, int expand_expr_29_0, int expand_expr_30_0, int expand_expr_31_0, int expand_expr_32_0, int expand_expr_33_0, int expand_expr_34_0, int expand_expr_35_0, int expand_expr_36_0, int expand_expr_37_0, int expand_expr_38_0, int expand_expr_39_0, int expand_expr_40_0, int expand_expr_41_0, int expand_expr_42_0, int expand_expr_43_0, int expand_expr_44_0, int expand_expr_45_0, int expand_expr_46_0, int expand_expr_47_0, int expand_expr_48_0, int expand_expr_49_0, int expand_expr_50_0, int expand_expr_51_0, int expand_expr_52_0, int expand_expr_53_0, int expand_expr_54_0, int expand_expr_55_0, int expand_expr_56_0, int expand_expr_57_0, int expand_expr_58_0, int expand_expr_59_0, int expand_expr_60_0, int expand_expr_61_0, int expand_expr_62_0, int expand_expr_63_0, int expand_expr_64_0, int expand_expr_65_0, int expand_expr_66_0, int expand_expr_67_0, int expand_expr_68_0, int expand_expr_69_0, int expand_expr_70_0, int expand_expr_71_0, int expand_expr_72_0, int expand_expr_73_0, int expand_expr_74_0, int expand_expr_75_0, int expand_expr_76_0, int expand_expr_77_0, int expand_expr_78_0, int expand_expr_79_0, int expand_expr_80_0, int expand_expr_81_0, int expand_expr_82_0, int expand_expr_83_0, int expand_expr_84_0, int expand_expr_85_0, int expand_expr_86_0, int expand_expr_87_0, int expand_expr_88_0, int expand_expr_89_0, int expand_expr_90_0, int expand_expr_91_0, int expand_expr_92_0, int expand_expr_93_0, int expand_expr_94_0, int expand_expr_95_0, int expand_expr_96_0, int expand_expr_97_0, int expand_expr_98_0, int expand_expr_99_0, int expand_expr_100_0) throws java.io.IOException {
/* 492 */     boolean expand_isNull_103 = true;
/* 493 */     int expand_value_103 =
/* 494 */     -1;
...
/* 792 */     for (int expand_i_0 = 0; expand_i_0 < 50; expand_i_0 ++) {
/* 793 */       if (expand_i_0 == 0) {
/* 794 */         expand_isNull_103 = true;
/* 795 */         expand_value_103 = -1;
/* 796 */
...
/* 1095 */       else
/* 1096 */       if (expand_i_0 == 1) {
/* 1097 */         expand_isNull_103 = false;
/* 1098 */         expand_value_103 = expand_expr_58_0;
/* 1099 */
...
/* 15639 */       else
/* 15640 */       if (expand_i_0 == 49) {
/* 15641 */         expand_isNull_103 = true;
/* 15642 */         expand_value_103 = -1;
/* 15643 */
...
/* 15940 */       }
/* 15941 */       ((org.apache.spark.sql.execution.metric.SQLMetric) references[7] /* numOutputRows */).add(1);
/* 15942 */
/* 15943 */       agg_doConsume_0(expand_expr_0_0, expand_exprIsNull_0_0, expand_expr_1_0, expand_exprIsNull_1_0, expand_value_103, expand_isNull_103, expand_value_104, expand_isNull_104, expand_value_105, expand_isNull_105, expand_value_106, expand_isNull_106, expand_value_107, expand_isNull_107, expand_value_108, expand_isNull_108, expand_value_109, expand_isNull_109, expand_value_110, expand_isNull_110, expand_value_111, expand_isNull_111, expand_value_112, expand_isNull_112, expand_value_113, expand_isNull_113, expand_value_114, expand_isNull_114, expand_value_115, expand_isNull_115, expand_value_116, expand_isNull_116, expand_value_117, expand_isNull_117, expand_value_118, expand_isNull_118, expand_value_119, expand_isNull_119, expand_value_120, expand_isNull_120, expand_value_121, expand_isNull_121, expand_value_122, expand_isNull_122, expand_value_123, expand_isNull_123, expand_value_124, expand_isNull_124, expand_value_125, expand_isNull_125, expand_value_126, expand_isNull_126, expand_value_127, expand_isNull_127, expand_value_128, expand_isNull_128, expand_value_129, expand_isNull_129, expand_value_130, expand_isNull_130, expand_value_131, expand_isNull_131, expand_value_132, expand_isNull_132, expand_value_133, expand_isNull_133, expand_value_134, expand_isNull_134, expand_value_135, expand_isNull_135, expand_value_136, expand_isNull_136, expand_value_137, expand_isNull_137, expand_value_138, expand_isNull_138, expand_value_139, expand_isNull_139, expand_value_140, expand_isNull_140, expand_value_141, expand_isNull_141, expand_value_142, expand_isNull_142, expand_value_143, expand_isNull_143, expand_value_144, expand_isNull_144, expand_value_145, expand_isNull_145, expand_value_146, expand_isNull_146, expand_value_147, expand_isNull_147, expand_value_148, expand_isNull_148, expand_value_149, expand_isNull_149, expand_value_150, expand_isNull_150, expand_value_151, expand_isNull_151, expand_value_152, expand_value_153, expand_isNull_153, expand_value_154, expand_isNull_154, expand_value_155, expand_isNull_155, expand_value_156, expand_isNull_156, expand_value_157, expand_isNull_157, expand_value_158, expand_isNull_158, expand_value_159, expand_isNull_159, expand_value_160, expand_isNull_160, expand_value_161, expand_isNull_161, expand_value_162, expand_isNull_162, expand_value_163, expand_isNull_163, expand_value_164, expand_isNull_164, expand_value_165, expand_isNull_165, expand_value_166, expand_isNull_166, expand_value_167, expand_isNull_167, expand_value_168, expand_isNull_168, expand_value_169, expand_isNull_169, expand_value_170, expand_isNull_170, expand_value_171, expand_isNull_171, expand_value_172, expand_isNull_172, expand_value_173, expand_isNull_173, expand_value_174, expand_isNull_174, expand_value_175, expand_isNull_175, expand_value_176, expand_isNull_176, expand_value_177, expand_isNull_177, expand_value_178, expand_isNull_178, expand_value_179, expand_isNull_179, expand_value_180, expand_isNull_180, expand_value_181, expand_isNull_181, expand_value_182, expand_isNull_182, expand_value_183, expand_isNull_183, expand_value_184, expand_isNull_184, expand_value_185, expand_isNull_185, expand_value_186, expand_isNull_186, expand_value_187, expand_isNull_187, expand_value_188, expand_isNull_188, expand_value_189, expand_isNull_189, expand_value_190, expand_isNull_190, expand_value_191, expand_isNull_191, expand_value_192, expand_isNull_192, expand_value_193, expand_isNull_193, expand_value_194, expand_isNull_194, expand_value_195, expand_isNull_195, expand_value_196, expand_isNull_196, expand_value_197, expand_isNull_197, expand_value_198, expand_isNull_198, expand_value_199, expand_isNull_199, expand_value_200, expand_isNull_200, expand_value_201, expand_isNull_201, expand_value_202, expand_isNull_202);
/* 15944 */
/* 15945 */     }
```

### Why are the changes needed?

We got some report on failure on user's query which Janino throws error on compiling generated code. The issue is here: janino-compiler/janino#113 It contains the information of generated code, symptom (error), and analysis of the bug, so please refer the link for more details.

We provided the patch to Janino via janino-compiler/janino#114 and Janino 3.1.1 was released which contains the patch, but we realized lots of unit tests fail once we apply Janino 3.1.1.

We have asked about releasing Janino 3.0.16 to Janino maintainer (see janino-compiler/janino#115), but given there's no guarantee to get it, we'd be better to have our own workaround.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

New UT. Confirmed that changing ExpandExec to not use `CodegenContext.disallowSwitchStatement` made the new test fail.