### PR TITLE
[SPARK-31129][SQL][Tests] Fix IntervalBenchmark and DateTimeBenchmark

### DIFF
--- a/sql/core/benchmarks/DateTimeBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-jdk11-results.txt
@@ -2,428 +2,428 @@
 Extract components
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    408            445          53         24.5          40.8       1.0X
-cast to timestamp wholestage on                     401            453          63         24.9          40.1       1.0X
+cast to timestamp wholestage off                    221            232          16         45.3          22.1       1.0X
+cast to timestamp wholestage on                     213            256          71         46.9          21.3       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                   1197           1246          69          8.4         119.7       1.0X
-year of timestamp wholestage on                    1111           1123          10          9.0         111.1       1.1X
+year of timestamp wholestage off                    863            961         139         11.6          86.3       1.0X
+year of timestamp wholestage on                     783            821          26         12.8          78.3       1.1X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                1451           1462          16          6.9         145.1       1.0X
-quarter of timestamp wholestage on                 1409           1424          13          7.1         140.9       1.0X
+quarter of timestamp wholestage off                1008           1013           7          9.9         100.8       1.0X
+quarter of timestamp wholestage on                  926            963          36         10.8          92.6       1.1X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                  1106           1109           3          9.0         110.6       1.0X
-month of timestamp wholestage on                   1092           1095           4          9.2         109.2       1.0X
+month of timestamp wholestage off                   794            813          27         12.6          79.4       1.0X
+month of timestamp wholestage on                    737            758          23         13.6          73.7       1.1X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off             1675           1677           3          6.0         167.5       1.0X
-weekofyear of timestamp wholestage on              1616           1625           7          6.2         161.6       1.0X
+weekofyear of timestamp wholestage off             1063           1076          18          9.4         106.3       1.0X
+weekofyear of timestamp wholestage on              1070           1366         305          9.3         107.0       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                    1111           1115           6          9.0         111.1       1.0X
-day of timestamp wholestage on                     1090           1098          10          9.2         109.0       1.0X
+day of timestamp wholestage off                     847            854           9         11.8          84.7       1.0X
+day of timestamp wholestage on                      799            836          37         12.5          79.9       1.1X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off              1162           1167           7          8.6         116.2       1.0X
-dayofyear of timestamp wholestage on               1136           1142           6          8.8         113.6       1.0X
+dayofyear of timestamp wholestage off               816            830          20         12.2          81.6       1.0X
+dayofyear of timestamp wholestage on                856            925          62         11.7          85.6       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off             1102           1107           7          9.1         110.2       1.0X
-dayofmonth of timestamp wholestage on              1092           1111          16          9.2         109.2       1.0X
+dayofmonth of timestamp wholestage off             1150           1159          12          8.7         115.0       1.0X
+dayofmonth of timestamp wholestage on               945           1165         308         10.6          94.5       1.2X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off              1254           1260           9          8.0         125.4       1.0X
-dayofweek of timestamp wholestage on               1264           1269           7          7.9         126.4       1.0X
+dayofweek of timestamp wholestage off              1062           1074          16          9.4         106.2       1.0X
+dayofweek of timestamp wholestage on                942           1029          74         10.6          94.2       1.1X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                1211           1215           5          8.3         121.1       1.0X
-weekday of timestamp wholestage on                 1197           1206          12          8.4         119.7       1.0X
+weekday of timestamp wholestage off                 870            872           3         11.5          87.0       1.0X
+weekday of timestamp wholestage on                  821            855          21         12.2          82.1       1.1X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                    899            904           6         11.1          89.9       1.0X
-hour of timestamp wholestage on                     823            827           3         12.2          82.3       1.1X
+hour of timestamp wholestage off                    578            582           5         17.3          57.8       1.0X
+hour of timestamp wholestage on                     533            544          14         18.8          53.3       1.1X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  906            923          24         11.0          90.6       1.0X
-minute of timestamp wholestage on                   821            830          13         12.2          82.1       1.1X
+minute of timestamp wholestage off                  611            613           3         16.4          61.1       1.0X
+minute of timestamp wholestage on                   551            557           8         18.2          55.1       1.1X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  902            908           7         11.1          90.2       1.0X
-second of timestamp wholestage on                   823            833           9         12.2          82.3       1.1X
+second of timestamp wholestage off                  705            716          16         14.2          70.5       1.0X
+second of timestamp wholestage on                   569            669          99         17.6          56.9       1.2X
 
 
 ================================================================================================
 Current date and time
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         300            301           2         33.3          30.0       1.0X
-current_date wholestage on                          309            312           3         32.4          30.9       1.0X
+current_date wholestage off                         177            177           0         56.6          17.7       1.0X
+current_date wholestage on                          164            180          13         60.9          16.4       1.1X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    303            337          47         33.0          30.3       1.0X
-current_timestamp wholestage on                     320            448         160         31.3          32.0       0.9X
+current_timestamp wholestage off                    182            182           1         55.1          18.2       1.0X
+current_timestamp wholestage on                     168            194          53         59.4          16.8       1.1X
 
 
 ================================================================================================
 Date arithmetic
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                         910            912           2         11.0          91.0       1.0X
-cast to date wholestage on                          930            937           6         10.8          93.0       1.0X
+cast to date wholestage off                         615            632          24         16.3          61.5       1.0X
+cast to date wholestage on                          596            660          40         16.8          59.6       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                            1122           1123           1          8.9         112.2       1.0X
-last_day wholestage on                             1100           1109           6          9.1         110.0       1.0X
+last_day wholestage off                             717            728          16         13.9          71.7       1.0X
+last_day wholestage on                              764            834          42         13.1          76.4       0.9X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                             991            992           2         10.1          99.1       1.0X
-next_day wholestage on                              981            984           4         10.2          98.1       1.0X
+next_day wholestage off                             677            677           0         14.8          67.7       1.0X
+next_day wholestage on                              645            796         140         15.5          64.5       1.1X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                             927            927           1         10.8          92.7       1.0X
-date_add wholestage on                              908            915          12         11.0          90.8       1.0X
+date_add wholestage off                             637            663          37         15.7          63.7       1.0X
+date_add wholestage on                              659            675          16         15.2          65.9       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                             921            921           0         10.9          92.1       1.0X
-date_sub wholestage on                              907            910           4         11.0          90.7       1.0X
+date_sub wholestage off                             630            682          73         15.9          63.0       1.0X
+date_sub wholestage on                              720            762          37         13.9          72.0       0.9X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                          1255           1257           3          8.0         125.5       1.0X
-add_months wholestage on                           1242           1259          13          8.1         124.2       1.0X
+add_months wholestage off                          1064           1088          35          9.4         106.4       1.0X
+add_months wholestage on                            883            909          25         11.3          88.3       1.2X
 
 
 ================================================================================================
 Formatting dates
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         4912           4968          79          2.0         491.2       1.0X
-format date wholestage on                          4734           4757          16          2.1         473.4       1.0X
+format date wholestage off                         3667           3854         265          2.7         366.7       1.0X
+format date wholestage on                          3355           3548         195          3.0         335.5       1.1X
 
 
 ================================================================================================
 Formatting timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       8692           8701          13          1.2         869.2       1.0X
-from_unixtime wholestage on                        8717           8730          14          1.1         871.7       1.0X
+from_unixtime wholestage off                       4664           4704          57          2.1         466.4       1.0X
+from_unixtime wholestage on                        4596           4772         193          2.2         459.6       1.0X
 
 
 ================================================================================================
 Convert timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                  1339           1348          12          7.5         133.9       1.0X
-from_utc_timestamp wholestage on                   1398           1404           6          7.2         139.8       1.0X
+from_utc_timestamp wholestage off                   810            819          13         12.3          81.0       1.0X
+from_utc_timestamp wholestage on                    795            814          16         12.6          79.5       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                    1936           1951          21          5.2         193.6       1.0X
-to_utc_timestamp wholestage on                     1783           1792           8          5.6         178.3       1.1X
+to_utc_timestamp wholestage off                    1130           1146          22          8.8         113.0       1.0X
+to_utc_timestamp wholestage on                     1034           1063          40          9.7         103.4       1.1X
 
 
 ================================================================================================
 Intervals
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        350            353           4         28.6          35.0       1.0X
-cast interval wholestage on                         348            355           4         28.7          34.8       1.0X
+cast interval wholestage off                        192            194           2         52.1          19.2       1.0X
+cast interval wholestage on                         172            180           5         58.2          17.2       1.1X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                            1679           1680           2          6.0         167.9       1.0X
-datediff wholestage on                             1674           1687          11          6.0         167.4       1.0X
+datediff wholestage off                            1070           1082          17          9.3         107.0       1.0X
+datediff wholestage on                             1039           1059          13          9.6         103.9       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      4116           4120           5          2.4         411.6       1.0X
-months_between wholestage on                       4092           4140          90          2.4         409.2       1.0X
+months_between wholestage off                      3118           3137          27          3.2         311.8       1.0X
+months_between wholestage on                       3079           3122          48          3.2         307.9       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                              2236           2396         227          0.4        2235.9       1.0X
-window wholestage on                              47208          47298         171          0.0       47208.3       0.0X
+window wholestage off                              1147           1157          14          0.9        1146.6       1.0X
+window wholestage on                              16698          17304         715          0.1       16698.2       0.1X
 
 
 ================================================================================================
 Truncation
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                     1939           1947          11          5.2         193.9       1.0X
-date_trunc YEAR wholestage on                      1890           1899           6          5.3         189.0       1.0X
+date_trunc YEAR wholestage off                     1478           1485           9          6.8         147.8       1.0X
+date_trunc YEAR wholestage on                      1458           1587         213          6.9         145.8       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                     1947           1950           5          5.1         194.7       1.0X
-date_trunc YYYY wholestage on                      1903           1909           7          5.3         190.3       1.0X
+date_trunc YYYY wholestage off                     1467           1481          20          6.8         146.7       1.0X
+date_trunc YYYY wholestage on                      1457           1513          52          6.9         145.7       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                       1941           1952          15          5.2         194.1       1.0X
-date_trunc YY wholestage on                        1895           1907          10          5.3         189.5       1.0X
+date_trunc YY wholestage off                       1551           1556           7          6.4         155.1       1.0X
+date_trunc YY wholestage on                        1468           1538          78          6.8         146.8       1.1X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                      1912           1934          30          5.2         191.2       1.0X
-date_trunc MON wholestage on                       1899           1923          20          5.3         189.9       1.0X
+date_trunc MON wholestage off                      1481           1493          16          6.8         148.1       1.0X
+date_trunc MON wholestage on                       1476           1501          28          6.8         147.6       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                    1923           1931          11          5.2         192.3       1.0X
-date_trunc MONTH wholestage on                     1897           1908          10          5.3         189.7       1.0X
+date_trunc MONTH wholestage off                    1470           1477          10          6.8         147.0       1.0X
+date_trunc MONTH wholestage on                     1449           1610         260          6.9         144.9       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                       1923           1924           2          5.2         192.3       1.0X
-date_trunc MM wholestage on                        1902           1911          10          5.3         190.2       1.0X
+date_trunc MM wholestage off                       1487           1495          12          6.7         148.7       1.0X
+date_trunc MM wholestage on                        1467           1489          17          6.8         146.7       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                      1713           1717           6          5.8         171.3       1.0X
-date_trunc DAY wholestage on                       1693           1699           4          5.9         169.3       1.0X
+date_trunc DAY wholestage off                      1321           1328          10          7.6         132.1       1.0X
+date_trunc DAY wholestage on                       1279           1306          28          7.8         127.9       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                       1711           1712           1          5.8         171.1       1.0X
-date_trunc DD wholestage on                        1691           1697          12          5.9         169.1       1.0X
+date_trunc DD wholestage off                       1366           1368           3          7.3         136.6       1.0X
+date_trunc DD wholestage on                        1297           1314          18          7.7         129.7       1.1X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                     1715           1715           0          5.8         171.5       1.0X
-date_trunc HOUR wholestage on                      1699           1705           4          5.9         169.9       1.0X
+date_trunc HOUR wholestage off                     1338           1354          23          7.5         133.8       1.0X
+date_trunc HOUR wholestage on                      1403           1482          71          7.1         140.3       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    520            524           7         19.2          52.0       1.0X
-date_trunc MINUTE wholestage on                     500            505           6         20.0          50.0       1.0X
+date_trunc MINUTE wholestage off                    241            242           2         41.5          24.1       1.0X
+date_trunc MINUTE wholestage on                     196            204           6         51.0          19.6       1.2X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    501            502           1         20.0          50.1       1.0X
-date_trunc SECOND wholestage on                     497            501           3         20.1          49.7       1.0X
+date_trunc SECOND wholestage off                    211            222          15         47.3          21.1       1.0X
+date_trunc SECOND wholestage on                     205            243          64         48.8          20.5       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                     1839           1840           1          5.4         183.9       1.0X
-date_trunc WEEK wholestage on                      1820           1827           8          5.5         182.0       1.0X
+date_trunc WEEK wholestage off                     1492           1515          32          6.7         149.2       1.0X
+date_trunc WEEK wholestage on                      1465           1490          39          6.8         146.5       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                  2624           2624           0          3.8         262.4       1.0X
-date_trunc QUARTER wholestage on                   2573           2583           7          3.9         257.3       1.0X
+date_trunc QUARTER wholestage off                  1908           1982         104          5.2         190.8       1.0X
+date_trunc QUARTER wholestage on                   1879           2020          99          5.3         187.9       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           315            317           3         31.8          31.5       1.0X
-trunc year wholestage on                            314            328          16         31.9          31.4       1.0X
+trunc year wholestage off                           326            419         132         30.7          32.6       1.0X
+trunc year wholestage on                            187            199           8         53.4          18.7       1.7X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           314            317           4         31.8          31.4       1.0X
-trunc yyyy wholestage on                            312            315           3         32.1          31.2       1.0X
+trunc yyyy wholestage off                           194            194           0         51.6          19.4       1.0X
+trunc yyyy wholestage on                            192            207          10         52.1          19.2       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             314            315           0         31.8          31.4       1.0X
-trunc yy wholestage on                              312            317           6         32.0          31.2       1.0X
+trunc yy wholestage off                             177            180           4         56.5          17.7       1.0X
+trunc yy wholestage on                              185            193           9         53.9          18.5       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            314            315           1         31.8          31.4       1.0X
-trunc mon wholestage on                             310            314           4         32.2          31.0       1.0X
+trunc mon wholestage off                            208            210           3         48.0          20.8       1.0X
+trunc mon wholestage on                             195            204           8         51.3          19.5       1.1X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          313            314           2         32.0          31.3       1.0X
-trunc month wholestage on                           312            316           6         32.1          31.2       1.0X
+trunc month wholestage off                          182            185           4         55.1          18.2       1.0X
+trunc month wholestage on                           185            222          70         54.0          18.5       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             312            313           1         32.0          31.2       1.0X
-trunc mm wholestage on                              309            312           3         32.3          30.9       1.0X
+trunc mm wholestage off                             208            218          14         48.0          20.8       1.0X
+trunc mm wholestage on                              197            206          10         50.8          19.7       1.1X
 
 
 ================================================================================================
 Parsing
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                     170            173           5          5.9         170.0       1.0X
-to timestamp str wholestage on                      156            161           5          6.4         155.9       1.1X
+to timestamp str wholestage off                     121            130          13          8.3         120.7       1.0X
+to timestamp str wholestage on                      128            134           6          7.8         128.4       0.9X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                        1741           1746           8          0.6        1740.7       1.0X
-to_timestamp wholestage on                         1887           1896          11          0.5        1886.6       0.9X
+to_timestamp wholestage off                        1201           1272         100          0.8        1200.8       1.0X
+to_timestamp wholestage on                          973           1019          53          1.0         972.7       1.2X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                   1928           1934           9          0.5        1927.7       1.0X
-to_unix_timestamp wholestage on                    1857           1862           3          0.5        1857.5       1.0X
+to_unix_timestamp wholestage off                   1002           1077         106          1.0        1001.8       1.0X
+to_unix_timestamp wholestage on                     988           1079         100          1.0         987.8       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          161            162           0          6.2         161.5       1.0X
-to date str wholestage on                           151            156           3          6.6         151.4       1.1X
+to date str wholestage off                          157            165          12          6.4         157.2       1.0X
+to date str wholestage on                           137            140           3          7.3         137.0       1.1X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                             2513           2519           8          0.4        2513.1       1.0X
-to_date wholestage on                              2484           2500          15          0.4        2484.2       1.0X
+to_date wholestage off                             1597           1614          25          0.6        1597.0       1.0X
+to_date wholestage on                              1503           1573          58          0.7        1502.8       1.1X
 
 
 ================================================================================================
 Conversion from/to external types
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 To/from java.sql.Timestamp:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Timestamp                             340            347           8         14.7          68.0       1.0X
-Collect longs                                      1170           1217          42          4.3         234.1       0.3X
-Collect timestamps                                 1771           2267         836          2.8         354.1       0.2X
+From java.sql.Timestamp                             197            202           6         25.4          39.4       1.0X
+Collect longs                                       794            911         110          6.3         158.7       0.2X
+Collect timestamps                                 1030           1079          51          4.9         205.9       0.2X
 
 

--- a/sql/core/benchmarks/DateTimeBenchmark-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-results.txt
@@ -2,428 +2,428 @@
 Extract components
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    447            462          21         22.4          44.7       1.0X
-cast to timestamp wholestage on                     390            426          54         25.7          39.0       1.1X
+cast to timestamp wholestage off                    230            240          13         43.5          23.0       1.0X
+cast to timestamp wholestage on                     194            208          20         51.4          19.4       1.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                   1189           1285         135          8.4         118.9       1.0X
-year of timestamp wholestage on                    1146           1156           9          8.7         114.6       1.0X
+year of timestamp wholestage off                    806            822          22         12.4          80.6       1.0X
+year of timestamp wholestage on                     748            761          13         13.4          74.8       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                1290           1293           4          7.8         129.0       1.0X
-quarter of timestamp wholestage on                 1237           1251          13          8.1         123.7       1.0X
+quarter of timestamp wholestage off                 828            832           5         12.1          82.8       1.0X
+quarter of timestamp wholestage on                  821            858          45         12.2          82.1       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                  1096           1101           7          9.1         109.6       1.0X
-month of timestamp wholestage on                   1088           1095           7          9.2         108.8       1.0X
+month of timestamp wholestage off                   709            713           5         14.1          70.9       1.0X
+month of timestamp wholestage on                    714            722          10         14.0          71.4       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off             1635           1636           1          6.1         163.5       1.0X
-weekofyear of timestamp wholestage on              1711           1714           4          5.8         171.1       1.0X
+weekofyear of timestamp wholestage off             1217           1220           4          8.2         121.7       1.0X
+weekofyear of timestamp wholestage on              1019           1043          24          9.8         101.9       1.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                    1094           1108          20          9.1         109.4       1.0X
-day of timestamp wholestage on                     1083           1092           8          9.2         108.3       1.0X
+day of timestamp wholestage off                     706            712           9         14.2          70.6       1.0X
+day of timestamp wholestage on                      694            704           8         14.4          69.4       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off              1145           1145           1          8.7         114.5       1.0X
-dayofyear of timestamp wholestage on               1131           1141          12          8.8         113.1       1.0X
+dayofyear of timestamp wholestage off               717            728          16         14.0          71.7       1.0X
+dayofyear of timestamp wholestage on                724            736          10         13.8          72.4       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off             1112           1124          17          9.0         111.2       1.0X
-dayofmonth of timestamp wholestage on              1082           1096          14          9.2         108.2       1.0X
+dayofmonth of timestamp wholestage off              719            721           3         13.9          71.9       1.0X
+dayofmonth of timestamp wholestage on               706            714           8         14.2          70.6       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off              1254           1255           2          8.0         125.4       1.0X
-dayofweek of timestamp wholestage on               1250           1260          10          8.0         125.0       1.0X
+dayofweek of timestamp wholestage off               904            979         106         11.1          90.4       1.0X
+dayofweek of timestamp wholestage on                796            819          14         12.6          79.6       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                1190           1196           8          8.4         119.0       1.0X
-weekday of timestamp wholestage on                 1204           1218          11          8.3         120.4       1.0X
+weekday of timestamp wholestage off                 813            819           9         12.3          81.3       1.0X
+weekday of timestamp wholestage on                  788            809          13         12.7          78.8       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                    859            862           4         11.6          85.9       1.0X
-hour of timestamp wholestage on                     825            827           2         12.1          82.5       1.0X
+hour of timestamp wholestage off                    567            582          21         17.6          56.7       1.0X
+hour of timestamp wholestage on                     539            551          11         18.6          53.9       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  841            851          15         11.9          84.1       1.0X
-minute of timestamp wholestage on                   817            824           6         12.2          81.7       1.0X
+minute of timestamp wholestage off                  554            563          13         18.1          55.4       1.0X
+minute of timestamp wholestage on                   520            531           7         19.2          52.0       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  901            905           5         11.1          90.1       1.0X
-second of timestamp wholestage on                   830            844          12         12.1          83.0       1.1X
+second of timestamp wholestage off                  651            654           5         15.4          65.1       1.0X
+second of timestamp wholestage on                   535            546          12         18.7          53.5       1.2X
 
 
 ================================================================================================
 Current date and time
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         290            292           2         34.4          29.0       1.0X
-current_date wholestage on                          301            309          10         33.3          30.1       1.0X
+current_date wholestage off                         172            175           4         58.0          17.2       1.0X
+current_date wholestage on                          174            177           3         57.5          17.4       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    300            301           0         33.3          30.0       1.0X
-current_timestamp wholestage on                     316            348          36         31.6          31.6       0.9X
+current_timestamp wholestage off                    184            185           0         54.3          18.4       1.0X
+current_timestamp wholestage on                     196            212          14         51.0          19.6       0.9X
 
 
 ================================================================================================
 Date arithmetic
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                         964            973          13         10.4          96.4       1.0X
-cast to date wholestage on                          900            905           4         11.1          90.0       1.1X
+cast to date wholestage off                         652            662          13         15.3          65.2       1.0X
+cast to date wholestage on                          645            690          29         15.5          64.5       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                            1125           1138          19          8.9         112.5       1.0X
-last_day wholestage on                             1111           1122          12          9.0         111.1       1.0X
+last_day wholestage off                             801            808          11         12.5          80.1       1.0X
+last_day wholestage on                              765            829          37         13.1          76.5       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                             970            982          16         10.3          97.0       1.0X
-next_day wholestage on                              955            958           4         10.5          95.5       1.0X
+next_day wholestage off                             676            676           0         14.8          67.6       1.0X
+next_day wholestage on                              674            708          33         14.8          67.4       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                             894            914          29         11.2          89.4       1.0X
-date_add wholestage on                              880            884           4         11.4          88.0       1.0X
+date_add wholestage off                             644            646           2         15.5          64.4       1.0X
+date_add wholestage on                              640            661          32         15.6          64.0       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                             901            901           1         11.1          90.1       1.0X
-date_sub wholestage on                              883            892          16         11.3          88.3       1.0X
+date_sub wholestage off                             704            718          20         14.2          70.4       1.0X
+date_sub wholestage on                              684            728          34         14.6          68.4       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                          1212           1213           0          8.2         121.2       1.0X
-add_months wholestage on                           1212           1219          11          8.3         121.2       1.0X
+add_months wholestage off                          1011           1017           8          9.9         101.1       1.0X
+add_months wholestage on                            837            860          25         11.9          83.7       1.2X
 
 
 ================================================================================================
 Formatting dates
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         4973           5069         136          2.0         497.3       1.0X
-format date wholestage on                          5061           5075          18          2.0         506.1       1.0X
+format date wholestage off                         3467           3591         176          2.9         346.7       1.0X
+format date wholestage on                          3417           3482          66          2.9         341.7       1.0X
 
 
 ================================================================================================
 Formatting timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       8827           8835          11          1.1         882.7       1.0X
-from_unixtime wholestage on                        8840           8845           5          1.1         884.0       1.0X
+from_unixtime wholestage off                       4823           4850          38          2.1         482.3       1.0X
+from_unixtime wholestage on                        4774           4811          29          2.1         477.4       1.0X
 
 
 ================================================================================================
 Convert timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                  1143           1145           2          8.7         114.3       1.0X
-from_utc_timestamp wholestage on                   1174           1187          12          8.5         117.4       1.0X
+from_utc_timestamp wholestage off                   703            717          20         14.2          70.3       1.0X
+from_utc_timestamp wholestage on                    665            671           7         15.0          66.5       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                    1721           1725           7          5.8         172.1       1.0X
-to_utc_timestamp wholestage on                     1605           1613           5          6.2         160.5       1.1X
+to_utc_timestamp wholestage off                    1000           1016          22         10.0         100.0       1.0X
+to_utc_timestamp wholestage on                      917            933          11         10.9          91.7       1.1X
 
 
 ================================================================================================
 Intervals
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        342            345           5         29.3          34.2       1.0X
-cast interval wholestage on                         329            336          13         30.4          32.9       1.0X
+cast interval wholestage off                        195            198           3         51.2          19.5       1.0X
+cast interval wholestage on                         176            181           5         56.9          17.6       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                            1643           1645           3          6.1         164.3       1.0X
-datediff wholestage on                             1645           1657           8          6.1         164.5       1.0X
+datediff wholestage off                            1022           1025           5          9.8         102.2       1.0X
+datediff wholestage on                             1003           1015          10         10.0         100.3       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      3369           3375           8          3.0         336.9       1.0X
-months_between wholestage on                       3356           3362           5          3.0         335.6       1.0X
+months_between wholestage off                      2562           2579          24          3.9         256.2       1.0X
+months_between wholestage on                       2503           2524          17          4.0         250.3       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                              2017           2029          18          0.5        2016.8       1.0X
-window wholestage on                              44825          44909          56          0.0       44824.9       0.0X
+window wholestage off                              1067           1077          15          0.9        1066.6       1.0X
+window wholestage on                              14503          19089         NaN          0.1       14502.6       0.1X
 
 
 ================================================================================================
 Truncation
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                     1628           1629           0          6.1         162.8       1.0X
-date_trunc YEAR wholestage on                      1589           1599           9          6.3         158.9       1.0X
+date_trunc YEAR wholestage off                     1497           1543          64          6.7         149.7       1.0X
+date_trunc YEAR wholestage on                      1412           1533         138          7.1         141.2       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                     1634           1646          17          6.1         163.4       1.0X
-date_trunc YYYY wholestage on                      1596           1606          13          6.3         159.6       1.0X
+date_trunc YYYY wholestage off                     1725           1729           5          5.8         172.5       1.0X
+date_trunc YYYY wholestage on                      1413           1481          56          7.1         141.3       1.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                       1627           1627           0          6.1         162.7       1.0X
-date_trunc YY wholestage on                        1590           1598          10          6.3         159.0       1.0X
+date_trunc YY wholestage off                       1456           1459           5          6.9         145.6       1.0X
+date_trunc YY wholestage on                        1369           1380           7          7.3         136.9       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                      1633           1634           1          6.1         163.3       1.0X
-date_trunc MON wholestage on                       1602           1607           5          6.2         160.2       1.0X
+date_trunc MON wholestage off                      1459           1471          17          6.9         145.9       1.0X
+date_trunc MON wholestage on                       1359           1377          21          7.4         135.9       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                    1637           1644          11          6.1         163.7       1.0X
-date_trunc MONTH wholestage on                     1601           1609           5          6.2         160.1       1.0X
+date_trunc MONTH wholestage off                    1455           1480          35          6.9         145.5       1.0X
+date_trunc MONTH wholestage on                     1344           1468         170          7.4         134.4       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                       1639           1653          20          6.1         163.9       1.0X
-date_trunc MM wholestage on                        1602           1606           4          6.2         160.2       1.0X
+date_trunc MM wholestage off                       1437           1463          37          7.0         143.7       1.0X
+date_trunc MM wholestage on                        1273           1285           9          7.9         127.3       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                      1635           1643          11          6.1         163.5       1.0X
-date_trunc DAY wholestage on                       1511           1517           6          6.6         151.1       1.1X
+date_trunc DAY wholestage off                      1198           1209          16          8.3         119.8       1.0X
+date_trunc DAY wholestage on                       1137           1192          70          8.8         113.7       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                       1640           1646           8          6.1         164.0       1.0X
-date_trunc DD wholestage on                        1516           1519           4          6.6         151.6       1.1X
+date_trunc DD wholestage off                       1201           1215          20          8.3         120.1       1.0X
+date_trunc DD wholestage on                        1132           1144          14          8.8         113.2       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                     1533           1535           4          6.5         153.3       1.0X
-date_trunc HOUR wholestage on                      1532           1538           7          6.5         153.2       1.0X
+date_trunc HOUR wholestage off                     1236           1238           3          8.1         123.6       1.0X
+date_trunc HOUR wholestage on                      1134           1150          15          8.8         113.4       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    381            382           1         26.2          38.1       1.0X
-date_trunc MINUTE wholestage on                     337            343           9         29.7          33.7       1.1X
+date_trunc MINUTE wholestage off                    206            207           2         48.6          20.6       1.0X
+date_trunc MINUTE wholestage on                     185            186           2         54.0          18.5       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    376            376           1         26.6          37.6       1.0X
-date_trunc SECOND wholestage on                     341            344           6         29.4          34.1       1.1X
+date_trunc SECOND wholestage off                    209            210           2         47.9          20.9       1.0X
+date_trunc SECOND wholestage on                     174            185           7         57.4          17.4       1.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                     1556           1556           0          6.4         155.6       1.0X
-date_trunc WEEK wholestage on                      1498           1507           9          6.7         149.8       1.0X
+date_trunc WEEK wholestage off                     1231           1293          86          8.1         123.1       1.0X
+date_trunc WEEK wholestage on                      1186           1219          35          8.4         118.6       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                  2340           2346           9          4.3         234.0       1.0X
-date_trunc QUARTER wholestage on                   2309           2315           4          4.3         230.9       1.0X
+date_trunc QUARTER wholestage off                  1785           1792          10          5.6         178.5       1.0X
+date_trunc QUARTER wholestage on                   1671           1708          28          6.0         167.1       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           323            323           0         31.0          32.3       1.0X
-trunc year wholestage on                            304            307           4         32.9          30.4       1.1X
+trunc year wholestage off                           186            199          18         53.8          18.6       1.0X
+trunc year wholestage on                            161            165           5         62.3          16.1       1.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           323            324           2         31.0          32.3       1.0X
-trunc yyyy wholestage on                            303            313          12         33.0          30.3       1.1X
+trunc yyyy wholestage off                           184            184           0         54.4          18.4       1.0X
+trunc yyyy wholestage on                            156            162           6         64.3          15.6       1.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             325            327           2         30.8          32.5       1.0X
-trunc yy wholestage on                              304            308           3         32.9          30.4       1.1X
+trunc yy wholestage off                             171            174           5         58.6          17.1       1.0X
+trunc yy wholestage on                              161            172          10         62.1          16.1       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            327            351          34         30.5          32.7       1.0X
-trunc mon wholestage on                             301            302           2         33.3          30.1       1.1X
+trunc mon wholestage off                            175            176           1         57.1          17.5       1.0X
+trunc mon wholestage on                             166            167           1         60.3          16.6       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          319            319           1         31.4          31.9       1.0X
-trunc month wholestage on                           301            305           4         33.2          30.1       1.1X
+trunc month wholestage off                          177            186          12         56.4          17.7       1.0X
+trunc month wholestage on                           160            168           8         62.4          16.0       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             319            320           1         31.3          31.9       1.0X
-trunc mm wholestage on                              300            307           7         33.3          30.0       1.1X
+trunc mm wholestage off                             173            175           2         57.8          17.3       1.0X
+trunc mm wholestage on                              167            178          10         59.9          16.7       1.0X
 
 
 ================================================================================================
 Parsing
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                     218            219           2          4.6         217.7       1.0X
-to timestamp str wholestage on                      212            217           5          4.7         212.4       1.0X
+to timestamp str wholestage off                     166            168           3          6.0         166.3       1.0X
+to timestamp str wholestage on                      170            192          37          5.9         169.8       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                        2063           2066           5          0.5        2062.5       1.0X
-to_timestamp wholestage on                         2000           2014           8          0.5        2000.3       1.0X
+to_timestamp wholestage off                         975           1042          95          1.0         975.1       1.0X
+to_timestamp wholestage on                          976            982           5          1.0         976.0       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                   2038           2040           4          0.5        2037.7       1.0X
-to_unix_timestamp wholestage on                    2021           2029          11          0.5        2020.5       1.0X
+to_unix_timestamp wholestage off                    978            984           8          1.0         978.4       1.0X
+to_unix_timestamp wholestage on                     956            979          20          1.0         955.8       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          209            215           8          4.8         209.0       1.0X
-to date str wholestage on                           203            205           2          4.9         203.1       1.0X
+to date str wholestage off                          169            173           5          5.9         168.9       1.0X
+to date str wholestage on                           155            159           4          6.4         155.4       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                             2191           2201          14          0.5        2191.3       1.0X
-to_date wholestage on                              2124           2137          16          0.5        2124.4       1.0X
+to_date wholestage off                             1583           1594          15          0.6        1583.2       1.0X
+to_date wholestage on                              1586           1635          52          0.6        1586.1       1.0X
 
 
 ================================================================================================
 Conversion from/to external types
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 To/from java.sql.Timestamp:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Timestamp                             284            289           5         17.6          56.9       1.0X
-Collect longs                                      1413           2057         930          3.5         282.6       0.2X
-Collect timestamps                                 1605           1712          93          3.1         321.0       0.2X
+From java.sql.Timestamp                             174            176           3         28.8          34.7       1.0X
+Collect longs                                       945           1275         538          5.3         189.0       0.2X
+Collect timestamps                                 1019           1422         633          4.9         203.8       0.2X
 
 

--- a/sql/core/benchmarks/IntervalBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/IntervalBenchmark-jdk11-results.txt
@@ -1,29 +1,29 @@
-OpenJDK 64-Bit Server VM 11.0.5+10-post-Ubuntu-0ubuntu1.118.04 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 cast strings to intervals:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-prepare string w/ interval                          756            831          78          1.3         756.4       1.0X
-prepare string w/o interval                         622            637          15          1.6         622.4       1.2X
-1 units w/ interval                                 506            532          22          2.0         506.2       1.5X
-1 units w/o interval                                472            477           9          2.1         471.6       1.6X
-2 units w/ interval                                 699            710          11          1.4         698.5       1.1X
-2 units w/o interval                                670            674           6          1.5         669.9       1.1X
-3 units w/ interval                                1431           1437           7          0.7        1431.3       0.5X
-3 units w/o interval                               1418           1429          11          0.7        1418.2       0.5X
-4 units w/ interval                                1687           1692           8          0.6        1686.8       0.4X
-4 units w/o interval                               1679           1688           7          0.6        1679.4       0.5X
-5 units w/ interval                                1862           1864           3          0.5        1861.9       0.4X
-5 units w/o interval                               1847           1864          15          0.5        1846.9       0.4X
-6 units w/ interval                                2067           2081          12          0.5        2066.9       0.4X
-6 units w/o interval                               2070           2071           2          0.5        2069.6       0.4X
-7 units w/ interval                                2458           2468          13          0.4        2457.7       0.3X
-7 units w/o interval                               2450           2453           3          0.4        2450.1       0.3X
-8 units w/ interval                                2833           2838           8          0.4        2832.6       0.3X
-8 units w/o interval                               2830           2839           8          0.4        2829.8       0.3X
-9 units w/ interval                                2873           2880           6          0.3        2873.4       0.3X
-9 units w/o interval                               2860           2863           3          0.3        2860.1       0.3X
-10 units w/ interval                               3252           3257           5          0.3        3252.2       0.2X
-10 units w/o interval                              3212           3220           8          0.3        3211.6       0.2X
-11 units w/ interval                               3369           3376           6          0.3        3368.5       0.2X
-11 units w/o interval                              3384           3395          15          0.3        3384.2       0.2X
+prepare string w/ interval                          448            469          20          2.2         447.6       1.0X
+prepare string w/o interval                         405            409           4          2.5         404.6       1.1X
+1 units w/ interval                                 321            328           6          3.1         321.4       1.4X
+1 units w/o interval                                303            307           4          3.3         303.1       1.5X
+2 units w/ interval                                 445            458          12          2.2         444.6       1.0X
+2 units w/o interval                                416            424          10          2.4         416.2       1.1X
+3 units w/ interval                                1006           1012           8          1.0        1006.4       0.4X
+3 units w/o interval                               1240           1249           8          0.8        1239.6       0.4X
+4 units w/ interval                                1295           1418         106          0.8        1295.4       0.3X
+4 units w/o interval                               1172           1188          15          0.9        1171.6       0.4X
+5 units w/ interval                                1326           1335          11          0.8        1325.6       0.3X
+5 units w/o interval                               1309           1336          44          0.8        1308.7       0.3X
+6 units w/ interval                                1441           1464          29          0.7        1441.0       0.3X
+6 units w/o interval                               1350           1369          17          0.7        1350.1       0.3X
+7 units w/ interval                                1606           1669          99          0.6        1605.6       0.3X
+7 units w/o interval                               1546           1557          12          0.6        1546.3       0.3X
+8 units w/ interval                                1771           1875         120          0.6        1770.6       0.3X
+8 units w/o interval                               1775           1789          13          0.6        1775.2       0.3X
+9 units w/ interval                                2126           2757         849          0.5        2126.4       0.2X
+9 units w/o interval                               2053           2070          21          0.5        2053.3       0.2X
+10 units w/ interval                               2209           2243          30          0.5        2209.1       0.2X
+10 units w/o interval                              2400           2702         365          0.4        2400.2       0.2X
+11 units w/ interval                               2616           2699          72          0.4        2616.5       0.2X
+11 units w/o interval                              3218           3380         195          0.3        3218.4       0.1X
 

--- a/sql/core/benchmarks/IntervalBenchmark-results.txt
+++ b/sql/core/benchmarks/IntervalBenchmark-results.txt
@@ -1,29 +1,29 @@
-OpenJDK 64-Bit Server VM 1.8.0_232-8u232-b09-0ubuntu1~18.04.1-b09 on Linux 4.15.0-1044-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 cast strings to intervals:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-prepare string w/ interval                          648            721          94          1.5         648.3       1.0X
-prepare string w/o interval                         562            596          49          1.8         562.3       1.2X
-1 units w/ interval                                 568            590          21          1.8         568.5       1.1X
-1 units w/o interval                                522            538          20          1.9         521.7       1.2X
-2 units w/ interval                                 751            754           3          1.3         751.5       0.9X
-2 units w/o interval                                716            723           6          1.4         716.1       0.9X
-3 units w/ interval                                1402           1411          11          0.7        1401.6       0.5X
-3 units w/o interval                               1381           1387           5          0.7        1381.2       0.5X
-4 units w/ interval                                1591           1595           6          0.6        1591.2       0.4X
-4 units w/o interval                               1582           1585           3          0.6        1582.3       0.4X
-5 units w/ interval                                1747           1749           2          0.6        1747.3       0.4X
-5 units w/o interval                               1738           1746          10          0.6        1737.7       0.4X
-6 units w/ interval                                1929           1931           3          0.5        1929.1       0.3X
-6 units w/o interval                               1919           1922           2          0.5        1919.0       0.3X
-7 units w/ interval                                2345           2354           8          0.4        2345.0       0.3X
-7 units w/o interval                               2334           2336           2          0.4        2334.1       0.3X
-8 units w/ interval                                2533           2546          16          0.4        2533.0       0.3X
-8 units w/o interval                               2519           2521           1          0.4        2519.4       0.3X
-9 units w/ interval                                2885           2889           5          0.3        2884.5       0.2X
-9 units w/o interval                               2804           2813          12          0.4        2803.9       0.2X
-10 units w/ interval                               3041           3060          16          0.3        3041.3       0.2X
-10 units w/o interval                              3031           3043          15          0.3        3031.2       0.2X
-11 units w/ interval                               3270           3280           9          0.3        3269.9       0.2X
-11 units w/o interval                              3273           3280           7          0.3        3272.6       0.2X
+prepare string w/ interval                          389            410          21          2.6         388.7       1.0X
+prepare string w/o interval                         340            360          18          2.9         340.5       1.1X
+1 units w/ interval                                 378            389          16          2.6         377.8       1.0X
+1 units w/o interval                                346            350           5          2.9         346.2       1.1X
+2 units w/ interval                                 444            457          11          2.3         444.2       0.9X
+2 units w/o interval                                455            464          12          2.2         455.1       0.9X
+3 units w/ interval                                 942            964          20          1.1         941.5       0.4X
+3 units w/o interval                                927           1020          93          1.1         927.3       0.4X
+4 units w/ interval                                1114           1127          17          0.9        1113.9       0.3X
+4 units w/o interval                               1100           1105           4          0.9        1100.3       0.4X
+5 units w/ interval                                1180           1244          57          0.8        1180.1       0.3X
+5 units w/o interval                               1135           1141           6          0.9        1135.2       0.3X
+6 units w/ interval                                1284           1316          48          0.8        1284.0       0.3X
+6 units w/o interval                               1276           1357         122          0.8        1276.1       0.3X
+7 units w/ interval                                1609           1636          32          0.6        1609.1       0.2X
+7 units w/o interval                               1551           1578          36          0.6        1550.9       0.3X
+8 units w/ interval                                1787           1874         129          0.6        1787.1       0.2X
+8 units w/o interval                               1751           1767          15          0.6        1750.6       0.2X
+9 units w/ interval                                1960           2065         141          0.5        1959.7       0.2X
+9 units w/o interval                               1885           1908          39          0.5        1885.1       0.2X
+10 units w/ interval                               2178           2185          11          0.5        2177.9       0.2X
+10 units w/o interval                              2150           2255         164          0.5        2150.1       0.2X
+11 units w/ interval                               2457           2542         139          0.4        2456.7       0.2X
+11 units w/o interval                              2557           2770         188          0.4        2556.7       0.2X
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
@@ -114,12 +114,12 @@ object DateTimeBenchmark extends SqlBasedBenchmark {
     }
     runBenchmark("Parsing") {
       val n = 1000000
-      val timestampStrExpr = "concat('2019-01-27 11:02:01.', cast(mod(id, 1000) as string))"
+      val timestampStrExpr = "concat('2019-01-27 11:02:01.', rpad(mod(id, 1000), 3, '0'))"
       val pattern = "'yyyy-MM-dd HH:mm:ss.SSS'"
       run(n, "to timestamp str", timestampStrExpr)
       run(n, "to_timestamp", s"to_timestamp($timestampStrExpr, $pattern)")
       run(n, "to_unix_timestamp", s"to_unix_timestamp($timestampStrExpr, $pattern)")
-      val dateStrExpr = "concat('2019-01-', cast(mod(id, 25) as string))"
+      val dateStrExpr = "concat('2019-01-', lpad(mod(id, 25), 2, '0'))"
       run(n, "to date str", dateStrExpr)
       run(n, "to_date", s"to_date($dateStrExpr, 'yyyy-MM-dd')")
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/IntervalBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/IntervalBenchmark.scala
@@ -44,7 +44,9 @@ object IntervalBenchmark extends SqlBasedBenchmark {
       spark
         .range(0, cardinality, 1, 1)
         .select(exprs: _*)
-        .noop()
+        .queryExecution
+        .toRdd
+        .foreach(_ => ())
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to recover `IntervalBenchmark` and `DataTimeBenchmark` due to banning intervals as output.

### Why are the changes needed?

This PR recovers the benchmark suite.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Manually, re-run the benchmark.