### PR TITLE
[SPARK-31138][ML] Add ANOVA Selector for continuous features and categorical labels

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/ANOVASelector.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/ANOVASelector.scala
@@ -98,10 +98,6 @@ final class ANOVASelector @Since("3.1.0")(@Since("3.1.0") override val uid: Stri
   @Since("3.1.0")
   override def fit(dataset: Dataset[_]): ANOVASelectorModel = {
     transformSchema(dataset.schema, logging = true)
-    dataset.select(col($(labelCol)).cast(DoubleType), col($(featuresCol))).rdd.map {
-      case Row(label: Double, features: Vector) =>
-        LabeledPoint(label, features)
-    }
 
     val testResult = ANOVATest.testClassification(dataset, getFeaturesCol, getLabelCol)
       .zipWithIndex

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/ANOVASelector.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/ANOVASelector.scala
@@ -250,11 +250,9 @@ class ANOVASelectorModel private[ml](
     val newIndices = new ArrayBuilder.ofInt
     var i = 0
     var j = 0
-    var indicesIdx = 0
-    var filterIndicesIdx = 0
     while (i < indices.length && j < selectedFeatures.length) {
-      indicesIdx = indices(i)
-      filterIndicesIdx = selectedFeatures(j)
+      val indicesIdx = indices(i)
+      val filterIndicesIdx = selectedFeatures(j)
       if (indicesIdx == filterIndicesIdx) {
         newIndices += j
         newValues += values(i)

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/ANOVASelector.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/ANOVASelector.scala
@@ -1,0 +1,316 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.feature
+
+import scala.collection.mutable.ArrayBuilder
+
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.annotation.Since
+import org.apache.spark.ml._
+import org.apache.spark.ml.attribute._
+import org.apache.spark.ml.linalg._
+import org.apache.spark.ml.param._
+import org.apache.spark.ml.stat.{ANOVATest, SelectionTestResult}
+import org.apache.spark.ml.util._
+import org.apache.spark.sql._
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.{DoubleType, StructField, StructType}
+
+
+/**
+ * ANOVA F-value Classification selector, which selects continuous features to use for predicting a
+ * categorical label.
+ * The selector supports different selection methods: `numTopFeatures`, `percentile`, `fpr`,
+ * `fdr`, `fwe`.
+ *  - `numTopFeatures` chooses a fixed number of top features according to a F value classification
+ *     test.
+ *  - `percentile` is similar but chooses a fraction of all features instead of a fixed number.
+ *  - `fpr` chooses all features whose p-value are below a threshold, thus controlling the false
+ *    positive rate of selection.
+ *  - `fdr` uses the [Benjamini-Hochberg procedure]
+ *    (https://en.wikipedia.org/wiki/False_discovery_rate#Benjamini.E2.80.93Hochberg_procedure)
+ *    to choose all features whose false discovery rate is below a threshold.
+ *  - `fwe` chooses all features whose p-values are below a threshold. The threshold is scaled by
+ *    1/numFeatures, thus controlling the family-wise error rate of selection.
+ * By default, the selection method is `numTopFeatures`, with the default number of top features
+ * set to 50.
+ */
+@Since("3.1.0")
+final class ANOVASelector @Since("3.1.0")(@Since("3.1.0") override val uid: String)
+  extends Estimator[ANOVASelectorModel] with FValueSelectorParams
+    with DefaultParamsWritable {
+
+  @Since("3.1.0")
+  def this() = this(Identifiable.randomUID("ANOVASelector"))
+
+  /** @group setParam */
+  @Since("3.1.0")
+  def setNumTopFeatures(value: Int): this.type = set(numTopFeatures, value)
+
+  /** @group setParam */
+  @Since("3.1.0")
+  def setPercentile(value: Double): this.type = set(percentile, value)
+
+  /** @group setParam */
+  @Since("3.1.0")
+  def setFpr(value: Double): this.type = set(fpr, value)
+
+  /** @group setParam */
+  @Since("3.1.0")
+  def setFdr(value: Double): this.type = set(fdr, value)
+
+  /** @group setParam */
+  @Since("3.1.0")
+  def setFwe(value: Double): this.type = set(fwe, value)
+
+  /** @group setParam */
+  @Since("3.1.0")
+  def setSelectorType(value: String): this.type = set(selectorType, value)
+
+  /** @group setParam */
+  @Since("3.1.0")
+  def setFeaturesCol(value: String): this.type = set(featuresCol, value)
+
+  /** @group setParam */
+  @Since("3.1.0")
+  def setOutputCol(value: String): this.type = set(outputCol, value)
+
+  /** @group setParam */
+  @Since("3.1.0")
+  def setLabelCol(value: String): this.type = set(labelCol, value)
+
+  @Since("3.1.0")
+  override def fit(dataset: Dataset[_]): ANOVASelectorModel = {
+    transformSchema(dataset.schema, logging = true)
+    dataset.select(col($(labelCol)).cast(DoubleType), col($(featuresCol))).rdd.map {
+      case Row(label: Double, features: Vector) =>
+        LabeledPoint(label, features)
+    }
+
+    val testResult = ANOVATest.testClassification(dataset, getFeaturesCol, getLabelCol)
+      .zipWithIndex
+    val features = $(selectorType) match {
+      case "numTopFeatures" =>
+        testResult
+          .sortBy { case (res, _) => res.pValue }
+          .take(getNumTopFeatures)
+      case "percentile" =>
+        testResult
+          .sortBy { case (res, _) => res.pValue }
+          .take((testResult.length * getPercentile).toInt)
+      case "fpr" =>
+        testResult
+          .filter { case (res, _) => res.pValue < getFpr }
+      case "fdr" =>
+        // This uses the Benjamini-Hochberg procedure.
+        // https://en.wikipedia.org/wiki/False_discovery_rate#Benjamini.E2.80.93Hochberg_procedure
+        val tempRes = testResult
+          .sortBy { case (res, _) => res.pValue }
+        val selected = tempRes
+          .zipWithIndex
+          .filter { case ((res, _), index) =>
+            res.pValue <= getFdr * (index + 1) / testResult.length }
+        if (selected.isEmpty) {
+          Array.empty[(SelectionTestResult, Int)]
+        } else {
+          val maxIndex = selected.map(_._2).max
+          tempRes.take(maxIndex + 1)
+        }
+      case "fwe" =>
+        testResult
+          .filter { case (res, _) => res.pValue < getFwe / testResult.length }
+      case errorType =>
+        throw new IllegalStateException(s"Unknown Selector Type: $errorType")
+    }
+    val indices = features.map { case (_, index) => index }
+    copyValues(new ANOVASelectorModel(uid, indices.sorted)
+      .setParent(this))
+  }
+
+  @Since("3.1.0")
+  override def transformSchema(schema: StructType): StructType = {
+    SchemaUtils.checkColumnType(schema, $(featuresCol), new VectorUDT)
+    SchemaUtils.checkNumericType(schema, $(labelCol))
+    SchemaUtils.appendColumn(schema, $(outputCol), new VectorUDT)
+  }
+
+  @Since("3.1.0")
+  override def copy(extra: ParamMap): ANOVASelector = defaultCopy(extra)
+}
+
+@Since("3.1.0")
+object ANOVASelector extends DefaultParamsReadable[ANOVASelector] {
+
+  @Since("3.1.0")
+  override def load(path: String): ANOVASelector = super.load(path)
+}
+
+/**
+ * Model fitted by [[ANOVASelector]].
+ */
+@Since("3.1.0")
+class ANOVASelectorModel private[ml](
+    @Since("3.1.0") override val uid: String,
+    @Since("3.1.0") val selectedFeatures: Array[Int])
+  extends Model[ANOVASelectorModel] with FValueSelectorParams with MLWritable {
+
+  if (selectedFeatures.length >= 2) {
+    require(selectedFeatures.sliding(2).forall(l => l(0) < l(1)),
+      "Index should be strictly increasing.")
+  }
+
+  /** @group setParam */
+  @Since("3.1.0")
+  def setFeaturesCol(value: String): this.type = set(featuresCol, value)
+
+  /** @group setParam */
+  @Since("3.1.0")
+  def setOutputCol(value: String): this.type = set(outputCol, value)
+
+  @Since("3.1.0")
+  override def transform(dataset: Dataset[_]): DataFrame = {
+    val outputSchema = transformSchema(dataset.schema, logging = true)
+
+    val newSize = selectedFeatures.length
+    val func = { vector: Vector =>
+      vector match {
+        case SparseVector(_, indices, values) =>
+          val (newIndices, newValues) = compressSparse(indices, values)
+          Vectors.sparse(newSize, newIndices, newValues)
+        case DenseVector(values) =>
+          Vectors.dense(selectedFeatures.map(values))
+        case other =>
+          throw new UnsupportedOperationException(
+            s"Only sparse and dense vectors are supported but got ${other.getClass}.")
+      }
+    }
+
+    val transformer = udf(func)
+    dataset.withColumn($(outputCol), transformer(col($(featuresCol))),
+      outputSchema($(outputCol)).metadata)
+  }
+
+  @Since("3.1.0")
+  override def transformSchema(schema: StructType): StructType = {
+    SchemaUtils.checkColumnType(schema, $(featuresCol), new VectorUDT)
+    val newField = prepOutputField(schema)
+    SchemaUtils.appendColumn(schema, newField)
+  }
+
+  /**
+   * Prepare the output column field, including per-feature metadata.
+   */
+  private def prepOutputField(schema: StructType): StructField = {
+    val selector = selectedFeatures.toSet
+    val origAttrGroup = AttributeGroup.fromStructField(schema($(featuresCol)))
+    val featureAttributes: Array[Attribute] = if (origAttrGroup.attributes.nonEmpty) {
+      origAttrGroup.attributes.get.zipWithIndex.filter(x => selector.contains(x._2)).map(_._1)
+    } else {
+      Array.fill[Attribute](selector.size)(NominalAttribute.defaultAttr)
+    }
+    val newAttributeGroup = new AttributeGroup($(outputCol), featureAttributes)
+    newAttributeGroup.toStructField()
+  }
+
+  @Since("3.1.0")
+  override def copy(extra: ParamMap): ANOVASelectorModel = {
+    val copied = new ANOVASelectorModel(uid, selectedFeatures)
+      .setParent(parent)
+    copyValues(copied, extra)
+  }
+
+  @Since("3.1.0")
+  override def write: MLWriter = new ANOVASelectorModel.ANOVASelectorModelWriter(this)
+
+  @Since("3.1.0")
+  override def toString: String = {
+    s"ANOVASelectorModel: uid=$uid, numSelectedFeatures=${selectedFeatures.length}"
+  }
+
+  private[spark] def compressSparse(
+      indices: Array[Int],
+      values: Array[Double]): (Array[Int], Array[Double]) = {
+    val newValues = new ArrayBuilder.ofDouble
+    val newIndices = new ArrayBuilder.ofInt
+    var i = 0
+    var j = 0
+    var indicesIdx = 0
+    var filterIndicesIdx = 0
+    while (i < indices.length && j < selectedFeatures.length) {
+      indicesIdx = indices(i)
+      filterIndicesIdx = selectedFeatures(j)
+      if (indicesIdx == filterIndicesIdx) {
+        newIndices += j
+        newValues += values(i)
+        j += 1
+        i += 1
+      } else {
+        if (indicesIdx > filterIndicesIdx) {
+          j += 1
+        } else {
+          i += 1
+        }
+      }
+    }
+    // TODO: Sparse representation might be ineffective if (newSize ~= newValues.size)
+    (newIndices.result(), newValues.result())
+  }
+}
+
+@Since("3.1.0")
+object ANOVASelectorModel extends MLReadable[ANOVASelectorModel] {
+
+  @Since("3.1.0")
+  override def read: MLReader[ANOVASelectorModel] =
+    new ANOVASelectorModelReader
+
+  @Since("3.1.0")
+  override def load(path: String): ANOVASelectorModel = super.load(path)
+
+  private[ANOVASelectorModel] class ANOVASelectorModelWriter(
+      instance: ANOVASelectorModel) extends MLWriter {
+
+    private case class Data(selectedFeatures: Seq[Int])
+
+    override protected def saveImpl(path: String): Unit = {
+      DefaultParamsWriter.saveMetadata(instance, path, sc)
+      val data = Data(instance.selectedFeatures.toSeq)
+      val dataPath = new Path(path, "data").toString
+      sparkSession.createDataFrame(Seq(data)).repartition(1).write.parquet(dataPath)
+    }
+  }
+
+  private class ANOVASelectorModelReader extends
+    MLReader[ANOVASelectorModel] {
+
+    /** Checked against metadata when loading model */
+    private val className = classOf[ANOVASelectorModel].getName
+
+    override def load(path: String): ANOVASelectorModel = {
+      val metadata = DefaultParamsReader.loadMetadata(path, sc, className)
+      val dataPath = new Path(path, "data").toString
+      val data = sparkSession.read.parquet(dataPath)
+        .select("selectedFeatures").head()
+      val selectedFeatures = data.getAs[Seq[Int]](0).toArray
+      val model = new ANOVASelectorModel(metadata.uid, selectedFeatures)
+      metadata.getAndSetParams(model)
+      model
+    }
+  }
+}

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/ANOVATest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/ANOVATest.scala
@@ -47,7 +47,7 @@ object ANOVATest {
    * @return DataFrame containing the test result for every feature against the label.
    *         This DataFrame will contain a single Row with the following fields:
    *          - `pValues: Vector`
-   *          - `degreesOfFreedom: Array[Int]`
+   *          - `degreesOfFreedom: Array[Long]`
    *          - `fValues: Vector`
    *         Each of these fields has one value per feature.
    */

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/ANOVATest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/ANOVATest.scala
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.stat
+
+import org.apache.commons.math3.distribution.FDistribution
+
+import org.apache.spark.annotation.Since
+import org.apache.spark.ml.feature.LabeledPoint
+import org.apache.spark.ml.linalg.{Vector, Vectors, VectorUDT}
+import org.apache.spark.ml.util.SchemaUtils
+import org.apache.spark.sql._
+import org.apache.spark.sql.functions.col
+import org.apache.spark.util.collection.OpenHashMap
+
+
+/**
+ * ANOVA Test
+ */
+@Since("3.1.0")
+object ANOVATest {
+
+  /** Used to construct output schema of tests */
+  private case class ANOVAResult(
+      pValues: Vector,
+      degreesOfFreedom: Array[Long],
+      fValues: Vector)
+
+  /**
+   * @param dataset  DataFrame of categorical labels and continuous features.
+   * @param featuresCol  Name of features column in dataset, of type `Vector` (`VectorUDT`)
+   * @param labelCol  Name of label column in dataset, of any numerical type
+   * @return DataFrame containing the test result for every feature against the label.
+   *         This DataFrame will contain a single Row with the following fields:
+   *          - `pValues: Vector`
+   *          - `degreesOfFreedom: Array[Int]`
+   *          - `fValues: Vector`
+   *         Each of these fields has one value per feature.
+   */
+  @Since("3.1.0")
+  def test(dataset: DataFrame, featuresCol: String, labelCol: String): DataFrame = {
+    val spark = dataset.sparkSession
+    val testResults = testClassification(dataset, featuresCol, labelCol)
+    val pValues: Vector = Vectors.dense(testResults.map(_.pValue))
+    val degreesOfFreedom: Array[Long] = testResults.map(_.degreesOfFreedom)
+    val fValues: Vector = Vectors.dense(testResults.map(_.statistic))
+    spark.createDataFrame(
+      Seq(new ANOVAResult(pValues, degreesOfFreedom, fValues)))
+  }
+
+  /**
+   * @param dataset  DataFrame of categorical labels and continuous features.
+   * @param featuresCol  Name of features column in dataset, of type `Vector` (`VectorUDT`)
+   * @param labelCol  Name of label column in dataset, of any numerical type
+   * @return Array containing the ANOVATestResult for every feature against the
+   *         label.
+   */
+  private[ml] def testClassification(
+      dataset: Dataset[_],
+      featuresCol: String,
+      labelCol: String): Array[SelectionTestResult] = {
+
+    val spark = dataset.sparkSession
+    import spark.implicits._
+
+    SchemaUtils.checkColumnType(dataset.schema, featuresCol, new VectorUDT)
+    SchemaUtils.checkNumericType(dataset.schema, labelCol)
+
+    val labeledPointRdd = dataset.select(col("label").cast("double"), col("features"))
+      .as[(Double, Vector)]
+      .rdd.map { case (label, features) => LabeledPoint(label, features) }
+
+    val numFeatures = labeledPointRdd.first().features.size
+    val numSamples = labeledPointRdd.count()
+    val numClasses = labeledPointRdd.map(d => d.label).distinct.count
+
+    labeledPointRdd.flatMap { case LabeledPoint(label, features) =>
+      features.iterator.map { case (col, value) =>
+        (col, (label, value, value * value))
+      }
+    }.aggregateByKey[(Double, Double, OpenHashMap[Double, Double], OpenHashMap[Double, Long])](
+      (0.0, 0.0, new OpenHashMap[Double, Double], new OpenHashMap[Double, Long]))(
+      seqOp = {
+        case (
+          (sum: Double, sumOfSq: Double, mapOfSumPerClass, mapOfCountPerClass),
+          (label, feature, featureSq)
+         ) =>
+          mapOfSumPerClass.changeValue(label, feature, _ + feature)
+          mapOfCountPerClass.changeValue(label, 1L, _ + 1L)
+          (mapOfSumPerClass, mapOfCountPerClass)
+          (sum + feature, sumOfSq + featureSq, mapOfSumPerClass, mapOfCountPerClass)
+      },
+      combOp = {
+        case (
+          (sum1, sumOfSq1, mapOfSumPerClass1, mapOfCountPerClass1),
+          (sum2, sumOfSq2, mapOfSumPerClass2, mapOfCountPerClass2)
+        ) =>
+          mapOfSumPerClass2.foreach { case (v, w) =>
+            mapOfSumPerClass1.changeValue(v, w, _ + w)
+          }
+          mapOfCountPerClass2.foreach { case (v, w) =>
+            mapOfCountPerClass1.changeValue(v, w, _ + w)
+          }
+          (sum1 + sum2, sumOfSq1 + sumOfSq2, mapOfSumPerClass1, mapOfCountPerClass1)
+      }
+    ).map {
+      case (col, (sum, sumOfSq, mapOfSumPerClass, mapOfCountPerClass)) =>
+        // e.g. feature is [3.3, 2.5, 1.0, 3.0, 2.0] and labels are [1, 2, 1, 3, 3]
+        // sum: sum of all the features (3.3+2.5+1.0+3.0+2.0)
+        // sumOfSq: sum of squares of all the features (3.3^2+2.5^2+1.0^2+3.0^2+2.0^2)
+        // mapOfSumPerClass key: label, value: sum of features for each label
+        //                                         ( 1 -> 3.3 + 1.0, 2 -> 2.5, 3 -> 3.0 + 2.0 )
+        // mapOfCountPerClass key: label, value: count of features for each label
+        //                                         ( 1 -> 2, 2 -> 2, 3 -> 2 )
+        // sqSum: square of sum of all data ((3.3+2.5+1.0+3.0+2.0)^2)
+        val sqSum = sum * sum
+        val ssTot = sumOfSq - sqSum / numSamples
+
+        // sumOfSqSumPerClass:
+        //     sum( sq_sum_classes[k] / n_samples_per_class[k] for k in range(n_classes))
+        //     e.g. ((3.3+1.0)^2 / 2 + 2.5^2 / 1 + (3.0+2.0)^2 / 2)
+        var sumOfSqSumPerClass = 0.0
+        val (keys1, values1) = mapOfSumPerClass.iterator.toSeq.sortBy(_._1).unzip
+        val keysArray1 = keys1.toArray
+        val valuesArray1 = values1.toArray
+        val (keys2, values2) = mapOfCountPerClass.iterator.toSeq.sortBy(_._1).unzip
+        val keysArray2 = keys2.toArray
+        val valuesArray2 = values2.toArray
+        for (i <- 0 until mapOfSumPerClass.size) {
+          sumOfSqSumPerClass += (valuesArray1(i) * valuesArray1(i))/ valuesArray2(i)
+        }
+        // Sums of Squares Between
+        val ssbn = sumOfSqSumPerClass - (sqSum / numSamples)
+        // Sums of Squares Within
+        val sswn = ssTot - ssbn
+
+        // degrees of freedom between
+        val dfbn = numClasses - 1
+        // degrees of freedom within
+        val dfwn = numSamples - numClasses
+        // mean square between
+        val msb = ssbn / dfbn
+        // mean square within
+        val msw = sswn / dfwn
+        val fValue = msb / msw
+        val pValue = 1 - new FDistribution(dfbn, dfwn).cumulativeProbability(fValue)
+        (col, pValue, dfbn + dfwn, fValue)
+    }.collect().sortBy(_._1).map {
+      case (col, pValue, degreesOfFreedom, fValue) =>
+        new ANOVATestResult(pValue, degreesOfFreedom, fValue)
+    }
+  }
+}

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/ANOVATest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/ANOVATest.scala
@@ -119,7 +119,7 @@ object ANOVATest {
       }
     ).map {
       case (col, (sum, sumOfSq, mapOfSumPerClass, mapOfCountPerClass)) =>
-        // e.g. feature is [3.3, 2.5, 1.0, 3.0, 2.0] and labels are [1, 2, 1, 3, 3]
+        // e.g. features are [3.3, 2.5, 1.0, 3.0, 2.0] and labels are [1, 2, 1, 3, 3]
         // sum: sum of all the features (3.3+2.5+1.0+3.0+2.0)
         // sumOfSq: sum of squares of all the features (3.3^2+2.5^2+1.0^2+3.0^2+2.0^2)
         // mapOfSumPerClass key: label, value: sum of features for each label
@@ -134,10 +134,10 @@ object ANOVATest {
         //     sum( sq_sum_classes[k] / n_samples_per_class[k] for k in range(n_classes))
         //     e.g. ((3.3+1.0)^2 / 2 + 2.5^2 / 1 + (3.0+2.0)^2 / 2)
         var sumOfSqSumPerClass = 0.0
-        val (keys1, values1) = mapOfSumPerClass.iterator.toSeq.sortBy(_._1).unzip
+        val (keys1, values1) = mapOfSumPerClass.toSeq.sortBy(_._1).unzip
         val keysArray1 = keys1.toArray
         val valuesArray1 = values1.toArray
-        val (keys2, values2) = mapOfCountPerClass.iterator.toSeq.sortBy(_._1).unzip
+        val (keys2, values2) = mapOfCountPerClass.toSeq.sortBy(_._1).unzip
         val keysArray2 = keys2.toArray
         val valuesArray2 = values2.toArray
         for (i <- 0 until mapOfSumPerClass.size) {
@@ -147,7 +147,6 @@ object ANOVATest {
         val ssbn = sumOfSqSumPerClass - (sqSum / numSamples)
         // Sums of Squares Within
         val sswn = ssTot - ssbn
-
         // degrees of freedom between
         val dfbn = numClasses - 1
         // degrees of freedom within

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/ANOVATest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/ANOVATest.scala
@@ -28,7 +28,10 @@ import org.apache.spark.util.collection.OpenHashMap
 
 
 /**
- * ANOVA Test
+ * ANOVA Test for continuous data.
+ *
+ * See <a href="https://en.wikipedia.org/wiki/Analysis_of_variance">Wikipedia</a> for more
+ * information on ANOVA test.
  */
 @Since("3.1.0")
 object ANOVATest {
@@ -87,69 +90,69 @@ object ANOVATest {
       .as[(Double, Vector)]
       .rdd
       .flatMap { case (label, features) =>
-        features.iterator.map { case (col, value) => (col, (label, value, value * value))}
-    }.aggregateByKey[(Double, Double, OpenHashMap[Double, Double], OpenHashMap[Double, Long])](
-      (0.0, 0.0, new OpenHashMap[Double, Double], new OpenHashMap[Double, Long]))(
-      seqOp = {
-        case (
-          // sums: mapOfSumPerClass (key: label, value: sum of features for each label)
-          // counts: mapOfCountPerClass key: label, value: count of features for each label
-          (sum: Double, sumOfSq: Double, sums, counts),
-          (label, feature, featureSq)
-         ) =>
-          sums.changeValue(label, feature, _ + feature)
-          counts.changeValue(label, 1L, _ + 1L)
-          (sum + feature, sumOfSq + featureSq, sums, counts)
-      },
-      combOp = {
-        case (
-          (sum1, sumOfSq1, sums1, counts1),
-          (sum2, sumOfSq2, sums2, counts2)
-        ) =>
-          sums2.foreach { case (v, w) =>
-            sums1.changeValue(v, w, _ + w)
-          }
-          counts2.foreach { case (v, w) =>
-            counts1.changeValue(v, w, _ + w)
-          }
-          (sum1 + sum2, sumOfSq1 + sumOfSq2, sums1, counts1)
-      }
-    ).map {
-      case (col, (sum, sumOfSq, sums, counts)) =>
-        // e.g. features are [3.3, 2.5, 1.0, 3.0, 2.0] and labels are [1, 2, 1, 3, 3]
-        // sum: sum of all the features (3.3+2.5+1.0+3.0+2.0)
-        // sumOfSq: sum of squares of all the features (3.3^2+2.5^2+1.0^2+3.0^2+2.0^2)
-        // sums: mapOfSumPerClass (key: label, value: sum of features for each label)
-        //                                         ( 1 -> 3.3 + 1.0, 2 -> 2.5, 3 -> 3.0 + 2.0 )
-        // counts: mapOfCountPerClass (key: label, value: count of features for each label)
-        //                                         ( 1 -> 2, 2 -> 2, 3 -> 2 )
-        // sqSum: square of sum of all data ((3.3+2.5+1.0+3.0+2.0)^2)
-        val sqSum = sum * sum
-        val ssTot = sumOfSq - sqSum / numSamples
+        features.iterator.map { case (col, value) => (col, (label, value, value * value)) }
+      }.aggregateByKey[(Double, Double, OpenHashMap[Double, Double], OpenHashMap[Double, Long])](
+        (0.0, 0.0, new OpenHashMap[Double, Double], new OpenHashMap[Double, Long]))(
+        seqOp = {
+          case (
+            // sums: mapOfSumPerClass (key: label, value: sum of features for each label)
+            // counts: mapOfCountPerClass key: label, value: count of features for each label
+            (sum: Double, sumOfSq: Double, sums, counts),
+            (label, feature, featureSq)
+           ) =>
+            sums.changeValue(label, feature, _ + feature)
+            counts.changeValue(label, 1L, _ + 1L)
+            (sum + feature, sumOfSq + featureSq, sums, counts)
+        },
+        combOp = {
+          case (
+            (sum1, sumOfSq1, sums1, counts1),
+            (sum2, sumOfSq2, sums2, counts2)
+          ) =>
+            sums2.foreach { case (v, w) =>
+              sums1.changeValue(v, w, _ + w)
+            }
+            counts2.foreach { case (v, w) =>
+              counts1.changeValue(v, w, _ + w)
+            }
+            (sum1 + sum2, sumOfSq1 + sumOfSq2, sums1, counts1)
+        }
+        ).map {
+          case (col, (sum, sumOfSq, sums, counts)) =>
+            // e.g. features are [3.3, 2.5, 1.0, 3.0, 2.0] and labels are [1, 2, 1, 3, 3]
+            // sum: sum of all the features (3.3+2.5+1.0+3.0+2.0)
+            // sumOfSq: sum of squares of all the features (3.3^2+2.5^2+1.0^2+3.0^2+2.0^2)
+            // sums: mapOfSumPerClass (key: label, value: sum of features for each label)
+            //                                         ( 1 -> 3.3 + 1.0, 2 -> 2.5, 3 -> 3.0 + 2.0 )
+            // counts: mapOfCountPerClass (key: label, value: count of features for each label)
+            //                                         ( 1 -> 2, 2 -> 2, 3 -> 2 )
+            // sqSum: square of sum of all data ((3.3+2.5+1.0+3.0+2.0)^2)
+            val sqSum = sum * sum
+            val ssTot = sumOfSq - sqSum / numSamples
 
-        // sumOfSqSumPerClass:
-        //     sum( sq_sum_classes[k] / n_samples_per_class[k] for k in range(n_classes))
-        //     e.g. ((3.3+1.0)^2 / 2 + 2.5^2 / 1 + (3.0+2.0)^2 / 2)
-        val sumOfSqSumPerClass = sums.iterator
-          .map {case (label, sum) => sum * sum / counts(label)}.sum
-        // Sums of Squares Between
-        val ssbn = sumOfSqSumPerClass - (sqSum / numSamples)
-        // Sums of Squares Within
-        val sswn = ssTot - ssbn
-        // degrees of freedom between
-        val dfbn = numClasses - 1
-        // degrees of freedom within
-        val dfwn = numSamples - numClasses
-        // mean square between
-        val msb = ssbn / dfbn
-        // mean square within
-        val msw = sswn / dfwn
-        val fValue = msb / msw
-        val pValue = 1 - new FDistribution(dfbn, dfwn).cumulativeProbability(fValue)
-        (col, pValue, dfbn + dfwn, fValue)
-    }.collect().sortBy(_._1).map {
-      case (col, pValue, degreesOfFreedom, fValue) =>
-        new ANOVATestResult(pValue, degreesOfFreedom, fValue)
-    }
+            // sumOfSqSumPerClass:
+            //     sum( sq_sum_classes[k] / n_samples_per_class[k] for k in range(n_classes))
+            //     e.g. ((3.3+1.0)^2 / 2 + 2.5^2 / 1 + (3.0+2.0)^2 / 2)
+            val sumOfSqSumPerClass = sums.iterator
+              .map { case (label, sum) => sum * sum / counts(label) }.sum
+            // Sums of Squares Between
+            val ssbn = sumOfSqSumPerClass - (sqSum / numSamples)
+            // Sums of Squares Within
+            val sswn = ssTot - ssbn
+            // degrees of freedom between
+            val dfbn = numClasses - 1
+            // degrees of freedom within
+            val dfwn = numSamples - numClasses
+            // mean square between
+            val msb = ssbn / dfbn
+            // mean square within
+            val msw = sswn / dfwn
+            val fValue = msb / msw
+            val pValue = 1 - new FDistribution(dfbn, dfwn).cumulativeProbability(fValue)
+            (col, pValue, dfbn + dfwn, fValue)
+        }.collect().sortBy(_._1).map {
+          case (col, pValue, degreesOfFreedom, fValue) =>
+            new ANOVATestResult(pValue, degreesOfFreedom, fValue)
+        }
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/ANOVATest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/ANOVATest.scala
@@ -20,7 +20,6 @@ package org.apache.spark.ml.stat
 import org.apache.commons.math3.distribution.FDistribution
 
 import org.apache.spark.annotation.Since
-import org.apache.spark.ml.feature.LabeledPoint
 import org.apache.spark.ml.linalg.{Vector, Vectors, VectorUDT}
 import org.apache.spark.ml.util.{MetadataUtils, SchemaUtils}
 import org.apache.spark.sql._

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/FValueTest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/FValueTest.scala
@@ -83,7 +83,7 @@ object FValueTest {
       .select("summary.mean", "summary.std", "yMean", "yStd", "summary.count")
       .first()
 
-    val labeledPointRdd = dataset.select(col("label").cast("double"), col("features"))
+    val labeledPointRdd = dataset.select(col(labelCol).cast("double"), col(featuresCol))
       .as[(Double, Vector)].rdd
 
     val numFeatures = xMeans.size

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/FValueTest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/FValueTest.scala
@@ -44,7 +44,7 @@ object FValueTest {
    * @return DataFrame containing the test result for every feature against the label.
    *         This DataFrame will contain a single Row with the following fields:
    *          - `pValues: Vector`
-   *          - `degreesOfFreedom: Array[Int]`
+   *          - `degreesOfFreedom: Array[Long]`
    *          - `fValues: Vector`
    *         Each of these fields has one value per feature.
    */

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/FValueTest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/FValueTest.scala
@@ -63,11 +63,12 @@ object FValueTest {
    * @param dataset  DataFrame of continuous labels and continuous features.
    * @param featuresCol  Name of features column in dataset, of type `Vector` (`VectorUDT`)
    * @param labelCol  Name of label column in dataset, of any numerical type
-   * @return Array containing the FRegressionTestResult for every feature against the label.
+   * @return Array containing the FValueTestResult for every feature against the label.
    */
-  @Since("3.1.0")
-  private[ml] def testRegression(dataset: Dataset[_], featuresCol: String, labelCol: String):
-  Array[SelectionTestResult] = {
+  private[ml] def testRegression(
+      dataset: Dataset[_],
+      featuresCol: String,
+      labelCol: String): Array[SelectionTestResult] = {
 
     val spark = dataset.sparkSession
     import spark.implicits._

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/SelectionTestResult.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/SelectionTestResult.scala
@@ -99,3 +99,19 @@ class FValueTestResult private[stat] (
       s"F Value = $statistic \n"
   }
 }
+
+/**
+ * Object containing the test results for the ANOVA classification test.
+ */
+@Since("3.1.0")
+class ANOVATestResult private[stat] (
+    override val pValue: Double,
+    override val degreesOfFreedom: Long,
+    override val statistic: Double) extends SelectionTestResult {
+
+  override def toString: String = {
+    "ANOVA Regression test summary:\n" +
+      super.toString +
+      s"F Value = $statistic \n"
+  }
+}

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/ANOVASelectorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/ANOVASelectorSuite.scala
@@ -204,6 +204,3 @@ object ANOVASelectorSuite {
     "outputCol" -> "myOutput"
   )
 }
-
-
-

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/ANOVASelectorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/ANOVASelectorSuite.scala
@@ -127,8 +127,6 @@ class ANOVASelectorSuite extends MLTest with DefaultReadWriteTest {
         5.16336729e-01, 9.99776159e-01, 3.15769738e-01), Vectors.dense(-2.99454508e-01)))
 
     dataset = spark.createDataFrame(data).toDF("label", "features", "topFeature")
-    dataset.show(false)
-
   }
 
   test("params") {

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/ANOVASelectorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/ANOVASelectorSuite.scala
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.feature
+
+import org.apache.spark.ml.linalg.{Vector, Vectors}
+import org.apache.spark.ml.param.ParamsSuite
+import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTest}
+import org.apache.spark.ml.util.TestingUtils._
+import org.apache.spark.sql.{Dataset, Row}
+
+class ANOVASelectorSuite extends MLTest with DefaultReadWriteTest {
+
+  import testImplicits._
+
+  @transient var dataset: Dataset[_] = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    // scalastyle:off
+    /*
+      X:
+      array([[4.65415496e-03, 1.03550567e-01, -1.17358140e+00,
+      1.61408773e-01,  3.92492111e-01,  7.31240882e-01],
+      [-9.01651741e-01, -5.28905302e-01,  1.27636785e+00,
+      7.02154563e-01,  6.21348351e-01,  1.88397353e-01],
+      [ 3.85692159e-01, -9.04639637e-01,  5.09782604e-02,
+      8.40043971e-01,  7.45977857e-01,  8.78402288e-01],
+      [ 1.36264353e+00,  2.62454094e-01,  7.96306202e-01,
+      6.14948000e-01,  7.44948187e-01,  9.74034830e-01],
+      [ 9.65874070e-01,  2.52773665e+00, -2.19380094e+00,
+      2.33408080e-01,  1.86340919e-01,  8.23390433e-01],
+      [ 1.12324305e+01, -2.77121515e-01,  1.12740513e-01,
+      2.35184013e-01,  3.46668895e-01,  9.38500782e-02],
+      [ 1.06195839e+01, -1.82891238e+00,  2.25085601e-01,
+      9.09979851e-01,  6.80257535e-02,  8.24017480e-01],
+      [ 1.12806837e+01,  1.30686889e+00,  9.32839108e-02,
+      3.49784755e-01,  1.71322408e-02,  7.48465194e-02],
+      [ 9.98689462e+00,  9.50808938e-01, -2.90786359e-01,
+      2.31253009e-01,  7.46270968e-01,  1.60308169e-01],
+      [ 1.08428551e+01, -1.02749936e+00,  1.73951508e-01,
+      8.92482744e-02,  1.42651730e-01,  7.66751625e-01],
+      [-1.98641448e+00,  1.12811990e+01, -2.35246756e-01,
+      8.22809049e-01,  3.26739456e-01,  7.88268404e-01],
+      [-6.09864090e-01,  1.07346276e+01, -2.18805509e-01,
+      7.33931213e-01,  1.42554396e-01,  7.11225605e-01],
+      [-1.58481268e+00,  9.19364039e+00, -5.87490459e-02,
+      2.51532056e-01,  2.82729807e-01,  7.16245686e-01],
+      [-2.50949277e-01,  1.12815254e+01, -6.94806734e-01,
+      5.93898886e-01,  5.68425656e-01,  8.49762330e-01],
+      [ 7.63485129e-01,  1.02605138e+01,  1.32617719e+00,
+      5.49682879e-01,  8.59931442e-01,  4.88677978e-02],
+      [ 9.34900015e-01,  4.11379043e-01,  8.65010205e+00,
+      9.23509168e-01,  1.16995043e-01,  5.91894106e-03],
+      [ 4.73734933e-01, -1.48321181e+00,  9.73349621e+00,
+      4.09421563e-01,  5.09375719e-01,  5.93157850e-01],
+      [ 3.41470679e-01, -6.88972582e-01,  9.60347938e+00,
+      3.62654055e-01,  2.43437468e-01,  7.13052838e-01],
+      [-5.29614251e-01, -1.39262856e+00,  1.01354144e+01,
+      8.24123861e-01,  5.84074506e-01,  6.54461558e-01],
+      [-2.99454508e-01,  2.20457263e+00,  1.14586015e+01,
+      5.16336729e-01,  9.99776159e-01,  3.15769738e-01]])
+      y:
+      array([1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4])
+      scikit-learn result:
+      >>> f_classif(X, y)
+      (array([228.27701422,  84.33070501, 134.25330675,   0.82211775, 0.82991363,   1.08478943]),
+       array([2.43864448e-13, 5.09088367e-10, 1.49033067e-11, 5.00596446e-01, 4.96684374e-01, 3.83798191e-01]))
+    */
+    // scalastyle:on
+
+    val data = Seq(
+      (1, Vectors.dense(4.65415496e-03, 1.03550567e-01, -1.17358140e+00,
+      1.61408773e-01, 3.92492111e-01, 7.31240882e-01), Vectors.dense(4.65415496e-03)),
+      (1, Vectors.dense(-9.01651741e-01, -5.28905302e-01, 1.27636785e+00,
+      7.02154563e-01, 6.21348351e-01, 1.88397353e-01), Vectors.dense(-9.01651741e-01)),
+      (1, Vectors.dense(3.85692159e-01, -9.04639637e-01, 5.09782604e-02,
+      8.40043971e-01, 7.45977857e-01, 8.78402288e-01), Vectors.dense(3.85692159e-01)),
+      (1, Vectors.dense(1.36264353e+00, 2.62454094e-01, 7.96306202e-01,
+      6.14948000e-01, 7.44948187e-01, 9.74034830e-01), Vectors.dense(1.36264353e+00)),
+      (1, Vectors.dense(9.65874070e-01, 2.52773665e+00, -2.19380094e+00,
+        2.33408080e-01, 1.86340919e-01, 8.23390433e-01), Vectors.dense(9.65874070e-01)),
+      (2, Vectors.dense(1.12324305e+01, -2.77121515e-01, 1.12740513e-01,
+        2.35184013e-01, 3.46668895e-01, 9.38500782e-02), Vectors.dense(1.12324305e+01)),
+      (2, Vectors.dense(1.06195839e+01, -1.82891238e+00, 2.25085601e-01,
+        9.09979851e-01, 6.80257535e-02, 8.24017480e-01), Vectors.dense(1.06195839e+01)),
+      (2, Vectors.dense(1.12806837e+01, 1.30686889e+00, 9.32839108e-02,
+        3.49784755e-01, 1.71322408e-02, 7.48465194e-02), Vectors.dense(1.12806837e+01)),
+      (2, Vectors.dense(9.98689462e+00, 9.50808938e-01, -2.90786359e-01,
+        2.31253009e-01, 7.46270968e-01, 1.60308169e-01), Vectors.dense(9.98689462e+00)),
+      (2, Vectors.dense(1.08428551e+01, -1.02749936e+00, 1.73951508e-01,
+        8.92482744e-02, 1.42651730e-01, 7.66751625e-01), Vectors.dense(1.08428551e+01)),
+      (3, Vectors.dense(-1.98641448e+00, 1.12811990e+01, -2.35246756e-01,
+        8.22809049e-01, 3.26739456e-01, 7.88268404e-01), Vectors.dense(-1.98641448e+00)),
+      (3, Vectors.dense(-6.09864090e-01, 1.07346276e+01, -2.18805509e-01,
+        7.33931213e-01, 1.42554396e-01, 7.11225605e-01), Vectors.dense(-6.09864090e-01)),
+      (3, Vectors.dense(-1.58481268e+00, 9.19364039e+00, -5.87490459e-02,
+        2.51532056e-01, 2.82729807e-01, 7.16245686e-01), Vectors.dense(-1.58481268e+00)),
+      (3, Vectors.dense(-2.50949277e-01, 1.12815254e+01, -6.94806734e-01,
+        5.93898886e-01, 5.68425656e-01, 8.49762330e-01), Vectors.dense(-2.50949277e-01)),
+      (3, Vectors.dense(7.63485129e-01, 1.02605138e+01, 1.32617719e+00,
+        5.49682879e-01, 8.59931442e-01, 4.88677978e-02), Vectors.dense(7.63485129e-01)),
+      (4, Vectors.dense(9.34900015e-01, 4.11379043e-01, 8.65010205e+00,
+        9.23509168e-01, 1.16995043e-01, 5.91894106e-03), Vectors.dense(9.34900015e-01)),
+      (4, Vectors.dense(4.73734933e-01, -1.48321181e+00, 9.73349621e+00,
+        4.09421563e-01, 5.09375719e-01, 5.93157850e-01), Vectors.dense(4.73734933e-01)),
+      (4, Vectors.dense(3.41470679e-01, -6.88972582e-01, 9.60347938e+00,
+        3.62654055e-01, 2.43437468e-01, 7.13052838e-01), Vectors.dense(3.41470679e-01)),
+      (4, Vectors.dense(-5.29614251e-01, -1.39262856e+00, 1.01354144e+01,
+        8.24123861e-01, 5.84074506e-01, 6.54461558e-01), Vectors.dense(-5.29614251e-01)),
+      (4, Vectors.dense(-2.99454508e-01, 2.20457263e+00, 1.14586015e+01,
+        5.16336729e-01, 9.99776159e-01, 3.15769738e-01), Vectors.dense(-2.99454508e-01)))
+
+    dataset = spark.createDataFrame(data).toDF("label", "features", "topFeature")
+    dataset.show(false)
+
+  }
+
+  test("params") {
+    ParamsSuite.checkParams(new ANOVASelector())
+  }
+
+  test("Test ANOVAFValue calssification selector: numTopFeatures") {
+    val selector = new ANOVASelector()
+      .setOutputCol("filtered").setSelectorType("numTopFeatures").setNumTopFeatures(1)
+    val model = selector.fit(dataset)
+    testSelector(selector, dataset)
+  }
+
+  test("Test ANOVAFValue calssification selector: percentile") {
+    val selector = new ANOVASelector()
+      .setOutputCol("filtered").setSelectorType("percentile").setPercentile(0.17)
+    val model = selector.fit(dataset)
+    testSelector(selector, dataset)
+  }
+
+  test("Test ANOVAFValue calssification selector: fpr") {
+    val selector = new ANOVASelector()
+      .setOutputCol("filtered").setSelectorType("fpr").setFpr(1.0E-12)
+    val model = selector.fit(dataset)
+    testSelector(selector, dataset)
+  }
+
+  test("Test ANOVAFValue calssification selector: fdr") {
+    val selector = new ANOVASelector()
+      .setOutputCol("filtered").setSelectorType("fdr").setFdr(6.0E-12)
+    testSelector(selector, dataset)
+  }
+
+  test("Test ANOVAFValue calssification selector: fwe") {
+    val selector = new ANOVASelector()
+      .setOutputCol("filtered").setSelectorType("fwe").setFwe(6.0E-12)
+    testSelector(selector, dataset)
+  }
+
+  test("read/write") {
+    def checkModelData(model: ANOVASelectorModel, model2: ANOVASelectorModel): Unit = {
+      assert(model.selectedFeatures === model2.selectedFeatures)
+    }
+    val anovaSelector = new ANOVASelector()
+    testEstimatorAndModelReadWrite(anovaSelector, dataset,
+      ANOVASelectorSuite.allParamSettings,
+      ANOVASelectorSuite.allParamSettings, checkModelData)
+  }
+
+  private def testSelector(selector: ANOVASelector, data: Dataset[_]):
+  ANOVASelectorModel = {
+    val selectorModel = selector.fit(data)
+    testTransformer[(Double, Vector, Vector)](data.toDF(), selectorModel,
+      "filtered", "topFeature") {
+      case Row(vec1: Vector, vec2: Vector) =>
+        assert(vec1 ~== vec2 absTol 1e-1)
+    }
+    selectorModel
+  }
+}
+
+object ANOVASelectorSuite {
+
+  /**
+   * Mapping from all Params to valid settings which differ from the defaults.
+   * This is useful for tests which need to exercise all Params, such as save/load.
+   * This excludes input columns to simplify some tests.
+   */
+  val allParamSettings: Map[String, Any] = Map(
+    "selectorType" -> "percentile",
+    "numTopFeatures" -> 1,
+    "percentile" -> 0.12,
+    "outputCol" -> "myOutput"
+  )
+}
+
+
+

--- a/mllib/src/test/scala/org/apache/spark/ml/stat/ANOVATestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/stat/ANOVATestSuite.scala
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.stat
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.ml.feature.LabeledPoint
+import org.apache.spark.ml.linalg.{Vector, Vectors}
+import org.apache.spark.ml.util.DefaultReadWriteTest
+import org.apache.spark.ml.util.TestingUtils._
+import org.apache.spark.mllib.util.MLlibTestSparkContext
+
+class ANOVATestSuite
+  extends SparkFunSuite with MLlibTestSparkContext with DefaultReadWriteTest {
+
+  import testImplicits._
+
+  test("test DataFrame of labeled points") {
+  // scalastyle:off
+  /*
+  Use the following sklearn data in this test
+
+  >>> from sklearn.feature_selection import f_classif
+  >>> import numpy as np
+  >>> X = np.random.rand(20, 6)
+  >>> X
+  array([[1.77744923e-01, 4.46602900e-01, 7.62487415e-01, 5.81095198e-01,
+          9.64228053e-01, 2.31090547e-01],
+         [8.87725538e-01, 7.39137344e-01, 5.76073881e-01, 7.38266678e-01,
+          2.28188254e-01, 4.10480664e-01],
+         [1.26764947e-01, 9.53144673e-01, 2.50788458e-01, 3.17260250e-01,
+          8.76189581e-01, 2.56902552e-01],
+         [3.74475030e-01, 9.23768847e-02, 6.19433427e-01, 4.10280293e-02,
+          7.59799273e-04, 3.87053403e-01],
+         [8.91109208e-01, 5.21208840e-01, 7.83435405e-02, 8.37642752e-01,
+          5.26969965e-02, 3.07387671e-02],
+         [7.94006669e-01, 8.55618651e-02, 9.25974068e-01, 4.07848340e-01,
+          9.47526767e-01, 2.10230156e-01],
+         [6.38404274e-01, 1.71793581e-01, 9.82515893e-01, 3.34181329e-01,
+          9.96800651e-02, 4.48531617e-01],
+         [1.42029531e-01, 2.53590255e-02, 4.00032820e-01, 3.75843553e-01,
+          9.73971121e-01, 3.32346317e-01],
+         [9.94329513e-01, 5.61156964e-01, 5.96579626e-01, 1.92286208e-01,
+          9.71888097e-01, 2.48574337e-01],
+         [9.71838692e-01, 8.50908993e-02, 6.15917459e-01, 1.61320964e-01,
+          2.43025079e-01, 7.78200314e-01],
+         [7.76735907e-01, 6.10769335e-01, 1.58097504e-01, 2.95018676e-01,
+          3.94466695e-01, 7.71700212e-01],
+         [8.44787012e-01, 4.76682368e-01, 9.43624130e-01, 2.20926735e-01,
+          8.43054317e-02, 8.51276967e-01],
+         [3.38797773e-01, 6.78991156e-01, 7.90036698e-01, 4.40145825e-01,
+          8.33432294e-01, 9.91810731e-01],
+         [1.73295200e-01, 6.83267374e-01, 8.88625086e-01, 6.89072609e-01,
+          8.35407299e-01, 9.70359856e-01],
+         [7.74552650e-01, 5.70846800e-01, 5.39894150e-01, 5.92696042e-01,
+          5.72618852e-01, 7.00850299e-01],
+         [7.84482121e-01, 7.80094912e-01, 4.03710589e-02, 4.97916309e-01,
+          2.55871739e-01, 5.27961039e-01],
+         [1.45590738e-01, 2.43124833e-01, 1.69582546e-01, 6.16891208e-01,
+          2.96795519e-01, 9.19985890e-01],
+         [6.89274903e-01, 7.13295249e-01, 1.65640967e-01, 5.74821962e-01,
+          9.11149662e-01, 1.09691820e-01],
+         [3.33334361e-01, 3.40817958e-01, 6.73779642e-01, 6.01719487e-01,
+          3.97932741e-01, 6.39527734e-01],
+         [2.33981601e-01, 1.41349421e-01, 8.13246213e-01, 9.09664223e-01,
+          2.36111304e-01, 9.00214578e-01]])
+  >>> y = np.array([3, 2, 1, 5, 4, 4, 5, 4, 2, 1, 1, 2, 3, 4, 5, 1, 5, 3, 1, 1])
+  >>> y
+  array([3, 2, 1, 5, 4, 4, 5, 4, 2, 1, 1, 2, 3, 4, 5, 1, 5, 3, 1, 1])
+  >>> f_classif(X, y)
+  (array([1.22822174, 1.10202387, 0.3884059 , 0.41225633, 2.43153435,
+         0.50553798]), array([0.34047275, 0.39149917, 0.81363895, 0.79712747, 0.09303083,
+         0.73241872]))
+  */
+  // scalastyle:on
+
+  val data = Seq(
+    LabeledPoint(3, Vectors.dense(1.77744923e-01, 4.46602900e-01, 7.62487415e-01, 5.81095198e-01,
+      9.64228053e-01, 2.31090547e-01)),
+    LabeledPoint(2, Vectors.dense(8.87725538e-01, 7.39137344e-01, 5.76073881e-01, 7.38266678e-01,
+      2.28188254e-01, 4.10480664e-01)),
+    LabeledPoint(1, Vectors.dense(1.26764947e-01, 9.53144673e-01, 2.50788458e-01, 3.17260250e-01,
+      8.76189581e-01, 2.56902552e-01)),
+    LabeledPoint(5, Vectors.dense(3.74475030e-01, 9.23768847e-02, 6.19433427e-01, 4.10280293e-02,
+      7.59799273e-04, 3.87053403e-01)),
+    LabeledPoint(4, Vectors.dense(8.91109208e-01, 5.21208840e-01, 7.83435405e-02, 8.37642752e-01,
+      5.26969965e-02, 3.07387671e-02)),
+    LabeledPoint(4, Vectors.dense(7.94006669e-01, 8.55618651e-02, 9.25974068e-01, 4.07848340e-01,
+      9.47526767e-01, 2.10230156e-01)),
+    LabeledPoint(5, Vectors.dense(6.38404274e-01, 1.71793581e-01, 9.82515893e-01, 3.34181329e-01,
+      9.96800651e-02, 4.48531617e-01)),
+    LabeledPoint(4, Vectors.dense(1.42029531e-01, 2.53590255e-02, 4.00032820e-01, 3.75843553e-01,
+      9.73971121e-01, 3.32346317e-01)),
+    LabeledPoint(2, Vectors.dense(9.94329513e-01, 5.61156964e-01, 5.96579626e-01, 1.92286208e-01,
+      9.71888097e-01, 2.48574337e-01)),
+    LabeledPoint(1, Vectors.dense(9.71838692e-01, 8.50908993e-02, 6.15917459e-01, 1.61320964e-01,
+      2.43025079e-01, 7.78200314e-01)),
+    LabeledPoint(1, Vectors.dense(7.76735907e-01, 6.10769335e-01, 1.58097504e-01, 2.95018676e-01,
+      3.94466695e-01, 7.71700212e-01)),
+    LabeledPoint(2, Vectors.dense(8.44787012e-01, 4.76682368e-01, 9.43624130e-01, 2.20926735e-01,
+      8.43054317e-02, 8.51276967e-01)),
+    LabeledPoint(3, Vectors.dense(3.38797773e-01, 6.78991156e-01, 7.90036698e-01, 4.40145825e-01,
+      8.33432294e-01, 9.91810731e-01)),
+    LabeledPoint(4, Vectors.dense(1.73295200e-01, 6.83267374e-01, 8.88625086e-01, 6.89072609e-01,
+      8.35407299e-01, 9.70359856e-01)),
+    LabeledPoint(5, Vectors.dense(7.74552650e-01, 5.70846800e-01, 5.39894150e-01, 5.92696042e-01,
+      5.72618852e-01, 7.00850299e-01)),
+    LabeledPoint(1, Vectors.dense(7.84482121e-01, 7.80094912e-01, 4.03710589e-02, 4.97916309e-01,
+      2.55871739e-01, 5.27961039e-01)),
+    LabeledPoint(5, Vectors.dense(1.45590738e-01, 2.43124833e-01, 1.69582546e-01, 6.16891208e-01,
+      2.96795519e-01, 9.19985890e-01)),
+    LabeledPoint(3, Vectors.dense(6.89274903e-01, 7.13295249e-01, 1.65640967e-01, 5.74821962e-01,
+      9.11149662e-01, 1.09691820e-01)),
+    LabeledPoint(1, Vectors.dense(3.33334361e-01, 3.40817958e-01, 6.73779642e-01, 6.01719487e-01,
+      3.97932741e-01, 6.39527734e-01)),
+    LabeledPoint(1, Vectors.dense(2.33981601e-01, 1.41349421e-01, 8.13246213e-01, 9.09664223e-01,
+      2.36111304e-01, 9.00214578e-01)))
+
+    for (numParts <- List(2, 4, 6, 8)) {
+      val df = spark.createDataFrame(sc.parallelize(data, numParts))
+      val anovaResult = ANOVATest.test(df, "features", "label")
+      val (pValues: Vector, fValues: Vector) =
+        anovaResult.select("pValues", "fValues")
+          .as[(Vector, Vector)].head()
+      assert(pValues ~== Vectors.dense(0.34047275, 0.39149917, 0.81363895, 0.79712747, 0.09303083,
+        0.73241872) relTol 1e-6)
+      assert(fValues ~== Vectors.dense(1.22822174, 1.10202387, 0.3884059, 0.41225633, 2.43153435,
+        0.50553798) relTol 1e-6)
+    }
+  }
+
+  test("test DataFrame with sparse vector") {
+    val df = spark.createDataFrame(Seq(
+      (3, Vectors.sparse(6, Array((0, 6.0), (1, 7.0), (3, 7.0), (4, 6.0)))),
+      (1, Vectors.sparse(6, Array((1, 9.0), (2, 6.0), (4, 5.0), (5, 9.0)))),
+      (3, Vectors.sparse(6, Array((1, 9.0), (2, 3.0), (4, 5.0), (5, 5.0)))),
+      (2, Vectors.dense(Array(0.0, 9.0, 8.0, 5.0, 6.0, 4.0))),
+      (2, Vectors.dense(Array(8.0, 9.0, 6.0, 5.0, 4.0, 4.0))),
+      (3, Vectors.dense(Array(8.0, 9.0, 6.0, 4.0, 0.0, 0.0)))
+    )).toDF("label", "features")
+
+    val anovaResult = ANOVATest.test(df, "features", "label")
+    val (pValues: Vector, fValues: Vector) =
+      anovaResult.select("pValues", "fValues")
+        .as[(Vector, Vector)].head()
+    assert(pValues ~== Vectors.dense(0.71554175, 0.71554175, 0.34278574, 0.45824059, 0.84633632,
+      0.15673368) relTol 1e-6)
+    assert(fValues ~== Vectors.dense(0.375, 0.375, 1.5625, 1.02364865, 0.17647059,
+      3.66) relTol 1e-6)
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add ANOVA Selector


### Why are the changes needed?
Currently Spark only supports selection of categorical features, while there are many requirements for the selection of continuous distribution features.

https://github.com/apache/spark/pull/27679 added FValueSelector for continuous features and continuous labels.
This PR adds ANOVASelector for continuous features and categorical labels. 

### Does this PR introduce any user-facing change?
Yes, add a new Selector.


### How was this patch tested?
add new test suites
