### PR TITLE
[SPARK-31149][PySpark] PySpark job not killing Spark Daemon processes…

### DIFF
--- a/python/pyspark/daemon.py
+++ b/python/pyspark/daemon.py
@@ -100,7 +100,7 @@ def manager():
     def shutdown(code):
         signal.signal(SIGTERM, SIG_DFL)
         # Send SIGHUP to notify workers of shutdown
-        os.kill(0, SIGHUP)
+        os.kill(0, SIGTERM)
         sys.exit(code)
 
     def handle_sigterm(*args):


### PR DESCRIPTION
### What changes were proposed in this pull request?
Changes made to daemon.py under /python/pyspark:
def shutdown(code):
        signal.signal(SIGTERM, SIG_DFL)
        # Send SIGHUP to notify workers of shutdown
        os.kill(0, SIGTERM) #Line104
        exit(code)

Solution to SPARK-31149. SIGHUP does not kill all pyspark daemon in all cases, so more strict SIGKILL is required
### Why are the changes needed?
Pyspark was running Spark Daemon processes even after killing the Spark job on Yarn. After making below changes to daemon.py the job killed the Spark Daemon processes.

### Does this PR introduce any user-facing change?
No
### How was this patch tested?

Before the fix:
ps -ef|grep -i pyspark.daemon
/apps/anaconda3-5.3.0/bin/python -m pyspark.daemon
/apps/anaconda3-5.3.0/bin/python -m pyspark.daemon
/apps/anaconda3-5.3.0/bin/python -m pyspark.daemon

After the fix:
ps -ef|grep -i pyspark.daemon
