### PR TITLE
[SPARK-31144][SQL][2.4] Wrap Error with QueryExecutionException to notify QueryExecutionListener

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -677,7 +677,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
       val end = System.nanoTime()
       session.listenerManager.onSuccess(name, qe, end - start)
     } catch {
-      case e: Exception =>
+      case e: Throwable =>
         session.listenerManager.onFailure(name, qe, e)
         throw e
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -3373,7 +3373,7 @@ class Dataset[T] private[sql](
       sparkSession.listenerManager.onSuccess(name, qe, end - start)
       result
     } catch {
-      case e: Exception =>
+      case e: Throwable =>
         sparkSession.listenerManager.onFailure(name, qe, e)
         throw e
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

When `java.lang.Error` is thrown during the execution, `ExecutionListenerManager` will wrap it with `QueryExecutionException` so that we can send it to `QueryExecutionListener.onFailure` which only accepts `Exception`.

### Why are the changes needed?

If ` java.lang.Error` is thrown during the execution, QueryExecutionListener doesn't get notified right now.

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

The new added unit test.