### PR TITLE
[SPARK-31125][K8S]Terminating pods have a deletion timestamp but they are not yet dead.

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodStates.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodStates.scala
@@ -34,4 +34,6 @@ case class PodFailed(pod: Pod) extends FinalPodState
 
 case class PodDeleted(pod: Pod) extends FinalPodState
 
+case class PodTerminating(pod: Pod) extends FinalPodState
+
 case class PodUnknown(pod: Pod) extends ExecutorPodState

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsSnapshot.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsSnapshot.scala
@@ -64,6 +64,8 @@ object ExecutorPodsSnapshot extends Logging {
           PodFailed(pod)
         case "succeeded" =>
           PodSucceeded(pod)
+        case "terminating" =>
+          PodTerminating(pod)
         case _ =>
           logWarning(s"Received unknown phase $phase for executor pod with name" +
             s" ${pod.getMetadata.getName} in namespace ${pod.getMetadata.getNamespace}")
@@ -72,5 +74,8 @@ object ExecutorPodsSnapshot extends Logging {
     }
   }
 
-  private def isDeleted(pod: Pod): Boolean = pod.getMetadata.getDeletionTimestamp != null
+  private def isDeleted(pod: Pod): Boolean = {
+    (pod.getMetadata.getDeletionTimestamp != null &&
+     pod.getStatus.getPhase.toLowerCase(Locale.ROOT) != "terminating")
+  }
 }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsSnapshot.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsSnapshot.scala
@@ -76,6 +76,10 @@ object ExecutorPodsSnapshot extends Logging {
 
   private def isDeleted(pod: Pod): Boolean = {
     (pod.getMetadata.getDeletionTimestamp != null &&
-     pod.getStatus.getPhase.toLowerCase(Locale.ROOT) != "terminating")
+      (
+        pod.getStatus == null ||
+        pod.getStatus.getPhase == null ||
+        pod.getStatus.getPhase.toLowerCase(Locale.ROOT) != "terminating"
+      ))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change what we consider a deleted pod to not include "Terminating"

### Why are the changes needed?

If we get a new snapshot while a pod is in the process of being cleaned up we shouldn't delete the executor until it is fully terminated.

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

This should be covered by the decommissioning tests in that they currently are flaky because we sometimes delete the executor instead of allowing it to decommission all the way.

I also ran this in a loop locally ~80 times with the only failures being the PV suite because of unrelated minikube mount issues.