### PR TITLE
[SPARK-31154][SQL] Expose basic write metrics for InsertIntoDataSourceCommand

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/BasicWriteStatsTracker.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/BasicWriteStatsTracker.scala
@@ -164,10 +164,10 @@ class BasicWriteJobStatsTracker(
 }
 
 object BasicWriteJobStatsTracker {
-  private val NUM_FILES_KEY = "numFiles"
-  private val NUM_OUTPUT_BYTES_KEY = "numOutputBytes"
-  private val NUM_OUTPUT_ROWS_KEY = "numOutputRows"
-  private val NUM_PARTS_KEY = "numParts"
+  val NUM_FILES_KEY = "numFiles"
+  val NUM_OUTPUT_BYTES_KEY = "numOutputBytes"
+  val NUM_OUTPUT_ROWS_KEY = "numOutputRows"
+  val NUM_PARTS_KEY = "numParts"
 
   def metrics: Map[String, SQLMetric] = {
     val sparkContext = SparkContext.getActive.get

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -21,6 +21,7 @@ import org.apache.spark.annotation.{Stable, Unstable}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.streaming.{Sink, Source}
 import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.sql.types.StructType
@@ -292,7 +293,9 @@ trait PrunedFilteredScan {
  */
 @Stable
 trait InsertableRelation {
-  def insert(data: DataFrame, overwrite: Boolean): Unit
+  def insert(data: DataFrame, overwrite: Boolean): Unit = {}
+
+  def insert(data: DataFrame, overwrite: Boolean, metrics: Map[String, SQLMetric]): Unit = {}
 }
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -295,7 +295,9 @@ trait PrunedFilteredScan {
 trait InsertableRelation {
   def insert(data: DataFrame, overwrite: Boolean): Unit = {}
 
-  def insert(data: DataFrame, overwrite: Boolean, metrics: Map[String, SQLMetric]): Unit = {}
+  def insert(data: DataFrame, overwrite: Boolean, metrics: Map[String, SQLMetric]): Unit = {
+    insert(data, overwrite)
+  }
 }
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/InsertIntoDataSourceCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/InsertIntoDataSourceCommandSuite.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType}
+import org.apache.spark.sql.sources.SimpleInsertSource
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{LongType, StringType, StructType}
+
+class InsertIntoDataSourceCommandSuite extends SharedSparkSession {
+  test("inserting with metrics") {
+    withTable("test_table") {
+      val schema = new StructType()
+        .add("i", LongType, false)
+        .add("s", StringType, false)
+      val newTable = CatalogTable(
+        identifier = TableIdentifier("test_table", None),
+        tableType = CatalogTableType.EXTERNAL,
+        storage = CatalogStorageFormat(
+          locationUri = None,
+          inputFormat = None,
+          outputFormat = None,
+          serde = None,
+          compressed = false,
+          properties = Map.empty),
+        schema = schema,
+        provider = Some(classOf[SimpleInsertSource].getName))
+
+      spark.sessionState.catalog.createTable(newTable, false)
+
+      val df = sql("INSERT INTO TABLE test_table SELECT 1, 'a'")
+      val insertedRowCount = df.queryExecution.sparkPlan.metrics
+        .get("numOutputRows").map(_.value).getOrElse(0L)
+      assert(insertedRowCount == 1L)
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -27,6 +27,8 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType}
 import org.apache.spark.sql.catalyst.parser.ParseException
+import org.apache.spark.sql.execution.datasources.BasicWriteJobStatsTracker
+import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.PartitionOverwriteMode
 import org.apache.spark.sql.test.SharedSparkSession
@@ -51,6 +53,15 @@ case class SimpleInsert(userSpecifiedSchema: StructType)(@transient val sparkSes
 
   override def insert(input: DataFrame, overwrite: Boolean): Unit = {
     input.collect
+  }
+
+  override def insert(input: DataFrame, overwrite: Boolean,
+      metrics: Map[String, SQLMetric]): Unit = {
+    input.collect
+    metrics(BasicWriteJobStatsTracker.NUM_FILES_KEY).set(1L)
+    metrics(BasicWriteJobStatsTracker.NUM_OUTPUT_BYTES_KEY).set(100L)
+    metrics(BasicWriteJobStatsTracker.NUM_OUTPUT_ROWS_KEY).set(1L)
+    metrics(BasicWriteJobStatsTracker.NUM_PARTS_KEY).set(0L)
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Spark provides interface `InsertableRelation` and the `InsertIntoDataSourceCommand` to delegate the inserting processing to a data source. Unlike `DataWritingCommand`, the metrics in InsertIntoDataSourceCommand is empty and has no chance to update. So we cannot get "number of written files" or "number of output rows" from its metrics.

For example, if a table is a Spark parquet table. We can get the writing metrics by:
```scala
val df = sql("INSERT INTO TABLE test_table SELECT 1, 'a'")
val numFiles = df.queryExecution.sparkPlan.metrics("numFiles").value
```
But if it is a Delta table, we cannot.

If this PR accepted, we can easily to expose the metrics from Delta to Spark.
Such as modifying method `writeFiles` in `TransactionalWrite.scala`:
```scala
      // after written, expose the metrics
      basicWriteJobStatsTracker.metrics.foreach { kv =>
        metricsToExpose.get(kv._1).foreach(s => s.merge(kv._2))
      }
```

### Does this PR introduce any user-facing change?
Add a method in `InsertableRelation`:
```scala
def insert(data: DataFrame, overwrite: Boolean, metrics: Map[String, SQLMetric]): Unit
```
But still keep the old one.


### How was this patch tested?
Add a unit suite.