### PR TITLE
[SPARK-30954][ML][R]Make class name the same as file name

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/r/DecisionTreeClassificationWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/DecisionTreeClassificationWrapper.scala
@@ -30,12 +30,12 @@ import org.apache.spark.ml.r.RWrapperUtils._
 import org.apache.spark.ml.util._
 import org.apache.spark.sql.{DataFrame, Dataset}
 
-private[r] class DecisionTreeClassifierWrapper private (
+private[r] class DecisionTreeClassificationWrapper private (
   val pipeline: PipelineModel,
   val formula: String,
   val features: Array[String]) extends MLWritable {
 
-  import DecisionTreeClassifierWrapper._
+  import DecisionTreeClassificationWrapper._
 
   private val dtcModel: DecisionTreeClassificationModel =
     pipeline.stages(1).asInstanceOf[DecisionTreeClassificationModel]
@@ -54,10 +54,11 @@ private[r] class DecisionTreeClassifierWrapper private (
   }
 
   override def write: MLWriter = new
-      DecisionTreeClassifierWrapper.DecisionTreeClassifierWrapperWriter(this)
+      DecisionTreeClassificationWrapper.DecisionTreeClassificationWrapperWriter(this)
 }
 
-private[r] object DecisionTreeClassifierWrapper extends MLReadable[DecisionTreeClassifierWrapper] {
+private[r] object DecisionTreeClassificationWrapper extends
+  MLReadable[DecisionTreeClassificationWrapper] {
 
   val PREDICTED_LABEL_INDEX_COL = "pred_label_idx"
   val PREDICTED_LABEL_COL = "prediction"
@@ -74,7 +75,7 @@ private[r] object DecisionTreeClassifierWrapper extends MLReadable[DecisionTreeC
       seed: String,
       maxMemoryInMB: Int,
       cacheNodeIds: Boolean,
-      handleInvalid: String): DecisionTreeClassifierWrapper = {
+      handleInvalid: String): DecisionTreeClassificationWrapper = {
 
     val rFormula = new RFormula()
       .setFormula(formula)
@@ -110,15 +111,15 @@ private[r] object DecisionTreeClassifierWrapper extends MLReadable[DecisionTreeC
       .setStages(Array(rFormulaModel, dtc, idxToStr))
       .fit(data)
 
-    new DecisionTreeClassifierWrapper(pipeline, formula, features)
+    new DecisionTreeClassificationWrapper(pipeline, formula, features)
   }
 
-  override def read: MLReader[DecisionTreeClassifierWrapper] =
-    new DecisionTreeClassifierWrapperReader
+  override def read: MLReader[DecisionTreeClassificationWrapper] =
+    new DecisionTreeClassificationWrapperReader
 
-  override def load(path: String): DecisionTreeClassifierWrapper = super.load(path)
+  override def load(path: String): DecisionTreeClassificationWrapper = super.load(path)
 
-  class DecisionTreeClassifierWrapperWriter(instance: DecisionTreeClassifierWrapper)
+  class DecisionTreeClassificationWrapperWriter(instance: DecisionTreeClassificationWrapper)
     extends MLWriter {
 
     override protected def saveImpl(path: String): Unit = {
@@ -135,9 +136,10 @@ private[r] object DecisionTreeClassifierWrapper extends MLReadable[DecisionTreeC
     }
   }
 
-  class DecisionTreeClassifierWrapperReader extends MLReader[DecisionTreeClassifierWrapper] {
+  class DecisionTreeClassificationWrapperReader
+    extends MLReader[DecisionTreeClassificationWrapper] {
 
-    override def load(path: String): DecisionTreeClassifierWrapper = {
+    override def load(path: String): DecisionTreeClassificationWrapper = {
       implicit val format = DefaultFormats
       val rMetadataPath = new Path(path, "rMetadata").toString
       val pipelinePath = new Path(path, "pipeline").toString
@@ -148,7 +150,7 @@ private[r] object DecisionTreeClassifierWrapper extends MLReadable[DecisionTreeC
       val formula = (rMetadata \ "formula").extract[String]
       val features = (rMetadata \ "features").extract[Array[String]]
 
-      new DecisionTreeClassifierWrapper(pipeline, formula, features)
+      new DecisionTreeClassificationWrapper(pipeline, formula, features)
     }
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/r/DecisionTreeRegressionWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/DecisionTreeRegressionWrapper.scala
@@ -30,7 +30,7 @@ import org.apache.spark.ml.regression.{DecisionTreeRegressionModel, DecisionTree
 import org.apache.spark.ml.util._
 import org.apache.spark.sql.{DataFrame, Dataset}
 
-private[r] class DecisionTreeRegressorWrapper private (
+private[r] class DecisionTreeRegressionWrapper private (
   val pipeline: PipelineModel,
   val formula: String,
   val features: Array[String]) extends MLWritable {
@@ -49,10 +49,10 @@ private[r] class DecisionTreeRegressorWrapper private (
   }
 
   override def write: MLWriter = new
-      DecisionTreeRegressorWrapper.DecisionTreeRegressorWrapperWriter(this)
+      DecisionTreeRegressionWrapper.DecisionTreeRegressionWrapperWriter(this)
 }
 
-private[r] object DecisionTreeRegressorWrapper extends MLReadable[DecisionTreeRegressorWrapper] {
+private[r] object DecisionTreeRegressionWrapper extends MLReadable[DecisionTreeRegressionWrapper] {
   def fit(  // scalastyle:ignore
       data: DataFrame,
       formula: String,
@@ -64,7 +64,7 @@ private[r] object DecisionTreeRegressorWrapper extends MLReadable[DecisionTreeRe
       checkpointInterval: Int,
       seed: String,
       maxMemoryInMB: Int,
-      cacheNodeIds: Boolean): DecisionTreeRegressorWrapper = {
+      cacheNodeIds: Boolean): DecisionTreeRegressionWrapper = {
 
     val rFormula = new RFormula()
       .setFormula(formula)
@@ -94,14 +94,14 @@ private[r] object DecisionTreeRegressorWrapper extends MLReadable[DecisionTreeRe
       .setStages(Array(rFormulaModel, dtr))
       .fit(data)
 
-    new DecisionTreeRegressorWrapper(pipeline, formula, features)
+    new DecisionTreeRegressionWrapper(pipeline, formula, features)
   }
 
-  override def read: MLReader[DecisionTreeRegressorWrapper] = new DecisionTreeRegressorWrapperReader
+  override def read: MLReader[DecisionTreeRegressionWrapper] = new DecisionTreeRegressionWrapperReader
 
-  override def load(path: String): DecisionTreeRegressorWrapper = super.load(path)
+  override def load(path: String): DecisionTreeRegressionWrapper = super.load(path)
 
-  class DecisionTreeRegressorWrapperWriter(instance: DecisionTreeRegressorWrapper)
+  class DecisionTreeRegressionWrapperWriter(instance: DecisionTreeRegressionWrapper)
     extends MLWriter {
 
     override protected def saveImpl(path: String): Unit = {
@@ -118,9 +118,9 @@ private[r] object DecisionTreeRegressorWrapper extends MLReadable[DecisionTreeRe
     }
   }
 
-  class DecisionTreeRegressorWrapperReader extends MLReader[DecisionTreeRegressorWrapper] {
+  class DecisionTreeRegressionWrapperReader extends MLReader[DecisionTreeRegressionWrapper] {
 
-    override def load(path: String): DecisionTreeRegressorWrapper = {
+    override def load(path: String): DecisionTreeRegressionWrapper = {
       implicit val format = DefaultFormats
       val rMetadataPath = new Path(path, "rMetadata").toString
       val pipelinePath = new Path(path, "pipeline").toString
@@ -131,7 +131,7 @@ private[r] object DecisionTreeRegressorWrapper extends MLReadable[DecisionTreeRe
       val formula = (rMetadata \ "formula").extract[String]
       val features = (rMetadata \ "features").extract[Array[String]]
 
-      new DecisionTreeRegressorWrapper(pipeline, formula, features)
+      new DecisionTreeRegressionWrapper(pipeline, formula, features)
     }
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/r/GBTClassificationWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/GBTClassificationWrapper.scala
@@ -30,12 +30,12 @@ import org.apache.spark.ml.r.RWrapperUtils._
 import org.apache.spark.ml.util._
 import org.apache.spark.sql.{DataFrame, Dataset}
 
-private[r] class GBTClassifierWrapper private (
+private[r] class GBTClassificationWrapper private (
   val pipeline: PipelineModel,
   val formula: String,
   val features: Array[String]) extends MLWritable {
 
-  import GBTClassifierWrapper._
+  import GBTClassificationWrapper._
 
   private val gbtcModel: GBTClassificationModel =
     pipeline.stages(1).asInstanceOf[GBTClassificationModel]
@@ -56,10 +56,10 @@ private[r] class GBTClassifierWrapper private (
   }
 
   override def write: MLWriter = new
-      GBTClassifierWrapper.GBTClassifierWrapperWriter(this)
+      GBTClassificationWrapper.GBTClassificationWrapperWriter(this)
 }
 
-private[r] object GBTClassifierWrapper extends MLReadable[GBTClassifierWrapper] {
+private[r] object GBTClassificationWrapper extends MLReadable[GBTClassificationWrapper] {
 
   val PREDICTED_LABEL_INDEX_COL = "pred_label_idx"
   val PREDICTED_LABEL_COL = "prediction"
@@ -79,7 +79,7 @@ private[r] object GBTClassifierWrapper extends MLReadable[GBTClassifierWrapper] 
       subsamplingRate: Double,
       maxMemoryInMB: Int,
       cacheNodeIds: Boolean,
-      handleInvalid: String): GBTClassifierWrapper = {
+      handleInvalid: String): GBTClassificationWrapper = {
 
     val rFormula = new RFormula()
       .setFormula(formula)
@@ -118,14 +118,14 @@ private[r] object GBTClassifierWrapper extends MLReadable[GBTClassifierWrapper] 
       .setStages(Array(rFormulaModel, rfc, idxToStr))
       .fit(data)
 
-    new GBTClassifierWrapper(pipeline, formula, features)
+    new GBTClassificationWrapper(pipeline, formula, features)
   }
 
-  override def read: MLReader[GBTClassifierWrapper] = new GBTClassifierWrapperReader
+  override def read: MLReader[GBTClassificationWrapper] = new GBTClassificationWrapperReader
 
-  override def load(path: String): GBTClassifierWrapper = super.load(path)
+  override def load(path: String): GBTClassificationWrapper = super.load(path)
 
-  class GBTClassifierWrapperWriter(instance: GBTClassifierWrapper)
+  class GBTClassificationWrapperWriter(instance: GBTClassificationWrapper)
     extends MLWriter {
 
     override protected def saveImpl(path: String): Unit = {
@@ -142,9 +142,9 @@ private[r] object GBTClassifierWrapper extends MLReadable[GBTClassifierWrapper] 
     }
   }
 
-  class GBTClassifierWrapperReader extends MLReader[GBTClassifierWrapper] {
+  class GBTClassificationWrapperReader extends MLReader[GBTClassificationWrapper] {
 
-    override def load(path: String): GBTClassifierWrapper = {
+    override def load(path: String): GBTClassificationWrapper = {
       implicit val format = DefaultFormats
       val rMetadataPath = new Path(path, "rMetadata").toString
       val pipelinePath = new Path(path, "pipeline").toString
@@ -155,7 +155,7 @@ private[r] object GBTClassifierWrapper extends MLReadable[GBTClassifierWrapper] 
       val formula = (rMetadata \ "formula").extract[String]
       val features = (rMetadata \ "features").extract[Array[String]]
 
-      new GBTClassifierWrapper(pipeline, formula, features)
+      new GBTClassificationWrapper(pipeline, formula, features)
     }
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/r/GBTRegressionWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/GBTRegressionWrapper.scala
@@ -30,7 +30,7 @@ import org.apache.spark.ml.regression.{GBTRegressionModel, GBTRegressor}
 import org.apache.spark.ml.util._
 import org.apache.spark.sql.{DataFrame, Dataset}
 
-private[r] class GBTRegressorWrapper private (
+private[r] class GBTRegressionWrapper private (
   val pipeline: PipelineModel,
   val formula: String,
   val features: Array[String]) extends MLWritable {
@@ -51,10 +51,10 @@ private[r] class GBTRegressorWrapper private (
   }
 
   override def write: MLWriter = new
-      GBTRegressorWrapper.GBTRegressorWrapperWriter(this)
+      GBTRegressionWrapper.GBTRegressionWrapperWriter(this)
 }
 
-private[r] object GBTRegressorWrapper extends MLReadable[GBTRegressorWrapper] {
+private[r] object GBTRegressionWrapper extends MLReadable[GBTRegressionWrapper] {
   def fit(  // scalastyle:ignore
       data: DataFrame,
       formula: String,
@@ -69,7 +69,7 @@ private[r] object GBTRegressorWrapper extends MLReadable[GBTRegressorWrapper] {
       seed: String,
       subsamplingRate: Double,
       maxMemoryInMB: Int,
-      cacheNodeIds: Boolean): GBTRegressorWrapper = {
+      cacheNodeIds: Boolean): GBTRegressionWrapper= {
 
     val rFormula = new RFormula()
       .setFormula(formula)
@@ -102,14 +102,14 @@ private[r] object GBTRegressorWrapper extends MLReadable[GBTRegressorWrapper] {
       .setStages(Array(rFormulaModel, rfr))
       .fit(data)
 
-    new GBTRegressorWrapper(pipeline, formula, features)
+    new GBTRegressionWrapper(pipeline, formula, features)
   }
 
-  override def read: MLReader[GBTRegressorWrapper] = new GBTRegressorWrapperReader
+  override def read: MLReader[GBTRegressionWrapper] = new GBTRegressionWrapperReader
 
-  override def load(path: String): GBTRegressorWrapper = super.load(path)
+  override def load(path: String): GBTRegressionWrapper = super.load(path)
 
-  class GBTRegressorWrapperWriter(instance: GBTRegressorWrapper)
+  class GBTRegressionWrapperWriter(instance: GBTRegressionWrapper)
     extends MLWriter {
 
     override protected def saveImpl(path: String): Unit = {
@@ -126,9 +126,9 @@ private[r] object GBTRegressorWrapper extends MLReadable[GBTRegressorWrapper] {
     }
   }
 
-  class GBTRegressorWrapperReader extends MLReader[GBTRegressorWrapper] {
+  class GBTRegressionWrapperReader extends MLReader[GBTRegressionWrapper] {
 
-    override def load(path: String): GBTRegressorWrapper = {
+    override def load(path: String): GBTRegressionWrapper = {
       implicit val format = DefaultFormats
       val rMetadataPath = new Path(path, "rMetadata").toString
       val pipelinePath = new Path(path, "pipeline").toString
@@ -139,7 +139,7 @@ private[r] object GBTRegressorWrapper extends MLReadable[GBTRegressorWrapper] {
       val formula = (rMetadata \ "formula").extract[String]
       val features = (rMetadata \ "features").extract[Array[String]]
 
-      new GBTRegressorWrapper(pipeline, formula, features)
+      new GBTRegressionWrapper(pipeline, formula, features)
     }
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/r/RWrappers.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/RWrappers.scala
@@ -60,8 +60,8 @@ private[r] object RWrappers extends MLReader[Object] {
         RandomForestRegressionWrapper.load(path)
       case "org.apache.spark.ml.r.RandomForestClassificationWrapper" =>
         RandomForestClassificationWrapper.load(path)
-      case "org.apache.spark.ml.r.DecisionTreeRegressorWrapper" =>
-        DecisionTreeRegressorWrapper.load(path)
+      case "org.apache.spark.ml.r.DecisionTreeRegressionWrapper" =>
+        DecisionTreeRegressionWrapper.load(path)
       case "org.apache.spark.ml.r.DecisionTreeClassificationWrapper" =>
         DecisionTreeClassificationWrapper.load(path)
       case "org.apache.spark.ml.r.GBTRegressionWrapper" =>

--- a/mllib/src/main/scala/org/apache/spark/ml/r/RWrappers.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/RWrappers.scala
@@ -56,18 +56,18 @@ private[r] object RWrappers extends MLReader[Object] {
         ALSWrapper.load(path)
       case "org.apache.spark.ml.r.LogisticRegressionWrapper" =>
         LogisticRegressionWrapper.load(path)
-      case "org.apache.spark.ml.r.RandomForestRegressorWrapper" =>
-        RandomForestRegressorWrapper.load(path)
-      case "org.apache.spark.ml.r.RandomForestClassifierWrapper" =>
-        RandomForestClassifierWrapper.load(path)
+      case "org.apache.spark.ml.r.RandomForestRegressionWrapper" =>
+        RandomForestRegressionWrapper.load(path)
+      case "org.apache.spark.ml.r.RandomForestClassificationWrapper" =>
+        RandomForestClassificationWrapper.load(path)
       case "org.apache.spark.ml.r.DecisionTreeRegressorWrapper" =>
         DecisionTreeRegressorWrapper.load(path)
-      case "org.apache.spark.ml.r.DecisionTreeClassifierWrapper" =>
-        DecisionTreeClassifierWrapper.load(path)
-      case "org.apache.spark.ml.r.GBTRegressorWrapper" =>
-        GBTRegressorWrapper.load(path)
-      case "org.apache.spark.ml.r.GBTClassifierWrapper" =>
-        GBTClassifierWrapper.load(path)
+      case "org.apache.spark.ml.r.DecisionTreeClassificationWrapper" =>
+        DecisionTreeClassificationWrapper.load(path)
+      case "org.apache.spark.ml.r.GBTRegressionWrapper" =>
+        GBTRegressionWrapper.load(path)
+      case "org.apache.spark.ml.r.GBTClassificationWrapper" =>
+        GBTClassificationWrapper.load(path)
       case "org.apache.spark.ml.r.BisectingKMeansWrapper" =>
         BisectingKMeansWrapper.load(path)
       case "org.apache.spark.ml.r.LinearSVCWrapper" =>

--- a/mllib/src/main/scala/org/apache/spark/ml/r/RandomForestClassificationWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/RandomForestClassificationWrapper.scala
@@ -30,12 +30,12 @@ import org.apache.spark.ml.r.RWrapperUtils._
 import org.apache.spark.ml.util._
 import org.apache.spark.sql.{DataFrame, Dataset}
 
-private[r] class RandomForestClassifierWrapper private (
+private[r] class RandomForestClassificationWrapper private (
   val pipeline: PipelineModel,
   val formula: String,
   val features: Array[String]) extends MLWritable {
 
-  import RandomForestClassifierWrapper._
+  import RandomForestClassificationWrapper._
 
   private val rfcModel: RandomForestClassificationModel =
     pipeline.stages(1).asInstanceOf[RandomForestClassificationModel]
@@ -56,10 +56,11 @@ private[r] class RandomForestClassifierWrapper private (
   }
 
   override def write: MLWriter = new
-      RandomForestClassifierWrapper.RandomForestClassifierWrapperWriter(this)
+      RandomForestClassificationWrapper.RandomForestClassificationWrapperWriter(this)
 }
 
-private[r] object RandomForestClassifierWrapper extends MLReadable[RandomForestClassifierWrapper] {
+private[r] object RandomForestClassificationWrapper
+  extends MLReadable[RandomForestClassificationWrapper] {
 
   val PREDICTED_LABEL_INDEX_COL = "pred_label_idx"
   val PREDICTED_LABEL_COL = "prediction"
@@ -80,7 +81,7 @@ private[r] object RandomForestClassifierWrapper extends MLReadable[RandomForestC
       maxMemoryInMB: Int,
       cacheNodeIds: Boolean,
       handleInvalid: String,
-      bootstrap: Boolean): RandomForestClassifierWrapper = {
+      bootstrap: Boolean): RandomForestClassificationWrapper = {
 
     val rFormula = new RFormula()
       .setFormula(formula)
@@ -120,15 +121,15 @@ private[r] object RandomForestClassifierWrapper extends MLReadable[RandomForestC
       .setStages(Array(rFormulaModel, rfc, idxToStr))
       .fit(data)
 
-    new RandomForestClassifierWrapper(pipeline, formula, features)
+    new RandomForestClassificationWrapper(pipeline, formula, features)
   }
 
-  override def read: MLReader[RandomForestClassifierWrapper] =
-    new RandomForestClassifierWrapperReader
+  override def read: MLReader[RandomForestClassificationWrapper] =
+    new RandomForestClassificationWrapperReader
 
-  override def load(path: String): RandomForestClassifierWrapper = super.load(path)
+  override def load(path: String): RandomForestClassificationWrapper = super.load(path)
 
-  class RandomForestClassifierWrapperWriter(instance: RandomForestClassifierWrapper)
+  class RandomForestClassificationWrapperWriter(instance: RandomForestClassificationWrapper)
     extends MLWriter {
 
     override protected def saveImpl(path: String): Unit = {
@@ -145,9 +146,10 @@ private[r] object RandomForestClassifierWrapper extends MLReadable[RandomForestC
     }
   }
 
-  class RandomForestClassifierWrapperReader extends MLReader[RandomForestClassifierWrapper] {
+  class RandomForestClassificationWrapperReader
+    extends MLReader[RandomForestClassificationWrapper] {
 
-    override def load(path: String): RandomForestClassifierWrapper = {
+    override def load(path: String): RandomForestClassificationWrapper = {
       implicit val format = DefaultFormats
       val rMetadataPath = new Path(path, "rMetadata").toString
       val pipelinePath = new Path(path, "pipeline").toString
@@ -158,7 +160,7 @@ private[r] object RandomForestClassifierWrapper extends MLReadable[RandomForestC
       val formula = (rMetadata \ "formula").extract[String]
       val features = (rMetadata \ "features").extract[Array[String]]
 
-      new RandomForestClassifierWrapper(pipeline, formula, features)
+      new RandomForestClassificationWrapper(pipeline, formula, features)
     }
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/r/RandomForestRegressionWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/RandomForestRegressionWrapper.scala
@@ -30,7 +30,7 @@ import org.apache.spark.ml.regression.{RandomForestRegressionModel, RandomForest
 import org.apache.spark.ml.util._
 import org.apache.spark.sql.{DataFrame, Dataset}
 
-private[r] class RandomForestRegressorWrapper private (
+private[r] class RandomForestRegressionWrapper private (
   val pipeline: PipelineModel,
   val formula: String,
   val features: Array[String]) extends MLWritable {
@@ -51,10 +51,10 @@ private[r] class RandomForestRegressorWrapper private (
   }
 
   override def write: MLWriter = new
-      RandomForestRegressorWrapper.RandomForestRegressorWrapperWriter(this)
+      RandomForestRegressionWrapper.RandomForestRegressionWrapperWriter(this)
 }
 
-private[r] object RandomForestRegressorWrapper extends MLReadable[RandomForestRegressorWrapper] {
+private[r] object RandomForestRegressionWrapper extends MLReadable[RandomForestRegressionWrapper] {
   def fit(  // scalastyle:ignore
       data: DataFrame,
       formula: String,
@@ -70,7 +70,7 @@ private[r] object RandomForestRegressorWrapper extends MLReadable[RandomForestRe
       subsamplingRate: Double,
       maxMemoryInMB: Int,
       cacheNodeIds: Boolean,
-      bootstrap: Boolean): RandomForestRegressorWrapper = {
+      bootstrap: Boolean): RandomForestRegressionWrapper = {
 
     val rFormula = new RFormula()
       .setFormula(formula)
@@ -104,14 +104,14 @@ private[r] object RandomForestRegressorWrapper extends MLReadable[RandomForestRe
       .setStages(Array(rFormulaModel, rfr))
       .fit(data)
 
-    new RandomForestRegressorWrapper(pipeline, formula, features)
+    new RandomForestRegressionWrapper(pipeline, formula, features)
   }
 
-  override def read: MLReader[RandomForestRegressorWrapper] = new RandomForestRegressorWrapperReader
+  override def read: MLReader[RandomForestRegressionWrapper = new RandomForestRegressionWrapperReader
 
-  override def load(path: String): RandomForestRegressorWrapper = super.load(path)
+  override def load(path: String): RandomForestRegressionWrapper = super.load(path)
 
-  class RandomForestRegressorWrapperWriter(instance: RandomForestRegressorWrapper)
+  class RandomForestRegressionWrapperWriter(instance: RandomForestRegressionWrapper)
     extends MLWriter {
 
     override protected def saveImpl(path: String): Unit = {
@@ -128,9 +128,9 @@ private[r] object RandomForestRegressorWrapper extends MLReadable[RandomForestRe
     }
   }
 
-  class RandomForestRegressorWrapperReader extends MLReader[RandomForestRegressorWrapper] {
+  class RandomForestRegressionWrapperReader extends MLReader[RandomForestRegressionWrapper] {
 
-    override def load(path: String): RandomForestRegressorWrapper = {
+    override def load(path: String): RandomForestRegressionWrapper = {
       implicit val format = DefaultFormats
       val rMetadataPath = new Path(path, "rMetadata").toString
       val pipelinePath = new Path(path, "pipeline").toString
@@ -141,7 +141,7 @@ private[r] object RandomForestRegressorWrapper extends MLReadable[RandomForestRe
       val formula = (rMetadata \ "formula").extract[String]
       val features = (rMetadata \ "features").extract[Array[String]]
 
-      new RandomForestRegressorWrapper(pipeline, formula, features)
+      new RandomForestRegressionWrapper(pipeline, formula, features)
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Based on [Spark-30954](https://issues.apache.org/jira/browse/SPARK-30954), under `org.apache.spark.ml.r`, most class names are the same as the file name, except these class namees

- `DecisionTreeClassificationWrapper.scala`

- `GBTClassificationWrapper.scala`

- `GBTRegressionWrapper.scala`

- `RandomForestClassificationWrapper.scala`

- `RandomForestRegressionWrapper.scala`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Make the name consistence in the `R` package.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
run the R test

`./R/run-tests.sh`