### PR TITLE
[SPARK-31081][UI][SQL] Make display of stageId/stageAttemptId/taskId of sql metrics toggleable

### DIFF
--- a/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.css
+++ b/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.css
@@ -35,7 +35,7 @@
 }
 
 /* Highlight the SparkPlan node name */
-#plan-viz-graph svg text :first-child {
+#plan-viz-graph svg text :first-child:not(.stageId-and-taskId-metrics) {
   font-weight: bold;
 }
 

--- a/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
+++ b/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
@@ -47,6 +47,7 @@ function renderPlanViz() {
   }
 
   resizeSvg(svg);
+  setupForAdditionalMetrics();
 }
 
 /* -------------------- *
@@ -157,4 +158,49 @@ function getAbsolutePosition(d3selection) {
     }
   }
   return { x: _x, y: _y };
+}
+
+/*
+ * Helper function to setup for additional metrics.
+ */
+function setupForAdditionalMetrics() {
+    // With dagre-d3, we can choose normal text (default) or HTML as a label type.
+    // HTML label for node works well but not for cluster so we need to choose the default label type
+    // and manipulate DOM.
+    $("g.cluster text tspan")
+        .each(function() {
+            var originalText = $(this).text();
+            if (originalText.indexOf("<span") > 0) {
+                var newTexts = originalText.match("^(.*)<span .*>(.*)</span>(.*)$");
+                var thisD3Node = d3.selectAll($(this));
+                thisD3Node.text(newTexts[1]);
+                thisD3Node.append("tspan").attr("class", "stageId-and-taskId-metrics").text(newTexts[2]);
+                $(this).append(newTexts[3]);
+            }
+            else { return originalText; }
+        });
+
+    var checkboxNode = $("#stageId-and-taskId-checkbox");
+    checkboxNode.click(function() {
+        onClickAdditionalMetricsCheckbox($(this));
+    });
+
+    var isChecked = window.localStorage.getItem("stageId-and-taskId-checked") == "true";
+    $("#stageId-and-taskId-checkbox").prop("checked", isChecked);
+    $(".stageId-and-taskId-metrics").hide();
+    onClickAdditionalMetricsCheckbox(checkboxNode);
+}
+
+/*
+ * Helper function which defines the action on click the checkbox.
+ */
+function onClickAdditionalMetricsCheckbox(checkboxNode) {
+    var additionalMetrics = $(".stageId-and-taskId-metrics");
+    var isChecked = checkboxNode.prop("checked");
+    if (isChecked) {
+        additionalMetrics.show();
+    } else {
+        additionalMetrics.hide();
+    }
+    window.localStorage.setItem("stageId-and-taskId-checked", isChecked);
 }

--- a/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
+++ b/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
@@ -176,8 +176,9 @@ function setupForAdditionalMetrics() {
                 thisD3Node.text(newTexts[1]);
                 thisD3Node.append("tspan").attr("class", "stageId-and-taskId-metrics").text(newTexts[2]);
                 $(this).append(newTexts[3]);
+            } else {
+                return originalText;
             }
-            else { return originalText; }
         });
 
     var checkboxNode = $("#stageId-and-taskId-checkbox");

--- a/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
+++ b/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
@@ -96,7 +96,7 @@ function preprocessGraphLayout(g) {
     } else {
       firstSearator = "<span class='stageId-and-taskId-metrics'>";
       secondSeparator = "</span>";
-      splitter = "<br>"
+      splitter = "<br>";
     }
 
     node.label.split(splitter).forEach(function(text, i) {

--- a/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
+++ b/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
@@ -212,7 +212,6 @@ function postprocessForAdditionalMetrics() {
   });
   var isChecked = window.localStorage.getItem("stageId-and-taskId-checked") == "true";
   $("#stageId-and-taskId-checkbox").prop("checked", isChecked);
-  $(".stageId-and-taskId-metrics").hide();
   onClickAdditionalMetricsCheckbox(checkboxNode);
 }
 
@@ -223,9 +222,9 @@ function onClickAdditionalMetricsCheckbox(checkboxNode) {
   var additionalMetrics = $(".stageId-and-taskId-metrics");
   var isChecked = checkboxNode.prop("checked");
   if (isChecked) {
-      additionalMetrics.show();
+    additionalMetrics.show();
   } else {
-      additionalMetrics.hide();
+    additionalMetrics.hide();
   }
   window.localStorage.setItem("stageId-and-taskId-checked", isChecked);
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
@@ -116,8 +116,12 @@ object SQLMetrics {
     // data size total (min, med, max):
     // 100GB (100MB, 1GB, 10GB)
     val acc = new SQLMetric(SIZE_METRIC, -1)
-    acc.register(sc, name = Some(s"$name total (min, med, max (stageId (attemptId): taskId))"),
+    // scalastyle:off
+    acc.register(
+      sc,
+      name = Some(s"$name total (min, med, max<span class='stageId-and-taskId-metrics'> (stageId (attemptId): taskId)</span>)"),
       countFailedValues = false)
+    // scalastyle:on
     acc
   }
 
@@ -126,16 +130,24 @@ object SQLMetrics {
     // duration(min, med, max):
     // 5s (800ms, 1s, 2s)
     val acc = new SQLMetric(TIMING_METRIC, -1)
-    acc.register(sc, name = Some(s"$name total (min, med, max (stageId (attemptId): taskId))"),
+    // scalastyle:off
+    acc.register(
+      sc,
+      name = Some(s"$name total (min, med, max<span class='stageId-and-taskId-metrics'> (stageId (attemptId): taskId)</span>)"),
       countFailedValues = false)
+    // scalastyle:on
     acc
   }
 
   def createNanoTimingMetric(sc: SparkContext, name: String): SQLMetric = {
     // Same with createTimingMetric, just normalize the unit of time to millisecond.
     val acc = new SQLMetric(NS_TIMING_METRIC, -1)
-    acc.register(sc, name = Some(s"$name total (min, med, max (stageId (attemptId): taskId))"),
+    // scalastyle:off
+    acc.register(
+      sc,
+      name = Some(s"$name total (min, med, max<span class='stageId-and-taskId-metrics'> (stageId (attemptId): taskId)</span>)"),
       countFailedValues = false)
+    // scalastyle:on
     acc
   }
 
@@ -150,8 +162,12 @@ object SQLMetrics {
     // probe avg (min, med, max):
     // (1.2, 2.2, 6.3)
     val acc = new SQLMetric(AVERAGE_METRIC)
-    acc.register(sc, name = Some(s"$name (min, med, max (stageId (attemptId): taskId))"),
+    // scalastyle:off
+    acc.register(
+      sc,
+      name = Some(s"$name (min, med, max<span class='stageId-and-taskId-metrics'> (stageId (attemptId): taskId)</span>)"),
       countFailedValues = false)
+    // scalastyle:on
     acc
   }
 
@@ -173,7 +189,9 @@ object SQLMetrics {
     val stringMetric = if (maxMetrics.isEmpty) {
       "(driver)"
     } else {
-      s"(stage ${maxMetrics(1)} (attempt ${maxMetrics(2)}): task ${maxMetrics(3)})"
+      // scalastyle:off
+      s"<span class='stageId-and-taskId-metrics'>(stage ${maxMetrics(1)} (attempt ${maxMetrics(2)}): task ${maxMetrics(3)})</span>"
+      // scalastyle:on
     }
     if (metricsType == SUM_METRIC) {
       val numberFormat = NumberFormat.getIntegerInstance(Locale.US)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
@@ -116,12 +116,8 @@ object SQLMetrics {
     // data size total (min, med, max):
     // 100GB (100MB, 1GB, 10GB)
     val acc = new SQLMetric(SIZE_METRIC, -1)
-    // scalastyle:off
-    acc.register(
-      sc,
-      name = Some(s"$name total (min, med, max<span class='stageId-and-taskId-metrics'> (stageId (attemptId): taskId)</span>)"),
+    acc.register(sc, name = Some(s"$name total (min, med, max (stageId (attemptId): taskId))"),
       countFailedValues = false)
-    // scalastyle:on
     acc
   }
 
@@ -130,24 +126,16 @@ object SQLMetrics {
     // duration(min, med, max):
     // 5s (800ms, 1s, 2s)
     val acc = new SQLMetric(TIMING_METRIC, -1)
-    // scalastyle:off
-    acc.register(
-      sc,
-      name = Some(s"$name total (min, med, max<span class='stageId-and-taskId-metrics'> (stageId (attemptId): taskId)</span>)"),
+    acc.register(sc, name = Some(s"$name total (min, med, max (stageId (attemptId): taskId))"),
       countFailedValues = false)
-    // scalastyle:on
     acc
   }
 
   def createNanoTimingMetric(sc: SparkContext, name: String): SQLMetric = {
     // Same with createTimingMetric, just normalize the unit of time to millisecond.
     val acc = new SQLMetric(NS_TIMING_METRIC, -1)
-    // scalastyle:off
-    acc.register(
-      sc,
-      name = Some(s"$name total (min, med, max<span class='stageId-and-taskId-metrics'> (stageId (attemptId): taskId)</span>)"),
+    acc.register(sc, name = Some(s"$name total (min, med, max (stageId (attemptId): taskId))"),
       countFailedValues = false)
-    // scalastyle:on
     acc
   }
 
@@ -162,12 +150,8 @@ object SQLMetrics {
     // probe avg (min, med, max):
     // (1.2, 2.2, 6.3)
     val acc = new SQLMetric(AVERAGE_METRIC)
-    // scalastyle:off
-    acc.register(
-      sc,
-      name = Some(s"$name (min, med, max<span class='stageId-and-taskId-metrics'> (stageId (attemptId): taskId)</span>)"),
+    acc.register(sc, name = Some(s"$name (min, med, max (stageId (attemptId): taskId))"),
       countFailedValues = false)
-    // scalastyle:on
     acc
   }
 
@@ -189,9 +173,7 @@ object SQLMetrics {
     val stringMetric = if (maxMetrics.isEmpty) {
       "(driver)"
     } else {
-      // scalastyle:off
-      s"<span class='stageId-and-taskId-metrics'>(stage ${maxMetrics(1)} (attempt ${maxMetrics(2)}): task ${maxMetrics(3)})</span>"
-      // scalastyle:on
+      s"(stage ${maxMetrics(1)} (attempt ${maxMetrics(2)}): task ${maxMetrics(3)})"
     }
     if (metricsType == SUM_METRIC) {
       val numberFormat = NumberFormat.getIntegerInstance(Locale.US)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
@@ -71,6 +71,10 @@ class ExecutionPage(parent: SQLTab) extends WebUIPage("execution") with Logging 
             {jobLinks(JobExecutionStatus.FAILED, "Failed Jobs:")}
           </ul>
         </div>
+        <div>
+          <input type="checkbox" id="stageId-and-taskId-checkbox"></input>
+          <span>Show Stage/Task IDs</span>
+        </div>
 
       val metrics = sqlStore.executionMetrics(executionId)
       val graph = sqlStore.planGraph(executionId)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
@@ -73,7 +73,7 @@ class ExecutionPage(parent: SQLTab) extends WebUIPage("execution") with Logging 
         </div>
         <div>
           <input type="checkbox" id="stageId-and-taskId-checkbox"></input>
-          <span>Show Stage/Task IDs</span>
+          <span>Show the Stage (Stage Attempt): Task ID that corresponds to the max metric</span>
         </div>
 
       val metrics = sqlStore.executionMetrics(executionId)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
@@ -160,7 +160,7 @@ private[ui] class SparkPlanGraphNode(
     val metrics: Seq[SQLPlanMetric]) {
 
   def makeDotNode(metricsValue: Map[Long, String]): String = {
-    val builder = new mutable.StringBuilder(name)
+    val builder = new mutable.StringBuilder("<b>" + name + "</b>")
 
     val values = for {
       metric <- metrics
@@ -173,9 +173,10 @@ private[ui] class SparkPlanGraphNode(
       // If there are metrics, display each entry in a separate line.
       // Note: whitespace between two "\n"s is to create an empty line between the name of
       // SparkPlan and metrics. If removing it, it won't display the empty line in UI.
-      builder ++= "\n \n"
-      builder ++= values.mkString("\n")
-      s"""  $id [label="${StringEscapeUtils.escapeJava(builder.toString())}"];"""
+      builder ++= "<br><br>"
+      builder ++= values.mkString("<br>")
+      val labelStr = StringEscapeUtils.escapeJava(builder.toString().replaceAll("\n", "<br>"))
+      s"""  $id [labelType="html" label="${labelStr}"];"""
     } else {
       // SPARK-30684: when there is no metrics, add empty lines to increase the height of the node,
       // so that there won't be gaps between an edge and a small node.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
@@ -211,6 +211,7 @@ private[ui] class SparkPlanGraphCluster(
     }
     s"""
        |  subgraph cluster${id} {
+       |    isCluster="true";
        |    label="${StringEscapeUtils.escapeJava(labelStr)}";
        |    ${nodes.map(_.makeDotNode(metricsValue)).mkString("    \n")}
        |  }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This is another solution for `SPARK-31081` and #27849 .
I added a checkbox which can toggle display of stageId/taskid in the SQL's DAG page.
Mainly, I implemented the toggleable texts in boxes with HTML label feature provided by `dagre-d3`.
The additional metrics are enclosed by `<span>` and control the appearance of the text.
But the exception is additional metrics in clusters.
We can use HTML label for cluster but layout will be broken so I choosed normal text label for clusters.
Due to that, this solution contains a little bit tricky code in`spark-sql-viz.js` to manipulate the metric texts and generate DOMs.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
It makes metrics harder to read after #26843 and user may not interest in extra info(stageId/StageAttemptId/taskId ) when they do not need debug. 
#27849 control the appearance by a new configuration property but providing a checkbox is more flexible.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
Yes.
[Additional metrics shown]
![with-checked](https://user-images.githubusercontent.com/4736016/77244214-0f6cd780-6c56-11ea-9275-a30758dd5339.png)



[Additional metrics hidden]
![without-chedked](https://user-images.githubusercontent.com/4736016/77244219-14ca2200-6c56-11ea-9874-33a466085fce.png)


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Tested manually with a simple DataFrame operation.
* The appearance of additional metrics in the boxes are controlled by the newly added checkbox.
* No error found with JS-debugger.
* Checked/not-checked state is preserved after reloading.