### PR TITLE
[SPARK-31193][CORE] set spark.master and spark.app.name conf default value

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -385,10 +385,10 @@ class SparkContext(config: SparkConf) extends Logging {
     _conf.validateSettings()
 
     if (!_conf.contains("spark.master")) {
-      throw new SparkException("A master URL must be set in your configuration")
+      _conf.set("spark.master", "local[*]")
     }
     if (!_conf.contains("spark.app.name")) {
-      throw new SparkException("An application name must be set in your configuration")
+      _conf.setAppName(java.util.UUID.randomUUID().toString)
     }
 
     _driverLogger = DriverLogger(_conf)

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -881,6 +881,15 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
       }
     }
   }
+
+  test("test without set master and name") {
+    val conf = new SparkConf()
+    conf.remove("spark.master")
+
+    val sc = new SparkContext(conf)
+    sc.parallelize(1 to 10).collect()
+    sc.stop()
+  }
 }
 
 object SparkContextSuite {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
set spark.master and spark.app.name default config


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
I see the default value of master setting in spark-submit client

```scala
// Global defaults. These should be keep to minimum to avoid confusing behavior.
master = Option(master).getOrElse("local[*]")
```

but during our development and debugging, We will encounter this kind of problem 

Exception in thread "main" org.apache.spark.SparkException: A master URL must be set in your configuration

This conflicts with the default setting

```scala
//If we do
val sparkConf = new SparkConf().setAppName(“app”)
//When using the client to submit tasks to the cluster, the matser will be overwritten by the local
sparkConf.set("spark.master", "local[*]")
```

so we have to do like this

```scala
val sparkConf = new SparkConf().setAppName(“app”)
//Because the program runs to set the priority of the master, we have to first determine whether to set the master to avoid submitting the cluster to run.
sparkConf.set("spark.master",sparkConf.get("spark.master","local[*]"))
```

so is spark.app.name

Is it better for users to handle it like submit client ?

Optimize the development process

### Does this PR introduce any user-facing change?
no


### How was this patch tested?
do not set config test
