### PR TITLE
[SPARK-31202][CORE]Improve SizeEstimator for AppendOnlyMap

### DIFF
--- a/core/src/main/scala/org/apache/spark/Aggregator.scala
+++ b/core/src/main/scala/org/apache/spark/Aggregator.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark
 
+import scala.reflect.ClassTag
+
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.util.collection.ExternalAppendOnlyMap
 
@@ -29,7 +31,7 @@ import org.apache.spark.util.collection.ExternalAppendOnlyMap
  * @param mergeCombiners function to merge outputs from multiple mergeValue function.
  */
 @DeveloperApi
-case class Aggregator[K, V, C] (
+case class Aggregator[K, V, C: ClassTag] (
     createCombiner: V => C,
     mergeValue: (C, V) => C,
     mergeCombiners: (C, C) => C) {

--- a/core/src/main/scala/org/apache/spark/Dependency.scala
+++ b/core/src/main/scala/org/apache/spark/Dependency.scala
@@ -90,6 +90,10 @@ class ShuffleDependency[K: ClassTag, V: ClassTag, C: ClassTag](
   private[spark] val combinerClassName: Option[String] =
     Option(reflect.classTag[C]).map(_.runtimeClass.getName)
 
+  private[spark] val keyClassTag = reflect.classTag[K]
+  private[spark] val valueClassTag = reflect.classTag[V]
+  private[spark] val combinerClassTag = reflect.classTag[C]
+
   val shuffleId: Int = _rdd.context.newShuffleId()
 
   val shuffleHandle: ShuffleHandle = _rdd.context.env.shuffleManager.registerShuffle(

--- a/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
@@ -124,7 +124,8 @@ private[spark] class BlockStoreShuffleReader[K, C](
       case Some(keyOrd: Ordering[K]) =>
         // Create an ExternalSorter to sort the data.
         val sorter =
-          new ExternalSorter[K, C, C](context, ordering = Some(keyOrd), serializer = dep.serializer)
+          new ExternalSorter[K, C, C](
+            context, ordering = Some(keyOrd), serializer = dep.serializer)(dep.combinerClassTag)
         sorter.insertAll(aggregatedIter)
         context.taskMetrics().incMemoryBytesSpilled(sorter.memoryBytesSpilled)
         context.taskMetrics().incDiskBytesSpilled(sorter.diskBytesSpilled)

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleManager.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleManager.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.shuffle
 
-import scala.reflect.ClassTag
-
 import org.apache.spark.{ShuffleDependency, TaskContext}
 
 /**

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleManager.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleManager.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.shuffle
 
+import scala.reflect.ClassTag
+
 import org.apache.spark.{ShuffleDependency, TaskContext}
 
 /**

--- a/core/src/main/scala/org/apache/spark/util/collection/AppendOnlyMap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/AppendOnlyMap.scala
@@ -19,7 +19,6 @@ package org.apache.spark.util.collection
 
 import java.util.Comparator
 
-import scala.collection.mutable
 import scala.reflect.{classTag, ClassTag}
 
 import com.google.common.hash.Hashing
@@ -65,7 +64,7 @@ class AppendOnlyMap[K, V: ClassTag](initialCapacity: Int = 64)
   private var nullValue: V = null.asInstanceOf[V]
 
   // Use to track key positions, the size is small enough for most cases.
-  private var keyPositions = new mutable.BitSet(capacity)
+  private val keyPositions = new java.util.BitSet()
 
   // Tracks the total number of elements in the values, mainly used to do estimation for container
   // value type like CompactBuffer[_] and Array[CompactBuffer[_]]
@@ -123,7 +122,7 @@ class AppendOnlyMap[K, V: ClassTag](initialCapacity: Int = 64)
       if (curKey.eq(null)) {
         data(2 * pos) = k
         data(2 * pos + 1) = value.asInstanceOf[AnyRef]
-        keyPositions += 2 * pos
+        keyPositions.set(2 * pos)
         totalValueElements += 1
         incrementSize()  // Since we added a new key
         return
@@ -162,7 +161,7 @@ class AppendOnlyMap[K, V: ClassTag](initialCapacity: Int = 64)
         data(2 * pos) = k
         data(2 * pos + 1) = newValue.asInstanceOf[AnyRef]
         incrementSize()
-        keyPositions += 2 * pos
+        keyPositions.set(2 * pos)
         totalValueElements += 1
         return newValue
       } else if (k.eq(curKey) || k.equals(curKey)) {
@@ -227,7 +226,7 @@ class AppendOnlyMap[K, V: ClassTag](initialCapacity: Int = 64)
     }
   }
 
-  def getKeyPositions(): mutable.BitSet = {
+  def getKeyPositions(): java.util.BitSet = {
     keyPositions
   }
 
@@ -261,7 +260,7 @@ class AppendOnlyMap[K, V: ClassTag](initialCapacity: Int = 64)
           if (curKey.eq(null)) {
             newData(2 * newPos) = key
             newData(2 * newPos + 1) = value
-            keyPositions += 2 * newPos
+            keyPositions.set(2 * newPos)
             keepGoing = false
           } else {
             val delta = i

--- a/core/src/main/scala/org/apache/spark/util/collection/AppendOnlyMap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/AppendOnlyMap.scala
@@ -71,7 +71,7 @@ class AppendOnlyMap[K, V: ClassTag](initialCapacity: Int = 64)
   // value type like CompactBuffer[_] and Array[CompactBuffer[_]]
   private var totalValueElements = 0
 
-  private val updateValueElementsIfNeeded: Map[Class[_], () => Unit] = Map(
+  private val updateValueElements: Map[Class[_], () => Unit] = Map(
     (classOf[CompactBuffer[_]], () => totalValueElements += 1),
     (classOf[Array[CompactBuffer[_]]], () => totalValueElements += 1)
   )
@@ -168,7 +168,9 @@ class AppendOnlyMap[K, V: ClassTag](initialCapacity: Int = 64)
       } else if (k.eq(curKey) || k.equals(curKey)) {
         val newValue = updateFunc(true, data(2 * pos + 1).asInstanceOf[V])
         data(2 * pos + 1) = newValue.asInstanceOf[AnyRef]
-        updateValueElementsIfNeeded(valueClassTag.runtimeClass)()
+        if (updateValueElements.isDefinedAt(valueClassTag.runtimeClass)) {
+          updateValueElements(valueClassTag.runtimeClass)()
+        }
         return newValue
       } else {
         val delta = i

--- a/core/src/main/scala/org/apache/spark/util/collection/AppendOnlyMap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/AppendOnlyMap.scala
@@ -168,7 +168,7 @@ class AppendOnlyMap[K, V: ClassTag](initialCapacity: Int = 64)
       } else if (k.eq(curKey) || k.equals(curKey)) {
         val newValue = updateFunc(true, data(2 * pos + 1).asInstanceOf[V])
         data(2 * pos + 1) = newValue.asInstanceOf[AnyRef]
-        updateValueElementsIfNeeded(valueClassTag.runtimeClass)
+        updateValueElementsIfNeeded(valueClassTag.runtimeClass)()
         return newValue
       } else {
         val delta = i
@@ -241,6 +241,7 @@ class AppendOnlyMap[K, V: ClassTag](initialCapacity: Int = 64)
     // capacity < MAXIMUM_CAPACITY (2 ^ 29) so capacity * 2 won't overflow
     val newCapacity = capacity * 2
     require(newCapacity <= MAXIMUM_CAPACITY, s"Can't contain more than ${growThreshold} elements")
+    keyPositions.clear()
     val newData = new Array[AnyRef](2 * newCapacity)
     val newMask = newCapacity - 1
     // Insert all our old values into the new array. Note that because our old keys are
@@ -258,6 +259,7 @@ class AppendOnlyMap[K, V: ClassTag](initialCapacity: Int = 64)
           if (curKey.eq(null)) {
             newData(2 * newPos) = key
             newData(2 * newPos + 1) = value
+            keyPositions += 2 * newPos
             keepGoing = false
           } else {
             val delta = i

--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
@@ -23,6 +23,7 @@ import java.util.Comparator
 import scala.collection.BufferedIterator
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
+import scala.reflect.ClassTag
 
 import com.google.common.io.ByteStreams
 
@@ -52,7 +53,7 @@ import org.apache.spark.util.collection.ExternalAppendOnlyMap.HashComparator
  * non-spilling AppendOnlyMap.
  */
 @DeveloperApi
-class ExternalAppendOnlyMap[K, V, C](
+class ExternalAppendOnlyMap[K, V, C: ClassTag](
     createCombiner: V => C,
     mergeValue: (C, V) => C,
     mergeCombiners: (C, C) => C,

--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalSorter.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalSorter.scala
@@ -22,6 +22,7 @@ import java.util.Comparator
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
+import scala.reflect.ClassTag
 
 import com.google.common.io.ByteStreams
 
@@ -89,7 +90,7 @@ import org.apache.spark.util.{Utils => TryUtils}
  *
  *  - Users are expected to call stop() at the end to delete all the intermediate files.
  */
-private[spark] class ExternalSorter[K, V, C](
+private[spark] class ExternalSorter[K, V, C: ClassTag](
     context: TaskContext,
     aggregator: Option[Aggregator[K, V, C]] = None,
     partitioner: Option[Partitioner] = None,

--- a/core/src/main/scala/org/apache/spark/util/collection/PartitionedAppendOnlyMap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/PartitionedAppendOnlyMap.scala
@@ -19,13 +19,15 @@ package org.apache.spark.util.collection
 
 import java.util.Comparator
 
+import scala.reflect.ClassTag
+
 import org.apache.spark.util.collection.WritablePartitionedPairCollection._
 
 /**
  * Implementation of WritablePartitionedPairCollection that wraps a map in which the keys are tuples
  * of (partition ID, K)
  */
-private[spark] class PartitionedAppendOnlyMap[K, V]
+private[spark] class PartitionedAppendOnlyMap[K, V: ClassTag]
   extends SizeTrackingAppendOnlyMap[(Int, K), V] with WritablePartitionedPairCollection[K, V] {
 
   def partitionedDestructiveSortedIterator(keyComparator: Option[Comparator[K]])

--- a/core/src/main/scala/org/apache/spark/util/collection/SizeTrackingAppendOnlyMap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/SizeTrackingAppendOnlyMap.scala
@@ -17,10 +17,12 @@
 
 package org.apache.spark.util.collection
 
+import scala.reflect.{ClassTag}
+
 /**
  * An append-only map that keeps track of its estimated size in bytes.
  */
-private[spark] class SizeTrackingAppendOnlyMap[K, V]
+private[spark] class SizeTrackingAppendOnlyMap[K, V: ClassTag]
   extends AppendOnlyMap[K, V] with SizeTracker
 {
   override def update(key: K, value: V): Unit = {

--- a/core/src/test/scala/org/apache/spark/util/SizeEstimatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/SizeEstimatorSuite.scala
@@ -248,9 +248,9 @@ class SizeEstimatorSuite
     }
 
     val keyNums = Array.fill(100)(1000) ++ Array.fill(100000)(1)
+    Random.setSeed(42)
     for (i <- keyNums.indices) {
       val key = Random.nextString(100)
-      val valueBuffer = new CompactBuffer[DummyString]
       for (j <- 0 until keyNums(i)) {
         val value = DummyString(Random.nextString(100))
         val updateFunc: (Boolean, CompactBuffer[DummyString]) => CompactBuffer[DummyString] =
@@ -258,7 +258,6 @@ class SizeEstimatorSuite
             if (hadVal) mergeValue(oldVal, value) else createCombiner(value)
           }
         map.changeValue(key, updateFunc)
-        valueBuffer += value
       }
     }
 

--- a/core/src/test/scala/org/apache/spark/util/SizeEstimatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/SizeEstimatorSuite.scala
@@ -247,7 +247,7 @@ class SizeEstimatorSuite
       CompactBuffer[DummyString](v)
     }
 
-    val keyNums = Array.fill(10)(1000) ++ Array.fill(10000)(1)
+    val keyNums = Array.fill(100)(1000) ++ Array.fill(100000)(1)
     for (i <- keyNums.indices) {
       val key = Random.nextString(100)
       val valueBuffer = new CompactBuffer[DummyString]

--- a/core/src/test/scala/org/apache/spark/util/collection/SizeTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/SizeTrackerSuite.scala
@@ -80,7 +80,7 @@ class SizeTrackerSuite extends SparkFunSuite {
     }
   }
 
-  def testMap[K, V](numElements: Int, makeElement: (Int) => (K, V)): Unit = {
+  def testMap[K, V: ClassTag](numElements: Int, makeElement: (Int) => (K, V)): Unit = {
     val map = new SizeTrackingAppendOnlyMap[K, V]
     for (i <- 0 until numElements) {
       val (k, v) = makeElement(i)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Currently, spark's memory management depends on the size estimation for execution and storage.
In our real cluster, users always meet the issue OOM due to the inaccurate size estimation for ` AppendOnlyMap`, that's because spark stores `KV` in an `Array[AnyRef]` in `AppendOnlyMap` for memory locality, and this value can be `CompactBuffer[_]` or `Array[CompactBuffer[_]]` for transformation like cogroup/join/groupBy, but current `SizeEstimator` will still treat this special array as an normal array, so in many cases, we noticed a great bias between the estimated size and the acutal memory consuption.

In this PR, I propose to improve the estimation for `AppendOnlyMap` when the value type is `CompactBuffer`/`Array[CompactBuffer]`.


### Why are the changes needed?
Improvements and can avoid OOM for many cases.


### Does this PR introduce any user-facing change?

No.


### How was this patch tested?

Existing UT & Added UT
