### PR TITLE
[SPARK-31203][BUILD] Upgrade derby to 10.14.2.0 from 10.12.1.1

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.7-hive-1.2
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-1.2
@@ -58,7 +58,7 @@ curator-recipes/2.7.1//curator-recipes-2.7.1.jar
 datanucleus-api-jdo/3.2.6//datanucleus-api-jdo-3.2.6.jar
 datanucleus-core/3.2.10//datanucleus-core-3.2.10.jar
 datanucleus-rdbms/3.2.9//datanucleus-rdbms-3.2.9.jar
-derby/10.12.1.1//derby-10.12.1.1.jar
+derby/10.14.2.0//derby-10.14.2.0.jar
 flatbuffers-java/1.9.0//flatbuffers-java-1.9.0.jar
 generex/1.0.2//generex-1.0.2.jar
 gson/2.2.4//gson-2.2.4.jar

--- a/dev/deps/spark-deps-hadoop-2.7-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-2.3
@@ -56,7 +56,7 @@ curator-recipes/2.7.1//curator-recipes-2.7.1.jar
 datanucleus-api-jdo/4.2.4//datanucleus-api-jdo-4.2.4.jar
 datanucleus-core/4.1.17//datanucleus-core-4.1.17.jar
 datanucleus-rdbms/4.1.19//datanucleus-rdbms-4.1.19.jar
-derby/10.12.1.1//derby-10.12.1.1.jar
+derby/10.14.2.0//derby-10.14.2.0.jar
 dropwizard-metrics-hadoop-metrics2-reporter/0.1.2//dropwizard-metrics-hadoop-metrics2-reporter-0.1.2.jar
 flatbuffers-java/1.9.0//flatbuffers-java-1.9.0.jar
 generex/1.0.2//generex-1.0.2.jar

--- a/dev/deps/spark-deps-hadoop-3.2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3.2-hive-2.3
@@ -53,7 +53,7 @@ curator-recipes/2.13.0//curator-recipes-2.13.0.jar
 datanucleus-api-jdo/4.2.4//datanucleus-api-jdo-4.2.4.jar
 datanucleus-core/4.1.17//datanucleus-core-4.1.17.jar
 datanucleus-rdbms/4.1.19//datanucleus-rdbms-4.1.19.jar
-derby/10.12.1.1//derby-10.12.1.1.jar
+derby/10.14.2.0//derby-10.14.2.0.jar
 dnsjava/2.1.7//dnsjava-2.1.7.jar
 dropwizard-metrics-hadoop-metrics2-reporter/0.1.2//dropwizard-metrics-hadoop-metrics2-reporter-0.1.2.jar
 ehcache/3.3.1//ehcache-3.3.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
     <hive.version.short>2.3</hive.version.short>
     <!-- note that this should be compatible with Kafka brokers version 0.10 and up -->
     <kafka.version>2.4.1</kafka.version>
-    <derby.version>10.12.1.1</derby.version>
+    <derby.version>10.14.2.0</derby.version>
     <parquet.version>1.10.1</parquet.version>
     <orc.version>1.5.9</orc.version>
     <orc.classifier></orc.classifier>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR(SPARK-31203) aims to upgrade derby.

Some major changes from this upgrade are
[DERBY-6987](https://issues.apache.org/jira/browse/DERBY-6987)   The default Network Server security policy file could be trimmed down somewhat.
[DERBY-6986](https://issues.apache.org/jira/browse/DERBY-6986)  Network Server COMMAND_TESTCONNECTION need not try to open a database
[DERBY-6726](https://issues.apache.org/jira/browse/DERBY-6726)	NPE from trigger

### Why are the changes needed?
To bring some bug fixes.

### Does this PR introduce any user-facing change?
no

### How was this patch tested?
manual build
