### PR TITLE
[SPARK-31206][SQL] AQE should not use the same SubqueryExec when reuse is off

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -1647,7 +1647,7 @@ class SubquerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     checkAnswer(df, Nil)
   }
 
-  test("AQE should not silently reuse subquery") {
+  test("SPARK-31206: AQE should not use same SubqueryExec when reuse is off") {
     Seq(true, false).foreach { reuse =>
       withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
         SQLConf.SUBQUERY_REUSE_ENABLED.key -> reuse.toString) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Make it always compile a Subquery(even with the same `exprId`) in `InsertAdaptiveSparkPlan. buildSubqueryMap` when reuse subquery is off.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Currently, in `InsertAdaptiveSparkPlan. buildSubqueryMap`, it will skip compiling a subquery when it has same `exprId` with a compiled subquery. And this leads to use the same `SubqueryExec` for the `SubqueryExpression` with the same `exprId`. Thus, the behavior here is not consistent compare to `PlanSubqueries` without AQE.

Here's an example for the issue(please note the difference of subquery plan #id):

```
spark.sql("set spark.sql.adaptive.enabled=true")
spark.sql("set spark.sql.execution.reuseSubquery=false")
spark.sql( "select b as b1, b as b2 from (select a, (select b from t2 where b = 51) b from t1)").queryExecution.executedPlan

/** Before **/
AdaptiveSparkPlan(isFinalPlan=false)
+- Project [Subquery subquery34, [id=#57] AS b1#36L, Subquery subquery34, [id=#57] AS b2#37L]
   :  :- Subquery subquery34, [id=#57]
   :  :  +- AdaptiveSparkPlan(isFinalPlan=false)
   :  :     +- Project [id#4L AS b#6L]
   :  :        +- Filter (id#4L = 51)
   :  :           +- Range (0, 10, step=1, splits=16)
   :  +- Subquery subquery34, [id=#57]
   :     +- AdaptiveSparkPlan(isFinalPlan=false)
   :        +- Project [id#4L AS b#6L]
   :           +- Filter (id#4L = 51)
   :              +- Range (0, 10, step=1, splits=16)
   +- Range (0, 10, step=1, splits=16)

/** After **/
AdaptiveSparkPlan(isFinalPlan=false)
+- Project [Subquery subquery28, [id=#28] AS b1#30L, Subquery subquery28, [id=#38] AS b2#31L]
   :  :- Subquery subquery28, [id=#28]
   :  :  +- AdaptiveSparkPlan(isFinalPlan=false)
   :  :     +- Project [id#20L AS b#22L]
   :  :        +- Filter (id#20L = 51)
   :  :           +- Range (0, 10, step=1, splits=16)
   :  +- Subquery subquery28, [id=#38]
   :     +- AdaptiveSparkPlan(isFinalPlan=false)
   :        +- Project [id#20L AS b#22L]
   :           +- Filter (id#20L = 51)
   :              +- Range (0, 10, step=1, splits=16)
   +- Range (0, 10, step=1, splits=16)
```





### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Added a test.
