### PR TITLE
[SPARK-31222][ML] Make ANOVATest Sparsity-Aware

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/stat/ANOVATest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/ANOVATest.scala
@@ -148,7 +148,9 @@ object ANOVATest {
           (sum1 + sum2, sumOfSq1 + sumOfSq2, sums1)
       }
     ).mapValues { case (sum, sumOfSq, sums) =>
+      val counts = bcCounts.value
       counts.keysIterator.foreach { label =>
+        // adjust sums if all related feature values are 0 for some label
         if (!sums.contains(label)) sums.update(label, 0.0)
       }
       computeANOVA(sum, sumOfSq, sums.toMap, counts)

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/ANOVATest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/ANOVATest.scala
@@ -20,8 +20,9 @@ package org.apache.spark.ml.stat
 import org.apache.commons.math3.distribution.FDistribution
 
 import org.apache.spark.annotation.Since
-import org.apache.spark.ml.linalg.{Vector, Vectors, VectorUDT}
+import org.apache.spark.ml.linalg._
 import org.apache.spark.ml.util.SchemaUtils
+import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
 import org.apache.spark.util.collection.OpenHashMap
@@ -80,65 +81,137 @@ object ANOVATest {
     SchemaUtils.checkColumnType(dataset.schema, featuresCol, new VectorUDT)
     SchemaUtils.checkNumericType(dataset.schema, labelCol)
 
-    dataset.select(col(labelCol).cast("double"), col(featuresCol))
-      .as[(Double, Vector)]
-      .rdd
-      .flatMap { case (label, features) =>
-        features.iterator.map { case (col, value) => (col, (label, value)) }
-      }.aggregateByKey[(Double, Double, OpenHashMap[Double, Double], OpenHashMap[Double, Long])](
-        (0.0, 0.0, new OpenHashMap[Double, Double], new OpenHashMap[Double, Long]))(
-        seqOp = {
-          case ((sum, sumOfSq, sums, counts), (label, value)) =>
-            // sums: mapOfSumPerClass (key: label, value: sum of features for each label)
-            // counts: mapOfCountPerClass key: label, value: count of features for each label
-            sums.changeValue(label, value, _ + value)
-            counts.changeValue(label, 1L, _ + 1L)
-            (sum + value, sumOfSq + value * value, sums, counts)
-        },
-        combOp = {
-          case ((sum1, sumOfSq1, sums1, counts1), (sum2, sumOfSq2, sums2, counts2)) =>
-            sums2.foreach { case (v, w) => sums1.changeValue(v, w, _ + w) }
-            counts2.foreach { case (v, w) => counts1.changeValue(v, w, _ + w) }
-            (sum1 + sum2, sumOfSq1 + sumOfSq2, sums1, counts1)
-        }
-        ).map { case (col, (sum, sumOfSq, sums, counts)) =>
-          val numSamples = counts.iterator.map(_._2).sum
-          val numClasses = counts.size
+    val points = dataset.select(col(labelCol).cast("double"), col(featuresCol))
+      .as[(Double, Vector)].rdd
 
-          // e.g. features are [3.3, 2.5, 1.0, 3.0, 2.0] and labels are [1, 2, 1, 3, 3]
-          // sum: sum of all the features (3.3+2.5+1.0+3.0+2.0)
-          // sumOfSq: sum of squares of all the features (3.3^2+2.5^2+1.0^2+3.0^2+2.0^2)
+    points.first()._2 match {
+      case dv: DenseVector =>
+        testClassificationDenseFeatures(points, dv.size)
+      case sv: SparseVector =>
+        testClassificationSparseFeatures(points, sv.size)
+    }
+  }
+
+  private def testClassificationDenseFeatures(
+      points: RDD[(Double, Vector)],
+      numFeatures: Int): Array[SelectionTestResult] = {
+    points.flatMap { case (label, features) =>
+      require(features.size == numFeatures,
+        s"Number of features must be $numFeatures but got ${features.size}")
+      features.iterator.map { case (col, value) => (col, (label, value)) }
+    }.aggregateByKey[(Double, Double, OpenHashMap[Double, Double], OpenHashMap[Double, Long])](
+      (0.0, 0.0, new OpenHashMap[Double, Double], new OpenHashMap[Double, Long]))(
+      seqOp = {
+        case ((sum, sumOfSq, sums, counts), (label, value)) =>
           // sums: mapOfSumPerClass (key: label, value: sum of features for each label)
-          //                                         ( 1 -> 3.3 + 1.0, 2 -> 2.5, 3 -> 3.0 + 2.0 )
-          // counts: mapOfCountPerClass (key: label, value: count of features for each label)
-          //                                         ( 1 -> 2, 2 -> 2, 3 -> 2 )
-          // sqSum: square of sum of all data ((3.3+2.5+1.0+3.0+2.0)^2)
-          val sqSum = sum * sum
-          val ssTot = sumOfSq - sqSum / numSamples
+          // counts: mapOfCountPerClass key: label, value: count of features for each label
+          sums.changeValue(label, value, _ + value)
+          counts.changeValue(label, 1L, _ + 1L)
+          (sum + value, sumOfSq + value * value, sums, counts)
+      },
+      combOp = {
+        case ((sum1, sumOfSq1, sums1, counts1), (sum2, sumOfSq2, sums2, counts2)) =>
+          sums2.foreach { case (v, w) => sums1.changeValue(v, w, _ + w) }
+          counts2.foreach { case (v, w) => counts1.changeValue(v, w, _ + w) }
+          (sum1 + sum2, sumOfSq1 + sumOfSq2, sums1, counts1)
+      }
+    ).mapValues { case (sum, sumOfSq, sums, counts) =>
+      computeANOVA(sum, sumOfSq, sums.toMap, counts.toMap)
+    }.collect().sortBy(_._1).map {
+      case (_, (pValue, degreesOfFreedom, fValue)) =>
+        new ANOVATestResult(pValue, degreesOfFreedom, fValue)
+    }
+  }
 
-          // sumOfSqSumPerClass:
-          //     sum( sq_sum_classes[k] / n_samples_per_class[k] for k in range(n_classes))
-          //     e.g. ((3.3+1.0)^2 / 2 + 2.5^2 / 1 + (3.0+2.0)^2 / 2)
-          val sumOfSqSumPerClass = sums.iterator
-            .map { case (label, sum) => sum * sum / counts(label) }.sum
-          // Sums of Squares Between
-          val ssbn = sumOfSqSumPerClass - (sqSum / numSamples)
-          // Sums of Squares Within
-          val sswn = ssTot - ssbn
-          // degrees of freedom between
-          val dfbn = numClasses - 1
-          // degrees of freedom within
-          val dfwn = numSamples - numClasses
-          // mean square between
-          val msb = ssbn / dfbn
-          // mean square within
-          val msw = sswn / dfwn
-          val fValue = msb / msw
-          val pValue = 1 - new FDistribution(dfbn, dfwn).cumulativeProbability(fValue)
-          (col, pValue, dfbn + dfwn, fValue)
-        }.collect().sortBy(_._1).map {
-          case (col, pValue, degreesOfFreedom, fValue) =>
-            new ANOVATestResult(pValue, degreesOfFreedom, fValue)
-        }
+  private def testClassificationSparseFeatures(
+      points: RDD[(Double, Vector)],
+      numFeatures: Int): Array[SelectionTestResult] = {
+    val sc = points.sparkContext
+    val counts = points.map(_._1).countByValue().toMap
+    val bcCounts = sc.broadcast(counts)
+
+    val results = points.flatMap { case (label, features) =>
+      require(features.size == numFeatures,
+        s"Number of features must be $numFeatures but got ${features.size}")
+      features.nonZeroIterator.map { case (col, value) => (col, (label, value)) }
+    }.aggregateByKey[(Double, Double, OpenHashMap[Double, Double])](
+      (0.0, 0.0, new OpenHashMap[Double, Double]))(
+      seqOp = {
+        case ((sum, sumOfSq, sums), (label, value)) =>
+          // sums: mapOfSumPerClass (key: label, value: sum of features for each label)
+          sums.changeValue(label, value, _ + value)
+          (sum + value, sumOfSq + value * value, sums)
+      },
+      combOp = {
+        case ((sum1, sumOfSq1, sums1), (sum2, sumOfSq2, sums2)) =>
+          sums2.foreach { case (v, w) => sums1.changeValue(v, w, _ + w) }
+          (sum1 + sum2, sumOfSq1 + sumOfSq2, sums1)
+      }
+    ).mapValues { case (sum, sumOfSq, sums) =>
+      if (counts.contains(0.0)) { sums.update(0.0, 0.0) }
+      computeANOVA(sum, sumOfSq, sums.toMap, counts)
+    }.collectAsMap()
+
+    bcCounts.destroy()
+
+    val finalResults = Array.ofDim[SelectionTestResult](numFeatures)
+    results.foreach { case (col, (pValue, degreesOfFreedom, fValue)) =>
+      finalResults(col) = new ANOVATestResult(pValue, degreesOfFreedom, fValue)
+    }
+
+    if (results.size < numFeatures) {
+      // if some column only contains 0 values
+      val (pValue, degreesOfFreedom, fValue) =
+        computeANOVA(0.0, 0.0, counts.mapValues(_ => 0.0), counts)
+      val zeroRes = new ANOVATestResult(pValue, degreesOfFreedom, fValue)
+
+      Iterator.range(0, numFeatures)
+        .filterNot(results.contains)
+        .foreach (col => finalResults(col) = zeroRes)
+    }
+
+    finalResults
+  }
+
+  private def computeANOVA(
+      sum: Double,
+      sumOfSq: Double,
+      sums: Map[Double, Double],
+      counts: Map[Double, Long]): (Double, Long, Double) = {
+    val numSamples = counts.valuesIterator.sum
+    val numClasses = counts.size
+
+    // e.g. features are [3.3, 2.5, 1.0, 3.0, 2.0] and labels are [1, 2, 1, 3, 3]
+    // sum: sum of all the features (3.3+2.5+1.0+3.0+2.0)
+    // sumOfSq: sum of squares of all the features (3.3^2+2.5^2+1.0^2+3.0^2+2.0^2)
+    // sums: mapOfSumPerClass (key: label, value: sum of features for each label)
+    //                                         ( 1 -> 3.3 + 1.0, 2 -> 2.5, 3 -> 3.0 + 2.0 )
+    // counts: mapOfCountPerClass (key: label, value: count of features for each label)
+    //                                         ( 1 -> 2, 2 -> 2, 3 -> 2 )
+    // sqSum: square of sum of all data ((3.3+2.5+1.0+3.0+2.0)^2)
+    val sqSum = sum * sum
+    val ssTot = sumOfSq - sqSum / numSamples
+
+    // totalSqSum:
+    //     sum( sq_sum_classes[k] / n_samples_per_class[k] for k in range(n_classes))
+    //     e.g. ((3.3+1.0)^2 / 2 + 2.5^2 / 1 + (3.0+2.0)^2 / 2)
+    val totalSqSum = sums.iterator
+      .map { case (label, sum) => sum * sum / counts(label) }.sum
+    // Sums of Squares Between
+    val ssbn = totalSqSum - (sqSum / numSamples)
+    // Sums of Squares Within
+    val sswn = ssTot - ssbn
+    // degrees of freedom between
+    val dfbn = numClasses - 1
+    // degrees of freedom within
+    val dfwn = numSamples - numClasses
+    // mean square between
+    val msb = ssbn / dfbn
+    // mean square within
+    val msw = sswn / dfwn
+    val fValue = msb / msw
+    val pValue = 1 - new FDistribution(dfbn, dfwn).cumulativeProbability(fValue)
+    val degreesOfFreedom = dfbn + dfwn
+    (pValue, degreesOfFreedom, fValue)
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/ANOVATest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/ANOVATest.scala
@@ -148,7 +148,9 @@ object ANOVATest {
           (sum1 + sum2, sumOfSq1 + sumOfSq2, sums1)
       }
     ).mapValues { case (sum, sumOfSq, sums) =>
-      if (counts.contains(0.0)) { sums.update(0.0, 0.0) }
+      counts.keysIterator.foreach { label =>
+        if (!sums.contains(label)) sums.update(label, 0.0)
+      }
       computeANOVA(sum, sumOfSq, sums.toMap, counts)
     }.collectAsMap()
 

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/ANOVATest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/ANOVATest.scala
@@ -128,16 +128,17 @@ object ANOVATest {
       numFeatures: Int): Array[SelectionTestResult] = {
     val counts = points.map(_._1).countByValue().toMap
 
+    val numParts = points.getNumPartitions
     points.mapPartitionsWithIndex { case (pid, iter) =>
       iter.flatMap { case (label, features) =>
         require(features.size == numFeatures,
           s"Number of features must be $numFeatures but got ${features.size}")
         features.nonZeroIterator.map { case (col, value) => (col, (label, value)) }
       } ++ {
-        if (pid == 0) {
-          // append this to make sure that all columns are taken into account
-          Iterator.tabulate(numFeatures)(col => (col, null))
-        } else Iterator.empty
+        // append this to make sure that all columns are taken into account
+        Iterator.range(0, numFeatures)
+          .filter(_ % numParts == pid)
+          .map(col => (col, null))
       }
     }.aggregateByKey[(Double, Double, OpenHashMap[Double, Double])](
       (0.0, 0.0, new OpenHashMap[Double, Double]))(

--- a/mllib/src/main/scala/org/apache/spark/mllib/stat/test/ChiSqTest.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/stat/test/ChiSqTest.scala
@@ -126,7 +126,8 @@ private[spark] object ChiSqTest extends Logging {
 
     data.mapPartitionsWithIndex { case (pid, iter) =>
       iter.flatMap { case LabeledPoint(label, features) =>
-        require(features.size == numFeatures)
+        require(features.size == numFeatures,
+          s"Number of features must be $numFeatures but got ${features.size}")
         features.nonZeroIterator.map { case (col, value) => (col, (label, value)) }
       } ++ {
         if (pid == 0) {

--- a/mllib/src/main/scala/org/apache/spark/mllib/stat/test/ChiSqTest.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/stat/test/ChiSqTest.scala
@@ -93,7 +93,8 @@ private[spark] object ChiSqTest extends Logging {
       numFeatures: Int,
       methodName: String = PEARSON.name): Array[ChiSqTestResult] = {
     data.flatMap { case LabeledPoint(label, features) =>
-      require(features.size == numFeatures)
+      require(features.size == numFeatures,
+        s"Number of features must be $numFeatures but got ${features.size}")
       features.iterator.map { case (col, value) => (col, (label, value)) }
     }.aggregateByKey(new OpenHashMap[(Double, Double), Long])(
       seqOp = { case (counts, t) =>
@@ -127,7 +128,8 @@ private[spark] object ChiSqTest extends Logging {
     val bcLabelCounts = sc.broadcast(labelCounts)
 
     val results = data.flatMap { case LabeledPoint(label, features) =>
-      require(features.size == numFeatures)
+      require(features.size == numFeatures,
+        s"Number of features must be $numFeatures but got ${features.size}")
       features.nonZeroIterator.map { case (col, value) => (col, (label, value)) }
     }.aggregateByKey(new OpenHashMap[(Double, Double), Long])(
       seqOp = { case (counts, t) =>

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/ANOVASelectorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/ANOVASelectorSuite.scala
@@ -136,21 +136,18 @@ class ANOVASelectorSuite extends MLTest with DefaultReadWriteTest {
   test("Test ANOVAFValue calssification selector: numTopFeatures") {
     val selector = new ANOVASelector()
       .setOutputCol("filtered").setSelectorType("numTopFeatures").setNumTopFeatures(1)
-    val model = selector.fit(dataset)
     testSelector(selector, dataset)
   }
 
   test("Test ANOVAFValue calssification selector: percentile") {
     val selector = new ANOVASelector()
       .setOutputCol("filtered").setSelectorType("percentile").setPercentile(0.17)
-    val model = selector.fit(dataset)
     testSelector(selector, dataset)
   }
 
   test("Test ANOVAFValue calssification selector: fpr") {
     val selector = new ANOVASelector()
       .setOutputCol("filtered").setSelectorType("fpr").setFpr(1.0E-12)
-    val model = selector.fit(dataset)
     testSelector(selector, dataset)
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
when input dataset is sparse, make `ANOVATest` only process non-zero value


### Why are the changes needed?
for performance


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
existing testsuites
