### PR TITLE
[SPARK-31231][BUILD] Explicitly setuptools version as 46.0.0 in pip package test

### DIFF
--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -110,7 +110,7 @@ for python in "${PYTHON_EXECS[@]}"; do
     cd /
 
     echo "Run basic sanity check on pip installed version with spark-submit"
-    ls -al $(dirname $(dirname $(which spark-submit)))/lib/python3.6/site-packages/pyspark/bin/spark-class
+    # ls -al $(dirname $(dirname $(which spark-submit)))/lib/python3.6/site-packages/pyspark/bin/spark-class
     spark-submit "$FWDIR"/dev/pip-sanity-check.py
     echo "Run basic sanity check with import based"
     python3 "$FWDIR"/dev/pip-sanity-check.py

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -110,7 +110,7 @@ for python in "${PYTHON_EXECS[@]}"; do
     cd /
 
     echo "Run basic sanity check on pip installed version with spark-submit"
-    ls -al `which spark-submit`
+    ls -al $(dirname $(dirname $(which ln)))/lib/python3.6/site-packages/pyspark/bin/spark-class
     spark-submit "$FWDIR"/dev/pip-sanity-check.py
     echo "Run basic sanity check with import based"
     python3 "$FWDIR"/dev/pip-sanity-check.py

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -110,7 +110,7 @@ for python in "${PYTHON_EXECS[@]}"; do
     cd /
 
     echo "Run basic sanity check on pip installed version with spark-submit"
-    ls -al $(dirname $(dirname $(which spark-summit)))/lib/python3.6/site-packages/pyspark/bin/spark-class
+    ls -al $(dirname $(dirname $(which spark-submit)))/lib/python3.6/site-packages/pyspark/bin/spark-class
     spark-submit "$FWDIR"/dev/pip-sanity-check.py
     echo "Run basic sanity check with import based"
     python3 "$FWDIR"/dev/pip-sanity-check.py

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -110,6 +110,7 @@ for python in "${PYTHON_EXECS[@]}"; do
     cd /
 
     echo "Run basic sanity check on pip installed version with spark-submit"
+    ls -al `which spark-submit`
     spark-submit "$FWDIR"/dev/pip-sanity-check.py
     echo "Run basic sanity check with import based"
     python3 "$FWDIR"/dev/pip-sanity-check.py

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -110,7 +110,7 @@ for python in "${PYTHON_EXECS[@]}"; do
     cd /
 
     echo "Run basic sanity check on pip installed version with spark-submit"
-    ls -al $(dirname $(dirname $(which ln)))/lib/python3.6/site-packages/pyspark/bin/spark-class
+    ls -al $(dirname $(dirname $(which spark-summit)))/lib/python3.6/site-packages/pyspark/bin/spark-class
     spark-submit "$FWDIR"/dev/pip-sanity-check.py
     echo "Run basic sanity check with import based"
     python3 "$FWDIR"/dev/pip-sanity-check.py

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -76,7 +76,7 @@ for python in "${PYTHON_EXECS[@]}"; do
     VIRTUALENV_PATH="$VIRTUALENV_BASE"/$python
     rm -rf "$VIRTUALENV_PATH"
     if [ -n "$USE_CONDA" ]; then
-      conda create -y -p "$VIRTUALENV_PATH" python=$python numpy pandas pip setuptools
+      conda create -y -p "$VIRTUALENV_PATH" python=$python numpy pandas pip setuptools<46.1.0
       source activate "$VIRTUALENV_PATH"
     else
       mkdir -p "$VIRTUALENV_PATH"

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -110,7 +110,6 @@ for python in "${PYTHON_EXECS[@]}"; do
     cd /
 
     echo "Run basic sanity check on pip installed version with spark-submit"
-    # ls -al $(dirname $(dirname $(which spark-submit)))/lib/python3.6/site-packages/pyspark/bin/spark-class
     spark-submit "$FWDIR"/dev/pip-sanity-check.py
     echo "Run basic sanity check with import based"
     python3 "$FWDIR"/dev/pip-sanity-check.py

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -76,7 +76,7 @@ for python in "${PYTHON_EXECS[@]}"; do
     VIRTUALENV_PATH="$VIRTUALENV_BASE"/$python
     rm -rf "$VIRTUALENV_PATH"
     if [ -n "$USE_CONDA" ]; then
-      conda create -y -p "$VIRTUALENV_PATH" python=$python numpy pandas pip setuptools<46.1.0
+      conda create -y -p "$VIRTUALENV_PATH" python=$python numpy pandas pip setuptools=46.0.0
       source activate "$VIRTUALENV_PATH"
     else
       mkdir -p "$VIRTUALENV_PATH"

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -618,13 +618,14 @@ def main():
     test_modules = determine_modules_to_test(changed_modules)
 
     # license checks
-    run_apache_rat_checks()
+    # run_apache_rat_checks()
 
     # style checks
     if not changed_files or any(f.endswith(".scala")
                                 or f.endswith("scalastyle-config.xml")
                                 for f in changed_files):
-        run_scala_style_checks(extra_profiles)
+        # run_scala_style_checks(extra_profiles)
+        pass
     should_run_java_style_checks = False
     if not changed_files or any(f.endswith(".java")
                                 or f.endswith("checkstyle.xml")
@@ -636,12 +637,14 @@ def main():
                                 or f.endswith("tox.ini")
                                 or f.endswith(".py")
                                 for f in changed_files):
-        run_python_style_checks()
+        # run_python_style_checks()
+        pass
     if not changed_files or any(f.endswith(".R")
                                 or f.endswith("lint-r")
                                 or f.endswith(".lintr")
                                 for f in changed_files):
-        run_sparkr_style_checks()
+        # run_sparkr_style_checks()
+        pass
 
     # determine if docs were changed and if we're inside the amplab environment
     # note - the below commented out until *all* Jenkins workers can get `jekyll` installed
@@ -649,7 +652,8 @@ def main():
     #    build_spark_documentation()
 
     if any(m.should_run_build_tests for m in test_modules):
-        run_build_tests()
+        # run_build_tests()
+        pass
 
     # spark build
     build_apache_spark(build_tool, extra_profiles)
@@ -663,18 +667,19 @@ def main():
         build_spark_assembly_sbt(extra_profiles, should_run_java_style_checks)
 
     # run the test suites
-    run_scala_tests(build_tool, extra_profiles, test_modules, excluded_tags)
+    # run_scala_tests(build_tool, extra_profiles, test_modules, excluded_tags)
 
     modules_with_python_tests = [m for m in test_modules if m.python_test_goals]
     if modules_with_python_tests:
         # We only run PySpark tests with coverage report in one specific job with
         # Spark master with SBT in Jenkins.
         is_sbt_master_job = "SPARK_MASTER_SBT_HADOOP_2_7" in os.environ
-        run_python_tests(
-            modules_with_python_tests, opts.parallelism, with_coverage=is_sbt_master_job)
+        # run_python_tests(
+        #     modules_with_python_tests, opts.parallelism, with_coverage=is_sbt_master_job)
         run_python_packaging_tests()
     if any(m.should_run_r_tests for m in test_modules):
-        run_sparkr_tests()
+        # run_sparkr_tests()
+        pass
 
 
 def _test():

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -618,14 +618,13 @@ def main():
     test_modules = determine_modules_to_test(changed_modules)
 
     # license checks
-    # run_apache_rat_checks()
+    run_apache_rat_checks()
 
     # style checks
     if not changed_files or any(f.endswith(".scala")
                                 or f.endswith("scalastyle-config.xml")
                                 for f in changed_files):
-        # run_scala_style_checks(extra_profiles)
-        pass
+        run_scala_style_checks(extra_profiles)
     should_run_java_style_checks = False
     if not changed_files or any(f.endswith(".java")
                                 or f.endswith("checkstyle.xml")
@@ -637,14 +636,12 @@ def main():
                                 or f.endswith("tox.ini")
                                 or f.endswith(".py")
                                 for f in changed_files):
-        # run_python_style_checks()
-        pass
+        run_python_style_checks()
     if not changed_files or any(f.endswith(".R")
                                 or f.endswith("lint-r")
                                 or f.endswith(".lintr")
                                 for f in changed_files):
-        # run_sparkr_style_checks()
-        pass
+        run_sparkr_style_checks()
 
     # determine if docs were changed and if we're inside the amplab environment
     # note - the below commented out until *all* Jenkins workers can get `jekyll` installed
@@ -652,8 +649,7 @@ def main():
     #    build_spark_documentation()
 
     if any(m.should_run_build_tests for m in test_modules):
-        # run_build_tests()
-        pass
+        run_build_tests()
 
     # spark build
     build_apache_spark(build_tool, extra_profiles)
@@ -667,19 +663,18 @@ def main():
         build_spark_assembly_sbt(extra_profiles, should_run_java_style_checks)
 
     # run the test suites
-    # run_scala_tests(build_tool, extra_profiles, test_modules, excluded_tags)
+    run_scala_tests(build_tool, extra_profiles, test_modules, excluded_tags)
 
     modules_with_python_tests = [m for m in test_modules if m.python_test_goals]
     if modules_with_python_tests:
         # We only run PySpark tests with coverage report in one specific job with
         # Spark master with SBT in Jenkins.
         is_sbt_master_job = "SPARK_MASTER_SBT_HADOOP_2_7" in os.environ
-        # run_python_tests(
-        #     modules_with_python_tests, opts.parallelism, with_coverage=is_sbt_master_job)
+        run_python_tests(
+            modules_with_python_tests, opts.parallelism, with_coverage=is_sbt_master_job)
         run_python_packaging_tests()
     if any(m.should_run_r_tests for m in test_modules):
-        # run_sparkr_tests()
-        pass
+        run_sparkr_tests()
 
 
 def _test():


### PR DESCRIPTION
### What changes were proposed in this pull request?

For a bit of background,
PIP packaging test started to fail (see [this logs](https://amplab.cs.berkeley.edu/jenkins/job/SparkPullRequestBuilder/120218/testReport/)) as of  setuptools 46.1.0 release. In https://github.com/pypa/setuptools/issues/1424, they decided to don't keep the modes in `package_data`.

In PySpark pip installation, we keep the executable scripts in `package_data` https://github.com/apache/spark/blob/fc4e56a54c15e20baf085e6061d3d83f5ce1185d/python/setup.py#L199-L200, and expose their symbolic links as executable scripts.

So, the symbolic links (or copied scripts) executes the scripts copied from `package_data`, which doesn't have the executable permission in its mode:

```
/tmp/tmp.UmkEGNFdKF/3.6/bin/spark-submit: line 27: /tmp/tmp.UmkEGNFdKF/3.6/lib/python3.6/site-packages/pyspark/bin/spark-class: Permission denied
/tmp/tmp.UmkEGNFdKF/3.6/bin/spark-submit: line 27: exec: /tmp/tmp.UmkEGNFdKF/3.6/lib/python3.6/site-packages/pyspark/bin/spark-class: cannot execute: Permission denied
```

The current issue is being tracked at https://github.com/pypa/setuptools/issues/2041

</br>

For what this PR proposes:
It sets the setuptools version in PR builder for now to unblock other PRs.  _This PR does not solve the issue yet_. I will make a fix after monitoring https://github.com/pypa/setuptools/issues/2041

### Why are the changes needed?

It currently affects users who uses the latest setuptools. So, _users seem unable to use PySpark with the latest setuptools._ See also https://github.com/pypa/setuptools/issues/2041#issuecomment-602566667

### Does this PR introduce any user-facing change?

It makes CI pass for now. No user-facing change yet.

### How was this patch tested?

Jenkins will test.