### PR TITLE
[SPARK-31233][Core] Enhance RpcTimeoutException Log Message

### DIFF
--- a/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
@@ -252,7 +252,12 @@ private[netty] class NettyRpcEnv(
 
       val timeoutCancelable = timeoutScheduler.schedule(new Runnable {
         override def run(): Unit = {
-          onFailure(new TimeoutException(s"Cannot receive any reply from ${remoteAddr} " +
+          val remoteReceAddr = if (remoteAddr == null) {
+            message.receiver.client.getChannel.remoteAddress()
+          } else {
+            remoteAddr
+          }
+          onFailure(new TimeoutException(s"Cannot receive any reply from ${remoteReceAddr} " +
             s"in ${timeout.duration}"))
         }
       }, timeout.duration.toNanos, TimeUnit.NANOSECONDS)

--- a/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
@@ -253,7 +253,9 @@ private[netty] class NettyRpcEnv(
       val timeoutCancelable = timeoutScheduler.schedule(new Runnable {
         override def run(): Unit = {
           val remoteReceAddr = if (remoteAddr == null) {
-            message.receiver.client.getChannel.remoteAddress()
+            Try {
+              message.receiver.client.getChannel.remoteAddress()
+            }.toOption.orNull
           } else {
             remoteAddr
           }

--- a/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
@@ -47,9 +47,7 @@ private[netty] class NettyRpcEnv(
     javaSerializerInstance: JavaSerializerInstance,
     host: String,
     securityManager: SecurityManager,
-    numUsableCores: Int)
-    extends RpcEnv(conf)
-    with Logging {
+    numUsableCores: Int) extends RpcEnv(conf) with Logging {
   val role = conf.get(EXECUTOR_ID).map { id =>
     if (id == SparkContext.DRIVER_IDENTIFIER) "driver" else "executor"
   }
@@ -64,13 +62,13 @@ private[netty] class NettyRpcEnv(
 
   private val streamManager = new NettyStreamManager(this)
 
-  private val transportContext =
-    new TransportContext(transportConf, new NettyRpcHandler(dispatcher, this, streamManager))
+  private val transportContext = new TransportContext(transportConf,
+    new NettyRpcHandler(dispatcher, this, streamManager))
 
   private def createClientBootstraps(): java.util.List[TransportClientBootstrap] = {
     if (securityManager.isAuthenticationEnabled()) {
-      java.util.Arrays.asList(
-        new AuthClientBootstrap(transportConf, securityManager.getSaslUser(), securityManager))
+      java.util.Arrays.asList(new AuthClientBootstrap(transportConf,
+        securityManager.getSaslUser(), securityManager))
     } else {
       java.util.Collections.emptyList[TransportClientBootstrap]
     }
@@ -88,14 +86,14 @@ private[netty] class NettyRpcEnv(
    */
   @volatile private var fileDownloadFactory: TransportClientFactory = _
 
-  val timeoutScheduler =
-    ThreadUtils.newDaemonSingleThreadScheduledExecutor("netty-rpc-env-timeout")
+  val timeoutScheduler = ThreadUtils.newDaemonSingleThreadScheduledExecutor("netty-rpc-env-timeout")
 
   // Because TransportClientFactory.createClient is blocking, we need to run it in this thread pool
   // to implement non-blocking send/ask.
   // TODO: a non-blocking TransportClientFactory.createClient in future
-  private[netty] val clientConnectionExecutor =
-    ThreadUtils.newDaemonCachedThreadPool("netty-rpc-connection", conf.get(RPC_CONNECT_THREADS))
+  private[netty] val clientConnectionExecutor = ThreadUtils.newDaemonCachedThreadPool(
+    "netty-rpc-connection",
+    conf.get(RPC_CONNECT_THREADS))
 
   @volatile private var server: TransportServer = _
 
@@ -126,8 +124,7 @@ private[netty] class NettyRpcEnv(
       }
     server = transportContext.createServer(bindAddress, port, bootstraps)
     dispatcher.registerRpcEndpoint(
-      RpcEndpointVerifier.NAME,
-      new RpcEndpointVerifier(this, dispatcher))
+      RpcEndpointVerifier.NAME, new RpcEndpointVerifier(this, dispatcher))
   }
 
   @Nullable
@@ -143,18 +140,14 @@ private[netty] class NettyRpcEnv(
     val addr = RpcEndpointAddress(uri)
     val endpointRef = new NettyRpcEndpointRef(conf, addr, this)
     val verifier = new NettyRpcEndpointRef(
-      conf,
-      RpcEndpointAddress(addr.rpcAddress, RpcEndpointVerifier.NAME),
-      this)
-    verifier
-      .ask[Boolean](RpcEndpointVerifier.CheckExistence(endpointRef.name))
-      .flatMap { find =>
-        if (find) {
-          Future.successful(endpointRef)
-        } else {
-          Future.failed(new RpcEndpointNotFoundException(uri))
-        }
-      }(ThreadUtils.sameThread)
+      conf, RpcEndpointAddress(addr.rpcAddress, RpcEndpointVerifier.NAME), this)
+    verifier.ask[Boolean](RpcEndpointVerifier.CheckExistence(endpointRef.name)).flatMap { find =>
+      if (find) {
+        Future.successful(endpointRef)
+      } else {
+        Future.failed(new RpcEndpointNotFoundException(uri))
+      }
+    }(ThreadUtils.sameThread)
   }
 
   override def stop(endpointRef: RpcEndpointRef): Unit = {
@@ -166,8 +159,7 @@ private[netty] class NettyRpcEnv(
     if (receiver.client != null) {
       message.sendWith(receiver.client)
     } else {
-      require(
-        receiver.address != null,
+      require(receiver.address != null,
         "Cannot send message to client endpoint with no listen address.")
       val targetOutbox = {
         val outbox = outboxes.get(receiver.address)
@@ -213,15 +205,14 @@ private[netty] class NettyRpcEnv(
   }
 
   private[netty] def askAbortable[T: ClassTag](
-      message: RequestMessage,
-      timeout: RpcTimeout): AbortableRpcFuture[T] = {
+      message: RequestMessage, timeout: RpcTimeout): AbortableRpcFuture[T] = {
     val promise = Promise[Any]()
     val remoteAddr = message.receiver.address
 
     def onFailure(e: Throwable): Unit = {
       if (!promise.tryFailure(e)) {
         e match {
-          case e: RpcEnvStoppedException => logDebug(s"Ignored failure: $e")
+          case e : RpcEnvStoppedException => logDebug (s"Ignored failure: $e")
           case _ => logWarning(s"Ignored failure: $e")
         }
       }
@@ -248,8 +239,7 @@ private[netty] class NettyRpcEnv(
         }(ThreadUtils.sameThread)
         dispatcher.postLocalMessage(message, p)
       } else {
-        val rpcMessage = RpcOutboxMessage(
-          message.serialize(this),
+        val rpcMessage = RpcOutboxMessage(message.serialize(this),
           onFailure,
           (client, response) => onSuccess(deserialize[Any](client, response)))
         postToOutbox(message.receiver, rpcMessage)
@@ -260,21 +250,17 @@ private[netty] class NettyRpcEnv(
         }(ThreadUtils.sameThread)
       }
 
-      val timeoutCancelable = timeoutScheduler.schedule(
-        new Runnable {
-          override def run(): Unit = {
-            val remoteReceAddr = if (remoteAddr == null) {
-              message.receiver.client.getChannel.remoteAddress()
-            } else {
-              remoteAddr
-            }
-            onFailure(
-              new TimeoutException(s"Cannot receive any reply from ${remoteReceAddr} " +
-                s"in ${timeout.duration}"))
+      val timeoutCancelable = timeoutScheduler.schedule(new Runnable {
+        override def run(): Unit = {
+          val remoteReceAddr = if (remoteAddr == null) {
+            message.receiver.client.getChannel.remoteAddress()
+          } else {
+            remoteAddr
           }
-        },
-        timeout.duration.toNanos,
-        TimeUnit.NANOSECONDS)
+          onFailure(new TimeoutException(s"Cannot receive any reply from ${remoteReceAddr} " +
+            s"in ${timeout.duration}"))
+        }
+      }, timeout.duration.toNanos, TimeUnit.NANOSECONDS)
       promise.future.onComplete { v =>
         timeoutCancelable.cancel(true)
       }(ThreadUtils.sameThread)
@@ -393,12 +379,11 @@ private[netty] class NettyRpcEnv(
         val clone = conf.clone()
 
         // Copy any RPC configuration that is not overridden in the spark.files namespace.
-        conf.getAll.foreach {
-          case (key, value) =>
-            if (key.startsWith(prefix)) {
-              val opt = key.substring(prefix.length())
-              clone.setIfMissing(s"spark.$module.io.$opt", value)
-            }
+        conf.getAll.foreach { case (key, value) =>
+          if (key.startsWith(prefix)) {
+            val opt = key.substring(prefix.length())
+            clone.setIfMissing(s"spark.$module.io.$opt", value)
+          }
         }
 
         val ioThreads = clone.getInt("spark.files.io.threads", 1)
@@ -449,8 +434,7 @@ private[netty] class NettyRpcEnv(
   private class FileDownloadCallback(
       sink: WritableByteChannel,
       source: FileDownloadChannel,
-      client: TransportClient)
-      extends StreamCallback {
+      client: TransportClient) extends StreamCallback {
 
     override def onData(streamId: String, buf: ByteBuffer): Unit = {
       while (buf.remaining() > 0) {
@@ -472,7 +456,6 @@ private[netty] class NettyRpcEnv(
 }
 
 private[netty] object NettyRpcEnv extends Logging {
-
   /**
    * When deserializing the [[NettyRpcEndpointRef]], it needs a reference to [[NettyRpcEnv]].
    * Use `currentEnv` to wrap the deserialization codes. E.g.,
@@ -502,12 +485,8 @@ private[rpc] class NettyRpcEnvFactory extends RpcEnvFactory with Logging {
     val javaSerializerInstance =
       new JavaSerializer(sparkConf).newInstance().asInstanceOf[JavaSerializerInstance]
     val nettyEnv =
-      new NettyRpcEnv(
-        sparkConf,
-        javaSerializerInstance,
-        config.advertiseAddress,
-        config.securityManager,
-        config.numUsableCores)
+      new NettyRpcEnv(sparkConf, javaSerializerInstance, config.advertiseAddress,
+        config.securityManager, config.numUsableCores)
     if (!config.clientMode) {
       val startNettyRpcEnv: Int => (NettyRpcEnv, Int) = { actualPort =>
         nettyEnv.startServer(config.bindAddress, actualPort)
@@ -548,8 +527,7 @@ private[rpc] class NettyRpcEnvFactory extends RpcEnvFactory with Logging {
 private[netty] class NettyRpcEndpointRef(
     @transient private val conf: SparkConf,
     private val endpointAddress: RpcEndpointAddress,
-    @transient @volatile private var nettyEnv: NettyRpcEnv)
-    extends RpcEndpointRef(conf) {
+    @transient @volatile private var nettyEnv: NettyRpcEnv) extends RpcEndpointRef(conf) {
 
   @transient @volatile var client: TransportClient = _
 
@@ -569,8 +547,7 @@ private[netty] class NettyRpcEndpointRef(
   override def name: String = endpointAddress.name
 
   override def askAbortable[T: ClassTag](
-      message: Any,
-      timeout: RpcTimeout): AbortableRpcFuture[T] = {
+      message: Any, timeout: RpcTimeout): AbortableRpcFuture[T] = {
     nettyEnv.askAbortable(new RequestMessage(nettyEnv.address, this, message), timeout)
   }
 
@@ -690,9 +667,7 @@ private[netty] case class RpcFailure(e: Throwable)
 private[netty] class NettyRpcHandler(
     dispatcher: Dispatcher,
     nettyEnv: NettyRpcEnv,
-    streamManager: StreamManager)
-    extends RpcHandler
-    with Logging {
+    streamManager: StreamManager) extends RpcHandler with Logging {
 
   // A variable to track the remote RpcEnv addresses of all clients
   private val remoteAddresses = new ConcurrentHashMap[RpcAddress, RpcAddress]()
@@ -705,7 +680,9 @@ private[netty] class NettyRpcHandler(
     dispatcher.postRemoteMessage(messageToDispatch, callback)
   }
 
-  override def receive(client: TransportClient, message: ByteBuffer): Unit = {
+  override def receive(
+      client: TransportClient,
+      message: ByteBuffer): Unit = {
     val messageToDispatch = internalReceive(client, message)
     dispatcher.postOneWayMessage(messageToDispatch)
   }

--- a/core/src/test/scala/org/apache/spark/rpc/RpcEnvSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rpc/RpcEnvSuite.scala
@@ -190,6 +190,46 @@ abstract class RpcEnvSuite extends SparkFunSuite with BeforeAndAfterAll {
     }
   }
 
+  test("ask a message remotely timeout") {
+    var remoteRef: RpcEndpointRef = null
+    env.setupEndpoint("ask-remotely", new RpcEndpoint {
+      override val rpcEnv = env
+      override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {
+        case Register(ref) =>
+          remoteRef = ref
+          context.reply("okay")
+        case msg: String =>
+          context.reply(msg)
+      }
+    })
+    val conf = new SparkConf()
+    val anotherEnv = createRpcEnv(conf, "remote", 0, clientMode = true)
+    // Use anotherEnv to find out the RpcEndpointRef
+    val rpcEndpointRef = anotherEnv.setupEndpointRef(env.address, "ask-remotely")
+    // Register a rpcEndpointRef in anotherEnv
+    val anotherRef = anotherEnv.setupEndpoint("receiver", new RpcEndpoint {
+      override val rpcEnv = anotherEnv
+      override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {
+        case _ =>
+          Thread.sleep(1200)
+          context.reply("okay")
+      }
+    })
+    try {
+      val reply = rpcEndpointRef.askSync[String](Register(anotherRef))
+      assert("okay" === reply)
+      val answer = remoteRef.ask[String]("msg",
+        RpcTimeout(conf, Seq("spark.rpc.askTimeout", "spark.network.timeout"), "1s"))
+      val thrown = intercept[Exception] {
+        ThreadUtils.awaitResult(answer, Duration(1300, MILLISECONDS))
+      }
+      assert(thrown.getClass.equals(classOf[RpcTimeoutException]))
+      assert(!thrown.getMessage.contains("null"))
+    } finally {
+      anotherEnv.shutdown()
+      anotherEnv.awaitTermination()
+    }
+  }
   test("ask a message abort") {
     env.setupEndpoint("ask-abort", new RpcEndpoint {
       override val rpcEnv = env
@@ -988,6 +1028,8 @@ abstract class RpcEnvSuite extends SparkFunSuite with BeforeAndAfterAll {
     }
   }
 }
+
+case class Register(ref: RpcEndpointRef)
 
 class UnserializableClass
 

--- a/core/src/test/scala/org/apache/spark/rpc/RpcEnvSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rpc/RpcEnvSuite.scala
@@ -190,7 +190,7 @@ abstract class RpcEnvSuite extends SparkFunSuite with BeforeAndAfterAll {
     }
   }
 
-  test("ask a message remotely timeout") {
+  test("SPARK-31233: ask rpcEndpointRef in client mode timeout") {
     var remoteRef: RpcEndpointRef = null
     env.setupEndpoint("ask-remotely", new RpcEndpoint {
       override val rpcEnv = env
@@ -230,6 +230,7 @@ abstract class RpcEnvSuite extends SparkFunSuite with BeforeAndAfterAll {
       anotherEnv.awaitTermination()
     }
   }
+
   test("ask a message abort") {
     env.setupEndpoint("ask-abort", new RpcEndpoint {
       override val rpcEnv = env

--- a/core/src/test/scala/org/apache/spark/rpc/RpcEnvSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rpc/RpcEnvSuite.scala
@@ -192,7 +192,7 @@ abstract class RpcEnvSuite extends SparkFunSuite with BeforeAndAfterAll {
 
   test("SPARK-31233: ask rpcEndpointRef in client mode timeout") {
     var remoteRef: RpcEndpointRef = null
-    env.setupEndpoint("ask-remotely", new RpcEndpoint {
+    env.setupEndpoint("ask-remotely-server", new RpcEndpoint {
       override val rpcEnv = env
       override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {
         case Register(ref) =>
@@ -205,7 +205,7 @@ abstract class RpcEnvSuite extends SparkFunSuite with BeforeAndAfterAll {
     val conf = new SparkConf()
     val anotherEnv = createRpcEnv(conf, "remote", 0, clientMode = true)
     // Use anotherEnv to find out the RpcEndpointRef
-    val rpcEndpointRef = anotherEnv.setupEndpointRef(env.address, "ask-remotely")
+    val rpcEndpointRef = anotherEnv.setupEndpointRef(env.address, "ask-remotely-server")
     // Register a rpcEndpointRef in anotherEnv
     val anotherRef = anotherEnv.setupEndpoint("receiver", new RpcEndpoint {
       override val rpcEnv = anotherEnv

--- a/core/src/test/scala/org/apache/spark/rpc/netty/NettyRpcEnvSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rpc/netty/NettyRpcEnvSuite.scala
@@ -173,9 +173,7 @@ class NettyRpcEnvSuite extends RpcEnvSuite with MockitoSugar with TimeLimits {
         ThreadUtils.awaitResult(answer, Duration(1300, MILLISECONDS))
       }
       val remoteAddr = remoteRef.asInstanceOf[NettyRpcEndpointRef].client.getChannel.remoteAddress
-      val exptMsg = s"Cannot receive any reply from $remoteAddr in 1 second. " +
-        s"This timeout is controlled by spark.rpc.askTimeout"
-      assert(thrown.getMessage.equals(exptMsg))
+      assert(thrown.getMessage.contains(remoteAddr.toString))
     } finally {
       anotherEnv.shutdown()
       anotherEnv.awaitTermination()

--- a/core/src/test/scala/org/apache/spark/rpc/netty/NettyRpcEnvSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rpc/netty/NettyRpcEnvSuite.scala
@@ -173,7 +173,7 @@ class NettyRpcEnvSuite extends RpcEnvSuite with MockitoSugar with TimeLimits {
         ThreadUtils.awaitResult(answer, Duration(1300, MILLISECONDS))
       }
       val remoteAddr = remoteRef.asInstanceOf[NettyRpcEndpointRef].client.getChannel.remoteAddress
-      val exptMsg = s"Cannot receive any reply from ${remoteAddr} in 1 second. " +
+      val exptMsg = s"Cannot receive any reply from $remoteAddr in 1 second. " +
         s"This timeout is controlled by spark.rpc.askTimeout"
       assert(thrown.getMessage.equals(exptMsg))
     } finally {

--- a/core/src/test/scala/org/apache/spark/rpc/netty/NettyRpcEnvSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rpc/netty/NettyRpcEnvSuite.scala
@@ -27,6 +27,7 @@ import org.scalatestplus.mockito.MockitoSugar
 import org.apache.spark._
 import org.apache.spark.network.client.TransportClient
 import org.apache.spark.rpc._
+import org.apache.spark.util.ThreadUtils
 
 class NettyRpcEnvSuite extends RpcEnvSuite with MockitoSugar with TimeLimits {
 
@@ -130,6 +131,51 @@ class NettyRpcEnvSuite extends RpcEnvSuite with MockitoSugar with TimeLimits {
       failAfter(10.seconds) {
         assert(rpcEndpointRef.askSync[Int](100) === 100)
       }
+    } finally {
+      anotherEnv.shutdown()
+      anotherEnv.awaitTermination()
+    }
+  }
+
+
+  test("SPARK-31233: ask rpcEndpointRef in client mode timeout") {
+    var remoteRef: RpcEndpointRef = null
+    env.setupEndpoint("ask-remotely-server", new RpcEndpoint {
+      override val rpcEnv = env
+      override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {
+        case Register(ref) =>
+          remoteRef = ref
+          context.reply("okay")
+        case msg: String =>
+          context.reply(msg)
+      }
+    })
+    val conf = new SparkConf()
+    val anotherEnv = createRpcEnv(conf, "remote", 0, clientMode = true)
+    // Use anotherEnv to find out the RpcEndpointRef
+    val rpcEndpointRef = anotherEnv.setupEndpointRef(env.address, "ask-remotely-server")
+    // Register a rpcEndpointRef in anotherEnv
+    val anotherRef = anotherEnv.setupEndpoint("receiver", new RpcEndpoint {
+      override val rpcEnv = anotherEnv
+      override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {
+        case _ =>
+          Thread.sleep(1200)
+          context.reply("okay")
+      }
+    })
+    try {
+      val reply = rpcEndpointRef.askSync[String](Register(anotherRef))
+      assert("okay" === reply)
+      val timeout = "1s"
+      val answer = remoteRef.ask[String]("msg",
+        RpcTimeout(conf, Seq("spark.rpc.askTimeout", "spark.network.timeout"), timeout))
+      val thrown = intercept[RpcTimeoutException] {
+        ThreadUtils.awaitResult(answer, Duration(1300, MILLISECONDS))
+      }
+      val remoteAddr = remoteRef.asInstanceOf[NettyRpcEndpointRef].client.getChannel.remoteAddress
+      val exptMsg = s"Cannot receive any reply from ${remoteAddr} in 1 second. " +
+        s"This timeout is controlled by spark.rpc.askTimeout"
+      assert(thrown.getMessage.equals(exptMsg))
     } finally {
       anotherEnv.shutdown()
       anotherEnv.awaitTermination()

--- a/core/src/test/scala/org/apache/spark/rpc/netty/NettyRpcEnvSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rpc/netty/NettyRpcEnvSuite.scala
@@ -35,6 +35,7 @@ import org.apache.spark.network.client.{RpcResponseCallback, TransportClient}
 import org.apache.spark.rpc._
 import org.apache.spark.util.ThreadUtils
 
+
 class NettyRpcEnvSuite extends RpcEnvSuite with MockitoSugar with TimeLimits {
 
   private implicit val signaler: Signaler = ThreadSignaler
@@ -44,15 +45,8 @@ class NettyRpcEnvSuite extends RpcEnvSuite with MockitoSugar with TimeLimits {
       name: String,
       port: Int,
       clientMode: Boolean = false): RpcEnv = {
-    val config = RpcEnvConfig(
-      conf,
-      "test",
-      "localhost",
-      "localhost",
-      port,
-      new SecurityManager(conf),
-      0,
-      clientMode)
+    val config = RpcEnvConfig(conf, "test", "localhost", "localhost", port,
+      new SecurityManager(conf), 0, clientMode)
     new NettyRpcEnvFactory().create(config)
   }
 
@@ -64,19 +58,18 @@ class NettyRpcEnvSuite extends RpcEnvSuite with MockitoSugar with TimeLimits {
     val mockedClient = mock[TransportClient]
     when(mockedClient.sendRpc(any[ByteBuffer], any[RpcResponseCallback]))
       .thenAnswer(new Answer[Long]() {
-        override def answer(invocation: InvocationOnMock): Long = {
-          Thread.sleep(2000)
-          1000
-        }
-      })
+      override def answer(invocation: InvocationOnMock): Long = {
+        Thread.sleep(2000)
+        1000
+      }
+    })
     val channel = mock[Channel]
     val socketAddr = mock[SocketAddress]
     when(socketAddr.toString).thenReturn("mocked socket")
     when(channel.remoteAddress()).thenReturn(socketAddr)
     when(mockedClient.getChannel).thenReturn(channel)
     when(receiver.client).thenReturn(mockedClient)
-    val answer = nettyEnv.ask(
-      new RequestMessage(nettyEnv.address, receiver, "message"),
+    val answer = nettyEnv.ask(new RequestMessage(nettyEnv.address, receiver, "message"),
       RpcTimeout(nettyEnv.conf, Seq("spark.rpc.askTimeout", "spark.network.timeout"), "1s"))
     val thrown = intercept[Exception] {
       ThreadUtils.awaitResult(answer, 2 second)
@@ -96,15 +89,8 @@ class NettyRpcEnvSuite extends RpcEnvSuite with MockitoSugar with TimeLimits {
 
   test("advertise address different from bind address") {
     val sparkConf = new SparkConf()
-    val config = RpcEnvConfig(
-      sparkConf,
-      "test",
-      "localhost",
-      "example.com",
-      0,
-      new SecurityManager(sparkConf),
-      0,
-      false)
+    val config = RpcEnvConfig(sparkConf, "test", "localhost", "example.com", 0,
+      new SecurityManager(sparkConf), 0, false)
     val env = new NettyRpcEnvFactory().create(config)
     try {
       assert(env.address.hostPort.startsWith("example.com:"))
@@ -127,13 +113,19 @@ class NettyRpcEnvSuite extends RpcEnvSuite with MockitoSugar with TimeLimits {
     val receiver = new NettyRpcEndpointRef(nettyEnv.conf, receiverAddress, nettyEnv)
 
     val msg = new RequestMessage(senderAddress, receiver, "foo")
-    assertRequestMessageEquals(msg, RequestMessage(nettyEnv, client, msg.serialize(nettyEnv)))
+    assertRequestMessageEquals(
+      msg,
+      RequestMessage(nettyEnv, client, msg.serialize(nettyEnv)))
 
     val msg2 = new RequestMessage(null, receiver, "foo")
-    assertRequestMessageEquals(msg2, RequestMessage(nettyEnv, client, msg2.serialize(nettyEnv)))
+    assertRequestMessageEquals(
+      msg2,
+      RequestMessage(nettyEnv, client, msg2.serialize(nettyEnv)))
 
     val msg3 = new RequestMessage(senderAddress, receiver, null)
-    assertRequestMessageEquals(msg3, RequestMessage(nettyEnv, client, msg3.serialize(nettyEnv)))
+    assertRequestMessageEquals(
+      msg3,
+      RequestMessage(nettyEnv, client, msg3.serialize(nettyEnv)))
   }
 
   test("StackOverflowError should be sent back and Dispatcher should survive") {

--- a/core/src/test/scala/org/apache/spark/rpc/netty/NettyRpcEnvSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rpc/netty/NettyRpcEnvSuite.scala
@@ -50,7 +50,7 @@ class NettyRpcEnvSuite extends RpcEnvSuite with MockitoSugar with TimeLimits {
     new NettyRpcEnvFactory().create(config)
   }
 
-  test("Send message to clientMode RpcEnv with timeout") {
+  test("SPARK-31233: Send message to clientMode RpcEnv with timeout") {
     val nettyEnv = env.asInstanceOf[NettyRpcEnv]
     val receiver = mock[NettyRpcEndpointRef]
     when(receiver.address).thenReturn(null)

--- a/core/src/test/scala/org/apache/spark/rpc/netty/NettyRpcEnvSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rpc/netty/NettyRpcEnvSuite.scala
@@ -17,24 +17,16 @@
 
 package org.apache.spark.rpc.netty
 
-import java.net.SocketAddress
-import java.nio.ByteBuffer
 import java.util.concurrent.ExecutionException
 
-import io.netty.channel.Channel
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito._
-import org.mockito.invocation.InvocationOnMock
-import org.mockito.stubbing.Answer
-import org.scalatest.concurrent.{Signaler, ThreadSignaler, TimeLimits}
-import org.scalatestplus.mockito.MockitoSugar
 import scala.concurrent.duration._
 
-import org.apache.spark._
-import org.apache.spark.network.client.{RpcResponseCallback, TransportClient}
-import org.apache.spark.rpc._
-import org.apache.spark.util.ThreadUtils
+import org.scalatest.concurrent.{Signaler, ThreadSignaler, TimeLimits}
+import org.scalatestplus.mockito.MockitoSugar
 
+import org.apache.spark._
+import org.apache.spark.network.client.TransportClient
+import org.apache.spark.rpc._
 
 class NettyRpcEnvSuite extends RpcEnvSuite with MockitoSugar with TimeLimits {
 
@@ -48,34 +40,6 @@ class NettyRpcEnvSuite extends RpcEnvSuite with MockitoSugar with TimeLimits {
     val config = RpcEnvConfig(conf, "test", "localhost", "localhost", port,
       new SecurityManager(conf), 0, clientMode)
     new NettyRpcEnvFactory().create(config)
-  }
-
-  test("SPARK-31233: Send message to clientMode RpcEnv with timeout") {
-    val nettyEnv = env.asInstanceOf[NettyRpcEnv]
-    val receiver = mock[NettyRpcEndpointRef]
-    when(receiver.address).thenReturn(null)
-    when(receiver.name).thenReturn("mocked")
-    val mockedClient = mock[TransportClient]
-    when(mockedClient.sendRpc(any[ByteBuffer], any[RpcResponseCallback]))
-      .thenAnswer(new Answer[Long]() {
-      override def answer(invocation: InvocationOnMock): Long = {
-        Thread.sleep(2000)
-        1000
-      }
-    })
-    val channel = mock[Channel]
-    val socketAddr = mock[SocketAddress]
-    when(socketAddr.toString).thenReturn("mocked socket")
-    when(channel.remoteAddress()).thenReturn(socketAddr)
-    when(mockedClient.getChannel).thenReturn(channel)
-    when(receiver.client).thenReturn(mockedClient)
-    val answer = nettyEnv.ask(new RequestMessage(nettyEnv.address, receiver, "message"),
-      RpcTimeout(nettyEnv.conf, Seq("spark.rpc.askTimeout", "spark.network.timeout"), "1s"))
-    val thrown = intercept[Exception] {
-      ThreadUtils.awaitResult(answer, 2 second)
-    }
-    assert(thrown.getClass.equals(classOf[RpcTimeoutException]))
-    assert(thrown.getMessage.contains("Cannot receive any reply from mocked socket in 1 second"))
   }
 
   test("non-existent endpoint") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
askAbortable method throw TimeoutException while it does no complete in time. Currently, the error message contains null as remoteAddr when receiver is in client mode. 
This change is to print out correct rpcAddress instead of null in the error message.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
It provides the address of an endpoint which does not reply in time. It helps users to find slow executors when timeout happens. 

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Add a unit test.