### PR TITLE
[SPARK-26329][CORE][FOLLOWUP] Fix ExecutorMetricsPoller class comment miss parameter

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/ExecutorMetricsPoller.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ExecutorMetricsPoller.scala
@@ -45,6 +45,7 @@ import org.apache.spark.util.{ThreadUtils, Utils}
  *
  * @param memoryManager the memory manager used by the executor.
  * @param pollingInterval the polling interval in milliseconds.
+ * @param executorMetricsSource the source of Executor Metrics used by Dropwizard metrics system
  */
 private[spark] class ExecutorMetricsPoller(
     memoryManager: MemoryManager,


### PR DESCRIPTION

### What changes were proposed in this pull request?
Fix ExecutorMetricsPoller class comment comment miss parameter

### Why are the changes needed?
Fix comment comment miss parameter

### Does this PR introduce any user-facing change?
NO

### How was this patch tested?
Not need
