### PR TITLE
[SPARK-31021][SQL] Support MariaDB Kerberos login in JDBC connector

### DIFF
--- a/external/docker-integration-tests/pom.xml
+++ b/external/docker-integration-tests/pom.xml
@@ -121,13 +121,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.postgresql</groupId>
-      <artifactId>postgresql</artifactId>
+      <groupId>org.mariadb.jdbc</groupId>
+      <artifactId>mariadb-java-client</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mariadb.jdbc</groupId>
-      <artifactId>mariadb-java-client</artifactId>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
       <scope>test</scope>
     </dependency>
     <!-- Oracle ojdbc jar, used for oracle  integration suite for docker testing.

--- a/external/docker-integration-tests/pom.xml
+++ b/external/docker-integration-tests/pom.xml
@@ -121,13 +121,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.postgresql</groupId>
-      <artifactId>postgresql</artifactId>
+      <groupId>org.mariadb.jdbc</groupId>
+      <artifactId>mariadb-java-client</artifactId>
       <scope>test</scope>
     </dependency>
     <!-- Oracle ojdbc jar, used for oracle  integration suite for docker testing.

--- a/external/docker-integration-tests/src/test/resources/mariadb_docker_entrypoint.sh
+++ b/external/docker-integration-tests/src/test/resources/mariadb_docker_entrypoint.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+dpkg-divert --add /bin/systemctl && ln -sT /bin/true /bin/systemctl
+apt update
+apt install -y mariadb-plugin-gssapi-server
+echo "gssapi_keytab_path=/docker-entrypoint-initdb.d/mariadb.keytab" >> /etc/mysql/mariadb.conf.d/auth_gssapi.cnf
+echo "gssapi_principal_name=mariadb/__IP_ADDRESS_REPLACE_ME__@EXAMPLE.COM" >> /etc/mysql/mariadb.conf.d/auth_gssapi.cnf
+docker-entrypoint.sh mysqld

--- a/external/docker-integration-tests/src/test/resources/mariadb_krb_setup.sh
+++ b/external/docker-integration-tests/src/test/resources/mariadb_krb_setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+mysql -u root -p'rootpass' -e 'CREATE USER "mariadb/__IP_ADDRESS_REPLACE_ME__@EXAMPLE.COM" IDENTIFIED WITH gssapi;'
+mysql -u root -p'rootpass' -D mysql -e 'GRANT ALL PRIVILEGES ON *.* TO "mariadb/__IP_ADDRESS_REPLACE_ME__@EXAMPLE.COM";'

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DB2IntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DB2IntegrationSuite.scala
@@ -41,7 +41,6 @@ class DB2IntegrationSuite extends DockerJDBCIntegrationSuite {
     override val jdbcPort: Int = 50000
     override def getJdbcUrl(ip: String, port: Int): String =
       s"jdbc:db2://$ip:$port/foo:user=db2inst1;password=rootpass;retrieveMessagesFromServerOnGetMessage=true;" //scalastyle:ignore
-    override def getEntryPoint: Option[String] = None
     override def getStartupProcessName: Option[String] = Some("db2start")
   }
 

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DB2IntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DB2IntegrationSuite.scala
@@ -39,8 +39,10 @@ class DB2IntegrationSuite extends DockerJDBCIntegrationSuite {
     )
     override val usesIpc = false
     override val jdbcPort: Int = 50000
+    override var dbName: Option[String] = Some("foo")
     override def getJdbcUrl(ip: String, port: Int): String =
-      s"jdbc:db2://$ip:$port/foo:user=db2inst1;password=rootpass;retrieveMessagesFromServerOnGetMessage=true;" //scalastyle:ignore
+      s"jdbc:db2://$ip:$port/${dbName.get}:user=db2inst1;password=rootpass;retrieveMessagesFromServerOnGetMessage=true;" //scalastyle:ignore
+    override def getEntryPoint: Option[String] = None
     override def getStartupProcessName: Option[String] = Some("db2start")
   }
 

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DB2IntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DB2IntegrationSuite.scala
@@ -39,9 +39,8 @@ class DB2IntegrationSuite extends DockerJDBCIntegrationSuite {
     )
     override val usesIpc = false
     override val jdbcPort: Int = 50000
-    override var dbName: Option[String] = Some("foo")
     override def getJdbcUrl(ip: String, port: Int): String =
-      s"jdbc:db2://$ip:$port/${dbName.get}:user=db2inst1;password=rootpass;retrieveMessagesFromServerOnGetMessage=true;" //scalastyle:ignore
+      s"jdbc:db2://$ip:$port/foo:user=db2inst1;password=rootpass;retrieveMessagesFromServerOnGetMessage=true;" //scalastyle:ignore
     override def getEntryPoint: Option[String] = None
     override def getStartupProcessName: Option[String] = Some("db2start")
   }

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
@@ -65,6 +65,10 @@ abstract class DatabaseOnDocker {
 
   /**
    * Optional entry point when container starts
+   *
+   * Startup process is a parameter of entry point. This may or may not be considered during
+   * startup. Prefer entry point to startup process when you need a command always to be executed or
+   * you want to change the initialization order.
    */
   def getEntryPoint: Option[String]
 

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
@@ -54,11 +54,6 @@ abstract class DatabaseOnDocker {
   val jdbcPort: Int
 
   /**
-   * Optional database name to connect to (not all database drivers need this).
-   */
-  var dbName: Option[String]
-
-  /**
    * Return a JDBC URL that connects to the database running at the given IP address and port.
    */
   def getJdbcUrl(ip: String, port: Int): String

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
@@ -65,12 +65,12 @@ abstract class DatabaseOnDocker {
    * startup. Prefer entry point to startup process when you need a command always to be executed or
    * you want to change the initialization order.
    */
-  def getEntryPoint: Option[String]
+  def getEntryPoint: Option[String] = None
 
   /**
    * Optional process to run when container starts
    */
-  def getStartupProcessName: Option[String]
+  def getStartupProcessName: Option[String] = None
 
   /**
    * Optional step before container starts
@@ -128,10 +128,10 @@ abstract class DockerJDBCIntegrationSuite extends SharedSparkSession with Eventu
         .networkDisabled(false)
         .env(db.env.map { case (k, v) => s"$k=$v" }.toSeq.asJava)
         .exposedPorts(s"${db.jdbcPort}/tcp")
-      if(db.getEntryPoint.isDefined) {
+      if (db.getEntryPoint.isDefined) {
         containerConfigBuilder.entrypoint(db.getEntryPoint.get)
       }
-      if(db.getStartupProcessName.isDefined) {
+      if (db.getStartupProcessName.isDefined) {
         containerConfigBuilder.cmd(db.getStartupProcessName.get)
       }
       db.beforeContainerStart(hostConfigBuilder, containerConfigBuilder)

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerKrbJDBCIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerKrbJDBCIntegrationSuite.scala
@@ -18,17 +18,22 @@
 package org.apache.spark.sql.jdbc
 
 import java.io.{File, FileInputStream, FileOutputStream}
+import java.sql.Connection
+import java.util.Properties
 import javax.security.auth.login.Configuration
 
 import scala.io.Source
 
 import org.apache.hadoop.minikdc.MiniKdc
 
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.StringType
 import org.apache.spark.util.{SecurityUtils, Utils}
 
 abstract class DockerKrbJDBCIntegrationSuite extends DockerJDBCIntegrationSuite {
   private var kdc: MiniKdc = _
-  protected var workDir: File = _
+  protected var entryPointDir: File = _
+  protected var initDbDir: File = _
   protected val userName: String
   protected var principal: String = _
   protected val keytabFileName: String
@@ -46,8 +51,9 @@ abstract class DockerKrbJDBCIntegrationSuite extends DockerJDBCIntegrationSuite 
 
     principal = s"$userName@${kdc.getRealm}"
 
-    workDir = Utils.createTempDir()
-    val keytabFile = new File(workDir, keytabFileName)
+    entryPointDir = Utils.createTempDir()
+    initDbDir = Utils.createTempDir()
+    val keytabFile = new File(initDbDir, keytabFileName)
     keytabFullPath = keytabFile.getAbsolutePath
     kdc.createPrincipal(keytabFile, userName)
     logInfo(s"Created keytab file: $keytabFullPath")
@@ -62,6 +68,7 @@ abstract class DockerKrbJDBCIntegrationSuite extends DockerJDBCIntegrationSuite 
     try {
       if (kdc != null) {
         kdc.stop()
+        kdc = null
       }
       Configuration.setConfiguration(null)
       SecurityUtils.setGlobalKrbDebug(false)
@@ -71,7 +78,7 @@ abstract class DockerKrbJDBCIntegrationSuite extends DockerJDBCIntegrationSuite 
   }
 
   protected def copyExecutableResource(
-      fileName: String, dir: File, processLine: String => String) = {
+      fileName: String, dir: File, processLine: String => String = identity) = {
     val newEntry = new File(dir.getAbsolutePath, fileName)
     newEntry.createNewFile()
     Utils.tryWithResource(
@@ -90,5 +97,67 @@ abstract class DockerKrbJDBCIntegrationSuite extends DockerJDBCIntegrationSuite 
     newEntry.setExecutable(true, false)
     logInfo(s"Created executable resource file: ${newEntry.getAbsolutePath}")
     newEntry
+  }
+
+  override def dataPreparation(conn: Connection): Unit = {
+    conn.prepareStatement("CREATE DATABASE foo").executeUpdate()
+    conn.setCatalog("foo")
+    conn.prepareStatement("CREATE TABLE bar (c0 text)").executeUpdate()
+    conn.prepareStatement("INSERT INTO bar VALUES ('hello')").executeUpdate()
+  }
+
+  test("Basic read test in query option") {
+    // This makes sure Spark must do authentication
+    Configuration.setConfiguration(null)
+
+    val expectedResult = Set("hello").map(Row(_))
+
+    val query = "SELECT c0 FROM bar"
+    // query option to pass on the query string.
+    val df = spark.read.format("jdbc")
+      .option("url", jdbcUrl)
+      .option("keytab", keytabFullPath)
+      .option("principal", principal)
+      .option("query", query)
+      .load()
+    assert(df.collect().toSet === expectedResult)
+  }
+
+  test("Basic read test in create table path") {
+    // This makes sure Spark must do authentication
+    Configuration.setConfiguration(null)
+
+    val expectedResult = Set("hello").map(Row(_))
+
+    val query = "SELECT c0 FROM bar"
+    // query option in the create table path.
+    sql(
+      s"""
+         |CREATE OR REPLACE TEMPORARY VIEW queryOption
+         |USING org.apache.spark.sql.jdbc
+         |OPTIONS (url '$jdbcUrl', query '$query', keytab '$keytabFullPath', principal '$principal')
+       """.stripMargin.replaceAll("\n", " "))
+    assert(sql("select c0 from queryOption").collect().toSet === expectedResult)
+  }
+
+  test("Basic write test") {
+    // This makes sure Spark must do authentication
+    Configuration.setConfiguration(null)
+
+    val props = new Properties
+    props.setProperty("keytab", keytabFullPath)
+    props.setProperty("principal", principal)
+
+    val tableName = "write_test"
+    sqlContext.createDataFrame(Seq(("foo", "bar")))
+      .write.jdbc(jdbcUrl, tableName, props)
+    val df = sqlContext.read.jdbc(jdbcUrl, tableName, props)
+
+    val schema = df.schema
+    assert(schema.map(_.dataType).toSeq === Seq(StringType, StringType))
+    val rows = df.collect()
+    assert(rows.length === 1)
+    assert(rows(0).getString(0) === "foo")
+    assert(rows(0).getString(1) === "bar")
   }
 }

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerKrbJDBCIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerKrbJDBCIntegrationSuite.scala
@@ -100,8 +100,6 @@ abstract class DockerKrbJDBCIntegrationSuite extends DockerJDBCIntegrationSuite 
   }
 
   override def dataPreparation(conn: Connection): Unit = {
-    conn.prepareStatement("CREATE DATABASE foo").executeUpdate()
-    conn.setCatalog("foo")
     conn.prepareStatement("CREATE TABLE bar (c0 text)").executeUpdate()
     conn.prepareStatement("INSERT INTO bar VALUES ('hello')").executeUpdate()
   }

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MariaDBKrbIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MariaDBKrbIntegrationSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.jdbc
 
+import java.sql.Connection
 import javax.security.auth.login.Configuration
 
 import com.spotify.docker.client.messages.{ContainerConfig, HostConfig}
@@ -25,23 +26,24 @@ import org.apache.spark.sql.execution.datasources.jdbc.connection.SecureConnecti
 import org.apache.spark.tags.DockerTest
 
 @DockerTest
-class PostgresKrbIntegrationSuite extends DockerKrbJDBCIntegrationSuite {
-  override protected val userName = s"postgres/$dockerIp"
-  override protected val keytabFileName = "postgres.keytab"
+class MariaDBKrbIntegrationSuite extends DockerKrbJDBCIntegrationSuite {
+  override protected val userName = s"mariadb/$dockerIp"
+  override protected val keytabFileName = "mariadb.keytab"
 
   override val db = new DatabaseOnDocker {
-    override val imageName = "postgres:12.0"
+    override val imageName = "mariadb:10.4"
     override val env = Map(
-      "POSTGRES_PASSWORD" -> "rootpass"
+      "MYSQL_ROOT_PASSWORD" -> "rootpass"
     )
     override val usesIpc = false
-    override val jdbcPort = 5432
+    override val jdbcPort = 3306
 
-    override var dbName: Option[String] = Some("postgres")
+    override var dbName: Option[String] = Some("mysql")
     override def getJdbcUrl(ip: String, port: Int): String =
-      s"jdbc:postgresql://$ip:$port/${dbName.get}?user=$principal&gsslib=gssapi"
+      s"jdbc:mysql://$ip:$port/${dbName.get}?user=$principal"
 
-    override def getEntryPoint: Option[String] = None
+    override def getEntryPoint: Option[String] =
+      Some("/docker-entrypoint/mariadb_docker_entrypoint.sh")
 
     override def getStartupProcessName: Option[String] = None
 
@@ -49,9 +51,12 @@ class PostgresKrbIntegrationSuite extends DockerKrbJDBCIntegrationSuite {
         hostConfigBuilder: HostConfig.Builder,
         containerConfigBuilder: ContainerConfig.Builder): Unit = {
       def replaceIp(s: String): String = s.replace("__IP_ADDRESS_REPLACE_ME__", dockerIp)
-      copyExecutableResource("postgres_krb_setup.sh", initDbDir, replaceIp)
+      copyExecutableResource("mariadb_docker_entrypoint.sh", entryPointDir, replaceIp)
+      copyExecutableResource("mariadb_krb_setup.sh", initDbDir, replaceIp)
 
       hostConfigBuilder.appendBinds(
+        HostConfig.Bind.from(entryPointDir.getAbsolutePath)
+          .to("/docker-entrypoint").readOnly(true).build(),
         HostConfig.Bind.from(initDbDir.getAbsolutePath)
           .to("/docker-entrypoint-initdb.d").readOnly(true).build()
       )
@@ -60,7 +65,13 @@ class PostgresKrbIntegrationSuite extends DockerKrbJDBCIntegrationSuite {
 
   override protected def setAuthentication(keytabFile: String, principal: String): Unit = {
     val config = new SecureConnectionProvider.JDBCConfiguration(
-      Configuration.getConfiguration, "pgjdbc", keytabFile, principal)
+      Configuration.getConfiguration, "Krb5ConnectorContext", keytabFile, principal)
     Configuration.setConfiguration(config)
+  }
+
+  override def dataPreparation(conn: Connection): Unit = {
+    super.dataPreparation(conn)
+    db.dbName = Some("foo")
+    jdbcUrl = db.getJdbcUrl(dockerIp, externalPort)
   }
 }

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MariaDBKrbIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MariaDBKrbIntegrationSuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.jdbc
 
-import java.sql.Connection
 import javax.security.auth.login.Configuration
 
 import com.spotify.docker.client.messages.{ContainerConfig, HostConfig}
@@ -38,9 +37,8 @@ class MariaDBKrbIntegrationSuite extends DockerKrbJDBCIntegrationSuite {
     override val usesIpc = false
     override val jdbcPort = 3306
 
-    override var dbName: Option[String] = Some("mysql")
     override def getJdbcUrl(ip: String, port: Int): String =
-      s"jdbc:mysql://$ip:$port/${dbName.get}?user=$principal"
+      s"jdbc:mysql://$ip:$port/mysql?user=$principal"
 
     override def getEntryPoint: Option[String] =
       Some("/docker-entrypoint/mariadb_docker_entrypoint.sh")
@@ -67,11 +65,5 @@ class MariaDBKrbIntegrationSuite extends DockerKrbJDBCIntegrationSuite {
     val config = new SecureConnectionProvider.JDBCConfiguration(
       Configuration.getConfiguration, "Krb5ConnectorContext", keytabFile, principal)
     Configuration.setConfiguration(config)
-  }
-
-  override def dataPreparation(conn: Connection): Unit = {
-    super.dataPreparation(conn)
-    db.dbName = Some("foo")
-    jdbcUrl = db.getJdbcUrl(dockerIp, externalPort)
   }
 }

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MariaDBKrbIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MariaDBKrbIntegrationSuite.scala
@@ -43,8 +43,6 @@ class MariaDBKrbIntegrationSuite extends DockerKrbJDBCIntegrationSuite {
     override def getEntryPoint: Option[String] =
       Some("/docker-entrypoint/mariadb_docker_entrypoint.sh")
 
-    override def getStartupProcessName: Option[String] = None
-
     override def beforeContainerStart(
         hostConfigBuilder: HostConfig.Builder,
         containerConfigBuilder: ContainerConfig.Builder): Unit = {

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MsSqlServerIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MsSqlServerIntegrationSuite.scala
@@ -35,9 +35,11 @@ class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationSuite {
     override val usesIpc = false
     override val jdbcPort: Int = 1433
 
+    override var dbName: Option[String] = None
     override def getJdbcUrl(ip: String, port: Int): String =
       s"jdbc:sqlserver://$ip:$port;user=sa;password=Sapass123;"
 
+    override def getEntryPoint: Option[String] = None
     override def getStartupProcessName: Option[String] = None
   }
 

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MsSqlServerIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MsSqlServerIntegrationSuite.scala
@@ -35,7 +35,6 @@ class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationSuite {
     override val usesIpc = false
     override val jdbcPort: Int = 1433
 
-    override var dbName: Option[String] = None
     override def getJdbcUrl(ip: String, port: Int): String =
       s"jdbc:sqlserver://$ip:$port;user=sa;password=Sapass123;"
 

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MsSqlServerIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MsSqlServerIntegrationSuite.scala
@@ -37,9 +37,6 @@ class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationSuite {
 
     override def getJdbcUrl(ip: String, port: Int): String =
       s"jdbc:sqlserver://$ip:$port;user=sa;password=Sapass123;"
-
-    override def getEntryPoint: Option[String] = None
-    override def getStartupProcessName: Option[String] = None
   }
 
   override def dataPreparation(conn: Connection): Unit = {

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MySQLIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MySQLIntegrationSuite.scala
@@ -35,8 +35,6 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationSuite {
     override val jdbcPort: Int = 3306
     override def getJdbcUrl(ip: String, port: Int): String =
       s"jdbc:mysql://$ip:$port/mysql?user=root&password=rootpass"
-    override def getEntryPoint: Option[String] = None
-    override def getStartupProcessName: Option[String] = None
   }
 
   override def dataPreparation(conn: Connection): Unit = {

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MySQLIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MySQLIntegrationSuite.scala
@@ -33,9 +33,8 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationSuite {
     )
     override val usesIpc = false
     override val jdbcPort: Int = 3306
-    override var dbName: Option[String] = Some("mysql")
     override def getJdbcUrl(ip: String, port: Int): String =
-      s"jdbc:mysql://$ip:$port/${dbName.get}?user=root&password=rootpass"
+      s"jdbc:mysql://$ip:$port/mysql?user=root&password=rootpass"
     override def getEntryPoint: Option[String] = None
     override def getStartupProcessName: Option[String] = None
   }

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MySQLIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MySQLIntegrationSuite.scala
@@ -33,8 +33,10 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationSuite {
     )
     override val usesIpc = false
     override val jdbcPort: Int = 3306
+    override var dbName: Option[String] = Some("mysql")
     override def getJdbcUrl(ip: String, port: Int): String =
-      s"jdbc:mysql://$ip:$port/mysql?user=root&password=rootpass"
+      s"jdbc:mysql://$ip:$port/${dbName.get}?user=root&password=rootpass"
+    override def getEntryPoint: Option[String] = None
     override def getStartupProcessName: Option[String] = None
   }
 

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
@@ -64,8 +64,10 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationSuite with SharedSpark
     )
     override val usesIpc = false
     override val jdbcPort: Int = 1521
+    override var dbName: Option[String] = None
     override def getJdbcUrl(ip: String, port: Int): String =
       s"jdbc:oracle:thin:system/oracle@//$ip:$port/xe"
+    override def getEntryPoint: Option[String] = None
     override def getStartupProcessName: Option[String] = None
   }
 

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
@@ -66,8 +66,6 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationSuite with SharedSpark
     override val jdbcPort: Int = 1521
     override def getJdbcUrl(ip: String, port: Int): String =
       s"jdbc:oracle:thin:system/oracle@//$ip:$port/xe"
-    override def getEntryPoint: Option[String] = None
-    override def getStartupProcessName: Option[String] = None
   }
 
   override def dataPreparation(conn: Connection): Unit = {

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
@@ -64,7 +64,6 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationSuite with SharedSpark
     )
     override val usesIpc = false
     override val jdbcPort: Int = 1521
-    override var dbName: Option[String] = None
     override def getJdbcUrl(ip: String, port: Int): String =
       s"jdbc:oracle:thin:system/oracle@//$ip:$port/xe"
     override def getEntryPoint: Option[String] = None

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
@@ -35,8 +35,10 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationSuite {
     )
     override val usesIpc = false
     override val jdbcPort = 5432
+    override var dbName: Option[String] = Some("postgres")
     override def getJdbcUrl(ip: String, port: Int): String =
-      s"jdbc:postgresql://$ip:$port/postgres?user=postgres&password=rootpass"
+      s"jdbc:postgresql://$ip:$port/${dbName.get}?user=postgres&password=rootpass"
+    override def getEntryPoint: Option[String] = None
     override def getStartupProcessName: Option[String] = None
   }
 

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
@@ -37,8 +37,6 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationSuite {
     override val jdbcPort = 5432
     override def getJdbcUrl(ip: String, port: Int): String =
       s"jdbc:postgresql://$ip:$port/postgres?user=postgres&password=rootpass"
-    override def getEntryPoint: Option[String] = None
-    override def getStartupProcessName: Option[String] = None
   }
 
   override def dataPreparation(conn: Connection): Unit = {

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
@@ -35,9 +35,8 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationSuite {
     )
     override val usesIpc = false
     override val jdbcPort = 5432
-    override var dbName: Option[String] = Some("postgres")
     override def getJdbcUrl(ip: String, port: Int): String =
-      s"jdbc:postgresql://$ip:$port/${dbName.get}?user=postgres&password=rootpass"
+      s"jdbc:postgresql://$ip:$port/postgres?user=postgres&password=rootpass"
     override def getEntryPoint: Option[String] = None
     override def getStartupProcessName: Option[String] = None
   }

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresKrbIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresKrbIntegrationSuite.scala
@@ -37,9 +37,8 @@ class PostgresKrbIntegrationSuite extends DockerKrbJDBCIntegrationSuite {
     override val usesIpc = false
     override val jdbcPort = 5432
 
-    override var dbName: Option[String] = Some("postgres")
     override def getJdbcUrl(ip: String, port: Int): String =
-      s"jdbc:postgresql://$ip:$port/${dbName.get}?user=$principal&gsslib=gssapi"
+      s"jdbc:postgresql://$ip:$port/postgres?user=$principal&gsslib=gssapi"
 
     override def getEntryPoint: Option[String] = None
 

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresKrbIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresKrbIntegrationSuite.scala
@@ -40,10 +40,6 @@ class PostgresKrbIntegrationSuite extends DockerKrbJDBCIntegrationSuite {
     override def getJdbcUrl(ip: String, port: Int): String =
       s"jdbc:postgresql://$ip:$port/postgres?user=$principal&gsslib=gssapi"
 
-    override def getEntryPoint: Option[String] = None
-
-    override def getStartupProcessName: Option[String] = None
-
     override def beforeContainerStart(
         hostConfigBuilder: HostConfig.Builder,
         containerConfigBuilder: ContainerConfig.Builder): Unit = {

--- a/pom.xml
+++ b/pom.xml
@@ -952,6 +952,12 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.mariadb.jdbc</groupId>
+        <artifactId>mariadb-java-client</artifactId>
+        <version>2.5.4</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
         <version>42.2.6</version>

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -131,8 +131,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
+      <groupId>org.mariadb.jdbc</groupId>
+      <artifactId>mariadb-java-client</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProvider.scala
@@ -28,6 +28,9 @@ import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
  * the parameters.
  */
 private[jdbc] trait ConnectionProvider {
+  /**
+   * Opens connection toward the database.
+   */
   def getConnection(): Connection
 }
 
@@ -42,6 +45,10 @@ private[jdbc] object ConnectionProvider extends Logging {
         case PostgresConnectionProvider.driverClass =>
           logDebug("Postgres connection provider found")
           new PostgresConnectionProvider(driver, options)
+
+        case MariaDBConnectionProvider.driverClass =>
+          logDebug("MariaDB connection provider found")
+          new MariaDBConnectionProvider(driver, options)
 
         case _ =>
           throw new IllegalArgumentException(s"Driver ${options.driverClass} does not support " +

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/MariaDBConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/MariaDBConnectionProvider.scala
@@ -18,23 +18,29 @@
 package org.apache.spark.sql.execution.datasources.jdbc.connection
 
 import java.sql.Driver
-import java.util.Properties
 import javax.security.auth.login.Configuration
+
+import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 
-private[jdbc] class PostgresConnectionProvider(driver: Driver, options: JDBCOptions)
+private[jdbc] class MariaDBConnectionProvider(driver: Driver, options: JDBCOptions)
     extends SecureConnectionProvider(driver, options) {
   override val appEntry: String = {
-    val parseURL = driver.getClass.getMethod("parseURL", classOf[String], classOf[Properties])
-    val properties = parseURL.invoke(driver, options.url, null).asInstanceOf[Properties]
-    properties.getProperty("jaasApplicationName", "pgjdbc")
+    "Krb5ConnectorContext"
   }
 
   override def setAuthenticationConfigIfNeeded(): Unit = {
     val parent = Configuration.getConfiguration
     val configEntry = parent.getAppConfigurationEntry(appEntry)
-    if (configEntry == null || configEntry.isEmpty) {
+    /**
+     * Couple of things to mention here:
+     * 1. MariaDB doesn't support JAAS application name configuration
+     * 2. MariaDB sets a default JAAS config if "java.security.auth.login.config" not set
+     */
+    val entryUsesKeytab = configEntry != null && configEntry
+      .exists(_.getOptions.asScala.exists(o => o._1 == "useKeyTab" && o._2 == "true"))
+    if (configEntry == null || configEntry.isEmpty || !entryUsesKeytab) {
       val config = new SecureConnectionProvider.JDBCConfiguration(
         parent, appEntry, options.keytab, options.principal)
       logDebug("Adding database specific security configuration")
@@ -43,6 +49,6 @@ private[jdbc] class PostgresConnectionProvider(driver: Driver, options: JDBCOpti
   }
 }
 
-private[sql] object PostgresConnectionProvider {
-  val driverClass = "org.postgresql.Driver"
+private[sql] object MariaDBConnectionProvider {
+  val driverClass = "org.mariadb.jdbc.Driver"
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/MariaDBConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/MariaDBConnectionProvider.scala
@@ -38,8 +38,8 @@ private[jdbc] class MariaDBConnectionProvider(driver: Driver, options: JDBCOptio
      * 1. MariaDB doesn't support JAAS application name configuration
      * 2. MariaDB sets a default JAAS config if "java.security.auth.login.config" is not set
      */
-    val entryUsesKeytab = configEntry != null && configEntry
-      .exists(_.getOptions.asScala.exists(o => o._1 == "useKeyTab" && o._2 == "true"))
+    val entryUsesKeytab = configEntry != null &&
+      configEntry.exists(_.getOptions().get("useKeyTab") == "true")
     if (configEntry == null || configEntry.isEmpty || !entryUsesKeytab) {
       val config = new SecureConnectionProvider.JDBCConfiguration(
         parent, appEntry, options.keytab, options.principal)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/MariaDBConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/MariaDBConnectionProvider.scala
@@ -36,7 +36,7 @@ private[jdbc] class MariaDBConnectionProvider(driver: Driver, options: JDBCOptio
     /**
      * Couple of things to mention here:
      * 1. MariaDB doesn't support JAAS application name configuration
-     * 2. MariaDB sets a default JAAS config if "java.security.auth.login.config" not set
+     * 2. MariaDB sets a default JAAS config if "java.security.auth.login.config" is not set
      */
     val entryUsesKeytab = configEntry != null && configEntry
       .exists(_.getOptions.asScala.exists(o => o._1 == "useKeyTab" && o._2 == "true"))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/SecureConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/SecureConnectionProvider.scala
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.jdbc.connection
+
+import java.sql.{Connection, Driver}
+import javax.security.auth.login.{AppConfigurationEntry, Configuration}
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
+import org.apache.spark.util.SecurityUtils
+
+private[jdbc] abstract class SecureConnectionProvider(driver: Driver, options: JDBCOptions)
+    extends BasicConnectionProvider(driver, options) with Logging {
+  override def getConnection(): Connection = {
+    setAuthenticationConfigIfNeeded()
+    super.getConnection()
+  }
+
+  /**
+   * Returns JAAS application name. This is sometimes configurable on the JDBC driver level.
+   */
+  val appEntry: String
+
+  /**
+   * Sets database specific authentication configuration when needed. If configuration already set
+   * then later calls must be no op.
+   */
+  def setAuthenticationConfigIfNeeded(): Unit
+}
+
+object SecureConnectionProvider {
+  class JDBCConfiguration(
+    parent: Configuration,
+    appEntry: String,
+    keytab: String,
+    principal: String) extends Configuration {
+  val entry =
+    new AppConfigurationEntry(
+      SecurityUtils.getKrb5LoginModuleName(),
+      AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
+      Map[String, Object](
+        "useTicketCache" -> "false",
+        "useKeyTab" -> "true",
+        "keyTab" -> keytab,
+        "principal" -> principal,
+        "debug" -> "true"
+      ).asJava
+    )
+
+    override def getAppConfigurationEntry(name: String): Array[AppConfigurationEntry] = {
+      if (name.equals(appEntry)) {
+        Array(entry)
+      } else {
+        parent.getAppConfigurationEntry(name)
+      }
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProviderSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProviderSuiteBase.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.jdbc.connection
+
+import java.sql.{Driver, DriverManager}
+import javax.security.auth.login.Configuration
+
+import scala.collection.JavaConverters._
+
+import org.scalatest.BeforeAndAfterEach
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.execution.datasources.jdbc.{DriverRegistry, JDBCOptions}
+
+abstract class ConnectionProviderSuiteBase extends SparkFunSuite with BeforeAndAfterEach {
+  protected def registerDriver(driverClass: String): Driver = {
+    DriverRegistry.register(driverClass)
+    DriverManager.getDrivers.asScala.collectFirst {
+      case d if d.getClass.getCanonicalName == driverClass => d
+    }.get
+  }
+
+  protected def options(url: String) = new JDBCOptions(Map[String, String](
+    JDBCOptions.JDBC_URL -> url,
+    JDBCOptions.JDBC_TABLE_NAME -> "table",
+    JDBCOptions.JDBC_KEYTAB -> "/path/to/keytab",
+    JDBCOptions.JDBC_PRINCIPAL -> "principal"
+  ))
+
+  override def afterEach(): Unit = {
+    try {
+      Configuration.setConfiguration(null)
+    } finally {
+      super.afterEach()
+    }
+  }
+
+  protected def testSecureConnectionProvider(provider: SecureConnectionProvider): Unit = {
+    // Make sure no authentication for the database is set
+    assert(Configuration.getConfiguration.getAppConfigurationEntry(provider.appEntry) == null)
+
+    // Make sure the first call sets authentication properly
+    val savedConfig = Configuration.getConfiguration
+    provider.setAuthenticationConfigIfNeeded()
+    val config = Configuration.getConfiguration
+    assert(savedConfig != config)
+    val appEntry = config.getAppConfigurationEntry(provider.appEntry)
+    assert(appEntry != null)
+
+    // Make sure a second call is not modifying the existing authentication
+    provider.setAuthenticationConfigIfNeeded()
+    assert(config.getAppConfigurationEntry(provider.appEntry) === appEntry)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/MariaDBConnectionProviderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/MariaDBConnectionProviderSuite.scala
@@ -17,16 +17,11 @@
 
 package org.apache.spark.sql.execution.datasources.jdbc.connection
 
-class PostgresConnectionProviderSuite extends ConnectionProviderSuiteBase {
+class MariaDBConnectionProviderSuite extends ConnectionProviderSuiteBase {
   test("setAuthenticationConfigIfNeeded must set authentication if not set") {
-    val driver = registerDriver(PostgresConnectionProvider.driverClass)
-    val defaultProvider = new PostgresConnectionProvider(
-      driver, options("jdbc:postgresql://localhost/postgres"))
-    val customProvider = new PostgresConnectionProvider(
-      driver, options(s"jdbc:postgresql://localhost/postgres?jaasApplicationName=custompgjdbc"))
+    val driver = registerDriver(MariaDBConnectionProvider.driverClass)
+    val provider = new MariaDBConnectionProvider(driver, options("jdbc:mysql://localhost/mysql"))
 
-    assert(defaultProvider.appEntry !== customProvider.appEntry)
-    testSecureConnectionProvider(defaultProvider)
-    testSecureConnectionProvider(customProvider)
+    testSecureConnectionProvider(provider)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
When loading DataFrames from JDBC datasource with Kerberos authentication, remote executors (yarn-client/cluster etc. modes) fail to establish a connection due to lack of Kerberos ticket or ability to generate it.

This is a real issue when trying to ingest data from kerberized data sources (SQL Server, Oracle) in enterprise environment where exposing simple authentication access is not an option due to IT policy issues.

In this PR I've added MariaDB support (other supported databases will come in later PRs).

What this PR contains:
* Introduced `SecureConnectionProvider` and added basic secure functionalities
* Added `MariaDBConnectionProvider`
* Added `MariaDBConnectionProviderSuite`
* Added `MariaDBKrbIntegrationSuite` docker integration test
* Added some missing code documentation

### Why are the changes needed?
Missing JDBC kerberos support.

### Does this PR introduce any user-facing change?
Yes, now user is able to connect to MariaDB using kerberos.

### How was this patch tested?
* Additional + existing unit tests
* Additional + existing integration tests
* Test on cluster manually
