### PR TITLE
[SPARK-31186][PySpark][SQL] toPandas should not fail on duplicate column names

### DIFF
--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -135,7 +135,7 @@ class PandasConversionMixin(object):
         dtype = [None] * len(self.schema)
         for fieldIdx in range(len(self.schema)):
             field = self.schema[fieldIdx]
-            pandas_col = pdf.iloc[:,fieldIdx]
+            pandas_col = pdf.iloc[:, fieldIdx]
 
             pandas_type = PandasConversionMixin._to_corrected_pandas_type(field.dataType)
             # SPARK-21766: if an integer field is nullable and has null values, it can be
@@ -156,10 +156,10 @@ class PandasConversionMixin(object):
         for index in range(len(dtype)):
             t = dtype[index]
             if t is not None:
-                series = pdf.iloc[:,index].astype(t, copy=False)
+                series = pdf.iloc[:, index].astype(t, copy=False)
             else:
-                series = pdf.iloc[:,index]
-            df.insert(index, self.schema[index].name, series, allow_duplicates = True)
+                series = pdf.iloc[:, index]
+            df.insert(index, self.schema[index].name, series, allow_duplicates=True)
 
         pdf = df
 

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -153,8 +153,7 @@ class PandasConversionMixin(object):
                 dtype[fieldIdx] = np.object
 
         df = pd.DataFrame()
-        for index in range(len(dtype)):
-            t = dtype[index]
+        for index, t in enumerate(dtype):
             if t is not None:
                 series = pdf.iloc[:, index].astype(t, copy=False)
             else:

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -136,6 +136,7 @@ class PandasConversionMixin(object):
 
         dtype = [None] * len(self.schema)
         for fieldIdx, field in enumerate(self.schema):
+            # For duplicate column name, we use `iloc` to access it.
             if column_counter[field.name] > 1:
                 pandas_col = pdf.iloc[:, fieldIdx]
             else:
@@ -160,6 +161,7 @@ class PandasConversionMixin(object):
         for index, t in enumerate(dtype):
             column_name = self.schema[index].name
 
+            # For duplicate column name, we use `iloc` to access it.
             if column_counter[column_name] > 1:
                 series = pdf.iloc[:, index]
             else:
@@ -168,6 +170,9 @@ class PandasConversionMixin(object):
             if t is not None:
                 series = series.astype(t, copy=False)
 
+            # `insert` API makes copy of data, we only do it for Series of duplicate column names.
+            # `pdf.iloc[:, index] = pdf.iloc[:, index]...` doesn't always work because `iloc` could
+            # return a view or a copy depending by context.
             if column_counter[column_name] > 1:
                 df.insert(index, column_name, series, allow_duplicates=True)
             else:

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -547,7 +547,6 @@ class DataFrameTests(ReusedSQLTestCase):
             self.assertEquals(types.iloc[0], np.int32)
             self.assertEquals(types.iloc[1], np.int32)
 
-
     @unittest.skipIf(have_pandas, "Required Pandas was found.")
     def test_to_pandas_required_pandas_not_found(self):
         with QuietTest(self.sc):

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -529,6 +529,25 @@ class DataFrameTests(ReusedSQLTestCase):
         self.assertEquals(types[4], np.object)  # datetime.date
         self.assertEquals(types[5], 'datetime64[ns]')
 
+    @unittest.skipIf(not have_pandas, pandas_requirement_message)
+    def test_to_pandas_on_cross_join(self):
+        import numpy as np
+
+        sql = """
+        select t1.*, t2.* from (
+          select explode(sequence(1, 3)) v
+        ) t1 left join (
+          select explode(sequence(1, 3)) v
+        ) t2
+        """
+        with self.sql_conf({"spark.sql.crossJoin.enabled": True}):
+            df = self.spark.sql(sql)
+            pdf = df.toPandas()
+            types = pdf.dtypes
+            self.assertEquals(types.iloc[0], np.int32)
+            self.assertEquals(types.iloc[1], np.int32)
+
+
     @unittest.skipIf(have_pandas, "Required Pandas was found.")
     def test_to_pandas_required_pandas_not_found(self):
         with QuietTest(self.sc):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

When `toPandas` API works on duplicate column names produced from operators like join, we see the error like:

```
ValueError: The truth value of a Series is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().
```

This patch fixes the error in `toPandas` API.  

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

To make `toPandas` work on dataframe with duplicate column names.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

Yes. Previously calling `toPandas` API on a dataframe with duplicate column names will fail. After this patch, it will produce correct result.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Unit test.