### PR TITLE
[SPARK-31263][SHUFFLE] Enable yarn shuffle service to close the idle connections

### DIFF
--- a/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
+++ b/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
@@ -188,7 +188,7 @@ public class YarnShuffleService extends AuxiliaryService {
 
       int port = conf.getInt(
         SPARK_SHUFFLE_SERVICE_PORT_KEY, DEFAULT_SPARK_SHUFFLE_SERVICE_PORT);
-      transportContext = new TransportContext(transportConf, blockHandler);
+      transportContext = new TransportContext(transportConf, blockHandler, true);
       shuffleServer = transportContext.createServer(port, bootstraps);
       // the port should normally be fixed, but for tests its useful to find an open port
       port = shuffleServer.getPort();


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable yarn shuffle service to close the idle connections.


### Why are the changes needed?
Without this pr, connections leak may occur.

### Does this PR introduce any user-facing change?
No.


### How was this patch tested?
Existing UT.
