### PR TITLE
[SPARK-31268][CORE]Initial Task Executor Metrics with latestMetrics

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/ExecutorMetricsPoller.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ExecutorMetricsPoller.scala
@@ -147,6 +147,10 @@ private[spark] class ExecutorMetricsPoller(
    * Called by TaskRunner#run.
    */
   def getTaskMetricPeaks(taskId: Long): Array[Long] = {
+    // If task running duration is less then pollInterval, task metric peak may not updated
+    // call poll() update to latest metrics
+    poll()
+
     // If this is called with an invalid taskId or a valid taskId but the task was killed and
     // onTaskStart was therefore not called, then we return an array of zeros.
     val currentPeaks = taskMetricPeaks.get(taskId) // may be null

--- a/core/src/main/scala/org/apache/spark/executor/ExecutorMetricsPoller.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ExecutorMetricsPoller.scala
@@ -61,6 +61,7 @@ private[spark] class ExecutorMetricsPoller(
   // Map of taskId to executor metric peaks
   private val taskMetricPeaks = new ConcurrentHashMap[Long, AtomicLongArray]
 
+  private var latestMetrics = ExecutorMetrics.getCurrentMetrics(memoryManager)
   private val poller =
     if (pollingInterval > 0) {
       Some(ThreadUtils.newDaemonSingleThreadScheduledExecutor("executor-metrics-poller"))
@@ -79,7 +80,7 @@ private[spark] class ExecutorMetricsPoller(
     // with this function via calls to methods of this class.
 
     // get the latest values for the metrics
-    val latestMetrics = ExecutorMetrics.getCurrentMetrics(memoryManager)
+    latestMetrics = ExecutorMetrics.getCurrentMetrics(memoryManager)
     executorMetricsSource.foreach(_.updateMetricsSnapshot(latestMetrics))
 
     def updatePeaks(metrics: AtomicLongArray): Unit = {
@@ -107,8 +108,8 @@ private[spark] class ExecutorMetricsPoller(
    * Called by TaskRunner#run.
    */
   def onTaskStart(taskId: Long, stageId: Int, stageAttemptId: Int): Unit = {
-    // Put an entry in taskMetricPeaks for the task.
-    taskMetricPeaks.put(taskId, new AtomicLongArray(ExecutorMetricType.numMetrics))
+    // Put an entry in taskMetricPeaks for the task with latestMetrics.
+    taskMetricPeaks.put(taskId, new AtomicLongArray(latestMetrics))
 
     // Put a new entry in stageTCMP for the stage if there isn't one already.
     // Increment the task count.


### PR DESCRIPTION
### What changes were proposed in this pull request?
I found that TaskEnd event with zero Executor Metrics when task duration less then poll interval when I add some info to SparkWebUI in task detail table

![image](https://user-images.githubusercontent.com/46485123/77646742-15d5b900-6fa0-11ea-9d60-e600d270e4d3.png)

so initial taskExecutorMetrics with latestMetrics

### Why are the changes needed?
Fix zero value


### Does this PR introduce any user-facing change?
NO

### How was this patch tested?
NO