### PR TITLE
[SPARK-26341][CORE]Expose executor memory metrics at the stage level, in the Stages tab

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
@@ -245,7 +245,7 @@ function createRowMetadataForColumn(colKey, data, checkboxId) {
 function reselectCheckboxesBasedOnTaskTableState() {
     var allChecked = true;
     var taskSummaryMetricsTableCurrentFilteredArray = taskSummaryMetricsTableCurrentStateArray.slice();
-    if (typeof taskTableSelector !== 'undefined' && taskSummaryMetricsTableCurrentStateArray.length > 0) {
+    if (typeof taskTableSelector !== 'undefined' && typeof executorSummaryTableSelector !== 'undefined' && taskSummaryMetricsTableCurrentStateArray.length > 0) {
         for (var k = 0; k < optionalColumns.length; k++) {
             if (taskTableSelector.column(optionalColumns[k]).visible()) {
                 $("#box-"+optionalColumns[k]).prop('checked', true);

--- a/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
@@ -257,7 +257,7 @@ function reselectCheckboxesBasedOnTaskTableState() {
         }
         for (var k = 0; k < executorOptionalColumns.length; k++) {
             if (executorSummaryTableSelector.column(executorOptionalColumns[k]).visible()) {
-                $("#executor-box-"+optionalColumns[k]).prop('checked', true);
+                $("#executor-box-"+executorOptionalColumns[k]).prop('checked', true);
             } else {
                 allChecked = false;
             }
@@ -306,10 +306,10 @@ $(document).ready(function () {
         "<div id='result_serialization_time' class='result-serialization-time-checkbox-div'><input type='checkbox' class='toggle-vis' id='box-15' data-column='15' column-type='task'> Result Serialization Time</div>" +
         "<div id='getting_result_time' class='getting-result-time-checkbox-div'><input type='checkbox' class='toggle-vis' id='box-16' data-column='16' column-type='task'> Getting Result Time</div>" +
         "<div id='peak_execution_memory' class='peak-execution-memory-checkbox-div'><input type='checkbox' class='toggle-vis' id='box-17' data-column='17' column-type='task'> Peak Execution Memory</div>" +
-        "<div id='executor_jvm_on_off_heap_memory' class='executor-jvm-om-off-heap-memory-checkbox-div'><input type='checkbox' class='toggle-vis' id='executor-box-15'  data-column='15' column-type='executor'> Executor  JVMOnHeapMemory / JVMOffHeapMemory</div>" +
-        "<div id='executor_on_off_heap_execution_memory' class='executor-on-off-heap-execution-memory-checkbox-div'><input type='checkbox' class='toggle-vis' id='executor-box-16' data-column='16' column-type='executor'> Executor  OnHeapExecutionMemory / OffHeapExecutionMemory</div>" +
-        "<div id='executor_on_off_heap_storage_memory' class='executor-on-off-heap-storage-memory-checkbox-div'><input type='checkbox' class='toggle-vis' id='executor-box-17' data-column='17' column-type='executor'> Executor OnHeapStorageMemory / OffHeapStorageMemory</div>" +
-        "<div id='executor_direct_mapped_pool_memory' class='executor-direct-mapped-pool-memory-checkbox-div'><input type='checkbox' class='toggle-vis' id='executor-box-18' data-column='18' column-type='executor'> Executor DirectPoolMemory / MappedPoolMemory</div>" +
+        "<div id='executor_jvm_on_off_heap_memory' class='executor-jvm-metrics-checkbox-div'><input type='checkbox' class='toggle-vis' id='executor-box-15'  data-column='15' column-type='executor'> Executor  JVMOnHeapMemory / JVMOffHeapMemory</div>" +
+        "<div id='executor_on_off_heap_execution_memory' class='executor-jvm-metrics-checkbox-div'><input type='checkbox' class='toggle-vis' id='executor-box-16' data-column='16' column-type='executor'> Executor  OnHeapExecutionMemory / OffHeapExecutionMemory</div>" +
+        "<div id='executor_on_off_heap_storage_memory' class='executor-jvm-metrics-checkbox-div'><input type='checkbox' class='toggle-vis' id='executor-box-17' data-column='17' column-type='executor'> Executor OnHeapStorageMemory / OffHeapStorageMemory</div>" +
+        "<div id='executor_direct_mapped_pool_memory' class='executor-jvm-metrics-checkbox-div'><input type='checkbox' class='toggle-vis' id='executor-box-18' data-column='18' column-type='executor'> Executor DirectPoolMemory / MappedPoolMemory</div>" +
         "</div>");
 
     $('#scheduler_delay').attr("data-toggle", "tooltip")

--- a/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
@@ -255,6 +255,13 @@ function reselectCheckboxesBasedOnTaskTableState() {
                 allChecked = false;
             }
         }
+        for (var k = 0; k < executorOptionalColumns.length; k++) {
+            if (executorSummaryTableSelector.column(executorOptionalColumns[k]).visible()) {
+                $("#executor-box-"+optionalColumns[k]).prop('checked', true);
+            } else {
+                allChecked = false;
+            }
+        }
         if (allChecked) {
             $("#box-0").prop('checked', true);
         }
@@ -278,6 +285,9 @@ var taskSummaryMetricsDataTable;
 var optionalColumns = [11, 12, 13, 14, 15, 16, 17, 21];
 var taskTableSelector;
 
+var executorOptionalColumns = [15, 16, 17, 18];
+var executorSummaryTableSelector;
+
 $(document).ready(function () {
     setDataTableDefaults();
 
@@ -288,14 +298,18 @@ $(document).ready(function () {
         "</a></div>" +
         "<div class='container-fluid-div ml-4 d-none' id='toggle-metrics'>" +
         "<div id='select_all' class='select-all-checkbox-div'><input type='checkbox' class='toggle-vis' id='box-0' data-column='0'> Select All</div>" +
-        "<div id='scheduler_delay' class='scheduler-delay-checkbox-div'><input type='checkbox' class='toggle-vis' id='box-11' data-column='11'> Scheduler Delay</div>" +
-        "<div id='task_deserialization_time' class='task-deserialization-time-checkbox-div'><input type='checkbox' class='toggle-vis' id='box-12' data-column='12'> Task Deserialization Time</div>" +
-        "<div id='shuffle_read_blocked_time' class='shuffle-read-blocked-time-checkbox-div'><input type='checkbox' class='toggle-vis' id='box-13' data-column='13'> Shuffle Read Blocked Time</div>" +
-        "<div id='shuffle_remote_reads' class='shuffle-remote-reads-checkbox-div'><input type='checkbox' class='toggle-vis' id='box-14' data-column='14'> Shuffle Remote Reads</div>" +
-        "<div id='shuffle_write_time' class='shuffle-write-time-checkbox-div'><input type='checkbox' class='toggle-vis' id='box-21' data-column='21'> Shuffle Write Time</div>" +
-        "<div id='result_serialization_time' class='result-serialization-time-checkbox-div'><input type='checkbox' class='toggle-vis' id='box-15' data-column='15'> Result Serialization Time</div>" +
-        "<div id='getting_result_time' class='getting-result-time-checkbox-div'><input type='checkbox' class='toggle-vis' id='box-16' data-column='16'> Getting Result Time</div>" +
-        "<div id='peak_execution_memory' class='peak-execution-memory-checkbox-div'><input type='checkbox' class='toggle-vis' id='box-17' data-column='17'> Peak Execution Memory</div>" +
+        "<div id='scheduler_delay' class='scheduler-delay-checkbox-div'><input type='checkbox' class='toggle-vis' id='box-11' data-column='11' column-type='task'> Scheduler Delay</div>" +
+        "<div id='task_deserialization_time' class='task-deserialization-time-checkbox-div'><input type='checkbox' class='toggle-vis' id='box-12' data-column='12' column-type='task'> Task Deserialization Time</div>" +
+        "<div id='shuffle_read_blocked_time' class='shuffle-read-blocked-time-checkbox-div'><input type='checkbox' class='toggle-vis' id='box-13' data-column='13' column-type='task'> Shuffle Read Blocked Time</div>" +
+        "<div id='shuffle_remote_reads' class='shuffle-remote-reads-checkbox-div'><input type='checkbox' class='toggle-vis' id='box-14' data-column='14' column-type='task'> Shuffle Remote Reads</div>" +
+        "<div id='shuffle_write_time' class='shuffle-write-time-checkbox-div'><input type='checkbox' class='toggle-vis' id='box-21' data-column='21' column-type='task'> Shuffle Write Time</div>" +
+        "<div id='result_serialization_time' class='result-serialization-time-checkbox-div'><input type='checkbox' class='toggle-vis' id='box-15' data-column='15' column-type='task'> Result Serialization Time</div>" +
+        "<div id='getting_result_time' class='getting-result-time-checkbox-div'><input type='checkbox' class='toggle-vis' id='box-16' data-column='16' column-type='task'> Getting Result Time</div>" +
+        "<div id='peak_execution_memory' class='peak-execution-memory-checkbox-div'><input type='checkbox' class='toggle-vis' id='box-17' data-column='17' column-type='task'> Peak Execution Memory</div>" +
+        "<div id='executor_jvm_on_off_heap_memory' class='executor-jvm-om-off-heap-memory-checkbox-div'><input type='checkbox' class='toggle-vis' id='executor-box-15'  data-column='15' column-type='executor'> Executor  JVMOnHeapMemory / JVMOffHeapMemory</div>" +
+        "<div id='executor_on_off_heap_execution_memory' class='executor-on-off-heap-execution-memory-checkbox-div'><input type='checkbox' class='toggle-vis' id='executor-box-16' data-column='16' column-type='executor'> Executor  OnHeapExecutionMemory / OffHeapExecutionMemory</div>" +
+        "<div id='executor_on_off_heap_storage_memory' class='executor-on-off-heap-storage-memory-checkbox-div'><input type='checkbox' class='toggle-vis' id='executor-box-17' data-column='17' column-type='executor'> Executor OnHeapStorageMemory / OffHeapStorageMemory</div>" +
+        "<div id='executor_direct_mapped_pool_memory' class='executor-direct-mapped-pool-memory-checkbox-div'><input type='checkbox' class='toggle-vis' id='executor-box-18' data-column='18' column-type='executor'> Executor DirectPoolMemory / MappedPoolMemory</div>" +
         "</div>");
 
     $('#scheduler_delay').attr("data-toggle", "tooltip")
@@ -472,13 +486,20 @@ $(document).ready(function () {
                              }
                          }
                     ],
+                    "columnDefs": [
+                        { "visible": false, "targets": 15 },
+                        { "visible": false, "targets": 16 },
+                        { "visible": false, "targets": 17 },
+                        { "visible": false, "targets": 18 }
+                    ],
+                    "deferRender": true,
                     "order": [[0, "asc"]],
                     "bAutoWidth": false,
                     "oLanguage": {
                         "sEmptyTable": "No data to show yet"
                     }
                 };
-                var executorSummaryTableSelector =
+                executorSummaryTableSelector =
                     $("#summary-executor-table").DataTable(executorSummaryConf);
                 $('#parent-container [data-toggle="tooltip"]').tooltip();
 
@@ -930,30 +951,39 @@ $(document).ready(function () {
                     var para = $(this).attr('data-column');
                     if (para == "0") {
                         var allColumns = taskTableSelector.columns(optionalColumns);
+                        var executorAllColumns = executorSummaryTableSelector.columns(executorOptionalColumns);
                         if ($(this).is(":checked")) {
                             $(".toggle-vis").prop('checked', true);
                             allColumns.visible(true);
+                            executorAllColumns.visible(true);
                             createDataTableForTaskSummaryMetricsTable(taskSummaryMetricsTableArray);
                         } else {
                             $(".toggle-vis").prop('checked', false);
                             allColumns.visible(false);
+                            executorAllColumns.visible(false);
                             var taskSummaryMetricsTableFilteredArray =
                                 taskSummaryMetricsTableArray.filter(row => row.checkboxId < 11);
                             createDataTableForTaskSummaryMetricsTable(taskSummaryMetricsTableFilteredArray);
                         }
                     } else {
-                        var column = taskTableSelector.column(para);
-                        // Toggle the visibility
-                        column.visible(!column.visible());
-                        var taskSummaryMetricsTableFilteredArray = [];
-                        if ($(this).is(":checked")) {
-                            taskSummaryMetricsTableCurrentStateArray.push(taskSummaryMetricsTableArray.filter(row => (row.checkboxId).toString() == para)[0]);
-                            taskSummaryMetricsTableFilteredArray = taskSummaryMetricsTableCurrentStateArray.slice();
+                        var columnType = $(this).attr("column-type");
+                        if(columnType == 'task') {
+                            var column = taskTableSelector.column(para);
+                            // Toggle the visibility
+                            column.visible(!column.visible());
+                            var taskSummaryMetricsTableFilteredArray = [];
+                            if ($(this).is(":checked")) {
+                                taskSummaryMetricsTableCurrentStateArray.push(taskSummaryMetricsTableArray.filter(row => (row.checkboxId).toString() == para)[0]);
+                                taskSummaryMetricsTableFilteredArray = taskSummaryMetricsTableCurrentStateArray.slice();
+                            } else {
+                                taskSummaryMetricsTableFilteredArray =
+                                    taskSummaryMetricsTableCurrentStateArray.filter(row => (row.checkboxId).toString() != para);
+                            }
+                            createDataTableForTaskSummaryMetricsTable(taskSummaryMetricsTableFilteredArray);
                         } else {
-                            taskSummaryMetricsTableFilteredArray =
-                                taskSummaryMetricsTableCurrentStateArray.filter(row => (row.checkboxId).toString() != para);
+                            var column = executorSummaryTableSelector.column(para);
+                            column.visible(!column.visible());
                         }
-                        createDataTableForTaskSummaryMetricsTable(taskSummaryMetricsTableFilteredArray);
                     }
                 });
 

--- a/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
@@ -454,7 +454,23 @@ $(document).ready(function () {
                             data : function (row, type) {
                                 return typeof row.diskBytesSpilled != 'undefined' ? formatBytes(row.diskBytesSpilled, type) : "";
                             }
-                        }
+                        },{
+                            data: function(row, type) {
+                                return formatBytes(row.jvmHeapMemory, type) + "/" + formatBytes(row.jvmOffHeapMemory, type);
+                            }
+                        },{
+                             data: function(row, type) {
+                                 return formatBytes(row.onHeapExecutionMemory, type) + "/" + formatBytes(row.offHeapExecutionMemory, type);
+                             }
+                         },{
+                             data: function(row, type) {
+                                 return formatBytes(row.onHeapStorageMemory, type) + "/" + formatBytes(row.offHeapStorageMemory, type);
+                             }
+                         },{
+                             data: function(row, type) {
+                                 return formatBytes(row.directPoolMemory, type) + "/" + formatBytes(row.mappedPoolMemory, type);
+                             }
+                         }
                     ],
                     "order": [[0, "asc"]],
                     "bAutoWidth": false,

--- a/core/src/main/resources/org/apache/spark/ui/static/stagespage-template.html
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagespage-template.html
@@ -59,6 +59,10 @@ limitations under the License.
                 <th><span id="executor-summary-shuffle-write">Shuffle Write Size / Records</span></th>
                 <th>Spill (Memory) </th>
                 <th>Spill (Disk) </th>
+                <th>JVMHeapMemory / JVMOffHeapMemory</th>
+                <th>OnHeapExecutionMemory / OffHeapExecutionMemory</th>
+                <th>OnHeapStorageMemory / OffHeapStorageMemory</th>
+                <th>DirectPoolMemory / MappedPoolMemory</th>
                 </tr>
             </thead>
             <tbody>

--- a/core/src/main/resources/org/apache/spark/ui/static/webui.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/webui.css
@@ -353,19 +353,7 @@ a.expandbutton {
   width: 180px;
 }
 
-.executor-jvm-om-off-heap-memory-checkbox-div {
-  width: 480px;
-}
-
-.executor-on-off-heap-execution-memory-checkbox-div {
-  width: 480px;
-}
-
-.executor-on-off-heap-storage-memory-checkbox-div {
-  width: 480px;
-}
-
-.executor-direct-mapped-pool-memory-checkbox-div {
+.executor-jvm-metrics-checkbox-div {
   width: 480px;
 }
 

--- a/core/src/main/resources/org/apache/spark/ui/static/webui.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/webui.css
@@ -353,6 +353,22 @@ a.expandbutton {
   width: 180px;
 }
 
+.executor-jvm-om-off-heap-memory-checkbox-div {
+  width: 480px;
+}
+
+.executor-on-off-heap-execution-memory-checkbox-div {
+  width: 480px;
+}
+
+.executor-on-off-heap-storage-memory-checkbox-div {
+  width: 480px;
+}
+
+.executor-direct-mapped-pool-memory-checkbox-div {
+  width: 480px;
+}
+
 #active-tasks-table th {
   border-top: 1px solid #dddddd;
   border-bottom: 1px solid #dddddd;

--- a/core/src/main/scala/org/apache/spark/status/LiveEntity.scala
+++ b/core/src/main/scala/org/apache/spark/status/LiveEntity.scala
@@ -347,6 +347,8 @@ private class LiveExecutorStageSummary(
 
   var metrics = createMetrics(default = 0L)
 
+  var executorMetrics = new ExecutorMetrics()
+
   override protected def doUpdate(): Any = {
     val info = new v1.ExecutorStageSummary(
       taskTime,
@@ -363,7 +365,16 @@ private class LiveExecutorStageSummary(
       metrics.shuffleWriteMetrics.recordsWritten,
       metrics.memoryBytesSpilled,
       metrics.diskBytesSpilled,
-      isBlacklisted)
+      isBlacklisted,
+      executorMetrics.getMetricValue("JVMHeapMemory"),
+      executorMetrics.getMetricValue("JVMOffHeapMemory"),
+      executorMetrics.getMetricValue("OnHeapExecutionMemory"),
+      executorMetrics.getMetricValue("OffHeapExecutionMemory"),
+      executorMetrics.getMetricValue("OnHeapStorageMemory"),
+      executorMetrics.getMetricValue("OffHeapStorageMemory"),
+      executorMetrics.getMetricValue("DirectPoolMemory"),
+      executorMetrics.getMetricValue("MappedPoolMemory")
+    )
     new ExecutorStageSummaryWrapper(stageId, attemptId, executorId, info)
   }
 

--- a/core/src/main/scala/org/apache/spark/status/api/v1/api.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/api.scala
@@ -77,7 +77,15 @@ class ExecutorStageSummary private[spark](
     val shuffleWriteRecords : Long,
     val memoryBytesSpilled : Long,
     val diskBytesSpilled : Long,
-    val isBlacklistedForStage: Boolean)
+    val isBlacklistedForStage: Boolean,
+    val jvmHeapMemory: Long,
+    val jvmOffHeapMemory: Long,
+    val onHeapExecutionMemory: Long,
+    val offHeapExecutionMemory: Long,
+    val onHeapStorageMemory: Long,
+    val offHeapStorageMemory: Long,
+    val directPoolMemory: Long,
+    val mappedPoolMemory: Long)
 
 class ExecutorSummary private[spark](
     val id: String,

--- a/core/src/test/resources/HistoryServerExpectations/blacklisting_for_stage_expectation.json
+++ b/core/src/test/resources/HistoryServerExpectations/blacklisting_for_stage_expectation.json
@@ -697,7 +697,15 @@
       "shuffleWriteRecords" : 0,
       "memoryBytesSpilled" : 0,
       "diskBytesSpilled" : 0,
-      "isBlacklistedForStage" : true
+      "isBlacklistedForStage" : true,
+      "jvmHeapMemory" : 0,
+      "jvmOffHeapMemory" : 0,
+      "onHeapExecutionMemory" : 0,
+      "offHeapExecutionMemory" : 0,
+      "onHeapStorageMemory" : 0,
+      "offHeapStorageMemory" : 0,
+      "directPoolMemory" : 0,
+      "mappedPoolMemory" : 0
     },
     "1" : {
       "taskTime" : 708,
@@ -714,7 +722,15 @@
       "shuffleWriteRecords" : 10,
       "memoryBytesSpilled" : 0,
       "diskBytesSpilled" : 0,
-      "isBlacklistedForStage" : false
+      "isBlacklistedForStage" : false,
+      "jvmHeapMemory" : 0,
+      "jvmOffHeapMemory" : 0,
+      "onHeapExecutionMemory" : 0,
+      "offHeapExecutionMemory" : 0,
+      "onHeapStorageMemory" : 0,
+      "offHeapStorageMemory" : 0,
+      "directPoolMemory" : 0,
+      "mappedPoolMemory" : 0
     }
   },
   "killedTasksSummary" : { }

--- a/core/src/test/resources/HistoryServerExpectations/blacklisting_node_for_stage_expectation.json
+++ b/core/src/test/resources/HistoryServerExpectations/blacklisting_node_for_stage_expectation.json
@@ -805,7 +805,15 @@
       "shuffleWriteRecords" : 0,
       "memoryBytesSpilled" : 0,
       "diskBytesSpilled" : 0,
-      "isBlacklistedForStage" : true
+      "isBlacklistedForStage" : true,
+      "jvmHeapMemory" : 0,
+      "jvmOffHeapMemory" : 0,
+      "onHeapExecutionMemory" : 0,
+      "offHeapExecutionMemory" : 0,
+      "onHeapStorageMemory" : 0,
+      "offHeapStorageMemory" : 0,
+      "directPoolMemory" : 0,
+      "mappedPoolMemory" : 0
     },
     "5" : {
       "taskTime" : 1579,
@@ -822,7 +830,15 @@
       "shuffleWriteRecords" : 0,
       "memoryBytesSpilled" : 0,
       "diskBytesSpilled" : 0,
-      "isBlacklistedForStage" : true
+      "isBlacklistedForStage" : true,
+      "jvmHeapMemory" : 0,
+      "jvmOffHeapMemory" : 0,
+      "onHeapExecutionMemory" : 0,
+      "offHeapExecutionMemory" : 0,
+      "onHeapStorageMemory" : 0,
+      "offHeapStorageMemory" : 0,
+      "directPoolMemory" : 0,
+      "mappedPoolMemory" : 0
     },
     "1" : {
       "taskTime" : 2411,
@@ -839,7 +855,15 @@
       "shuffleWriteRecords" : 12,
       "memoryBytesSpilled" : 0,
       "diskBytesSpilled" : 0,
-      "isBlacklistedForStage" : false
+      "isBlacklistedForStage" : false,
+      "jvmHeapMemory" : 0,
+      "jvmOffHeapMemory" : 0,
+      "onHeapExecutionMemory" : 0,
+      "offHeapExecutionMemory" : 0,
+      "onHeapStorageMemory" : 0,
+      "offHeapStorageMemory" : 0,
+      "directPoolMemory" : 0,
+      "mappedPoolMemory" : 0
     },
     "2" : {
       "taskTime" : 2446,
@@ -856,7 +880,15 @@
       "shuffleWriteRecords" : 15,
       "memoryBytesSpilled" : 0,
       "diskBytesSpilled" : 0,
-      "isBlacklistedForStage" : false
+      "isBlacklistedForStage" : false,
+      "jvmHeapMemory" : 0,
+      "jvmOffHeapMemory" : 0,
+      "onHeapExecutionMemory" : 0,
+      "offHeapExecutionMemory" : 0,
+      "onHeapStorageMemory" : 0,
+      "offHeapStorageMemory" : 0,
+      "directPoolMemory" : 0,
+      "mappedPoolMemory" : 0
     },
     "3" : {
       "taskTime" : 1774,
@@ -873,7 +905,15 @@
       "shuffleWriteRecords" : 3,
       "memoryBytesSpilled" : 0,
       "diskBytesSpilled" : 0,
-      "isBlacklistedForStage" : true
+      "isBlacklistedForStage" : true,
+      "jvmHeapMemory" : 0,
+      "jvmOffHeapMemory" : 0,
+      "onHeapExecutionMemory" : 0,
+      "offHeapExecutionMemory" : 0,
+      "onHeapStorageMemory" : 0,
+      "offHeapStorageMemory" : 0,
+      "directPoolMemory" : 0,
+      "mappedPoolMemory" : 0
     }
   },
   "killedTasksSummary" : { }

--- a/core/src/test/resources/HistoryServerExpectations/one_stage_attempt_json_expectation.json
+++ b/core/src/test/resources/HistoryServerExpectations/one_stage_attempt_json_expectation.json
@@ -459,7 +459,15 @@
       "shuffleWriteRecords" : 0,
       "memoryBytesSpilled" : 0,
       "diskBytesSpilled" : 0,
-      "isBlacklistedForStage" : false
+      "isBlacklistedForStage" : false,
+      "jvmHeapMemory" : 0,
+      "jvmOffHeapMemory" : 0,
+      "onHeapExecutionMemory" : 0,
+      "offHeapExecutionMemory" : 0,
+      "onHeapStorageMemory" : 0,
+      "offHeapStorageMemory" : 0,
+      "directPoolMemory" : 0,
+      "mappedPoolMemory" : 0
     }
   },
   "killedTasksSummary" : { }

--- a/core/src/test/resources/HistoryServerExpectations/one_stage_json_expectation.json
+++ b/core/src/test/resources/HistoryServerExpectations/one_stage_json_expectation.json
@@ -459,7 +459,15 @@
       "shuffleWriteRecords" : 0,
       "memoryBytesSpilled" : 0,
       "diskBytesSpilled" : 0,
-      "isBlacklistedForStage" : false
+      "isBlacklistedForStage" : false,
+      "jvmHeapMemory" : 0,
+      "jvmOffHeapMemory" : 0,
+      "onHeapExecutionMemory" : 0,
+      "offHeapExecutionMemory" : 0,
+      "onHeapStorageMemory" : 0,
+      "offHeapStorageMemory" : 0,
+      "directPoolMemory" : 0,
+      "mappedPoolMemory" : 0
     }
   },
   "killedTasksSummary" : { }

--- a/core/src/test/resources/HistoryServerExpectations/stage_with_accumulable_json_expectation.json
+++ b/core/src/test/resources/HistoryServerExpectations/stage_with_accumulable_json_expectation.json
@@ -503,7 +503,15 @@
       "shuffleWriteRecords" : 0,
       "memoryBytesSpilled" : 0,
       "diskBytesSpilled" : 0,
-      "isBlacklistedForStage" : false
+      "isBlacklistedForStage" : false,
+      "jvmHeapMemory" : 0,
+      "jvmOffHeapMemory" : 0,
+      "onHeapExecutionMemory" : 0,
+      "offHeapExecutionMemory" : 0,
+      "onHeapStorageMemory" : 0,
+      "offHeapStorageMemory" : 0,
+      "directPoolMemory" : 0,
+      "mappedPoolMemory" : 0
     }
   },
   "killedTasksSummary" : { }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Expose executor memory metrics at the stage level, in the Stages tab,
Current like below, and I am not sure which column we will truly need.

![image](https://user-images.githubusercontent.com/46485123/80859575-a0db5a80-8c94-11ea-88eb-9339d01ce2ef.png)

![image](https://user-images.githubusercontent.com/46485123/80859579-a8026880-8c94-11ea-8b1b-8c978d443d4b.png)

![image](https://user-images.githubusercontent.com/46485123/80859660-0b8c9600-8c95-11ea-8bc4-d519535c48dd.png)


### Why are the changes needed?
User can know executor jvm usage more directly in SparkUI


### Does this PR introduce any user-facing change?
User can know executor jvm usage more directly in SparkUI


### How was this patch tested?
Manual Tested
