### PR TITLE
[SPARK-25556][SPARK-17636][SPARK-31026][SPARK-31060][FOLLOWUP][3.0] Fix build error due to conf version

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1864,7 +1864,6 @@ object SQLConf {
         "containing `dots` to data sources. Currently, Parquet implements both optimizations " +
         "while ORC only supports predicates for names containing `dots`. The other data sources" +
         "don't support this feature yet.")
-      .version("3.0.0")
       .booleanConf
       .createWithDefault(true)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This fixes the build error.

### Why are the changes needed?

`branch-3.0` doesn't have conf version.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Passing the GitHub Action is enough.
