### PR TITLE
[SPARK-31142][PYSPARK]Remove useless conf set in pyspark context

### DIFF
--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -181,11 +181,6 @@ class SparkContext(object):
         self.appName = self._conf.get("spark.app.name")
         self.sparkHome = self._conf.get("spark.home", None)
 
-        for (k, v) in self._conf.getAll():
-            if k.startswith("spark.executorEnv."):
-                varName = k[len("spark.executorEnv."):]
-                self.environment[varName] = v
-
         self.environment["PYTHONHASHSEED"] = os.environ.get("PYTHONHASHSEED", "0")
 
         # Create the Java SparkContext through Py4J


### PR DESCRIPTION
 ### What changes were proposed in this pull request?
In Pyspark/context.py, we extract the configuration of the "spark.executorEnv" prefix from conf and put it in env. But in PythonWorkerFactory, we have already obtained these environment variables from ProgressBuilder, thus we do not need the extra copy.
In addition, in some special environment deployments, user-configured environment variables such as "spark.executorEnv.Path=/usr/lib:$PATH" will be automatically parsed as actual machine confs. If we still directly copy and overwrite it, the configuration will be a wrong config.

### Does this PR introduce any user-facing change?
No


### How was this patch tested?
run suite tests