### PR TITLE
[SPARK-31288][SQL] Remove `getRawTable` in `alterPartitions`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -153,10 +153,12 @@ class InMemoryCatalog(
   }
 
   override def alterDatabase(dbDefinition: CatalogDatabase): Unit = synchronized {
+    requireDbExists(dbDefinition.name)
     catalog(dbDefinition.name).db = dbDefinition
   }
 
   override def getDatabase(db: String): CatalogDatabase = synchronized {
+    requireDbExists(db)
     catalog(db).db
   }
 
@@ -183,6 +185,7 @@ class InMemoryCatalog(
       ignoreIfExists: Boolean): Unit = synchronized {
     assert(tableDefinition.identifier.database.isDefined)
     val db = tableDefinition.identifier.database.get
+    requireDbExists(db)
     val table = tableDefinition.identifier.table
     if (tableExists(db, table)) {
       if (!ignoreIfExists) {
@@ -223,6 +226,7 @@ class InMemoryCatalog(
       table: String,
       ignoreIfNotExists: Boolean,
       purge: Boolean): Unit = synchronized {
+    requireDbExists(db)
     if (tableExists(db, table)) {
       val tableMeta = getTable(db, table)
       if (tableMeta.tableType == CatalogTableType.MANAGED) {
@@ -264,6 +268,8 @@ class InMemoryCatalog(
       db: String,
       oldName: String,
       newName: String): Unit = synchronized {
+    requireTableExists(db, oldName)
+    requireTableNotExists(db, newName)
     val oldDesc = catalog(db).tables(oldName)
     oldDesc.table = oldDesc.table.copy(identifier = TableIdentifier(newName, Some(db)))
 
@@ -291,6 +297,7 @@ class InMemoryCatalog(
   override def alterTable(tableDefinition: CatalogTable): Unit = synchronized {
     assert(tableDefinition.identifier.database.isDefined)
     val db = tableDefinition.identifier.database.get
+    requireTableExists(db, tableDefinition.identifier.table)
     val updatedProperties = tableDefinition.properties.filter(kv => kv._1 != "comment")
     val newTableDefinition = tableDefinition.copy(properties = updatedProperties)
     catalog(db).tables(tableDefinition.identifier.table).table = newTableDefinition
@@ -300,6 +307,7 @@ class InMemoryCatalog(
       db: String,
       table: String,
       newDataSchema: StructType): Unit = synchronized {
+    requireTableExists(db, table)
     val origTable = catalog(db).tables(table).table
     val newSchema = StructType(newDataSchema ++ origTable.partitionSchema)
     catalog(db).tables(table).table = origTable.copy(schema = newSchema)
@@ -309,23 +317,28 @@ class InMemoryCatalog(
       db: String,
       table: String,
       stats: Option[CatalogStatistics]): Unit = synchronized {
+    requireTableExists(db, table)
     val origTable = catalog(db).tables(table).table
     catalog(db).tables(table).table = origTable.copy(stats = stats)
   }
 
   override def getTable(db: String, table: String): CatalogTable = synchronized {
+    requireTableExists(db, table)
     catalog(db).tables(table).table
   }
 
   override def getTablesByName(db: String, tables: Seq[String]): Seq[CatalogTable] = {
+    requireDbExists(db)
     tables.flatMap(catalog(db).tables.get).map(_.table)
   }
 
   override def tableExists(db: String, table: String): Boolean = synchronized {
+    requireDbExists(db)
     catalog(db).tables.contains(table)
   }
 
   override def listTables(db: String): Seq[String] = synchronized {
+    requireDbExists(db)
     catalog(db).tables.keySet.toSeq.sorted
   }
 
@@ -372,6 +385,7 @@ class InMemoryCatalog(
       table: String,
       parts: Seq[CatalogTablePartition],
       ignoreIfExists: Boolean): Unit = synchronized {
+    requireTableExists(db, table)
     val existingParts = catalog(db).tables(table).partitions
     if (!ignoreIfExists) {
       val dupSpecs = parts.collect { case p if existingParts.contains(p.spec) => p.spec }
@@ -412,6 +426,7 @@ class InMemoryCatalog(
       ignoreIfNotExists: Boolean,
       purge: Boolean,
       retainData: Boolean): Unit = synchronized {
+    requireTableExists(db, table)
     val existingParts = catalog(db).tables(table).partitions
     if (!ignoreIfNotExists) {
       val missingSpecs = partSpecs.collect { case s if !existingParts.contains(s) => s }
@@ -529,6 +544,8 @@ class InMemoryCatalog(
       db: String,
       table: String,
       partialSpec: Option[TablePartitionSpec] = None): Seq[CatalogTablePartition] = synchronized {
+    requireTableExists(db, table)
+
     partialSpec match {
       case None => catalog(db).tables(table).partitions.values.toSeq
       case Some(partial) =>
@@ -553,6 +570,7 @@ class InMemoryCatalog(
   // --------------------------------------------------------------------------
 
   override def createFunction(db: String, func: CatalogFunction): Unit = synchronized {
+    requireDbExists(db)
     requireFunctionNotExists(db, func.identifier.funcName)
     catalog(db).functions.put(func.identifier.funcName, func)
   }
@@ -563,6 +581,7 @@ class InMemoryCatalog(
   }
 
   override def alterFunction(db: String, func: CatalogFunction): Unit = synchronized {
+    requireDbExists(db)
     requireFunctionExists(db, func.identifier.funcName)
     catalog(db).functions.put(func.identifier.funcName, func)
   }
@@ -584,10 +603,12 @@ class InMemoryCatalog(
   }
 
   override def functionExists(db: String, funcName: String): Boolean = synchronized {
+    requireDbExists(db)
     catalog(db).functions.contains(funcName)
   }
 
   override def listFunctions(db: String, pattern: String): Seq[String] = synchronized {
+    requireDbExists(db)
     StringUtils.filterPattern(catalog(db).functions.keysIterator.toSeq, pattern)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -219,8 +219,9 @@ case class DropTableCommand(
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val catalog = sparkSession.sessionState.catalog
     val isTempView = catalog.isTemporaryTable(tableName)
+    lazy val isTableExist = catalog.tableExists(tableName)
 
-    if (!isTempView && catalog.tableExists(tableName)) {
+    if (!isTempView && isTableExist) {
       // If the command DROP VIEW is to drop a table or DROP TABLE is to drop a view
       // issue an exception.
       catalog.getTableMetadata(tableName).tableType match {
@@ -234,7 +235,7 @@ case class DropTableCommand(
       }
     }
 
-    if (isTempView || catalog.tableExists(tableName)) {
+    if (isTempView || isTableExist) {
       try {
         sparkSession.sharedState.cacheManager.uncacheQuery(
           sparkSession.table(tableName), cascade = !isTempView)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -219,9 +219,8 @@ case class DropTableCommand(
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val catalog = sparkSession.sessionState.catalog
     val isTempView = catalog.isTemporaryTable(tableName)
-    val isTableExist = catalog.tableExists(tableName)
 
-    if (!isTempView && isTableExist) {
+    if (!isTempView && catalog.tableExists(tableName)) {
       // If the command DROP VIEW is to drop a table or DROP TABLE is to drop a view
       // issue an exception.
       catalog.getTableMetadata(tableName).tableType match {
@@ -235,7 +234,7 @@ case class DropTableCommand(
       }
     }
 
-    if (isTempView || isTableExist) {
+    if (isTempView || catalog.tableExists(tableName)) {
       try {
         sparkSession.sharedState.cacheManager.uncacheQuery(
           sparkSession.table(tableName), cascade = !isTempView)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -219,8 +219,9 @@ case class DropTableCommand(
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val catalog = sparkSession.sessionState.catalog
     val isTempView = catalog.isTemporaryTable(tableName)
+    val isTableExist = catalog.tableExists(tableName)
 
-    if (!isTempView && catalog.tableExists(tableName)) {
+    if (!isTempView && isTableExist) {
       // If the command DROP VIEW is to drop a table or DROP TABLE is to drop a view
       // issue an exception.
       catalog.getTableMetadata(tableName).tableType match {
@@ -234,7 +235,7 @@ case class DropTableCommand(
       }
     }
 
-    if (isTempView || catalog.tableExists(tableName)) {
+    if (isTempView || isTableExist) {
       try {
         sparkSession.sharedState.cacheManager.uncacheQuery(
           sparkSession.table(tableName), cascade = !isTempView)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -243,7 +243,6 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     assert(tableDefinition.identifier.database.isDefined)
     val db = tableDefinition.identifier.database.get
     val table = tableDefinition.identifier.table
-    requireDbExists(db)
     verifyTableProperties(tableDefinition)
     verifyDataSchema(
       tableDefinition.identifier, tableDefinition.tableType, tableDefinition.dataSchema)
@@ -512,7 +511,6 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
       table: String,
       ignoreIfNotExists: Boolean,
       purge: Boolean): Unit = withClient {
-    requireDbExists(db)
     client.dropTable(db, table, ignoreIfNotExists, purge)
   }
 
@@ -570,7 +568,6 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
   override def alterTable(tableDefinition: CatalogTable): Unit = withClient {
     assert(tableDefinition.identifier.database.isDefined)
     val db = tableDefinition.identifier.database.get
-    requireTableExists(db, tableDefinition.identifier.table)
     verifyTableProperties(tableDefinition)
 
     if (tableDefinition.tableType == VIEW) {
@@ -667,7 +664,6 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
       db: String,
       table: String,
       newDataSchema: StructType): Unit = withClient {
-    requireTableExists(db, table)
     val oldTable = getTable(db, table)
     verifyDataSchema(oldTable.identifier, oldTable.tableType, newDataSchema)
     val schemaProps =
@@ -699,7 +695,6 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
       db: String,
       table: String,
       stats: Option[CatalogStatistics]): Unit = withClient {
-    requireTableExists(db, table)
     val rawTable = getRawTable(db, table)
 
     // convert table statistics to properties so that we can persist them through hive client
@@ -852,12 +847,10 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
   }
 
   override def listTables(db: String): Seq[String] = withClient {
-    requireDbExists(db)
     client.listTables(db)
   }
 
   override def listTables(db: String, pattern: String): Seq[String] = withClient {
-    requireDbExists(db)
     client.listTables(db, pattern)
   }
 
@@ -867,7 +860,6 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
       loadPath: String,
       isOverwrite: Boolean,
       isSrcLocal: Boolean): Unit = withClient {
-    requireTableExists(db, table)
     client.loadTable(
       loadPath,
       s"$db.$table",
@@ -883,8 +875,6 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
       isOverwrite: Boolean,
       inheritTableSpecs: Boolean,
       isSrcLocal: Boolean): Unit = withClient {
-    requireTableExists(db, table)
-
     val orderedPartitionSpec = new util.LinkedHashMap[String, String]()
     getTable(db, table).partitionColumnNames.foreach { colName =>
       // Hive metastore is not case preserving and keeps partition columns with lower cased names,
@@ -978,8 +968,6 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
       table: String,
       parts: Seq[CatalogTablePartition],
       ignoreIfExists: Boolean): Unit = withClient {
-    requireTableExists(db, table)
-
     val tableMeta = getTable(db, table)
     val partitionColumnNames = tableMeta.partitionColumnNames
     val tablePath = new Path(tableMeta.location)
@@ -1004,7 +992,6 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
       ignoreIfNotExists: Boolean,
       purge: Boolean,
       retainData: Boolean): Unit = withClient {
-    requireTableExists(db, table)
     client.dropPartitions(
       db, table, parts.map(lowerCasePartitionSpec), ignoreIfNotExists, purge, retainData)
   }
@@ -1142,9 +1129,6 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
       table: String,
       newParts: Seq[CatalogTablePartition]): Unit = withClient {
     val lowerCasedParts = newParts.map(p => p.copy(spec = lowerCasePartitionSpec(p.spec)))
-
-    val rawTable = getRawTable(db, table)
-
     // convert partition statistics to properties so that we can persist them through hive api
     val withStatsProps = lowerCasedParts.map { p =>
       if (p.stats.isDefined) {
@@ -1273,7 +1257,6 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
   override def createFunction(
       db: String,
       funcDefinition: CatalogFunction): Unit = withClient {
-    requireDbExists(db)
     // Hive's metastore is case insensitive. However, Hive's createFunction does
     // not normalize the function name (unlike the getFunction part). So,
     // we are normalizing the function name.
@@ -1290,7 +1273,6 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
 
   override def alterFunction(
       db: String, funcDefinition: CatalogFunction): Unit = withClient {
-    requireDbExists(db)
     val functionName = funcDefinition.identifier.funcName.toLowerCase(Locale.ROOT)
     requireFunctionExists(db, functionName)
     val functionIdentifier = funcDefinition.identifier.copy(funcName = functionName)
@@ -1312,12 +1294,10 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
   }
 
   override def functionExists(db: String, funcName: String): Boolean = withClient {
-    requireDbExists(db)
     client.functionExists(db, funcName)
   }
 
   override def listFunctions(db: String, pattern: String): Seq[String] = withClient {
-    requireDbExists(db)
     client.listFunctions(db, pattern)
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR (SPARK-31288) removes `getRawTable` from `alterPartitions`.

### Why are the changes needed?
Reduce calls to Hive Metastore.


### Does this PR introduce any user-facing change?
No.


### How was this patch tested?
Exist test.
