### PR TITLE
[SPARK-31291][SQL][TEST] SQLQueryTestSuite: Sharing test data and test tables among multiple test cases

### DIFF
--- a/sql/core/src/test/resources/sql-tests/results/limit.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/limit.sql.out
@@ -7,8 +7,8 @@ SELECT * FROM testdata LIMIT 2
 -- !query schema
 struct<key:int,value:string>
 -- !query output
-51	51
-52	52
+1	1
+2	2
 
 
 -- !query
@@ -34,9 +34,9 @@ SELECT * FROM testdata LIMIT 2 + 1
 -- !query schema
 struct<key:int,value:string>
 -- !query output
-51	51
-52	52
-53	53
+1	1
+2	2
+3	3
 
 
 -- !query
@@ -44,7 +44,7 @@ SELECT * FROM testdata LIMIT CAST(1 AS int)
 -- !query schema
 struct<key:int,value:string>
 -- !query output
-51	51
+1	1
 
 
 -- !query
@@ -70,7 +70,7 @@ SELECT * FROM testdata LIMIT CAST(1 AS INT)
 -- !query schema
 struct<key:int,value:string>
 -- !query output
-51	51
+1	1
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/limit.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/limit.sql.out
@@ -7,8 +7,8 @@ SELECT * FROM testdata LIMIT 2
 -- !query schema
 struct<key:int,value:string>
 -- !query output
-1	1
-2	2
+51	51
+52	52
 
 
 -- !query
@@ -34,9 +34,9 @@ SELECT * FROM testdata LIMIT 2 + 1
 -- !query schema
 struct<key:int,value:string>
 -- !query output
-1	1
-2	2
-3	3
+51	51
+52	52
+53	53
 
 
 -- !query
@@ -44,7 +44,7 @@ SELECT * FROM testdata LIMIT CAST(1 AS int)
 -- !query schema
 struct<key:int,value:string>
 -- !query output
-1	1
+51	51
 
 
 -- !query
@@ -70,7 +70,7 @@ SELECT * FROM testdata LIMIT CAST(1 AS INT)
 -- !query schema
 struct<key:int,value:string>
 -- !query output
-1	1
+51	51
 
 
 -- !query
@@ -88,7 +88,7 @@ SELECT * FROM testdata LIMIT key > 3
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-The limit expression must evaluate to a constant value, but got (testdata.`key` > 3);
+The limit expression must evaluate to a constant value, but got (spark_catalog.default.testdata.`key` > 3);
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/show-tables.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/show-tables.sql.out
@@ -63,15 +63,9 @@ SHOW TABLES
 -- !query schema
 struct<database:string,tableName:string,isTemporary:boolean>
 -- !query output
-aggtest
-arraydata
-mapdata
-onek
 show_t1
 show_t2
 show_t3
-tenk1
-testdata
 
 
 -- !query
@@ -79,15 +73,9 @@ SHOW TABLES IN showdb
 -- !query schema
 struct<database:string,tableName:string,isTemporary:boolean>
 -- !query output
-aggtest
-arraydata
-mapdata
-onek
 show_t1
 show_t2
 show_t3
-tenk1
-testdata
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/show-views.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/show-views.sql.out
@@ -63,12 +63,6 @@ SHOW VIEWS
 -- !query schema
 struct<namespace:string,viewName:string,isTemporary:boolean>
 -- !query output
-aggtest
-arraydata
-mapdata
-onek
-tenk1
-testdata
 view_1
 view_2
 view_4
@@ -79,12 +73,6 @@ SHOW VIEWS FROM showdb
 -- !query schema
 struct<namespace:string,viewName:string,isTemporary:boolean>
 -- !query output
-aggtest
-arraydata
-mapdata
-onek
-tenk1
-testdata
 view_1
 view_2
 view_4
@@ -95,12 +83,6 @@ SHOW VIEWS IN showdb
 -- !query schema
 struct<namespace:string,viewName:string,isTemporary:boolean>
 -- !query output
-aggtest
-arraydata
-mapdata
-onek
-tenk1
-testdata
 view_1
 view_2
 view_4
@@ -111,12 +93,6 @@ SHOW VIEWS IN global_temp
 -- !query schema
 struct<namespace:string,viewName:string,isTemporary:boolean>
 -- !query output
-aggtest
-arraydata
-mapdata
-onek
-tenk1
-testdata
 view_3
 view_4
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -575,6 +575,7 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession {
     import session.implicits._
 
     (1 to 100).map(i => (i, i.toString)).toDF("key", "value")
+      .repartition(1)
       .write
       .format("parquet")
       .saveAsTable("testdata")

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -571,7 +571,7 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession {
   }
 
   /** Load built-in test tables into the SparkSession. */
-  private def loadTestData(session: SparkSession): Unit = {
+  private def createTestTables(session: SparkSession): Unit = {
     import session.implicits._
 
     (1 to 100).map(i => (i, i.toString)).toDF("key", "value")
@@ -663,7 +663,7 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession {
       .saveAsTable("tenk1")
   }
 
-  private def unloadTestData(session: SparkSession): Unit = {
+  private def removeTestTables(session: SparkSession): Unit = {
     session.sql("DROP TABLE IF EXISTS testdata")
     session.sql("DROP TABLE IF EXISTS arraydata")
     session.sql("DROP TABLE IF EXISTS mapdata")
@@ -677,7 +677,7 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    loadTestData(spark)
+    createTestTables(spark)
     // Timezone is fixed to America/Los_Angeles for those timezone sensitive tests (timestamp_*)
     TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"))
     // Add Locale setting
@@ -691,7 +691,7 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession {
     try {
       TimeZone.setDefault(originalTimeZone)
       Locale.setDefault(originalLocale)
-      unloadTestData(spark)
+      removeTestTables(spark)
 
       // For debugging dump some statistics about how much time was spent in various optimizer rules
       logWarning(RuleExecutor.dumpTimeSpent())


### PR DESCRIPTION
### What changes were proposed in this pull request?
`SQLQueryTestSuite` spend 35 minutes time to test.
I've listed the 10 test cases that took the longest time in the `SQL` module below.

Class | Spend time  ↑ | Failure | Skip | Pass | Total test case
-- | -- | -- | -- | -- | --
SQLQueryTestSuite | 35 minutes | 0 | 1 | 230 | 231
TPCDSQuerySuite | 3 minutes 8 seconds | 0 | 0 | 156 | 156
SQLQuerySuite | 2 minutes 52 seconds | 0 | 0 | 185 | 185
DynamicPartitionPruningSuiteAEOff | 1 minutes 52 seconds | 0 | 0 | 22 | 22
DataFrameFunctionsSuite | 1 minutes 37 seconds | 0 | 0 | 102 | 102
DynamicPartitionPruningSuiteAEOn | 1 minutes 24 seconds | 0 | 0 | 22 | 22
DataFrameSuite | 1 minutes 14 seconds | 0 | 2 | 157 | 159
SubquerySuite | 1 minutes 12 seconds | 0 | 1 | 70 | 71
SingleLevelAggregateHashMapSuite | 1 minutes 1 seconds | 0 | 0 | 50 | 50
DataFrameAggregateSuite | 59 seconds | 0 | 0 | 50 | 50

I checked the code of `SQLQueryTestSuite` and found `SQLQueryTestSuite` load test data repeatedly.
This PR will improve the performance of `SQLQueryTestSuite`.

The total time run `SQLQueryTestSuite` before and after this PR show below.
Before
No | Time
-- | --
1 | 20 minutes, 22 seconds
2 | 23 minutes, 21 seconds
3 | 21 minutes, 19 seconds
4 | 22 minutes, 26 seconds
5 | 20 minutes, 8 seconds

After
No | Time
-- | --
1 | 20 minutes, 52 seconds
2 | 20 minutes, 47 seconds
3 | 20 minutes, 7 seconds
4 | 21 minutes, 10 seconds
5 | 20 minutes, 4 seconds




### Why are the changes needed?
Improve the performance of `SQLQueryTestSuite`.


### Does this PR introduce any user-facing change?
'No'.


### How was this patch tested?
Jenkins test
