### PR TITLE
[MINOR][CORE] Remove two unused variables in LiveListenerBus

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/LiveListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/LiveListenerBus.scala
@@ -54,12 +54,6 @@ private[spark] class LiveListenerBus(conf: SparkConf) {
   // Indicate if `stop()` is called
   private val stopped = new AtomicBoolean(false)
 
-  /** A counter for dropped events. It will be reset every time we log it. */
-  private val droppedEventsCounter = new AtomicLong(0L)
-
-  /** When `droppedEventsCounter` was logged last time in milliseconds. */
-  @volatile private var lastReportTimestamp = 0L
-
   private val queues = new CopyOnWriteArrayList[AsyncEventQueue]()
 
   // Visible for testing.


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR removes two unused variables in `LiveListenerBus`. These two variables have moved  to [AsyncEventQueue.scala#L67-L71](https://github.com/apache/spark/blob/5b873420b039f61b85bf349443eb830556fab339/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala#L67-L71)

### Why are the changes needed?
Removes unused variables.


### Does this PR introduce any user-facing change?
No.


### How was this patch tested?
Exist test.

