### PR TITLE
[SPARK-31265][YARN] Add -XX:MaxDirectMemorySize jvm options in yarn mode

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -886,7 +886,10 @@ private[spark] class Client(
     var prefixEnv: Option[String] = None
 
     // Add Xmx for AM memory
-    javaOpts += "-Xmx" + amMemory + "m"
+    javaOpts += s"-Xmx${amMemory}m"
+    if (isClusterMode) {
+      javaOpts += s"-XX:MaxDirectMemorySize=${amMemoryOverhead}m"
+    }
 
     val tmpDir = new Path(Environment.PWD.$$(), YarnConfiguration.DEFAULT_CONTAINER_TEMP_DIR)
     javaOpts += "-Djava.io.tmpdir=" + tmpDir

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
@@ -39,6 +39,7 @@ import org.apache.hadoop.yarn.util.Records
 import org.apache.spark.{SecurityManager, SparkConf, SparkException}
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
+import org.apache.spark.internal.config.Python._
 import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.resource.ResourceProfile
 import org.apache.spark.util.Utils


### PR DESCRIPTION
### What changes were proposed in this pull request?
Current memory composition `amMemory` + `amMemoryOverhead`
```
val capability = Records.newRecord(classOf[Resource])
capability.setMemory(amMemory + amMemoryOverhead)
capability.setVirtualCores(amCores)
if (amResources.nonEmpty) {
 ResourceRequestHelper.setResourceRequests(amResources, capability)
}
logDebug(s"Created resource capability for AM request: $capability")

...

 // Add Xmx for AM memory 
javaOpts += "-Xmx" + amMemory + "m"
```
It is possible that the physical memory of the container exceeds the limit and is killed by yarn.
I suggest setting `-XX:MaxDirectMemorySize` here
```
// Add Xmx for AM memory
 javaOpts += s"-Xmx${amMemory}m"
if (isClusterMode) {
   javaOpts += s"-XX:MaxDirectMemorySize=${amMemoryOverhead}m"
 }
```


### How was this patch tested?
Tested by verifying JVM parameters in the following cases:
- client and cluster mode