### PR TITLE
[SPARK-31305][SQL][DOCS] Add a page to list all commands in SQL Reference

### DIFF
--- a/docs/_data/menu-sql.yaml
+++ b/docs/_data/menu-sql.yaml
@@ -123,6 +123,8 @@
               url: sql-ref-syntax-ddl-truncate-table.html
             - text: REPAIR TABLE
               url: sql-ref-syntax-ddl-repair-table.html
+            - text: USE DATABASE
+              url: sql-ref-syntax-qry-select-usedb.html
         - text: Data Manipulation Statements
           url: sql-ref-syntax-dml.html
           subitems:
@@ -152,8 +154,6 @@
                   url: sql-ref-syntax-qry-select-distribute-by.html
                 - text: LIMIT Clause 
                   url: sql-ref-syntax-qry-select-limit.html
-                - text: USE database
-                  url: sql-ref-syntax-qry-select-usedb.html
             - text: EXPLAIN
               url: sql-ref-syntax-qry-explain.html
         - text: Auxiliary Statements

--- a/docs/sql-ref-syntax-ddl.md
+++ b/docs/sql-ref-syntax-ddl.md
@@ -36,3 +36,4 @@ Data Definition Statements are used to create or modify the structure of databas
 - [DROP VIEW](sql-ref-syntax-ddl-drop-view.html)
 - [TRUNCATE TABLE](sql-ref-syntax-ddl-truncate-table.html)
 - [REPAIR TABLE](sql-ref-syntax-ddl-repair-table.html)
+- [USE DATABASE](sql-ref-syntax-qry-select-usedb.html)

--- a/docs/sql-ref-syntax.md
+++ b/docs/sql-ref-syntax.md
@@ -19,4 +19,64 @@ license: |
   limitations under the License.
 ---
 
-Spark SQL is Apache Spark's module for working with structured data. The SQL Syntax section describes the SQL syntax in detail along with usage examples when applicable.
+Spark SQL is Apache Spark's module for working with structured data. The SQL Syntax section describes the SQL syntax in detail along with usage examples when applicable. This document provides a list of Data Definition and Data Manipulation Statements, as well as Data Retrieval and Auxiliary Statements.
+
+### Data Definition Statements
+- [ALTER DATABASE](sql-ref-syntax-ddl-alter-database.html)
+- [ALTER TABLE](sql-ref-syntax-ddl-alter-table.html)
+- [ALTER VIEW](sql-ref-syntax-ddl-alter-view.html)
+- [CREATE DATABASE](sql-ref-syntax-ddl-create-database.html)
+- [CREATE FUNCTION](sql-ref-syntax-ddl-create-function.html)
+- [CREATE TABLE](sql-ref-syntax-ddl-create-table.html)
+- [CREATE VIEW](sql-ref-syntax-ddl-create-view.html)
+- [DROP DATABASE](sql-ref-syntax-ddl-drop-database.html)
+- [DROP FUNCTION](sql-ref-syntax-ddl-drop-function.html)
+- [DROP TABLE](sql-ref-syntax-ddl-drop-table.html)
+- [DROP VIEW](sql-ref-syntax-ddl-drop-view.html)
+- [REPAIR TABLE](sql-ref-syntax-ddl-repair-table.html)
+- [TRUNCATE TABLE](sql-ref-syntax-ddl-truncate-table.html)
+- [USE DATABASE](sql-ref-syntax-qry-select-usedb.html)
+
+### Data Manipulation Statements
+- [INSERT INTO](sql-ref-syntax-dml-insert-into.html)
+- [INSERT OVERWRITE](sql-ref-syntax-dml-insert-overwrite-table.html)
+- [INSERT OVERWRITE DIRECTORY](sql-ref-syntax-dml-insert-overwrite-directory.html)
+- [INSERT OVERWRITE DIRECTORY with Hive format](sql-ref-syntax-dml-insert-overwrite-directory-hive.html)
+- [LOAD](sql-ref-syntax-dml-load.html)
+
+### Data Retrieval Statements
+- [CLUSTER BY Clause](sql-ref-syntax-qry-select-clusterby.html)
+- [DISTRIBUTE BY Clause](sql-ref-syntax-qry-select-distribute-by.html)
+- [EXPLAIN](sql-ref-syntax-qry-explain.html)
+- [GROUP BY Clause](sql-ref-syntax-qry-select-groupby.html)
+- [HAVING Clause](sql-ref-syntax-qry-select-having.html)
+- [LIMIT Clause](sql-ref-syntax-qry-select-limit.html)
+- [ORDER BY Clause](sql-ref-syntax-qry-select-orderby.html)
+- [SORT BY Clause](sql-ref-syntax-qry-select-sortby.html)
+- [WHERE Clause](sql-ref-syntax-qry-select-where.html)
+
+### Auxiliary Statements
+- [ADD FILE](sql-ref-syntax-aux-resource-mgmt-add-file.html)
+- [ADD JAR](sql-ref-syntax-aux-resource-mgmt-add-jar.html)
+- [ANALYZE TABLE](sql-ref-syntax-aux-analyze-table.html)
+- [CACHE TABLE](sql-ref-syntax-aux-cache-cache-table.html)
+- [CLEAR CACHE](sql-ref-syntax-aux-cache-clear-cache.html)
+- [DESCRIBE DATABASE](sql-ref-syntax-aux-describe-database.html)
+- [DESCRIBE FUNCTION](sql-ref-syntax-aux-describe-function.html)
+- [DESCRIBE QUERY](sql-ref-syntax-aux-describe-query.html)
+- [DESCRIBE TABLE](sql-ref-syntax-aux-describe-table.html)
+- [LIST FILE](sql-ref-syntax-aux-resource-mgmt-list-file.html)
+- [LIST JAR](sql-ref-syntax-aux-resource-mgmt-list-jar.html)
+- [REFRESH](sql-ref-syntax-aux-cache-refresh.html)
+- [REFRESH TABLE](sql-ref-syntax-aux-refresh-table.html)
+- [SET](sql-ref-syntax-aux-conf-mgmt-set.html)
+- [SHOW COLUMNS](sql-ref-syntax-aux-show-columns.html)
+- [SHOW CREATE TABLE](sql-ref-syntax-aux-show-create-table.html)
+- [SHOW DATABASES](sql-ref-syntax-aux-show-databases.html)
+- [SHOW FUNCTIONS](sql-ref-syntax-aux-show-functions.html)
+- [SHOW PARTITIONS](sql-ref-syntax-aux-show-partitions.html)
+- [SHOW TABLE EXTENDED](sql-ref-syntax-aux-show-table.html)
+- [SHOW TABLES](sql-ref-syntax-aux-show-tables.html)
+- [SHOW TBLPROPERTIES](sql-ref-syntax-aux-show-tblproperties.html)
+- [UNCACHE TABLE](sql-ref-syntax-aux-cache-uncache-table.html)
+- [UNSET](sql-ref-syntax-aux-conf-mgmt-reset.html)

--- a/docs/sql-ref-syntax.md
+++ b/docs/sql-ref-syntax.md
@@ -21,7 +21,7 @@ license: |
 
 Spark SQL is Apache Spark's module for working with structured data. The SQL Syntax section describes the SQL syntax in detail along with usage examples when applicable. This document provides a list of Data Definition and Data Manipulation Statements, as well as Data Retrieval and Auxiliary Statements.
 
-### Data Definition Statements
+### DDL Statements
 - [ALTER DATABASE](sql-ref-syntax-ddl-alter-database.html)
 - [ALTER TABLE](sql-ref-syntax-ddl-alter-table.html)
 - [ALTER VIEW](sql-ref-syntax-ddl-alter-view.html)
@@ -37,7 +37,7 @@ Spark SQL is Apache Spark's module for working with structured data. The SQL Syn
 - [TRUNCATE TABLE](sql-ref-syntax-ddl-truncate-table.html)
 - [USE DATABASE](sql-ref-syntax-qry-select-usedb.html)
 
-### Data Manipulation Statements
+### DML Statements
 - [INSERT INTO](sql-ref-syntax-dml-insert-into.html)
 - [INSERT OVERWRITE](sql-ref-syntax-dml-insert-overwrite-table.html)
 - [INSERT OVERWRITE DIRECTORY](sql-ref-syntax-dml-insert-overwrite-directory.html)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a page to list all commands in SQL Reference...


### Why are the changes needed?
so it's easier for user to find a specific command.


### Does this PR introduce any user-facing change?
before:
![image](https://user-images.githubusercontent.com/13592258/77938658-ec03e700-726a-11ea-983c-7a559cc0aae2.png)



after:
![image](https://user-images.githubusercontent.com/13592258/77937899-d3df9800-7269-11ea-85db-749a9521576a.png)

![image](https://user-images.githubusercontent.com/13592258/77937924-db9f3c80-7269-11ea-9441-7603feee421c.png)


Also move ```use database``` from query category to ddl category.


### How was this patch tested?
Manually build and check

