### PR TITLE
[SPARK-31309][ML] Migrate the ChiSquareTest from MLlib to ML

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
@@ -31,7 +31,7 @@ import org.apache.spark.ml.stat.{ChiSquareTest, SelectionTestResult}
 import org.apache.spark.ml.util._
 import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.types.{DoubleType, StructField, StructType}
+import org.apache.spark.sql.types.{StructField, StructType}
 
 /**
  * Params for [[ChiSqSelector]] and [[ChiSqSelectorModel]].
@@ -197,12 +197,9 @@ final class ChiSqSelector @Since("1.6.0") (@Since("1.6.0") override val uid: Str
   @Since("2.0.0")
   override def fit(dataset: Dataset[_]): ChiSqSelectorModel = {
     transformSchema(dataset.schema, logging = true)
-    dataset.select(col($(labelCol)).cast(DoubleType), col($(featuresCol))).rdd.map {
-      case Row(label: Double, features: Vector) =>
-        LabeledPoint(label, features)
-    }
 
-    val testResult = ChiSquareTest.testChiSquare(dataset, getFeaturesCol, getLabelCol)
+    val testResult = ChiSquareTest
+      .testChiSquare(dataset, getFeaturesCol, getLabelCol)
       .zipWithIndex
     val features = $(selectorType) match {
       case "numTopFeatures" =>

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
@@ -198,8 +198,7 @@ final class ChiSqSelector @Since("1.6.0") (@Since("1.6.0") override val uid: Str
   override def fit(dataset: Dataset[_]): ChiSqSelectorModel = {
     transformSchema(dataset.schema, logging = true)
 
-    val testResult = ChiSquareTest
-      .testChiSquare(dataset, getFeaturesCol, getLabelCol)
+    val testResult = ChiSquareTest.testChiSquare(dataset, getFeaturesCol, getLabelCol)
       .zipWithIndex
     val features = $(selectorType) match {
       case "numTopFeatures" =>

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/ANOVATest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/ANOVATest.scala
@@ -136,8 +136,7 @@ object ANOVATest {
         features.nonZeroIterator.map { case (col, value) => (col, (label, value)) }
       } ++ {
         // append this to make sure that all columns are taken into account
-        Iterator.range(0, numFeatures)
-          .filter(_ % numParts == pid)
+        Iterator.range(pid, numFeatures, numParts)
           .map(col => (col, null))
       }
     }.aggregateByKey[(Double, Double, OpenHashMap[Double, Double])](

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/ChiSquareTest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/ChiSquareTest.scala
@@ -161,7 +161,9 @@ object ChiSquareTest {
       }
     }.aggregateByKey(new OpenHashMap[(Double, Double), Long])(
       seqOp = { case (counts, labelAndValue) =>
-        if (labelAndValue != null) counts.changeValue(labelAndValue, 1L, _ + 1L)
+        if (labelAndValue != null) {
+          counts.changeValue(labelAndValue, 1L, _ + 1L)
+        }
         counts
       },
       combOp = { case (counts1, counts2) =>

--- a/mllib/src/main/scala/org/apache/spark/mllib/stat/Statistics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/stat/Statistics.scala
@@ -189,7 +189,11 @@ object Statistics {
    */
   @Since("1.1.0")
   def chiSqTest(data: RDD[LabeledPoint]): Array[ChiSqTestResult] = {
-    ChiSqTest.chiSquaredFeatures(data)
+    val points = data.map { l => (l.label, l.features.asML) }
+    ChiSquareTest.chiSquared(points).map { result =>
+      new ChiSqTestResult(result.pValue, result.degreesOfFreedom.toInt, result.statistic,
+        ChiSqTest.PEARSON.name, ChiSqTest.NullHypothesis.independence.toString)
+    }
   }
 
   /**

--- a/mllib/src/test/scala/org/apache/spark/ml/stat/ChiSquareTestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/stat/ChiSquareTestSuite.scala
@@ -108,7 +108,7 @@ class ChiSquareTestSuite
 
   test("fail on continuous features or labels") {
     val tooManyCategories: Int = 100000
-    assert(tooManyCategories > ChiSqTest.maxCategories, "This unit test requires that " +
+    assert(tooManyCategories > ChiSquareTest.maxCategories, "This unit test requires that " +
       "tooManyCategories be large enough to cause ChiSqTest to throw an exception.")
 
     val random = new Random(11L)


### PR DESCRIPTION
### What changes were proposed in this pull request?
1, Move the impl of ChiSq from .mllib to the .ml side;
2, in `.mllib.ChiSqTest`,  call the impl in `.ml.ChiSquareTest`

### Why are the changes needed?
We should migrate the algs from MLlib to ML


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
existing testsuites
