### PR TITLE
[SPARK-30921][PySpark] Predicates on python udf should not be pushdown through Aggregate

### DIFF
--- a/python/pyspark/sql/tests/test_pandas_udf_grouped_agg.py
+++ b/python/pyspark/sql/tests/test_pandas_udf_grouped_agg.py
@@ -492,7 +492,7 @@ class GroupedAggPandasUDFTests(ReusedSQLTestCase):
             assert_frame_equal(agg1.toPandas(), agg2.toPandas())
 
     def test_no_predicate_pushdown_through(self):
-        # SPARK-12345: We should not pushdown predicates of PythonUDFs through Aggregate.
+        # SPARK-30921: We should not pushdown predicates of PythonUDFs through Aggregate.
         import numpy as np
 
         @pandas_udf('float', PandasUDFType.GROUPED_AGG)

--- a/python/pyspark/sql/tests/test_pandas_udf_grouped_agg.py
+++ b/python/pyspark/sql/tests/test_pandas_udf_grouped_agg.py
@@ -492,7 +492,7 @@ class GroupedAggPandasUDFTests(ReusedSQLTestCase):
             assert_frame_equal(agg1.toPandas(), agg2.toPandas())
 
     def test_no_predicate_pushdown_through(self):
-        from pyspark.sql.functions import monotonically_increasing_id, explode_outer
+        # SPARK-12345: We should not pushdown predicates of PythonUDFs through Aggregate.
         import numpy as np
 
         @pandas_udf('float', PandasUDFType.GROUPED_AGG)
@@ -500,18 +500,13 @@ class GroupedAggPandasUDFTests(ReusedSQLTestCase):
             return np.mean(x)
 
         df = self.spark.createDataFrame([
-            Row(foo=[Row(bar=42), Row(bar=43), Row(bar=44)]),
+            Row(id=1, foo=42), Row(id=2, foo=1), Row(id=2, foo=2)
         ])
 
-        df_with_id = df.withColumn('id', monotonically_increasing_id())
-        exploded = df_with_id.select('id', explode_outer('foo').alias('foos'))
+        agg = df.groupBy('id').agg(mean('foo').alias("mean"))
+        filtered = agg.filter(agg['mean'] > 40.0)
 
-        agg = exploded.groupBy('id').agg(mean('foos.bar').alias("mean"))
-
-        joined = df_with_id.join(agg, 'id', 'left').select(df_with_id['id'], 'mean')
-        filtered = joined.filter(joined['mean'] > 1.0)
-
-        assert(filtered.collect()[0]["mean"] == 43.0)
+        assert(filtered.collect()[0]["mean"] == 42.0)
 
 
 if __name__ == "__main__":

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1190,7 +1190,8 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
     // Find all the aliased expressions in the aggregate list that don't include any actual
     // AggregateExpression, and create a map from the alias to the expression
     val aliasMap = plan.aggregateExpressions.collect {
-      case a: Alias if a.child.find(_.isInstanceOf[AggregateExpression]).isEmpty =>
+      case a: Alias if a.child.find(_.isInstanceOf[AggregateExpression]).isEmpty &&
+          a.child.find(_.isInstanceOf[PythonUDF]).isEmpty =>
         (a.toAttribute, a.child)
     }
     AttributeMap(aliasMap)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1191,7 +1191,7 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
     // AggregateExpression or PythonUDF, and create a map from the alias to the expression
     val aliasMap = plan.aggregateExpressions.collect {
       case a: Alias if a.child.find(e => e.isInstanceOf[AggregateExpression] ||
-          e.isInstanceOf[PythonUDF]).isEmpty =>
+          PythonUDF.isGroupedAggPandasUDF(e)).isEmpty =>
         (a.toAttribute, a.child)
     }
     AttributeMap(aliasMap)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1188,10 +1188,10 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
 
   def getAliasMap(plan: Aggregate): AttributeMap[Expression] = {
     // Find all the aliased expressions in the aggregate list that don't include any actual
-    // AggregateExpression, and create a map from the alias to the expression
+    // AggregateExpression or PythonUDF, and create a map from the alias to the expression
     val aliasMap = plan.aggregateExpressions.collect {
-      case a: Alias if a.child.find(_.isInstanceOf[AggregateExpression]).isEmpty &&
-          a.child.find(_.isInstanceOf[PythonUDF]).isEmpty =>
+      case a: Alias if a.child.find(e => e.isInstanceOf[AggregateExpression] ||
+          e.isInstanceOf[PythonUDF]).isEmpty =>
         (a.toAttribute, a.child)
     }
     AttributeMap(aliasMap)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This patch proposed to skip predicates on PythonUDFs to be pushdown through Aggregate.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The predicates on PythonUDFs cannot be pushdown through Aggregate. Pushed down predicates cannot be evaluate because PythonUDFs cannot be evaluated on Filter and cause error like:

```
Caused by: java.lang.UnsupportedOperationException: Cannot generate code for expression: mean(input[1, struct<bar:bigint>, true].bar)                                        
        at org.apache.spark.sql.catalyst.expressions.Unevaluable.doGenCode(Expression.scala:304)                                                                             
        at org.apache.spark.sql.catalyst.expressions.Unevaluable.doGenCode$(Expression.scala:303)                                                                            
        at org.apache.spark.sql.catalyst.expressions.PythonUDF.doGenCode(PythonUDF.scala:52)                                                                                 
        at org.apache.spark.sql.catalyst.expressions.Expression.$anonfun$genCode$3(Expression.scala:146)                                                                     
        at scala.Option.getOrElse(Option.scala:189)                                                                                                                          
        at org.apache.spark.sql.catalyst.expressions.Expression.genCode(Expression.scala:141)                                                                                
        at org.apache.spark.sql.catalyst.expressions.CastBase.doGenCode(Cast.scala:821)                                                                                      
        at org.apache.spark.sql.catalyst.expressions.Expression.$anonfun$genCode$3(Expression.scala:146)                                                                     
        at scala.Option.getOrElse(Option.scala:189)                                           
```

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

Yes. Previously the predicates on PythonUDFs will be pushdown through Aggregate can cause error. After this change, the query can work.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Unit test.