### PR TITLE
[SPARK-30973][SQL]ScriptTransformationExec should wait for the termination

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/ScriptTransformationExec.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/ScriptTransformationExec.scala
@@ -132,6 +132,7 @@ case class ScriptTransformationExec(
         lazy val unwrappers = outputSoi.getAllStructFieldRefs.asScala.map(unwrapperFor)
 
         private def checkFailureAndPropagate(cause: Throwable = null): Unit = {
+          proc.waitFor()
           if (writerThread.exception.isDefined) {
             throw writerThread.exception.get
           }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In  `org.apache.spark.sql.hive.execution.ScriptTransformationExec`, when check error, sometimes we can't catch write error in subproc, when call `checkFailureAndPropagate` we should always wait for subproc stop

For UT I added, when without code change in ScriptTransformExec will always got error like below
![image](https://user-images.githubusercontent.com/46485123/78213693-f7af1200-74e5-11ea-9e14-9b11c51c451b.png)

### Why are the changes needed?
Catch error in script transform


### Does this PR introduce any user-facing change?
NO

### How was this patch tested?
Added UT