### PR TITLE
[SPARK-31316][SQL] SQLQueryTestSuite: Display the total generate time for generated java code.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
@@ -568,8 +568,8 @@ object WholeStageCodegenExec {
     numOfNestedFields(dataType) > conf.wholeStageMaxNumFields
   }
 
-  // The whole codegen generates java code on the driver side and sends it to the Executor side
-  // for execution after compilation. The whole codegen can bring significant performance
+  // The whole stage codegen generates java code on the driver side and sends it to the Executor
+  // side for execution after compilation. The whole codegen can bring significant performance
   // improvements in large data and distributed environments. However, in the test environment,
   // due to the small amount of data, the time to generate Java code takes up a major part of the
   // entire runtime. So we summarize the total generation time and output it to the execution log

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -661,7 +661,7 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession {
     Locale.setDefault(Locale.US)
     RuleExecutor.resetMetrics()
     CodeGenerator.resetCompileTime
-    WholeStageCodegenExec.resetGenerateJavaTime
+    WholeStageCodegenExec.resetCodeGenTime
   }
 
   override def afterAll(): Unit = {
@@ -672,11 +672,11 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession {
       // For debugging dump some statistics about how much time was spent in various optimizer rules
       logWarning(RuleExecutor.dumpTimeSpent())
 
-      val generateJavaTime = WholeStageCodegenExec.generateJavaTime
+      val generateJavaTime = WholeStageCodegenExec.codeGenTime
       val codegenInfo =
         s"""
-           |=== Metrics of Whole Codegen ===
-           |Total generate time: ${generateJavaTime.toDouble / NANOS_PER_SECOND} seconds
+           |=== Metrics of Whole-Stage Codegen ===
+           |Total code generation time: ${generateJavaTime.toDouble / NANOS_PER_SECOND} seconds
            |Total compile time: ${CodeGenerator.compileTime.toDouble / NANOS_PER_SECOND} seconds
          """.stripMargin
       logWarning(codegenInfo)

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -31,8 +31,8 @@ import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 import org.apache.spark.sql.catalyst.util.{fileToString, stringToFile}
 import org.apache.spark.sql.catalyst.util.DateTimeConstants.NANOS_PER_SECOND
+import org.apache.spark.sql.execution.{SQLExecution, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.HiveResult.hiveResultString
-import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.execution.command.{DescribeColumnCommand, DescribeCommandBase}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
@@ -661,6 +661,7 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession {
     Locale.setDefault(Locale.US)
     RuleExecutor.resetMetrics()
     CodeGenerator.resetCompileTime
+    WholeStageCodegenExec.resetGenerateJavaTime
   }
 
   override def afterAll(): Unit = {
@@ -671,9 +672,11 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession {
       // For debugging dump some statistics about how much time was spent in various optimizer rules
       logWarning(RuleExecutor.dumpTimeSpent())
 
+      val generateJavaTime = WholeStageCodegenExec.generateJavaTime
       val codegenInfo =
         s"""
            |=== Metrics of Whole Codegen ===
+           |Total generate time: ${generateJavaTime.toDouble / NANOS_PER_SECOND} seconds
            |Total compile time: ${CodeGenerator.compileTime.toDouble / NANOS_PER_SECOND} seconds
          """.stripMargin
       logWarning(codegenInfo)


### PR DESCRIPTION
### What changes were proposed in this pull request?
After my investigation, SQLQueryTestSuite spent a lot of time to generate java code.
This PR is related to https://github.com/apache/spark/pull/28081.
https://github.com/apache/spark/pull/28081 used to display compile time, but this PR used to display generate time.
This PR will add the following to `SQLQueryTestSuite`'s output.
```
=== Metrics of Whole Codegen ===

Total generate time: 82.640913862 seconds

Total compile time: 98.649663572 seconds
```


### Why are the changes needed?
Display the total generate time for generated java code.


### Does this PR introduce any user-facing change?
'No'.


### How was this patch tested?
Jenkins test.
