### PR TITLE
[SPARK-31353][SQL] Set a time zone in DateTimeBenchmark and DateTimeRebaseBenchmark

### DIFF
--- a/sql/core/benchmarks/DateTimeBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-jdk11-results.txt
@@ -2,428 +2,428 @@
 Extract components
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    217            225          10         46.0          21.7       1.0X
-cast to timestamp wholestage on                     195            224          35         51.2          19.5       1.1X
+cast to timestamp wholestage off                    411            449          54         24.3          41.1       1.0X
+cast to timestamp wholestage on                     392            408          11         25.5          39.2       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                    735            739           5         13.6          73.5       1.0X
-year of timestamp wholestage on                     728            742          10         13.7          72.8       1.0X
+year of timestamp wholestage off                   1368           1376          11          7.3         136.8       1.0X
+year of timestamp wholestage on                    1272           1293          21          7.9         127.2       1.1X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                 940            941           2         10.6          94.0       1.0X
-quarter of timestamp wholestage on                  910            930          12         11.0          91.0       1.0X
+quarter of timestamp wholestage off                1607           1632          34          6.2         160.7       1.0X
+quarter of timestamp wholestage on                 1534           1553          22          6.5         153.4       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                   796            808          17         12.6          79.6       1.0X
-month of timestamp wholestage on                    688            706          11         14.5          68.8       1.2X
+month of timestamp wholestage off                  1252           1259          10          8.0         125.2       1.0X
+month of timestamp wholestage on                   1270           1282          13          7.9         127.0       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off             1013           1016           3          9.9         101.3       1.0X
-weekofyear of timestamp wholestage on               988           1011          18         10.1          98.8       1.0X
+weekofyear of timestamp wholestage off             2234           2242          12          4.5         223.4       1.0X
+weekofyear of timestamp wholestage on              1830           1844          10          5.5         183.0       1.2X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                     686            698          17         14.6          68.6       1.0X
-day of timestamp wholestage on                      693            708          13         14.4          69.3       1.0X
+day of timestamp wholestage off                    1248           1256          11          8.0         124.8       1.0X
+day of timestamp wholestage on                     1248           1255          10          8.0         124.8       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off               711            716           7         14.1          71.1       1.0X
-dayofyear of timestamp wholestage on                713            723          12         14.0          71.3       1.0X
+dayofyear of timestamp wholestage off              1290           1303          18          7.8         129.0       1.0X
+dayofyear of timestamp wholestage on               1285           1306          20          7.8         128.5       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off              706            726          28         14.2          70.6       1.0X
-dayofmonth of timestamp wholestage on               698            714          11         14.3          69.8       1.0X
+dayofmonth of timestamp wholestage off             1261           1263           2          7.9         126.1       1.0X
+dayofmonth of timestamp wholestage on              1253           1259           5          8.0         125.3       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off               797            798           2         12.6          79.7       1.0X
-dayofweek of timestamp wholestage on                794            807          18         12.6          79.4       1.0X
+dayofweek of timestamp wholestage off              1419           1421           2          7.0         141.9       1.0X
+dayofweek of timestamp wholestage on               1406           1417          11          7.1         140.6       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                 783            796          17         12.8          78.3       1.0X
-weekday of timestamp wholestage on                  759            778          21         13.2          75.9       1.0X
+weekday of timestamp wholestage off                1346           1350           6          7.4         134.6       1.0X
+weekday of timestamp wholestage on                 1348           1360          10          7.4         134.8       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                    573            575           2         17.5          57.3       1.0X
-hour of timestamp wholestage on                     512            522          16         19.5          51.2       1.1X
+hour of timestamp wholestage off                   1051           1057           8          9.5         105.1       1.0X
+hour of timestamp wholestage on                     991           1002           9         10.1          99.1       1.1X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  550            555           7         18.2          55.0       1.0X
-minute of timestamp wholestage on                   507            527          21         19.7          50.7       1.1X
+minute of timestamp wholestage off                 1041           1042           1          9.6         104.1       1.0X
+minute of timestamp wholestage on                   971            978           9         10.3          97.1       1.1X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  562            587          35         17.8          56.2       1.0X
-second of timestamp wholestage on                   516            529          12         19.4          51.6       1.1X
+second of timestamp wholestage off                  989            991           3         10.1          98.9       1.0X
+second of timestamp wholestage on                   986            999          12         10.1          98.6       1.0X
 
 
 ================================================================================================
 Current date and time
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         161            164           4         61.9          16.1       1.0X
-current_date wholestage on                          163            170           8         61.2          16.3       1.0X
+current_date wholestage off                         305            313          12         32.8          30.5       1.0X
+current_date wholestage on                          302            316          17         33.1          30.2       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    174            177           4         57.5          17.4       1.0X
-current_timestamp wholestage on                     159            173          12         62.8          15.9       1.1X
+current_timestamp wholestage off                    359            388          41         27.8          35.9       1.0X
+current_timestamp wholestage on                     300            412         143         33.3          30.0       1.2X
 
 
 ================================================================================================
 Date arithmetic
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                         672            688          23         14.9          67.2       1.0X
-cast to date wholestage on                          592            605          10         16.9          59.2       1.1X
+cast to date wholestage off                        1080           1083           5          9.3         108.0       1.0X
+cast to date wholestage on                         1045           1055          10          9.6         104.5       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                             806            809           4         12.4          80.6       1.0X
-last_day wholestage on                              700            713          14         14.3          70.0       1.2X
+last_day wholestage off                            1253           1253           1          8.0         125.3       1.0X
+last_day wholestage on                             1257           1272          20          8.0         125.7       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                             639            683          63         15.7          63.9       1.0X
-next_day wholestage on                              628            640          15         15.9          62.8       1.0X
+next_day wholestage off                            1129           1137          11          8.9         112.9       1.0X
+next_day wholestage on                             1083           1092          11          9.2         108.3       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                             688            695          10         14.5          68.8       1.0X
-date_add wholestage on                              588            603          13         17.0          58.8       1.2X
+date_add wholestage off                            1067           1071           6          9.4         106.7       1.0X
+date_add wholestage on                             1061           1072           7          9.4         106.1       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                             588            600          18         17.0          58.8       1.0X
-date_sub wholestage on                              597            624          40         16.8          59.7       1.0X
+date_sub wholestage off                            1065           1068           4          9.4         106.5       1.0X
+date_sub wholestage on                             1065           1072           6          9.4         106.5       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                           802            816          20         12.5          80.2       1.0X
-add_months wholestage on                            777            836          61         12.9          77.7       1.0X
+add_months wholestage off                          1404           1409           7          7.1         140.4       1.0X
+add_months wholestage on                           1429           1439          15          7.0         142.9       1.0X
 
 
 ================================================================================================
 Formatting dates
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         3328           3635         435          3.0         332.8       1.0X
-format date wholestage on                          3335           3549         253          3.0         333.5       1.0X
+format date wholestage off                         5642           5741         140          1.8         564.2       1.0X
+format date wholestage on                          5874           5900          18          1.7         587.4       1.0X
 
 
 ================================================================================================
 Formatting timestamps
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       4414           4548         189          2.3         441.4       1.0X
-from_unixtime wholestage on                        4455           4499          65          2.2         445.5       1.0X
+from_unixtime wholestage off                       7504           7515          15          1.3         750.4       1.0X
+from_unixtime wholestage on                        7579           7612          37          1.3         757.9       1.0X
 
 
 ================================================================================================
 Convert timestamps
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                   781            790          13         12.8          78.1       1.0X
-from_utc_timestamp wholestage on                    819            823           5         12.2          81.9       1.0X
+from_utc_timestamp wholestage off                  1250           1254           6          8.0         125.0       1.0X
+from_utc_timestamp wholestage on                   1287           1294          10          7.8         128.7       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                    1101           1108          10          9.1         110.1       1.0X
-to_utc_timestamp wholestage on                     1044           1055          10          9.6         104.4       1.1X
+to_utc_timestamp wholestage off                    1916           1918           2          5.2         191.6       1.0X
+to_utc_timestamp wholestage on                     1781           1792          12          5.6         178.1       1.1X
 
 
 ================================================================================================
 Intervals
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        198            202           6         50.6          19.8       1.0X
-cast interval wholestage on                         181            193          14         55.2          18.1       1.1X
+cast interval wholestage off                        347            354           9         28.8          34.7       1.0X
+cast interval wholestage on                         308            313           3         32.5          30.8       1.1X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                            1037           1043          10          9.6         103.7       1.0X
-datediff wholestage on                             1006           1037          21          9.9         100.6       1.0X
+datediff wholestage off                            1884           1895          15          5.3         188.4       1.0X
+datediff wholestage on                             1824           1833           9          5.5         182.4       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      2957           2972          21          3.4         295.7       1.0X
-months_between wholestage on                       2931           2952          16          3.4         293.1       1.0X
+months_between wholestage off                      5674           5685          16          1.8         567.4       1.0X
+months_between wholestage on                       5600           5616          14          1.8         560.0       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                              1130           1147          24          0.9        1130.0       1.0X
-window wholestage on                              16253          17068         580          0.1       16253.2       0.1X
+window wholestage off                              1971           2180         295          0.5        1971.1       1.0X
+window wholestage on                              47323          47354          35          0.0       47322.7       0.0X
 
 
 ================================================================================================
 Truncation
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                     1361           1380          27          7.3         136.1       1.0X
-date_trunc YEAR wholestage on                      1346           1381          28          7.4         134.6       1.0X
+date_trunc YEAR wholestage off                     2571           2588          23          3.9         257.1       1.0X
+date_trunc YEAR wholestage on                      2581           2591           6          3.9         258.1       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                     1352           1364          16          7.4         135.2       1.0X
-date_trunc YYYY wholestage on                      1391           1424          37          7.2         139.1       1.0X
+date_trunc YYYY wholestage off                     2564           2568           5          3.9         256.4       1.0X
+date_trunc YYYY wholestage on                      2583           2592           6          3.9         258.3       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                       1346           1356          15          7.4         134.6       1.0X
-date_trunc YY wholestage on                        1355           1366           9          7.4         135.5       1.0X
+date_trunc YY wholestage off                       2574           2577           5          3.9         257.4       1.0X
+date_trunc YY wholestage on                        2579           2588           8          3.9         257.9       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                      1355           1365          15          7.4         135.5       1.0X
-date_trunc MON wholestage on                       1388           1457          78          7.2         138.8       1.0X
+date_trunc MON wholestage off                      2598           2599           1          3.8         259.8       1.0X
+date_trunc MON wholestage on                       2593           2604          11          3.9         259.3       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                    1336           1357          30          7.5         133.6       1.0X
-date_trunc MONTH wholestage on                     1361           1390          22          7.3         136.1       1.0X
+date_trunc MONTH wholestage off                    2599           2613          19          3.8         259.9       1.0X
+date_trunc MONTH wholestage on                     2604           2610           5          3.8         260.4       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                       1350           1361          16          7.4         135.0       1.0X
-date_trunc MM wholestage on                        1370           1384          13          7.3         137.0       1.0X
+date_trunc MM wholestage off                       2605           2613          10          3.8         260.5       1.0X
+date_trunc MM wholestage on                        2595           2601           4          3.9         259.5       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                      1328           1361          46          7.5         132.8       1.0X
-date_trunc DAY wholestage on                       1356           1432          69          7.4         135.6       1.0X
+date_trunc DAY wholestage off                      2361           2367           9          4.2         236.1       1.0X
+date_trunc DAY wholestage on                       2370           2383          11          4.2         237.0       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                       1403           1445          59          7.1         140.3       1.0X
-date_trunc DD wholestage on                        1359           1405          49          7.4         135.9       1.0X
+date_trunc DD wholestage off                       2376           2385          13          4.2         237.6       1.0X
+date_trunc DD wholestage on                        2368           2372           3          4.2         236.8       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                     1447           1494          67          6.9         144.7       1.0X
-date_trunc HOUR wholestage on                      1387           1416          31          7.2         138.7       1.0X
+date_trunc HOUR wholestage off                     2399           2404           7          4.2         239.9       1.0X
+date_trunc HOUR wholestage on                      2387           2399          14          4.2         238.7       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    206            215          13         48.5          20.6       1.0X
-date_trunc MINUTE wholestage on                     233            240           4         42.9          23.3       0.9X
+date_trunc MINUTE wholestage off                    357            370          18         28.0          35.7       1.0X
+date_trunc MINUTE wholestage on                     373            378           5         26.8          37.3       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    200            213          18         49.9          20.0       1.0X
-date_trunc SECOND wholestage on                     219            227           7         45.6          21.9       0.9X
+date_trunc SECOND wholestage off                    382            382           1         26.2          38.2       1.0X
+date_trunc SECOND wholestage on                     372            380           8         26.9          37.2       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                     1287           1293           9          7.8         128.7       1.0X
-date_trunc WEEK wholestage on                      1310           1341          28          7.6         131.0       1.0X
+date_trunc WEEK wholestage off                     2501           2512          14          4.0         250.1       1.0X
+date_trunc WEEK wholestage on                      2484           2498          12          4.0         248.4       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                  1852           1880          39          5.4         185.2       1.0X
-date_trunc QUARTER wholestage on                   1857           1877          14          5.4         185.7       1.0X
+date_trunc QUARTER wholestage off                  3407           3410           4          2.9         340.7       1.0X
+date_trunc QUARTER wholestage on                   3371           3378           5          3.0         337.1       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           172            178           9         58.2          17.2       1.0X
-trunc year wholestage on                            213            222           8         47.0          21.3       0.8X
+trunc year wholestage off                           318            319           2         31.4          31.8       1.0X
+trunc year wholestage on                            343            347           8         29.2          34.3       0.9X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           175            182           9         57.1          17.5       1.0X
-trunc yyyy wholestage on                            224            233          12         44.7          22.4       0.8X
+trunc yyyy wholestage off                           315            316           2         31.7          31.5       1.0X
+trunc yyyy wholestage on                            342            355          18         29.2          34.2       0.9X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             167            180          18         59.7          16.7       1.0X
-trunc yy wholestage on                              212            226           9         47.3          21.2       0.8X
+trunc yy wholestage off                             317            318           1         31.5          31.7       1.0X
+trunc yy wholestage on                              339            348          12         29.5          33.9       0.9X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            175            175           1         57.2          17.5       1.0X
-trunc mon wholestage on                             219            241          17         45.7          21.9       0.8X
+trunc mon wholestage off                            317            319           3         31.5          31.7       1.0X
+trunc mon wholestage on                             337            349          10         29.7          33.7       0.9X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          176            176           0         56.8          17.6       1.0X
-trunc month wholestage on                           220            226           6         45.4          22.0       0.8X
+trunc month wholestage off                          315            316           1         31.7          31.5       1.0X
+trunc month wholestage on                           341            352          14         29.3          34.1       0.9X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             173            173           1         57.9          17.3       1.0X
-trunc mm wholestage on                              219            230           8         45.7          21.9       0.8X
+trunc mm wholestage off                             314            315           1         31.8          31.4       1.0X
+trunc mm wholestage on                              343            348           8         29.2          34.3       0.9X
 
 
 ================================================================================================
 Parsing
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                      98            102           5         10.2          97.9       1.0X
-to timestamp str wholestage on                      102            112           5          9.8         102.5       1.0X
+to timestamp str wholestage off                     163            165           2          6.1         163.2       1.0X
+to timestamp str wholestage on                      158            159           1          6.3         157.7       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                        1373           1380          11          0.7        1373.0       1.0X
-to_timestamp wholestage on                          928           1100         103          1.1         928.1       1.5X
+to_timestamp wholestage off                        1490           1491           2          0.7        1489.5       1.0X
+to_timestamp wholestage on                         1522           1530          10          0.7        1522.0       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                   1416           1438          32          0.7        1416.0       1.0X
-to_unix_timestamp wholestage on                    1094           1261         194          0.9        1093.6       1.3X
+to_unix_timestamp wholestage off                   1561           1574          18          0.6        1561.4       1.0X
+to_unix_timestamp wholestage on                    1531           1540           9          0.7        1531.4       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          120            123           5          8.3         120.0       1.0X
-to date str wholestage on                           142            148           6          7.0         142.1       0.8X
+to date str wholestage off                          206            219          18          4.9         206.1       1.0X
+to date str wholestage on                           211            214           4          4.7         211.1       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                             1661           1673          17          0.6        1661.0       1.0X
-to_date wholestage on                              1567           1617          55          0.6        1567.3       1.1X
+to_date wholestage off                             3195           3208          18          0.3        3195.3       1.0X
+to_date wholestage on                              3179           3189          12          0.3        3179.2       1.0X
 
 
 ================================================================================================
 Conversion from/to external types
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 To/from java.sql.Timestamp:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Timestamp                             216            234          16         23.1          43.2       1.0X
-Collect longs                                       913           1204         266          5.5         182.6       0.2X
-Collect timestamps                                 1392           1515         124          3.6         278.3       0.2X
+From java.sql.Timestamp                            1390           1400           9          3.6         277.9       1.0X
+Collect longs                                      1781           2342         496          2.8         356.2       0.8X
+Collect timestamps                                 5837           6037         180          0.9        1167.3       0.2X
 
 

--- a/sql/core/benchmarks/DateTimeBenchmark-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-results.txt
@@ -2,428 +2,428 @@
 Extract components
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    243            256          18         41.2          24.3       1.0X
-cast to timestamp wholestage on                     193            206          19         51.9          19.3       1.3X
+cast to timestamp wholestage off                    413            435          31         24.2          41.3       1.0X
+cast to timestamp wholestage on                     357            375          16         28.0          35.7       1.2X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                    784            786           3         12.8          78.4       1.0X
-year of timestamp wholestage on                     738            758          15         13.5          73.8       1.1X
+year of timestamp wholestage off                   1311           1335          34          7.6         131.1       1.0X
+year of timestamp wholestage on                    1541           1561          21          6.5         154.1       0.9X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                 823            825           3         12.2          82.3       1.0X
-quarter of timestamp wholestage on                  791            804          12         12.6          79.1       1.0X
+quarter of timestamp wholestage off                1449           1467          26          6.9         144.9       1.0X
+quarter of timestamp wholestage on                 1403           1418          12          7.1         140.3       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                   681            692          16         14.7          68.1       1.0X
-month of timestamp wholestage on                    683            703          14         14.6          68.3       1.0X
+month of timestamp wholestage off                  1221           1231          14          8.2         122.1       1.0X
+month of timestamp wholestage on                   1252           1266           8          8.0         125.2       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off             1015           1032          23          9.8         101.5       1.0X
-weekofyear of timestamp wholestage on              1016           1106          72          9.8         101.6       1.0X
+weekofyear of timestamp wholestage off             1939           1947          11          5.2         193.9       1.0X
+weekofyear of timestamp wholestage on              1932           1942           9          5.2         193.2       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                     683            689           9         14.6          68.3       1.0X
-day of timestamp wholestage on                      685            702          11         14.6          68.5       1.0X
+day of timestamp wholestage off                    1216           1222           9          8.2         121.6       1.0X
+day of timestamp wholestage on                     1246           1256          14          8.0         124.6       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off               713            716           4         14.0          71.3       1.0X
-dayofyear of timestamp wholestage on                704            713           9         14.2          70.4       1.0X
+dayofyear of timestamp wholestage off              1278           1286          12          7.8         127.8       1.0X
+dayofyear of timestamp wholestage on               1283           1291           8          7.8         128.3       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off              738            746          11         13.5          73.8       1.0X
-dayofmonth of timestamp wholestage on               684            704          16         14.6          68.4       1.1X
+dayofmonth of timestamp wholestage off             1220           1226           9          8.2         122.0       1.0X
+dayofmonth of timestamp wholestage on              1232           1249          15          8.1         123.2       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off               810            821          15         12.3          81.0       1.0X
-dayofweek of timestamp wholestage on                784            789           5         12.8          78.4       1.0X
+dayofweek of timestamp wholestage off              1409           1423          21          7.1         140.9       1.0X
+dayofweek of timestamp wholestage on               1396           1403           7          7.2         139.6       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                 767            777          13         13.0          76.7       1.0X
-weekday of timestamp wholestage on                  765            777          11         13.1          76.5       1.0X
+weekday of timestamp wholestage off                1346           1362          22          7.4         134.6       1.0X
+weekday of timestamp wholestage on                 1330           1341          11          7.5         133.0       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                    534            543          13         18.7          53.4       1.0X
-hour of timestamp wholestage on                     499            529          22         20.0          49.9       1.1X
+hour of timestamp wholestage off                    962            963           2         10.4          96.2       1.0X
+hour of timestamp wholestage on                     981            999          19         10.2          98.1       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  526            544          26         19.0          52.6       1.0X
-minute of timestamp wholestage on                   495            515          20         20.2          49.5       1.1X
+minute of timestamp wholestage off                  996            999           5         10.0          99.6       1.0X
+minute of timestamp wholestage on                   975            984          11         10.3          97.5       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  537            538           2         18.6          53.7       1.0X
-second of timestamp wholestage on                   508            512           5         19.7          50.8       1.1X
+second of timestamp wholestage off                 1004           1005           2         10.0         100.4       1.0X
+second of timestamp wholestage on                   979            988           6         10.2          97.9       1.0X
 
 
 ================================================================================================
 Current date and time
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         164            169           6         60.8          16.4       1.0X
-current_date wholestage on                          165            171           4         60.4          16.5       1.0X
+current_date wholestage off                         285            289           6         35.1          28.5       1.0X
+current_date wholestage on                          302            308           8         33.1          30.2       0.9X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    161            168          10         62.0          16.1       1.0X
-current_timestamp wholestage on                     161            165           5         62.1          16.1       1.0X
+current_timestamp wholestage off                    296            298           2         33.8          29.6       1.0X
+current_timestamp wholestage on                     303            311           7         33.0          30.3       1.0X
 
 
 ================================================================================================
 Date arithmetic
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                         691            692           2         14.5          69.1       1.0X
-cast to date wholestage on                          572            586          16         17.5          57.2       1.2X
+cast to date wholestage off                        1041           1042           1          9.6         104.1       1.0X
+cast to date wholestage on                         1027           1039           9          9.7         102.7       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                             713            723          14         14.0          71.3       1.0X
-last_day wholestage on                              695            747          41         14.4          69.5       1.0X
+last_day wholestage off                            1250           1254           6          8.0         125.0       1.0X
+last_day wholestage on                             1267           1273           8          7.9         126.7       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                             627            630           4         15.9          62.7       1.0X
-next_day wholestage on                              615            660          39         16.3          61.5       1.0X
+next_day wholestage off                            1118           1122           6          8.9         111.8       1.0X
+next_day wholestage on                             1081           1096          10          9.2         108.1       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                             604            649          63         16.5          60.4       1.0X
-date_add wholestage on                              590            598           8         17.0          59.0       1.0X
+date_add wholestage off                            1053           1055           4          9.5         105.3       1.0X
+date_add wholestage on                             1059           1061           2          9.4         105.9       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                             588            592           5         17.0          58.8       1.0X
-date_sub wholestage on                              597            620          39         16.7          59.7       1.0X
+date_sub wholestage off                            1055           1064          13          9.5         105.5       1.0X
+date_sub wholestage on                             1055           1060           6          9.5         105.5       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                           777            782           8         12.9          77.7       1.0X
-add_months wholestage on                            769            786          22         13.0          76.9       1.0X
+add_months wholestage off                          1373           1375           2          7.3         137.3       1.0X
+add_months wholestage on                           1383           1393          13          7.2         138.3       1.0X
 
 
 ================================================================================================
 Formatting dates
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         3335           3498         231          3.0         333.5       1.0X
-format date wholestage on                          3386           3488         103          3.0         338.6       1.0X
+format date wholestage off                         5590           5603          19          1.8         559.0       1.0X
+format date wholestage on                          5974           5985           8          1.7         597.4       0.9X
 
 
 ================================================================================================
 Formatting timestamps
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       5291           5601         438          1.9         529.1       1.0X
-from_unixtime wholestage on                        5684           5952         256          1.8         568.4       0.9X
+from_unixtime wholestage off                       8650           8662          18          1.2         865.0       1.0X
+from_unixtime wholestage on                        8671           8685          15          1.2         867.1       1.0X
 
 
 ================================================================================================
 Convert timestamps
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                   963            981          25         10.4          96.3       1.0X
-from_utc_timestamp wholestage on                    731            794          40         13.7          73.1       1.3X
+from_utc_timestamp wholestage off                  1152           1157           7          8.7         115.2       1.0X
+from_utc_timestamp wholestage on                   1193           1200           7          8.4         119.3       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                    1129           1135           7          8.9         112.9       1.0X
-to_utc_timestamp wholestage on                      921            973          68         10.9          92.1       1.2X
+to_utc_timestamp wholestage off                    1414           1417           3          7.1         141.4       1.0X
+to_utc_timestamp wholestage on                     1390           1397           7          7.2         139.0       1.0X
 
 
 ================================================================================================
 Intervals
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        197            197           0         50.8          19.7       1.0X
-cast interval wholestage on                         172            179           8         58.3          17.2       1.1X
+cast interval wholestage off                        332            350          25         30.1          33.2       1.0X
+cast interval wholestage on                         325            333           7         30.8          32.5       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                            1039           1105          93          9.6         103.9       1.0X
-datediff wholestage on                             1129           1162          22          8.9         112.9       0.9X
+datediff wholestage off                            1814           1819           7          5.5         181.4       1.0X
+datediff wholestage on                             1811           1822           9          5.5         181.1       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      2624           2654          42          3.8         262.4       1.0X
-months_between wholestage on                       2612           2709          57          3.8         261.2       1.0X
+months_between wholestage off                      4660           4661           1          2.1         466.0       1.0X
+months_between wholestage on                       4577           4586           5          2.2         457.7       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                              1229           1247          25          0.8        1229.4       1.0X
-window wholestage on                              14409          15033         534          0.1       14409.2       0.1X
+window wholestage off                              2006           2119         161          0.5        2005.6       1.0X
+window wholestage on                              43855          43884          41          0.0       43855.4       0.0X
 
 
 ================================================================================================
 Truncation
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                     1203           1218          22          8.3         120.3       1.0X
-date_trunc YEAR wholestage on                      1162           1172          10          8.6         116.2       1.0X
+date_trunc YEAR wholestage off                     2336           2339           5          4.3         233.6       1.0X
+date_trunc YEAR wholestage on                      2204           2211           6          4.5         220.4       1.1X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                     1185           1199          20          8.4         118.5       1.0X
-date_trunc YYYY wholestage on                      1148           1173          22          8.7         114.8       1.0X
+date_trunc YYYY wholestage off                     2338           2339           1          4.3         233.8       1.0X
+date_trunc YYYY wholestage on                      2200           2208           5          4.5         220.0       1.1X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                       1189           1192           4          8.4         118.9       1.0X
-date_trunc YY wholestage on                        1168           1179          16          8.6         116.8       1.0X
+date_trunc YY wholestage off                       2337           2340           5          4.3         233.7       1.0X
+date_trunc YY wholestage on                        2202           2209           6          4.5         220.2       1.1X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                      1308           1317          14          7.6         130.8       1.0X
-date_trunc MON wholestage on                       1303           1352          37          7.7         130.3       1.0X
+date_trunc MON wholestage off                      2238           2239           1          4.5         223.8       1.0X
+date_trunc MON wholestage on                       2222           2233          11          4.5         222.2       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                    1301           1320          27          7.7         130.1       1.0X
-date_trunc MONTH wholestage on                     1171           1226          41          8.5         117.1       1.1X
+date_trunc MONTH wholestage off                    2243           2243           1          4.5         224.3       1.0X
+date_trunc MONTH wholestage on                     2216           2224           9          4.5         221.6       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                       1237           1259          31          8.1         123.7       1.0X
-date_trunc MM wholestage on                        1181           1195          11          8.5         118.1       1.0X
+date_trunc MM wholestage off                       2237           2239           3          4.5         223.7       1.0X
+date_trunc MM wholestage on                        2217           2221           3          4.5         221.7       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                      1364           1370           8          7.3         136.4       1.0X
-date_trunc DAY wholestage on                       1189           1223          31          8.4         118.9       1.1X
+date_trunc DAY wholestage off                      1894           1896           3          5.3         189.4       1.0X
+date_trunc DAY wholestage on                       1851           1856           5          5.4         185.1       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                       1297           1328          45          7.7         129.7       1.0X
-date_trunc DD wholestage on                        1171           1242          43          8.5         117.1       1.1X
+date_trunc DD wholestage off                       1887           1899          17          5.3         188.7       1.0X
+date_trunc DD wholestage on                        1846           1855           6          5.4         184.6       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                     1261           1317          79          7.9         126.1       1.0X
-date_trunc HOUR wholestage on                      1171           1225          48          8.5         117.1       1.1X
+date_trunc HOUR wholestage off                     1947           1951           5          5.1         194.7       1.0X
+date_trunc HOUR wholestage on                      1909           1918           7          5.2         190.9       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    210            211           2         47.7          21.0       1.0X
-date_trunc MINUTE wholestage on                     178            200          18         56.2          17.8       1.2X
+date_trunc MINUTE wholestage off                    381            386           7         26.3          38.1       1.0X
+date_trunc MINUTE wholestage on                     321            323           1         31.2          32.1       1.2X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    206            211           7         48.5          20.6       1.0X
-date_trunc SECOND wholestage on                     186            200           9         53.9          18.6       1.1X
+date_trunc SECOND wholestage off                    368            368           0         27.2          36.8       1.0X
+date_trunc SECOND wholestage on                     324            327           3         30.9          32.4       1.1X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                     1275           1307          46          7.8         127.5       1.0X
-date_trunc WEEK wholestage on                      1190           1244          63          8.4         119.0       1.1X
+date_trunc WEEK wholestage off                     2213           2213           0          4.5         221.3       1.0X
+date_trunc WEEK wholestage on                      2113           2123          11          4.7         211.3       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                  1688           1719          44          5.9         168.8       1.0X
-date_trunc QUARTER wholestage on                   1732           1795          45          5.8         173.2       1.0X
+date_trunc QUARTER wholestage off                  3071           3081          14          3.3         307.1       1.0X
+date_trunc QUARTER wholestage on                   3031           3035           3          3.3         303.1       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           201            214          19         49.7          20.1       1.0X
-trunc year wholestage on                            150            157          11         66.5          15.0       1.3X
+trunc year wholestage off                           326            328           3         30.7          32.6       1.0X
+trunc year wholestage on                            307            318          12         32.6          30.7       1.1X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           169            174           6         59.0          16.9       1.0X
-trunc yyyy wholestage on                            159            174          10         62.9          15.9       1.1X
+trunc yyyy wholestage off                           327            333           7         30.5          32.7       1.0X
+trunc yyyy wholestage on                            305            320          17         32.8          30.5       1.1X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             171            179          12         58.5          17.1       1.0X
-trunc yy wholestage on                              170            180           9         58.8          17.0       1.0X
+trunc yy wholestage off                             322            323           1         31.1          32.2       1.0X
+trunc yy wholestage on                              304            343          67         32.9          30.4       1.1X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            174            177           4         57.5          17.4       1.0X
-trunc mon wholestage on                             162            171           7         61.7          16.2       1.1X
+trunc mon wholestage off                            321            321           1         31.2          32.1       1.0X
+trunc mon wholestage on                             303            313           9         33.0          30.3       1.1X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          195            196           2         51.2          19.5       1.0X
-trunc month wholestage on                           166            176           8         60.2          16.6       1.2X
+trunc month wholestage off                          319            323           4         31.3          31.9       1.0X
+trunc month wholestage on                           305            359          75         32.8          30.5       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             156            160           6         64.2          15.6       1.0X
-trunc mm wholestage on                              147            162          13         68.1          14.7       1.1X
+trunc mm wholestage off                             322            323           1         31.0          32.2       1.0X
+trunc mm wholestage on                              317            351          53         31.5          31.7       1.0X
 
 
 ================================================================================================
 Parsing
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                     154            154           1          6.5         153.8       1.0X
-to timestamp str wholestage on                      127            132           6          7.9         126.5       1.2X
+to timestamp str wholestage off                     219            219           0          4.6         219.4       1.0X
+to timestamp str wholestage on                      214            216           2          4.7         214.0       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                         973           1001          40          1.0         972.6       1.0X
-to_timestamp wholestage on                          912            922          12          1.1         912.3       1.1X
+to_timestamp wholestage off                        1947           1951           6          0.5        1946.8       1.0X
+to_timestamp wholestage on                         1950           1958          12          0.5        1949.6       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                    970            986          23          1.0         969.7       1.0X
-to_unix_timestamp wholestage on                     907            910           3          1.1         906.9       1.1X
+to_unix_timestamp wholestage off                   1975           1979           5          0.5        1974.8       1.0X
+to_unix_timestamp wholestage on                    1895           1908          12          0.5        1895.3       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          154            155           1          6.5         154.3       1.0X
-to date str wholestage on                           156            165           6          6.4         155.9       1.0X
+to date str wholestage off                          284            286           2          3.5         284.3       1.0X
+to date str wholestage on                           263            266           4          3.8         263.3       1.1X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                             1757           1760           4          0.6        1756.6       1.0X
-to_date wholestage on                              1563           1626          41          0.6        1562.7       1.1X
+to_date wholestage off                             3460           3485          36          0.3        3459.8       1.0X
+to_date wholestage on                              3413           3431          25          0.3        3413.0       1.0X
 
 
 ================================================================================================
 Conversion from/to external types
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 To/from java.sql.Timestamp:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Timestamp                             182            186           4         27.5          36.4       1.0X
-Collect longs                                      1041           1652         964          4.8         208.2       0.2X
-Collect timestamps                                 1003           1029          31          5.0         200.7       0.2X
+From java.sql.Timestamp                            2032           2038           6          2.5         406.5       1.0X
+Collect longs                                      1276           1597         419          3.9         255.1       1.6X
+Collect timestamps                                 6254           7606        1172          0.8        1250.7       0.3X
 
 

--- a/sql/core/benchmarks/DateTimeRebaseBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/DateTimeRebaseBenchmark-jdk11-results.txt
@@ -6,49 +6,49 @@ OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Save dates to parquet:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, noop                                   9392           9392           0         10.6          93.9       1.0X
-before 1582, noop                                  9324           9324           0         10.7          93.2       1.0X
-after 1582, rebase off                            20975          20975           0          4.8         209.7       0.4X
-after 1582, rebase on                             20016          20016           0          5.0         200.2       0.5X
-before 1582, rebase off                           20088          20088           0          5.0         200.9       0.5X
-before 1582, rebase on                            20310          20310           0          4.9         203.1       0.5X
+after 1582, noop                                  18597          18597           0          5.4         186.0       1.0X
+before 1582, noop                                 10565          10565           0          9.5         105.7       1.8X
+after 1582, rebase off                            29811          29811           0          3.4         298.1       0.6X
+after 1582, rebase on                             31110          31110           0          3.2         311.1       0.6X
+before 1582, rebase off                           23144          23144           0          4.3         231.4       0.8X
+before 1582, rebase on                            23689          23689           0          4.2         236.9       0.8X
 
 OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Load dates from parquet:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, vec off, rebase off                   13371          13463         154          7.5         133.7       1.0X
-after 1582, vec off, rebase on                    13482          13533          57          7.4         134.8       1.0X
-after 1582, vec on, rebase off                     3713           3781          96         26.9          37.1       3.6X
-after 1582, vec on, rebase on                      5153           5173          29         19.4          51.5       2.6X
-before 1582, vec off, rebase off                  12939          12998          97          7.7         129.4       1.0X
-before 1582, vec off, rebase on                   14160          14255          85          7.1         141.6       0.9X
-before 1582, vec on, rebase off                    3748           3776          28         26.7          37.5       3.6X
-before 1582, vec on, rebase on                     5532           5575          54         18.1          55.3       2.4X
+after 1582, vec off, rebase off                   12944          13064         104          7.7         129.4       1.0X
+after 1582, vec off, rebase on                    13223          13255          34          7.6         132.2       1.0X
+after 1582, vec on, rebase off                     3656           3793         219         27.4          36.6       3.5X
+after 1582, vec on, rebase on                      5176           5205          38         19.3          51.8       2.5X
+before 1582, vec off, rebase off                  12926          12970          45          7.7         129.3       1.0X
+before 1582, vec off, rebase on                   13836          13872          40          7.2         138.4       0.9X
+before 1582, vec on, rebase off                    3664           3672           7         27.3          36.6       3.5X
+before 1582, vec on, rebase on                     6049           6078          30         16.5          60.5       2.1X
 
 OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Save timestamps to parquet:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, noop                                   2795           2795           0         35.8          27.9       1.0X
-before 1582, noop                                  2806           2806           0         35.6          28.1       1.0X
-after 1582, rebase off                            16113          16113           0          6.2         161.1       0.2X
-after 1582, rebase on                             70198          70198           0          1.4         702.0       0.0X
-before 1582, rebase off                           16690          16690           0          6.0         166.9       0.2X
-before 1582, rebase on                            75706          75706           0          1.3         757.1       0.0X
+after 1582, noop                                   2831           2831           0         35.3          28.3       1.0X
+before 1582, noop                                  2769           2769           0         36.1          27.7       1.0X
+after 1582, rebase off                            17296          17296           0          5.8         173.0       0.2X
+after 1582, rebase on                             81434          81434           0          1.2         814.3       0.0X
+before 1582, rebase off                           17563          17563           0          5.7         175.6       0.2X
+before 1582, rebase on                            94977          94977           0          1.1         949.8       0.0X
 
 OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Load timestamps from parquet:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, vec off, rebase off                   15631          15753         111          6.4         156.3       1.0X
-after 1582, vec off, rebase on                    45834          46027         193          2.2         458.3       0.3X
-after 1582, vec on, rebase off                     4883           4964          70         20.5          48.8       3.2X
-after 1582, vec on, rebase on                     34514          34563          63          2.9         345.1       0.5X
-before 1582, vec off, rebase off                  15253          15354         104          6.6         152.5       1.0X
-before 1582, vec off, rebase on                   47353          47412          59          2.1         473.5       0.3X
-before 1582, vec on, rebase off                    4848           4894          69         20.6          48.5       3.2X
-before 1582, vec on, rebase on                    36125          36143          22          2.8         361.3       0.4X
+after 1582, vec off, rebase off                   14824          14920          87          6.7         148.2       1.0X
+after 1582, vec off, rebase on                    54660          54859         210          1.8         546.6       0.3X
+after 1582, vec on, rebase off                     4876           4954          69         20.5          48.8       3.0X
+after 1582, vec on, rebase on                     44509          44573          65          2.2         445.1       0.3X
+before 1582, vec off, rebase off                  14909          14939          30          6.7         149.1       1.0X
+before 1582, vec off, rebase on                   56092          56346         326          1.8         560.9       0.3X
+before 1582, vec on, rebase off                    4846           4858          13         20.6          48.5       3.1X
+before 1582, vec on, rebase on                    46267          46341          64          2.2         462.7       0.3X
 
 
 ================================================================================================
@@ -59,36 +59,36 @@ OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Save dates to ORC:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, noop                                   9160           9160           0         10.9          91.6       1.0X
-before 1582, noop                                  9235           9235           0         10.8          92.4       1.0X
-after 1582                                        17154          17154           0          5.8         171.5       0.5X
-before 1582                                       17545          17545           0          5.7         175.5       0.5X
+after 1582, noop                                  18035          18035           0          5.5         180.3       1.0X
+before 1582, noop                                 10571          10571           0          9.5         105.7       1.7X
+after 1582                                        26341          26341           0          3.8         263.4       0.7X
+before 1582                                       19589          19589           0          5.1         195.9       0.9X
 
 OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Load dates from ORC:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, vec off                               21024          21146         205          4.8         210.2       1.0X
-after 1582, vec on                                 3814           3838          21         26.2          38.1       5.5X
-before 1582, vec off                              24293          24347          82          4.1         242.9       0.9X
-before 1582, vec on                                4143           4168          22         24.1          41.4       5.1X
+after 1582, vec off                               34955          35025          98          2.9         349.6       1.0X
+after 1582, vec on                                 3892           3942          43         25.7          38.9       9.0X
+before 1582, vec off                              33360          33457          87          3.0         333.6       1.0X
+before 1582, vec on                                4514           4526          11         22.2          45.1       7.7X
 
 OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Save timestamps to ORC:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, noop                                   2797           2797           0         35.8          28.0       1.0X
-before 1582, noop                                  2826           2826           0         35.4          28.3       1.0X
-after 1582                                        40021          40021           0          2.5         400.2       0.1X
-before 1582                                       41500          41500           0          2.4         415.0       0.1X
+after 1582, noop                                   2867           2867           0         34.9          28.7       1.0X
+before 1582, noop                                  2812           2812           0         35.6          28.1       1.0X
+after 1582                                        57133          57133           0          1.8         571.3       0.1X
+before 1582                                       53435          53435           0          1.9         534.4       0.1X
 
 OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Load timestamps from ORC:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, vec off                               32517          32541          23          3.1         325.2       1.0X
-after 1582, vec on                                19644          19725         128          5.1         196.4       1.7X
-before 1582, vec off                              37204          37305         104          2.7         372.0       0.9X
-before 1582, vec on                               24105          24120          13          4.1         241.1       1.3X
+after 1582, vec off                               38475          38551         127          2.6         384.7       1.0X
+after 1582, vec on                                31382          31537         136          3.2         313.8       1.2X
+before 1582, vec off                              42159          42240         128          2.4         421.6       0.9X
+before 1582, vec on                               34735          35129         393          2.9         347.3       1.1X
 
 

--- a/sql/core/benchmarks/DateTimeRebaseBenchmark-results.txt
+++ b/sql/core/benchmarks/DateTimeRebaseBenchmark-results.txt
@@ -6,49 +6,49 @@ OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Save dates to parquet:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, noop                                   9488           9488           0         10.5          94.9       1.0X
-before 1582, noop                                  9301           9301           0         10.8          93.0       1.0X
-after 1582, rebase off                            20109          20109           0          5.0         201.1       0.5X
-after 1582, rebase on                             20004          20004           0          5.0         200.0       0.5X
-before 1582, rebase off                           19906          19906           0          5.0         199.1       0.5X
-before 1582, rebase on                            20466          20466           0          4.9         204.7       0.5X
+after 1582, noop                                  23840          23840           0          4.2         238.4       1.0X
+before 1582, noop                                 10842          10842           0          9.2         108.4       2.2X
+after 1582, rebase off                            35883          35883           0          2.8         358.8       0.7X
+after 1582, rebase on                             36090          36090           0          2.8         360.9       0.7X
+before 1582, rebase off                           23293          23293           0          4.3         232.9       1.0X
+before 1582, rebase on                            23803          23803           0          4.2         238.0       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Load dates from parquet:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, vec off, rebase off                   12593          12653          52          7.9         125.9       1.0X
-after 1582, vec off, rebase on                    13350          13489         121          7.5         133.5       0.9X
-after 1582, vec on, rebase off                     3665           3681          25         27.3          36.6       3.4X
-after 1582, vec on, rebase on                      5193           5210          16         19.3          51.9       2.4X
-before 1582, vec off, rebase off                  13023          13059          32          7.7         130.2       1.0X
-before 1582, vec off, rebase on                   13855          13937         115          7.2         138.6       0.9X
-before 1582, vec on, rebase off                    3651           3665          12         27.4          36.5       3.4X
-before 1582, vec on, rebase on                     5623           5671          45         17.8          56.2       2.2X
+after 1582, vec off, rebase off                   12608          12658          43          7.9         126.1       1.0X
+after 1582, vec off, rebase on                    13385          13585         239          7.5         133.9       0.9X
+after 1582, vec on, rebase off                     3749           3792          58         26.7          37.5       3.4X
+after 1582, vec on, rebase on                      5256           5296          49         19.0          52.6       2.4X
+before 1582, vec off, rebase off                  13015          13140         109          7.7         130.1       1.0X
+before 1582, vec off, rebase on                   14273          14372         109          7.0         142.7       0.9X
+before 1582, vec on, rebase off                    3742           3766          22         26.7          37.4       3.4X
+before 1582, vec on, rebase on                     6068           6076           7         16.5          60.7       2.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Save timestamps to parquet:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, noop                                   2798           2798           0         35.7          28.0       1.0X
-before 1582, noop                                  2955           2955           0         33.8          29.6       0.9X
-after 1582, rebase off                            15889          15889           0          6.3         158.9       0.2X
-after 1582, rebase on                             84247          84247           0          1.2         842.5       0.0X
-before 1582, rebase off                           16134          16134           0          6.2         161.3       0.2X
-before 1582, rebase on                           100006         100006           0          1.0        1000.1       0.0X
+after 1582, noop                                   2783           2783           0         35.9          27.8       1.0X
+before 1582, noop                                  2783           2783           0         35.9          27.8       1.0X
+after 1582, rebase off                            17016          17016           0          5.9         170.2       0.2X
+after 1582, rebase on                            107890         107890           0          0.9        1078.9       0.0X
+before 1582, rebase off                           17352          17352           0          5.8         173.5       0.2X
+before 1582, rebase on                           122807         122807           0          0.8        1228.1       0.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Load timestamps from parquet:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, vec off, rebase off                   14920          15045         116          6.7         149.2       1.0X
-after 1582, vec off, rebase on                    55062          55171         140          1.8         550.6       0.3X
-after 1582, vec on, rebase off                     4871           4952          72         20.5          48.7       3.1X
-after 1582, vec on, rebase on                     44955          44981          23          2.2         449.5       0.3X
-before 1582, vec off, rebase off                  15236          15386         142          6.6         152.4       1.0X
-before 1582, vec off, rebase on                   57290          57368          79          1.7         572.9       0.3X
-before 1582, vec on, rebase off                    4919           4930          15         20.3          49.2       3.0X
-before 1582, vec on, rebase on                    47351          47713         400          2.1         473.5       0.3X
+after 1582, vec off, rebase off                   15066          15104          38          6.6         150.7       1.0X
+after 1582, vec off, rebase on                    68057          68312         222          1.5         680.6       0.2X
+after 1582, vec on, rebase off                     4878           4953          77         20.5          48.8       3.1X
+after 1582, vec on, rebase on                     57278          57320          41          1.7         572.8       0.3X
+before 1582, vec off, rebase off                  15293          15389          84          6.5         152.9       1.0X
+before 1582, vec off, rebase on                   72951          73139         163          1.4         729.5       0.2X
+before 1582, vec on, rebase off                    4883           4951          78         20.5          48.8       3.1X
+before 1582, vec on, rebase on                    59369          59543         226          1.7         593.7       0.3X
 
 
 ================================================================================================
@@ -59,36 +59,36 @@ OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Save dates to ORC:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, noop                                   9451           9451           0         10.6          94.5       1.0X
-before 1582, noop                                  9765           9765           0         10.2          97.7       1.0X
-after 1582                                        18722          18722           0          5.3         187.2       0.5X
-before 1582                                       18864          18864           0          5.3         188.6       0.5X
+after 1582, noop                                  23498          23498           0          4.3         235.0       1.0X
+before 1582, noop                                 10828          10828           0          9.2         108.3       2.2X
+after 1582                                        32267          32267           0          3.1         322.7       0.7X
+before 1582                                       20339          20339           0          4.9         203.4       1.2X
 
 OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Load dates from ORC:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, vec off                               24897          25095         247          4.0         249.0       1.0X
-after 1582, vec on                                 3719           3780          84         26.9          37.2       6.7X
-before 1582, vec off                              31290          31347          50          3.2         312.9       0.8X
-before 1582, vec on                                4166           4188          25         24.0          41.7       6.0X
+after 1582, vec off                               46140          46161          21          2.2         461.4       1.0X
+after 1582, vec on                                 3711           3748          33         26.9          37.1      12.4X
+before 1582, vec off                              42527          42745         189          2.4         425.3       1.1X
+before 1582, vec on                                4159           4169          15         24.0          41.6      11.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Save timestamps to ORC:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, noop                                   2882           2882           0         34.7          28.8       1.0X
-before 1582, noop                                  2991           2991           0         33.4          29.9       1.0X
-after 1582                                        53951          53951           0          1.9         539.5       0.1X
-before 1582                                       54276          54276           0          1.8         542.8       0.1X
+after 1582, noop                                   2876           2876           0         34.8          28.8       1.0X
+before 1582, noop                                  2957           2957           0         33.8          29.6       1.0X
+after 1582                                        68393          68393           0          1.5         683.9       0.0X
+before 1582                                       68847          68847           0          1.5         688.5       0.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Load timestamps from ORC:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, vec off                               41411          41514          97          2.4         414.1       1.0X
-after 1582, vec on                                32163          32201          36          3.1         321.6       1.3X
-before 1582, vec off                              43013          43111         131          2.3         430.1       1.0X
-before 1582, vec on                               34114          34152          45          2.9         341.1       1.2X
+after 1582, vec off                               55967          56011          43          1.8         559.7       1.0X
+after 1582, vec on                                48930          49156         342          2.0         489.3       1.1X
+before 1582, vec off                              60544          60863         311          1.7         605.4       0.9X
+before 1582, vec on                               52539          52665         109          1.9         525.4       1.1X
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
@@ -20,6 +20,8 @@ package org.apache.spark.sql.execution.benchmark
 import java.sql.Timestamp
 
 import org.apache.spark.benchmark.Benchmark
+import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.{withDefaultTimeZone, LA}
+import org.apache.spark.sql.internal.SQLConf
 
 /**
  * Synthetic benchmark for date and timestamp functions.
@@ -53,96 +55,100 @@ object DateTimeBenchmark extends SqlBasedBenchmark {
   }
 
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
-    val N = 10000000
-    runBenchmark("Extract components") {
-      run(N, "cast to timestamp", "cast(id as timestamp)")
-      run(N, "year")
-      run(N, "quarter")
-      run(N, "month")
-      run(N, "weekofyear")
-      run(N, "day")
-      run(N, "dayofyear")
-      run(N, "dayofmonth")
-      run(N, "dayofweek")
-      run(N, "weekday")
-      run(N, "hour")
-      run(N, "minute")
-      run(N, "second")
-    }
-    runBenchmark("Current date and time") {
-      run(N, "current_date", "current_date")
-      run(N, "current_timestamp", "current_timestamp")
-    }
-    runBenchmark("Date arithmetic") {
-      val dateExpr = "cast(cast(id as timestamp) as date)"
-      run(N, "cast to date", dateExpr)
-      run(N, "last_day", s"last_day($dateExpr)")
-      run(N, "next_day", s"next_day($dateExpr, 'TU')")
-      run(N, "date_add", s"date_add($dateExpr, 10)")
-      run(N, "date_sub", s"date_sub($dateExpr, 10)")
-      run(N, "add_months", s"add_months($dateExpr, 10)")
-    }
-    runBenchmark("Formatting dates") {
-      val dateExpr = "cast(cast(id as timestamp) as date)"
-      run(N, "format date", s"date_format($dateExpr, 'MMM yyyy')")
-    }
-    runBenchmark("Formatting timestamps") {
-      run(N, "from_unixtime", "from_unixtime(id, 'yyyy-MM-dd HH:mm:ss.SSSSSS')")
-    }
-    runBenchmark("Convert timestamps") {
-      val timestampExpr = "cast(id as timestamp)"
-      run(N, "from_utc_timestamp", s"from_utc_timestamp($timestampExpr, 'CET')")
-      run(N, "to_utc_timestamp", s"to_utc_timestamp($timestampExpr, 'CET')")
-    }
-    runBenchmark("Intervals") {
-      val (start, end) = ("cast(id as timestamp)", "cast((id+8640000) as timestamp)")
-      run(N, "cast interval", start, end)
-      run(N, "datediff", s"datediff($start, $end)")
-      run(N, "months_between", s"months_between($start, $end)")
-      run(1000000, "window", s"window($start, 100, 10, 1)")
-    }
-    runBenchmark("Truncation") {
-      val timestampExpr = "cast(id as timestamp)"
-      Seq("YEAR", "YYYY", "YY", "MON", "MONTH", "MM", "DAY", "DD", "HOUR", "MINUTE",
-          "SECOND", "WEEK", "QUARTER").foreach { level =>
-        run(N, s"date_trunc $level", s"date_trunc('$level', $timestampExpr)")
+    withDefaultTimeZone(LA) {
+      withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> LA.getId) {
+        val N = 10000000
+        runBenchmark("Extract components") {
+          run(N, "cast to timestamp", "cast(id as timestamp)")
+          run(N, "year")
+          run(N, "quarter")
+          run(N, "month")
+          run(N, "weekofyear")
+          run(N, "day")
+          run(N, "dayofyear")
+          run(N, "dayofmonth")
+          run(N, "dayofweek")
+          run(N, "weekday")
+          run(N, "hour")
+          run(N, "minute")
+          run(N, "second")
+        }
+        runBenchmark("Current date and time") {
+          run(N, "current_date", "current_date")
+          run(N, "current_timestamp", "current_timestamp")
+        }
+        runBenchmark("Date arithmetic") {
+          val dateExpr = "cast(cast(id as timestamp) as date)"
+          run(N, "cast to date", dateExpr)
+          run(N, "last_day", s"last_day($dateExpr)")
+          run(N, "next_day", s"next_day($dateExpr, 'TU')")
+          run(N, "date_add", s"date_add($dateExpr, 10)")
+          run(N, "date_sub", s"date_sub($dateExpr, 10)")
+          run(N, "add_months", s"add_months($dateExpr, 10)")
+        }
+        runBenchmark("Formatting dates") {
+          val dateExpr = "cast(cast(id as timestamp) as date)"
+          run(N, "format date", s"date_format($dateExpr, 'MMM yyyy')")
+        }
+        runBenchmark("Formatting timestamps") {
+          run(N, "from_unixtime", "from_unixtime(id, 'yyyy-MM-dd HH:mm:ss.SSSSSS')")
+        }
+        runBenchmark("Convert timestamps") {
+          val timestampExpr = "cast(id as timestamp)"
+          run(N, "from_utc_timestamp", s"from_utc_timestamp($timestampExpr, 'CET')")
+          run(N, "to_utc_timestamp", s"to_utc_timestamp($timestampExpr, 'CET')")
+        }
+        runBenchmark("Intervals") {
+          val (start, end) = ("cast(id as timestamp)", "cast((id+8640000) as timestamp)")
+          run(N, "cast interval", start, end)
+          run(N, "datediff", s"datediff($start, $end)")
+          run(N, "months_between", s"months_between($start, $end)")
+          run(1000000, "window", s"window($start, 100, 10, 1)")
+        }
+        runBenchmark("Truncation") {
+          val timestampExpr = "cast(id as timestamp)"
+          Seq("YEAR", "YYYY", "YY", "MON", "MONTH", "MM", "DAY", "DD", "HOUR", "MINUTE",
+            "SECOND", "WEEK", "QUARTER").foreach { level =>
+            run(N, s"date_trunc $level", s"date_trunc('$level', $timestampExpr)")
+          }
+          val dateExpr = "cast(cast(id as timestamp) as date)"
+          Seq("year", "yyyy", "yy", "mon", "month", "mm").foreach { level =>
+            run(N, s"trunc $level", s"trunc('$level', $dateExpr)")
+          }
+        }
+        runBenchmark("Parsing") {
+          val n = 1000000
+          val timestampStrExpr = "concat('2019-01-27 11:02:01.', cast(mod(id, 1000) as string))"
+          val pattern = "'yyyy-MM-dd HH:mm:ss.SSS'"
+          run(n, "to timestamp str", timestampStrExpr)
+          run(n, "to_timestamp", s"to_timestamp($timestampStrExpr, $pattern)")
+          run(n, "to_unix_timestamp", s"to_unix_timestamp($timestampStrExpr, $pattern)")
+          val dateStrExpr = "concat('2019-01-', lpad(mod(id, 25), 2, '0'))"
+          run(n, "to date str", dateStrExpr)
+          run(n, "to_date", s"to_date($dateStrExpr, 'yyyy-MM-dd')")
+        }
+        runBenchmark("Conversion from/to external types") {
+          import spark.implicits._
+          val rowsNum = 5000000
+          val numIters = 3
+          val benchmark = new Benchmark("To/from java.sql.Timestamp", rowsNum, output = output)
+          benchmark.addCase("From java.sql.Timestamp", numIters) { _ =>
+            spark.range(rowsNum)
+              .map(millis => new Timestamp(millis))
+              .noop()
+          }
+          benchmark.addCase("Collect longs", numIters) { _ =>
+            spark.range(0, rowsNum, 1, 1)
+              .collect()
+          }
+          benchmark.addCase("Collect timestamps", numIters) { _ =>
+            spark.range(0, rowsNum, 1, 1)
+              .map(millis => new Timestamp(millis))
+              .collect()
+          }
+          benchmark.run()
+        }
       }
-      val dateExpr = "cast(cast(id as timestamp) as date)"
-      Seq("year", "yyyy", "yy", "mon", "month", "mm").foreach { level =>
-        run(N, s"trunc $level", s"trunc('$level', $dateExpr)")
-      }
-    }
-    runBenchmark("Parsing") {
-      val n = 1000000
-      val timestampStrExpr = "concat('2019-01-27 11:02:01.', cast(mod(id, 1000) as string))"
-      val pattern = "'yyyy-MM-dd HH:mm:ss.SSS'"
-      run(n, "to timestamp str", timestampStrExpr)
-      run(n, "to_timestamp", s"to_timestamp($timestampStrExpr, $pattern)")
-      run(n, "to_unix_timestamp", s"to_unix_timestamp($timestampStrExpr, $pattern)")
-      val dateStrExpr = "concat('2019-01-', lpad(mod(id, 25), 2, '0'))"
-      run(n, "to date str", dateStrExpr)
-      run(n, "to_date", s"to_date($dateStrExpr, 'yyyy-MM-dd')")
-    }
-    runBenchmark("Conversion from/to external types") {
-      import spark.implicits._
-      val rowsNum = 5000000
-      val numIters = 3
-      val benchmark = new Benchmark("To/from java.sql.Timestamp", rowsNum, output = output)
-      benchmark.addCase("From java.sql.Timestamp", numIters) { _ =>
-        spark.range(rowsNum)
-          .map(millis => new Timestamp(millis))
-          .noop()
-      }
-      benchmark.addCase("Collect longs", numIters) { _ =>
-        spark.range(0, rowsNum, 1, 1)
-          .collect()
-      }
-      benchmark.addCase("Collect timestamps", numIters) { _ =>
-        spark.range(0, rowsNum, 1, 1)
-          .map(millis => new Timestamp(millis))
-          .collect()
-      }
-      benchmark.run()
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to set the `America/Los_Angeles` time zone in the date-time benchmarks `DateTimeBenchmark` and `DateTimeRebaseBenchmark` via `withDefaultTimeZone(LA)` and `withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> LA.getId)`.

The results of affected benchmarks was given on an Amazon EC2 instance w/ the configuration:
| Item | Description |
| ---- | ----|
| Region | us-west-2 (Oregon) |
| Instance | r3.xlarge |
| AMI | ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20190722.1 (ami-06f2f779464715dc5) |
| Java | OpenJDK8/11 |

### Why are the changes needed?
Performance of date-time functions can depend on the system JVM time zone or SQL config `spark.sql.session.timeZone`. The changes allow to avoid any fluctuations of benchmarks results related to time zones, and set a reliable baseline for future optimization. 

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
By regenerating results of DateTimeBenchmark and DateTimeRebaseBenchmark.