### PR TITLE
[SPARK-31346][SQL]Add new configuration to make sure temporary directory cleaned

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -784,6 +784,15 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
+  val HIVE_CONFIRM_TEMPORARY_DIRECTORY_DELETED =
+    buildConf("spark.sql.hive.confirmTempDirDeleted")
+      .doc("When set true, keep deleteOnExit of the temporary directory to ensure that " +
+        "the temporary directory can be cleaned. Sometimes (e.g., when speculative task is enabled), " +
+        "temporary directories may be left uncleaned, thus we use this config to confirm " +
+        "temporary directories to be deleted.")
+      .booleanConf
+      .createWithDefault(false)
+
   val HIVE_VERIFY_PARTITION_PATH = buildConf("spark.sql.hive.verifyPartitionPath")
     .doc("When true, check all the partition paths under the table\'s root directory " +
          "when reading data stored in HDFS. This configuration will be deprecated in the future " +
@@ -2786,6 +2795,8 @@ class SQLConf extends Serializable with Logging {
   def orcFilterPushDown: Boolean = getConf(ORC_FILTER_PUSHDOWN_ENABLED)
 
   def isOrcSchemaMergingEnabled: Boolean = getConf(ORC_SCHEMA_MERGING_ENABLED)
+
+  def confirmTempDirDeleted: Boolean = getConf(HIVE_CONFIRM_TEMPORARY_DIRECTORY_DELETED)
 
   def verifyPartitionPath: Boolean = getConf(HIVE_VERIFY_PARTITION_PATH)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -787,9 +787,8 @@ object SQLConf {
   val HIVE_CONFIRM_TEMPORARY_DIRECTORY_DELETED =
     buildConf("spark.sql.hive.confirmTempDirDeleted")
       .doc("When set true, keep deleteOnExit of the temporary directory to ensure that " +
-        "the temporary directory can be cleaned. Sometimes (e.g., when speculative task is enabled), " +
-        "temporary directories may be left uncleaned, thus we use this config to confirm " +
-        "temporary directories to be deleted.")
+        "the temporary directory, which is generated while inserting into hive dir or " +
+        "hive table, can be cleaned.")
       .booleanConf
       .createWithDefault(false)
 


### PR DESCRIPTION
### Why are the changes needed?
In InsertIntoHiveTable and InsertIntoHiveDirCommand, we use deleteExternalTmpPath to clean temporary directories after Job committed and cancel deleteOnExit if succeeded. 
But sometimes (e.g., when speculative task is enabled), temporary directories may be left uncleaned. This is happened if there are still some tasks running after we called deleteExternalTmpPath. Thus it maybe necessary to keep deleteOnExit, even if temporary directory has already deleted, to make sure the temporary directories cleaned.

### How was this patch tested?
run tests
