### PR TITLE
[SPARK-29554][SQL][FOLLOWUP] Update Auto-generated Alias Name for Version

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -173,6 +173,7 @@ case class SparkVersion() extends LeafExpression with CodegenFallback {
   override def nullable: Boolean = false
   override def foldable: Boolean = true
   override def dataType: DataType = StringType
+  override def prettyName: String = "version"
   override def eval(input: InternalRow): Any = {
     UTF8String.fromString(SPARK_VERSION_SHORT + " " + SPARK_REVISION)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
@@ -34,9 +34,11 @@ class MiscFunctionsSuite extends QueryTest with SharedSparkSession {
   }
 
   test("version") {
+    val df = sql("SELECT version()")
     checkAnswer(
-      Seq("").toDF("a").selectExpr("version()"),
+      df,
       Row(SPARK_VERSION_SHORT + " " + SPARK_REVISION))
+    assert(df.schema.fieldNames === Seq("version()"))
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The auto-generated alias name of built-in function `version()` is `sparkversion()`. After this PR, it is updated to `version()`. 

### Why are the changes needed?
Based on our auto-generated alias name convention for the built-in functions, the alias names should be consistent with the function names. 

This built-in function `version` is added in the upcoming Spark 3.0. Thus, we should fix it before the release.

### Does this PR introduce any user-facing change?
Yes. Update the column name in schema if users do not specify the alias.

### How was this patch tested?
Added a test case.