### PR TITLE
[SPARK-31156][SQL] DataFrameStatFunctions API to be consistent with respect to Column type

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -69,10 +69,10 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    * @since 2.0.0
    */
   def approxQuantile(
-      colName: String,
+      col: String,
       probabilities: Array[Double],
       relativeError: Double): Array[Double] = {
-    approxQuantile(Array(df.col(colName)), probabilities, relativeError).head
+    approxQuantile(Array(df.col(col)), probabilities, relativeError).head
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -116,7 +116,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    * @note null and NaN values will be ignored in numerical columns before calculation. For
    *   columns only containing null or NaN values, an empty array is returned.
    *
-   * @since 3.0.0
+   * @since 3.1.0
    */
   def approxQuantile(
       cols: Array[Column],
@@ -174,7 +174,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    *    res1: Double = 0.065...
    * }}}
    *
-   * @since 3.0.0
+   * @since 3.1.0
    */
   def cov(col1: Column, col2: Column): Double = {
     StatFunctions.calculateCovByColumns(df, Seq(col1, col2))
@@ -220,7 +220,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    *    res1: Double = 0.613...
    * }}}
    *
-   * @since 3.0.0
+   * @since 3.1.0
    */
   def corr(col1: Column, col2: Column, method: String): Double = {
     require(method == "pearson", "Currently only the calculation of the Pearson Correlation " +
@@ -263,7 +263,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    *    res1: Double = 0.613...
    * }}}
    *
-   * @since 3.0.0
+   * @since 3.1.0
    */
   def corr(col1: Column, col2: Column): Double = {
     corr(col1, col2, "pearson")
@@ -330,7 +330,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    *    +---------+---+---+---+
    * }}}
    *
-   * @since 3.0.0
+   * @since 3.1.0
    */
   def crosstab(col1: Column, col2: Column): DataFrame = {
     StatFunctions.crossTabulateByColumns(df, col1, col2)
@@ -410,7 +410,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    * @param cols the columns to search frequent items in.
    * @return A Local DataFrame with the Array of frequent items for each column.
    *
-   * @since 3.0.0
+   * @since 3.1.0
    */
   def freqItems(cols: Array[Column]): DataFrame = {
     FrequentItems.singlePassFreqItemsByColumns(df, cols, 0.01)
@@ -426,7 +426,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    *                than 1e-4.
    * @return A Local DataFrame with the Array of frequent items for each column.
    *
-   * @since 3.0.0
+   * @since 3.1.0
    */
   def freqItems(cols: Array[Column], support: Double): DataFrame = {
     FrequentItems.singlePassFreqItemsByColumns(df, cols, support)
@@ -565,7 +565,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    *    +-----+---+
    * }}}
    *
-   * @since 3.0.0
+   * @since 3.1.0
    */
   def sampleBy[T](col: Column, fractions: Map[T, Double], seed: Long): DataFrame = {
     require(fractions.values.forall(p => p >= 0.0 && p <= 1.0),
@@ -588,7 +588,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    * @tparam T stratum type
    * @return a new `DataFrame` that represents the stratified sample
    *
-   * @since 3.0.0
+   * @since 3.1.0
    */
   def sampleBy[T](col: Column, fractions: ju.Map[T, jl.Double], seed: Long): DataFrame = {
     sampleBy(col, fractions.asScala.toMap.asInstanceOf[Map[T, Double]], seed)

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -97,7 +97,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
       cols: Array[String],
       probabilities: Array[Double],
       relativeError: Double): Array[Array[Double]] = {
-    approxQuantile(cols.map(col), probabilities, relativeError)
+    approxQuantile(cols.map(df.col), probabilities, relativeError)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -161,7 +161,6 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
 
   /**
    * Calculate the sample covariance of two numerical columns of a DataFrame.
-   * This version of cov accepts [[Column]] rather than names.
    *
    * @param col1 the first column
    * @param col2 the second column
@@ -207,8 +206,6 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    * Correlation Coefficient. For Spearman Correlation, consider using RDD methods found in
    * MLlib's Statistics.
    *
-   * This version of corr accepts [[Column]] rather than names.
-   *
    * @param col1 the first column
    * @param col2 the column to calculate the correlation against
    * @return The Pearson Correlation Coefficient as a Double.
@@ -250,7 +247,6 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
 
   /**
    * Calculates the Pearson Correlation Coefficient of two columns of a DataFrame.
-   * This version of corr accepts [[Column]] rather than names.
    *
    * @param col1 the first column
    * @param col2 the column to calculate the correlation against
@@ -307,7 +303,6 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
 
   /**
    * Computes a pair-wise frequency table of the given columns.
-   * This version of crosstab accepts [[Column]] rather than names.
    * @see `crosstab(col1:String, col2:String)` for detailed description.
    *
    * @param col1 The first column. Distinct items will make the first item of
@@ -404,7 +399,6 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
 
   /**
    * Finding frequent items for columns, possibly with false positives.
-   * This version of freqItems accepts [[Column]] rather than names.
    * @see `freqItesm(cols: Array[String])` for detailed description.
    *
    * @param cols the columns to search frequent items in.
@@ -418,7 +412,6 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
 
   /**
    * Finding frequent items for columns, possibly with false positives.
-   * This version of freqItems accepts [[Column]] rather than names.
    * @see `freqItesm(cols: Array[String], support:Double)` for detailed description.
    *
    * @param cols the columns to search frequent items in.

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -156,11 +156,13 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    * @since 1.4.0
    */
   def cov(col1: String, col2: String): Double = {
-    cov(Column(col1), Column(col2))
+    cov(df.col(col1), df.col(col2))
   }
 
   /**
    * Calculate the sample covariance of two numerical columns of a DataFrame.
+   * This version of cov accepts [[Column]] rather than names.
+   *
    * @param col1 the first column
    * @param col2 the second column
    * @return the covariance of the two columns.
@@ -197,13 +199,14 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    * @since 1.4.0
    */
   def corr(col1: String, col2: String, method: String): Double = {
-    corr(Column(col1), Column(col2), method)
+    corr(df.col(col1), df.col(col2), method)
   }
 
   /**
    * Calculates the correlation of two columns of a DataFrame. Currently only supports the Pearson
    * Correlation Coefficient. For Spearman Correlation, consider using RDD methods found in
    * MLlib's Statistics.
+   * This version of corr accepts [[Column]] rather than names.
    *
    * @param col1 the first column
    * @param col2 the column to calculate the correlation against
@@ -246,6 +249,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
 
   /**
    * Calculates the Pearson Correlation Coefficient of two columns of a DataFrame.
+   * This version of corr accepts [[Column]] rather than names.
    *
    * @param col1 the first column
    * @param col2 the column to calculate the correlation against

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -206,6 +206,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    * Calculates the correlation of two columns of a DataFrame. Currently only supports the Pearson
    * Correlation Coefficient. For Spearman Correlation, consider using RDD methods found in
    * MLlib's Statistics.
+   *
    * This version of corr accepts [[Column]] rather than names.
    *
    * @param col1 the first column
@@ -301,11 +302,12 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    * @since 1.4.0
    */
   def crosstab(col1: String, col2: String): DataFrame = {
-    crosstab(Column(col1), Column(col2))
+    crosstab(df.col(col1), df.col(col2))
   }
 
   /**
    * Computes a pair-wise frequency table of the given columns.
+   * This version of crosstab accepts [[Column]] rather than names.
    * @see `crosstab(col1:String, col2:String)` for detailed description.
    *
    * @param col1 The first column. Distinct items will make the first item of

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -380,7 +380,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    * @since 1.4.0
    */
   def freqItems(cols: Array[String], support: Double): DataFrame = {
-    FrequentItems.singlePassFreqItems(df, cols, support)
+    freqItems(cols.map(df.col), support)
   }
 
   /**
@@ -399,7 +399,37 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    * @since 1.4.0
    */
   def freqItems(cols: Array[String]): DataFrame = {
-    FrequentItems.singlePassFreqItems(df, cols, 0.01)
+    freqItems(cols.map(df.col), 0.01)
+  }
+
+  /**
+   * Finding frequent items for columns, possibly with false positives.
+   * This version of freqItems accepts [[Column]] rather than names.
+   * @see `freqItesm(cols: Array[String])` for detailed description.
+   *
+   * @param cols the columns to search frequent items in.
+   * @return A Local DataFrame with the Array of frequent items for each column.
+   *
+   * @since 3.0.0
+   */
+  def freqItems(cols: Array[Column]): DataFrame = {
+    FrequentItems.singlePassFreqItemsByColumns(df, cols, 0.01)
+  }
+
+  /**
+   * Finding frequent items for columns, possibly with false positives.
+   * This version of freqItems accepts [[Column]] rather than names.
+   * @see `freqItesm(cols: Array[String], support:Double)` for detailed description.
+   *
+   * @param cols the columns to search frequent items in.
+   * @param support The minimum frequency for an item to be considered `frequent`. Should be greater
+   *                than 1e-4.
+   * @return A Local DataFrame with the Array of frequent items for each column.
+   *
+   * @since 3.0.0
+   */
+  def freqItems(cols: Array[Column], support: Double): DataFrame = {
+    FrequentItems.singlePassFreqItemsByColumns(df, cols, support)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -72,7 +72,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
       colName: String,
       probabilities: Array[Double],
       relativeError: Double): Array[Double] = {
-    approxQuantile(Array(col(colName)), probabilities, relativeError).head
+    approxQuantile(Array(df.col(colName)), probabilities, relativeError).head
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -177,7 +177,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    * @since 3.0.0
    */
   def cov(col1: Column, col2: Column): Double = {
-    StatFunctions.calculateCovColumns(df, Seq(col1, col2))
+    StatFunctions.calculateCovByColumns(df, Seq(col1, col2))
   }
 
   /**
@@ -225,7 +225,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
   def corr(col1: Column, col2: Column, method: String): Double = {
     require(method == "pearson", "Currently only the calculation of the Pearson Correlation " +
       "coefficient is supported.")
-    StatFunctions.pearsonCorrelationColumns(df, Seq(col1, col2))
+    StatFunctions.pearsonCorrelationByColumns(df, Seq(col1, col2))
   }
 
   /**
@@ -333,7 +333,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    * @since 3.0.0
    */
   def crosstab(col1: Column, col2: Column): DataFrame = {
-    StatFunctions.crossTabulateColumns(df, col1, col2)
+    StatFunctions.crossTabulateByColumns(df, col1, col2)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
@@ -128,7 +128,7 @@ object StatFunctions extends Logging {
 
   /** Calculate the Pearson Correlation Coefficient for the given columns */
   def pearsonCorrelation(df: DataFrame, cols: Seq[String]): Double = {
-    pearsonCorrelationColumns(df, cols.map(df.col))
+    pearsonCorrelationByColumns(df, cols.map(df.col))
   }
 
   /**
@@ -136,8 +136,8 @@ object StatFunctions extends Logging {
    *  Overloading the same function to provide both Seq[String] and Seq[Column]
    *  arguments is not possible because of type erasure.
    */
-  private[sql] def pearsonCorrelationColumns(df: DataFrame, cols: Seq[Column]): Double = {
-    val counts = collectStatisticalDataColumns(df, cols, "correlation")
+  private[sql] def pearsonCorrelationByColumns(df: DataFrame, cols: Seq[Column]): Double = {
+    val counts = collectStatisticalDataByColumns(df, cols, "correlation")
     counts.Ck / math.sqrt(counts.MkX * counts.MkY)
   }
 
@@ -183,7 +183,7 @@ object StatFunctions extends Logging {
 
   private def collectStatisticalData(df: DataFrame, cols: Seq[String],
               functionName: String): CovarianceCounter = {
-    collectStatisticalDataColumns(df, cols.map(df.col), functionName)
+    collectStatisticalDataByColumns(df, cols.map(df.col), functionName)
   }
 
 
@@ -192,7 +192,7 @@ object StatFunctions extends Logging {
    *  Overloading the same function to provide both Seq[String] and Seq[Column]
    *  arguments is not possible because of type erasure.
    */
-  private def collectStatisticalDataColumns(df: DataFrame, cols: Seq[Column],
+  private def collectStatisticalDataByColumns(df: DataFrame, cols: Seq[Column],
               functionName: String): CovarianceCounter = {
     require(cols.length == 2, s"Currently $functionName calculation is supported " +
       "between two columns.")
@@ -228,14 +228,14 @@ object StatFunctions extends Logging {
    * @param cols the columns
    * @return the covariance of the two columns.
    */
-  def calculateCovColumns(df: DataFrame, cols: Seq[Column]): Double = {
-    val counts = collectStatisticalDataColumns(df, cols, "covariance")
+  def calculateCovByColumns(df: DataFrame, cols: Seq[Column]): Double = {
+    val counts = collectStatisticalDataByColumns(df, cols, "covariance")
     counts.cov
   }
 
   /** Generate a table of frequencies for the elements of two columns. */
   def crossTabulate(df: DataFrame, col1: String, col2: String): DataFrame = {
-    crossTabulateColumns(df, df.col(col1), df.col(col2))
+    crossTabulateByColumns(df, df.col(col1), df.col(col2))
   }
 
   /**
@@ -243,7 +243,7 @@ object StatFunctions extends Logging {
    *  Overloading the same function to provide both Seq[String] and Seq[Column]
    *  arguments is not possible because of type erasure.
    */
-  private[sql] def crossTabulateColumns(df: DataFrame, col1: Column, col2: Column): DataFrame = {
+  private[sql] def crossTabulateByColumns(df: DataFrame, col1: Column, col2: Column): DataFrame = {
     val colName1 = resolveColumn(df, col1).named.name
     val colName2 = resolveColumn(df, col2).named.name
     val tableName = s"${colName1}_$colName2"

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
@@ -218,8 +218,7 @@ object StatFunctions extends Logging {
    * @return the covariance of the two columns.
    */
   def calculateCov(df: DataFrame, cols: Seq[String]): Double = {
-    val counts = collectStatisticalData(df, cols, "covariance")
-    counts.cov
+    calculateCovByColumns(df, cols.map(df.col))
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
@@ -221,11 +221,8 @@ object StatFunctions extends Logging {
   }
 
   private def columnName(col: Column): Option[String] = {
-    if col.expr.isInstanceOf[NamedExpression] {
-      Some(col.expr.toString)
-    } else {
-      None
-    }
+    if (col.expr.isInstanceOf[NamedExpression]) Some(col.expr.toString)
+    else None
   }
 
   /** Helper method to provide Column-type API for stat functions SPARK-31156).

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
@@ -34,6 +34,9 @@ import org.apache.spark.unsafe.types.UTF8String
 object StatFunctions extends Logging {
 
   /** Helper function to resolve column to expr (if not yet) */
+  // TODO: it might be helpful to have this helper in Dataset.scala,
+  // e.g. `drop` function uses exactly the same flow to deal with
+  // `Column` arguments
   private def resolveColumn(df: DataFrame, col: Column): Expression = {
     col match {
       case Column(u: UnresolvedAttribute) =>

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
@@ -286,7 +286,7 @@ public class JavaDataFrameSuite {
   }
 
   @Test
-  public void testCrosstabByColumn() {
+  public void testCrosstabByColumns() {
     Dataset<Row> df = spark.table("testData2");
     Dataset<Row> crosstab = df.stat().crosstab(col("a"), col("b"));
     String[] columnNames = crosstab.schema().fieldNames();
@@ -320,7 +320,7 @@ public class JavaDataFrameSuite {
   }
 
   @Test
-  public void testCorrelationByColumn() {
+  public void testCorrelationByColumns() {
     Dataset<Row> df = spark.table("testData2");
     Double pearsonCorr = df.stat().corr(col("a"), col("b"), "pearson");
     Assert.assertTrue(Math.abs(pearsonCorr) < 1.0e-6);
@@ -334,7 +334,7 @@ public class JavaDataFrameSuite {
   }
 
   @Test
-  public void testCovarianceByColumn() {
+  public void testCovarianceByColumns() {
     Dataset<Row> df = spark.table("testData2");
     Double result = df.stat().cov(col("a"), col("b"));
     Assert.assertTrue(Math.abs(result) < 1.0e-6);

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
@@ -286,6 +286,25 @@ public class JavaDataFrameSuite {
   }
 
   @Test
+  public void testCrosstabByColumn() {
+    Dataset<Row> df = spark.table("testData2");
+    Dataset<Row> crosstab = df.stat().crosstab(col("a"), col("b"));
+    String[] columnNames = crosstab.schema().fieldNames();
+    Assert.assertEquals("a_b", columnNames[0]);
+    Assert.assertEquals("1", columnNames[1]);
+    Assert.assertEquals("2", columnNames[2]);
+    List<Row> rows = crosstab.collectAsList();
+    rows.sort(crosstabRowComparator);
+    Integer count = 1;
+    for (Row row : rows) {
+      Assert.assertEquals(row.get(0).toString(), count.toString());
+      Assert.assertEquals(1L, row.getLong(1));
+      Assert.assertEquals(1L, row.getLong(2));
+      count++;
+    }
+  }
+
+  @Test
   public void testFrequentItems() {
     Dataset<Row> df = spark.table("testData2");
     String[] cols = {"a"};

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
@@ -301,9 +301,23 @@ public class JavaDataFrameSuite {
   }
 
   @Test
+  public void testCorrelationByColumn() {
+    Dataset<Row> df = spark.table("testData2");
+    Double pearsonCorr = df.stat().corr(col("a"), col("b"), "pearson");
+    Assert.assertTrue(Math.abs(pearsonCorr) < 1.0e-6);
+  }
+
+  @Test
   public void testCovariance() {
     Dataset<Row> df = spark.table("testData2");
     Double result = df.stat().cov("a", "b");
+    Assert.assertTrue(Math.abs(result) < 1.0e-6);
+  }
+
+  @Test
+  public void testCovarianceByColumn() {
+    Dataset<Row> df = spark.table("testData2");
+    Double result = df.stat().cov(col("a"), col("b"));
     Assert.assertTrue(Math.abs(result) < 1.0e-6);
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
@@ -124,8 +124,8 @@ class DataFrameStatSuite extends QueryTest with SharedSparkSession {
     // > cor(a, b)
     // [1] 0.957233913947585835
     val df2 = Seq.tabulate(20)(x => (x, x * x - 2 * x + 3.5)).toDF("a", "b")
-    val corr3 = df2.stat.corr("a", "b", "pearson")
-    assert(math.abs(corr3 - 0.95723391394758572) < 1e-12)
+    val corr4 = df2.stat.corr("a", "b", "pearson")
+    assert(math.abs(corr4 - 0.95723391394758572) < 1e-12)
   }
 
   test("SPARK-30532 stat functions to understand fully-qualified column name") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
@@ -316,6 +316,9 @@ class DataFrameStatSuite extends QueryTest with SharedSparkSession {
           assert(row.getLong(col) === expected.getOrElse((i, j), 0).toLong)
         }
       }
+      val crosstabByColumns = df.stat.crosstab(col("a"), col("b"))
+      val columnNamesByColumns = crosstabByColumns.schema.fieldNames
+      assert(columnNamesByColumns(0) === "a_b")
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
@@ -109,6 +109,8 @@ class DataFrameStatSuite extends QueryTest with SharedSparkSession {
     assert(math.abs(corr1 - 1.0) < 1e-12)
     val corr2 = df.stat.corr("a", "c", "pearson")
     assert(math.abs(corr2 + 1.0) < 1e-12)
+    val corr3 = df.stat.corr(col("a"), col("c"), "pearson")
+    assert(math.abs(corr3 + 1.0) < 1e-12)
     // non-trivial example. To reproduce in python, use:
     // >>> from scipy.stats import pearsonr
     // >>> import numpy as np
@@ -157,6 +159,8 @@ class DataFrameStatSuite extends QueryTest with SharedSparkSession {
 
     val results = df.stat.cov("singles", "doubles")
     assert(math.abs(results - 55.0 / 3) < 1e-12)
+    val results2 = df.stat.cov(df("singles"), df("doubles"))
+    assert(math.abs(results2 - 55.0 / 3) < 1e-12)
     intercept[IllegalArgumentException] {
       df.stat.cov("singles", "letters") // doesn't accept non-numerical dataTypes
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

PR introduces overloaded methods for
* `stat.approxQuantile`
* `stat.corr`
* `stat.cov`
* `stat.crosstab`
* `stat.freqItems`

to work with arguments passed as `Column`s rather than column names.

### Why are the changes needed?

Some other functions from `StatFunctions` module already provide `Column`-based versions, namely:
* `stat.bloomFilter`
* `stat.countMinSketch`
* `stat.sampleBy`

The change proposed allows more flexible usage patterns along side with API consistency.

### Does this PR introduce any user-facing change?

Yes, new signatures for stat API functions.

### How was this patch tested?

Corresponding test cases are included.

### Thoughts

* Python and R API should probably also be revisited (I can do this in separate PR or include here)
* `stat.freqItems` with `Array` argument is overloaded, but `stat.freqItems` with Scala-only `Seq` API could not be overloaded to provide same functionality (because of type erasure)
* I decided to keep old versions of helper functions from `StatFunctions`, e.g. `pearsonCorrelation` and add new `pearsonCorrelationByColumn` (it seems like API is internal but it's public and removal of public method might introduce issues)
* `resolveColumn` helper introduces for `StatFunctions` should probably be the part of `Dataset` API (e.g. `Dataset.drop` uses quite the same approach when dealing with `Column` arguments), should I move it in this PR or create another one (don't want to put to many changes in a single bucket)?