### PR TITLE
[SPARK-31366][DOCS][SQL] Add doc for the aggregation in SQL reference guide

### DIFF
--- a/docs/_data/menu-sql.yaml
+++ b/docs/_data/menu-sql.yaml
@@ -158,6 +158,8 @@
                   url: sql-ref-syntax-qry-select-hints.html
             - text: EXPLAIN
               url: sql-ref-syntax-qry-explain.html
+            - text: AGGREGATION
+              url: sql-ref-syntax-qry-aggregation.html
         - text: Auxiliary Statements
           url: sql-ref-syntax-aux.html
           subitems:

--- a/docs/sql-ref-syntax-qry-aggregation.md
+++ b/docs/sql-ref-syntax-qry-aggregation.md
@@ -1,7 +1,7 @@
 ---
 layout: global
-title: Aggregation (CUBE/ROLLUP/GROUPING)
-displayTitle: Aggregation (CUBE/ROLLUP/GROUPING) 
+title: AGGREGATION
+displayTitle: AGGREGATION
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -19,4 +19,16 @@ license: |
   limitations under the License.
 ---
 
-**This page is under construction**
+
+An aggregate function operates on a group of rows and returns a single value.
+Spark supports various aggregations.
+Some examples of the common aggregation functions are <code>SUM</code>, <code>MIN</code>, <code>MAX</code> and <code>COUNT</code>.
+There are a rich set of aggregate functions that can be used along with the
+<code>GROUP BY</code> clause in <code>SELECT</code> queries.
+Spark also supports advanced aggregations using the <code>CUBE</code>, <code>GROUPING SETS</code> and <code>ROLLUP</code> clauses in <code>GROUP BY</code>.
+
+The following sections describe the query syntax and usage for the different aggregation functions.
+* [BUILT-IN AGGREGATE FUNCTIONS](sql-ref-functions-builtin-aggregate.html)
+* [CUBE](sql-ref-syntax-qry-select-groupby.html)
+* [GROUPING SETS](sql-ref-syntax-qry-select-groupby.html)
+* [ROLLUP](sql-ref-syntax-qry-select-groupby.html)

--- a/docs/sql-ref-syntax-qry.md
+++ b/docs/sql-ref-syntax-qry.md
@@ -25,6 +25,7 @@ and brief description of supported clauses are explained in
 [SELECT](sql-ref-syntax-qry-select.html) section. Spark also provides the
 ability to generate logical and physical plan for a given query using
 [EXPLAIN](sql-ref-syntax-qry-explain.html) statement.
+Spark has support for a rich set of [aggregations](sql-ref-syntax-qry-aggregation.html).
 
 
 - [WHERE Clause](sql-ref-syntax-qry-select-where.html)
@@ -36,3 +37,4 @@ ability to generate logical and physical plan for a given query using
 - [DISTRIBUTE BY Clause](sql-ref-syntax-qry-select-distribute-by.html)
 - [LIMIT Clause](sql-ref-syntax-qry-select-limit.html)
 - [EXPLAIN Statement](sql-ref-syntax-qry-explain.html)
+- [AGGREGATION](sql-ref-syntax-qry-aggregation.html)

--- a/docs/sql-ref-syntax.md
+++ b/docs/sql-ref-syntax.md
@@ -45,6 +45,7 @@ Spark SQL is Apache Spark's module for working with structured data. The SQL Syn
 - [LOAD](sql-ref-syntax-dml-load.html)
 
 ### Data Retrieval Statements
+- [AGGREGATION](sql-ref-syntax-qry-aggregation.html)
 - [CLUSTER BY Clause](sql-ref-syntax-qry-select-clusterby.html)
 - [DISTRIBUTE BY Clause](sql-ref-syntax-qry-select-distribute-by.html)
 - [EXPLAIN](sql-ref-syntax-qry-explain.html)


### PR DESCRIPTION

### What changes were proposed in this pull request?
Add aggregation doc in SQL reference, adding a structure to point to the CUBE, ROLLUP and GROUPING SETS part of aggregation and also the built-in aggregate functions.

### Why are the changes needed?
Needed for SQL Reference guide

### Does this PR introduce any user-facing change?
Yes. New doc.

![image](https://user-images.githubusercontent.com/16563220/78615526-a6c15580-7826-11ea-9205-5b5b3c608b44.png)


### How was this patch tested?
Manually by generating the doc.