### PR TITLE
[SPARK-31384][SQL] Fix NPE in OptimizeSkewedJoin

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.execution.adaptive
 
-import org.apache.spark.MapOutputStatistics
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.SparkPlan
@@ -54,9 +53,9 @@ case class CoalesceShufflePartitions(session: SparkSession) extends Rule[SparkPl
     if (!shuffleStages.forall(_.shuffle.canChangeNumPartitions)) {
       plan
     } else {
-      // `ShuffleQueryStageExec` gives null mapOutputStatistics when the input RDD
+      // `ShuffleQueryStageExec` returns None MapOutputStatistics when the input RDD
       // has 0 partitions, we should skip it when calculating the `partitionStartIndices`.
-      val validMetrics = shuffleStages.flatMap(ExtractMapStats.unapply)
+      val validMetrics = shuffleStages.flatMap(_.mapStats)
 
       // We may have different pre-shuffle partition numbers, don't reduce shuffle partition number
       // in that case. For example when we union fully aggregated data (data is arranged to a single

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
@@ -54,7 +54,7 @@ case class CoalesceShufflePartitions(session: SparkSession) extends Rule[SparkPl
     if (!shuffleStages.forall(_.shuffle.canChangeNumPartitions)) {
       plan
     } else {
-      // `ShuffleQueryStageExec` gives empty mapOutputStatistics when the input RDD
+      // `ShuffleQueryStageExec` gives null mapOutputStatistics when the input RDD
       // has 0 partitions, we should skip it when calculating the `partitionStartIndices`.
       val validMetrics = shuffleStages.flatMap(ExtractMapStats.unapply)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
@@ -53,8 +53,8 @@ case class CoalesceShufflePartitions(session: SparkSession) extends Rule[SparkPl
     if (!shuffleStages.forall(_.shuffle.canChangeNumPartitions)) {
       plan
     } else {
-      // `ShuffleQueryStageExec` returns None MapOutputStatistics when the input RDD
-      // has 0 partitions, we should skip it when calculating the `partitionStartIndices`.
+      // `ShuffleQueryStageExec#mapStats` returns None when the input RDD has 0 partitions,
+      // we should skip it when calculating the `partitionStartIndices`.
       val validMetrics = shuffleStages.flatMap(_.mapStats)
 
       // We may have different pre-shuffle partition numbers, don't reduce shuffle partition number

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CustomShuffleReaderExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CustomShuffleReaderExec.scala
@@ -99,18 +99,17 @@ case class CustomShuffleReaderExec private(
     val maxSize = SQLMetrics.createSizeMetric(sparkContext, "maximum partition data size")
     val minSize = SQLMetrics.createSizeMetric(sparkContext, "minimum partition data size")
     val avgSize = SQLMetrics.createSizeMetric(sparkContext, "average partition data size")
-    val mapStats = shuffleStage.get.mapStats
-    val sizes = if (mapStats.isDefined) {
-      val mapSizes = mapStats.get.bytesByPartitionId
+    val mapStatsOpt = shuffleStage.get.mapStats
+    val sizes = mapStatsOpt.map { mapStats =>
+      val mapSizes = mapStats.bytesByPartitionId
       partitionSpecs.map {
         case CoalescedPartitionSpec(startReducerIndex, endReducerIndex) =>
           startReducerIndex.until(endReducerIndex).map(mapSizes).sum
         case p: PartialReducerPartitionSpec => p.dataSize
         case p => throw new IllegalStateException("unexpected " + p)
       }
-    } else {
-      Seq(0L)
-    }
+    }.getOrElse(Seq(0L))
+
     maxSize.set(sizes.max)
     minSize.set(sizes.min)
     avgSize.set(sizes.sum / sizes.length)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CustomShuffleReaderExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CustomShuffleReaderExec.scala
@@ -99,12 +99,17 @@ case class CustomShuffleReaderExec private(
     val maxSize = SQLMetrics.createSizeMetric(sparkContext, "maximum partition data size")
     val minSize = SQLMetrics.createSizeMetric(sparkContext, "minimum partition data size")
     val avgSize = SQLMetrics.createSizeMetric(sparkContext, "average partition data size")
-    val mapStats = shuffleStage.get.mapStats.bytesByPartitionId
-    val sizes = partitionSpecs.map {
-      case CoalescedPartitionSpec(startReducerIndex, endReducerIndex) =>
-        startReducerIndex.until(endReducerIndex).map(mapStats(_)).sum
-      case p: PartialReducerPartitionSpec => p.dataSize
-      case p => throw new IllegalStateException("unexpected " + p)
+    val sizes = shuffleStage.get match {
+      case ExtractMapStats(mapStats) =>
+        val sizes = mapStats.bytesByPartitionId
+        partitionSpecs.map {
+          case CoalescedPartitionSpec(startReducerIndex, endReducerIndex) =>
+            startReducerIndex.until(endReducerIndex).map(sizes(_)).sum
+          case p: PartialReducerPartitionSpec => p.dataSize
+          case p => throw new IllegalStateException("unexpected " + p)
+        }
+
+      case _ => Seq(0L)
     }
     maxSize.set(sizes.max)
     minSize.set(sizes.min)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/DemoteBroadcastHashJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/DemoteBroadcastHashJoin.scala
@@ -28,9 +28,9 @@ import org.apache.spark.sql.internal.SQLConf
 case class DemoteBroadcastHashJoin(conf: SQLConf) extends Rule[LogicalPlan] {
 
   private def shouldDemote(plan: LogicalPlan): Boolean = plan match {
-    case LogicalQueryStage(_, s: ShuffleQueryStageExec) if s.resultOption.isEmpty => false
-    case LogicalQueryStage(_, s: ShuffleQueryStageExec) if s.mapStats.isDefined =>
-      val mapStats = s.mapStats.get
+    case LogicalQueryStage(_, stage: ShuffleQueryStageExec) if stage.resultOption.isDefined
+      && stage.mapStats.isDefined =>
+      val mapStats = stage.mapStats.get
       val partitionCnt = mapStats.bytesByPartitionId.length
       val nonZeroCnt = mapStats.bytesByPartitionId.count(_ > 0)
       partitionCnt > 0 && nonZeroCnt > 0 &&

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
@@ -288,15 +288,15 @@ case class OptimizeSkewedJoin(conf: SQLConf) extends Rule[SparkPlan] {
 
 private object ShuffleStage {
   def unapply(plan: SparkPlan): Option[ShuffleStageInfo] = plan match {
-    case s: ShuffleQueryStageExec =>
-      val sizes = s.mapStats.bytesByPartitionId
+    case s @ ExtractMapStats(mapStats) =>
+      val sizes = mapStats.bytesByPartitionId
       val partitions = sizes.zipWithIndex.map {
         case (size, i) => CoalescedPartitionSpec(i, i + 1) -> size
       }
-      Some(ShuffleStageInfo(s, s.mapStats, partitions))
+      Some(ShuffleStageInfo(s, mapStats, partitions))
 
-    case CustomShuffleReaderExec(s: ShuffleQueryStageExec, partitionSpecs) =>
-      val sizes = s.mapStats.bytesByPartitionId
+    case CustomShuffleReaderExec(s @ ExtractMapStats(mapStats), partitionSpecs) =>
+      val sizes = mapStats.bytesByPartitionId
       val partitions = partitionSpecs.map {
         case spec @ CoalescedPartitionSpec(start, end) =>
           var sum = 0L
@@ -309,7 +309,7 @@ private object ShuffleStage {
         case other => throw new IllegalArgumentException(
           s"Expect CoalescedPartitionSpec but got $other")
       }
-      Some(ShuffleStageInfo(s, s.mapStats, partitions))
+      Some(ShuffleStageInfo(s, mapStats, partitions))
 
     case _ => None
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageExec.scala
@@ -161,14 +161,12 @@ case class ShuffleQueryStageExec(
       case _ =>
     }
   }
-}
 
-private object ExtractMapStats {
-  def unapply(s: ShuffleQueryStageExec): Option[MapOutputStatistics] = {
-    assert(s.resultOption.isDefined, "ShuffleQueryStageExec should already be ready")
-    val mapStats = s.resultOption.get.asInstanceOf[MapOutputStatistics]
+  def mapStats: Option[MapOutputStatistics] = {
+    assert(resultOption.isDefined, "ShuffleQueryStageExec should already be ready")
+    val stats = resultOption.get.asInstanceOf[MapOutputStatistics]
     // mapStats can be null when the input RDD of a plan has 0 partition
-    Option(mapStats)
+    Option(stats)
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageExec.scala
@@ -161,10 +161,14 @@ case class ShuffleQueryStageExec(
       case _ =>
     }
   }
+}
 
-  def mapStats: MapOutputStatistics = {
-    assert(resultOption.isDefined)
-    resultOption.get.asInstanceOf[MapOutputStatistics]
+private object ExtractMapStats {
+  def unapply(s: ShuffleQueryStageExec): Option[MapOutputStatistics] = {
+    assert(s.resultOption.isDefined, "ShuffleQueryStageExec should already be ready")
+    val mapStats = s.resultOption.get.asInstanceOf[MapOutputStatistics]
+    // mapStats can be null when the input RDD of a plan has 0 partition
+    Option(mapStats)
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageExec.scala
@@ -162,10 +162,13 @@ case class ShuffleQueryStageExec(
     }
   }
 
+  /**
+   * Returns the Option[MapOutputStatistics]. If the shuffle map stage has no partition,
+   * this method returns None, as there is no map statistics.
+   */
   def mapStats: Option[MapOutputStatistics] = {
     assert(resultOption.isDefined, "ShuffleQueryStageExec should already be ready")
     val stats = resultOption.get.asInstanceOf[MapOutputStatistics]
-    // mapStats can be null when the input RDD of a plan has 0 partition
     Option(stats)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -782,7 +782,7 @@ class AdaptiveQueryExecSuite
     }
   }
 
-  test("avoid NPE in OptimizeSkewedJoin when there's 0 partition plan") {
+  test("SPARK-31384: avoid NPE in OptimizeSkewedJoin when there's 0 partition plan") {
     withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
       withTempView("t2") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BuildLeft, B
 import org.apache.spark.sql.execution.ui.SparkListenerSQLAdaptiveExecutionUpdate
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{IntegerType, StructType}
 import org.apache.spark.util.Utils
 
 class AdaptiveQueryExecSuite
@@ -777,6 +778,19 @@ class AdaptiveQueryExecSuite
     levels.foreach { level =>
       withSQLConf(SQLConf.ADAPTIVE_EXECUTION_LOG_LEVEL.key -> level._1) {
         verifyLog(level._2)
+      }
+    }
+  }
+
+  test("avoid NPE in OptimizeSkewedJoin when there's 0 partition plan") {
+    withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      withTempView("t2") {
+        // create DataFrame with 0 partition
+        spark.createDataFrame(sparkContext.emptyRDD[Row], new StructType().add("b", IntegerType))
+          .createOrReplaceTempView("t2")
+        // should run successfully without NPE
+        runAdaptiveAndVerifyResult("SELECT * FROM testData2 t1 left semi join t2 ON t1.a=t2.b")
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

1. Fix NPE in `OptimizeSkewedJoin`

2. prevent other potential NPE errors in AQE.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

When there's a `inputRDD` of a plan has 0 partition, rule `OptimizeSkewedJoin` can hit NPE error because this kind of RDD means a null `MapOutputStatistics` due to:

https://github.com/apache/spark/blob/d98df7626b8a88cb9a1fee4f454b19333a9f3ced/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala#L68-L69


Thus, we should take care of such NPE errors in other places too.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Added a test.
