### PR TITLE
[WIP][SPARK-31363][SQL] Add DataSourceRegisterV2

### DIFF
--- a/dev/.rat-excludes
+++ b/dev/.rat-excludes
@@ -123,3 +123,4 @@ vote.tmpl
 SessionManager.java
 SessionHandler.java
 GangliaReporter.java
+dsregistration-v2/*

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -719,7 +719,8 @@ object DataSource extends Logging {
   }
 
   /**
-   * Returns an optional [[TableProvider]] instance for the given provider registered via [[DataSourceRegisterV2]].
+   * Returns an optional [[TableProvider]] instance for the given provider
+   * registered via [[DataSourceRegisterV2]].
    */
   def lookupDataSourceViaRegistrationV2(provider: String, conf: SQLConf): Class[_] = {
     val loader = Utils.getContextOrSparkClassLoader

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -51,9 +51,10 @@ trait DataSourceRegister {
 }
 
 /**
- * Extended version of [[DataSourceRegister]] which allows a data source to select an implementing class at runtime.
- * This allows plugin developers to choose the correct implementation at runtime, depending on the version of Spark the
- * user is using.
+ * Extended version of [[DataSourceRegister]] which allows a data source to
+ * select an implementing class at runtime.  This allows plugin developers to
+ * choose the correct implementation at runtime, depending on the version of
+ * Spark the user is using.
  *
  *  A new instance of this class will be instantiated each time a DDL call is made.
  *
@@ -72,12 +73,13 @@ trait DataSourceRegisterV2 {
   def shortName(): String
 
   /**
-   * The class that implements the appropriate top-level DSv2 interface (e.g. DataSourceV2 in Spark2.4, or TableProvider
-   * in Spark3.0).
+   * The class that implements the appropriate top-level DSv2 interface (e.g.
+   * DataSourceV2 in Spark2.4, or TableProvider in Spark3.0).
    *
-   * @note The return type of Class is on purpose to avoid tying the registration interface to the underlying
-   *       implementation type. Users of this interface are expected to return a class which can be successfully casted
-   *       to the type required by the currently-running version of spark
+   * @note The return type of Class is on purpose to avoid tying the
+   *       registration interface to the underlying implementation type. Users of
+   *       this interface are expected to return a class which can be successfully
+   *       casted to the type required by the currently-running version of spark
    */
   def getImplementation(): Class[_]
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -51,6 +51,38 @@ trait DataSourceRegister {
 }
 
 /**
+ * Extended version of [[DataSourceRegister]] which allows a data source to select an implementing class at runtime.
+ * This allows plugin developers to choose the correct implementation at runtime, depending on the version of Spark the
+ * user is using.
+ *
+ *  A new instance of this class will be instantiated each time a DDL call is made.
+ *
+ */
+trait DataSourceRegisterV2 {
+
+  /**
+   * The string that represents the format that this data source provider uses. This is
+   * overridden by children to provide a nice alias for the data source. For example:
+   *
+   * {{{
+   *   override def shortName(): String = "parquet"
+   * }}}
+   *
+   */
+  def shortName(): String
+
+  /**
+   * The class that implements the appropriate top-level DSv2 interface (e.g. DataSourceV2 in Spark2.4, or TableProvider
+   * in Spark3.0).
+   *
+   * @note The return type of Class is on purpose to avoid tying the registration interface to the underlying
+   *       implementation type. Users of this interface are expected to return a class which can be successfully casted
+   *       to the type required by the currently-running version of spark
+   */
+  def getImplementation(): Class[_]
+}
+
+/**
  * Implemented by objects that produce relations for a specific kind of data source.  When
  * Spark SQL is given a DDL operation with a USING clause specified (to specify the implemented
  * RelationProvider), this interface is used to pass in the parameters specified by a user.

--- a/sql/core/src/test/resources/dsregistration-v2/v1Registration1
+++ b/sql/core/src/test/resources/dsregistration-v2/v1Registration1
@@ -1,0 +1,1 @@
+org.apache.spark.sql.execution.datasources.v1TableProvider1

--- a/sql/core/src/test/resources/dsregistration-v2/v1Registration2
+++ b/sql/core/src/test/resources/dsregistration-v2/v1Registration2
@@ -1,0 +1,2 @@
+org.apache.spark.sql.execution.datasources.v1TableProvider1
+org.apache.spark.sql.execution.datasources.v1TableProvider2

--- a/sql/core/src/test/resources/dsregistration-v2/v2Registration1
+++ b/sql/core/src/test/resources/dsregistration-v2/v2Registration1
@@ -1,0 +1,1 @@
+org.apache.spark.sql.execution.datasources.v2Registration2

--- a/sql/core/src/test/resources/dsregistration-v2/v2Registration2
+++ b/sql/core/src/test/resources/dsregistration-v2/v2Registration2
@@ -1,0 +1,2 @@
+org.apache.spark.sql.execution.datasources.v2Registration1
+org.apache.spark.sql.execution.datasources.v2Registration2

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceRegistrationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceRegistrationSuite.scala
@@ -20,15 +20,15 @@ package org.apache.spark.sql.execution.datasources
 import java.net.URL
 import java.util
 
-import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.connector.catalog.{Table, TableProvider}
+import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.{DataSourceRegister, DataSourceRegisterV2}
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.Utils
-import org.junit.Assert
 
 class DataSourceRegistrationSuite extends SharedSparkSession {
   private var cl = null : DataSourceRegistrationSuiteTestingClassLoader
@@ -86,19 +86,33 @@ class DataSourceRegistrationSuite extends SharedSparkSession {
 }
 
 class v1TableProvider1 extends TableProvider with DataSourceRegister {
-  override def getTable(options: CaseInsensitiveStringMap): Table = return null
 
   override def shortName(): String = "testProvider"
+
+  override def inferSchema(options: CaseInsensitiveStringMap): StructType = null
+
+  override def getTable(schema: StructType,
+                        partitioning: Array[Transform],
+                        properties: util.Map[String, String]): Table = null
 }
 
 class v1TableProvider2 extends TableProvider with DataSourceRegister {
-  override def getTable(options: CaseInsensitiveStringMap): Table = return null
 
   override def shortName(): String = "testProvider"
+
+  override def inferSchema(options: CaseInsensitiveStringMap): StructType = null
+
+  override def getTable(schema: StructType,
+                        partitioning: Array[Transform],
+                        properties: util.Map[String, String]): Table = null
 }
 
 class v2TableProvider extends TableProvider {
-  override def getTable(options: CaseInsensitiveStringMap): Table = return null
+  override def inferSchema(options: CaseInsensitiveStringMap): StructType = null
+
+  override def getTable(schema: StructType,
+                        partitioning: Array[Transform],
+                        properties: util.Map[String, String]): Table = null
 }
 
 class v2Registration1 extends DataSourceRegisterV2 {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceRegistrationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceRegistrationSuite.scala
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import java.net.URL
+import java.util
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.connector.catalog.{Table, TableProvider}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.sources.{DataSourceRegister, DataSourceRegisterV2}
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.util.Utils
+import org.junit.Assert
+
+class DataSourceRegistrationSuite extends SharedSparkSession {
+  private var cl = null : DataSourceRegistrationSuiteTestingClassLoader
+  private var oldcl = Utils.getContextOrSparkClassLoader : ClassLoader
+  val myconf = new SQLConf()
+
+  /*
+   * Set a custom classloader for this suite
+   */
+  protected override def beforeAll(): Unit = {
+    cl = new DataSourceRegistrationSuiteTestingClassLoader(oldcl)
+    Thread.currentThread.setContextClassLoader(cl)
+    assert(Utils.getContextOrSparkClassLoader == cl)
+    super.beforeAll()
+  }
+
+  protected override def afterAll(): Unit = {
+    Thread.currentThread().setContextClassLoader(oldcl)
+    assert(Utils.getContextOrSparkClassLoader == cl)
+    super.afterAll()
+  }
+
+  test("load with 0 DSv2, 0 DSv1") {
+    cl.setResources("unknown", "unknown")
+    intercept[ClassNotFoundException] {
+      DataSource.lookupDataSourceV2("testProvider", myconf)
+    }
+  }
+
+  test("load with 1 DSv2, 0 DSv1") {
+    cl.setResources("unknown", "dsregistration-v2/v2Registration1")
+    val ret = DataSource.lookupDataSourceV2("testProvider", myconf)
+    assert(ret.get.getClass() === new v2TableProvider().getClass())
+  }
+
+  test("load with 2 DSv2, 0 DSv1") {
+    cl.setResources("unknown", "dsregistration-v2/v2Registration2")
+    intercept[AnalysisException] {
+      DataSource.lookupDataSourceV2("testProvider", myconf)
+    }
+  }
+
+  test("load with 0 DSv2, 1 DSv1") {
+    cl.setResources("dsregistration-v2/v1Registration1", "unknown")
+    val ret = DataSource.lookupDataSourceV2("testProvider", myconf)
+    assert(ret.get.getClass() === new v1TableProvider1().getClass())
+  }
+
+  test("load with 0 DSv2, 2 DSv1") {
+    cl.setResources("dsregistration-v2/v1Registration2", "unknown")
+    intercept[AnalysisException] {
+      DataSource.lookupDataSourceV2("testProvider", myconf)
+    }
+  }
+}
+
+class v1TableProvider1 extends TableProvider with DataSourceRegister {
+  override def getTable(options: CaseInsensitiveStringMap): Table = return null
+
+  override def shortName(): String = "testProvider"
+}
+
+class v1TableProvider2 extends TableProvider with DataSourceRegister {
+  override def getTable(options: CaseInsensitiveStringMap): Table = return null
+
+  override def shortName(): String = "testProvider"
+}
+
+class v2TableProvider extends TableProvider {
+  override def getTable(options: CaseInsensitiveStringMap): Table = return null
+}
+
+class v2Registration1 extends DataSourceRegisterV2 {
+  override def shortName(): String = "testProvider"
+
+  override def getImplementation(): Class[_] = {
+    return new v2TableProvider().getClass()
+  }
+}
+
+class v2Registration2 extends DataSourceRegisterV2 {
+  override def shortName(): String = "testProvider"
+
+  override def getImplementation(): Class[_] = {
+    return new v2TableProvider().getClass()
+  }
+}
+
+/**
+ * Custom classloader to override the default classloader's resource lookup
+ * for these tests
+ */
+private class DataSourceRegistrationSuiteTestingClassLoader(parent: ClassLoader)
+  extends ClassLoader {
+  var v1Resource = "unknown": String
+  var v2Resource = "unknown": String
+
+  def setResources(v1name: String, v2name: String): Unit = {
+    v1Resource = v1name
+    v2Resource = v2name
+  }
+
+  override def getResources(name: String): util.Enumeration[URL] =
+    if (name.equals("META-INF/services/org.apache.spark.sql.sources.DataSourceRegisterV2")) {
+      super.getResources(v2Resource)
+    } else if (name.equals("META-INF/services/org.apache.spark.sql.sources.DataSourceRegister")) {
+        super.getResources(v1Resource)
+    } else {
+      super.getResources(name)
+    }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
Add DataSourceRegisterV2, an alternative method for DataSourceV2 plugins to register themselves. The motivation is to add a layer of indirection between the data source registration and data source provider, so plugin developers have a chance choose at runtime which implementation Spark should use.  Discussion at:

http://apache-spark-developers-list.1001551.n3.nabble.com/DSv2-amp-DataSourceRegister-td29187.html

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
As the DSv2 API evolves, some breaking changes are occasionally made to the API. It's possible to split a plugin into a "common" part and multiple version-specific parts and this works good to have a single artifact for users. The one part that can't be currently worked around is the DataSourceRegister trait. This is an issue because users cargo-cult configuration values, and choosing the wrong plugin version gives a particularly baroque error message that bubbles up through ServiceLoader.


<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce any user-facing change?
No, developer only.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit tests were added
