### PR TITLE
[SPARK-31401][K8S] Show JDK11 usage in `bin/docker-image-tool.sh`

### DIFF
--- a/bin/docker-image-tool.sh
+++ b/bin/docker-image-tool.sh
@@ -248,6 +248,10 @@ Examples:
   - Build and push image with tag "v2.3.0" to docker.io/myrepo
     $0 -r docker.io/myrepo -t v2.3.0 build
     $0 -r docker.io/myrepo -t v2.3.0 push
+
+  - Build and push JDK11-based image with tag "v3.0.0" to docker.io/myrepo
+    $0 -r docker.io/myrepo -t v3.0.0 -b java_image_tag=11-jre-slim build
+    $0 -r docker.io/myrepo -t v3.0.0 push
 EOF
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds an JDK11-based build example in `bin/docker-image-tool.sh`.

### Why are the changes needed?

This helps the users migrate to JDK11 more easily.

### Does this PR introduce any user-facing change?

Yes, but this is a usage help.

### How was this patch tested?

First, check the help usage manually.
```
$ bin/docker-image-tool.sh -h
...
  - Build and push JDK11-based image with tag "v3.0.0" to docker.io/myrepo
    bin/docker-image-tool.sh -r docker.io/myrepo -t v3.0.0 -b java_image_tag=11-jre-slim build
    bin/docker-image-tool.sh -r docker.io/myrepo -t v3.0.0 push {code}
```

Then, build the image and check Java version.
```
$ docker run -it --rm docker.io/myrepo/spark:v3.0.0 java --version | tail -n3
openjdk 11.0.6 2020-01-14
OpenJDK Runtime Environment 18.9 (build 11.0.6+10)
OpenJDK 64-Bit Server VM 18.9 (build 11.0.6+10, mixed mode)
```