### PR TITLE
[SPARK-31389][SQL][TESTS] Add codegen-on test coverage for some tests in SQLMetricsSuite

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -375,12 +375,12 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils {
         // ... -> BroadcastNestedLoopJoin(nodeId = 1) -> TungstenProject(nodeId = 0)
         val query = "SELECT * FROM testData2 left JOIN testDataForJoin ON " +
           "testData2.a * testDataForJoin.a != testData2.a + testDataForJoin.a"
-        Seq((1L, false), (0L, true)).foreach { args =>
+        Seq(false, true).foreach { enableWholeStage =>
           val df = spark.sql(query)
-          testSparkPlanMetrics(df, 3, Map(
-            args._1 -> (("BroadcastNestedLoopJoin", Map(
+          testSparkPlanMetrics(df, 2, Map(
+            0L -> (("BroadcastNestedLoopJoin", Map(
               "number of output rows" -> 12L)))),
-            args._2
+            enableWholeStage
           )
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -333,30 +333,20 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils {
       // +- Exchange(nodeId = 5)
       // +- Project(nodeId = 6)
       // +- LocalTableScan(nodeId = 7)
-      val df = df1.join(df2, "key")
-      testSparkPlanMetrics(df, 1, Map(
-        1L -> (("ShuffledHashJoin", Map(
-          "number of output rows" -> 2L))),
-        2L -> (("Exchange", Map(
-          "shuffle records written" -> 2L,
-          "records read" -> 2L))),
-        5L -> (("Exchange", Map(
-          "shuffle records written" -> 10L,
-          "records read" -> 10L))))
-      )
-
-      val df3 = df1.join(df2, "key")
-      testSparkPlanMetrics(df3, 1, Map(
-        2L -> (("ShuffledHashJoin", Map(
-          "number of output rows" -> 2L))),
-        3L -> (("Exchange", Map(
-          "shuffle records written" -> 2L,
-          "records read" -> 2L))),
-        7L -> (("Exchange", Map(
-          "shuffle records written" -> 10L,
-          "records read" -> 10L)))),
-        true
-      )
+      Seq((1L, 2L, 5L, false), (2L, 3L, 7L, true)).foreach{args =>
+        val df = df1.join(df2, "key")
+        testSparkPlanMetrics(df, 1, Map(
+          args._1 -> (("ShuffledHashJoin", Map(
+            "number of output rows" -> 2L))),
+          args._2 -> (("Exchange", Map(
+            "shuffle records written" -> 2L,
+            "records read" -> 2L))),
+          args._3 -> (("Exchange", Map(
+            "shuffle records written" -> 10L,
+            "records read" -> 10L)))),
+          args._4
+        )
+      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -265,29 +265,20 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils {
       // ... -> SortMergeJoin(nodeId = 1) -> TungstenProject(nodeId = 0)
       val query = "SELECT * FROM testData2 JOIN testDataForJoin ON testData2.a = testDataForJoin.a"
       val df = spark.sql(query)
-      testSparkPlanMetrics(df, 1, Map(
-        0L -> (("SortMergeJoin", Map(
-          // It's 4 because we only read 3 rows in the first partition and 1 row in the second one
-          "number of output rows" -> 4L))),
-        2L -> (("Exchange", Map(
-          "records read" -> 4L,
-          "local blocks read" -> 2L,
-          "remote blocks read" -> 0L,
-          "shuffle records written" -> 2L))))
-      )
 
-      val df1 = spark.sql(query)
-      testSparkPlanMetrics(df1, 1, Map(
-        1L -> (("SortMergeJoin", Map(
-          // It's 4 because we only read 3 rows in the first partition and 1 row in the second one
-          "number of output rows" -> 4L))),
-        4L -> (("Exchange", Map(
-          "records read" -> 4L,
-          "local blocks read" -> 2L,
-          "remote blocks read" -> 0L,
-          "shuffle records written" -> 2L)))),
-        true
-      )
+      Seq((0L, 2L, false), (0L, 2L, true)).foreach(args => {
+        testSparkPlanMetrics(df, 1, Map(
+          args._1 -> (("SortMergeJoin", Map(
+            // It's 4 because we only read 3 rows in the first partition and 1 row in the second one
+            "number of output rows" -> 4L))),
+          args._2 -> (("Exchange", Map(
+            "records read" -> 4L,
+            "local blocks read" -> 2L,
+            "remote blocks read" -> 0L,
+            "shuffle records written" -> 2L)))),
+          args._3
+        )
+      })
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -266,7 +266,7 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils {
       val query = "SELECT * FROM testData2 JOIN testDataForJoin ON testData2.a = testDataForJoin.a"
       val df = spark.sql(query)
 
-      Seq((0L, 2L, false), (0L, 2L, true)).foreach(args => {
+      Seq((0L, 2L, false), (1L, 4L, true)).foreach(args => {
         testSparkPlanMetrics(df, 1, Map(
           args._1 -> (("SortMergeJoin", Map(
             // It's 4 because we only read 3 rows in the first partition and 1 row in the second one

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -263,8 +263,8 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils {
     withTempView("testDataForJoin") {
       // Assume the execution plan is
       // ... -> SortMergeJoin(nodeId = 1) -> TungstenProject(nodeId = 0)
-      val df = spark.sql(
-        "SELECT * FROM testData2 JOIN testDataForJoin ON testData2.a = testDataForJoin.a")
+      val query = "SELECT * FROM testData2 JOIN testDataForJoin ON testData2.a = testDataForJoin.a"
+      val df = spark.sql(query)
       testSparkPlanMetrics(df, 1, Map(
         0L -> (("SortMergeJoin", Map(
           // It's 4 because we only read 3 rows in the first partition and 1 row in the second one
@@ -276,8 +276,7 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils {
           "shuffle records written" -> 2L))))
       )
 
-      val df1 = spark.sql(
-        "SELECT * FROM testData2 JOIN testDataForJoin ON testData2.a = testDataForJoin.a")
+      val df1 = spark.sql(query)
       testSparkPlanMetrics(df1, 1, Map(
         1L -> (("SortMergeJoin", Map(
           // It's 4 because we only read 3 rows in the first partition and 1 row in the second one
@@ -300,16 +299,16 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils {
     withTempView("testDataForJoin") {
       // Assume the execution plan is
       // ... -> SortMergeJoin(nodeId = 1) -> TungstenProject(nodeId = 0)
-      val df = spark.sql(
-        "SELECT * FROM testData2 left JOIN testDataForJoin ON testData2.a = testDataForJoin.a")
+      val leftJoinQuery = "SELECT * FROM testData2 left JOIN testDataForJoin ON " +
+        "testData2.a = testDataForJoin.a"
+      val df = spark.sql(leftJoinQuery)
       testSparkPlanMetrics(df, 1, Map(
         0L -> (("SortMergeJoin", Map(
           // It's 8 because we read 6 rows in the left and 2 row in the right one
           "number of output rows" -> 8L))))
       )
 
-      val df1 = spark.sql(
-        "SELECT * FROM testData2 left JOIN testDataForJoin ON testData2.a = testDataForJoin.a")
+      val df1 = spark.sql(leftJoinQuery)
       testSparkPlanMetrics(df1, 1, Map(
         0L -> (("SortMergeJoin", Map(
           // It's 8 because we read 6 rows in the left and 2 rows in the right one
@@ -317,15 +316,15 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils {
         true
       )
 
-      val df2 = spark.sql(
-        "SELECT * FROM testDataForJoin right JOIN testData2 ON testData2.a = testDataForJoin.a")
+      val rightJoinQuery = "SELECT * FROM testDataForJoin right JOIN testData2 ON " +
+        "testData2.a = testDataForJoin.a"
+      val df2 = spark.sql(rightJoinQuery)
       testSparkPlanMetrics(df2, 1, Map(
         0L -> (("SortMergeJoin", Map(
           // It's 8 because we read 6 rows in the left and 2 rows in the right one
           "number of output rows" -> 8L)))))
 
-      val df3 = spark.sql(
-        "SELECT * FROM testDataForJoin right JOIN testData2 ON testData2.a = testDataForJoin.a")
+      val df3 = spark.sql(rightJoinQuery)
       testSparkPlanMetrics(df3, 1, Map(
         0L -> (("SortMergeJoin", Map(
           // It's 8 because we read 6 rows in the left and 2 rows in the right one
@@ -435,17 +434,15 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils {
       withTempView("testDataForJoin") {
         // Assume the execution plan is
         // ... -> BroadcastNestedLoopJoin(nodeId = 1) -> TungstenProject(nodeId = 0)
-        val df = spark.sql(
-          "SELECT * FROM testData2 left JOIN testDataForJoin ON " +
-            "testData2.a * testDataForJoin.a != testData2.a + testDataForJoin.a")
+        val query = "SELECT * FROM testData2 left JOIN testDataForJoin ON " +
+          "testData2.a * testDataForJoin.a != testData2.a + testDataForJoin.a"
+        val df = spark.sql(query)
         testSparkPlanMetrics(df, 3, Map(
           1L -> (("BroadcastNestedLoopJoin", Map(
             "number of output rows" -> 12L))))
         )
 
-        val df1 = spark.sql(
-          "SELECT * FROM testData2 left JOIN testDataForJoin ON " +
-            "testData2.a * testDataForJoin.a != testData2.a + testDataForJoin.a")
+        val df1 = spark.sql(query)
         testSparkPlanMetrics(df1, 3, Map(
           0L -> (("BroadcastNestedLoopJoin", Map(
             "number of output rows" -> 12L)))),
@@ -501,14 +498,13 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils {
     val anti = testData2.filter("a > 2")
     withTempView("antiData") {
       anti.createOrReplaceTempView("antiData")
-      val df = spark.sql(
-        "SELECT * FROM testData2 ANTI JOIN antiData ON testData2.a = antiData.a")
+      val query = "SELECT * FROM testData2 ANTI JOIN antiData ON testData2.a = antiData.a"
+      val df = spark.sql(query)
       testSparkPlanMetrics(df, 1, Map(
         0L -> (("SortMergeJoin", Map("number of output rows" -> 4L))))
       )
 
-      val df1 = spark.sql(
-        "SELECT * FROM testData2 ANTI JOIN antiData ON testData2.a = antiData.a")
+      val df1 = spark.sql(query)
       testSparkPlanMetrics(df1, 1, Map(
         0L -> (("SortMergeJoin", Map("number of output rows" -> 4L))))
       )

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsTestUtils.scala
@@ -214,14 +214,16 @@ trait SQLMetricsTestUtils extends SQLTestUtils {
   protected def testSparkPlanMetrics(
       df: DataFrame,
       expectedNumOfJobs: Int,
-      expectedMetrics: Map[Long, (String, Map[String, Any])]): Unit = {
+      expectedMetrics: Map[Long, (String, Map[String, Any])],
+      enableWholeStage: Boolean = false): Unit = {
     val expectedMetricsPredicates = expectedMetrics.mapValues { case (nodeName, nodeMetrics) =>
       (nodeName, nodeMetrics.mapValues(expectedMetricValue =>
         (actualMetricValue: Any) => {
           actualMetricValue.toString.matches(expectedMetricValue.toString)
         }))
     }
-    testSparkPlanMetricsWithPredicates(df, expectedNumOfJobs, expectedMetricsPredicates)
+    testSparkPlanMetricsWithPredicates(df, expectedNumOfJobs, expectedMetricsPredicates,
+      enableWholeStage)
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
Adding missing unit tests in SQLMetricSuite to cover the code generated path.
**Additional tests were added in the following unit tests.**
Filter metrics, SortMergeJoin metrics, SortMergeJoin(outer) metrics, BroadcastHashJoin metrics,  ShuffledHashJoin metrics, BroadcastHashJoin(outer) metrics, BroadcastNestedLoopJoin metrics, BroadcastLeftSemiJoinHash metrics, CartesianProduct metrics,  SortMergeJoin(left-anti) metrics

### Why are the changes needed?
The existing tests in SQLMetricSuite only cover the interpreted path.
It is necessary for the tests to cover code generated path as well since CodeGenerated path is often used in production.

The PR doesn't change test("Aggregate metrics") and test("ObjectHashAggregate metrics"). The test("Aggregate metrics") tests metrics when a HashAggregate is used. Enabling codegen forces the test to use ObjectHashAggregate rather than the regular HashAggregate. ObjectHashAggregate has a test of its own. Therefore, I feel these two tests need not enabling codegen is not necessary.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
I added debug statements in the code to make sure both Code generated and Interpreted paths are being exercised.
I further used Intellij debugger to ensure that the newly added unit tests are in fact exercising both code generated and interpreted paths.