### PR TITLE
[SPARK-31301][ML] Flatten the result dataframe of tests in testChiSquare

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
@@ -200,9 +200,8 @@ final class ChiSqSelector @Since("1.6.0") (@Since("1.6.0") override val uid: Str
     val spark = dataset.sparkSession
     import spark.implicits._
 
-    val numFeatures = MetadataUtils.getNumFeatures(dataset, $(featuresCol))
-
     val resultDF = ChiSquareTest.test(dataset.toDF, $(featuresCol), $(labelCol), true)
+    val numFeatures = resultDF.count()
 
     val indices = $(selectorType) match {
       case "numTopFeatures" =>

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
@@ -200,8 +200,8 @@ final class ChiSqSelector @Since("1.6.0") (@Since("1.6.0") override val uid: Str
     val spark = dataset.sparkSession
     import spark.implicits._
 
+    val numFeatures = MetadataUtils.getNumFeatures(dataset, $(featuresCol))
     val resultDF = ChiSquareTest.test(dataset.toDF, $(featuresCol), $(labelCol), true)
-    val numFeatures = resultDF.count()
 
     val indices = $(selectorType) match {
       case "numTopFeatures" =>

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
@@ -223,13 +223,14 @@ final class ChiSqSelector @Since("1.6.0") (@Since("1.6.0") override val uid: Str
       case "fdr" =>
         // This uses the Benjamini-Hochberg procedure.
         // https://en.wikipedia.org/wiki/False_discovery_rate#Benjamini.E2.80.93Hochberg_procedure
+        val f = $(fdr) / numFeatures
         val maxIndex = resultDF.sort("pValue", "featureIndex")
           .select("pValue", "featureIndex")
           .as[(Double, Int)].rdd
           .zipWithIndex
           .flatMap { case ((pValue, featureIndex), index) =>
-            if (pValue <= $(fdr) * (index + 1) / numFeatures) {
-              Iterator.single(featureIndex)
+            if (pValue <= f * (index + 1)) {
+              Iterator.single(index.toInt)
             } else Iterator.empty
           }.fold(-1)(math.max)
         if (maxIndex >= 0) {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
@@ -221,11 +221,11 @@ final class ChiSqSelector @Since("1.6.0") (@Since("1.6.0") override val uid: Str
       case "fdr" =>
         // This uses the Benjamini-Hochberg procedure.
         // https://en.wikipedia.org/wiki/False_discovery_rate#Benjamini.E2.80.93Hochberg_procedure
-        val maxIndex = resultDF.sort("pValue")
-          .select("featureIndex", "pValue")
-          .as[(Int, Double)].rdd
+        val maxIndex = resultDF.sort("pValue", "featureIndex")
+          .select("pValue", "featureIndex")
+          .as[(Double, Int)].rdd
           .zipWithIndex
-          .flatMap { case ((featureIndex, pValue), index) =>
+          .flatMap { case ((pValue, featureIndex), index) =>
             if (pValue <= $(fdr) * (index + 1) / numFeatures) {
               Iterator.single(featureIndex)
             } else Iterator.empty

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
@@ -218,7 +218,7 @@ final class ChiSqSelector @Since("1.6.0") (@Since("1.6.0") override val uid: Str
         getTopIndices((numFeatures * getPercentile).toInt)
       case "fpr" =>
         resultDF.select("featureIndex")
-          .where(col("pValue").lt($(fpr)))
+          .where(col("pValue") < $(fpr))
           .as[Int].collect()
       case "fdr" =>
         // This uses the Benjamini-Hochberg procedure.
@@ -238,7 +238,7 @@ final class ChiSqSelector @Since("1.6.0") (@Since("1.6.0") override val uid: Str
         } else Array.emptyIntArray
       case "fwe" =>
         resultDF.select("featureIndex")
-          .where(col("pValue").lt($(fwe) / numFeatures))
+          .where(col("pValue") < $(fwe) / numFeatures)
           .as[Int].collect()
       case errorType =>
         throw new IllegalStateException(s"Unknown Selector Type: $errorType")

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
@@ -206,7 +206,9 @@ final class ChiSqSelector @Since("1.6.0") (@Since("1.6.0") override val uid: Str
     def getTopIndices(k: Int): Array[Int] = {
       resultDF.sort("pValue", "featureIndex")
         .select("featureIndex")
-        .as[Int].take(k)
+        .limit(k)
+        .as[Int]
+        .collect()
     }
 
     val indices = $(selectorType) match {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
@@ -225,10 +225,10 @@ final class ChiSqSelector @Since("1.6.0") (@Since("1.6.0") override val uid: Str
         // https://en.wikipedia.org/wiki/False_discovery_rate#Benjamini.E2.80.93Hochberg_procedure
         val f = $(fdr) / numFeatures
         val maxIndex = resultDF.sort("pValue", "featureIndex")
-          .select("pValue", "featureIndex")
-          .as[(Double, Int)].rdd
+          .select("pValue")
+          .as[Double].rdd
           .zipWithIndex
-          .flatMap { case ((pValue, featureIndex), index) =>
+          .flatMap { case (pValue, index) =>
             if (pValue <= f * (index + 1)) {
               Iterator.single(index.toInt)
             } else Iterator.empty

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/ChiSqSelector.scala
@@ -204,9 +204,9 @@ final class ChiSqSelector @Since("1.6.0") (@Since("1.6.0") override val uid: Str
     val resultDF = ChiSquareTest.test(dataset.toDF, $(featuresCol), $(labelCol), true)
 
     def getTopIndices(k: Int): Array[Int] = {
-      resultDF.select(-col("pValue"), col("featureIndex"))
-        .as[(Double, Int)].rdd
-        .top(k).map(_._2)
+      resultDF.sort("pValue", "featureIndex")
+        .select("featureIndex")
+        .as[Int].take(k)
     }
 
     val indices = $(selectorType) match {

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/ChiSquareTest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/ChiSquareTest.scala
@@ -83,11 +83,11 @@ object ChiSquareTest {
     val resultRDD = OldChiSqTest.computeChiSquared(data)
 
     if (flatten) {
-      resultRDD.map { case (col, (pValue, degreesOfFreedom, statistic, _)) =>
+      resultRDD.map { case (col, pValue, degreesOfFreedom, statistic, _) =>
         (col, pValue, degreesOfFreedom, statistic)
       }.toDF("featureIndex", "pValue", "degreesOfFreedom", "statistic")
     } else {
-      resultRDD.map { case (col, (pValue, degreesOfFreedom, statistic, _)) =>
+      resultRDD.map { case (col, pValue, degreesOfFreedom, statistic, _) =>
         (0, (col, pValue, degreesOfFreedom, statistic))
       }.groupByKey().map { case (_, seq) =>
         val results = seq.toArray.sortBy(_._1)

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/ChiSquareTest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/ChiSquareTest.scala
@@ -21,11 +21,9 @@ import org.apache.spark.annotation.Since
 import org.apache.spark.ml.linalg.{Vector, Vectors, VectorUDT}
 import org.apache.spark.ml.util.SchemaUtils
 import org.apache.spark.mllib.linalg.{Vectors => OldVectors}
-import org.apache.spark.mllib.regression.{LabeledPoint => OldLabeledPoint}
-import org.apache.spark.mllib.stat.{Statistics => OldStatistics}
-import org.apache.spark.sql.{DataFrame, Dataset, Row}
+import org.apache.spark.mllib.stat.test.{ChiSqTest => OldChiSqTest}
+import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.functions.col
-import org.apache.spark.sql.types.DoubleType
 
 
 /**
@@ -36,12 +34,6 @@ import org.apache.spark.sql.types.DoubleType
  */
 @Since("2.2.0")
 object ChiSquareTest {
-
-  /** Used to construct output schema of tests */
-  private case class ChiSquareResult(
-      pValues: Vector,
-      degreesOfFreedom: Array[Int],
-      statistics: Vector)
 
   /**
    * Conduct Pearson's independence test for every feature against the label. For each feature, the
@@ -63,18 +55,7 @@ object ChiSquareTest {
    */
   @Since("2.2.0")
   def test(dataset: DataFrame, featuresCol: String, labelCol: String): DataFrame = {
-    val spark = dataset.sparkSession
-    import spark.implicits._
-
-    SchemaUtils.checkColumnType(dataset.schema, featuresCol, new VectorUDT)
-    SchemaUtils.checkNumericType(dataset.schema, labelCol)
-    val rdd = dataset.select(col(labelCol).cast("double"), col(featuresCol)).as[(Double, Vector)]
-      .rdd.map { case (label, features) => OldLabeledPoint(label, OldVectors.fromML(features)) }
-    val testResults = OldStatistics.chiSqTest(rdd)
-    val pValues = Vectors.dense(testResults.map(_.pValue))
-    val degreesOfFreedom = testResults.map(_.degreesOfFreedom)
-    val statistics = Vectors.dense(testResults.map(_.statistic))
-    spark.createDataFrame(Seq(ChiSquareResult(pValues, degreesOfFreedom, statistics)))
+    test(dataset, featuresCol, labelCol, false)
   }
 
   /**
@@ -82,21 +63,39 @@ object ChiSquareTest {
    *                 Real-valued features will be treated as categorical for each distinct value.
    * @param featuresCol  Name of features column in dataset, of type `Vector` (`VectorUDT`)
    * @param labelCol  Name of label column in dataset, of any numerical type
-   * @return Array containing the SelectionTestResult for every feature against the label.
+   * @param flatten  If false, the returned DataFrame contains only a single Row, otherwise, one
+   *                 row per feature.
    */
   @Since("3.1.0")
-  def testChiSquare(
-      dataset: Dataset[_],
+  def test(
+      dataset: DataFrame,
       featuresCol: String,
-      labelCol: String): Array[SelectionTestResult] = {
-
+      labelCol: String,
+      flatten: Boolean): DataFrame = {
     SchemaUtils.checkColumnType(dataset.schema, featuresCol, new VectorUDT)
     SchemaUtils.checkNumericType(dataset.schema, labelCol)
-    val input = dataset.select(col(labelCol).cast(DoubleType), col(featuresCol)).rdd
-      .map { case Row(label: Double, features: Vector) =>
-        OldLabeledPoint(label, OldVectors.fromML(features))
-      }
-    val chiTestResult = OldStatistics.chiSqTest(input)
-    chiTestResult.map(r => new ChiSqTestResult(r.pValue, r.degreesOfFreedom, r.statistic))
+
+    val spark = dataset.sparkSession
+    import spark.implicits._
+
+    val data = dataset.select(col(labelCol).cast("double"), col(featuresCol)).rdd
+      .map { case Row(label: Double, vec: Vector) => (label, OldVectors.fromML(vec)) }
+    val resultRDD = OldChiSqTest.computeChiSquared(data)
+
+    if (flatten) {
+      resultRDD.map { case (col, (pValue, degreesOfFreedom, statistic, _)) =>
+        (col, pValue, degreesOfFreedom, statistic)
+      }.toDF("featureIndex", "pValue", "degreesOfFreedom", "statistic")
+    } else {
+      resultRDD.map { case (col, (pValue, degreesOfFreedom, statistic, _)) =>
+        (0, (col, pValue, degreesOfFreedom, statistic))
+      }.groupByKey().map { case (_, seq) =>
+        val results = seq.toArray.sortBy(_._1)
+        val pValues = Vectors.dense(results.map(_._2))
+        val degreesOfFreedom = results.map(_._3)
+        val statistics = Vectors.dense(results.map(_._4))
+        (pValues, degreesOfFreedom, statistics)
+      }.toDF("pValues", "degreesOfFreedom", "statistics")
+    }
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/stat/ChiSquareTest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/stat/ChiSquareTest.scala
@@ -90,7 +90,7 @@ object ChiSquareTest {
       resultDF
     } else {
       resultDF.groupBy()
-        .agg(collect_list(struct("featureIndex", "pValue", "degreesOfFreedom", "statistic")))
+        .agg(collect_list(struct("*")))
         .as[Seq[(Int, Double, Int, Double)]]
         .map { seq =>
           val results = seq.toArray.sortBy(_._1)

--- a/mllib/src/main/scala/org/apache/spark/mllib/stat/test/ChiSqTest.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/stat/test/ChiSqTest.scala
@@ -79,9 +79,20 @@ private[spark] object ChiSqTest extends Logging {
    * the independence test.
    * Returns an array containing the ChiSquaredTestResult for every feature against the label.
    */
-  def chiSquaredFeatures(data: RDD[LabeledPoint],
+  def chiSquaredFeatures(
+      data: RDD[LabeledPoint],
       methodName: String = PEARSON.name): Array[ChiSqTestResult] = {
-    data.first().features match {
+    computeChiSquared(data.map(l => (l.label, l.features)), methodName)
+      .collect().sortBy(_._1).map {
+      case (_, (pValue, degreesOfFreedom, statistic, nullHypothesis)) =>
+        new ChiSqTestResult(pValue, degreesOfFreedom, statistic, methodName, nullHypothesis)
+    }
+  }
+
+  private[spark] def computeChiSquared(
+      data: RDD[(Double, Vector)],
+      methodName: String = PEARSON.name): RDD[(Int, (Double, Int, Double, String))] = {
+    data.first()._2 match {
       case dv: DenseVector =>
         chiSquaredDenseFeatures(data, dv.size, methodName)
       case sv: SparseVector =>
@@ -89,10 +100,11 @@ private[spark] object ChiSqTest extends Logging {
     }
   }
 
-  private def chiSquaredDenseFeatures(data: RDD[LabeledPoint],
+  private def chiSquaredDenseFeatures(
+      data: RDD[(Double, Vector)],
       numFeatures: Int,
-      methodName: String = PEARSON.name): Array[ChiSqTestResult] = {
-    data.flatMap { case LabeledPoint(label, features) =>
+      methodName: String = PEARSON.name): RDD[(Int, (Double, Int, Double, String))] = {
+    data.flatMap { case (label, features) =>
       require(features.size == numFeatures,
         s"Number of features must be $numFeatures but got ${features.size}")
       features.iterator.map { case (col, value) => (col, (label, value)) }
@@ -107,16 +119,14 @@ private[spark] object ChiSqTest extends Logging {
       }
     ).map { case (col, counts) =>
       (col, computeChiSq(counts.toMap, methodName, col))
-    }.collect().sortBy(_._1).map {
-      case (_, (pValue, degreesOfFreedom, statistic, nullHypothesis)) =>
-        new ChiSqTestResult(pValue, degreesOfFreedom, statistic, methodName, nullHypothesis)
     }
   }
 
-  private def chiSquaredSparseFeatures(data: RDD[LabeledPoint],
+  private def chiSquaredSparseFeatures(
+      data: RDD[(Double, Vector)],
       numFeatures: Int,
-      methodName: String = PEARSON.name): Array[ChiSqTestResult] = {
-    val labelCounts = data.map(_.label).countByValue().toMap
+      methodName: String = PEARSON.name): RDD[(Int, (Double, Int, Double, String))] = {
+    val labelCounts = data.map(_._1).countByValue().toMap
     val numInstances = labelCounts.valuesIterator.sum
     val numLabels = labelCounts.size
     if (numLabels > maxCategories) {
@@ -126,15 +136,13 @@ private[spark] object ChiSqTest extends Logging {
 
     val numParts = data.getNumPartitions
     data.mapPartitionsWithIndex { case (pid, iter) =>
-      iter.flatMap { case LabeledPoint(label, features) =>
+      iter.flatMap { case (label, features) =>
         require(features.size == numFeatures,
           s"Number of features must be $numFeatures but got ${features.size}")
         features.nonZeroIterator.map { case (col, value) => (col, (label, value)) }
       } ++ {
         // append this to make sure that all columns are taken into account
-        Iterator.range(0, numFeatures)
-          .filter(_ % numParts == pid)
-          .map(col => (col, null))
+        Iterator.range(pid, numFeatures, numParts).map(col => (col, null))
       }
     }.aggregateByKey(new OpenHashMap[(Double, Double), Long])(
       seqOp = { case (counts, labelAndValue) =>
@@ -164,9 +172,6 @@ private[spark] object ChiSqTest extends Logging {
       }
 
       (col, computeChiSq(counts.toMap, methodName, col))
-    }.collect().sortBy(_._1).map {
-      case (_, (pValue, degreesOfFreedom, statistic, nullHypothesis)) =>
-        new ChiSqTestResult(pValue, degreesOfFreedom, statistic, methodName, nullHypothesis)
     }
   }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/stat/ChiSquareTestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/stat/ChiSquareTestSuite.scala
@@ -117,7 +117,7 @@ class ChiSquareTestSuite
     withClue("ChiSquare should throw an exception when given a continuous-valued label") {
       intercept[SparkException] {
         val df = spark.createDataFrame(continuousLabel)
-        ChiSquareTest.test(df, "features", "label")
+        ChiSquareTest.test(df, "features", "label").count()
       }
     }
     val continuousFeature = Seq.fill(tooManyCategories)(
@@ -125,7 +125,7 @@ class ChiSquareTestSuite
     withClue("ChiSquare should throw an exception when given continuous-valued features") {
       intercept[SparkException] {
         val df = spark.createDataFrame(continuousFeature)
-        ChiSquareTest.test(df, "features", "label")
+        ChiSquareTest.test(df, "features", "label").count()
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
1, remove newly added method: `def testChiSquare(dataset: Dataset[_], featuresCol: String, labelCol: String): Array[SelectionTestResult]`, because: 1) it is only used in `ChiSqSelector`; 2, since the returned dataframe of `def test(dataset: DataFrame, featuresCol: String, labelCol: String): DataFrame` only contains one row, after collect it back to driver, the results are similar;
2, add method `def test(dataset: DataFrame, featuresCol: String, labelCol: String, flatten: Boolean): DataFrame` to return the flatten results;


### Why are the changes needed?
1, when get returned result dataframe, we may want to filter it like `pValue<0.1`, but current returned dataframe is hard to use;
2, current impl need to collect all test results of all columns back to the driver, this is a bottleneck, if we return the flatten datafame, we no longer to collect them to driver;

### Does this PR introduce any user-facing change?
Yes:
1, `def testChiSquare(dataset: Dataset[_], featuresCol: String, labelCol: String): Array[SelectionTestResult]` removed;
2, the returned dataframe need an action to trigger computation;


### How was this patch tested?
updated testsuites