### PR TITLE
[SPARK-29799][Streaming] add an implemention for issue SPARK-29799.

### DIFF
--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/package.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/package.scala
@@ -72,5 +72,10 @@ package object kafka010 { //scalastyle:ignore
       .booleanConf
       .createWithDefault(false)
 
+  private[spark] val KAFKA_PARTITION_MULTIPLIER =
+    ConfigBuilder("spark.streaming.kafka.partition.multiplier")
+      .version("3.1.0")
+      .intConf
+      .createWithDefault(1)
 }
 


### PR DESCRIPTION

### What changes were proposed in this pull request?

When we use Spark Streaming to consume records from kafka, the generated KafkaRDD‘s partition number is equal to kafka topic's partition number, so we can not use more cpu cores to execute the streaming task except we change the topic's partition number, but we can not increase the topic's partition number infinitely.

We can split a kafka partition into multiple KafkaRDD partitions, and we can config it, then we can use more cpu cores to execute the streaming task. This pull request add an implemention for it.


### Why are the changes needed?
We can use more cpu cores to consume kafka topic records faster.

### Does this PR introduce any user-facing change?
No


### How was this patch tested?
Test it in a real environment.

