### PR TITLE
[SPARK-29791][CORE][SCHEDULER]add an implemention for issue SPARK-29791.

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1836,4 +1836,10 @@ package object config {
       .version("3.1.0")
       .booleanConf
       .createWithDefault(false)
+
+  private[spark] val EXECUTOR_CORES_VIRTUAL_MULTIPLIER =
+    ConfigBuilder("spark.executor.cores.virtual.multiplier")
+      .version("3.1.0")
+      .intConf
+      .createWithDefault(1)
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/StandaloneSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/StandaloneSchedulerBackend.scala
@@ -186,7 +186,7 @@ private[spark] class StandaloneSchedulerBackend(
   }
 
   override def sufficientResourcesRegistered(): Boolean = {
-    totalCoreCount.get() >= totalExpectedCores * minRegisteredRatio
+    totalCoreCount.get() >= totalExpectedCores * virtualMultiplier * minRegisteredRatio
   }
 
   override def applicationId(): String =

--- a/core/src/test/scala/org/apache/spark/scheduler/CoarseGrainedSchedulerBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/CoarseGrainedSchedulerBackendSuite.scala
@@ -75,6 +75,20 @@ class CoarseGrainedSchedulerBackendSuite extends SparkFunSuite with LocalSparkCo
     assert(sc.maxNumConcurrentTasks(ResourceProfile.getOrCreateDefaultProfile(conf)) == 12)
   }
 
+  test("compute max number of concurrent tasks can be launched when" +
+    " spark.executor.cores.virtual.multiplier > 1") {
+    val conf = new SparkConf()
+      .set(EXECUTOR_CORES_VIRTUAL_MULTIPLIER, 2)
+      .setMaster("local-cluster[4, 3, 1024]")
+      .setAppName("test")
+    sc = new SparkContext(conf)
+    eventually(timeout(executorUpTimeout)) {
+      // Ensure all executors have been launched.
+      assert(sc.getExecutorIds().length == 4)
+    }
+    assert(sc.maxNumConcurrentTasks(ResourceProfile.getOrCreateDefaultProfile(conf)) == 24)
+  }
+
   test("compute max number of concurrent tasks can be launched when spark.task.cpus > 1") {
     val conf = new SparkConf()
       .set(CPUS_PER_TASK, 2)


### PR DESCRIPTION

### What changes were proposed in this pull request?

We can config the executor cores by "spark.executor.cores". For example, if we config 8 cores for a executor, then the driver can only scheduler 8 tasks to this executor concurrently. In fact, most cases a task does not always occupy a core or more. More time, tasks spent on disk IO or network IO, so we can make driver to scheduler more than 8 tasks(virtual the cores to 16, 32 or more the executor report to driver) to this executor concurrently, it will make the whole job execute more quickly. This pull request add an implemention for it.


### Why are the changes needed?
We can use more virtual cores to scheduler more tasks at the same time.

### Does this PR introduce any user-facing change?
No


### How was this patch tested?
Add a test case.
