### PR TITLE
[SPARK-31431][SQL] Add CalendarInterval encoder support

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoders.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoders.scala
@@ -141,7 +141,7 @@ object Encoders {
    *
    * @since 3.1.0
    */
-  def CALENDARINTERVAL: Encoder[CalendarInterval] = ExpressionEncoder()
+  def INTERVAL: Encoder[CalendarInterval] = ExpressionEncoder()
 
   /**
    * Creates an encoder for Java Bean of type T.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoders.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoders.scala
@@ -137,7 +137,7 @@ object Encoders {
   def BINARY: Encoder[Array[Byte]] = ExpressionEncoder()
 
   /**
-   * An encoder for [[CalendarInterval]]
+   * An encoder for `CalendarInterval`
    *
    * @since 3.1.0
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoders.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoders.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.catalyst.encoders.{encoderFor, ExpressionEncoder}
 import org.apache.spark.sql.catalyst.expressions.{BoundReference, Cast}
 import org.apache.spark.sql.catalyst.expressions.objects.{DecodeUsingSerializer, EncodeUsingSerializer}
 import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.CalendarInterval
 
 /**
  * Methods for creating an [[Encoder]].
@@ -134,6 +135,13 @@ object Encoders {
    * @since 1.6.1
    */
   def BINARY: Encoder[Array[Byte]] = ExpressionEncoder()
+
+  /**
+   * An encoder for [[CalendarInterval]]
+   *
+   * @since 3.1.0
+   */
+  def CALENDARINTERVAL: Encoder[CalendarInterval] = ExpressionEncoder()
 
   /**
    * Creates an encoder for Java Bean of type T.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
@@ -34,6 +34,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.objects._
 import org.apache.spark.sql.catalyst.util.ArrayBasedMapData
 import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.CalendarInterval
 
 /**
  * Type-inference utilities for POJOs and Java collections.
@@ -118,6 +119,7 @@ object JavaTypeInference {
       case c: Class[_] if c == classOf[java.sql.Date] => (DateType, true)
       case c: Class[_] if c == classOf[java.time.Instant] => (TimestampType, true)
       case c: Class[_] if c == classOf[java.sql.Timestamp] => (TimestampType, true)
+      case c: Class[_] if c == classOf[CalendarInterval] => (CalendarIntervalType, true)
 
       case _ if typeToken.isArray =>
         val (dataType, nullable) = inferDataType(typeToken.getComponentType, seenTypeSet)
@@ -248,6 +250,8 @@ object JavaTypeInference {
 
       case c if c == classOf[java.sql.Timestamp] =>
         createDeserializerForSqlTimestamp(path)
+
+      case c if c == classOf[CalendarInterval] => path
 
       case c if c == classOf[java.lang.String] =>
         createDeserializerForString(path, returnNullable = true)
@@ -405,6 +409,8 @@ object JavaTypeInference {
         case c if c == classOf[java.time.LocalDate] => createSerializerForJavaLocalDate(inputObject)
 
         case c if c == classOf[java.sql.Date] => createSerializerForSqlDate(inputObject)
+
+        case c if c == classOf[CalendarInterval] => inputObject
 
         case c if c == classOf[java.math.BigDecimal] =>
           createSerializerForJavaBigDecimal(inputObject)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -126,6 +126,7 @@ object ScalaReflection extends ScalaReflection {
       case t if isSubtype(t, definitions.ShortTpe) => classOf[Array[Short]]
       case t if isSubtype(t, definitions.ByteTpe) => classOf[Array[Byte]]
       case t if isSubtype(t, definitions.BooleanTpe) => classOf[Array[Boolean]]
+      case t if isSubtype(t, localTypeOf[CalendarInterval]) => classOf[Array[CalendarInterval]]
       case other =>
         // There is probably a better way to do this, but I couldn't find it...
         val elementType = dataTypeFor(other).asInstanceOf[ObjectType].cls

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -235,6 +235,7 @@ object ScalaReflection extends ScalaReflection {
       case t if isSubtype(t, localTypeOf[java.lang.String]) =>
         createDeserializerForString(path, returnNullable = false)
 
+      case t if isSubtype(t, localTypeOf[CalendarInterval]) => path
       case t if isSubtype(t, localTypeOf[java.math.BigDecimal]) =>
         createDeserializerForJavaBigDecimal(path, returnNullable = false)
 
@@ -497,6 +498,8 @@ object ScalaReflection extends ScalaReflection {
         createSerializerForJavaLocalDate(inputObject)
 
       case t if isSubtype(t, localTypeOf[java.sql.Date]) => createSerializerForSqlDate(inputObject)
+
+      case t if isSubtype(t, localTypeOf[CalendarInterval]) => inputObject
 
       case t if isSubtype(t, localTypeOf[BigDecimal]) =>
         createSerializerForScalaBigDecimal(inputObject)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
@@ -437,4 +437,11 @@ class ScalaReflectionSuite extends SparkFunSuite {
       StructField("f2", StringType))))
     assert(deserializerFor[FooWithAnnotation].dataType == ObjectType(classOf[FooWithAnnotation]))
   }
+
+  test("serde for CalendarInterval") {
+    val ser = serializerFor[CalendarInterval]
+    assert(ser.dataType === CalendarIntervalType)
+    val deser = deserializerFor[CalendarInterval]
+    assert(deser.dataType === CalendarIntervalType)
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
@@ -89,6 +89,9 @@ abstract class SQLImplicits extends LowPrioritySQLImplicits {
   /** @since 3.0.0 */
   implicit def newInstantEncoder: Encoder[java.time.Instant] = Encoders.INSTANT
 
+  /** @since 3.1.0 */
+  implicit def newIntervalEncoder: Encoder[CalendarInterval] = Encoders.INTERVAL
+
   // Boxed primitives
 
   /** @since 2.0.0 */
@@ -238,8 +241,6 @@ abstract class SQLImplicits extends LowPrioritySQLImplicits {
    */
   implicit def symbolToColumn(s: Symbol): ColumnName = new ColumnName(s.name)
 
-  /** @since 3.1.0 */
-  implicit def newIntervalEncoder: Encoder[CalendarInterval] = Encoders.INTERVAL
 }
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
@@ -214,6 +214,9 @@ abstract class SQLImplicits extends LowPrioritySQLImplicits {
   /** @since 1.6.1 */
   implicit def newStringArrayEncoder: Encoder[Array[String]] = ExpressionEncoder()
 
+  /** @since 3.1.0 */
+  implicit def newIntervalArrayEncoder: Encoder[Array[CalendarInterval]] = ExpressionEncoder()
+
   /** @since 1.6.1 */
   implicit def newProductArrayEncoder[A <: Product : TypeTag]: Encoder[Array[A]] =
     ExpressionEncoder()

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
@@ -23,6 +23,7 @@ import scala.reflect.runtime.universe.TypeTag
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+import org.apache.spark.unsafe.types.CalendarInterval
 
 /**
  * A collection of implicit methods for converting common Scala objects into [[Dataset]]s.
@@ -237,6 +238,8 @@ abstract class SQLImplicits extends LowPrioritySQLImplicits {
    */
   implicit def symbolToColumn(s: Symbol): ColumnName = new ColumnName(s.name)
 
+  /** @since 3.1.0 */
+  implicit def newIntervalEncoder: Encoder[CalendarInterval] = Encoders.CALENDARINTERVAL
 }
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
@@ -239,7 +239,7 @@ abstract class SQLImplicits extends LowPrioritySQLImplicits {
   implicit def symbolToColumn(s: Symbol): ColumnName = new ColumnName(s.name)
 
   /** @since 3.1.0 */
-  implicit def newIntervalEncoder: Encoder[CalendarInterval] = Encoders.CALENDARINTERVAL
+  implicit def newIntervalEncoder: Encoder[CalendarInterval] = Encoders.INTERVAL
 }
 
 /**

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
@@ -19,6 +19,7 @@ package test.org.apache.spark.sql;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.sql.Array;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -284,13 +285,19 @@ public class JavaDatasetSuite implements Serializable {
 
   public static class IntervalBean implements Serializable {
     private CalendarInterval i;
+    private CalendarInterval[] ia;
 
     public void setI(CalendarInterval i) {
       this.i = i;
+      this.ia = new CalendarInterval[]{i};
     }
 
     public CalendarInterval getI() {
       return this.i;
+    }
+
+    public CalendarInterval[] getIA() {
+      return this.ia;
     }
 
     @Override
@@ -320,6 +327,10 @@ public class JavaDatasetSuite implements Serializable {
     List<IntervalBean> data = Arrays.asList(ib1, ib2, ib3);
     Dataset<IntervalBean> ds1 =
       spark.createDataFrame(data, IntervalBean.class).as(Encoders.bean(IntervalBean.class));
+
+    ds1.collectAsList().forEach(ib -> {
+      if (ib.getI() != null) Assert.assertEquals(ib.getI(), ib.getIA()[0]);
+    });
     Dataset<CalendarInterval> ds2 =
       ds1.map((MapFunction<IntervalBean, CalendarInterval>) ib -> ib.getI(), Encoders.INTERVAL());
     Assert.assertEquals(

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
@@ -19,7 +19,6 @@ package test.org.apache.spark.sql;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
-import java.sql.Array;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.time.Instant;

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
@@ -324,7 +324,8 @@ public class JavaDatasetSuite implements Serializable {
       ds1.map((MapFunction<IntervalBean, CalendarInterval>) ib -> ib.getI(), Encoders.INTERVAL());
     Assert.assertEquals(
       Arrays.asList("1 months 2 days 1 hours", "4 months 5 days 1 hours", null),
-      ds2.select(expr("value + interval 1 hour").cast("string")).as(Encoders.STRING()).collectAsList());
+      ds2.select(expr("value + interval 1 hour").cast("string"))
+        .as(Encoders.STRING()).collectAsList());
   }
 
   @Test

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2360,16 +2360,18 @@ class DataFrameSuite extends QueryTest
   }
 
   test("CalendarInterval encoder support") {
-    val df = Seq(
-      new CalendarInterval(1, 2, 3),
-      new CalendarInterval(4, 5, 6),
-      null).toDF()
-    checkAnswer(df,
-      Seq(
-        Row(new CalendarInterval(1, 2, 3)),
-        Row(new CalendarInterval(4, 5, 6)),
-        Row(null)))
+    val i = new CalendarInterval(1, 2, 3)
+    val ii = new CalendarInterval(4, 5, 6)
+    checkAnswer(Seq(i, ii, null).toDF(), Seq(Row(i), Row(ii), Row(null)))
+    checkAnswer(Seq(Some(i), Some(ii), null).toDF(), Seq(Row(i), Row(ii), Row(null)))
+
+    checkAnswer(Seq(Seq(i), null).toDF(), Seq(Row(Array(i)), Row(null)))
+    checkAnswer(Seq(Set(i), null).toDF(), Seq(Row(Array(i)), Row(null)))
+    checkAnswer(Seq(Array(i), null).toDF(), Seq(Row(Array(i)), Row(null)))
+    checkAnswer(Seq(Map(i -> i), null).toDF(), Seq(Row(Map(i -> i)), Row(null)))
+    checkAnswer(Seq(Map(1 -> i), null).toDF(), Seq(Row(Map(1 -> i)), Row(null)))
   }
+
 }
 
 case class GroupByKey(a: Int, b: Int)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2354,11 +2354,6 @@ class DataFrameSuite extends QueryTest
     assert(e.getMessage.contains("Table or view not found:"))
   }
 
-  test("CalendarInterval reflection support") {
-    val df = Seq((1, new CalendarInterval(1, 2, 3))).toDF("a", "b")
-    checkAnswer(df.selectExpr("b"), Row(new CalendarInterval(1, 2, 3)))
-  }
-
   test("CalendarInterval encoder support") {
     val i = new CalendarInterval(1, 2, 3)
     val ii = new CalendarInterval(4, 5, 6)
@@ -2370,6 +2365,7 @@ class DataFrameSuite extends QueryTest
     checkAnswer(Seq(Array(i), null).toDF(), Seq(Row(Array(i)), Row(null)))
     checkAnswer(Seq(Map(i -> i), null).toDF(), Seq(Row(Map(i -> i)), Row(null)))
     checkAnswer(Seq(Map(1 -> i), null).toDF(), Seq(Row(Map(1 -> i)), Row(null)))
+    checkAnswer(Seq((1, i)).toDF("a", "b").selectExpr("b"), Row(i))
   }
 
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2358,6 +2358,18 @@ class DataFrameSuite extends QueryTest
     val df = Seq((1, new CalendarInterval(1, 2, 3))).toDF("a", "b")
     checkAnswer(df.selectExpr("b"), Row(new CalendarInterval(1, 2, 3)))
   }
+
+  test("CalendarInterval encoder support") {
+    val df = Seq(
+      new CalendarInterval(1, 2, 3),
+      new CalendarInterval(4, 5, 6),
+      null).toDF()
+    checkAnswer(df,
+      Seq(
+        Row(new CalendarInterval(1, 2, 3)),
+        Row(new CalendarInterval(4, 5, 6)),
+        Row(null)))
+  }
 }
 
 case class GroupByKey(a: Int, b: Int)


### PR DESCRIPTION

### What changes were proposed in this pull request?

CalenderInterval is available to be converted to/from internal Spark SQL representation when it is a member of a Scala's product type e.g tuples/ case class etc but not as a primitive type

In this PR, we add a new ser/de rules to map CalenderInterval to CalenderIntervalType directly.

### Why are the changes needed?

improve CalenderInterval


### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

yes, CalenderInterval are now can be implicitly converted to Dataset/DataFame without being wrapped as scala Products
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

add new tests