### PR TITLE
[SPARK-31432][DEPLOY] Make SPARK_JARS_DIR configurable

### DIFF
--- a/bin/spark-class
+++ b/bin/spark-class
@@ -37,14 +37,14 @@ fi
 
 # Find Spark jars.
 if [ -d "${SPARK_HOME}/jars" ]; then
-  SPARK_JARS_DIR="${SPARK_HOME}/jars"
+  SPARK_JARS_DIR="${SPARK_JARS_DIR:-"${SPARK_HOME}/jars"}"
 else
-  SPARK_JARS_DIR="${SPARK_HOME}/assembly/target/scala-$SPARK_SCALA_VERSION/jars"
+  SPARK_JARS_DIR="${SPARK_JARS_DIR:-"${SPARK_HOME}/assembly/target/scala-$SPARK_SCALA_VERSION/jars"}"
 fi
 
 if [ ! -d "$SPARK_JARS_DIR" ] && [ -z "$SPARK_TESTING$SPARK_SQL_TESTING" ]; then
   echo "Failed to find Spark jars directory ($SPARK_JARS_DIR)." 1>&2
-  echo "You need to build Spark with the target \"package\" before running this program." 1>&2
+  echo "You need to set an appropriate directory for SPARK_JARS_DIR or build Spark with the target \"package\" before running this program." 1>&2
   exit 1
 else
   LAUNCH_CLASSPATH="$SPARK_JARS_DIR/*"

--- a/bin/spark-class2.cmd
+++ b/bin/spark-class2.cmd
@@ -29,15 +29,18 @@ if "x%1"=="x" (
 )
 
 rem Find Spark jars.
-if exist "%SPARK_HOME%\jars" (
-  set SPARK_JARS_DIR="%SPARK_HOME%\jars"
-) else (
-  set SPARK_JARS_DIR="%SPARK_HOME%\assembly\target\scala-%SPARK_SCALA_VERSION%\jars"
+if [%SPARK_JARS_DIR%] == [] (
+  if exist "%SPARK_HOME%\jars" (
+    set SPARK_JARS_DIR="%SPARK_HOME%\jars"
+  ) else (
+    set SPARK_JARS_DIR="%SPARK_HOME%\assembly\target\scala-%SPARK_SCALA_VERSION%\jars"
+  )
 )
+
 
 if not exist "%SPARK_JARS_DIR%"\ (
   echo Failed to find Spark jars directory.
-  echo You need to build Spark before running this program.
+  echo You need to set an appropriate directory for SPARK_JARS_DIR or build Spark before running this program.
   exit /b 1
 )
 

--- a/conf/spark-env.sh.template
+++ b/conf/spark-env.sh.template
@@ -34,6 +34,7 @@
 
 # Options read in YARN client/cluster mode
 # - SPARK_CONF_DIR, Alternate conf dir. (Default: ${SPARK_HOME}/conf)
+# - SPARK_JARS_DIR, Alternate jars dir. (Default: ${SPARK_HOME}/jars)
 # - HADOOP_CONF_DIR, to point Spark towards Hadoop configuration files
 # - YARN_CONF_DIR, to point Spark towards YARN configuration files when you use YARN
 # - SPARK_EXECUTOR_CORES, Number of cores for the executors (Default: 1).
@@ -61,6 +62,7 @@
 
 # Generic options for the daemons used in the standalone deploy mode
 # - SPARK_CONF_DIR      Alternate conf dir. (Default: ${SPARK_HOME}/conf)
+# - SPARK_JARS_DIR      Alternate jars dir. (Default: ${SPARK_HOME}/jars)
 # - SPARK_LOG_DIR       Where log files are stored.  (Default: ${SPARK_HOME}/logs)
 # - SPARK_PID_DIR       Where the pid file is stored. (Default: /tmp)
 # - SPARK_IDENT_STRING  A string representing this instance of spark. (Default: $USER)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2941,7 +2941,12 @@ from this directory.
 
 # Overriding classpath default directory
 
-To specify a different classpath directory other than the default "SPARK_HOME/jars"  you can set SPARK_JARS_DIR. Any of the services under "SPARK_HOME/sbin" folder will use it.
+To specify a different classpath directory other than the default "SPARK_HOME/jars", you can set SPARK_JARS_DIR.
+
+The configuration affects to
+* The commands under "SPARK_HOME/bin", specifically the script uses `spark-class`.
+* The services under "SPARK_HOME/sbin", specifically the script uses `spark-config.sh`.
+* An application employs spark-launcher to run a spark application
 
 # Inheriting Hadoop Cluster Configuration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2939,6 +2939,10 @@ To specify a different configuration directory other than the default "SPARK_HOM
 you can set SPARK_CONF_DIR. Spark will use the configuration files (spark-defaults.conf, spark-env.sh, log4j.properties, etc)
 from this directory.
 
+# Overriding classpath default directory
+
+To specify a different classpath directory other than the default "SPARK_HOME/jars"  you can set SPARK_JARS_DIR. Any of the services under "SPARK_HOME/sbin" folder will use it.
+
 # Inheriting Hadoop Cluster Configuration
 
 If you plan to read and write from HDFS using Spark, there are two Hadoop configuration files that

--- a/launcher/pom.xml
+++ b/launcher/pom.xml
@@ -61,6 +61,11 @@
       <artifactId>slf4j-log4j12</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.spark</groupId>

--- a/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
@@ -319,31 +319,45 @@ class CommandBuilderUtils {
    * or a distribution directory.
    */
   static String findJarsDir(String sparkHome, String scalaVersion, boolean failIfNotFound) {
+    String envJarsDir = findEnvJarsDir(sparkHome, scalaVersion, failIfNotFound);
+    if (envJarsDir != null) {
+      return envJarsDir;
+    }
+    return findHomeJarsDir(sparkHome, scalaVersion, failIfNotFound);
+  }
+
+  private static String findEnvJarsDir(String sparkHome, String scalaVersion,
+          boolean failIfNotFound) {
     String envSparkJarsDir = System.getenv(ENV_SPARK_JARS_DIR);
     if (envSparkJarsDir != null && !envSparkJarsDir.isEmpty()) {
       File envJarsDir = new File(envSparkJarsDir);
       return handleJarsDir(envJarsDir, failIfNotFound,
-        "The specified SPARK_JARS_DIR '%s' does not exist; make sure SPARK_JARS_DIR is set appropriately.");
+        "The specified SPARK_JARS_DIR '%s' does not exist;" +
+        " make sure SPARK_JARS_DIR is set appropriately.");
     }
-    
+    return null;
+  }
+
+  private static String findHomeJarsDir(String sparkHome, String scalaVersion,
+          boolean failIfNotFound) {
     // TODO: change to the correct directory once the assembly build is changed.
     File libdir = new File(sparkHome, "jars");
     if (!libdir.isDirectory()) {
       libdir = new File(sparkHome, String.format("assembly/target/scala-%s/jars", scalaVersion));
       return handleJarsDir(libdir, failIfNotFound,
-          "Library directory '%s' does not exist; make sure Spark is built.");
+        "Library directory '%s' does not exist; make sure Spark is built.");
     }
     return libdir.getAbsolutePath();
   }
 
-  private static String handleJarsDir(File theDir, boolean failIfNotFound, String message) { 
-    if (!theDir.isDirectory()) {
+  private static String handleJarsDir(File dir, boolean failIfNotFound, String message) {
+    if (!dir.isDirectory()) {
       LOG.log(Level.WARNING, "The jar dir candidate {0} is skipped because it is not a directory.",
-          new Object[] { theDir });
-      checkState(!failIfNotFound, message, theDir.getAbsolutePath());
+          new Object[] { dir });
+      checkState(!failIfNotFound, message, dir.getAbsolutePath());
       return null;
     }
-    return theDir.getAbsolutePath();
+    return dir.getAbsolutePath();
   }
 
 }

--- a/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
@@ -30,6 +30,7 @@ class CommandBuilderUtils {
   static final String DEFAULT_MEM = "1g";
   static final String DEFAULT_PROPERTIES_FILE = "spark-defaults.conf";
   static final String ENV_SPARK_HOME = "SPARK_HOME";
+  static final String ENV_SPARK_JARS_DIR = "SPARK_JARS_DIR";
 
   /** Returns whether the given string is null or empty. */
   static boolean isEmpty(String s) {
@@ -315,7 +316,7 @@ class CommandBuilderUtils {
    */
   static String findJarsDir(String sparkHome, String scalaVersion, boolean failIfNotFound) {
     // TODO: change to the correct directory once the assembly build is changed.
-    File libdir = new File(sparkHome, "jars");
+    File libdir = new File(getJarsDir(sparkHome));
     if (!libdir.isDirectory()) {
       libdir = new File(sparkHome, String.format("assembly/target/scala-%s/jars", scalaVersion));
       if (!libdir.isDirectory()) {
@@ -326,6 +327,11 @@ class CommandBuilderUtils {
       }
     }
     return libdir.getAbsolutePath();
+  }
+
+  static String getJarsDir(String sparkHome) {
+    String jarsDir = System.getenv(ENV_SPARK_JARS_DIR);
+    return jarsDir != null ? jarsDir : join(File.separator, sparkHome, "jars");
   }
 
 }

--- a/launcher/src/test/java/org/apache/spark/launcher/CommandBuilderUtilsSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/CommandBuilderUtilsSuite.java
@@ -121,7 +121,7 @@ public class CommandBuilderUtilsSuite {
       findJarsDir(sparkHome, "2.13", true);
     } catch (IllegalStateException e) {
       assertEquals(
-        "Library directory '" + sparkHome + 
+        "Library directory '" + sparkHome +
         "/assembly/target/scala-2.13/jars' does not exist; make sure Spark is built.",
         e.getMessage());
     }
@@ -142,23 +142,25 @@ public class CommandBuilderUtilsSuite {
 
     // if we have SPARK_JARS_DIR, use it as jars dir
     File spefifiedJarsDir = tempFolder.newFolder("jars-dir");
-    environmentVariables.set("SPARK_JARS_DIR", spefifiedJarsDir.getAbsolutePath());
+    environmentVariables.set(ENV_SPARK_JARS_DIR, spefifiedJarsDir.getAbsolutePath());
     assertEquals(join(File.separator, tmpRoot, "jars-dir"),
       findJarsDir(sparkHome, "2.13", true));
 
     // if SPARK_JARS_DIR is specified but not exists, throws IllegalStateException
-    environmentVariables.set("SPARK_JARS_DIR", join(File.separator, tmpRoot, "jars-dir-not-exists"));
+    environmentVariables.set(ENV_SPARK_JARS_DIR,
+      join(File.separator, tmpRoot, "jars-dir-not-exists"));
     try {
       findJarsDir(sparkHome, "2.13", true);
     } catch (IllegalStateException e) {
       assertEquals(
-          "The specified SPARK_JARS_DIR '" + tmpRoot + File.separator + 
+          "The specified SPARK_JARS_DIR '" + tmpRoot + File.separator +
           "jars-dir-not-exists' does not exist; make sure SPARK_JARS_DIR is set appropriately.",
           e.getMessage());
     }
 
-    // but if failIfNotFound is false, return null without exception
-    assertEquals(null, findJarsDir(sparkHome, "2.13", false));
+    // but if failIfNotFound is false, warn and continue the old lookup behavior
+    assertEquals(join(File.separator, tmpRoot, "spark", "home", "jars"),
+      findJarsDir(sparkHome, "2.13", false));
   }
 
   private static void testOpt(String opts, List<String> expected) {

--- a/launcher/src/test/java/org/apache/spark/launcher/CommandBuilderUtilsSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/CommandBuilderUtilsSuite.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Test;
+
 import static org.junit.Assert.*;
 
 import static org.apache.spark.launcher.CommandBuilderUtils.*;
@@ -97,6 +98,11 @@ public class CommandBuilderUtilsSuite {
     assertEquals(9, javaMajorVersion("9"));
     assertEquals(9, javaMajorVersion("9.1.0"));
     assertEquals(10, javaMajorVersion("10"));
+  }
+
+  @Test
+  public void testGetJarsDir() {
+    assertEquals("/spark/home/jars", getJarsDir("/spark/home"));
   }
 
   private static void testOpt(String opts, List<String> expected) {

--- a/launcher/src/test/java/org/apache/spark/launcher/CommandBuilderUtilsSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/CommandBuilderUtilsSuite.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Test;
-
 import static org.junit.Assert.*;
 
 import static org.apache.spark.launcher.CommandBuilderUtils.*;

--- a/pom.xml
+++ b/pom.xml
@@ -929,6 +929,18 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>com.github.stefanbirkner</groupId>
+        <artifactId>system-rules</artifactId>
+        <version>1.19.0</version>
+        <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>junit</groupId>
+            <artifactId>junit-dep</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
         <groupId>com.spotify</groupId>
         <artifactId>docker-client</artifactId>
         <version>8.14.1</version>

--- a/sbin/spark-config.sh
+++ b/sbin/spark-config.sh
@@ -25,6 +25,8 @@ if [ -z "${SPARK_HOME}" ]; then
 fi
 
 export SPARK_CONF_DIR="${SPARK_CONF_DIR:-"${SPARK_HOME}/conf"}"
+export SPARK_JARS_DIR="${SPARK_JARS_DIR:-"${SPARK_HOME}/jars"}"
+
 # Add the PySpark classes to the PYTHONPATH:
 if [ -z "${PYSPARK_PYTHONPATH_SET}" ]; then
   export PYTHONPATH="${SPARK_HOME}/python:${PYTHONPATH}"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes SPARK_JARS_DIR configurable in scripts under bin/sbin and launcher.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
As I wrote in SPARK-31432, the change is benefitical for flexibility of deployment.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
No, as long as the user dose not set SPARK_JARS_DIR in the environemnt variable.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
scripts under bin/sbin
- I built release archive by ./dev/make-distribution.sh and run some tests by hand on linux and windows. The log of the test is https://gist.github.com/marblejenka/28cb3e14056e72c8d6e540c999516459

launcher
- I have added a testcase assuming SPARK_JARS_DIR is not set
- It is possible to write a testsase for SPARK_JARS_DIR is set, but it is difficult to do it with portability. I will add the testcase if reviewer requests.
