### PR TITLE
[SPARK-31330][INFRA][FOLLOW-UP] Move sbin and some files into appropriate categories in autolabeller

### DIFF
--- a/.github/autolabeler.yml
+++ b/.github/autolabeler.yml
@@ -57,16 +57,11 @@ CORE:
   - "/common/network-shuffle/"
   - "/python/pyspark/*.py"
   - "/python/pyspark/tests/*.py"
-  - "/sbin/*master*.sh"
-  - "/sbin/*slave*.sh"
-  - "/sbin/spark-config.sh"
-  - "/sbin/*daemon*.sh"
-  - "/sbin/*history*.sh"
-  - "/sbin/*mesos*.sh"
 SPARK SUBMIT:
   - "/bin/spark-submit*"
 SPARK SHELL:
   - "/repl/"
+  - "/bin/spark-shell*"
 SQL:
   - "sql/"
   - "/common/unsafe/"
@@ -122,6 +117,7 @@ YARN:
   - "/resource-managers/yarn/"
 MESOS:
   - "/resource-managers/mesos/"
+  - "/sbin/*mesos*.sh"
 KUBERNETES:
   - "/resource-managers/kubernetes/"
 WINDOWS:
@@ -129,3 +125,5 @@ WINDOWS:
   - "/R/pkg/tests/fulltests/test_Windows.R"
 WEB UI:
   - "ui/"
+DEPLOY:
+  - "/sbin/"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/commit/1b8701504457ec291e6221dd63eec6e6be999150. Now, we automatically label PRs, and seems working fine.

This PR proposes to correct some minor list and categories.

**1.** Move `sbin` from `CORE` into `DEPLOY` components.

```
$ ls sbin

decommission-slave.sh          start-all.sh                   start-slave.sh                 stop-master.sh                 stop-thriftserver.sh
slaves.sh                      start-history-server.sh        start-slaves.sh                stop-mesos-dispatcher.sh
spark-config.sh                start-master.sh                start-thriftserver.sh          stop-mesos-shuffle-service.sh
spark-daemon.sh                start-mesos-dispatcher.sh      stop-all.sh                    stop-slave.sh
spark-daemons.sh               start-mesos-shuffle-service.sh stop-history-server.sh         stop-slaves.sh
```

**2.** 

`/sbin/*mesos*.sh` -> `MESOS`
`/bin/spark-shell*` -> `SPARK SHELL`.

### Why are the changes needed?

To label correctly and dev can take an advantage of it such as checking the PRs of a specific component.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

It was not tested yet. It can be tested after it was merged.
