### PR TITLE
[SPARK-31440][SQL] Improve SQL Rest API

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusStore.scala
@@ -146,6 +146,4 @@ class SparkPlanGraphNodeWrapper(
 case class SQLPlanMetric(
     name: String,
     accumulatorId: Long,
-    metricType: String,
-    nodeId: Option[Long] = None,
-    nodeName: Option[String] = None)
+    metricType: String)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusStore.scala
@@ -146,4 +146,6 @@ class SparkPlanGraphNodeWrapper(
 case class SQLPlanMetric(
     name: String,
     accumulatorId: Long,
-    metricType: String)
+    metricType: String,
+    nodeId: Option[Long] = None,
+    nodeName: Option[String] = None)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
@@ -80,7 +80,8 @@ object SparkPlanGraph {
     planInfo.nodeName match {
       case name if name.startsWith("WholeStageCodegen") =>
         val metrics = planInfo.metrics.map { metric =>
-          SQLPlanMetric(metric.name, metric.accumulatorId, metric.metricType)
+          SQLPlanMetric(metric.name, metric.accumulatorId, metric.metricType,
+            Some(nodeIdGenerator.get()), Some(planInfo.nodeName))
         }
 
         val cluster = new SparkPlanGraphCluster(
@@ -123,7 +124,8 @@ object SparkPlanGraph {
         edges += SparkPlanGraphEdge(node.id, parent.id)
       case name =>
         val metrics = planInfo.metrics.map { metric =>
-          SQLPlanMetric(metric.name, metric.accumulatorId, metric.metricType)
+          SQLPlanMetric(metric.name, metric.accumulatorId, metric.metricType,
+            Some(nodeIdGenerator.get()), Some(planInfo.nodeName))
         }
         val node = new SparkPlanGraphNode(
           nodeIdGenerator.getAndIncrement(), planInfo.nodeName,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
@@ -195,7 +195,7 @@ private[ui] class SparkPlanGraphNode(
 /**
  * Represent a tree of SparkPlan for WholeStageCodegen.
  */
-private[ui] class SparkPlanGraphCluster(
+class SparkPlanGraphCluster(
     id: Long,
     name: String,
     desc: String,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
@@ -80,8 +80,7 @@ object SparkPlanGraph {
     planInfo.nodeName match {
       case name if name.startsWith("WholeStageCodegen") =>
         val metrics = planInfo.metrics.map { metric =>
-          SQLPlanMetric(metric.name, metric.accumulatorId, metric.metricType,
-            Some(nodeIdGenerator.get()), Some(planInfo.nodeName))
+          SQLPlanMetric(metric.name, metric.accumulatorId, metric.metricType)
         }
 
         val cluster = new SparkPlanGraphCluster(
@@ -124,8 +123,7 @@ object SparkPlanGraph {
         edges += SparkPlanGraphEdge(node.id, parent.id)
       case name =>
         val metrics = planInfo.metrics.map { metric =>
-          SQLPlanMetric(metric.name, metric.accumulatorId, metric.metricType,
-            Some(nodeIdGenerator.get()), Some(planInfo.nodeName))
+          SQLPlanMetric(metric.name, metric.accumulatorId, metric.metricType)
         }
         val node = new SparkPlanGraphNode(
           nodeIdGenerator.getAndIncrement(), planInfo.nodeName,
@@ -155,7 +153,7 @@ object SparkPlanGraph {
  * @param name the name of this SparkPlan node
  * @param metrics metrics that this SparkPlan node will track
  */
-private[ui] class SparkPlanGraphNode(
+class SparkPlanGraphNode(
     val id: Long,
     val name: String,
     val desc: String,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
@@ -231,7 +231,7 @@ class SparkPlanGraphCluster(
  * Represent an edge in the SparkPlan tree. `fromId` is the child node id, and `toId` is the parent
  * node id.
  */
-private[ui] case class SparkPlanGraphEdge(fromId: Long, toId: Long) {
+case class SparkPlanGraphEdge(fromId: Long, toId: Long) {
 
   def makeDotEdge: String = s"""  $fromId->$toId;\n"""
 }

--- a/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/SqlResource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/SqlResource.scala
@@ -42,7 +42,7 @@ private[v1] class SqlResource extends BaseAppResource {
       val sqlStore = new SQLAppStatusStore(ui.store.store)
       sqlStore.executionsList(offset, length).map { exec =>
         val (edges, nodeIdAndWSCGIdMap) = computeDetailsIfTrue(sqlStore, exec.executionId, details)
-        prepareExecutionData(exec, nodeIdAndWSCGIdMap, edges,
+        prepareExecutionData(exec, edges, nodeIdAndWSCGIdMap,
           details = details, planDescription = planDescription)
       }
     }
@@ -60,7 +60,7 @@ private[v1] class SqlResource extends BaseAppResource {
       val (edges, nodeIdAndWSCGIdMap) = computeDetailsIfTrue(sqlStore, execId, details)
       sqlStore
         .execution(execId)
-        .map(prepareExecutionData(_, nodeIdAndWSCGIdMap, edges, details, planDescription))
+        .map(prepareExecutionData(_, edges, nodeIdAndWSCGIdMap, details, planDescription))
         .getOrElse(throw new NotFoundException("unknown execution id: " + execId))
     }
   }
@@ -109,8 +109,8 @@ private[v1] class SqlResource extends BaseAppResource {
 
   private def prepareExecutionData(
     exec: SQLExecutionUIData,
-    nodeIdAndWSCGIdMap: Map[Long, Option[Long]] = Map.empty,
     sparkPlanGraphEdges: Seq[SparkPlanGraphEdge] = Seq.empty,
+    nodeIdAndWSCGIdMap: Map[Long, Option[Long]] = Map.empty,
     details: Boolean,
     planDescription: Boolean): ExecutionData = {
 

--- a/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/SqlResource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/SqlResource.scala
@@ -159,11 +159,13 @@ private[v1] class SqlResource extends BaseAppResource {
     nodeIdAndWSCGIdMap: Map[Long, Option[Long]]): Seq[Node] = {
 
     def getMetric(metricValues: Map[Long, String], accumulatorId: Long,
-                  metricName: String): Option[Metric] = {
+      metricName: String): Option[Metric] = {
+
       metricValues.get(accumulatorId).map( mv => {
         val metricValue = if (mv.startsWith("\n")) mv.substring(1, mv.length) else mv
         Metric(metricName, metricValue)
       })
+
     }
 
     val nodes = sparkPlanGraphNodes.map { node =>

--- a/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/SqlResource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/SqlResource.scala
@@ -66,8 +66,8 @@ private[v1] class SqlResource extends BaseAppResource {
   }
 
   private def computeDetailsIfTrue(sqlStore: SQLAppStatusStore,
-                               executionId: Long,
-                               details: Boolean):
+    executionId: Long,
+    details: Boolean):
   (Seq[SparkPlanGraphEdge], Map[Long, Option[Long]]) = {
     if (details) {
       val graph = sqlStore.planGraph(executionId)

--- a/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/SqlResource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/SqlResource.scala
@@ -24,7 +24,7 @@ import javax.ws.rs.core.MediaType
 import scala.util.{Failure, Success, Try}
 
 import org.apache.spark.JobExecutionStatus
-import org.apache.spark.sql.execution.ui.{SparkPlanGraph, SparkPlanGraphCluster, SparkPlanGraphEdge, SparkPlanGraphNode, SQLAppStatusStore, SQLExecutionUIData}
+import org.apache.spark.sql.execution.ui.{SparkPlanGraph, SparkPlanGraphCluster, SparkPlanGraphNode, SQLAppStatusStore, SQLExecutionUIData}
 import org.apache.spark.status.api.v1.{BaseAppResource, NotFoundException}
 
 @Produces(Array(MediaType.APPLICATION_JSON))
@@ -41,10 +41,8 @@ private[v1] class SqlResource extends BaseAppResource {
     withUI { ui =>
       val sqlStore = new SQLAppStatusStore(ui.store.store)
       sqlStore.executionsList(offset, length).map { exec =>
-        val (allNodes, edges, nodeIdAndWSCGIdMap) =
-          computeDetailsIfTrue(sqlStore, exec.executionId, details)
-        prepareExecutionData(exec, allNodes, edges, nodeIdAndWSCGIdMap,
-          details = details, planDescription = planDescription)
+        val graph = sqlStore.planGraph(exec.executionId)
+        prepareExecutionData(exec, graph, details, planDescription)
       }
     }
   }
@@ -58,52 +56,17 @@ private[v1] class SqlResource extends BaseAppResource {
       planDescription: Boolean): ExecutionData = {
     withUI { ui =>
       val sqlStore = new SQLAppStatusStore(ui.store.store)
-      val (allNodes, edges, nodeIdAndWSCGIdMap) = computeDetailsIfTrue(sqlStore, execId, details)
+      val graph = sqlStore.planGraph(execId)
       sqlStore
         .execution(execId)
-        .map(prepareExecutionData(_, allNodes, edges, nodeIdAndWSCGIdMap, details, planDescription))
+        .map(prepareExecutionData(_, graph, details, planDescription))
         .getOrElse(throw new NotFoundException("unknown query execution id: " + execId))
-    }
-  }
-
-  private def computeDetailsIfTrue(sqlStore: SQLAppStatusStore,
-    executionId: Long,
-    details: Boolean):
-  (Seq[SparkPlanGraphNode], Seq[SparkPlanGraphEdge], Map[Long, Option[Long]]) = {
-    if (details) {
-      val graph = sqlStore.planGraph(executionId)
-      val nodeIdAndWSCGIdMap: Map[Long, Option[Long]] = getNodeIdAndWSCGIdMap(graph)
-      (graph.allNodes, graph.edges, nodeIdAndWSCGIdMap)
-    } else {
-      (Seq.empty, Seq.empty, Map.empty)
-    }
-  }
-
-  private def getNodeIdAndWSCGIdMap(graph: SparkPlanGraph): Map[Long, Option[Long]] = {
-    val wscgNodes = graph.allNodes.filter(_.name.trim.startsWith(WHOLE_STAGE_CODEGEN))
-    val nodeIdAndWSCGIdMap: Map[Long, Option[Long]] = wscgNodes.flatMap {
-      _ match {
-        case x: SparkPlanGraphCluster => x.nodes.map(_.id -> getWholeStageCodegenId(x.name.trim))
-        case _ => Seq.empty
-      }
-    }.toMap
-
-    nodeIdAndWSCGIdMap
-  }
-
-  private def getWholeStageCodegenId(wscgNodeName: String): Option[Long] = {
-    Try(wscgNodeName.substring(
-      s"$WHOLE_STAGE_CODEGEN (".length, wscgNodeName.length - 1).toLong) match {
-      case Success(wscgId) => Some(wscgId)
-      case Failure(t) => None
     }
   }
 
   private def prepareExecutionData(
     exec: SQLExecutionUIData,
-    sparkPlanGraphNodes: Seq[SparkPlanGraphNode],
-    sparkPlanGraphEdges: Seq[SparkPlanGraphEdge],
-    nodeIdAndWSCGIdMap: Map[Long, Option[Long]],
+    graph: SparkPlanGraph,
     details: Boolean,
     planDescription: Boolean): ExecutionData = {
 
@@ -131,14 +94,8 @@ private[v1] class SqlResource extends BaseAppResource {
 
     val duration = exec.completionTime.getOrElse(new Date()).getTime - exec.submissionTime
     val planDetails = if (planDescription) exec.physicalPlanDescription else ""
-    val nodes =
-      if (details) {
-        printableMetrics(
-          sparkPlanGraphNodes, exec.metricValues, nodeIdAndWSCGIdMap)
-      } else {
-        Seq.empty
-      }
-    val edges = if (details) sparkPlanGraphEdges else Seq.empty
+    val nodes = if (details) printableMetrics(graph.allNodes, exec.metricValues) else Seq.empty
+    val edges = if (details) graph.edges else Seq.empty
 
     new ExecutionData(
       exec.executionId,
@@ -154,9 +111,8 @@ private[v1] class SqlResource extends BaseAppResource {
       edges)
   }
 
-  private def printableMetrics(sparkPlanGraphNodes: Seq[SparkPlanGraphNode],
-    metricValues: Map[Long, String],
-    nodeIdAndWSCGIdMap: Map[Long, Option[Long]]): Seq[Node] = {
+  private def printableMetrics(allNodes: Seq[SparkPlanGraphNode],
+    metricValues: Map[Long, String]): Seq[Node] = {
 
     def getMetric(metricValues: Map[Long, String], accumulatorId: Long,
       metricName: String): Option[Metric] = {
@@ -165,10 +121,10 @@ private[v1] class SqlResource extends BaseAppResource {
         val metricValue = if (mv.startsWith("\n")) mv.substring(1, mv.length) else mv
         Metric(metricName, metricValue)
       })
-
     }
 
-    val nodes = sparkPlanGraphNodes.map { node =>
+    val nodeIdAndWSCGIdMap = getNodeIdAndWSCGIdMap(allNodes)
+    val nodes = allNodes.map { node =>
       val wholeStageCodegenId = nodeIdAndWSCGIdMap.get(node.id).flatten
       val metrics =
         node.metrics.flatMap(m => getMetric(metricValues, m.accumulatorId, m.name.trim))
@@ -176,6 +132,26 @@ private[v1] class SqlResource extends BaseAppResource {
     }
 
     nodes.sortBy(_.nodeId).reverse
+  }
+
+  private def getNodeIdAndWSCGIdMap(allNodes: Seq[SparkPlanGraphNode]): Map[Long, Option[Long]] = {
+    val wscgNodes = allNodes.filter(_.name.trim.startsWith(WHOLE_STAGE_CODEGEN))
+    val nodeIdAndWSCGIdMap: Map[Long, Option[Long]] = wscgNodes.flatMap {
+      _ match {
+        case x: SparkPlanGraphCluster => x.nodes.map(_.id -> getWholeStageCodegenId(x.name.trim))
+        case _ => Seq.empty
+      }
+    }.toMap
+
+    nodeIdAndWSCGIdMap
+  }
+
+  private def getWholeStageCodegenId(wscgNodeName: String): Option[Long] = {
+    Try(wscgNodeName.substring(
+      s"$WHOLE_STAGE_CODEGEN (".length, wscgNodeName.length - 1).toLong) match {
+      case Success(wscgId) => Some(wscgId)
+      case Failure(t) => None
+    }
   }
 
 }

--- a/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/SqlResource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/SqlResource.scala
@@ -92,10 +92,12 @@ private[v1] class SqlResource extends BaseAppResource {
     metricDetails.sortBy(_.nodeId).reverse
   }
 
-  private def prepareExecutionData(exec: SQLExecutionUIData,
-                                   nodeIdAndWSCGIdMap: Map[Long, Option[Long]] = Map.empty,
-                                   details: Boolean,
-                                   planDescription: Boolean): ExecutionData = {
+  private def prepareExecutionData(
+    exec: SQLExecutionUIData,
+    nodeIdAndWSCGIdMap: Map[Long, Option[Long]] = Map.empty,
+    details: Boolean,
+    planDescription: Boolean): ExecutionData = {
+
     var running = Seq[Int]()
     var completed = Seq[Int]()
     var failed = Seq[Int]()
@@ -121,8 +123,12 @@ private[v1] class SqlResource extends BaseAppResource {
     val duration = exec.completionTime.getOrElse(new Date()).getTime - exec.submissionTime
     val planDetails = if (details && planDescription) exec.physicalPlanDescription else ""
     val metrics =
-      if (details) printableMetrics(exec.metrics, exec.metricValues, nodeIdAndWSCGIdMap)
-      else Seq.empty
+      if (details) {
+        printableMetrics(exec.metrics, exec.metricValues, nodeIdAndWSCGIdMap)
+      } else {
+        Seq.empty
+      }
+
     new ExecutionData(
       exec.executionId,
       status,
@@ -138,10 +144,11 @@ private[v1] class SqlResource extends BaseAppResource {
 
   private def getNodeIdAndWSCGIdMap(graph: SparkPlanGraph): Map[Long, Option[Long]] = {
     val wscgNodes = graph.allNodes.filter(_.name.trim.startsWith(WHOLE_STAGE_CODEGEN))
-    val nodeIdAndWSCGIdMap: Map[Long, Option[Long]] = wscgNodes.flatMap { _ match {
-      case x: SparkPlanGraphCluster => x.nodes.map(_.id -> getWholeStageCodegenId(x.name.trim))
-      case _ => Seq.empty
-    }
+    val nodeIdAndWSCGIdMap: Map[Long, Option[Long]] = wscgNodes.flatMap {
+      _ match {
+        case x: SparkPlanGraphCluster => x.nodes.map(_.id -> getWholeStageCodegenId(x.name.trim))
+        case _ => Seq.empty
+      }
     }.toMap
 
     nodeIdAndWSCGIdMap

--- a/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/SqlResource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/SqlResource.scala
@@ -34,7 +34,7 @@ private[v1] class SqlResource extends BaseAppResource {
 
   @GET
   def sqlList(
-      @DefaultValue("false") @QueryParam("details") details: Boolean,
+      @DefaultValue("true") @QueryParam("details") details: Boolean,
       @DefaultValue("true") @QueryParam("planDescription") planDescription: Boolean,
       @DefaultValue("0") @QueryParam("offset") offset: Int,
       @DefaultValue("20") @QueryParam("length") length: Int): Seq[ExecutionData] = {
@@ -52,7 +52,7 @@ private[v1] class SqlResource extends BaseAppResource {
   @Path("{executionId:\\d+}")
   def sql(
       @PathParam("executionId") execId: Long,
-      @DefaultValue("false") @QueryParam("details") details: Boolean,
+      @DefaultValue("true") @QueryParam("details") details: Boolean,
       @DefaultValue("true") @QueryParam("planDescription")
       planDescription: Boolean): ExecutionData = {
     withUI { ui =>
@@ -61,7 +61,7 @@ private[v1] class SqlResource extends BaseAppResource {
       sqlStore
         .execution(execId)
         .map(prepareExecutionData(_, edges, nodeIdAndWSCGIdMap, details, planDescription))
-        .getOrElse(throw new NotFoundException("unknown execution id: " + execId))
+        .getOrElse(throw new NotFoundException("unknown query execution id: " + execId))
     }
   }
 
@@ -137,7 +137,7 @@ private[v1] class SqlResource extends BaseAppResource {
     }
 
     val duration = exec.completionTime.getOrElse(new Date()).getTime - exec.submissionTime
-    val planDetails = if (details && planDescription) exec.physicalPlanDescription else ""
+    val planDetails = if (planDescription) exec.physicalPlanDescription else ""
     val nodes =
       if (details) {
         printableMetrics(exec.metrics, exec.metricValues, nodeIdAndWSCGIdMap)

--- a/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/api.scala
+++ b/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/api.scala
@@ -18,6 +18,8 @@ package org.apache.spark.status.api.v1.sql
 
 import java.util.Date
 
+import org.apache.spark.sql.execution.ui.SparkPlanGraphEdge
+
 class ExecutionData private[spark] (
     val id: Long,
     val status: String,
@@ -28,9 +30,10 @@ class ExecutionData private[spark] (
     val runningJobIds: Seq[Int],
     val successJobIds: Seq[Int],
     val failedJobIds: Seq[Int],
-    val metricDetails: Seq[MetricDetails])
+    val nodes: Seq[Node],
+    val edges: Seq[SparkPlanGraphEdge])
 
-case class MetricDetails private[spark] (
+case class Node private[spark](
     nodeId: Long,
     nodeName: String,
     wholeStageCodegenId: Option[Long] = None,

--- a/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/api.scala
+++ b/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/api.scala
@@ -30,9 +30,10 @@ class ExecutionData private[spark] (
     val failedJobIds: Seq[Int],
     val metricDetails: Seq[MetricDetails])
 
-case class MetricDetails private[spark] (nodeId: Long,
-                                         nodeName: String,
-                                         wholeStageCodegenId: Option[Long] = None,
-                                         metrics: Seq[Metric])
+case class MetricDetails private[spark] (
+    nodeId: Long,
+    nodeName: String,
+    wholeStageCodegenId: Option[Long] = None,
+    metrics: Seq[Metric])
 
 case class Metric private[spark] (name: String, value: String)

--- a/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/api.scala
+++ b/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/api.scala
@@ -23,11 +23,15 @@ class ExecutionData private[spark] (
     val status: String,
     val description: String,
     val planDescription: String,
-    val metrics: Seq[Metrics],
     val submissionTime: Date,
     val duration: Long,
     val runningJobIds: Seq[Int],
     val successJobIds: Seq[Int],
-    val failedJobIds: Seq[Int])
+    val failedJobIds: Seq[Int],
+    val metricDetails: Seq[MetricDetails])
 
-case class Metrics private[spark] (metricName: String, metricValue: String)
+case class MetricDetails private[spark] (nodeId: Long,
+                                         nodeName: String,
+                                         metrics: Seq[Metric])
+
+case class Metric private[spark] (name: String, value: String)

--- a/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/api.scala
+++ b/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/api.scala
@@ -32,6 +32,7 @@ class ExecutionData private[spark] (
 
 case class MetricDetails private[spark] (nodeId: Long,
                                          nodeName: String,
+                                         wholeStageCodegenId: Option[Long] = None,
                                          metrics: Seq[Metric])
 
 case class Metric private[spark] (name: String, value: String)

--- a/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceSuite.scala
@@ -22,8 +22,9 @@ import java.util.Date
 import scala.collection.mutable.ArrayBuffer
 
 import org.scalatest.PrivateMethodTester
+
 import org.apache.spark.{JobExecutionStatus, SparkFunSuite}
-import org.apache.spark.sql.execution.ui.{SQLExecutionUIData, SQLPlanMetric, SparkPlanGraphCluster, SparkPlanGraphEdge, SparkPlanGraphNode}
+import org.apache.spark.sql.execution.ui.{SparkPlanGraphCluster, SparkPlanGraphEdge, SparkPlanGraphNode, SQLExecutionUIData, SQLPlanMetric}
 
 object SqlResourceSuite {
 

--- a/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceSuite.scala
@@ -34,7 +34,7 @@ object SqlResourceSuite {
   val METADATA_TIME = "metadata time"
   val NUMBER_OF_FILES_READ = "number of files read"
   val SIZE_OF_FILES_READ = "size of files read"
-  val PLAN_DESCRIPTION = "== Physical Plan ==\nCollectLimit (3)\n+- * Filter (2)\n +- Scan text ..."
+  val PLAN_DESCRIPTION = "== Physical Plan ==\nCollectLimit (3)\n+- * Filter (2)\n +- Scan text..."
   val DESCRIPTION = "csv at MyDataFrames.scala:57"
 
   val edges: Seq[SparkPlanGraphEdge] =
@@ -139,7 +139,8 @@ class SqlResourceSuite extends SparkFunSuite with PrivateMethodTester {
     val executionData =
       sqlResource invokePrivate prepareExecutionData(
         sqlExecutionUIData, Seq.empty, nodeIdAndWSCGIdMap, false, false)
-    verifyExpectedExecutionData(executionData, edges = Seq.empty, nodes = Seq.empty, planDescription = "")
+    verifyExpectedExecutionData(executionData, edges = Seq.empty,
+      nodes = Seq.empty, planDescription = "")
   }
 
   test("Prepare ExecutionData when details = true and planDescription = false") {
@@ -166,7 +167,8 @@ class SqlResourceSuite extends SparkFunSuite with PrivateMethodTester {
 
   test("Prepare ExecutionData when details = true and planDescription = false and WSCG = off") {
     val executionData =
-      sqlResource invokePrivate prepareExecutionData(sqlExecutionUIData, edges, Map.empty, true, false)
+      sqlResource invokePrivate prepareExecutionData(
+        sqlExecutionUIData, edges, Map.empty, true, false)
     verifyExpectedExecutionData(
       executionData,
       nodes = getExpectedNodesWhenWholeStageCodegenIsOff(),

--- a/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceSuite.scala
@@ -106,9 +106,10 @@ object SqlResourceSuite {
   }
 
   private def verifyExpectedExecutionData(executionData: ExecutionData,
-                                          nodes: Seq[Node],
-                                          edges: Seq[SparkPlanGraphEdge],
-                                          planDescription: String): Unit = {
+    nodes: Seq[Node],
+    edges: Seq[SparkPlanGraphEdge],
+    planDescription: String): Unit = {
+
     assert(executionData.id == 0)
     assert(executionData.status == "COMPLETED")
     assert(executionData.description == DESCRIPTION)
@@ -120,7 +121,9 @@ object SqlResourceSuite {
     assert(executionData.failedJobIds == Seq.empty)
     assert(executionData.nodes == nodes)
     assert(executionData.edges == edges)
+
   }
+
 }
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceSuite.scala
@@ -19,9 +19,10 @@ package org.apache.spark.status.api.v1.sql
 
 import java.util.Date
 
-import org.apache.spark.sql.execution.ui.{SQLExecutionUIData, SQLPlanMetric}
-import org.apache.spark.{JobExecutionStatus, SparkFunSuite}
 import org.scalatest.PrivateMethodTester
+
+import org.apache.spark.{JobExecutionStatus, SparkFunSuite}
+import org.apache.spark.sql.execution.ui.{SQLExecutionUIData, SQLPlanMetric}
 
 object SqlResourceSuite {
 
@@ -104,8 +105,8 @@ object SqlResourceSuite {
 }
 
 /**
-  * Sql Resource Public API Unit Tests
-  */
+ * Sql Resource Public API Unit Tests.
+ */
 class SqlResourceSuite extends SparkFunSuite with PrivateMethodTester {
 
   import SqlResourceSuite._

--- a/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceSuite.scala
@@ -138,14 +138,14 @@ class SqlResourceSuite extends SparkFunSuite with PrivateMethodTester {
   test("Prepare ExecutionData when details = false and planDescription = false") {
     val executionData =
       sqlResource invokePrivate prepareExecutionData(
-        sqlExecutionUIData, nodeIdAndWSCGIdMap, Seq.empty, false, false)
-    verifyExpectedExecutionData(executionData, nodes = Seq.empty, edges = Seq.empty, planDescription = "")
+        sqlExecutionUIData, Seq.empty, nodeIdAndWSCGIdMap, false, false)
+    verifyExpectedExecutionData(executionData, edges = Seq.empty, nodes = Seq.empty, planDescription = "")
   }
 
   test("Prepare ExecutionData when details = true and planDescription = false") {
     val executionData =
       sqlResource invokePrivate prepareExecutionData(
-        sqlExecutionUIData, nodeIdAndWSCGIdMap, edges, true, false)
+        sqlExecutionUIData, edges, nodeIdAndWSCGIdMap, true, false)
     verifyExpectedExecutionData(
       executionData,
       nodes = getNodes(),
@@ -156,7 +156,7 @@ class SqlResourceSuite extends SparkFunSuite with PrivateMethodTester {
   test("Prepare ExecutionData when details = true and planDescription = true") {
     val executionData =
       sqlResource invokePrivate prepareExecutionData(
-        sqlExecutionUIData, nodeIdAndWSCGIdMap, edges, true, true)
+        sqlExecutionUIData, edges, nodeIdAndWSCGIdMap, true, true)
     verifyExpectedExecutionData(
       executionData,
       nodes = getNodes(),
@@ -166,7 +166,7 @@ class SqlResourceSuite extends SparkFunSuite with PrivateMethodTester {
 
   test("Prepare ExecutionData when details = true and planDescription = false and WSCG = off") {
     val executionData =
-      sqlResource invokePrivate prepareExecutionData(sqlExecutionUIData, Map.empty, edges, true, false)
+      sqlResource invokePrivate prepareExecutionData(sqlExecutionUIData, edges, Map.empty, true, false)
     verifyExpectedExecutionData(
       executionData,
       nodes = getExpectedNodesWhenWholeStageCodegenIsOff(),

--- a/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceSuite.scala
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.status.api.v1.sql
+
+import java.util.Date
+
+import org.apache.spark.sql.execution.ui.{SQLExecutionUIData, SQLPlanMetric}
+import org.apache.spark.{JobExecutionStatus, SparkFunSuite}
+import org.scalatest.PrivateMethodTester
+
+object SqlResourceSuite {
+
+  val SCAN_TEXT = "Scan text"
+  val FILTER = "Filter"
+  val WHOLE_STAGE_CODEGEN_1 = "WholeStageCodegen (1)"
+  val DURATION = "duration"
+  val NUMBER_OF_OUTPUT_ROWS = "number of output rows"
+  val METADATA_TIME = "metadata time"
+  val NUMBER_OF_FILES_READ = "number of files read"
+  val SIZE_OF_FILES_READ = "size of files read"
+  val PLAN_DESCRIPTION = "== Physical Plan ==\nCollectLimit (3)\n+- * Filter (2)\n +- Scan text ..."
+  val DESCRIPTION = "csv at MyDataFrames.scala:57"
+
+  private def getSQLExecutionUIData(): SQLExecutionUIData = {
+    def getMetrics(): Seq[SQLPlanMetric] = {
+      Seq(SQLPlanMetric(DURATION, 0, "", Some(1), Some(WHOLE_STAGE_CODEGEN_1)),
+        SQLPlanMetric(NUMBER_OF_OUTPUT_ROWS, 1, "", Some(2), Some(FILTER)),
+        SQLPlanMetric(METADATA_TIME, 2, "", Some(3), Some(SCAN_TEXT)),
+        SQLPlanMetric(NUMBER_OF_FILES_READ, 3, "", Some(3), Some(SCAN_TEXT)),
+        SQLPlanMetric(NUMBER_OF_OUTPUT_ROWS, 4, "", Some(3), Some(SCAN_TEXT)),
+        SQLPlanMetric(SIZE_OF_FILES_READ, 5, "", Some(3), Some(SCAN_TEXT)))
+    }
+
+    def getMetricValues() = {
+      Map[Long, String](
+        0L -> "0 ms",
+        1L -> "1",
+        2L -> "2 ms",
+        3L -> "1",
+        4L -> "1",
+        5L -> "330.0 B"
+      )
+    }
+
+    new SQLExecutionUIData(
+      executionId = 0,
+      description = DESCRIPTION,
+      details = "",
+      physicalPlanDescription = PLAN_DESCRIPTION,
+      metrics = getMetrics(),
+      submissionTime = 1586768888233L,
+      completionTime = Some(new Date(1586768888999L)),
+      jobs = Map[Int, JobExecutionStatus](
+        0 -> JobExecutionStatus.SUCCEEDED,
+        1 -> JobExecutionStatus.SUCCEEDED),
+      stages = Set[Int](),
+      metricValues = getMetricValues()
+    )
+  }
+
+  private def getExpectedMetricDetails(): Seq[MetricDetails] = {
+    val metricDetails =
+      MetricDetails(1, WHOLE_STAGE_CODEGEN_1, metrics = Seq(Metric(DURATION, "0 ms")))
+    val metricDetails2 = MetricDetails(2, FILTER, metrics = Seq(Metric(NUMBER_OF_OUTPUT_ROWS, "1")))
+    val metricDetails3 = MetricDetails(3, SCAN_TEXT,
+      metrics = Seq(Metric(METADATA_TIME, "2 ms"),
+        Metric(NUMBER_OF_FILES_READ, "1"),
+        Metric(NUMBER_OF_OUTPUT_ROWS, "1"),
+        Metric(SIZE_OF_FILES_READ, "330.0 B")))
+
+    // reverse order because of supporting execution order by aligning with Spark-UI
+    Seq(metricDetails3, metricDetails2, metricDetails)
+  }
+
+  private def verifyExpectedExecutionData(executionData: ExecutionData,
+                                          metricDetails: Seq[MetricDetails],
+                                          planDescription: String): Unit = {
+    assert(executionData.id == 0)
+    assert(executionData.status == "COMPLETED")
+    assert(executionData.description == DESCRIPTION)
+    assert(executionData.planDescription == planDescription)
+    assert(executionData.submissionTime == new Date(1586768888233L))
+    assert(executionData.duration == 766L)
+    assert(executionData.successJobIds == Seq[Int](0, 1))
+    assert(executionData.runningJobIds == Seq[Int]())
+    assert(executionData.failedJobIds == Seq.empty)
+    assert(executionData.metricDetails == metricDetails)
+  }
+}
+
+/**
+  * Sql Resource Public API Unit Tests
+  */
+class SqlResourceSuite extends SparkFunSuite with PrivateMethodTester {
+
+  import SqlResourceSuite._
+
+  val sqlResource = new SqlResource()
+  val sqlExecutionUIData = getSQLExecutionUIData()
+  val prepareExecutionData = PrivateMethod[ExecutionData]('prepareExecutionData)
+
+  test("Prepare ExecutionData when details = false and planDescription = false") {
+    val executionData =
+      sqlResource invokePrivate prepareExecutionData(sqlExecutionUIData, false, false)
+    verifyExpectedExecutionData(executionData, metricDetails = Seq.empty, planDescription = "")
+  }
+
+  test("Prepare ExecutionData when details = true and planDescription = false") {
+    val executionData =
+      sqlResource invokePrivate prepareExecutionData(sqlExecutionUIData, true, false)
+    verifyExpectedExecutionData(
+      executionData,
+      metricDetails = getExpectedMetricDetails(),
+      planDescription = "")
+  }
+
+  test("Prepare ExecutionData when details = true and planDescription = true") {
+    val executionData =
+      sqlResource invokePrivate prepareExecutionData(sqlExecutionUIData, true, true)
+    verifyExpectedExecutionData(
+      executionData,
+      metricDetails = getExpectedMetricDetails(),
+      planDescription = PLAN_DESCRIPTION)
+  }
+
+}

--- a/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceSuite.scala
@@ -75,8 +75,8 @@ object SqlResourceSuite {
   }
 
   private def getExpectedMetricDetails(): Seq[MetricDetails] = {
-    val metricDetails =
-      MetricDetails(1, WHOLE_STAGE_CODEGEN_1, wholeStageCodegenId = None, metrics = Seq(Metric(DURATION, "0 ms")))
+    val metricDetails = MetricDetails(1, WHOLE_STAGE_CODEGEN_1,
+      wholeStageCodegenId = None, metrics = Seq(Metric(DURATION, "0 ms")))
     val metricDetails2 = MetricDetails(2, FILTER,
       wholeStageCodegenId = Some(1), metrics = Seq(Metric(NUMBER_OF_OUTPUT_ROWS, "1")))
     val metricDetails3 = MetricDetails(3, SCAN_TEXT, wholeStageCodegenId = Some(1),
@@ -133,13 +133,15 @@ class SqlResourceSuite extends SparkFunSuite with PrivateMethodTester {
 
   test("Prepare ExecutionData when details = false and planDescription = false") {
     val executionData =
-      sqlResource invokePrivate prepareExecutionData(sqlExecutionUIData, nodeIdAndWSCGIdMap, false, false)
+      sqlResource invokePrivate prepareExecutionData(
+        sqlExecutionUIData, nodeIdAndWSCGIdMap, false, false)
     verifyExpectedExecutionData(executionData, metricDetails = Seq.empty, planDescription = "")
   }
 
   test("Prepare ExecutionData when details = true and planDescription = false") {
     val executionData =
-      sqlResource invokePrivate prepareExecutionData(sqlExecutionUIData, nodeIdAndWSCGIdMap, true, false)
+      sqlResource invokePrivate prepareExecutionData(
+        sqlExecutionUIData, nodeIdAndWSCGIdMap, true, false)
     verifyExpectedExecutionData(
       executionData,
       metricDetails = getExpectedMetricDetails(),
@@ -148,14 +150,15 @@ class SqlResourceSuite extends SparkFunSuite with PrivateMethodTester {
 
   test("Prepare ExecutionData when details = true and planDescription = true") {
     val executionData =
-      sqlResource invokePrivate prepareExecutionData(sqlExecutionUIData, nodeIdAndWSCGIdMap, true, true)
+      sqlResource invokePrivate prepareExecutionData(
+        sqlExecutionUIData, nodeIdAndWSCGIdMap, true, true)
     verifyExpectedExecutionData(
       executionData,
       metricDetails = getExpectedMetricDetails(),
       planDescription = PLAN_DESCRIPTION)
   }
 
-  test("Prepare ExecutionData when details = true and planDescription = false and WholeStageCodegen = off") {
+  test("Prepare ExecutionData when details = true and planDescription = false and WSCG = off") {
     val executionData =
       sqlResource invokePrivate prepareExecutionData(sqlExecutionUIData, Map.empty, true, false)
     verifyExpectedExecutionData(

--- a/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceSuite.scala
@@ -20,7 +20,9 @@ package org.apache.spark.status.api.v1.sql
 import java.util.Date
 
 import scala.collection.mutable.ArrayBuffer
+
 import org.scalatest.PrivateMethodTester
+
 import org.apache.spark.{JobExecutionStatus, SparkFunSuite}
 import org.apache.spark.sql.execution.ui.{SparkPlanGraph, SparkPlanGraphCluster, SparkPlanGraphEdge, SparkPlanGraphNode, SQLExecutionUIData, SQLPlanMetric}
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
SQL Rest API exposes query execution metrics as Public API. This PR aims to apply following improvements on SQL Rest API by aligning Spark-UI.

**Proposed Improvements:**
1- Support Physical Operations and group metrics per physical operation by aligning Spark UI.
2- Support `wholeStageCodegenId` for Physical Operations
3- `nodeId` can be useful for grouping metrics and sorting physical operations (according to execution order) to differentiate same operators (if used multiple times during the same query execution) and their metrics.
4- Filter `empty` metrics by aligning with Spark UI - SQL Tab. Currently, Spark UI does not show empty metrics.
5- Remove line breakers(`\n`) from `metricValue`.
6- `planDescription` can be `optional` Http parameter to avoid network cost where there is specially complex jobs creating big-plans.
7- `metrics` attribute needs to be exposed at the bottom order as `nodes`. Specially, this can be useful for the user where `nodes` array size is high. 
8- `edges` attribute is being exposed to show relationship between `nodes`. 
9- Reverse order on `metricDetails` aims to match with Spark UI by supporting Physical Operators' execution order.

### Why are the changes needed?
Proposed improvements provides more useful (e.g: physical operations and metrics correlation, grouping) and clear (e.g: filtering blank metrics, removing line breakers) result for the end-user.

### Does this PR introduce any user-facing change?
Yes. Please find both current and improved versions of the results as attached for following SQL Rest Endpoint:
```
curl -X GET http://localhost:4040/api/v1/applications/$appId/sql/$executionId?details=true
```
**Current version:**
https://issues.apache.org/jira/secure/attachment/12999821/current_version.json

**Improved version:**
https://issues.apache.org/jira/secure/attachment/13000621/improved_version.json

### Backward Compatibility
SQL Rest API will be started to expose with `Spark 3.0` and `3.0.0-preview2` (released on 12/23/19) does not cover this API so if PR can catch 3.0 release, this will not have any backward compatibility issue.

### How was this patch tested?
1. New Unit tests are added.
2. Also, patch has been tested manually through both **Spark Core** and **History Server** Rest APIs.

