### PR TITLE
[SPARK-31272][SQL] Support DB2 Kerberos login in JDBC connector

### DIFF
--- a/external/docker-integration-tests/pom.xml
+++ b/external/docker-integration-tests/pom.xml
@@ -149,20 +149,19 @@
           -Dmaven.repo.drivers=http://my.local.repo
 
         2) have a copy of the DB2 JCC driver and run the following commands :
-          mvn install:install-file -Dfile=${path to db2jcc4.jar} \
+          mvn install:install-file -Dfile=${path to jcc.jar} \
             -DgroupId=com.ibm.db2 \
-            -DartifactId=db2jcc4 \
-            -Dversion=10.5 \
+            -DartifactId=jcc \
+            -Dversion=11.5 \
             -Dpackaging=jar
 
        Note: IBM DB2 JCC driver is available for download at
           http://www-01.ibm.com/support/docview.wss?uid=swg21363866
      -->
     <dependency>
-      <groupId>com.ibm.db2.jcc</groupId>
-      <artifactId>db2jcc4</artifactId>
-      <version>10.5.0.5</version>
-      <type>jar</type>
+      <groupId>com.ibm.db2</groupId>
+      <artifactId>jcc</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.microsoft.sqlserver</groupId>

--- a/external/docker-integration-tests/src/test/resources/db2_krb_setup.sh
+++ b/external/docker-integration-tests/src/test/resources/db2_krb_setup.sh
@@ -19,6 +19,7 @@
 USERPROFILE=/database/config/db2inst1/sqllib/userprofile
 echo "export DB2_KRB5_PRINCIPAL=db2/__IP_ADDRESS_REPLACE_ME__@EXAMPLE.COM" >> $USERPROFILE
 echo "export KRB5_KTNAME=/var/custom/db2.keytab" >> $USERPROFILE
+# This trick is needed because DB2 forwards environment variables automatically only if it's starting with DB2.
 su - db2inst1 -c "db2set DB2ENVLIST=KRB5_KTNAME"
 
 su - db2inst1 -c "db2 UPDATE DBM CFG USING SRVCON_GSSPLUGIN_LIST IBMkrb5 IMMEDIATE"

--- a/external/docker-integration-tests/src/test/resources/db2_krb_setup.sh
+++ b/external/docker-integration-tests/src/test/resources/db2_krb_setup.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+USERPROFILE=/database/config/db2inst1/sqllib/userprofile
+echo "export DB2_KRB5_PRINCIPAL=db2/__IP_ADDRESS_REPLACE_ME__@EXAMPLE.COM" >> $USERPROFILE
+echo "export KRB5_KTNAME=/var/custom/db2.keytab" >> $USERPROFILE
+su - db2inst1 -c "db2set DB2ENVLIST=KRB5_KTNAME"
+
+su - db2inst1 -c "db2 UPDATE DBM CFG USING SRVCON_GSSPLUGIN_LIST IBMkrb5 IMMEDIATE"
+su - db2inst1 -c "db2 UPDATE DBM CFG USING SRVCON_AUTH KERBEROS IMMEDIATE"
+
+su - db2inst1 -c "db2stop force; db2start"

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DB2IntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DB2IntegrationSuite.scala
@@ -21,11 +21,14 @@ import java.math.BigDecimal
 import java.sql.{Connection, Date, Timestamp}
 import java.util.Properties
 
+import org.scalatest.Ignore
+
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{BooleanType, ByteType, ShortType, StructType}
 import org.apache.spark.tags.DockerTest
 
 @DockerTest
+@Ignore // AMPLab Jenkins needs to be updated before shared memory works on docker
 class DB2IntegrationSuite extends DockerJDBCIntegrationSuite {
   override val db = new DatabaseOnDocker {
     override val imageName = "lresende/db2express-c:10.5.0.5-3.10.0"

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DB2IntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DB2IntegrationSuite.scala
@@ -21,15 +21,11 @@ import java.math.BigDecimal
 import java.sql.{Connection, Date, Timestamp}
 import java.util.Properties
 
-import org.scalatest.Ignore
-
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{BooleanType, ByteType, ShortType, StructType}
 import org.apache.spark.tags.DockerTest
 
-
 @DockerTest
-@Ignore // AMPLab Jenkins needs to be updated before shared memory works on docker
 class DB2IntegrationSuite extends DockerJDBCIntegrationSuite {
   override val db = new DatabaseOnDocker {
     override val imageName = "lresende/db2express-c:10.5.0.5-3.10.0"

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DB2KrbIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DB2KrbIntegrationSuite.scala
@@ -58,7 +58,6 @@ class DB2KrbIntegrationSuite extends DockerKrbJDBCIntegrationSuite {
     override def beforeContainerStart(
         hostConfigBuilder: HostConfig.Builder,
         containerConfigBuilder: ContainerConfig.Builder): Unit = {
-      def replaceIp(s: String): String = s.replace("__IP_ADDRESS_REPLACE_ME__", dockerIp)
       copyExecutableResource("db2_krb_setup.sh", initDbDir, replaceIp)
 
       hostConfigBuilder.appendBinds(

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DB2KrbIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DB2KrbIntegrationSuite.scala
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.jdbc
+
+import java.security.PrivilegedExceptionAction
+import java.sql.Connection
+import javax.security.auth.login.Configuration
+
+import com.spotify.docker.client.messages.{ContainerConfig, HostConfig}
+import org.apache.hadoop.security.{SecurityUtil, UserGroupInformation}
+import org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod.KERBEROS
+
+import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
+import org.apache.spark.sql.execution.datasources.jdbc.connection.{DB2ConnectionProvider, SecureConnectionProvider}
+import org.apache.spark.tags.DockerTest
+
+@DockerTest
+class DB2KrbIntegrationSuite extends DockerKrbJDBCIntegrationSuite {
+  override protected val userName = s"db2/$dockerIp"
+  override protected val keytabFileName = "db2.keytab"
+
+  override val db = new DatabaseOnDocker {
+    override val imageName = "ibmcom/db2:11.5.0.0a"
+    override val env = Map(
+      "DB2INST1_PASSWORD" -> "rootpass",
+      "LICENSE" -> "accept",
+      "DBNAME" -> "db2"
+    )
+    override val usesIpc = false
+    override val jdbcPort = 50000
+    override val privileged = true
+    override def getJdbcUrl(ip: String, port: Int): String = s"jdbc:db2://$ip:$port/db2"
+    override def getJdbcProperties() = {
+      val options = new JDBCOptions(Map[String, String](
+        JDBCOptions.JDBC_URL -> getJdbcUrl(dockerIp, externalPort),
+        JDBCOptions.JDBC_TABLE_NAME -> "bar",
+        JDBCOptions.JDBC_KEYTAB -> keytabFileName,
+        JDBCOptions.JDBC_PRINCIPAL -> principal
+      ))
+      new DB2ConnectionProvider(null, options).getAdditionalProperties()
+    }
+
+    override def beforeContainerStart(
+        hostConfigBuilder: HostConfig.Builder,
+        containerConfigBuilder: ContainerConfig.Builder): Unit = {
+      def replaceIp(s: String): String = s.replace("__IP_ADDRESS_REPLACE_ME__", dockerIp)
+      copyExecutableResource("db2_krb_setup.sh", initDbDir, replaceIp)
+
+      hostConfigBuilder.appendBinds(
+        HostConfig.Bind.from(initDbDir.getAbsolutePath)
+          .to("/var/custom").readOnly(true).build()
+      )
+    }
+  }
+
+  override protected def setAuthentication(keytabFile: String, principal: String): Unit = {
+    val config = new SecureConnectionProvider.JDBCConfiguration(
+      Configuration.getConfiguration, "JaasClient", keytabFile, principal)
+    Configuration.setConfiguration(config)
+  }
+
+  override def getConnection(): Connection = {
+    val config = new org.apache.hadoop.conf.Configuration
+    SecurityUtil.setAuthenticationMethod(KERBEROS, config)
+    UserGroupInformation.setConfiguration(config)
+
+    UserGroupInformation.loginUserFromKeytabAndReturnUGI(principal, keytabFullPath).doAs(
+      new PrivilegedExceptionAction[Connection]() {
+        override def run(): Connection = {
+          DB2KrbIntegrationSuite.super.getConnection()
+        }
+      }
+    )
+  }
+}

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerKrbJDBCIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerKrbJDBCIntegrationSuite.scala
@@ -77,6 +77,8 @@ abstract class DockerKrbJDBCIntegrationSuite extends DockerJDBCIntegrationSuite 
     }
   }
 
+  protected def replaceIp(s: String): String = s.replace("__IP_ADDRESS_REPLACE_ME__", dockerIp)
+
   protected def copyExecutableResource(
       fileName: String, dir: File, processLine: String => String = identity) = {
     val newEntry = new File(dir.getAbsolutePath, fileName)

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerKrbJDBCIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerKrbJDBCIntegrationSuite.scala
@@ -100,7 +100,7 @@ abstract class DockerKrbJDBCIntegrationSuite extends DockerJDBCIntegrationSuite 
   }
 
   override def dataPreparation(conn: Connection): Unit = {
-    conn.prepareStatement("CREATE TABLE bar (c0 text)").executeUpdate()
+    conn.prepareStatement("CREATE TABLE bar (c0 VARCHAR(8))").executeUpdate()
     conn.prepareStatement("INSERT INTO bar VALUES ('hello')").executeUpdate()
   }
 

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MariaDBKrbIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MariaDBKrbIntegrationSuite.scala
@@ -46,7 +46,6 @@ class MariaDBKrbIntegrationSuite extends DockerKrbJDBCIntegrationSuite {
     override def beforeContainerStart(
         hostConfigBuilder: HostConfig.Builder,
         containerConfigBuilder: ContainerConfig.Builder): Unit = {
-      def replaceIp(s: String): String = s.replace("__IP_ADDRESS_REPLACE_ME__", dockerIp)
       copyExecutableResource("mariadb_docker_entrypoint.sh", entryPointDir, replaceIp)
       copyExecutableResource("mariadb_krb_setup.sh", initDbDir, replaceIp)
 

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresKrbIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresKrbIntegrationSuite.scala
@@ -43,7 +43,6 @@ class PostgresKrbIntegrationSuite extends DockerKrbJDBCIntegrationSuite {
     override def beforeContainerStart(
         hostConfigBuilder: HostConfig.Builder,
         containerConfigBuilder: ContainerConfig.Builder): Unit = {
-      def replaceIp(s: String): String = s.replace("__IP_ADDRESS_REPLACE_ME__", dockerIp)
       copyExecutableResource("postgres_krb_setup.sh", initDbDir, replaceIp)
 
       hostConfigBuilder.appendBinds(

--- a/pom.xml
+++ b/pom.xml
@@ -964,6 +964,12 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>com.ibm.db2</groupId>
+        <artifactId>jcc</artifactId>
+        <version>11.5.0.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>org.apache.curator</groupId>
         <artifactId>curator-recipes</artifactId>
         <version>${curator.version}</version>

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -141,6 +141,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.ibm.db2</groupId>
+      <artifactId>jcc</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-avro</artifactId>
       <scope>test</scope>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/BasicConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/BasicConnectionProvider.scala
@@ -19,13 +19,17 @@ package org.apache.spark.sql.execution.datasources.jdbc.connection
 
 import java.sql.{Connection, Driver}
 
+import scala.collection.JavaConverters._
+
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 
 private[jdbc] class BasicConnectionProvider(driver: Driver, options: JDBCOptions)
     extends ConnectionProvider {
   def getConnection(): Connection = {
     val properties = getAdditionalProperties()
-    properties.putAll(options.asConnectionProperties)
+    options.asConnectionProperties.entrySet().asScala.foreach { e =>
+      properties.put(e.getKey(), e.getValue())
+    }
     driver.connect(options.url, properties)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProvider.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.datasources.jdbc.connection
 
 import java.sql.{Connection, Driver}
+import java.util.Properties
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
@@ -28,6 +29,11 @@ import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
  * the parameters.
  */
 private[jdbc] trait ConnectionProvider {
+  /**
+   * Additional properties for data connection (Data source property takes precedence).
+   */
+  def getAdditionalProperties(): Properties = new Properties()
+
   /**
    * Opens connection toward the database.
    */
@@ -49,6 +55,10 @@ private[jdbc] object ConnectionProvider extends Logging {
         case MariaDBConnectionProvider.driverClass =>
           logDebug("MariaDB connection provider found")
           new MariaDBConnectionProvider(driver, options)
+
+        case DB2ConnectionProvider.driverClass =>
+          logDebug("DB2 connection provider found")
+          new DB2ConnectionProvider(driver, options)
 
         case _ =>
           throw new IllegalArgumentException(s"Driver ${options.driverClass} does not support " +

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/DB2ConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/DB2ConnectionProvider.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.execution.datasources.jdbc.connection
 import java.security.PrivilegedExceptionAction
 import java.sql.{Connection, Driver}
 import java.util.Properties
-import javax.security.auth.login.Configuration
 
 import org.apache.hadoop.security.UserGroupInformation
 
@@ -50,13 +49,9 @@ private[sql] class DB2ConnectionProvider(driver: Driver, options: JDBCOptions)
   }
 
   override def setAuthenticationConfigIfNeeded(): Unit = {
-    val parent = Configuration.getConfiguration
-    val configEntry = parent.getAppConfigurationEntry(appEntry)
+    val (parent, configEntry) = getConfigWithAppEntry()
     if (configEntry == null || configEntry.isEmpty) {
-      val config = new SecureConnectionProvider.JDBCConfiguration(
-        parent, appEntry, options.keytab, options.principal)
-      logDebug("Adding database specific security configuration")
-      Configuration.setConfiguration(config)
+      setAuthenticationConfig(parent)
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/DB2ConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/DB2ConnectionProvider.scala
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.jdbc.connection
+
+import java.security.PrivilegedExceptionAction
+import java.sql.{Connection, Driver}
+import java.util.Properties
+import javax.security.auth.login.Configuration
+
+import org.apache.hadoop.security.UserGroupInformation
+
+import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
+
+private[sql] class DB2ConnectionProvider(driver: Driver, options: JDBCOptions)
+    extends SecureConnectionProvider(driver, options) {
+  override val appEntry: String = "JaasClient"
+
+  override def getConnection(): Connection = {
+    setAuthenticationConfigIfNeeded()
+    UserGroupInformation.loginUserFromKeytabAndReturnUGI(options.principal, options.keytab).doAs(
+      new PrivilegedExceptionAction[Connection]() {
+        override def run(): Connection = {
+          DB2ConnectionProvider.super.getConnection()
+        }
+      }
+    )
+  }
+
+  override def getAdditionalProperties(): Properties = {
+    val result = new Properties()
+    // 11 is the integer value for kerberos
+    result.put("securityMechanism", new String("11"))
+    result.put("KerberosServerPrincipal", options.principal)
+    result
+  }
+
+  override def setAuthenticationConfigIfNeeded(): Unit = {
+    val parent = Configuration.getConfiguration
+    val configEntry = parent.getAppConfigurationEntry(appEntry)
+    if (configEntry == null || configEntry.isEmpty) {
+      val config = new SecureConnectionProvider.JDBCConfiguration(
+        parent, appEntry, options.keytab, options.principal)
+      logDebug("Adding database specific security configuration")
+      Configuration.setConfiguration(config)
+    }
+  }
+}
+
+private[sql] object DB2ConnectionProvider {
+  val driverClass = "com.ibm.db2.jcc.DB2Driver"
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProvider.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.execution.datasources.jdbc.connection
 
 import java.sql.Driver
 import java.util.Properties
-import javax.security.auth.login.Configuration
 
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 
@@ -32,13 +31,9 @@ private[jdbc] class PostgresConnectionProvider(driver: Driver, options: JDBCOpti
   }
 
   override def setAuthenticationConfigIfNeeded(): Unit = {
-    val parent = Configuration.getConfiguration
-    val configEntry = parent.getAppConfigurationEntry(appEntry)
+    val (parent, configEntry) = getConfigWithAppEntry()
     if (configEntry == null || configEntry.isEmpty) {
-      val config = new SecureConnectionProvider.JDBCConfiguration(
-        parent, appEntry, options.keytab, options.principal)
-      logDebug("Adding database specific security configuration")
-      Configuration.setConfiguration(config)
+      setAuthenticationConfig(parent)
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/SecureConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/SecureConnectionProvider.scala
@@ -43,6 +43,18 @@ private[jdbc] abstract class SecureConnectionProvider(driver: Driver, options: J
    * then later calls must be no op.
    */
   def setAuthenticationConfigIfNeeded(): Unit
+
+  protected def getConfigWithAppEntry(): (Configuration, Array[AppConfigurationEntry]) = {
+    val parent = Configuration.getConfiguration
+    (parent, parent.getAppConfigurationEntry(appEntry))
+  }
+
+  protected def setAuthenticationConfig(parent: Configuration) = {
+    val config = new SecureConnectionProvider.JDBCConfiguration(
+      parent, appEntry, options.keytab, options.principal)
+    logDebug("Adding database specific security configuration")
+    Configuration.setConfiguration(config)
+  }
 }
 
 object SecureConnectionProvider {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/DB2ConnectionProviderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/DB2ConnectionProviderSuite.scala
@@ -17,15 +17,11 @@
 
 package org.apache.spark.sql.execution.datasources.jdbc.connection
 
-import java.sql.{Connection, Driver}
+class DB2ConnectionProviderSuite extends ConnectionProviderSuiteBase {
+  test("setAuthenticationConfigIfNeeded must set authentication if not set") {
+    val driver = registerDriver(DB2ConnectionProvider.driverClass)
+    val provider = new DB2ConnectionProvider(driver, options("jdbc:db2://localhost/db2"))
 
-import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
-
-private[jdbc] class BasicConnectionProvider(driver: Driver, options: JDBCOptions)
-    extends ConnectionProvider {
-  def getConnection(): Connection = {
-    val properties = getAdditionalProperties()
-    properties.putAll(options.asConnectionProperties)
-    driver.connect(options.url, properties)
+    testSecureConnectionProvider(provider)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
When loading DataFrames from JDBC datasource with Kerberos authentication, remote executors (yarn-client/cluster etc. modes) fail to establish a connection due to lack of Kerberos ticket or ability to generate it.

This is a real issue when trying to ingest data from kerberized data sources (SQL Server, Oracle) in enterprise environment where exposing simple authentication access is not an option due to IT policy issues.

In this PR I've added DB2 support (other supported databases will come in later PRs).

What this PR contains:
* Added `DB2ConnectionProvider`
* Added `DB2ConnectionProviderSuite`
* Added `DB2KrbIntegrationSuite` docker integration test
* Changed DB2 JDBC driver to use the latest (test scope only)
* Changed test table data type to a type which is supported by all the databases
* Removed double connection creation on test side
* Increased connection timeout in docker tests because DB2 docker takes quite a time to start

### Why are the changes needed?
Missing JDBC kerberos support.

### Does this PR introduce any user-facing change?
Yes, now user is able to connect to DB2 using kerberos.

### How was this patch tested?
* Additional + existing unit tests
* Additional + existing integration tests
* Test on cluster manually
