### PR TITLE
[SPARK-31445][SQL][2.4] Avoid floating-point operations in `millisToDays`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -134,7 +134,7 @@ object DateTimeUtils {
     // SPARK-6785: use Math.floor so negative number of days (dates before 1970)
     // will correctly work as input for function toJavaDate(Int)
     val millisLocal = millisUtc + timeZone.getOffset(millisUtc)
-    Math.floor(millisLocal.toDouble / MILLIS_PER_DAY).toInt
+    Math.floorDiv(millisLocal, MILLIS_PER_DAY).toInt
   }
 
   // reverse of millisToDays


### PR DESCRIPTION
### What changes were proposed in this pull request?
Replacing a floating-point division and Math.floor of Double value by `Math.floorDiv` for Long in `DateTimeUtils.millisToDays()`.

### Why are the changes needed?
The changes improve performance, in particular, it speeds up the conversion from java.sql.Date as the ported `DateTimeBenchmark` in https://github.com/MaxGekk/spark/pull/27 and comparisons in https://github.com/apache/spark/pull/28205 show.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
By existing test suite `DateTimeUtilsSuite`, `DateFunctionsSuite` and `DateExpressionsSuite`.