### PR TITLE
SPARK-31447 Fix issue in ExtractIntervalPart expression

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/CalendarInterval.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/CalendarInterval.java
@@ -66,9 +66,8 @@ public final class CalendarInterval implements Serializable {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     CalendarInterval that = (CalendarInterval) o;
-    return months == that.months &&
-      days == that.days &&
-      microseconds == that.microseconds;
+    return ((this.months * MICROS_PER_MONTH) + (this.days * MICROS_PER_DAY) + this.microseconds) ==
+           ((that.months * MICROS_PER_MONTH) + (that.days * MICROS_PER_DAY) + that.microseconds);
   }
 
   @Override

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
@@ -58,10 +58,10 @@ case class ExtractIntervalYears(child: Expression)
   extends ExtractIntervalPart(child, IntegerType, getYears, "getYears")
 
 case class ExtractIntervalQuarters(child: Expression)
-  extends ExtractIntervalPart(child, ByteType, getQuarters, "getQuarters")
+  extends ExtractIntervalPart(child, IntegerType, getQuarters, "getQuarters")
 
 case class ExtractIntervalMonths(child: Expression)
-  extends ExtractIntervalPart(child, ByteType, getMonths, "getMonths")
+  extends ExtractIntervalPart(child, IntegerType, getMonths, "getMonths")
 
 case class ExtractIntervalDays(child: Expression)
   extends ExtractIntervalPart(child, IntegerType, getDays, "getDays")
@@ -70,13 +70,13 @@ case class ExtractIntervalHours(child: Expression)
   extends ExtractIntervalPart(child, LongType, getHours, "getHours")
 
 case class ExtractIntervalMinutes(child: Expression)
-  extends ExtractIntervalPart(child, ByteType, getMinutes, "getMinutes")
+  extends ExtractIntervalPart(child, LongType, getMinutes, "getMinutes")
 
 case class ExtractIntervalSeconds(child: Expression)
-  extends ExtractIntervalPart(child, DecimalType(8, 6), getSeconds, "getSeconds")
+  extends ExtractIntervalPart(child, DecimalType(18, 6), getSeconds, "getSeconds")
 
 case class ExtractIntervalMilliseconds(child: Expression)
-  extends ExtractIntervalPart(child, DecimalType(8, 3), getMilliseconds, "getMilliseconds")
+  extends ExtractIntervalPart(child, DecimalType(18, 3), getMilliseconds, "getMilliseconds")
 
 case class ExtractIntervalMicroseconds(child: Expression)
   extends ExtractIntervalPart(child, LongType, getMicroseconds, "getMicroseconds")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -971,4 +971,32 @@ object DateTimeUtils {
     val days = period.getDays
     new CalendarInterval(months, days, 0)
   }
+
+  /**
+   * Subtracts two timestamps.
+   * @param endTimestamp The end timestamp
+   * @param startTimestamp The start timestamp
+   * @return An interval between two timestamps. The interval can be negative
+   *         if the end timestamp is before the start timestamp.
+   */
+  def subtractTimestamps(endTimestamp: SQLTimestamp,
+                         startTimestamp: SQLTimestamp): CalendarInterval = {
+    durationToCalendarInterval(endTimestamp-startTimestamp)
+  }
+
+  /**
+   * Calculate CalendarInterval from duration
+   * @param microseconds Microseconds to calculate duration from
+   * @return A CalendarInterval from microseconds duration. The interval can be negative
+   *         if the input is negative.
+   */
+  def durationToCalendarInterval(microseconds: Long): CalendarInterval = {
+    val duration = Duration.ofMillis(MICROSECONDS.toMillis(microseconds))
+    val months = duration.toDays / DAYS_PER_MONTH
+    val days = duration.toDays - (months * DAYS_PER_MONTH)
+    var microSeconds = NANOSECONDS.toMicros(duration.minusDays(duration.toDays).toNanos)
+    microSeconds += microseconds%1000
+
+    new CalendarInterval(months.toInt, days.toInt, microSeconds)
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
#### ExtractIntervalPart change
`ExtractIntervalPart` expression get the interval parts information from `CalendarInterval`, which has three fields months, days and microseconds.

To get days interval `ExtractIntervalDays` expression simply returns the days field of provided `CalendarInterval` input. 

If input is `CalendarInterval(months=2, days=10, microseconds=0)`, it returns output as 10, but instead it should return total days in the interval. In this it has to return as 70 days.

#### CalendarInterval change
Another change I am proposing is equality comparision between two CalendarInterval object. 
Right now, `CalendarInterval(months=1, days=0, microseconds=0)` and `CalendarInterval(months=0, days=30, microseconds=0)` are not equal. 

I understand a month could have 30 or 31 days, but there should be way to compare two intervals even if they have different values in three fields but if both have same epoch it should be considered as equal

Change to equals method in `CalendarInterval` is not required to fix the issue in `ExtractIntervalPart`, but I feel we should fix how two CalendarInterval objects are compared in equals method.


### Why are the changes needed?
Below sql statement return output as 0 instead of 14 days 
`SELECT EXTRACT(DAY FROM (cast('2020-01-15 00:00:00' as timestamp) - cast('2020-01-01 00:00:00' as timestamp)))`

Below is why it returns wrong output

`val start = Instant.parse("2019-01-01T00:00:00.000000Z")`
`val end = Instant.parse("2019-01-15T00:00:00.000000Z")`

`SubtractTimestamps(Literal(end), Literal(start))` expression returns `CalendarInterval(months=0, days=0, microseconds=1209600000)`

So, when evaluating below expression `ExtractIntervalDays` returns the value in days field in interval, which is zero, but correct answer is 14 days
`ExtractIntervalDays(SubtractTimestamps(Literal(end), Literal(start)))`

### Does this PR introduce any user-facing change?
No


### How was this patch tested?
* Additional + existing unit tests
