### PR TITLE
[SPARK-31330][INFRA][FOLLOW-UP] Exclude 'ui' and 'UI.scala' in CORE and 'dev/.rat-excludes' in BUILD autolabeller

### DIFF
--- a/.github/autolabeler.yml
+++ b/.github/autolabeler.yml
@@ -36,6 +36,7 @@ BUILD:
   - "!/dev/github_jira_sync.py"
   - "!/dev/merge_spark_pr.py"
   - "!/dev/run-tests-jenkins*"
+  - "!/dev/.rat-excludes"
   - "/build/"
   - "/project/"
   - "/assembly/"

--- a/.github/autolabeler.yml
+++ b/.github/autolabeler.yml
@@ -52,6 +52,8 @@ EXAMPLES:
   - "/bin/run-example*"
 CORE:
   - "/core/"
+  - "!UI.scala"
+  - "!ui/"
   - "/common/kvstore/"
   - "/common/network-common/"
   - "/common/network-shuffle/"
@@ -125,5 +127,6 @@ WINDOWS:
   - "/R/pkg/tests/fulltests/test_Windows.R"
 WEB UI:
   - "ui/"
+  - "UI.scala"
 DEPLOY:
   - "/sbin/"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR excludes `ui` directly and `UI.scala` configuration file in `CORE` label, and exclude `dev/.rat-excludes` in `BUILD` label  in autolabeller. See https://github.com/apache/spark/pull/28218, https://github.com/apache/spark/pull/28217, https://github.com/apache/spark/pull/28214 and https://github.com/apache/spark/pull/28213

There are some contexts about this https://github.com/apache/spark/pull/28114.

The syntax is from https://git-scm.com/docs/gitignore#_pattern_format (see also https://github.com/kaelzhang/node-ignore)

### Why are the changes needed?

To label UI component properly.

### Does this PR introduce any user-facing change?

No, dev-only.

### How was this patch tested?

It uses the same syntax used for other places. I expect to see the actual results after it gets merged as it's difficult to test it out.