### PR TITLE
[SPARK-31458][SQL] LOAD DATA support for builtin datasource tables

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -314,8 +314,8 @@ case class LoadDataCommand(
       throw new AnalysisException(s"Target table in LOAD DATA cannot be a view: $tableIdentwithDB")
     }
 
-    if (targetTable.provider.isDefined && (!DDLUtils.isHiveTable(targetTable) ||
-      HiveSerDe.sourceToSerDe(targetTable.provider.get).isEmpty)) {
+    if (targetTable.provider.isDefined && !DDLUtils.isHiveTable(targetTable) &&
+      HiveSerDe.sourceToSerDe(targetTable.provider.get).isEmpty) {
       throw new AnalysisException(s"LOAD DATA is not supported for '${targetTable.provider.get}'" +
         s" datasource table: $tableIdentwithDB")
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -313,9 +313,11 @@ case class LoadDataCommand(
     if (targetTable.tableType == CatalogTableType.VIEW) {
       throw new AnalysisException(s"Target table in LOAD DATA cannot be a view: $tableIdentwithDB")
     }
-    if (DDLUtils.isDatasourceTable(targetTable)) {
-      throw new AnalysisException(
-        s"LOAD DATA is not supported for datasource tables: $tableIdentwithDB")
+
+    if (targetTable.provider.isDefined &&
+      HiveSerDe.sourceToSerDe(targetTable.provider.get).isEmpty) {
+      throw new AnalysisException(s"LOAD DATA is not supported for '${targetTable.provider.get}'" +
+        s" datasource table: $tableIdentwithDB")
     }
     if (targetTable.partitionColumnNames.nonEmpty) {
       if (partition.isEmpty) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -314,8 +314,8 @@ case class LoadDataCommand(
       throw new AnalysisException(s"Target table in LOAD DATA cannot be a view: $tableIdentwithDB")
     }
 
-    if (targetTable.provider.isDefined &&
-      HiveSerDe.sourceToSerDe(targetTable.provider.get).isEmpty) {
+    if (targetTable.provider.isDefined && (!DDLUtils.isHiveTable(targetTable) ||
+      HiveSerDe.sourceToSerDe(targetTable.provider.get).isEmpty)) {
       throw new AnalysisException(s"LOAD DATA is not supported for '${targetTable.provider.get}'" +
         s" datasource table: $tableIdentwithDB")
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

LOAD DATA support for builtin file-based datasource tables, such as parquet, orc, etc.


This PR simply changes the condition check for failing datasource tables. (Maybe we should add a config to leave it to end-users to decide whether their source can support load data)

### Why are the changes needed?

LOAD DATA is banned for datasource tables

### Does this PR introduce any user-facing change?

yes, LOAD DATA will not fail for datasouce tables with specific format

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

add new tests;
