### PR TITLE
[SPARK-31459][SQL]fix insert overwrite directory target path is an existing file

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveDirCommand.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveDirCommand.scala
@@ -90,6 +90,15 @@ case class InsertIntoHiveDirCommand(
         val dfs = qualifiedPath.getFileSystem(hadoopConf)
         (qualifiedPath, dfs)
       }
+
+    if (fs.exists(writeToPath) && fs.isFile(writeToPath)) {
+      if (overwrite) {
+        fs.delete(writeToPath, true)
+      } else {
+        throw new SparkException(s"Failed inserting overwrite directory, " +
+          s"the path ${writeToPath.toString} is a file and overwrite is false")
+      }
+    }
     if (!fs.exists(writeToPath)) {
       fs.mkdirs(writeToPath)
     }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveDirCommand.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveDirCommand.scala
@@ -91,7 +91,10 @@ case class InsertIntoHiveDirCommand(
         (qualifiedPath, dfs)
       }
 
-    if (fs.exists(writeToPath) && fs.isFile(writeToPath)) {
+    // SPARK-31459: If the target path already exists as a file,
+    // the last rename operation will cause only one result file to be moved,
+    // resulting in incorrect results.
+    if (fs.isFile(writeToPath)) {
       if (overwrite) {
         fs.delete(writeToPath, true)
       } else {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertSuite.scala
@@ -777,14 +777,12 @@ class InsertSuite extends QueryTest with TestHiveSingleton with BeforeAndAfter
         val tempFile = File.createTempFile("targetPath", "", dir)
         val path = tempFile.toURI.getPath
 
-        val testSql =
+        sql(
           s"""
-             |INSERT OVERWRITE LOCAL DIRECTORY '${path}'
-             |STORED AS orc
-             |SELECT * FROM test_insert_table
-          """.stripMargin
-
-        sql(testSql)
+            |INSERT OVERWRITE LOCAL DIRECTORY '${path}'
+            |STORED AS orc
+            |SELECT * FROM test_insert_table
+          """.stripMargin)
 
         // use orc data source to check the data of path is right.
         checkAnswer(


### PR DESCRIPTION
### What changes were proposed in this pull request?
When using the insert overwrite directory syntax, if the target path is an existing file, the final operation result is incorrect.
At present, Spark will not delete the existing files. After the calculation is completed, one of the result files will be renamed to the result path.
This is different from hive's behavior. Hive will delete the existing target file.
After the repair, it will determine whether the target path is an existing file, and if so, delete the file first.

### Why are the changes needed?
Be consistent with hive's behavior.


### Does this PR introduce any user-facing change?
NO


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
