### PR TITLE
[SPARK-31469][SQL][TESTS][FOLLOWUP] Remove unsupported fields from ExtractBenchmark

### DIFF
--- a/sql/core/benchmarks/ExtractBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/ExtractBenchmark-jdk11-results.txt
@@ -1,138 +1,124 @@
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke extract for timestamp:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp                                   311            331          18         32.2          31.1       1.0X
-MILLENNIUM of timestamp                             873            893          17         11.4          87.3       0.4X
-CENTURY of timestamp                                869            873           5         11.5          86.9       0.4X
-DECADE of timestamp                                 851            872          23         11.7          85.1       0.4X
-YEAR of timestamp                                   841            856          14         11.9          84.1       0.4X
-ISOYEAR of timestamp                                927            938          12         10.8          92.7       0.3X
-QUARTER of timestamp                                959            963           6         10.4          95.9       0.3X
-MONTH of timestamp                                  852            864          18         11.7          85.2       0.4X
-WEEK of timestamp                                  1124           1252         112          8.9         112.4       0.3X
-DAY of timestamp                                    848            867          19         11.8          84.8       0.4X
-DAYOFWEEK of timestamp                              977            987          16         10.2          97.7       0.3X
-DOW of timestamp                                    945            964          18         10.6          94.5       0.3X
-ISODOW of timestamp                                 924            929           5         10.8          92.4       0.3X
-DOY of timestamp                                    852            906          67         11.7          85.2       0.4X
-HOUR of timestamp                                   665            671           5         15.0          66.5       0.5X
-MINUTE of timestamp                                 655            670          15         15.3          65.5       0.5X
-SECOND of timestamp                                 757            763           7         13.2          75.7       0.4X
-MILLISECONDS of timestamp                           745            761          14         13.4          74.5       0.4X
-MICROSECONDS of timestamp                           691            697           7         14.5          69.1       0.5X
-EPOCH of timestamp                                  794            806          12         12.6          79.4       0.4X
+cast to timestamp                                   322            327           4         31.1          32.2       1.0X
+MILLENNIUM of timestamp                             834            841           8         12.0          83.4       0.4X
+CENTURY of timestamp                                828            841          15         12.1          82.8       0.4X
+DECADE of timestamp                                 813            825          13         12.3          81.3       0.4X
+YEAR of timestamp                                   800            817          18         12.5          80.0       0.4X
+ISOYEAR of timestamp                                882            889           6         11.3          88.2       0.4X
+QUARTER of timestamp                                900            908          12         11.1          90.0       0.4X
+MONTH of timestamp                                  809            816           8         12.4          80.9       0.4X
+WEEK of timestamp                                  1119           1123           4          8.9         111.9       0.3X
+DAY of timestamp                                    801            808           7         12.5          80.1       0.4X
+DAYOFWEEK of timestamp                              946            952           5         10.6          94.6       0.3X
+DOW of timestamp                                    939            945          10         10.6          93.9       0.3X
+ISODOW of timestamp                                 869            874           5         11.5          86.9       0.4X
+DOY of timestamp                                    822            835          14         12.2          82.2       0.4X
+HOUR of timestamp                                   633            647          12         15.8          63.3       0.5X
+MINUTE of timestamp                                 635            636           1         15.8          63.5       0.5X
+SECOND of timestamp                                 774            778           4         12.9          77.4       0.4X
+MILLISECONDS of timestamp                           735            743           7         13.6          73.5       0.4X
+MICROSECONDS of timestamp                           652            657           4         15.3          65.2       0.5X
+EPOCH of timestamp                                  794            800           5         12.6          79.4       0.4X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke date_part for timestamp:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp                                   273            274           1         36.6          27.3       1.0X
-MILLENNIUM of timestamp                             860            875          14         11.6          86.0       0.3X
-CENTURY of timestamp                                854            866          11         11.7          85.4       0.3X
-DECADE of timestamp                                 855            863          10         11.7          85.5       0.3X
-YEAR of timestamp                                   833            837           4         12.0          83.3       0.3X
-ISOYEAR of timestamp                               1022           1036          18          9.8         102.2       0.3X
-QUARTER of timestamp                               1067           1132          58          9.4         106.7       0.3X
-MONTH of timestamp                                  855            861           5         11.7          85.5       0.3X
-WEEK of timestamp                                  1312           1325          17          7.6         131.2       0.2X
-DAY of timestamp                                    837            847          10         12.0          83.7       0.3X
-DAYOFWEEK of timestamp                              965            969           4         10.4          96.5       0.3X
-DOW of timestamp                                    981           1038          56         10.2          98.1       0.3X
-ISODOW of timestamp                                 942            959          20         10.6          94.2       0.3X
-DOY of timestamp                                    994           1021          24         10.1          99.4       0.3X
-HOUR of timestamp                                   690            695           7         14.5          69.0       0.4X
-MINUTE of timestamp                                 764            788          21         13.1          76.4       0.4X
-SECOND of timestamp                                 776            795          34         12.9          77.6       0.4X
-MILLISECONDS of timestamp                           863            879          14         11.6          86.3       0.3X
-MICROSECONDS of timestamp                           689            695           7         14.5          68.9       0.4X
-EPOCH of timestamp                                  797            865          69         12.5          79.7       0.3X
+cast to timestamp                                   281            291          11         35.6          28.1       1.0X
+MILLENNIUM of timestamp                             814            825          19         12.3          81.4       0.3X
+CENTURY of timestamp                                842            850           7         11.9          84.2       0.3X
+DECADE of timestamp                                 812            814           3         12.3          81.2       0.3X
+YEAR of timestamp                                   787            798          10         12.7          78.7       0.4X
+ISOYEAR of timestamp                                956            962           6         10.5          95.6       0.3X
+QUARTER of timestamp                                948            954           6         10.6          94.8       0.3X
+MONTH of timestamp                                  797            817          26         12.5          79.7       0.4X
+WEEK of timestamp                                  1126           1134          10          8.9         112.6       0.2X
+DAY of timestamp                                    800            803           2         12.5          80.0       0.4X
+DAYOFWEEK of timestamp                              953            969          16         10.5          95.3       0.3X
+DOW of timestamp                                    978            986           9         10.2          97.8       0.3X
+ISODOW of timestamp                                 907            913           7         11.0          90.7       0.3X
+DOY of timestamp                                    831            844          14         12.0          83.1       0.3X
+HOUR of timestamp                                   646            650           3         15.5          64.6       0.4X
+MINUTE of timestamp                                 639            643           5         15.7          63.9       0.4X
+SECOND of timestamp                                 740            747           6         13.5          74.0       0.4X
+MILLISECONDS of timestamp                           745            752           7         13.4          74.5       0.4X
+MICROSECONDS of timestamp                           653            658           5         15.3          65.3       0.4X
+EPOCH of timestamp                                  724            738          12         13.8          72.4       0.4X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke extract for date:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date                                        763            774          13         13.1          76.3       1.0X
-MILLENNIUM of date                                  857            911          73         11.7          85.7       0.9X
-CENTURY of date                                     869            884          15         11.5          86.9       0.9X
-DECADE of date                                      860            868           7         11.6          86.0       0.9X
-YEAR of date                                        848            852           7         11.8          84.8       0.9X
-ISOYEAR of date                                    1028           1046          22          9.7         102.8       0.7X
-QUARTER of date                                     979            986           7         10.2          97.9       0.8X
-MONTH of date                                       857            862           4         11.7          85.7       0.9X
-WEEK of date                                       1218           1247          29          8.2         121.8       0.6X
-DAY of date                                         855            868          11         11.7          85.5       0.9X
-DAYOFWEEK of date                                   987           1081          82         10.1          98.7       0.8X
-DOW of date                                         986            996           9         10.1          98.6       0.8X
-ISODOW of date                                      938            947          10         10.7          93.8       0.8X
-DOY of date                                         877            890          11         11.4          87.7       0.9X
-HOUR of date                                       1656           1668          12          6.0         165.6       0.5X
-MINUTE of date                                     1652           1666          15          6.1         165.2       0.5X
-SECOND of date                                     1752           1776          23          5.7         175.2       0.4X
-MILLISECONDS of date                               1757           1766          11          5.7         175.7       0.4X
-MICROSECONDS of date                               1682           1691          14          5.9         168.2       0.5X
-EPOCH of date                                      1706           1721          14          5.9         170.6       0.4X
+cast to date                                        613            621           8         16.3          61.3       1.0X
+MILLENNIUM of date                                  738            741           3         13.6          73.8       0.8X
+CENTURY of date                                     735            737           3         13.6          73.5       0.8X
+DECADE of date                                      722            731           7         13.8          72.2       0.8X
+YEAR of date                                        715            719           4         14.0          71.5       0.9X
+ISOYEAR of date                                     881            883           2         11.4          88.1       0.7X
+QUARTER of date                                     857            867          10         11.7          85.7       0.7X
+MONTH of date                                       719            727           7         13.9          71.9       0.9X
+WEEK of date                                       1038           1043           8          9.6         103.8       0.6X
+DAY of date                                         715            719           4         14.0          71.5       0.9X
+DAYOFWEEK of date                                   861            873          12         11.6          86.1       0.7X
+DOW of date                                         847            865          16         11.8          84.7       0.7X
+ISODOW of date                                      788            796           7         12.7          78.8       0.8X
+DOY of date                                         744            747           4         13.4          74.4       0.8X
+HOUR of date                                       1485           1506          30          6.7         148.5       0.4X
+MINUTE of date                                     1502           1503           1          6.7         150.2       0.4X
+SECOND of date                                     1641           1650           9          6.1         164.1       0.4X
+MILLISECONDS of date                               1624           1639          14          6.2         162.4       0.4X
+MICROSECONDS of date                               1504           1505           2          6.6         150.4       0.4X
+EPOCH of date                                      1733           1748          19          5.8         173.3       0.4X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke date_part for date:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date                                        771            779          10         13.0          77.1       1.0X
-MILLENNIUM of date                                  839            858          22         11.9          83.9       0.9X
-CENTURY of date                                     853            872          22         11.7          85.3       0.9X
-DECADE of date                                      871            878           6         11.5          87.1       0.9X
-YEAR of date                                        853            863           9         11.7          85.3       0.9X
-ISOYEAR of date                                    1011           1021          11          9.9         101.1       0.8X
-QUARTER of date                                     981            988           7         10.2          98.1       0.8X
-MONTH of date                                       859            863           5         11.6          85.9       0.9X
-WEEK of date                                       1148           1159          12          8.7         114.8       0.7X
-DAY of date                                         852            855           2         11.7          85.2       0.9X
-DAYOFWEEK of date                                   937            952          12         10.7          93.7       0.8X
-DOW of date                                         953            956           3         10.5          95.3       0.8X
-ISODOW of date                                      899            916          16         11.1          89.9       0.9X
-DOY of date                                         857            865           7         11.7          85.7       0.9X
-HOUR of date                                       1644           1662          18          6.1         164.4       0.5X
-MINUTE of date                                     1633           1644          10          6.1         163.3       0.5X
-SECOND of date                                     1719           1727           9          5.8         171.9       0.4X
-MILLISECONDS of date                               1721           1733          11          5.8         172.1       0.4X
-MICROSECONDS of date                               1656           1680          34          6.0         165.6       0.5X
-EPOCH of date                                      1721           1736          15          5.8         172.1       0.4X
+cast to date                                        613            627          12         16.3          61.3       1.0X
+MILLENNIUM of date                                  722            734          11         13.9          72.2       0.8X
+CENTURY of date                                     740            746           8         13.5          74.0       0.8X
+DECADE of date                                      723            726           3         13.8          72.3       0.8X
+YEAR of date                                        705            717          11         14.2          70.5       0.9X
+ISOYEAR of date                                     876            885           9         11.4          87.6       0.7X
+QUARTER of date                                     857            877          21         11.7          85.7       0.7X
+MONTH of date                                       714            715           2         14.0          71.4       0.9X
+WEEK of date                                       1040           1043           4          9.6         104.0       0.6X
+DAY of date                                         703            714          10         14.2          70.3       0.9X
+DAYOFWEEK of date                                   861            869           7         11.6          86.1       0.7X
+DOW of date                                         856            863           8         11.7          85.6       0.7X
+ISODOW of date                                      791            797           5         12.6          79.1       0.8X
+DOY of date                                         721            728           6         13.9          72.1       0.9X
+HOUR of date                                       1488           1493           7          6.7         148.8       0.4X
+MINUTE of date                                     1488           1502          12          6.7         148.8       0.4X
+SECOND of date                                     1636           1651          14          6.1         163.6       0.4X
+MILLISECONDS of date                               1644           1665          34          6.1         164.4       0.4X
+MICROSECONDS of date                               1482           1516          42          6.7         148.2       0.4X
+EPOCH of date                                      1752           1790          34          5.7         175.2       0.4X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke extract for interval:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to interval                                    939            947           9         10.7          93.9       1.0X
-MILLENNIUM of interval                              953            960           6         10.5          95.3       1.0X
-CENTURY of interval                                 971            979          10         10.3          97.1       1.0X
-DECADE of interval                                  962            969           7         10.4          96.2       1.0X
-YEAR of interval                                    965            973          10         10.4          96.5       1.0X
-QUARTER of interval                                 967            979          15         10.3          96.7       1.0X
-MONTH of interval                                   951            979          26         10.5          95.1       1.0X
-DAY of interval                                     945            970          25         10.6          94.5       1.0X
-HOUR of interval                                    963            970           9         10.4          96.3       1.0X
-MINUTE of interval                                  972            991          24         10.3          97.2       1.0X
-SECOND of interval                                 1053           1057           8          9.5         105.3       0.9X
-MILLISECONDS of interval                           1042           1048          11          9.6         104.2       0.9X
-MICROSECONDS of interval                            963            967           4         10.4          96.3       1.0X
-EPOCH of interval                                  1051           1071          22          9.5         105.1       0.9X
+cast to interval                                    921            929           9         10.9          92.1       1.0X
+YEAR of interval                                    927            942          22         10.8          92.7       1.0X
+MONTH of interval                                   956            974          22         10.5          95.6       1.0X
+DAY of interval                                     897            915          16         11.2          89.7       1.0X
+HOUR of interval                                    952            975          35         10.5          95.2       1.0X
+MINUTE of interval                                  938            955          14         10.7          93.8       1.0X
+SECOND of interval                                 1066           1080          24          9.4         106.6       0.9X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke date_part for interval:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to interval                                    944            952           8         10.6          94.4       1.0X
-MILLENNIUM of interval                              955            960           5         10.5          95.5       1.0X
-CENTURY of interval                                 958            972          12         10.4          95.8       1.0X
-DECADE of interval                                  962            967           6         10.4          96.2       1.0X
-YEAR of interval                                    958            978          18         10.4          95.8       1.0X
-QUARTER of interval                                 979            998          19         10.2          97.9       1.0X
-MONTH of interval                                   949            963          12         10.5          94.9       1.0X
-DAY of interval                                     958            971          11         10.4          95.8       1.0X
-HOUR of interval                                    947            962          15         10.6          94.7       1.0X
-MINUTE of interval                                  989           1006          15         10.1          98.9       1.0X
-SECOND of interval                                 1061           1064           4          9.4         106.1       0.9X
-MILLISECONDS of interval                           1042           1061          18          9.6         104.2       0.9X
-MICROSECONDS of interval                            982            992          12         10.2          98.2       1.0X
-EPOCH of interval                                  1047           1057          13          9.5         104.7       0.9X
+cast to interval                                    944            960          21         10.6          94.4       1.0X
+YEAR of interval                                    978           1011          33         10.2          97.8       1.0X
+MONTH of interval                                   961            984          27         10.4          96.1       1.0X
+DAY of interval                                     921            927           7         10.9          92.1       1.0X
+HOUR of interval                                    913            919           8         11.0          91.3       1.0X
+MINUTE of interval                                  920            941          22         10.9          92.0       1.0X
+SECOND of interval                                  994           1012          19         10.1          99.4       0.9X
 

--- a/sql/core/benchmarks/ExtractBenchmark-results.txt
+++ b/sql/core/benchmarks/ExtractBenchmark-results.txt
@@ -1,138 +1,124 @@
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke extract for timestamp:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp                                   275            307          28         36.3          27.5       1.0X
-MILLENNIUM of timestamp                             911            924          20         11.0          91.1       0.3X
-CENTURY of timestamp                                846            850           5         11.8          84.6       0.3X
-DECADE of timestamp                                 744            761          21         13.4          74.4       0.4X
-YEAR of timestamp                                   750            764          15         13.3          75.0       0.4X
-ISOYEAR of timestamp                                815            828          11         12.3          81.5       0.3X
-QUARTER of timestamp                                882            895          12         11.3          88.2       0.3X
-MONTH of timestamp                                  739            760          19         13.5          73.9       0.4X
-WEEK of timestamp                                  1058           1082          23          9.4         105.8       0.3X
-DAY of timestamp                                    722            730           8         13.8          72.2       0.4X
-DAYOFWEEK of timestamp                              860            907          58         11.6          86.0       0.3X
-DOW of timestamp                                    853            860           7         11.7          85.3       0.3X
-ISODOW of timestamp                                 829            835           8         12.1          82.9       0.3X
-DOY of timestamp                                    757            772          20         13.2          75.7       0.4X
-HOUR of timestamp                                   586            594           7         17.1          58.6       0.5X
-MINUTE of timestamp                                 577            584           8         17.3          57.7       0.5X
-SECOND of timestamp                                 810            827          17         12.4          81.0       0.3X
-MILLISECONDS of timestamp                           687            704          16         14.6          68.7       0.4X
-MICROSECONDS of timestamp                           628            632           6         15.9          62.8       0.4X
-EPOCH of timestamp                                  750            761          12         13.3          75.0       0.4X
+cast to timestamp                                   306            337          27         32.7          30.6       1.0X
+MILLENNIUM of timestamp                            1002           1012          15         10.0         100.2       0.3X
+CENTURY of timestamp                               1055           1064           8          9.5         105.5       0.3X
+DECADE of timestamp                                 940            968          36         10.6          94.0       0.3X
+YEAR of timestamp                                   922            938          27         10.8          92.2       0.3X
+ISOYEAR of timestamp                               1036           1061          23          9.7         103.6       0.3X
+QUARTER of timestamp                               1081           1098          27          9.2         108.1       0.3X
+MONTH of timestamp                                  876            888          17         11.4          87.6       0.3X
+WEEK of timestamp                                  1218           1259          55          8.2         121.8       0.3X
+DAY of timestamp                                    890            911          33         11.2          89.0       0.3X
+DAYOFWEEK of timestamp                             1006           1019          17          9.9         100.6       0.3X
+DOW of timestamp                                    990           1006          22         10.1          99.0       0.3X
+ISODOW of timestamp                                 953            992          35         10.5          95.3       0.3X
+DOY of timestamp                                    883            889           6         11.3          88.3       0.3X
+HOUR of timestamp                                   661            667           6         15.1          66.1       0.5X
+MINUTE of timestamp                                 665            678          12         15.0          66.5       0.5X
+SECOND of timestamp                                 787            791           6         12.7          78.7       0.4X
+MILLISECONDS of timestamp                           800            814          12         12.5          80.0       0.4X
+MICROSECONDS of timestamp                           700            706           8         14.3          70.0       0.4X
+EPOCH of timestamp                                  793            819          40         12.6          79.3       0.4X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke date_part for timestamp:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp                                   238            242           4         42.0          23.8       1.0X
-MILLENNIUM of timestamp                             811            835          25         12.3          81.1       0.3X
-CENTURY of timestamp                                799            823          21         12.5          79.9       0.3X
-DECADE of timestamp                                 733            743          12         13.6          73.3       0.3X
-YEAR of timestamp                                   714            717           3         14.0          71.4       0.3X
-ISOYEAR of timestamp                                874            900          24         11.4          87.4       0.3X
-QUARTER of timestamp                                903            910          11         11.1          90.3       0.3X
-MONTH of timestamp                                  774            808          44         12.9          77.4       0.3X
-WEEK of timestamp                                  1053           1064          12          9.5         105.3       0.2X
-DAY of timestamp                                    755            770          14         13.2          75.5       0.3X
-DAYOFWEEK of timestamp                              831            841           9         12.0          83.1       0.3X
-DOW of timestamp                                    871            898          23         11.5          87.1       0.3X
-ISODOW of timestamp                                 832            887          59         12.0          83.2       0.3X
-DOY of timestamp                                    755            767          13         13.2          75.5       0.3X
-HOUR of timestamp                                   580            597          27         17.3          58.0       0.4X
-MINUTE of timestamp                                 572            589          15         17.5          57.2       0.4X
-SECOND of timestamp                                 716            730          12         14.0          71.6       0.3X
-MILLISECONDS of timestamp                           716            762          57         14.0          71.6       0.3X
-MICROSECONDS of timestamp                           600            610          12         16.7          60.0       0.4X
-EPOCH of timestamp                                  751            779          44         13.3          75.1       0.3X
+cast to timestamp                                   252            259           7         39.7          25.2       1.0X
+MILLENNIUM of timestamp                             917            936          18         10.9          91.7       0.3X
+CENTURY of timestamp                                943            952          12         10.6          94.3       0.3X
+DECADE of timestamp                                 863            867           5         11.6          86.3       0.3X
+YEAR of timestamp                                   839            854          16         11.9          83.9       0.3X
+ISOYEAR of timestamp                               1023           1027           4          9.8         102.3       0.2X
+QUARTER of timestamp                               1052           1060          10          9.5         105.2       0.2X
+MONTH of timestamp                                  835            846          14         12.0          83.5       0.3X
+WEEK of timestamp                                  1182           1198          14          8.5         118.2       0.2X
+DAY of timestamp                                    837            845          10         11.9          83.7       0.3X
+DAYOFWEEK of timestamp                              947            962          14         10.6          94.7       0.3X
+DOW of timestamp                                    946            964          17         10.6          94.6       0.3X
+ISODOW of timestamp                                 934            946          13         10.7          93.4       0.3X
+DOY of timestamp                                    857            859           3         11.7          85.7       0.3X
+HOUR of timestamp                                   660            661           1         15.1          66.0       0.4X
+MINUTE of timestamp                                 649            654           4         15.4          64.9       0.4X
+SECOND of timestamp                                 801            805           5         12.5          80.1       0.3X
+MILLISECONDS of timestamp                           820            825           7         12.2          82.0       0.3X
+MICROSECONDS of timestamp                           700            708          12         14.3          70.0       0.4X
+EPOCH of timestamp                                  789            797          10         12.7          78.9       0.3X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke extract for date:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date                                        629            634           6         15.9          62.9       1.0X
-MILLENNIUM of date                                  826            912          97         12.1          82.6       0.8X
-CENTURY of date                                     797            840          54         12.6          79.7       0.8X
-DECADE of date                                      734            737           4         13.6          73.4       0.9X
-YEAR of date                                        721            768          78         13.9          72.1       0.9X
-ISOYEAR of date                                     884            892          13         11.3          88.4       0.7X
-QUARTER of date                                     894            949          69         11.2          89.4       0.7X
-MONTH of date                                       726            729           2         13.8          72.6       0.9X
-WEEK of date                                       1013           1023           9          9.9         101.3       0.6X
-DAY of date                                         727            747          26         13.8          72.7       0.9X
-DAYOFWEEK of date                                   828            832           6         12.1          82.8       0.8X
-DOW of date                                         846            850           5         11.8          84.6       0.7X
-ISODOW of date                                      803            810           7         12.5          80.3       0.8X
-DOY of date                                         751            761          11         13.3          75.1       0.8X
-HOUR of date                                       1372           1376           5          7.3         137.2       0.5X
-MINUTE of date                                     1379           1398          20          7.3         137.9       0.5X
-SECOND of date                                     1530           1542          10          6.5         153.0       0.4X
-MILLISECONDS of date                               1532           1541           8          6.5         153.2       0.4X
-MICROSECONDS of date                               1442           1462          23          6.9         144.2       0.4X
-EPOCH of date                                      1573           1594          20          6.4         157.3       0.4X
+cast to date                                        747            751           6         13.4          74.7       1.0X
+MILLENNIUM of date                                  941            947           5         10.6          94.1       0.8X
+CENTURY of date                                     952            961           8         10.5          95.2       0.8X
+DECADE of date                                      864            877          15         11.6          86.4       0.9X
+YEAR of date                                        850            862          11         11.8          85.0       0.9X
+ISOYEAR of date                                    1031           1036           8          9.7         103.1       0.7X
+QUARTER of date                                    1038           1048           9          9.6         103.8       0.7X
+MONTH of date                                       852            865          12         11.7          85.2       0.9X
+WEEK of date                                       1174           1178           5          8.5         117.4       0.6X
+DAY of date                                         830            836           5         12.0          83.0       0.9X
+DAYOFWEEK of date                                   949            972          21         10.5          94.9       0.8X
+DOW of date                                         960            969           8         10.4          96.0       0.8X
+ISODOW of date                                      918            928           9         10.9          91.8       0.8X
+DOY of date                                         858            867          11         11.7          85.8       0.9X
+HOUR of date                                       1584           1591          10          6.3         158.4       0.5X
+MINUTE of date                                     1583           1589           6          6.3         158.3       0.5X
+SECOND of date                                     1721           1728           7          5.8         172.1       0.4X
+MILLISECONDS of date                               1711           1731          17          5.8         171.1       0.4X
+MICROSECONDS of date                               1647           1656           8          6.1         164.7       0.5X
+EPOCH of date                                      1796           1805          10          5.6         179.6       0.4X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke date_part for date:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date                                        622            633          14         16.1          62.2       1.0X
-MILLENNIUM of date                                  793            814          20         12.6          79.3       0.8X
-CENTURY of date                                     798            809          12         12.5          79.8       0.8X
-DECADE of date                                      735            740           6         13.6          73.5       0.8X
-YEAR of date                                        714            732          23         14.0          71.4       0.9X
-ISOYEAR of date                                     881            886           4         11.3          88.1       0.7X
-QUARTER of date                                     916            925          14         10.9          91.6       0.7X
-MONTH of date                                       732            737           5         13.7          73.2       0.8X
-WEEK of date                                       1022           1034          10          9.8         102.2       0.6X
-DAY of date                                         722            745          26         13.8          72.2       0.9X
-DAYOFWEEK of date                                   831            849          17         12.0          83.1       0.7X
-DOW of date                                         853            858           4         11.7          85.3       0.7X
-ISODOW of date                                      824            825           1         12.1          82.4       0.8X
-DOY of date                                         749            752           4         13.3          74.9       0.8X
-HOUR of date                                       1422           1425           3          7.0         142.2       0.4X
-MINUTE of date                                     1379           1394          13          7.3         137.9       0.5X
-SECOND of date                                     1525           1536           9          6.6         152.5       0.4X
-MILLISECONDS of date                               1542           1555          14          6.5         154.2       0.4X
-MICROSECONDS of date                               1446           1449           2          6.9         144.6       0.4X
-EPOCH of date                                      1589           1621          35          6.3         158.9       0.4X
+cast to date                                        731            740           8         13.7          73.1       1.0X
+MILLENNIUM of date                                  939            948          12         10.7          93.9       0.8X
+CENTURY of date                                     929            940          10         10.8          92.9       0.8X
+DECADE of date                                      845            861          15         11.8          84.5       0.9X
+YEAR of date                                        848            853           5         11.8          84.8       0.9X
+ISOYEAR of date                                    1011           1027          14          9.9         101.1       0.7X
+QUARTER of date                                    1038           1050          12          9.6         103.8       0.7X
+MONTH of date                                       847            872          22         11.8          84.7       0.9X
+WEEK of date                                       1143           1152          13          8.7         114.3       0.6X
+DAY of date                                         844            848           5         11.8          84.4       0.9X
+DAYOFWEEK of date                                   947            957           9         10.6          94.7       0.8X
+DOW of date                                         963            972           8         10.4          96.3       0.8X
+ISODOW of date                                      906            919          11         11.0          90.6       0.8X
+DOY of date                                         866            868           3         11.6          86.6       0.8X
+HOUR of date                                       1599           1604           7          6.3         159.9       0.5X
+MINUTE of date                                     1578           1594          13          6.3         157.8       0.5X
+SECOND of date                                     1722           1731          11          5.8         172.2       0.4X
+MILLISECONDS of date                               1699           1730          27          5.9         169.9       0.4X
+MICROSECONDS of date                               1620           1623           5          6.2         162.0       0.5X
+EPOCH of date                                      1742           1767          32          5.7         174.2       0.4X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke extract for interval:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to interval                                    913            921           8         11.0          91.3       1.0X
-MILLENNIUM of interval                              976            983          12         10.2          97.6       0.9X
-CENTURY of interval                                 976            979           3         10.2          97.6       0.9X
-DECADE of interval                                  975            987          10         10.3          97.5       0.9X
-YEAR of interval                                    964            968           5         10.4          96.4       0.9X
-QUARTER of interval                                 987            997          12         10.1          98.7       0.9X
-MONTH of interval                                   974            983          11         10.3          97.4       0.9X
-DAY of interval                                     959            962           3         10.4          95.9       1.0X
-HOUR of interval                                    972            986          13         10.3          97.2       0.9X
-MINUTE of interval                                  985            988           4         10.2          98.5       0.9X
-SECOND of interval                                 1128           1141          13          8.9         112.8       0.8X
-MILLISECONDS of interval                           1083           1086           3          9.2         108.3       0.8X
-MICROSECONDS of interval                            963            969           5         10.4          96.3       0.9X
-EPOCH of interval                                  1094           1116          23          9.1         109.4       0.8X
+cast to interval                                    920            941          18         10.9          92.0       1.0X
+YEAR of interval                                    955            967          12         10.5          95.5       1.0X
+MONTH of interval                                   954            966          11         10.5          95.4       1.0X
+DAY of interval                                     967            970           4         10.3          96.7       1.0X
+HOUR of interval                                    959            975          21         10.4          95.9       1.0X
+MINUTE of interval                                  966            981          16         10.4          96.6       1.0X
+SECOND of interval                                 1048           1066          16          9.5         104.8       0.9X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Invoke date_part for interval:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to interval                                    950            971          23         10.5          95.0       1.0X
-MILLENNIUM of interval                              989           1000          11         10.1          98.9       1.0X
-CENTURY of interval                                 984            990           6         10.2          98.4       1.0X
-DECADE of interval                                  962            978          14         10.4          96.2       1.0X
-YEAR of interval                                    945            963          16         10.6          94.5       1.0X
-QUARTER of interval                                 985            998          17         10.2          98.5       1.0X
-MONTH of interval                                   970            976           9         10.3          97.0       1.0X
-DAY of interval                                     953            962           8         10.5          95.3       1.0X
-HOUR of interval                                    942            956          17         10.6          94.2       1.0X
-MINUTE of interval                                  975            993          16         10.3          97.5       1.0X
-SECOND of interval                                 1110           1122          12          9.0         111.0       0.9X
-MILLISECONDS of interval                           1056           1074          22          9.5         105.6       0.9X
-MICROSECONDS of interval                            939            960          36         10.7          93.9       1.0X
-EPOCH of interval                                  1071           1093          21          9.3         107.1       0.9X
+cast to interval                                    928            954          26         10.8          92.8       1.0X
+YEAR of interval                                    955            960           4         10.5          95.5       1.0X
+MONTH of interval                                   956            971          13         10.5          95.6       1.0X
+DAY of interval                                     964           1003          41         10.4          96.4       1.0X
+HOUR of interval                                   1057           1293         248          9.5         105.7       0.9X
+MINUTE of interval                                  975           1091         155         10.3          97.5       1.0X
+SECOND of interval                                 1104           1286         311          9.1         110.4       0.8X
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ExtractBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ExtractBenchmark.scala
@@ -92,11 +92,7 @@ object ExtractBenchmark extends SqlBasedBenchmark {
       "DAY", "DAYOFWEEK", "DOW", "ISODOW",
       "DOY", "HOUR", "MINUTE", "SECOND",
       "MILLISECONDS", "MICROSECONDS", "EPOCH")
-    val intervalFields = Seq(
-      "MILLENNIUM", "CENTURY", "DECADE", "YEAR",
-      "QUARTER", "MONTH", "DAY",
-      "HOUR", "MINUTE", "SECOND",
-      "MILLISECONDS", "MICROSECONDS", "EPOCH")
+    val intervalFields = Seq("YEAR", "MONTH", "DAY", "HOUR", "MINUTE", "SECOND")
     val settings = Map(
       "timestamp" -> datetimeFields,
       "date" -> datetimeFields,


### PR DESCRIPTION


### What changes were proposed in this pull request?

In https://github.com/apache/spark/commit/697083c051304a5ac4f9c56a63274f2103caaef4, we remove  "MILLENNIUM", "CENTURY", "DECADE",  "QUARTER", "MILLISECONDS", "MICROSECONDS", "EPOCH" field for date_part and extract expression, this PR fix the related Benchmark.
### Why are the changes needed?

test fix.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

no
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
passing Jenkins