### PR TITLE
[SPARK-31477][SQL] Dump codegen and compile time in BenchmarkQueryTest

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -1324,7 +1324,7 @@ object CodeGenerator extends Logging {
 
   // Reset compile time.
   // Visible for testing
-  def resetCompileTime: Unit = _compileTime.reset()
+  def resetCompileTime(): Unit = _compileTime.reset()
 
   /**
    * Compile the Java source code into a Java class, using Janino.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
@@ -586,7 +586,7 @@ object WholeStageCodegenExec {
 
   // Reset generation time of Java source code.
   // Visible for testing
-  def resetCodeGenTime: Unit = _codeGenTime.set(0L)
+  def resetCodeGenTime(): Unit = _codeGenTime.set(0L)
 }
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/BenchmarkQueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/BenchmarkQueryTest.scala
@@ -37,13 +37,15 @@ abstract class BenchmarkQueryTest extends QueryTest with SharedSparkSession {
   protected override def afterAll(): Unit = {
     try {
       // For debugging dump some statistics about how much time was spent in various optimizer rules
+      // code generation, and compilation.
       logWarning(RuleExecutor.dumpTimeSpent())
-      val generateJavaTime = WholeStageCodegenExec.codeGenTime
+      val codeGenTime = WholeStageCodegenExec.codeGenTime.toDouble / NANOS_PER_SECOND
+      val compileTime = CodeGenerator.compileTime.toDouble / NANOS_PER_SECOND
       val codegenInfo =
         s"""
            |=== Metrics of Whole-stage Codegen ===
-           |Total code generation time: ${generateJavaTime.toDouble / NANOS_PER_SECOND} seconds
-           |Total compile time: ${CodeGenerator.compileTime.toDouble / NANOS_PER_SECOND} seconds
+           |Total code generation time: $codeGenTime seconds
+           |Total compile time: $compileTime seconds
          """.stripMargin
       logWarning(codegenInfo)
       spark.sessionState.catalog.reset()

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -683,8 +683,8 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession {
     // Add Locale setting
     Locale.setDefault(Locale.US)
     RuleExecutor.resetMetrics()
-    CodeGenerator.resetCompileTime
-    WholeStageCodegenExec.resetCodeGenTime
+    CodeGenerator.resetCompileTime()
+    WholeStageCodegenExec.resetCodeGenTime()
   }
 
   override def afterAll(): Unit = {
@@ -696,12 +696,13 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession {
       // For debugging dump some statistics about how much time was spent in various optimizer rules
       logWarning(RuleExecutor.dumpTimeSpent())
 
-      val generateJavaTime = WholeStageCodegenExec.codeGenTime
+      val codeGenTime = WholeStageCodegenExec.codeGenTime.toDouble / NANOS_PER_SECOND
+      val compileTime = CodeGenerator.compileTime.toDouble / NANOS_PER_SECOND
       val codegenInfo =
         s"""
            |=== Metrics of Whole-stage Codegen ===
-           |Total code generation time: ${generateJavaTime.toDouble / NANOS_PER_SECOND} seconds
-           |Total compile time: ${CodeGenerator.compileTime.toDouble / NANOS_PER_SECOND} seconds
+           |Total code generation time: $codeGenTime seconds
+           |Total compile time: $compileTime seconds
          """.stripMargin
       logWarning(codegenInfo)
     } finally {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -699,7 +699,7 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession {
       val generateJavaTime = WholeStageCodegenExec.codeGenTime
       val codegenInfo =
         s"""
-           |=== Metrics of Whole-Stage Codegen ===
+           |=== Metrics of Whole-stage Codegen ===
            |Total code generation time: ${generateJavaTime.toDouble / NANOS_PER_SECOND} seconds
            |Total compile time: ${CodeGenerator.compileTime.toDouble / NANOS_PER_SECOND} seconds
          """.stripMargin


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR is to dump the codegen and compilation time for benchmark query tests. 

### Why are the changes needed?
Measure the codegen and compilation time costs in TPC-DS queries

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Manual test in my local laptop:
```
23:13:12.845 WARN org.apache.spark.sql.TPCDSQuerySuite: 
=== Metrics of Whole-stage Codegen ===
Total code generation time: 21.275102261 seconds
Total compilation time: 12.223771828 seconds
```