### PR TITLE
[SPARK-31487][CORE] Move slots check of barrier job from DAGScheduler to TaskSchedulerImpl

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -772,6 +772,11 @@ private[spark] object SparkConf extends Logging {
         s"The configuration key $key is not supported anymore " +
           s"because Spark doesn't use Akka since 2.0")
     }
+    if (key.equals("spark.scheduler.barrier.maxConcurrentTasksCheck.interval") ||
+      key.equals("spark.scheduler.barrier.maxConcurrentTasksCheck.maxFailures")) {
+      logWarning(s"The configuration $key is not supported any more from Spark 3.0. " +
+        s"Please use ${BARRIER_WAIT_FOR_SCHEDULE_TIMEOUT.key} to tune barrier job instead.")
+    }
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -775,7 +775,7 @@ private[spark] object SparkConf extends Logging {
     if (key.equals("spark.scheduler.barrier.maxConcurrentTasksCheck.interval") ||
       key.equals("spark.scheduler.barrier.maxConcurrentTasksCheck.maxFailures")) {
       logWarning(s"The configuration $key is not supported any more from Spark 3.0. " +
-        s"Please use ${BARRIER_WAIT_FOR_SCHEDULE_TIMEOUT.key} to tune barrier job instead.")
+        s"Please use ${BARRIER_WAIT_FOR_SLOT_TIMEOUT.key} to tune barrier job instead.")
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1401,6 +1401,19 @@ package object config {
       .checkValue(v => v > 0, "The value should be a positive time value.")
       .createWithDefaultString("365d")
 
+
+  private[spark] val BARRIER_WAIT_FOR_SCHEDULE_TIMEOUT =
+    ConfigBuilder("spark.scheduler.barrier.waitForSchedule.timeout")
+      .doc("The timeout in seconds for a barrier stage before it gets scheduled. Spark only " +
+        "schedule for a barrier stage when the total number of slots in cluster currently " +
+        "is more than the required slots from the barrier stage. Thus, the timeout generally " +
+        "should be longer than the total launching time of executors which satisfy the " +
+        "minimum slots requirement.")
+      .version("3.0.0")
+      .timeConf(TimeUnit.SECONDS)
+      .checkValue(v => v > 0, "The value should be a positive time value.")
+      .createWithDefaultString("600s")
+
   private[spark] val UNSCHEDULABLE_TASKSET_TIMEOUT =
     ConfigBuilder("spark.scheduler.blacklist.unschedulableTaskSetTimeout")
       .doc("The timeout in seconds to wait to acquire a new executor and schedule a task " +
@@ -1409,35 +1422,6 @@ package object config {
       .timeConf(TimeUnit.SECONDS)
       .checkValue(v => v >= 0, "The value should be a non negative time value.")
       .createWithDefault(120)
-
-  private[spark] val BARRIER_MAX_CONCURRENT_TASKS_CHECK_INTERVAL =
-    ConfigBuilder("spark.scheduler.barrier.maxConcurrentTasksCheck.interval")
-      .doc("Time in seconds to wait between a max concurrent tasks check failure and the next " +
-        "check. A max concurrent tasks check ensures the cluster can launch more concurrent " +
-        "tasks than required by a barrier stage on job submitted. The check can fail in case " +
-        "a cluster has just started and not enough executors have registered, so we wait for a " +
-        "little while and try to perform the check again. If the check fails more than a " +
-        "configured max failure times for a job then fail current job submission. Note this " +
-        "config only applies to jobs that contain one or more barrier stages, we won't perform " +
-        "the check on non-barrier jobs.")
-      .version("2.4.0")
-      .timeConf(TimeUnit.SECONDS)
-      .createWithDefaultString("15s")
-
-  private[spark] val BARRIER_MAX_CONCURRENT_TASKS_CHECK_MAX_FAILURES =
-    ConfigBuilder("spark.scheduler.barrier.maxConcurrentTasksCheck.maxFailures")
-      .doc("Number of max concurrent tasks check failures allowed before fail a job submission. " +
-        "A max concurrent tasks check ensures the cluster can launch more concurrent tasks than " +
-        "required by a barrier stage on job submitted. The check can fail in case a cluster " +
-        "has just started and not enough executors have registered, so we wait for a little " +
-        "while and try to perform the check again. If the check fails more than a configured " +
-        "max failure times for a job then fail current job submission. Note this config only " +
-        "applies to jobs that contain one or more barrier stages, we won't perform the check on " +
-        "non-barrier jobs.")
-      .version("2.4.0")
-      .intConf
-      .checkValue(v => v > 0, "The max failures should be a positive value.")
-      .createWithDefault(40)
 
   private[spark] val UNSAFE_EXCEPTION_ON_MEMORY_LEAK =
     ConfigBuilder("spark.unsafe.exceptionOnMemoryLeak")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1402,9 +1402,9 @@ package object config {
       .createWithDefaultString("365d")
 
 
-  private[spark] val BARRIER_WAIT_FOR_SCHEDULE_TIMEOUT =
-    ConfigBuilder("spark.scheduler.barrier.waitForSchedule.timeout")
-      .doc("The timeout in seconds for a barrier stage before it gets scheduled. Spark only " +
+  private[spark] val BARRIER_WAIT_FOR_SLOT_TIMEOUT =
+    ConfigBuilder("spark.scheduler.barrier.waitForEnoughSlots.timeout")
+      .doc("The timeout in seconds for a barrier stage before it finds enough slots. Spark only " +
         "schedule for a barrier stage when the total number of slots in cluster currently " +
         "is more than the required slots from the barrier stage. Thus, the timeout generally " +
         "should be longer than the total launching time of executors which satisfy the " +

--- a/core/src/main/scala/org/apache/spark/scheduler/BarrierJobAllocationFailed.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/BarrierJobAllocationFailed.scala
@@ -33,12 +33,6 @@ private[spark] class BarrierJobRunWithDynamicAllocationException
   extends BarrierJobAllocationFailed(
     BarrierJobAllocationFailed.ERROR_MESSAGE_RUN_BARRIER_WITH_DYN_ALLOCATION)
 
-private[spark] class BarrierJobSlotsNumberCheckFailed(
-    val requiredConcurrentTasks: Int,
-    val maxConcurrentTasks: Int)
-  extends BarrierJobAllocationFailed(
-    BarrierJobAllocationFailed.ERROR_MESSAGE_BARRIER_REQUIRE_MORE_SLOTS_THAN_CURRENT_TOTAL_NUMBER)
-
 private[spark] object BarrierJobAllocationFailed {
 
   // Error message when running a barrier stage that have unsupported RDD chain pattern.
@@ -55,11 +49,4 @@ private[spark] object BarrierJobAllocationFailed {
     "[SPARK-24942]: Barrier execution mode does not support dynamic resource allocation for " +
       "now. You can disable dynamic resource allocation by setting Spark conf " +
       s""""${DYN_ALLOCATION_ENABLED.key}" to "false"."""
-
-  // Error message when running a barrier stage that requires more slots than current total number.
-  val ERROR_MESSAGE_BARRIER_REQUIRE_MORE_SLOTS_THAN_CURRENT_TOTAL_NUMBER =
-    "[SPARK-24819]: Barrier execution mode does not allow run a barrier stage that requires " +
-      "more slots than the total number of slots in the cluster currently. Please init a new " +
-      "cluster with more CPU cores or repartition the input RDD(s) to reduce the number of " +
-      "slots required to run this barrier stage."
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -19,7 +19,7 @@ package org.apache.spark.scheduler
 
 import java.io.NotSerializableException
 import java.util.Properties
-import java.util.concurrent.{ConcurrentHashMap, TimeUnit}
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.annotation.tailrec

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -597,9 +597,8 @@ private[spark] class TaskSchedulerImpl(
           } else {
             s"Timeout after waiting $barrierSlotsCheckTimeoutS seconds for enough slots"
           }
-          taskSet.abort(
-            s"$reason to schedule barrier task set ${taskSet.stageId}. " +
-              s"Required ${taskSet.numTasks} slots but got $numBarrierSlotsAvailable slots yet. " +
+          taskSet.abort(s"$reason to schedule barrier task set ${taskSet.stageId}. " +
+              s"Required ${taskSet.numTasks} slots but got $maxPossibleSlots slots yet. " +
               s"Please init a new cluster with more CPU cores or repartition the input RDD(s) " +
               s"to reduce the number of slots required to run this barrier stage. Or increase " +
               s"timeout using ${config.BARRIER_WAIT_FOR_SLOT_TIMEOUT.key} if executors " +

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -342,7 +342,6 @@ private[spark] class TaskSchedulerImpl(
       }
     }
     resetOnPreviousOffer -= manager.taskSet
-    barrierStageIdToSubmitTime.remove(manager.stageId)
     manager.parent.removeSchedulable(manager)
     logInfo(s"Removed TaskSet ${manager.taskSet.id}, whose tasks have all completed, from pool" +
       s" ${manager.parent.name}")
@@ -587,6 +586,25 @@ private[spark] class TaskSchedulerImpl(
       // we only need to calculate available slots if using barrier scheduling, otherwise the
       // value is -1
       val numBarrierSlotsAvailable = if (taskSet.isBarrier) {
+        val rp = sc.resourceProfileManager.resourceProfileFromId(taskSet.taskSet.resourceProfileId)
+        val maxPossibleSlots = sc.maxNumConcurrentTasks(rp)
+        if (maxPossibleSlots >= taskSet.numTasks) {
+          barrierStageIdToSubmitTime.remove(taskSet.stageId)
+        } else if (clock.getTimeMillis() - barrierStageIdToSubmitTime(taskSet.stageId) >
+          barrierSlotsCheckTimeoutS * 1000 || isLocal) {
+          val reason = if (isLocal) {
+            "Insufficient slots under local mode"
+          } else {
+            s"Timeout after waiting $barrierSlotsCheckTimeoutS seconds for enough slots"
+          }
+          taskSet.abort(
+            s"$reason to schedule barrier task set ${taskSet.stageId}. " +
+              s"Required ${taskSet.numTasks} slots but got $numBarrierSlotsAvailable slots yet. " +
+              s"Please init a new cluster with more CPU cores or repartition the input RDD(s) " +
+              s"to reduce the number of slots required to run this barrier stage. Or increase " +
+              s"timeout using ${config.BARRIER_WAIT_FOR_SLOT_TIMEOUT.key} if executors " +
+              s"haven't been fully launched.", None)
+        }
         val slots = calculateAvailableSlots(resourceProfileIds, availableCpus, availableResources,
           taskSet.taskSet.resourceProfileId)
         slots
@@ -594,33 +612,13 @@ private[spark] class TaskSchedulerImpl(
         -1
       }
       // Skip the barrier taskSet if the available slots are less than the number of pending tasks.
-      if (taskSet.isBarrier) {
-        val enoughSlots = numBarrierSlotsAvailable >= taskSet.numTasks
-        if (enoughSlots) {
-          barrierStageIdToSubmitTime.remove(taskSet.stageId)
-        } else if (clock.getTimeMillis() - barrierStageIdToSubmitTime(taskSet.stageId) >
-            barrierSlotsCheckTimeoutS * 1000 || isLocal) {
-          val reason = if (isLocal) {
-            "Insufficient slots under local mode"
-          } else {
-            s"Timeout after waiting $barrierSlotsCheckTimeoutS seconds for enough slots"
-          }
-          dagScheduler.taskSetFailed(taskSet.taskSet,
-            s"$reason to schedule barrier task set ${taskSet.stageId}. Required " +
-              s"${taskSet.numTasks} slots but got $numBarrierSlotsAvailable slots yet. " +
-              s"Please init a new cluster with more CPU cores or repartition the input RDD(s) " +
-              s"to reduce the number of slots required to run this barrier stage. Or increase " +
-              s"timeout using ${config.BARRIER_WAIT_FOR_SLOT_TIMEOUT.key} if executors " +
-              s"haven't been fully launched.", None)
-          return tasks
-        } else {
-          // Skip the launch process.
-          // TODO SPARK-24819 If the job requires more slots than available (both busy and free
-          // slots), fail the job on submit.
-          logInfo(s"Skip current round of resource offers for barrier stage ${taskSet.stageId} " +
-            s"because the barrier taskSet requires ${taskSet.numTasks} slots, while the total " +
-            s"number of available slots is $numBarrierSlotsAvailable.")
-        }
+      if (taskSet.isBarrier && numBarrierSlotsAvailable < taskSet.numTasks) {
+        // Skip the launch process.
+        // TODO SPARK-24819 If the job requires more slots than available (both busy and free
+        // slots), fail the job on submit.
+        logInfo(s"Skip current round of resource offers for barrier stage ${taskSet.stageId} " +
+          s"because the barrier taskSet requires ${taskSet.numTasks} slots, while the total " +
+          s"number of available slots is $numBarrierSlotsAvailable.")
       } else {
         var launchedAnyTask = false
         var noDelaySchedulingRejects = true

--- a/core/src/test/scala/org/apache/spark/BarrierStageOnSubmittedSuite.scala
+++ b/core/src/test/scala/org/apache/spark/BarrierStageOnSubmittedSuite.scala
@@ -216,7 +216,7 @@ class BarrierStageOnSubmittedSuite extends SparkFunSuite with LocalSparkContext 
     "local-cluster mode") {
     val conf = new SparkConf()
       .set(CPUS_PER_TASK, 2)
-      .set(BARRIER_WAIT_FOR_SCHEDULE_TIMEOUT.key, "3s")
+      .set(BARRIER_WAIT_FOR_SLOT_TIMEOUT.key, "3s")
       .setMaster("local-cluster[4, 3, 1024]")
       .setAppName("test")
     sc = createSparkContext(Some(conf))
@@ -230,7 +230,7 @@ class BarrierStageOnSubmittedSuite extends SparkFunSuite with LocalSparkContext 
     "local-cluster mode") {
     val conf = new SparkConf()
       .set(CPUS_PER_TASK, 2)
-      .set(BARRIER_WAIT_FOR_SCHEDULE_TIMEOUT.key, "3s")
+      .set(BARRIER_WAIT_FOR_SLOT_TIMEOUT.key, "3s")
       .setMaster("local-cluster[4, 3, 1024]")
       .setAppName("test")
     sc = createSparkContext(Some(conf))

--- a/core/src/test/scala/org/apache/spark/BarrierStageOnSubmittedSuite.scala
+++ b/core/src/test/scala/org/apache/spark/BarrierStageOnSubmittedSuite.scala
@@ -189,27 +189,18 @@ class BarrierStageOnSubmittedSuite extends SparkFunSuite with LocalSparkContext 
   test("submit a barrier ResultStage that requires more slots than current total under local " +
       "mode") {
     val conf = new SparkConf()
-      // Shorten the time interval between two failed checks to make the test fail faster.
-      .set(BARRIER_MAX_CONCURRENT_TASKS_CHECK_INTERVAL.key, "1s")
-      // Reduce max check failures allowed to make the test fail faster.
-      .set(BARRIER_MAX_CONCURRENT_TASKS_CHECK_MAX_FAILURES, 3)
       .setMaster("local[4]")
       .setAppName("test")
     sc = createSparkContext(Some(conf))
     val rdd = sc.parallelize(1 to 10, 5)
       .barrier()
       .mapPartitions(iter => iter)
-    testSubmitJob(sc, rdd,
-      message = ERROR_MESSAGE_BARRIER_REQUIRE_MORE_SLOTS_THAN_CURRENT_TOTAL_NUMBER)
+    testSubmitJob(sc, rdd, message = "Insufficient slots under local mode")
   }
 
   test("submit a barrier ShuffleMapStage that requires more slots than current total under " +
     "local mode") {
     val conf = new SparkConf()
-      // Shorten the time interval between two failed checks to make the test fail faster.
-      .set(BARRIER_MAX_CONCURRENT_TASKS_CHECK_INTERVAL.key, "1s")
-      // Reduce max check failures allowed to make the test fail faster.
-      .set(BARRIER_MAX_CONCURRENT_TASKS_CHECK_MAX_FAILURES, 3)
       .setMaster("local[4]")
       .setAppName("test")
     sc = createSparkContext(Some(conf))
@@ -218,36 +209,28 @@ class BarrierStageOnSubmittedSuite extends SparkFunSuite with LocalSparkContext 
       .mapPartitions(iter => iter)
       .repartition(2)
       .map(x => x + 1)
-    testSubmitJob(sc, rdd,
-      message = ERROR_MESSAGE_BARRIER_REQUIRE_MORE_SLOTS_THAN_CURRENT_TOTAL_NUMBER)
+    testSubmitJob(sc, rdd, message = "Insufficient slots under local mode")
   }
 
   test("submit a barrier ResultStage that requires more slots than current total under " +
     "local-cluster mode") {
     val conf = new SparkConf()
       .set(CPUS_PER_TASK, 2)
-      // Shorten the time interval between two failed checks to make the test fail faster.
-      .set(BARRIER_MAX_CONCURRENT_TASKS_CHECK_INTERVAL.key, "1s")
-      // Reduce max check failures allowed to make the test fail faster.
-      .set(BARRIER_MAX_CONCURRENT_TASKS_CHECK_MAX_FAILURES, 3)
+      .set(BARRIER_WAIT_FOR_SCHEDULE_TIMEOUT.key, "3s")
       .setMaster("local-cluster[4, 3, 1024]")
       .setAppName("test")
     sc = createSparkContext(Some(conf))
     val rdd = sc.parallelize(1 to 10, 5)
       .barrier()
       .mapPartitions(iter => iter)
-    testSubmitJob(sc, rdd,
-      message = ERROR_MESSAGE_BARRIER_REQUIRE_MORE_SLOTS_THAN_CURRENT_TOTAL_NUMBER)
+    testSubmitJob(sc, rdd, message = "Timeout after waiting 3 seconds to schedule barrier task set")
   }
 
   test("submit a barrier ShuffleMapStage that requires more slots than current total under " +
     "local-cluster mode") {
     val conf = new SparkConf()
       .set(CPUS_PER_TASK, 2)
-      // Shorten the time interval between two failed checks to make the test fail faster.
-      .set(BARRIER_MAX_CONCURRENT_TASKS_CHECK_INTERVAL.key, "1s")
-      // Reduce max check failures allowed to make the test fail faster.
-      .set(BARRIER_MAX_CONCURRENT_TASKS_CHECK_MAX_FAILURES, 3)
+      .set(BARRIER_WAIT_FOR_SCHEDULE_TIMEOUT.key, "3s")
       .setMaster("local-cluster[4, 3, 1024]")
       .setAppName("test")
     sc = createSparkContext(Some(conf))
@@ -256,7 +239,6 @@ class BarrierStageOnSubmittedSuite extends SparkFunSuite with LocalSparkContext 
       .mapPartitions(iter => iter)
       .repartition(2)
       .map(x => x + 1)
-    testSubmitJob(sc, rdd,
-      message = ERROR_MESSAGE_BARRIER_REQUIRE_MORE_SLOTS_THAN_CURRENT_TOTAL_NUMBER)
+    testSubmitJob(sc, rdd, message = "Timeout after waiting 3 seconds to schedule barrier task set")
   }
 }

--- a/core/src/test/scala/org/apache/spark/BarrierStageOnSubmittedSuite.scala
+++ b/core/src/test/scala/org/apache/spark/BarrierStageOnSubmittedSuite.scala
@@ -223,7 +223,8 @@ class BarrierStageOnSubmittedSuite extends SparkFunSuite with LocalSparkContext 
     val rdd = sc.parallelize(1 to 10, 5)
       .barrier()
       .mapPartitions(iter => iter)
-    testSubmitJob(sc, rdd, message = "Timeout after waiting 3 seconds to schedule barrier task set")
+    testSubmitJob(sc, rdd,
+      message = "Timeout after waiting 3 seconds for enough slots to schedule barrier task set")
   }
 
   test("submit a barrier ShuffleMapStage that requires more slots than current total under " +
@@ -239,6 +240,7 @@ class BarrierStageOnSubmittedSuite extends SparkFunSuite with LocalSparkContext 
       .mapPartitions(iter => iter)
       .repartition(2)
       .map(x => x + 1)
-    testSubmitJob(sc, rdd, message = "Timeout after waiting 3 seconds to schedule barrier task set")
+    testSubmitJob(sc, rdd, message =
+      "Timeout after waiting 3 seconds for enough slots to schedule barrier task set")
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Move slots check of barrier job from `DAGScheduler` to `TaskSchedulerImpl` and add new configuration `spark.scheduler.barrier.waitForEnoughSlots.timeout` to replace with `spark.scheduler.barrier.maxConcurrentTasksCheck.interval`/ `spark.scheduler.barrier.maxConcurrentTasksCheck.maxFailures`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

We do the slots check for a barrier job to ensure the job can be launched finally. We'll continuously resubmit the same job until we pass the check(find enough slots after some executors registered at driver). Thus, it introduces duplicate DAG planning for the same job, which may low down the throughput of the `DAGSchedule`. And it seems DAG planning could always be faster than executor launching, which makes duplicate DAG planning inevitable. Besides, we actually already did the similar slots check inside `TaskSchedulerImpl`. We can combine them as well.

One obvious benefit we can get after this improvement is reducing the time of barrier tests, e.g.

Before:

```
[info] BarrierTaskContextSuite:
[info] - global sync by barrier() call (18 seconds, 972 milliseconds)
[info] - share messages with allGather() call (17 seconds, 95 milliseconds)
[info] - throw exception if we attempt to synchronize with different blocking calls (16 seconds, 222 milliseconds)
[info] - successively sync with allGather and barrier (17 seconds, 532 milliseconds)
[info] - support multiple barrier() call within a single task (17 seconds, 792 milliseconds)
[info] - throw exception on barrier() call timeout (17 seconds, 85 milliseconds)
[info] - throw exception if barrier() call doesn't happen on every task (17 seconds, 166 milliseconds)
[info] - throw exception if the number of barrier() calls are not the same on every task (17 seconds, 149 milliseconds)
[info] - barrier task killed, no interrupt (16 seconds, 777 milliseconds)
[info] - barrier task killed, interrupt (16 seconds, 208 milliseconds)
[info] ScalaTest
[info] Run completed in 2 minutes, 54 seconds.
```

After:
```
[info] BarrierTaskContextSuite:
[info] - global sync by barrier() call (6 seconds, 694 milliseconds)
[info] - share messages with allGather() call (5 seconds, 885 milliseconds)
[info] - throw exception if we attempt to synchronize with different blocking calls (5 seconds, 384 milliseconds)
[info] - successively sync with allGather and barrier (6 seconds, 973 milliseconds)
[info] - support multiple barrier() call within a single task (6 seconds, 979 milliseconds)
[info] - throw exception on barrier() call timeout (6 seconds, 158 milliseconds)
[info] - throw exception if barrier() call doesn't happen on every task (6 seconds, 211 milliseconds)
[info] - throw exception if the number of barrier() calls are not the same on every task (6 seconds, 171 milliseconds)
[info] - barrier task killed, no interrupt (4 seconds, 776 milliseconds)
[info] - barrier task killed, interrupt (5 seconds, 190 milliseconds)
[info] ScalaTest
[info] Run completed in 1 minute, 3 seconds.
```

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

Yes, user can not use `spark.scheduler.barrier.maxConcurrentTasksCheck.interval`/ `spark.scheduler.barrier.maxConcurrentTasksCheck.maxFailures` any more since Spark 3.0 but should use 
`spark.scheduler.barrier.waitForEnoughSlots.timeout` instead.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Updated existed tests.
