### PR TITLE
[SPARK-31493][SQL] Optimize InSet to In according partition size at InSubqueryExec

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PartitionPruning.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PartitionPruning.scala
@@ -109,7 +109,7 @@ object PartitionPruning extends Rule[LogicalPlan] with PredicateHelper {
    * the size in bytes of the partitioned plan after filtering is greater than the size
    * in bytes of the plan on the other side of the join. We estimate the filtering ratio
    * using column statistics if they are available, otherwise we use the config value of
-   * `spark.sql.optimizer.joinFilterRatio`.
+   * `SQLConf.DYNAMIC_PARTITION_PRUNING_FALLBACK_FILTER_RATIO`.
    */
   private def pruningHasBenefit(
       partExpr: Expression,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/subquery.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/subquery.scala
@@ -147,8 +147,7 @@ case class InSubqueryExec(
     }
   }
 
-  // Visible for testing
-  private[sql] def predicate: Predicate = {
+  def predicate: Predicate = {
     if (result.length > plan.conf.optimizerInSetConversionThreshold) {
       InSet(child, result.toSet)
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/subquery.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/subquery.scala
@@ -149,7 +149,6 @@ case class InSubqueryExec(
 
   // Visible for testing
   private[sql] def predicate: Predicate = {
-    // respect `OptimizeIn`
     if (result.length > plan.conf.optimizerInSetConversionThreshold) {
       InSet(child, result.toSet)
     } else {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
@@ -1284,11 +1284,7 @@ abstract class DynamicPartitionPruningSuiteBase
   test("Use In when partition size not greater than optimizerInSetConversionThreshold") {
     def checkIn(plan: SparkPlan, expect: Boolean): Unit = {
       val hasIn = collectDynamicPruningExpressions(plan).exists {
-        case e: InSubqueryExec =>
-          e.predicate match {
-            case _: In => true
-            case _ => false
-          }
+        case e: InSubqueryExec => e.predicate.isInstanceOf[In]
         case _ => false
       }
       assert(hasIn == expect)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
@@ -1294,7 +1294,7 @@ abstract class DynamicPartitionPruningSuiteBase
       if (hasIn == expect) {
         // ok
       } else {
-        fail(s"expect: $hasIn, but get $expect")
+        fail(s"expect: $expect, but get $hasIn")
       }
     }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Now, `InSubqueryExec` always use `InSet` to filter partition. To respect `OptimizeIn`. Use `In` or `InSet` according partition size.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Better performance.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Add UT.