### PR TITLE
[SPARK-31502][SQL][DOCS] Document identifier in SQL Reference

### DIFF
--- a/docs/_data/menu-sql.yaml
+++ b/docs/_data/menu-sql.yaml
@@ -78,6 +78,8 @@
   subitems:
     - text: Data Types
       url: sql-ref-datatypes.html
+    - text: Identifiers
+      url: sql-ref-identifier.html
     - text: Literals
       url: sql-ref-literals.html
     - text: Null Semantics

--- a/docs/sql-ref-identifier.md
+++ b/docs/sql-ref-identifier.md
@@ -1,0 +1,75 @@
+---
+layout: global
+title: Identifiers
+displayTitle: Identifiers
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+### Description
+
+An identifier is a string used to identify a database object such as a table, view, schema, column, etc. Spark SQL has regular identifiers and delimited identifiers, which are enclosed within backticks. Both regular identifiers and delimited identifiers are case insensitive.
+
+### Syntax
+
+#### Regular Identifier
+{% highlight sql %}
+{ letter | digit | '_' } [ , ... ]
+{% endhighlight %}
+Note: If `spark.sql.ansi.enabled` is set to true, ANSI SQL reserved keywords cannot be used as identifiers. If `spark.sql.ansi.enabled` is set to false (this is the default), strict-non-reserved keywords cannot be used as table aliases. Please refer to [ANSI Compliance](sql-ref-ansi-compliance.html) for a complete list of the keywords.
+
+#### Delimited Identifier
+{% highlight sql %}
+`c [ ... ]`
+{% endhighlight %}
+
+### Parameters
+
+<dl>
+  <dt><code><em>letter</em></code></dt>
+  <dd>
+    Any letter from A-Z or a-z.
+  </dd>
+</dl>
+<dl>
+  <dt><code><em>digit</em></code></dt>
+  <dd>
+    Any numeral from 0 to 9.
+  </dd>
+</dl>
+<dl>
+  <dt><code><em>c</em></code></dt>
+  <dd>
+    Any character from the character set. Use <code>`</code> to escape <code>`</code>.
+  </dd>
+</dl>
+
+### Examples
+
+{% highlight sql %}
+
+-- This CREATE TABLE fails because of the illegal identifier name a.b
+CREATE TABLE test (a.b int);
+
+-- This CREATE TABLE works
+CREATE TABLE test (`a.b` int);
+
+-- This CREATE TABLE fails
+CREATE TABLE test1 (`a`b` int);
+
+-- This CREATE TABLE works
+CREATE TABLE test (`a``b` int);
+{% endhighlight %}

--- a/docs/sql-ref-identifier.md
+++ b/docs/sql-ref-identifier.md
@@ -64,12 +64,16 @@ Note: If `spark.sql.ansi.enabled` is set to true, ANSI SQL reserved keywords can
 {% highlight sql %}
 -- This CREATE TABLE fails with ParseException because of the illegal identifier name a.b
 CREATE TABLE test (a.b int);
+org.apache.spark.sql.catalyst.parser.ParseException:
+no viable alternative at input 'CREATE TABLE test (a.'(line 1, pos 20)
 
 -- This CREATE TABLE works
 CREATE TABLE test (`a.b` int);
 
 -- This CREATE TABLE fails with ParseException because special character ` is not escaped
 CREATE TABLE test1 (`a`b` int);
+org.apache.spark.sql.catalyst.parser.ParseException:
+no viable alternative at input 'CREATE TABLE test (`a`b`'(line 1, pos 23)
 
 -- This CREATE TABLE works
 CREATE TABLE test (`a``b` int);

--- a/docs/sql-ref-identifier.md
+++ b/docs/sql-ref-identifier.md
@@ -21,7 +21,7 @@ license: |
 
 ### Description
 
-An identifier is a string used to identify a database object such as a table, view, schema, column, etc. Spark SQL has regular identifiers and delimited identifiers, which are enclosed within backticks. When `spark.sql.caseSensitive` is set to false (default behavior since Spark 2.4), both regular identifiers and delimited identifiers are case-insensitive.
+An identifier is a string used to identify a database object such as a table, view, schema, column, etc. Spark SQL has regular identifiers and delimited identifiers, which are enclosed within backticks. Both regular identifiers and delimited identifiers are case-insensitive.
 
 ### Syntax
 
@@ -30,7 +30,7 @@ An identifier is a string used to identify a database object such as a table, vi
 {% highlight sql %}
 { letter | digit | '_' } [ , ... ]
 {% endhighlight %}
-Note: If `spark.sql.ansi.enabled` is set to true, ANSI SQL reserved keywords cannot be used as identifiers. For more details, please refer to [ANSI Compliance](sql-ref-ansi-compliance.html) for a complete list of the keywords.
+Note: If `spark.sql.ansi.enabled` is set to true, ANSI SQL reserved keywords cannot be used as identifiers. For more details, please refer to [ANSI Compliance](sql-ref-ansi-compliance.html).
 
 #### Delimited Identifier
 
@@ -62,13 +62,13 @@ Note: If `spark.sql.ansi.enabled` is set to true, ANSI SQL reserved keywords can
 ### Examples
 
 {% highlight sql %}
--- This CREATE TABLE fails because of the illegal identifier name a.b
+-- This CREATE TABLE fails with ParseException because of the illegal identifier name a.b
 CREATE TABLE test (a.b int);
 
 -- This CREATE TABLE works
 CREATE TABLE test (`a.b` int);
 
--- This CREATE TABLE fails
+-- This CREATE TABLE fails with ParseException because special character ` is not escaped
 CREATE TABLE test1 (`a`b` int);
 
 -- This CREATE TABLE works

--- a/docs/sql-ref-identifier.md
+++ b/docs/sql-ref-identifier.md
@@ -26,12 +26,14 @@ An identifier is a string used to identify a database object such as a table, vi
 ### Syntax
 
 #### Regular Identifier
+
 {% highlight sql %}
 { letter | digit | '_' } [ , ... ]
 {% endhighlight %}
 Note: If `spark.sql.ansi.enabled` is set to true, ANSI SQL reserved keywords cannot be used as identifiers. If `spark.sql.ansi.enabled` is set to false (this is the default), strict-non-reserved keywords cannot be used as table aliases. Please refer to [ANSI Compliance](sql-ref-ansi-compliance.html) for a complete list of the keywords.
 
 #### Delimited Identifier
+
 {% highlight sql %}
 `c [ ... ]`
 {% endhighlight %}
@@ -60,7 +62,6 @@ Note: If `spark.sql.ansi.enabled` is set to true, ANSI SQL reserved keywords can
 ### Examples
 
 {% highlight sql %}
-
 -- This CREATE TABLE fails because of the illegal identifier name a.b
 CREATE TABLE test (a.b int);
 

--- a/docs/sql-ref-identifier.md
+++ b/docs/sql-ref-identifier.md
@@ -21,7 +21,7 @@ license: |
 
 ### Description
 
-An identifier is a string used to identify a database object such as a table, view, schema, column, etc. Spark SQL has regular identifiers and delimited identifiers, which are enclosed within backticks. Both regular identifiers and delimited identifiers are case insensitive.
+An identifier is a string used to identify a database object such as a table, view, schema, column, etc. Spark SQL has regular identifiers and delimited identifiers, which are enclosed within backticks. When `spark.sql.caseSensitive` is set to false (default behavior since Spark 2.4), both regular identifiers and delimited identifiers are case-insensitive.
 
 ### Syntax
 
@@ -30,7 +30,7 @@ An identifier is a string used to identify a database object such as a table, vi
 {% highlight sql %}
 { letter | digit | '_' } [ , ... ]
 {% endhighlight %}
-Note: If `spark.sql.ansi.enabled` is set to true, ANSI SQL reserved keywords cannot be used as identifiers. If `spark.sql.ansi.enabled` is set to false (this is the default), strict-non-reserved keywords cannot be used as table aliases. Please refer to [ANSI Compliance](sql-ref-ansi-compliance.html) for a complete list of the keywords.
+Note: If `spark.sql.ansi.enabled` is set to true, ANSI SQL reserved keywords cannot be used as identifiers. For more details, please refer to [ANSI Compliance](sql-ref-ansi-compliance.html) for a complete list of the keywords.
 
 #### Delimited Identifier
 
@@ -55,7 +55,7 @@ Note: If `spark.sql.ansi.enabled` is set to true, ANSI SQL reserved keywords can
 <dl>
   <dt><code><em>c</em></code></dt>
   <dd>
-    Any character from the character set. Use <code>`</code> to escape <code>`</code>.
+    Any character from the character set. Use <code>`</code> to escape special characters (e.g., <code>`</code>).
   </dd>
 </dl>
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Document identifier in SQL Reference


### Why are the changes needed?
make SQL Reference complete


### Does this PR introduce any user-facing change?
Yes
<img width="1049" alt="Screen Shot 2020-04-23 at 11 14 10 PM" src="https://user-images.githubusercontent.com/13592258/80180695-2f2a4f00-85b8-11ea-819b-f96872956d05.png">

<img width="1050" alt="Screen Shot 2020-04-23 at 11 32 32 PM" src="https://user-images.githubusercontent.com/13592258/80182062-e6c06080-85ba-11ea-9502-1c38358c97c9.png">





### How was this patch tested?
Manually build and check
