### PR TITLE
[SPARK-31438][CORE][SQL] Support JobCleaned Status in SparkListener

### DIFF
--- a/core/src/main/java/org/apache/spark/SparkFirehoseListener.java
+++ b/core/src/main/java/org/apache/spark/SparkFirehoseListener.java
@@ -68,6 +68,11 @@ public class SparkFirehoseListener implements SparkListenerInterface {
   }
 
   @Override
+  public final void onJobCleaned(SparkListenerJobCleaned jobCleaned) {
+    onEvent(jobCleaned);
+  }
+
+  @Override
   public final void onEnvironmentUpdate(SparkListenerEnvironmentUpdate environmentUpdate) {
     onEvent(environmentUpdate);
   }

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -2101,7 +2101,7 @@ class SparkContext(config: SparkConf) extends Logging {
       func: (TaskContext, Iterator[T]) => U,
       partitions: Seq[Int],
       resultHandler: (Int, U) => Unit,
-      jobCleanedHook: Int => Unit): Unit = {
+      jobCleanedHook: Option[Int => Unit]): Unit = {
     if (stopped.get()) {
       throw new IllegalStateException("SparkContext has been shutdown")
     }
@@ -2112,7 +2112,8 @@ class SparkContext(config: SparkConf) extends Logging {
       logInfo("RDD's recursive dependencies:\n" + rdd.toDebugString)
     }
     dagScheduler.runJob(
-      rdd, cleanedFunc, partitions, callSite, resultHandler, localProperties.get, jobCleanedHook)
+      rdd, cleanedFunc, partitions, callSite,
+      resultHandler, localProperties.get, jobCleanedHook)
     progressBar.foreach(_.finishAll())
     rdd.doCheckpoint()
   }
@@ -2132,7 +2133,7 @@ class SparkContext(config: SparkConf) extends Logging {
       func: (TaskContext, Iterator[T]) => U,
       partitions: Seq[Int],
       resultHandler: (Int, U) => Unit): Unit = {
-    runJob(rdd, func, partitions, resultHandler, jobCleanedHook = Int => Unit)
+    runJob(rdd, func, partitions, resultHandler, None)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/scheduler/JobCleanedHookListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/JobCleanedHookListener.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scheduler
+
+import scala.collection.mutable.HashMap
+
+import org.apache.spark.internal.Logging
+
+/**
+ * JobCleanedHookListener is a basic job cleaned listener. It holds jobCleanedHooks for
+ * jobs and run cleaned hook after a job is cleaned.
+ */
+class JobCleanedHookListener extends SparkListener with Logging {
+  // use private val and synchronized to keep thread safe
+  private val jobCleanedHooks = new HashMap[Int, Int => Unit]()
+
+  def addCleanedHook(jobId: Int, fun: Int => Unit): Unit = synchronized{
+    jobCleanedHooks.put(jobId, fun)
+  }
+
+  def deleteCleanedHook(jobId: Int): Unit = synchronized {
+    jobCleanedHooks.remove(jobId)
+  }
+
+  override def onJobCleaned(jobCleaned: SparkListenerJobCleaned): Unit = {
+    jobCleanedHooks.get(jobCleaned.jobId)
+      .foreach{function =>
+        function(jobCleaned.jobId)
+        deleteCleanedHook(jobCleaned.jobId)
+      }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
@@ -89,6 +89,12 @@ case class SparkListenerJobEnd(
   extends SparkListenerEvent
 
 @DeveloperApi
+case class SparkListenerJobCleaned(
+    jobId: Int,
+    time: Long)
+  extends SparkListenerEvent
+
+@DeveloperApi
 case class SparkListenerEnvironmentUpdate(environmentDetails: Map[String, Seq[(String, String)]])
   extends SparkListenerEvent
 
@@ -252,6 +258,11 @@ private[spark] trait SparkListenerInterface {
   def onJobEnd(jobEnd: SparkListenerJobEnd): Unit
 
   /**
+   * Called when a job is cleaned
+   */
+  def onJobCleaned(jobCleaned: SparkListenerJobCleaned): Unit
+
+  /**
    * Called when environment properties have been updated
    */
   def onEnvironmentUpdate(environmentUpdate: SparkListenerEnvironmentUpdate): Unit
@@ -373,6 +384,8 @@ abstract class SparkListener extends SparkListenerInterface {
   override def onJobStart(jobStart: SparkListenerJobStart): Unit = { }
 
   override def onJobEnd(jobEnd: SparkListenerJobEnd): Unit = { }
+
+  override def onJobCleaned(jobCleaned: SparkListenerJobCleaned): Unit = { }
 
   override def onEnvironmentUpdate(environmentUpdate: SparkListenerEnvironmentUpdate): Unit = { }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/SparkListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SparkListenerBus.scala
@@ -37,6 +37,8 @@ private[spark] trait SparkListenerBus
         listener.onJobStart(jobStart)
       case jobEnd: SparkListenerJobEnd =>
         listener.onJobEnd(jobEnd)
+      case jobCleaned: SparkListenerJobCleaned =>
+        listener.onJobCleaned(jobCleaned)
       case taskStart: SparkListenerTaskStart =>
         listener.onTaskStart(taskStart)
       case taskGettingResult: SparkListenerTaskGettingResult =>

--- a/core/src/test/scala/org/apache/spark/scheduler/JobCleanedHookListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/JobCleanedHookListenerSuite.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scheduler
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.apache.spark.{LocalSparkContext, SparkContext, SparkFunSuite}
+
+class JobCleanedHookListenerSuite extends SparkFunSuite with LocalSparkContext {
+
+  test("JobCleanedHook was called once for each job") {
+    sc = new SparkContext("local", "CheckJobCleanedAfterJobRemoved")
+    val counter = new AtomicInteger(0)
+    var currentJobId = sc.dagScheduler.nextJobId.get()
+    sc.jobCleanedHookListener.addCleanedHook(currentJobId, jobId => counter.set(jobId))
+    sc.parallelize(1 to 100).count()
+    assert(sc.dagScheduler.jobIdToActiveJob.get(currentJobId).isEmpty)
+    assert(sc.dagScheduler.nextJobId.get() == currentJobId + 1)
+    assert(counter.get() == 0)
+
+    currentJobId = sc.dagScheduler.nextJobId.get()
+    sc.jobCleanedHookListener.addCleanedHook(currentJobId, jobId => counter.set(jobId))
+    sc.parallelize(1 to 100).count()
+    assert(sc.dagScheduler.jobIdToActiveJob.get(currentJobId).isEmpty)
+    assert(sc.dagScheduler.nextJobId.get() == currentJobId + 1)
+    assert(counter.get() == 1)
+  }
+
+  test("JobCleanedHood was called even if job failed") {
+    sc = new SparkContext("local", "CheckJobCleanedAfterJobFailed")
+    val counter = new AtomicInteger(0)
+    var currentJobId = sc.dagScheduler.nextJobId.get()
+    sc.jobCleanedHookListener.addCleanedHook(currentJobId, jobId => counter.set(jobId))
+    try {
+      sc.parallelize(1 to 100).map { index =>
+        if (index > 80) {
+          throw new Exception(s"current $index has run Failed")
+        }
+      }.count()
+    } catch {
+      case e: Exception =>
+        // Nothing to be done
+    }
+    assert(sc.dagScheduler.jobIdToActiveJob.get(currentJobId).isEmpty)
+    assert(sc.dagScheduler.nextJobId.get() == currentJobId + 1)
+    assert(counter.get() == 0)
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
@@ -51,7 +51,7 @@ object FileFormatWriter extends Logging {
       outputPath: String,
       customPartitionLocations: Map[TablePartitionSpec, String],
       outputColumns: Seq[Attribute],
-      cleanedHook: Int => Unit = Int => Unit)
+      cleanedHook: Option[Int => Unit] = None)
 
   /** A function that converts the empty string to null for partition values. */
   case class Empty2Null(child: Expression) extends UnaryExpression with String2StringExpression {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveDirCommand.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveDirCommand.scala
@@ -124,6 +124,8 @@ case class InsertIntoHiveDirCommand(
       }
     } catch {
       case e: Throwable =>
+        // Make sure tmp path deleted while getting Exception before sc.runJob
+        deleteExternalTmpPath(hadoopConf)
         throw new SparkException(
           "Failed inserting overwrite directory " + storage.locationUri.get, e)
     } finally {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveDirCommand.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveDirCommand.scala
@@ -124,11 +124,10 @@ case class InsertIntoHiveDirCommand(
       }
     } catch {
       case e: Throwable =>
-        // Make sure tmp path deleted while getting Exception before sc.runJob
-        deleteExternalTmpPath(hadoopConf)
         throw new SparkException(
           "Failed inserting overwrite directory " + storage.locationUri.get, e)
     } finally {
+      tempDirCleanedEnabled = true
       deleteExternalTmpPath(hadoopConf)
     }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -104,7 +104,7 @@ case class InsertIntoHiveTable(
         // Make sure tmp path deleted while getting Exception before sc.runJob
         deleteExternalTmpPath(hadoopConf)
         throw new SparkException(
-          s"Failed inserting ubti table ${table.identifier.quotedString}", e)
+          s"Failed inserting into table ${table.identifier.quotedString}", e)
     } finally {
       // Attempt to delete the staging directory and the inclusive files. If failed, the files are
       // expected to be dropped at the normal termination of VM since deleteOnExit is used.

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -99,6 +99,12 @@ case class InsertIntoHiveTable(
 
     try {
       processInsert(sparkSession, externalCatalog, hadoopConf, tableDesc, tmpLocation, child)
+    } catch {
+      case e: Throwable =>
+        // Make sure tmp path deleted while getting Exception before sc.runJob
+        deleteExternalTmpPath(hadoopConf)
+        throw new SparkException(
+          s"Failed inserting ubti table ${table.identifier.quotedString}", e)
     } finally {
       // Attempt to delete the staging directory and the inclusive files. If failed, the files are
       // expected to be dropped at the normal termination of VM since deleteOnExit is used.

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -99,15 +99,10 @@ case class InsertIntoHiveTable(
 
     try {
       processInsert(sparkSession, externalCatalog, hadoopConf, tableDesc, tmpLocation, child)
-    } catch {
-      case e: Throwable =>
-        // Make sure tmp path deleted while getting Exception before sc.runJob
-        deleteExternalTmpPath(hadoopConf)
-        throw new SparkException(
-          s"Failed inserting into table ${table.identifier.quotedString}", e)
     } finally {
       // Attempt to delete the staging directory and the inclusive files. If failed, the files are
       // expected to be dropped at the normal termination of VM since deleteOnExit is used.
+      tempDirCleanedEnabled = true
       deleteExternalTmpPath(hadoopConf)
     }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/SaveAsHiveFile.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/SaveAsHiveFile.scala
@@ -95,7 +95,7 @@ private[hive] trait SaveAsHiveFile extends DataWritingCommand {
         outputLocation,
         customPartitionLocations,
         outputColumns,
-        cleanedHook = Int => deleteExternalTmpPath(hadoopConf)),
+        cleanedHook = Some(Int => deleteExternalTmpPath(hadoopConf))),
       hadoopConf = hadoopConf,
       partitionColumns = partitionAttributes,
       bucketSpec = None,


### PR DESCRIPTION
 ### What changes were proposed in this pull request?
In Spark, we need do some hook after job cleaned, such as cleaning hive external temporary paths. This has already discussed in [GitHub Pull Request #28129](https://github.com/apache/spark/pull/28129).
The JobEnd Status is not suitable for this. As JobEnd is responsible for Job finished, once all result has generated, it should be finished. After finish, Scheduler will leave the still running tasks to be zombie tasks and delete abnormal tasks asynchronously.
Thus, we add JobCleaned Status to enable user to do some hook after all tasks cleaned in the job and add a JobCleanedListener to do some hooks.

### Does this PR introduce any user-facing change?
NO

### How was this patch tested?
run all tests