### PR TITLE
[SPARK-31418][SCHEDULER] Request more executors in case of dynamic allocation is enabled and a task becomes unschedulable due to spark's blacklisting feature.

### DIFF
--- a/core/src/main/java/org/apache/spark/SparkFirehoseListener.java
+++ b/core/src/main/java/org/apache/spark/SparkFirehoseListener.java
@@ -162,9 +162,14 @@ public class SparkFirehoseListener implements SparkListenerInterface {
     onEvent(speculativeTask);
   }
 
-  public void onUnschedulableTaskSet(
-      SparkListenerUnschedulableTaskSet unschedulableTaskSet) {
-    onEvent(unschedulableTaskSet);
+  public void onUnschedulableTaskSetAdded(
+      SparkListenerUnschedulableTaskSetAdded unschedulableTaskSetAdded) {
+    onEvent(unschedulableTaskSetAdded);
+  }
+
+  public void onUnschedulableTaskSetRemoved(
+      SparkListenerUnschedulableTaskSetRemoved unschedulableTaskSetRemoved) {
+    onEvent(unschedulableTaskSetRemoved);
   }
 
   @Override

--- a/core/src/main/java/org/apache/spark/SparkFirehoseListener.java
+++ b/core/src/main/java/org/apache/spark/SparkFirehoseListener.java
@@ -162,9 +162,9 @@ public class SparkFirehoseListener implements SparkListenerInterface {
     onEvent(speculativeTask);
   }
 
-  public void onUnschedulableBlacklistTaskSubmitted(
-      SparkListenerUnschedulableBlacklistTaskSubmitted blacklistTask) {
-    onEvent(blacklistTask);
+  public void onUnschedulableTaskSet(
+      SparkListenerUnschedulableTaskSet unschedulableTaskSet) {
+    onEvent(unschedulableTaskSet);
   }
 
   @Override

--- a/core/src/main/java/org/apache/spark/SparkFirehoseListener.java
+++ b/core/src/main/java/org/apache/spark/SparkFirehoseListener.java
@@ -162,6 +162,11 @@ public class SparkFirehoseListener implements SparkListenerInterface {
     onEvent(speculativeTask);
   }
 
+  public void onUnschedulableBlacklistTaskSubmitted(
+      SparkListenerUnschedulableBlacklistTaskSubmitted blacklistTask) {
+    onEvent(blacklistTask);
+  }
+
   @Override
   public void onResourceProfileAdded(SparkListenerResourceProfileAdded event) {
     onEvent(event);

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -806,7 +806,7 @@ private[spark] class ExecutorAllocationManager(
           case (Some(stageId), Some(stageAttemptId)) =>
             val stageAttempt = StageAttempt(stageId, stageAttemptId)
             unschedulableTaskSets.add(stageAttempt)
-          case (None, None) =>
+          case (None, _) =>
             // Clear unschedulableTaskSets since atleast one task becomes schedulable now
             unschedulableTaskSets.clear()
         }

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -882,13 +882,6 @@ private[spark] class ExecutorAllocationManager(
       attempts.filter(attempt => unschedulableTaskSets.contains(attempt)).size
     }
 
-    def hasPendingUnschedulableTasks: Boolean = {
-      val attemptSets = resourceProfileIdToStageAttempt.values
-      attemptSets.exists { attempts =>
-        attempts.exists(unschedulableTaskSets.contains(_))
-      }
-    }
-
     def hasPendingTasks: Boolean = {
       hasPendingSpeculativeTasks || hasPendingRegularTasks
     }

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1041,8 +1041,8 @@ private[spark] class DAGScheduler(
   }
 
   private[scheduler] def handleUnschedulableTaskSetRemoved(
-    stageId: Int,
-    stageAttemptId: Int): Unit = {
+      stageId: Int,
+      stageAttemptId: Int): Unit = {
     listenerBus.post(SparkListenerUnschedulableTaskSetRemoved(stageId, stageAttemptId))
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1028,7 +1028,7 @@ private[spark] class DAGScheduler(
       stageId: Option[Int],
       stageAttemptId: Option[Int]): Unit = {
     listenerBus.post(
-      SparkListenerUnschedulableBlacklistTaskSubmitted(stageId, stageAttemptId))
+      SparkListenerUnschedulableTaskSet(stageId, stageAttemptId))
   }
 
   private[scheduler] def handleTaskSetFailed(

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -313,7 +313,7 @@ private[spark] class DAGScheduler(
 
   /**
    * Called by the TaskSetManager when a taskset becomes unschedulable due to blacklisting and
-   * dynamic allocation is enabled
+   * dynamic allocation is enabled.
    */
   def unschedulableTaskSetAdded(
        stageId: Int,
@@ -323,7 +323,7 @@ private[spark] class DAGScheduler(
 
   /**
    * Called by the TaskSetManager when an unschedulable taskset becomes schedulable and dynamic
-   * allocation is enabled
+   * allocation is enabled.
    */
   def unschedulableTaskSetRemoved(
     stageId: Int,
@@ -1037,15 +1037,13 @@ private[spark] class DAGScheduler(
   private[scheduler] def handleUnschedulableTaskSetAdded(
       stageId: Int,
       stageAttemptId: Int): Unit = {
-    listenerBus.post(
-      SparkListenerUnschedulableTaskSetAdded(stageId, stageAttemptId))
+    listenerBus.post(SparkListenerUnschedulableTaskSetAdded(stageId, stageAttemptId))
   }
 
   private[scheduler] def handleUnschedulableTaskSetRemoved(
     stageId: Int,
     stageAttemptId: Int): Unit = {
-    listenerBus.post(
-      SparkListenerUnschedulableTaskSetRemoved(stageId, stageAttemptId))
+    listenerBus.post(SparkListenerUnschedulableTaskSetRemoved(stageId, stageAttemptId))
   }
 
   private[scheduler] def handleTaskSetFailed(

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -316,8 +316,8 @@ private[spark] class DAGScheduler(
    * dynamic allocation is enabled.
    */
   def unschedulableTaskSetAdded(
-       stageId: Int,
-       stageAttemptId: Int): Unit = {
+      stageId: Int,
+      stageAttemptId: Int): Unit = {
     eventProcessLoop.post(UnschedulableTaskSetAdded(stageId, stageAttemptId))
   }
 
@@ -326,8 +326,8 @@ private[spark] class DAGScheduler(
    * allocation is enabled.
    */
   def unschedulableTaskSetRemoved(
-    stageId: Int,
-    stageAttemptId: Int): Unit = {
+      stageId: Int,
+      stageAttemptId: Int): Unit = {
     eventProcessLoop.post(UnschedulableTaskSetRemoved(stageId, stageAttemptId))
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGSchedulerEvent.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGSchedulerEvent.scala
@@ -98,5 +98,10 @@ private[scheduler]
 case class SpeculativeTaskSubmitted(task: Task[_]) extends DAGSchedulerEvent
 
 private[scheduler]
-case class UnschedulableBlacklistTaskSubmitted(stageId: Option[Int], stageAttemptId: Option[Int])
+case class UnschedulableTaskSetAdded(stageId: Int, stageAttemptId: Int)
   extends DAGSchedulerEvent
+
+private[scheduler]
+case class UnschedulableTaskSetRemoved(stageId: Int, stageAttemptId: Int)
+  extends DAGSchedulerEvent
+

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGSchedulerEvent.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGSchedulerEvent.scala
@@ -97,3 +97,6 @@ private[scheduler] case object ResubmitFailedStages extends DAGSchedulerEvent
 private[scheduler]
 case class SpeculativeTaskSubmitted(task: Task[_]) extends DAGSchedulerEvent
 
+private[scheduler]
+case class UnschedulableBlacklistTaskSubmitted(stageId: Option[Int], stageAttemptId: Option[Int])
+  extends DAGSchedulerEvent

--- a/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
@@ -158,6 +158,11 @@ case class SparkListenerNodeUnblacklisted(time: Long, hostId: String)
   extends SparkListenerEvent
 
 @DeveloperApi
+case class SparkListenerUnschedulableBlacklistTaskSubmitted(
+  stageId: Option[Int],
+  stageAttemptId: Option[Int]) extends SparkListenerEvent
+
+@DeveloperApi
 case class SparkListenerBlockUpdated(blockUpdatedInfo: BlockUpdatedInfo) extends SparkListenerEvent
 
 /**
@@ -340,6 +345,12 @@ private[spark] trait SparkListenerInterface {
   def onNodeUnblacklisted(nodeUnblacklisted: SparkListenerNodeUnblacklisted): Unit
 
   /**
+   * Called when both dynamic allocation is enabled and there is an unschedulable blacklist task
+   */
+  def onUnschedulableBlacklistTaskSubmitted(
+    blacklistTask: SparkListenerUnschedulableBlacklistTaskSubmitted): Unit
+
+  /**
    * Called when the driver receives a block update info.
    */
   def onBlockUpdated(blockUpdated: SparkListenerBlockUpdated): Unit
@@ -424,6 +435,9 @@ abstract class SparkListener extends SparkListenerInterface {
 
   override def onNodeUnblacklisted(
       nodeUnblacklisted: SparkListenerNodeUnblacklisted): Unit = { }
+
+  override def onUnschedulableBlacklistTaskSubmitted(
+    blacklistTask: SparkListenerUnschedulableBlacklistTaskSubmitted): Unit = { }
 
   override def onBlockUpdated(blockUpdated: SparkListenerBlockUpdated): Unit = { }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
@@ -158,7 +158,7 @@ case class SparkListenerNodeUnblacklisted(time: Long, hostId: String)
   extends SparkListenerEvent
 
 @DeveloperApi
-case class SparkListenerUnschedulableBlacklistTaskSubmitted(
+case class SparkListenerUnschedulableTaskSet(
   stageId: Option[Int],
   stageAttemptId: Option[Int]) extends SparkListenerEvent
 
@@ -347,8 +347,8 @@ private[spark] trait SparkListenerInterface {
   /**
    * Called when both dynamic allocation is enabled and there is an unschedulable blacklist task
    */
-  def onUnschedulableBlacklistTaskSubmitted(
-    blacklistTask: SparkListenerUnschedulableBlacklistTaskSubmitted): Unit
+  def onUnschedulableTaskSet(
+    blacklistTask: SparkListenerUnschedulableTaskSet): Unit
 
   /**
    * Called when the driver receives a block update info.
@@ -436,8 +436,8 @@ abstract class SparkListener extends SparkListenerInterface {
   override def onNodeUnblacklisted(
       nodeUnblacklisted: SparkListenerNodeUnblacklisted): Unit = { }
 
-  override def onUnschedulableBlacklistTaskSubmitted(
-    blacklistTask: SparkListenerUnschedulableBlacklistTaskSubmitted): Unit = { }
+  override def onUnschedulableTaskSet(
+    unschedulableTaskSet: SparkListenerUnschedulableTaskSet): Unit = { }
 
   override def onBlockUpdated(blockUpdated: SparkListenerBlockUpdated): Unit = { }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
@@ -351,14 +351,14 @@ private[spark] trait SparkListenerInterface {
 
   /**
    * Called when a taskset becomes unschedulable due to blacklisting and dynamic allocation
-   * is enabled
+   * is enabled.
    */
   def onUnschedulableTaskSetAdded(
       unschedulableTaskSetAdded: SparkListenerUnschedulableTaskSetAdded): Unit
 
   /**
    * Called when an unschedulable taskset becomes schedulable and dynamic allocation
-   * is enabled
+   * is enabled.
    */
   def onUnschedulableTaskSetRemoved(
       unschedulableTaskSetRemoved: SparkListenerUnschedulableTaskSetRemoved): Unit

--- a/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
@@ -158,9 +158,14 @@ case class SparkListenerNodeUnblacklisted(time: Long, hostId: String)
   extends SparkListenerEvent
 
 @DeveloperApi
-case class SparkListenerUnschedulableTaskSet(
-  stageId: Option[Int],
-  stageAttemptId: Option[Int]) extends SparkListenerEvent
+case class SparkListenerUnschedulableTaskSetAdded(
+  stageId: Int,
+  stageAttemptId: Int) extends SparkListenerEvent
+
+@DeveloperApi
+case class SparkListenerUnschedulableTaskSetRemoved(
+  stageId: Int,
+  stageAttemptId: Int) extends SparkListenerEvent
 
 @DeveloperApi
 case class SparkListenerBlockUpdated(blockUpdatedInfo: BlockUpdatedInfo) extends SparkListenerEvent
@@ -345,10 +350,18 @@ private[spark] trait SparkListenerInterface {
   def onNodeUnblacklisted(nodeUnblacklisted: SparkListenerNodeUnblacklisted): Unit
 
   /**
-   * Called when both dynamic allocation is enabled and there is an unschedulable blacklist task
+   * Called when a taskset becomes unschedulable due to blacklisting and dynamic allocation
+   * is enabled
    */
-  def onUnschedulableTaskSet(
-    blacklistTask: SparkListenerUnschedulableTaskSet): Unit
+  def onUnschedulableTaskSetAdded(
+      unschedulableTaskSetAdded: SparkListenerUnschedulableTaskSetAdded): Unit
+
+  /**
+   * Called when an unschedulable taskset becomes schedulable and dynamic allocation
+   * is enabled
+   */
+  def onUnschedulableTaskSetRemoved(
+      unschedulableTaskSetRemoved: SparkListenerUnschedulableTaskSetRemoved): Unit
 
   /**
    * Called when the driver receives a block update info.
@@ -436,8 +449,11 @@ abstract class SparkListener extends SparkListenerInterface {
   override def onNodeUnblacklisted(
       nodeUnblacklisted: SparkListenerNodeUnblacklisted): Unit = { }
 
-  override def onUnschedulableTaskSet(
-    unschedulableTaskSet: SparkListenerUnschedulableTaskSet): Unit = { }
+  override def onUnschedulableTaskSetAdded(
+      unschedulableTaskSetAdded: SparkListenerUnschedulableTaskSetAdded): Unit = { }
+
+  override def onUnschedulableTaskSetRemoved(
+      unschedulableTaskSetRemoved: SparkListenerUnschedulableTaskSetRemoved): Unit = { }
 
   override def onBlockUpdated(blockUpdated: SparkListenerBlockUpdated): Unit = { }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/SparkListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SparkListenerBus.scala
@@ -79,8 +79,8 @@ private[spark] trait SparkListenerBus
         listener.onBlockUpdated(blockUpdated)
       case speculativeTaskSubmitted: SparkListenerSpeculativeTaskSubmitted =>
         listener.onSpeculativeTaskSubmitted(speculativeTaskSubmitted)
-      case blacklistTaskSubmitted: SparkListenerUnschedulableBlacklistTaskSubmitted =>
-        listener.onUnschedulableBlacklistTaskSubmitted(blacklistTaskSubmitted)
+      case unschedulableTaskSet: SparkListenerUnschedulableTaskSet =>
+        listener.onUnschedulableTaskSet(unschedulableTaskSet)
       case resourceProfileAdded: SparkListenerResourceProfileAdded =>
         listener.onResourceProfileAdded(resourceProfileAdded)
       case _ => listener.onOtherEvent(event)

--- a/core/src/main/scala/org/apache/spark/scheduler/SparkListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SparkListenerBus.scala
@@ -79,8 +79,10 @@ private[spark] trait SparkListenerBus
         listener.onBlockUpdated(blockUpdated)
       case speculativeTaskSubmitted: SparkListenerSpeculativeTaskSubmitted =>
         listener.onSpeculativeTaskSubmitted(speculativeTaskSubmitted)
-      case unschedulableTaskSet: SparkListenerUnschedulableTaskSet =>
-        listener.onUnschedulableTaskSet(unschedulableTaskSet)
+      case unschedulableTaskSetAdded: SparkListenerUnschedulableTaskSetAdded =>
+        listener.onUnschedulableTaskSetAdded(unschedulableTaskSetAdded)
+      case unschedulableTaskSetRemoved: SparkListenerUnschedulableTaskSetRemoved =>
+        listener.onUnschedulableTaskSetRemoved(unschedulableTaskSetRemoved)
       case resourceProfileAdded: SparkListenerResourceProfileAdded =>
         listener.onResourceProfileAdded(resourceProfileAdded)
       case _ => listener.onOtherEvent(event)

--- a/core/src/main/scala/org/apache/spark/scheduler/SparkListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SparkListenerBus.scala
@@ -79,6 +79,8 @@ private[spark] trait SparkListenerBus
         listener.onBlockUpdated(blockUpdated)
       case speculativeTaskSubmitted: SparkListenerSpeculativeTaskSubmitted =>
         listener.onSpeculativeTaskSubmitted(speculativeTaskSubmitted)
+      case blacklistTaskSubmitted: SparkListenerUnschedulableBlacklistTaskSubmitted =>
+        listener.onUnschedulableBlacklistTaskSubmitted(blacklistTaskSubmitted)
       case resourceProfileAdded: SparkListenerResourceProfileAdded =>
         listener.onResourceProfileAdded(resourceProfileAdded)
       case _ => listener.onOtherEvent(event)

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -524,7 +524,7 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
     assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) == 1)
 
     // Stage 0 becomes unschedulable due to blacklisting
-    post(SparkListenerUnschedulableBlacklistTaskSubmitted(Some(0), Some(0)))
+    post(SparkListenerUnschedulableTaskSet(Some(0), Some(0)))
     clock.advance(1000)
     manager invokePrivate _updateAndSyncNumExecutorsTarget(clock.nanoTime())
     // Assert that we are getting additional executor to schedule unschedulable tasks
@@ -535,7 +535,7 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
     onExecutorAddedDefaultProfile(manager, "1")
     // Now once the task becomes schedulable, clear the unschedulableTaskSets
     // by posting unschedulable event with (None, None)
-    post(SparkListenerUnschedulableBlacklistTaskSubmitted(None, None))
+    post(SparkListenerUnschedulableTaskSet(None, None))
     clock.advance(1000)
     manager invokePrivate _updateAndSyncNumExecutorsTarget(clock.nanoTime())
     assert(numExecutorsTarget(manager, defaultProfile.id) === 1)
@@ -581,8 +581,8 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
     post(SparkListenerStageCompleted(createStageInfo(0, 2)))
 
     // Stage 1 and 2 becomes unschedulable now due to blacklisting
-    post(SparkListenerUnschedulableBlacklistTaskSubmitted(Some(1), Some(0)))
-    post(SparkListenerUnschedulableBlacklistTaskSubmitted(Some(2), Some(0)))
+    post(SparkListenerUnschedulableTaskSet(Some(1), Some(0)))
+    post(SparkListenerUnschedulableTaskSet(Some(2), Some(0)))
 
     clock.advance(1000)
     manager invokePrivate _updateAndSyncNumExecutorsTarget(clock.nanoTime())
@@ -595,7 +595,7 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
 
     // Now once the task becomes schedulable, clear the unschedulableTaskSets
     // by posting unschedulable event with (None, None)
-    post(SparkListenerUnschedulableBlacklistTaskSubmitted(None, None))
+    post(SparkListenerUnschedulableTaskSet(None, None))
     clock.advance(1000)
     manager invokePrivate _updateAndSyncNumExecutorsTarget(clock.nanoTime())
     assert(numExecutorsTarget(manager, defaultProfile.id) === 2)
@@ -639,7 +639,7 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
     (0 to 3).foreach { i => onExecutorRemoved(manager, i.toString) }
 
     // Now due to blacklisting, the task becomes unschedulable
-    post(SparkListenerUnschedulableBlacklistTaskSubmitted(Some(0), Some(0)))
+    post(SparkListenerUnschedulableTaskSet(Some(0), Some(0)))
     clock.advance(1000)
     manager invokePrivate _updateAndSyncNumExecutorsTarget(clock.nanoTime())
     assert(numExecutorsTarget(manager, defaultProfile.id) === 2)
@@ -650,7 +650,7 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
 
     // Now once the task becomes schedulable, clear the unschedulableTaskSets
     // by posting unschedulable event with (None, None)
-    post(SparkListenerUnschedulableBlacklistTaskSubmitted(None, None))
+    post(SparkListenerUnschedulableTaskSet(None, None))
     clock.advance(1000)
     manager invokePrivate _updateAndSyncNumExecutorsTarget(clock.nanoTime())
     assert(numExecutorsTarget(manager, defaultProfile.id) === 1)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
In this change, when dynamic allocation is enabled instead of aborting immediately when there is an unschedulable taskset due to blacklisting, pass an event saying `SparkListenerUnschedulableTaskSetAdded` which will be handled by `ExecutorAllocationManager` and request more executors needed to schedule the unschedulable blacklisted tasks. Once the event is sent, we start the abortTimer similar to [SPARK-22148][SPARK-15815] to abort in the case when no new executors launched either due to max executors reached or cluster manager is out of capacity.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
This is an improvement. In the case when dynamic allocation is enabled, this would request more executors to schedule the unschedulable tasks instead of aborting the stage without even retrying upto spark.task.maxFailures times (in some cases not retrying at all). This is a potential issue with respect to Spark's Fault tolerance.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce any user-facing change?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->


### How was this patch tested?
Added unit tests both in ExecutorAllocationManagerSuite and TaskSchedulerImplSuite
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
