### PR TITLE
[MINOR][SQL] Add comments for filters values and return values of Row.get()/apply()

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/Row.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/Row.scala
@@ -165,8 +165,11 @@ trait Row extends Serializable {
    *   StringType -> String
    *   DecimalType -> java.math.BigDecimal
    *
-   *   DateType -> java.sql.Date
-   *   TimestampType -> java.sql.Timestamp
+   *   DateType -> java.sql.Date if spark.sql.datetime.java8API.enabled is false
+   *   DateType -> java.time.LocalDate if spark.sql.datetime.java8API.enabled is true
+   *
+   *   TimestampType -> java.sql.Timestamp if spark.sql.datetime.java8API.enabled is false
+   *   TimestampType -> java.time.Instant if spark.sql.datetime.java8API.enabled is true
    *
    *   BinaryType -> byte array
    *   ArrayType -> scala.collection.Seq (use getList for java.util.List)
@@ -190,8 +193,11 @@ trait Row extends Serializable {
    *   StringType -> String
    *   DecimalType -> java.math.BigDecimal
    *
-   *   DateType -> java.sql.Date
-   *   TimestampType -> java.sql.Timestamp
+   *   DateType -> java.sql.Date if spark.sql.datetime.java8API.enabled is false
+   *   DateType -> java.time.LocalDate if spark.sql.datetime.java8API.enabled is true
+   *
+   *   TimestampType -> java.sql.Timestamp if spark.sql.datetime.java8API.enabled is false
+   *   TimestampType -> java.time.Instant if spark.sql.datetime.java8API.enabled is true
    *
    *   BinaryType -> byte array
    *   ArrayType -> scala.collection.Seq (use getList for java.util.List)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/sources/filters.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/sources/filters.scala
@@ -25,21 +25,8 @@ import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.parseColumnPath
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /**
- * A filter predicate for data sources.
- *
- * Filters with DATE or TIMESTAMP column attributes have values of Java types with
- * date-time fields that are derived from filter date-time value at the default JVM time zone.
- *   - DATE filter values are instances of `java.sql.Date` that are constructed from local
- *     dates with fields (year, month, day). The local dates are derived from numbers of days
- *     since the epoch 1970-01-01 in Proleptic Gregorian calendar.
- *   - TIMESTAMP filter values are instances of `java.sql.Timestamp` that are constructed from
- *     local timestamps with the fields (year, month, day, hour, minute, second with fraction).
- *     The local timestamps are derived from microseconds since the epoch 1970-01-01 00:00:00Z
- *     representing the local timestamp at the default JVM time zone in Proleptic Gregorian
- *     calendar.
- * Since Spark 3.0, date-time filters values are rebased via local dates/timestamps from
- * Proleptic Gregorian calendar to the hybrid calendar (Julian + Gregorian since 1582-10-15)
- * which Java classes `java.sql.Date` and `java.sql.Timestamp` are based on.
+ * A filter predicate for data sources. Mapping between Spark SQL types and filter value
+ * types follow the convention for return type of [[org.apache.spark.sql.Row#get(int)]].
  *
  * @since 1.3.0
  */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/sources/filters.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/sources/filters.scala
@@ -27,6 +27,20 @@ import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.parseColumnPath
 /**
  * A filter predicate for data sources.
  *
+ * Filters with DATE or TIMESTAMP column attributes have values of Java types with
+ * date-time fields that are derived from filter date-time value at the default JVM time zone.
+ *   - DATE filter values are instances of `java.sql.Date` that are constructed from local
+ *     dates with fields (year, month, day). The local dates are derived from numbers of days
+ *     since the epoch 1970-01-01 in Proleptic Gregorian calendar.
+ *   - TIMESTAMP filter values are instances of `java.sql.Timestamp` that are constructed from
+ *     local timestamps with the fields (year, month, day, hour, minute, second with fraction).
+ *     The local timestamps are derived from microseconds since the epoch 1970-01-01 00:00:00Z
+ *     representing the local timestamp at the default JVM time zone in Proleptic Gregorian
+ *     calendar.
+ * Since Spark 3.0, date-time filters values are rebased via local dates/timestamps from
+ * Proleptic Gregorian calendar to the hybrid calendar (Julian + Gregorian since 1582-10-15)
+ * which Java classes `java.sql.Date` and `java.sql.Timestamp` are based on.
+ *
  * @since 1.3.0
  */
 @Stable


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Document row field values of `DATE` and `TIMESTAMP` type returned by `Row.get()` and `Row.apply`.
- Refer to `Row.get()` from the description of filter values

### Why are the changes needed?
Reflect current behaviour of Row's method `apply()` and `get()` in comments to inform users about different return types that are depended on the SQL config settings `spark.sql.datetime.java8API.enabled`.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Run `$ ./dev/scalastyle`