### PR TITLE
[SPARK-18886][CORE][FOLLOWUP] fix legacyResetOnTaskLaunch version and method docs

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -550,7 +550,7 @@ package object config {
       "anytime a task is scheduled. See Delay Scheduling section of TaskSchedulerImpl's class " +
       "documentation for more details.")
     .internal()
-    .version("3.0.0")
+    .version("3.1.0")
     .booleanConf
     .createWithDefault(false)
 

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -356,7 +356,7 @@ private[spark] class TaskSchedulerImpl(
    *                           value at index 'i' corresponds to shuffledOffers[i]
    * @param tasks tasks scheduled per offer, value at index 'i' corresponds to shuffledOffers[i]
    * @param addressesWithDescs tasks scheduler per host:port, used for barrier tasks
-   * @return tuple of (had delay schedule rejects?, option of min locality of launched task)
+   * @return tuple of (no delay schedule rejects?, option of min locality of launched task)
    */
   private def resourceOfferSingleTaskSet(
       taskSet: TaskSetManager,


### PR DESCRIPTION
# What changes were proposed in this pull request?
fix version for config spark.locality.wait.legacyResetOnTaskLaunch
fix method return type doc

### Why are the changes needed?
Incorrect docs/versioning for config


### Does this PR introduce any user-facing change?
No


### How was this patch tested?
Tests in PR

@viirya thanks, for catching these. good 👀 
@cloud-fan 
@tgravescs 