### PR TITLE
[SPARK-31364][SQL][TESTS] Benchmark Parquet Nested Field Predicate Pushdown

### DIFF
--- a/sql/core/benchmarks/ParquetNestedPredicatePushDownBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/ParquetNestedPredicatePushDownBenchmark-jdk11-results.txt
@@ -1,20 +1,21 @@
 OpenJDK 64-Bit Server VM 11.0.2+9 on Mac OS X 10.14.6
 Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz
-LoadNoRowGroupsWhenPredicatePushedDown:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+CanSkipAllRowGroupsWithNestedPredicatePushdown:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-NestedFieldsPredicatePushDownDisabled             35852          36874         793          2.9         341.9       1.0X
-NestedFieldsPredicatePushDownEnabled                 85            101          12       1238.9           0.8     423.6X
+Without nested predicate Pushdown                 36379          37296         781          2.9         346.9       1.0X
+With nested predicate Pushdown                       89            100           9       1183.5           0.8     410.6X
 
 OpenJDK 64-Bit Server VM 11.0.2+9 on Mac OS X 10.14.6
 Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz
-LoadSomeRowGroupsWhenPredicatePushedDown:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+CanSkipSomeRowGroupsWithNestedPredicatePushdown:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-NestedFieldsPredicatePushDownDisabled             36277          36626         314          2.9         346.0       1.0X
-NestedFieldsPredicatePushDownEnabled               3714           4513         NaN         28.2          35.4       9.8X
+Without nested predicate Pushdown                 36174          37605         NaN          2.9         345.0       1.0X
+With nested predicate Pushdown                     3653           3684          22         28.7          34.8       9.9X
 
 OpenJDK 64-Bit Server VM 11.0.2+9 on Mac OS X 10.14.6
 Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz
-LoadAllRowGroupsWhenPredicatePushedDown:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+NoRowGroupSkippedWithNestedPredicatePushdown:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-NestedFieldsPredicatePushDownDisabled             44274          46513         586          2.4         422.2       1.0X
-NestedFieldsPredicatePushDownEnabled              45424          46303         NaN          2.3         433.2       1.0X
+Without nested predicate Pushdown                 39290          40747         NaN          2.7         374.7       1.0X
+With nested predicate Pushdown                    38936          39447         587          2.7         371.3       1.0X
+

--- a/sql/core/benchmarks/ParquetNestedPredicatePushDownBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/ParquetNestedPredicatePushDownBenchmark-jdk11-results.txt
@@ -1,0 +1,20 @@
+OpenJDK 64-Bit Server VM 11.0.2+9 on Mac OS X 10.14.6
+Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz
+LoadNoRowGroupsWhenPredicatePushedDown:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+NestedFieldsPredicatePushDownDisabled             35852          36874         793          2.9         341.9       1.0X
+NestedFieldsPredicatePushDownEnabled                 85            101          12       1238.9           0.8     423.6X
+
+OpenJDK 64-Bit Server VM 11.0.2+9 on Mac OS X 10.14.6
+Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz
+LoadSomeRowGroupsWhenPredicatePushedDown:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+NestedFieldsPredicatePushDownDisabled             36277          36626         314          2.9         346.0       1.0X
+NestedFieldsPredicatePushDownEnabled               3714           4513         NaN         28.2          35.4       9.8X
+
+OpenJDK 64-Bit Server VM 11.0.2+9 on Mac OS X 10.14.6
+Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz
+LoadAllRowGroupsWhenPredicatePushedDown:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+NestedFieldsPredicatePushDownDisabled             44274          46513         586          2.4         422.2       1.0X
+NestedFieldsPredicatePushDownEnabled              45424          46303         NaN          2.3         433.2       1.0X

--- a/sql/core/benchmarks/ParquetNestedPredicatePushDownBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/ParquetNestedPredicatePushDownBenchmark-jdk11-results.txt
@@ -1,21 +1,21 @@
 OpenJDK 64-Bit Server VM 11.0.2+9 on Mac OS X 10.14.6
 Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz
-CanSkipAllRowGroupsWithNestedPredicatePushdown:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+Can skip all row groups:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without nested predicate Pushdown                 36379          37296         781          2.9         346.9       1.0X
-With nested predicate Pushdown                       89            100           9       1183.5           0.8     410.6X
+Without nested predicate Pushdown                 34214          35752         NaN          3.1         326.3       1.0X
+With nested predicate Pushdown                       86            102          11       1216.2           0.8     396.8X
 
 OpenJDK 64-Bit Server VM 11.0.2+9 on Mac OS X 10.14.6
 Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz
-CanSkipSomeRowGroupsWithNestedPredicatePushdown:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+Can skip some row groups:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without nested predicate Pushdown                 36174          37605         NaN          2.9         345.0       1.0X
-With nested predicate Pushdown                     3653           3684          22         28.7          34.8       9.9X
+Without nested predicate Pushdown                 34211          35162         843          3.1         326.3       1.0X
+With nested predicate Pushdown                     3470           3514          36         30.2          33.1       9.9X
 
 OpenJDK 64-Bit Server VM 11.0.2+9 on Mac OS X 10.14.6
 Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz
-NoRowGroupSkippedWithNestedPredicatePushdown:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+Can skip no row groups:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without nested predicate Pushdown                 39290          40747         NaN          2.7         374.7       1.0X
-With nested predicate Pushdown                    38936          39447         587          2.7         371.3       1.0X
+Without nested predicate Pushdown                 37533          37919         329          2.8         357.9       1.0X
+With nested predicate Pushdown                    37876          39132         536          2.8         361.2       1.0X
 

--- a/sql/core/benchmarks/ParquetNestedPredicatePushDownBenchmark-results.txt
+++ b/sql/core/benchmarks/ParquetNestedPredicatePushDownBenchmark-results.txt
@@ -1,21 +1,21 @@
 OpenJDK 64-Bit Server VM 1.8.0_252-b09 on Mac OS X 10.14.6
 Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz
-CanSkipAllRowGroupsWithNestedPredicatePushdown:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+Can skip all row groups:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without nested predicate Pushdown                 30955          33020         372          3.4         295.2       1.0X
-With nested predicate Pushdown                       82             92           8       1280.6           0.8     378.0X
+Without nested predicate Pushdown                 30687          31552         NaN          3.4         292.7       1.0X
+With nested predicate Pushdown                      105            150          61        999.3           1.0     292.5X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-b09 on Mac OS X 10.14.6
 Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz
-CanSkipSomeRowGroupsWithNestedPredicatePushdown:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+Can skip some row groups:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without nested predicate Pushdown                 30796          32251         918          3.4         293.7       1.0X
-With nested predicate Pushdown                     3218           3287          55         32.6          30.7       9.6X
+Without nested predicate Pushdown                 30505          31828         NaN          3.4         290.9       1.0X
+With nested predicate Pushdown                     3156           3215          77         33.2          30.1       9.7X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-b09 on Mac OS X 10.14.6
 Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz
-NoRowGroupSkippedWithNestedPredicatePushdown:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+Can skip no row groups:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without nested predicate Pushdown                 35003          36026         989          3.0         333.8       1.0X
-With nested predicate Pushdown                    34945          36033         415          3.0         333.3       1.0X
+Without nested predicate Pushdown                 34475          35302         NaN          3.0         328.8       1.0X
+With nested predicate Pushdown                    34003          34596         567          3.1         324.3       1.0X
 

--- a/sql/core/benchmarks/ParquetNestedPredicatePushDownBenchmark-results.txt
+++ b/sql/core/benchmarks/ParquetNestedPredicatePushDownBenchmark-results.txt
@@ -1,0 +1,21 @@
+OpenJDK 64-Bit Server VM 1.8.0_252-b09 on Mac OS X 10.14.6
+Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz
+LoadNoRowGroupsWhenPredicatePushedDown:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+NestedFieldsPredicatePushDownDisabled             33189          34705         443          3.2         316.5       1.0X
+NestedFieldsPredicatePushDownEnabled                 81             93           8       1291.5           0.8     408.8X
+
+OpenJDK 64-Bit Server VM 1.8.0_252-b09 on Mac OS X 10.14.6
+Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz
+LoadSomeRowGroupsWhenPredicatePushedDown:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+NestedFieldsPredicatePushDownDisabled             33122          34397         901          3.2         315.9       1.0X
+NestedFieldsPredicatePushDownEnabled               3393           3449          54         30.9          32.4       9.8X
+
+OpenJDK 64-Bit Server VM 1.8.0_252-b09 on Mac OS X 10.14.6
+Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz
+LoadAllRowGroupsWhenPredicatePushedDown:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+NestedFieldsPredicatePushDownDisabled             35266          35849         572          3.0         336.3       1.0X
+NestedFieldsPredicatePushDownEnabled              34682          36049         NaN          3.0         330.8       1.0X
+

--- a/sql/core/benchmarks/ParquetNestedPredicatePushDownBenchmark-results.txt
+++ b/sql/core/benchmarks/ParquetNestedPredicatePushDownBenchmark-results.txt
@@ -1,21 +1,21 @@
 OpenJDK 64-Bit Server VM 1.8.0_252-b09 on Mac OS X 10.14.6
 Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz
-LoadNoRowGroupsWhenPredicatePushedDown:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+CanSkipAllRowGroupsWithNestedPredicatePushdown:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-NestedFieldsPredicatePushDownDisabled             33189          34705         443          3.2         316.5       1.0X
-NestedFieldsPredicatePushDownEnabled                 81             93           8       1291.5           0.8     408.8X
+Without nested predicate Pushdown                 30955          33020         372          3.4         295.2       1.0X
+With nested predicate Pushdown                       82             92           8       1280.6           0.8     378.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-b09 on Mac OS X 10.14.6
 Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz
-LoadSomeRowGroupsWhenPredicatePushedDown:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+CanSkipSomeRowGroupsWithNestedPredicatePushdown:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-NestedFieldsPredicatePushDownDisabled             33122          34397         901          3.2         315.9       1.0X
-NestedFieldsPredicatePushDownEnabled               3393           3449          54         30.9          32.4       9.8X
+Without nested predicate Pushdown                 30796          32251         918          3.4         293.7       1.0X
+With nested predicate Pushdown                     3218           3287          55         32.6          30.7       9.6X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-b09 on Mac OS X 10.14.6
 Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz
-LoadAllRowGroupsWhenPredicatePushedDown:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+NoRowGroupSkippedWithNestedPredicatePushdown:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-NestedFieldsPredicatePushDownDisabled             35266          35849         572          3.0         336.3       1.0X
-NestedFieldsPredicatePushDownEnabled              34682          36049         NaN          3.0         330.8       1.0X
+Without nested predicate Pushdown                 35003          36026         989          3.0         333.8       1.0X
+With nested predicate Pushdown                    34945          36033         415          3.0         333.3       1.0X
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ParquetNestedPredicatePushDownBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ParquetNestedPredicatePushDownBenchmark.scala
@@ -39,15 +39,6 @@ object ParquetNestedPredicatePushDownBenchmark extends SqlBasedBenchmark {
   private val N = 100 * 1024 * 1024
   private val NUMBER_OF_ITER = 10
 
-  override def getSparkSession: SparkSession = {
-    val conf = new SparkConf()
-      .setAppName(this.getClass.getSimpleName)
-      // Since `spark.master` always exists, overrides this value
-      .set("spark.master", "local[1]")
-
-    SparkSession.builder().config(conf).getOrCreate()
-  }
-
   private val df: DataFrame = spark
     .range(1, N, 1, 4)
     .toDF("id")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ParquetNestedPredicatePushDownBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ParquetNestedPredicatePushDownBenchmark.scala
@@ -78,6 +78,7 @@ object ParquetNestedPredicatePushDownBenchmark extends SqlBasedBenchmark {
         benchmark.run()
     }
   }
+
   /**
    * Benchmark for sorted data with a filter which allows to filter out all the row groups
    * when nested fields predicate push down enabled
@@ -104,14 +105,12 @@ object ParquetNestedPredicatePushDownBenchmark extends SqlBasedBenchmark {
    * overhead or not if enable nested predicate push down.
    */
   def runLoadAllRowGroupsWhenPredicatePushedDown(): Unit = {
-
     // all row groups will be loaded with a whole range filter
     val filterFn: DataFrame => DataFrame = { df =>
       df.filter("nested.x >= 0").filter(s"nested.x <= $N")
     }
     createAndRunBenchmark("LoadAllRowGroupsWhenPredicatePushedDown", filterFn)
   }
-
 
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
     runLoadNoRowGroupWhenPredicatePushedDown()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ParquetNestedPredicatePushDownBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ParquetNestedPredicatePushDownBenchmark.scala
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.benchmark
+
+import org.apache.spark.SparkConf
+import org.apache.spark.benchmark.Benchmark
+import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Synthetic benchmark for nested fields predicate push down performance for Parquet datasource.
+ * To run this benchmark:
+ * {{{
+ *   1. without sbt:
+ *      bin/spark-submit --class <this class> --jars <spark core test jar> <sql core test jar>
+ *   2. build/sbt "sql/test:runMain <this class>"
+ *   3. generate result:
+ *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/test:runMain <this class>"
+ *      Results will be written to "benchmarks/ParquetNestedPredicatePushDownBenchmark-results.txt".
+ * }}}
+ */
+object ParquetNestedPredicatePushDownBenchmark extends SqlBasedBenchmark {
+
+  private val N = 100 * 1024 * 1024
+  private val NUMBER_OF_ITER = 10
+
+  override def getSparkSession: SparkSession = {
+    val conf = new SparkConf()
+      .setAppName(this.getClass.getSimpleName)
+      // Since `spark.master` always exists, overrides this value
+      .set("spark.master", "local[1]")
+
+    SparkSession.builder().config(conf).getOrCreate()
+  }
+
+  private val df: DataFrame = spark.range(1, N, 1, 4).toDF("id")
+    .selectExpr("id", "STRUCT(id x, STRUCT(CAST(id AS STRING) z) y) nested")
+    .sort("id")
+
+  private def addCase(benchmark: Benchmark, inputPath: String,
+                      enableNestedPD: Boolean,
+                      name: String, filterFn: DataFrame => DataFrame): Unit = {
+    val loadDF = spark.read.parquet(inputPath)
+    benchmark.addCase(name) {
+      _ =>
+        withSQLConf((SQLConf.NESTED_PREDICATE_PUSHDOWN_ENABLED.key,
+          enableNestedPD.toString)) {
+          filterFn(loadDF).noop()
+        }
+    }
+  }
+
+  private def createAndRunBenchmark(name: String, filterFn: DataFrame => DataFrame): Unit = {
+    withTempPath {
+      tempDir =>
+        val outputPath = tempDir.getCanonicalPath
+        df.write.mode(SaveMode.Overwrite).parquet(tempDir.getCanonicalPath)
+        val benchmark = new Benchmark(name, N, NUMBER_OF_ITER, output = output)
+        addCase(benchmark, outputPath, enableNestedPD = false,
+          "NestedFieldsPredicatePushDownDisabled", filterFn)
+        addCase(benchmark, outputPath, enableNestedPD = true,
+          "NestedFieldsPredicatePushDownEnabled", filterFn)
+        benchmark.run()
+    }
+  }
+  /**
+   * Benchmark for sorted data with a filter which allows to filter out all the row groups
+   * when nested fields predicate push down enabled
+   */
+  def runLoadNoRowGroupWhenPredicatePushedDown(): Unit = {
+    // no row group will be loaded when predicate pushed down
+    val filterFn: DataFrame => DataFrame = df => df.filter("nested.x < 0")
+    createAndRunBenchmark("LoadNoRowGroupsWhenPredicatePushedDown", filterFn)
+  }
+
+  /**
+   * Benchmark with a filter which allows to load only some row groups
+   * when nested fields predicate push down enabled
+   */
+  def runLoadSomeRowGroupWhenPredicatePushedDown(): Unit = {
+    // only a row group will be loaded when predicate pushed down
+    val filterFn: DataFrame => DataFrame = df => df.filter("nested.x = 100")
+    createAndRunBenchmark("LoadSomeRowGroupsWhenPredicatePushedDown", filterFn)
+  }
+
+  /**
+   * Benchmark with a filter which still requires to
+   * load all the row groups on sorted data to see if we introduce too much
+   * overhead or not if enable nested predicate push down.
+   */
+  def runLoadAllRowGroupsWhenPredicatePushedDown(): Unit = {
+
+    // all row groups will be loaded with a whole range filter
+    val filterFn: DataFrame => DataFrame = { df =>
+      df.filter("nested.x >= 0").filter(s"nested.x <= $N")
+    }
+    createAndRunBenchmark("LoadAllRowGroupsWhenPredicatePushedDown", filterFn)
+  }
+
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    runLoadNoRowGroupWhenPredicatePushedDown()
+    runLoadSomeRowGroupWhenPredicatePushedDown()
+    runLoadAllRowGroupsWhenPredicatePushedDown()
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a benchmark suite for nested predicate pushdown with parquet file:

Performance comparison: Nested predicate pushdown disabled vs enabled,  with the following queries scenarios:

1.  When predicate pushed down, parquet reader are able to filter out all the row groups without loading them.

2. When predicate pushed down, parquet reader only loads one of the row groups.

3. When predicate pushed down, parquet reader can't filter out any row group in order to see if we introduce too much overhead or not when enabling nested predicate push down. 

### Why are the changes needed?

No benchmark exists today for nested fields predicate pushdown performance evaluation.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
 Benchmark runs and reporting result.