### PR TITLE
[SPARK-31551][CORE] Fix createSparkUser lost user's non-Hadoop credentials

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -64,15 +64,9 @@ private[spark] class SparkHadoopUtil extends Logging {
   }
 
   def createSparkUser(): UserGroupInformation = {
-    val user = Utils.getCurrentUserName()
-    logDebug("creating UGI for user: " + user)
-    val ugi = UserGroupInformation.createRemoteUser(user)
-    transferCredentials(UserGroupInformation.getCurrentUser(), ugi)
+    val ugi = Utils.getCurrentUgi()
+    logDebug("created UGI for user: " + ugi)
     ugi
-  }
-
-  def transferCredentials(source: UserGroupInformation, dest: UserGroupInformation): Unit = {
-    dest.addCredentials(source.getCredentials())
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -842,10 +842,10 @@ private[spark] class SparkSubmit extends Logging {
   // renewer set to the YARN ResourceManager.  Since YARN isn't configured in Mesos or Kubernetes
   // mode, we must trick it into thinking we're YARN.
   private def setRMPrincipal(sparkConf: SparkConf): Unit = {
-    val shortUserName = UserGroupInformation.getCurrentUser.getShortUserName
+    val userName = UserGroupInformation.getCurrentUser.getUserName
     val key = s"spark.hadoop.${YarnConfiguration.RM_PRINCIPAL}"
-    logInfo(s"Setting ${key} to ${shortUserName}")
-    sparkConf.set(key, shortUserName)
+    logInfo(s"Setting ${key} to ${userName}")
+    sparkConf.set(key, userName)
   }
 
   private def getSubmitClassLoader(sparkConf: SparkConf): MutableURLClassLoader = {

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2408,8 +2408,19 @@ private[spark] object Utils extends Logging {
    * overridden by the `SPARK_USER` environment variable.
    */
   def getCurrentUserName(): String = {
-    Option(System.getenv("SPARK_USER"))
-      .getOrElse(UserGroupInformation.getCurrentUser().getShortUserName())
+    getCurrentUgi().getShortUserName()
+  }
+
+  def getCurrentUgi(): UserGroupInformation = {
+    val effectiveUser = System.getenv("SPARK_USER")
+    val currentUgi = UserGroupInformation.getCurrentUser()
+
+    if (effectiveUser == null ||
+      effectiveUser.equals(currentUgi.getUserName())) {
+      return currentUgi
+    } else {
+      return UserGroupInformation.createProxyUser(effectiveUser, currentUgi)
+    }
   }
 
   val EMPTY_USER_GROUPS = Set.empty[String]

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2419,7 +2419,11 @@ private[spark] object Utils extends Logging {
       effectiveUser.equals(currentUgi.getUserName())) {
       return currentUgi
     } else {
-      return UserGroupInformation.createProxyUser(effectiveUser, currentUgi)
+      val proxyUser = UserGroupInformation.createProxyUser(effectiveUser, currentUgi)
+      // Also clone Hadoop Delegation Token to effectiveUser, as Hadoop RPC client
+      // does not pick the Hadoop Delegation Token from realUser (currentUgi).
+      proxyUser.addCredentials(currentUgi.getCredentials())
+      return proxyUser
     }
   }
 

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -803,7 +803,7 @@ private[spark] class Client(
     val env = new HashMap[String, String]()
     populateClasspath(args, hadoopConf, sparkConf, env, sparkConf.get(DRIVER_CLASS_PATH))
     env("SPARK_YARN_STAGING_DIR") = stagingDirPath.toString
-    env("SPARK_USER") = UserGroupInformation.getCurrentUser().getShortUserName()
+    env("SPARK_USER") = UserGroupInformation.getCurrentUser().getUserName()
 
     // Pick up any environment variables for the AM provided through spark.yarn.appMasterEnv.*
     val amEnvPrefix = "spark.yarn.appMasterEnv."


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Using createProxyUser to avoid lost any subject creds.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
See https://issues.apache.org/jira/browse/SPARK-31551

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
Yes, after this change, the UGI, including all its creds, provided by current user will be used to authn.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Yes
