### PR TITLE
[SPARK-31377][SQL][TEST] Added unit tests to 'number of output rows metric' for some joins in SQLMetricSuite

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -390,13 +390,13 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils
           "testData2.a * testDataForJoin.a != testData2.a + testDataForJoin.a"
         Seq((leftQuery, false), (rightQuery, false), (leftQuery, true), (rightQuery, true))
           .foreach { case (query, enableWholeStage) =>
-            val df = spark.sql(query)
-            testSparkPlanMetrics(df, 2, Map(
-              0L -> (("BroadcastNestedLoopJoin", Map(
-                "number of output rows" -> 12L)))),
-              enableWholeStage
-            )
-          }
+          val df = spark.sql(query)
+          testSparkPlanMetrics(df, 2, Map(
+            0L -> (("BroadcastNestedLoopJoin", Map(
+              "number of output rows" -> 12L)))),
+            enableWholeStage
+          )
+        }
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -372,14 +372,12 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils
     // Assume the execution plan is
     // ... -> BroadcastHashJoin(nodeId = 0)
     Seq(("left_outer", 0L, 5L, false), ("right_outer", 0L, 6L, false), ("left_outer", 1L, 5L, true),
-      ("right_outer", 1L, 6L, true)).foreach {
-      case (joinType, nodeId, numRows, enableWholeStage) =>
-        val df = df1.join(broadcast(df2), $"key" === $"key2", joinType)
-        testSparkPlanMetrics(df, 2, Map(
-          nodeId -> (("BroadcastHashJoin", Map(
-            "number of output rows" -> numRows)))),
-          enableWholeStage
-        )
+      ("right_outer", 1L, 6L, true)).foreach { case (joinType, nodeId, numRows, enableWholeStage) =>
+      val df = df1.join(broadcast(df2), $"key" === $"key2", joinType)
+      testSparkPlanMetrics(df, 2, Map(
+        nodeId -> (("BroadcastHashJoin", Map("number of output rows" -> numRows)))),
+        enableWholeStage
+      )
     }
   }
 
@@ -590,9 +588,9 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils
 
   test("SPARK-25602: SparkPlan.getByteArrayRdd should not consume the input when not necessary") {
     def checkFilterAndRangeMetrics(
-                                    df: DataFrame,
-                                    filterNumOutputs: Int,
-                                    rangeNumOutputs: Int): Unit = {
+        df: DataFrame,
+        filterNumOutputs: Int,
+        rangeNumOutputs: Int): Unit = {
       val plan = df.queryExecution.executedPlan
 
       val filters = collectNodeWithinWholeStage[FilterExec](plan)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add unit tests to the 'number of output rows metric' for some join types in the SQLMetricSuite. A list of unit tests added are as follows.
- ShuffledHashJoin: leftOuter, RightOuter, LeftAnti, LeftSemi
- BroadcastNestedLoopJoin: RightOuter
- BroadcastHashJoin: LeftAnti


### Why are the changes needed?
For some combinations of JoinType and Join algorithm there is no test coverage for the 'number of output rows' metric.

### Does this PR introduce any user-facing change?
No


### How was this patch tested?
I added debug statements in the code to ensure the correct combination if JoinType and Join algorithms are triggered.
I further used Intellij debugger to test the same.
