### PR TITLE
[SPARK-31557][SQL] Legacy time parser should return Gregorian days rather than Julian days

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateFormatter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateFormatter.scala
@@ -66,7 +66,8 @@ trait LegacyDateFormatter extends DateFormatter {
   def formatDate(d: Date): String
 
   override def parse(s: String): Int = {
-    val micros = DateTimeUtils.millisToMicros(parseToDate(s).getTime)
+    val julianMicros = DateTimeUtils.millisToMicros(parseToDate(s).getTime)
+    val micros = RebaseDateTime.rebaseJulianToGregorianMicros(julianMicros)
     DateTimeUtils.microsToDays(micros)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateFormatter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateFormatter.scala
@@ -66,9 +66,9 @@ trait LegacyDateFormatter extends DateFormatter {
   def formatDate(d: Date): String
 
   override def parse(s: String): Int = {
-    val micros = DateTimeUtils.millisToMicros(parseToDate(s).getTime)
-    val julianDays = DateTimeUtils.microsToDays(micros)
-    RebaseDateTime.rebaseJulianToGregorianDays(julianDays)
+    val julianMicros = DateTimeUtils.millisToMicros(parseToDate(s).getTime)
+    val micros = RebaseDateTime.rebaseJulianToGregorianMicros(julianMicros)
+    DateTimeUtils.microsToDays(micros)
   }
 
   override def format(days: Int): String = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateFormatter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateFormatter.scala
@@ -66,9 +66,9 @@ trait LegacyDateFormatter extends DateFormatter {
   def formatDate(d: Date): String
 
   override def parse(s: String): Int = {
-    val julianMicros = DateTimeUtils.millisToMicros(parseToDate(s).getTime)
-    val micros = RebaseDateTime.rebaseJulianToGregorianMicros(julianMicros)
-    DateTimeUtils.microsToDays(micros)
+    val micros = DateTimeUtils.millisToMicros(parseToDate(s).getTime)
+    val julianDays = DateTimeUtils.microsToDays(micros)
+    RebaseDateTime.rebaseJulianToGregorianDays(julianDays)
   }
 
   override def format(days: Int): String = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateFormatter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateFormatter.scala
@@ -66,9 +66,7 @@ trait LegacyDateFormatter extends DateFormatter {
   def formatDate(d: Date): String
 
   override def parse(s: String): Int = {
-    val julianMicros = DateTimeUtils.millisToMicros(parseToDate(s).getTime)
-    val micros = RebaseDateTime.rebaseJulianToGregorianMicros(julianMicros)
-    DateTimeUtils.microsToDays(micros)
+    fromJavaDate(new java.sql.Date(parseToDate(s).getTime))
   }
 
   override def format(days: Int): String = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/util/DateFormatterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/util/DateFormatterSuite.scala
@@ -49,12 +49,12 @@ class DateFormatterSuite extends SparkFunSuite with SQLHelper {
 
   test("roundtrip date -> days -> date") {
     LegacyBehaviorPolicy.values.foreach { parserPolicy =>
-      withSQLConf("spark.sql.legacy.timeParserPolicy" -> parserPolicy.toString) {
+      withSQLConf(SQLConf.LEGACY_TIME_PARSER_POLICY.key -> parserPolicy.toString) {
         Seq(
           "0050-01-01",
           "0953-02-02",
-          "1582-10-15",
           "1423-03-08",
+          "1582-10-15",
           "1969-12-31",
           "1972-08-25",
           "1975-09-26",

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/util/DateFormatterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/util/DateFormatterSuite.scala
@@ -76,7 +76,7 @@ class DateFormatterSuite extends SparkFunSuite with SQLHelper {
 
   test("roundtrip days -> date -> days") {
     LegacyBehaviorPolicy.values.foreach { parserPolicy =>
-      withSQLConf("spark.sql.legacy.timeParserPolicy" -> parserPolicy.toString) {
+      withSQLConf(SQLConf.LEGACY_TIME_PARSER_POLICY.key -> parserPolicy.toString) {
         Seq(
           -701265,
           -371419,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR modifies LegacyDateFormatter#parse to return proleptic Gregorian days rather than hybrid Julian days.

### Why are the changes needed?

The legacy time parser currently returns epoch days in the hybrid Julian calendar. However, the callers to the legacy parser (e.g., UnivocityParser, JacksonParser) expect epoch days in the proleptic Gregorian calendar. As a result, pre-Gregorian dates like '1000-01-01' get interpreted as '1000-01-06'.

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

Manual testing and modified existing unit tests.
