### PR TITLE
[SPARK-31500][SQL] collect_set() of BinaryType returns duplicate elements

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/collect.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/collect.scala
@@ -46,13 +46,15 @@ abstract class Collect[T <: Growable[Any] with Iterable[Any]] extends TypedImper
   // actual order of input rows.
   override lazy val deterministic: Boolean = false
 
+  def getValueOnUpdate(value: Any): Any = InternalRow.copyValue(value)
+
   override def update(buffer: T, input: InternalRow): T = {
     val value = child.eval(input)
 
     // Do not allow null values. We follow the semantics of Hive's collect_list/collect_set here.
     // See: org.apache.hadoop.hive.ql.udf.generic.GenericUDAFMkCollectionEvaluator
     if (value != null) {
-      buffer += InternalRow.copyValue(value)
+      buffer += getValueOnUpdate(value)
     }
     buffer
   }
@@ -65,8 +67,10 @@ abstract class Collect[T <: Growable[Any] with Iterable[Any]] extends TypedImper
     new GenericArrayData(buffer.toArray)
   }
 
+  lazy val typeChild = child.dataType
+
   private lazy val projection = UnsafeProjection.create(
-    Array[DataType](ArrayType(elementType = child.dataType, containsNull = false)))
+    Array[DataType](ArrayType(elementType = typeChild, containsNull = false)))
   private lazy val row = new UnsafeRow(1)
 
   override def serialize(obj: T): Array[Byte] = {
@@ -77,7 +81,7 @@ abstract class Collect[T <: Growable[Any] with Iterable[Any]] extends TypedImper
   override def deserialize(bytes: Array[Byte]): T = {
     val buffer = createAggregationBuffer()
     row.pointTo(bytes, bytes.length)
-    row.getArray(0).foreach(child.dataType, (_, x: Any) => buffer += x)
+    row.getArray(0).foreach(typeChild, (_, x: Any) => buffer += x)
     buffer
   }
 }
@@ -139,19 +143,27 @@ case class CollectSet(
 
   def this(child: Expression) = this(child, 0, 0)
 
+  /* SPARK-31500
+   * Array[Byte](BinaryType) Scala equality don't works as expected
+   * so HashSet return duplicates, we have to change types to drop
+   * this duplicates and make collect_set work as expected for this
+   * data type
+   */
+  override lazy val typeChild = child.dataType match {
+    case BinaryType => ArrayType(BinaryType)
+    case other => other
+  }
+
+  override def getValueOnUpdate(value: Any): Any = InternalRow.copyValue(value) match {
+    case v: Array[Byte] => UnsafeArrayData.fromPrimitiveArray(v)
+    case other => other
+  }
+
   override def eval(buffer: mutable.HashSet[Any]): Any = {
-    /* SPARK-31500
-     * Array[Byte](BinaryType) Scala equality don't works as expected
-     * so HashSet return duplicates, we have to change types to drop
-     * this duplicates and make collect_set work as expected for this
-     * data type
-     * */
     val bufferUpdated: mutable.HashSet[Any] =
-      buffer match {
-        case b if b.exists(_.isInstanceOf[Array[Byte]]) =>
-          b.map(_.asInstanceOf[Array[Byte]].toSeq)
-            .map(_.asInstanceOf[mutable.WrappedArray[Byte]].toArray)
-        case other => other
+      child.dataType match {
+        case BinaryType => buffer.map(_.asInstanceOf[UnsafeArrayData].toByteArray)
+        case _ => buffer
       }
     super.eval(bufferUpdated)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/collect.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/collect.scala
@@ -155,10 +155,9 @@ case class CollectSet(
 
   override def convertToBufferElement(value: Any): Any = child.dataType match {
     /*
-     * SPARK-31500
      * collect_set() of BinaryType should not return duplicate elements,
      * Java byte arrays use referential equality and identity hash codes
-     * so we need to use a different Scala object
+     * so we need to use a different catalyst value for arrays
      */
     case BinaryType => UnsafeArrayData.fromPrimitiveArray(value.asInstanceOf[Array[Byte]])
     case _ => InternalRow.copyValue(value)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/collect.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/collect.scala
@@ -105,7 +105,7 @@ case class CollectList(
 
   def this(child: Expression) = this(child, 0, 0)
 
-  override val bufferElementType = child.dataType
+  override lazy val bufferElementType = child.dataType
 
   override def convertToBufferElement(value: Any): Any = InternalRow.copyValue(value)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/collect.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/collect.scala
@@ -149,7 +149,7 @@ case class CollectSet(
   def this(child: Expression) = this(child, 0, 0)
 
   override lazy val bufferElementType = child.dataType match {
-    case BinaryType => ArrayType(BinaryType)
+    case BinaryType => ArrayType(ByteType)
     case other => other
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -534,9 +534,7 @@ class DataFrameAggregateSuite extends QueryTest
     val bytesTest1 = "test1".getBytes
     val bytesTest2 = "test2".getBytes
     val df = Seq(bytesTest1, bytesTest1, bytesTest2).toDF("a")
-    val ret = df.select(collect_set($"a")).collect()
-      .map(r => r.getAs[Seq[_]](0)).head
-    assert(ret.length == 2)
+    checkAnswer(df.select(size(collect_set($"a"))), Row(2) :: Nil)
 
     val a = "aa".getBytes
     val b = "bb".getBytes
@@ -545,9 +543,7 @@ class DataFrameAggregateSuite extends QueryTest
     val df1 = Seq((a, b), (a, b), (c, d))
       .toDF("x", "y")
       .select(struct($"x", $"y").as("a"))
-    val ret1 = df1.select(collect_set($"a")).collect()
-      .map(r => r.getAs[Seq[_]](0)).head
-    assert(ret1.length == 2)
+    checkAnswer(df1.select(size(collect_set($"a"))), Row(2) :: Nil)
   }
 
   test("collect_set functions cannot have maps") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql
 
-import scala.collection.mutable
 import scala.util.Random
 
 import org.scalatest.Matchers.the

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql
 
+import scala.collection.mutable
 import scala.util.Random
 
 import org.scalatest.Matchers.the
@@ -32,8 +33,6 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.test.SQLTestData.DecimalData
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.CalendarInterval
-
-import scala.collection.mutable
 
 case class Fact(date: Int, hour: Int, minute: Int, room_name: String, temp: Double)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

The collect_set() aggregate function should produce a set of distinct elements. When the column argument's type is BinayType this is not the case.

Example:
```scala
import org.apache.spark.sql.functions._
import org.apache.spark.sql.expressions.Window

case class R(id: String, value: String, bytes: Array[Byte])
def makeR(id: String, value: String) = R(id, value, value.getBytes)
val df = Seq(makeR("a", "dog"), makeR("a", "cat"), makeR("a", "cat"), makeR("b", "fish")).toDF()
// In the example below "bytesSet" erroneously has duplicates but "stringSet" does not (as expected).
df.agg(collect_set('value) as "stringSet", collect_set('bytes) as "byteSet").show(truncate=false)
// The same problem is displayed when using window functions.
val win = Window.partitionBy('id).rowsBetween(Window.unboundedPreceding, Window.unboundedFollowing)
val result = df.select(
  collect_set('value).over(win) as "stringSet",
  collect_set('bytes).over(win) as "bytesSet"
)
.select('stringSet, 'bytesSet, size('stringSet) as "stringSetSize", size('bytesSet) as "bytesSetSize")
.show()
```

We use a HashSet buffer to accumulate the results, the problem is that arrays equality in Scala don't behave as expected, arrays ara just plain java arrays and the equality don't compare the content of the arrays
Array(1, 2, 3) == Array(1, 2, 3)  => False
The result is that duplicates are not removed in the hashset

The solution proposed is that in the last stage, when we have all the data in the Hashset buffer, we delete duplicates changing the type of the elements and then transform it to the original type.
This transformation is only applied when we have a BinaryType


### Why are the changes needed?
Fix the bug explained

### Does this PR introduce any user-facing change?
Yes. Now `collect_set()` correctly deduplicates array of byte. 

### How was this patch tested?
Unit testing