### PR TITLE
[WIP] Use R 4.0.0 in AppVeyor for Apache Spark 3.1.0

### DIFF
--- a/dev/appveyor-install-dependencies.ps1
+++ b/dev/appveyor-install-dependencies.ps1
@@ -50,7 +50,10 @@ Function InstallR {
 
 Function InstallRtools {
   $rtoolsver = $rToolsVer.Split('.')[0..1] -Join ''
-  $rtoolsurl = $CRAN + "/bin/windows/Rtools/Rtools$rtoolsver.exe"
+  $rtoolsurl = $CRAN + "/bin/windows/Rtools/Rtools$rtoolsver-x86_64.exe"
+  # R Tools 4.0 is not on cloud.r-project.org yet
+  $rtoolsurl = "https://cran.r-project.org/bin/windows/Rtools/Rtools$rtoolsver-x86_64.exe"
+  echo $rtoolsurl
 
   # Downloading Rtools
   Start-FileDownload $rtoolsurl "Rtools-current.exe"
@@ -115,8 +118,8 @@ $env:Path += ";$env:HADOOP_HOME\bin"
 Pop-Location
 
 # ========================== R
-$rVer = "3.6.2"
-$rToolsVer = "3.5.1"
+$rVer = "4.0.0"
+$rToolsVer = "4.0.0"
 
 InstallR
 InstallRtools

--- a/dev/appveyor-install-dependencies.ps1
+++ b/dev/appveyor-install-dependencies.ps1
@@ -52,7 +52,7 @@ Function InstallRtools {
   $rtoolsver = $rToolsVer.Split('.')[0..1] -Join ''
   $rtoolsurl = $CRAN + "/bin/windows/Rtools/Rtools$rtoolsver-x86_64.exe"
   # R Tools 4.0 is not on cloud.r-project.org yet
-  $rtoolsurl = "https://cran.r-project.org/bin/windows/Rtools/Rtools$rtoolsver-x86_64.exe"
+  $rtoolsurl = "https://cran.r-project.org/bin/windows/Rtools/rtools$rtoolsver-x86_64.exe"
   echo $rtoolsurl
 
   # Downloading Rtools


### PR DESCRIPTION
### What changes were proposed in this pull request?

This aims to see the readiness for R 4.0.0 at Apache Spark 3.1.0.

### Why are the changes needed?

R 4.0.0 is released on April 24th, 2020.
- https://stat.ethz.ch/pipermail/r-announce/2020/000653.html

### Does this PR introduce any user-facing change?

No. (This PR aims to test R 4.0.0 in AppVeyor environment.)

### How was this patch tested?

See the AppVeyor result.