### PR TITLE
[SPARK-31566][SQL][DOCS] Add SQL Rest API Documentation

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,5 +1,3 @@
-
-
 ---
 layout: global
 title: Monitoring and Instrumentation

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -548,7 +548,7 @@ can be identified by their `[attempt-id]`. In the API listed below, when running
     <td><code>/applications/[app-id]/sql</code></td>
     <td>A list of all queries for a given application.
     <br>
-    <code>?details=[true (default) | false]</code> lists metric details in addition to queries details.
+    <code>?details=[true (default) | false]</code> lists/hides details of Spark plan nodes.
     <br>
     <code>?planDescription=[true (default) | false]</code> enables/disables Physical <code>planDescription</code> on demand when Physical Plan size is high.
     <br>

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,3 +1,5 @@
+
+
 ---
 layout: global
 title: Monitoring and Instrumentation
@@ -543,6 +545,24 @@ can be identified by their `[attempt-id]`. In the API listed below, when running
   <tr>
     <td><code>/applications/[app-id]/streaming/batches/[batch-id]/operations/[outputOp-id]</code></td>
     <td>Details of the given operation and given batch.</td>
+  </tr>
+  <tr>
+    <td><code>/applications/[app-id]/sql</code></td>
+    <td>A list of all queries for a given application.
+    <br>
+    <code>?details=[true|false (default)]</code> lists metric details in addition to queries details.
+    <br>
+    <code>?details=true&planDescription=[true (default)|false]</code> enables/disables Physical <code>planDescription</code> on demand when Physical Plan size is high.
+    <br>
+    <code>?offset=[offset]&length=[len]</code> lists queries in the given range.
+  </tr>
+  <tr>
+    <td><code>/applications/[app-id]/sql/[execution-id]</code></td>
+    <td>Details for the given query.
+    <br>
+    <code>?details=[true|false (default)]</code> lists metric details in addition to given query details.
+    <br>
+    <code>?details=true&planDescription=[true (default)|false]</code> enables/disables Physical <code>planDescription</code> on demand for the given query when Physical Plan size is high.
   </tr>
   <tr>
     <td><code>/applications/[app-id]/environment</code></td>

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -558,7 +558,7 @@ can be identified by their `[attempt-id]`. In the API listed below, when running
     <td><code>/applications/[app-id]/sql/[execution-id]</code></td>
     <td>Details for the given query.
     <br>
-    <code>?details=[true (default) | false]</code> lists metric details in addition to given query details.
+    <code>?details=[true (default) | false]</code> lists/hides metric details in addition to given query details.
     <br>
     <code>?planDescription=[true (default) | false]</code> enables/disables Physical <code>planDescription</code> on demand for the given query when Physical Plan size is high.
   </tr>

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -548,9 +548,9 @@ can be identified by their `[attempt-id]`. In the API listed below, when running
     <td><code>/applications/[app-id]/sql</code></td>
     <td>A list of all queries for a given application.
     <br>
-    <code>?details=[true|false (default)]</code> lists metric details in addition to queries details.
+    <code>?details=[true (default) | false]</code> lists metric details in addition to queries details.
     <br>
-    <code>?details=true&planDescription=[true (default)|false]</code> enables/disables Physical <code>planDescription</code> on demand when Physical Plan size is high.
+    <code>?planDescription=[true (default) | false]</code> enables/disables Physical <code>planDescription</code> on demand when Physical Plan size is high.
     <br>
     <code>?offset=[offset]&length=[len]</code> lists queries in the given range.
   </tr>
@@ -558,9 +558,9 @@ can be identified by their `[attempt-id]`. In the API listed below, when running
     <td><code>/applications/[app-id]/sql/[execution-id]</code></td>
     <td>Details for the given query.
     <br>
-    <code>?details=[true|false (default)]</code> lists metric details in addition to given query details.
+    <code>?details=[true (default) | false]</code> lists metric details in addition to given query details.
     <br>
-    <code>?details=true&planDescription=[true (default)|false]</code> enables/disables Physical <code>planDescription</code> on demand for the given query when Physical Plan size is high.
+    <code>?planDescription=[true (default) | false]</code> enables/disables Physical <code>planDescription</code> on demand for the given query when Physical Plan size is high.
   </tr>
   <tr>
     <td><code>/applications/[app-id]/environment</code></td>


### PR DESCRIPTION
### What changes were proposed in this pull request?
SQL Rest API exposes query execution details and metrics as Public API. Its documentation will be useful for the end-users.

### Why are the changes needed?
SQL Rest API does not exist under Spark Rest API.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Manually build and check