### PR TITLE
[SPARK-31575][SQL] Synchronise global JVM security configuration modification

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/DB2ConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/DB2ConnectionProvider.scala
@@ -48,7 +48,7 @@ private[sql] class DB2ConnectionProvider(driver: Driver, options: JDBCOptions)
     result
   }
 
-  override def setAuthenticationConfigIfNeeded(): Unit = {
+  override def setAuthenticationConfigIfNeeded(): Unit = SecurityConfigurationLock.synchronized {
     val (parent, configEntry) = getConfigWithAppEntry()
     if (configEntry == null || configEntry.isEmpty) {
       setAuthenticationConfig(parent)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/MariaDBConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/MariaDBConnectionProvider.scala
@@ -27,7 +27,7 @@ private[jdbc] class MariaDBConnectionProvider(driver: Driver, options: JDBCOptio
     "Krb5ConnectorContext"
   }
 
-  override def setAuthenticationConfigIfNeeded(): Unit = {
+  override def setAuthenticationConfigIfNeeded(): Unit = SecurityConfigurationLock.synchronized {
     val (parent, configEntry) = getConfigWithAppEntry()
     /**
      * Couple of things to mention here:

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProvider.scala
@@ -30,7 +30,7 @@ private[jdbc] class PostgresConnectionProvider(driver: Driver, options: JDBCOpti
     properties.getProperty("jaasApplicationName", "pgjdbc")
   }
 
-  override def setAuthenticationConfigIfNeeded(): Unit = {
+  override def setAuthenticationConfigIfNeeded(): Unit = SecurityConfigurationLock.synchronized {
     val (parent, configEntry) = getConfigWithAppEntry()
     if (configEntry == null || configEntry.isEmpty) {
       setAuthenticationConfig(parent)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/SecureConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/SecureConnectionProvider.scala
@@ -26,6 +26,12 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 import org.apache.spark.util.SecurityUtils
 
+/**
+ * Some of the secure connection providers modify global JVM security configuration.
+ * In order to avoid race the modification must be synchronized with this.
+ */
+private[connection] object SecurityConfigurationLock
+
 private[jdbc] abstract class SecureConnectionProvider(driver: Driver, options: JDBCOptions)
     extends BasicConnectionProvider(driver, options) with Logging {
   override def getConnection(): Connection = {
@@ -40,7 +46,8 @@ private[jdbc] abstract class SecureConnectionProvider(driver: Driver, options: J
 
   /**
    * Sets database specific authentication configuration when needed. If configuration already set
-   * then later calls must be no op.
+   * then later calls must be no op. When the global JVM security configuration changed then the
+   * related code parts must be synchronized properly.
    */
   def setAuthenticationConfigIfNeeded(): Unit
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProviderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProviderSuite.scala
@@ -20,14 +20,6 @@ package org.apache.spark.sql.execution.datasources.jdbc.connection
 import javax.security.auth.login.Configuration
 
 class ConnectionProviderSuite extends ConnectionProviderSuiteBase {
-  override def afterEach(): Unit = {
-    try {
-      Configuration.setConfiguration(null)
-    } finally {
-      super.afterEach()
-    }
-  }
-
   test("Multiple security configs must be reachable") {
     Configuration.setConfiguration(null)
     val postgresDriver = registerDriver(PostgresConnectionProvider.driverClass)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProviderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProviderSuite.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.jdbc.connection
+
+import javax.security.auth.login.Configuration
+
+class ConnectionProviderSuite extends ConnectionProviderSuiteBase {
+  override def afterEach(): Unit = {
+    try {
+      Configuration.setConfiguration(null)
+    } finally {
+      super.afterEach()
+    }
+  }
+
+  test("Multiple security configs must be reachable") {
+    Configuration.setConfiguration(null)
+    val postgresDriver = registerDriver(PostgresConnectionProvider.driverClass)
+    val postgresProvider = new PostgresConnectionProvider(
+      postgresDriver, options("jdbc:postgresql://localhost/postgres"))
+    val db2Driver = registerDriver(DB2ConnectionProvider.driverClass)
+    val db2Provider = new DB2ConnectionProvider(db2Driver, options("jdbc:db2://localhost/db2"))
+
+    // Make sure no authentication for the databases are set
+    val oldConfig = Configuration.getConfiguration
+    assert(oldConfig.getAppConfigurationEntry(postgresProvider.appEntry) == null)
+    assert(oldConfig.getAppConfigurationEntry(db2Provider.appEntry) == null)
+
+    postgresProvider.setAuthenticationConfigIfNeeded()
+    db2Provider.setAuthenticationConfigIfNeeded()
+
+    // Make sure authentication for the databases are set
+    val newConfig = Configuration.getConfiguration
+    assert(oldConfig != newConfig)
+    assert(newConfig.getAppConfigurationEntry(postgresProvider.appEntry) != null)
+    assert(newConfig.getAppConfigurationEntry(db2Provider.appEntry) != null)
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
There is a race in secure JDBC connection providers. Namely multiple providers can read and/or write the exact same JVM security configuration at the same time. In this PR I've synchronised them with an object class. Since the configuration read and write takes couple of milliseconds it won't cause performance degradation.

### Why are the changes needed?
There is a race in secure JDBC connection providers.

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
Existing unit + integration tests.
