### PR TITLE
[SPARK-31527][SQL][TESTS][FOLLOWUP] Add a benchmark test for datetime add/subtract interval operations

### DIFF
--- a/sql/core/benchmarks/DateTimeBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-jdk11-results.txt
@@ -4,87 +4,20 @@ datetime +/- interval
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
-date + interval(m):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+datetime +/- interval:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date + interval(m) wholestage off                   928            943          22         10.8          92.8       1.0X
-date + interval(m) wholestage on                    880            894          16         11.4          88.0       1.1X
-
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
-date + interval(m, d):                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------
-date + interval(m, d) wholestage off                962            964           4         10.4          96.2       1.0X
-date + interval(m, d) wholestage on                 907            932          16         11.0          90.7       1.1X
-
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
-date + interval(m, d, ms):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------
-date + interval(m, d, ms) wholestage off           3854           3891          52          2.6         385.4       1.0X
-date + interval(m, d, ms) wholestage on            3774           3807          18          2.6         377.4       1.0X
-
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
-date - interval(m):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------
-date - interval(m) wholestage off                   912            916           6         11.0          91.2       1.0X
-date - interval(m) wholestage on                    859            880          20         11.6          85.9       1.1X
-
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
-date - interval(m, d):                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------
-date - interval(m, d) wholestage off                965            971           8         10.4          96.5       1.0X
-date - interval(m, d) wholestage on                 908            913           4         11.0          90.8       1.1X
-
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
-date - interval(m, d, ms):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------
-date - interval(m, d, ms) wholestage off           3937           3939           4          2.5         393.7       1.0X
-date - interval(m, d, ms) wholestage on            3849           3865          16          2.6         384.9       1.0X
-
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
-timestamp + interval(m):                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------
-timestamp + interval(m) wholestage off             1963           1978          21          5.1         196.3       1.0X
-timestamp + interval(m) wholestage on              1955           1978          22          5.1         195.5       1.0X
-
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
-timestamp + interval(m, d):               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------
-timestamp + interval(m, d) wholestage off           2046           2052           9          4.9         204.6       1.0X
-timestamp + interval(m, d) wholestage on           2021           2033          12          4.9         202.1       1.0X
-
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
-timestamp + interval(m, d, ms):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------
-timestamp + interval(m, d, ms) wholestage off           2212           2216           6          4.5         221.2       1.0X
-timestamp + interval(m, d, ms) wholestage on           2188           2210          23          4.6         218.8       1.0X
-
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
-timestamp - interval(m):                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------
-timestamp - interval(m) wholestage off             1970           1971           1          5.1         197.0       1.0X
-timestamp - interval(m) wholestage on              1968           1986          12          5.1         196.8       1.0X
-
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
-timestamp - interval(m, d):               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------
-timestamp - interval(m, d) wholestage off           2036           2049          18          4.9         203.6       1.0X
-timestamp - interval(m, d) wholestage on           2025           2038           8          4.9         202.5       1.0X
-
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
-timestamp - interval(m, d, ms):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------
-timestamp - interval(m, d, ms) wholestage off           2236           2279          61          4.5         223.6       1.0X
-timestamp - interval(m, d, ms) wholestage on           2197           2216          14          4.6         219.7       1.0X
+date + interval(m)                                  919            933          22          0.0   306237514.3       1.0X
+date + interval(m, d)                               910            916           9          0.0   303338619.0       1.0X
+date + interval(m, d, ms)                          3912           3923          16          0.0  1303942791.7       0.2X
+date - interval(m)                                  883            887           6          0.0   294268789.3       1.0X
+date - interval(m, d)                               898            911          18          0.0   299453403.0       1.0X
+date - interval(m, d, ms)                          3937           3944          11          0.0  1312269472.0       0.2X
+timestamp + interval(m)                            2226           2236          14          0.0   741972014.3       0.4X
+timestamp + interval(m, d)                         2264           2274          13          0.0   754709121.0       0.4X
+timestamp + interval(m, d, ms)                     2202           2223          30          0.0   734001075.0       0.4X
+timestamp - interval(m)                            1992           2005          17          0.0   664152744.7       0.5X
+timestamp - interval(m, d)                         2069           2075           9          0.0   689631159.0       0.4X
+timestamp - interval(m, d, ms)                     2240           2244           6          0.0   746538728.0       0.4X
 
 
 ================================================================================================
@@ -95,92 +28,92 @@ Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    184            191          10         54.3          18.4       1.0X
-cast to timestamp wholestage on                     180            186           6         55.5          18.0       1.0X
+cast to timestamp wholestage off                    178            180           3         56.1          17.8       1.0X
+cast to timestamp wholestage on                     189            192           4         53.0          18.9       0.9X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                    736            745          12         13.6          73.6       1.0X
-year of timestamp wholestage on                     715            730          17         14.0          71.5       1.0X
+year of timestamp wholestage off                    760            761           1         13.2          76.0       1.0X
+year of timestamp wholestage on                     731            741          10         13.7          73.1       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                 976            986          15         10.2          97.6       1.0X
-quarter of timestamp wholestage on                  948            957           7         10.5          94.8       1.0X
+quarter of timestamp wholestage off                1005           1013          10          9.9         100.5       1.0X
+quarter of timestamp wholestage on                  981            986           3         10.2          98.1       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                   745            748           4         13.4          74.5       1.0X
-month of timestamp wholestage on                    714            727           8         14.0          71.4       1.0X
+month of timestamp wholestage off                   754            758           6         13.3          75.4       1.0X
+month of timestamp wholestage on                    719            729          11         13.9          71.9       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off             1156           1166          15          8.6         115.6       1.0X
-weekofyear of timestamp wholestage on              1064           1079           8          9.4         106.4       1.1X
+weekofyear of timestamp wholestage off             1085           1088           4          9.2         108.5       1.0X
+weekofyear of timestamp wholestage on              1075           1091          13          9.3         107.5       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                     745            761          23         13.4          74.5       1.0X
-day of timestamp wholestage on                      721            724           2         13.9          72.1       1.0X
+day of timestamp wholestage off                     751            770          27         13.3          75.1       1.0X
+day of timestamp wholestage on                      735            741           7         13.6          73.5       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off               767            767           1         13.0          76.7       1.0X
-dayofyear of timestamp wholestage on                737            744           4         13.6          73.7       1.0X
+dayofyear of timestamp wholestage off               765            769           5         13.1          76.5       1.0X
+dayofyear of timestamp wholestage on                762            770           7         13.1          76.2       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off              760            763           4         13.2          76.0       1.0X
-dayofmonth of timestamp wholestage on               712            719           4         14.0          71.2       1.1X
+dayofmonth of timestamp wholestage off              780            782           2         12.8          78.0       1.0X
+dayofmonth of timestamp wholestage on               720            736          12         13.9          72.0       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off               877            880           4         11.4          87.7       1.0X
-dayofweek of timestamp wholestage on                817            824           5         12.2          81.7       1.1X
+dayofweek of timestamp wholestage off               887            899          17         11.3          88.7       1.0X
+dayofweek of timestamp wholestage on                820            847          20         12.2          82.0       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                 844            846           2         11.8          84.4       1.0X
-weekday of timestamp wholestage on                  785            802          10         12.7          78.5       1.1X
+weekday of timestamp wholestage off                 821            825           5         12.2          82.1       1.0X
+weekday of timestamp wholestage on                  802            814           9         12.5          80.2       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                    593            601          11         16.9          59.3       1.0X
-hour of timestamp wholestage on                     548            562          10         18.2          54.8       1.1X
+hour of timestamp wholestage off                    611            622          14         16.4          61.1       1.0X
+hour of timestamp wholestage on                     571            577           8         17.5          57.1       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  616            622           8         16.2          61.6       1.0X
-minute of timestamp wholestage on                   552            555           3         18.1          55.2       1.1X
+minute of timestamp wholestage off                  607            615          12         16.5          60.7       1.0X
+minute of timestamp wholestage on                   573            580           6         17.5          57.3       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  607            611           6         16.5          60.7       1.0X
-second of timestamp wholestage on                   553            558           4         18.1          55.3       1.1X
+second of timestamp wholestage off                  615            616           2         16.3          61.5       1.0X
+second of timestamp wholestage on                   564            575           8         17.7          56.4       1.1X
 
 
 ================================================================================================
@@ -191,15 +124,15 @@ Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         166            169           5         60.2          16.6       1.0X
-current_date wholestage on                          147            151           4         67.9          14.7       1.1X
+current_date wholestage off                         166            169           4         60.4          16.6       1.0X
+current_date wholestage on                          150            153           3         66.7          15.0       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    341            341           0         29.4          34.1       1.0X
-current_timestamp wholestage on                     156            237         172         64.1          15.6       2.2X
+current_timestamp wholestage off                    179            181           2         55.8          17.9       1.0X
+current_timestamp wholestage on                     162            324         138         61.9          16.2       1.1X
 
 
 ================================================================================================
@@ -210,43 +143,43 @@ Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                         667            674           9         15.0          66.7       1.0X
-cast to date wholestage on                          637            644           6         15.7          63.7       1.0X
+cast to date wholestage off                         658            661           5         15.2          65.8       1.0X
+cast to date wholestage on                          644            654          10         15.5          64.4       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                             748            752           5         13.4          74.8       1.0X
-last_day wholestage on                              726            739          10         13.8          72.6       1.0X
+last_day wholestage off                             768            772           5         13.0          76.8       1.0X
+last_day wholestage on                              737            750          12         13.6          73.7       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                             685            689           6         14.6          68.5       1.0X
-next_day wholestage on                              651            665           9         15.4          65.1       1.1X
+next_day wholestage off                             691            704          17         14.5          69.1       1.0X
+next_day wholestage on                              664            676          10         15.1          66.4       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                             633            640          10         15.8          63.3       1.0X
-date_add wholestage on                              613            621           6         16.3          61.3       1.0X
+date_add wholestage off                             646            646           0         15.5          64.6       1.0X
+date_add wholestage on                              623            640          13         16.1          62.3       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                             633            642          13         15.8          63.3       1.0X
-date_sub wholestage on                              616            619           2         16.2          61.6       1.0X
+date_sub wholestage off                             638            645           9         15.7          63.8       1.0X
+date_sub wholestage on                              618            629           8         16.2          61.8       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                           870            871           2         11.5          87.0       1.0X
-add_months wholestage on                            869            878           7         11.5          86.9       1.0X
+add_months wholestage off                           892            896           5         11.2          89.2       1.0X
+add_months wholestage on                            926            938           7         10.8          92.6       1.0X
 
 
 ================================================================================================
@@ -257,8 +190,8 @@ Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         3309           3352          60          3.0         330.9       1.0X
-format date wholestage on                          3306           3333          17          3.0         330.6       1.0X
+format date wholestage off                         3395           3439          62          2.9         339.5       1.0X
+format date wholestage on                          3418           3438          14          2.9         341.8       1.0X
 
 
 ================================================================================================
@@ -269,8 +202,8 @@ Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       4549           4573          33          2.2         454.9       1.0X
-from_unixtime wholestage on                        4498           4567          62          2.2         449.8       1.0X
+from_unixtime wholestage off                       4565           4592          38          2.2         456.5       1.0X
+from_unixtime wholestage on                        4608           4635          32          2.2         460.8       1.0X
 
 
 ================================================================================================
@@ -281,15 +214,15 @@ Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                   773            786          18         12.9          77.3       1.0X
-from_utc_timestamp wholestage on                    810            818           7         12.3          81.0       1.0X
+from_utc_timestamp wholestage off                   801            807           9         12.5          80.1       1.0X
+from_utc_timestamp wholestage on                    819            830           7         12.2          81.9       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                    1054           1071          24          9.5         105.4       1.0X
-to_utc_timestamp wholestage on                     1009           1023          19          9.9         100.9       1.0X
+to_utc_timestamp wholestage off                    1108           1114           8          9.0         110.8       1.0X
+to_utc_timestamp wholestage on                     1067           1078          13          9.4         106.7       1.0X
 
 
 ================================================================================================
@@ -300,29 +233,29 @@ Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        201            205           6         49.7          20.1       1.0X
-cast interval wholestage on                         178            183           3         56.0          17.8       1.1X
+cast interval wholestage off                        211            213           2         47.4          21.1       1.0X
+cast interval wholestage on                         185            188           3         54.1          18.5       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                            1119           1121           3          8.9         111.9       1.0X
-datediff wholestage on                             1075           1082          10          9.3         107.5       1.0X
+datediff wholestage off                            1120           1120           1          8.9         112.0       1.0X
+datediff wholestage on                             1174           1205          19          8.5         117.4       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      3573           4763        1682          2.8         357.3       1.0X
-months_between wholestage on                       3649           4046         514          2.7         364.9       1.0X
+months_between wholestage off                      3669           3688          26          2.7         366.9       1.0X
+months_between wholestage on                       3687           3819         181          2.7         368.7       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                              1194           1206          18          0.8        1193.8       1.0X
-window wholestage on                              17084          17444         255          0.1       17084.1       0.1X
+window wholestage off                              1147           1148           1          0.9        1146.6       1.0X
+window wholestage on                              16997          17207         226          0.1       16996.7       0.1X
 
 
 ================================================================================================
@@ -333,134 +266,134 @@ Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                     1745           1770          35          5.7         174.5       1.0X
-date_trunc YEAR wholestage on                      1768           1797          23          5.7         176.8       1.0X
+date_trunc YEAR wholestage off                     1824           1859          50          5.5         182.4       1.0X
+date_trunc YEAR wholestage on                      1844           1942          71          5.4         184.4       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                     1765           1777          16          5.7         176.5       1.0X
-date_trunc YYYY wholestage on                      1706           1768          46          5.9         170.6       1.0X
+date_trunc YYYY wholestage off                     1808           1815          11          5.5         180.8       1.0X
+date_trunc YYYY wholestage on                      1833           1864          49          5.5         183.3       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                       1758           1766          12          5.7         175.8       1.0X
-date_trunc YY wholestage on                        1745           1770          18          5.7         174.5       1.0X
+date_trunc YY wholestage off                       1867           1883          23          5.4         186.7       1.0X
+date_trunc YY wholestage on                        1843           1861          15          5.4         184.3       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                      1815           1845          42          5.5         181.5       1.0X
-date_trunc MON wholestage on                       1753           1778          38          5.7         175.3       1.0X
+date_trunc MON wholestage off                      1845           1858          18          5.4         184.5       1.0X
+date_trunc MON wholestage on                       1830           1893          42          5.5         183.0       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                    1807           1827          28          5.5         180.7       1.0X
-date_trunc MONTH wholestage on                     1714           1745          43          5.8         171.4       1.1X
+date_trunc MONTH wholestage off                    1822           1855          47          5.5         182.2       1.0X
+date_trunc MONTH wholestage on                     1832           1863          20          5.5         183.2       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                       1785           1786           3          5.6         178.5       1.0X
-date_trunc MM wholestage on                        1710           1751          36          5.8         171.0       1.0X
+date_trunc MM wholestage off                       1843           1848           7          5.4         184.3       1.0X
+date_trunc MM wholestage on                        1886           1905          14          5.3         188.6       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                      1511           1522          16          6.6         151.1       1.0X
-date_trunc DAY wholestage on                       1461           1485          15          6.8         146.1       1.0X
+date_trunc DAY wholestage off                      1542           1545           4          6.5         154.2       1.0X
+date_trunc DAY wholestage on                       1610           1616           5          6.2         161.0       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                       1547           1571          34          6.5         154.7       1.0X
-date_trunc DD wholestage on                        1465           1544          47          6.8         146.5       1.1X
+date_trunc DD wholestage off                       1521           1529          11          6.6         152.1       1.0X
+date_trunc DD wholestage on                        1595           1611          21          6.3         159.5       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                     1620           1637          24          6.2         162.0       1.0X
-date_trunc HOUR wholestage on                      1464           1531          48          6.8         146.4       1.1X
+date_trunc HOUR wholestage off                     1496           1543          67          6.7         149.6       1.0X
+date_trunc HOUR wholestage on                      1567           1594          18          6.4         156.7       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    265            270           6         37.7          26.5       1.0X
-date_trunc MINUTE wholestage on                     264            268           3         37.9          26.4       1.0X
+date_trunc MINUTE wholestage off                    230            230           1         43.5          23.0       1.0X
+date_trunc MINUTE wholestage on                     288            295           7         34.7          28.8       0.8X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    267            271           6         37.5          26.7       1.0X
-date_trunc SECOND wholestage on                     232            241           5         43.1          23.2       1.2X
+date_trunc SECOND wholestage off                    247            249           4         40.5          24.7       1.0X
+date_trunc SECOND wholestage on                     297            314          12         33.6          29.7       0.8X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                     1705           1744          55          5.9         170.5       1.0X
-date_trunc WEEK wholestage on                      1685           1747          43          5.9         168.5       1.0X
+date_trunc WEEK wholestage off                     1786           1788           3          5.6         178.6       1.0X
+date_trunc WEEK wholestage on                      1786           1832          46          5.6         178.6       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                  2251           2252           2          4.4         225.1       1.0X
-date_trunc QUARTER wholestage on                   2314           2323          11          4.3         231.4       1.0X
+date_trunc QUARTER wholestage off                  2319           2365          66          4.3         231.9       1.0X
+date_trunc QUARTER wholestage on                   2424           2551         182          4.1         242.4       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           216            219           4         46.2          21.6       1.0X
-trunc year wholestage on                            231            243           7         43.2          23.1       0.9X
+trunc year wholestage off                           180            189          12         55.5          18.0       1.0X
+trunc year wholestage on                            271            277           5         36.9          27.1       0.7X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           214            215           2         46.7          21.4       1.0X
-trunc yyyy wholestage on                            222            233          10         45.0          22.2       1.0X
+trunc yyyy wholestage off                           189            191           4         52.9          18.9       1.0X
+trunc yyyy wholestage on                            276            284           6         36.2          27.6       0.7X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             223            229           9         44.9          22.3       1.0X
-trunc yy wholestage on                              226            241          11         44.2          22.6       1.0X
+trunc yy wholestage off                             189            190           1         52.9          18.9       1.0X
+trunc yy wholestage on                              279            294          11         35.9          27.9       0.7X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            221            223           3         45.3          22.1       1.0X
-trunc mon wholestage on                             238            271          49         42.0          23.8       0.9X
+trunc mon wholestage off                            185            186           1         54.1          18.5       1.0X
+trunc mon wholestage on                             272            285          13         36.8          27.2       0.7X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          240            261          29         41.6          24.0       1.0X
-trunc month wholestage on                           237            254          14         42.2          23.7       1.0X
+trunc month wholestage off                          190            190           1         52.6          19.0       1.0X
+trunc month wholestage on                           293            300           4         34.1          29.3       0.6X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             228            231           4         43.9          22.8       1.0X
-trunc mm wholestage on                              320            346          25         31.2          32.0       0.7X
+trunc mm wholestage off                             178            182           6         56.3          17.8       1.0X
+trunc mm wholestage on                              306            312           5         32.7          30.6       0.6X
 
 
 ================================================================================================
@@ -471,36 +404,36 @@ Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                     158            162           6          6.3         157.9       1.0X
-to timestamp str wholestage on                      154            176          16          6.5         154.4       1.0X
+to timestamp str wholestage off                     111            117           8          9.0         110.9       1.0X
+to timestamp str wholestage on                      101            109           6          9.9         100.6       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                        1060           1100          57          0.9        1060.1       1.0X
-to_timestamp wholestage on                          891           1218         369          1.1         891.0       1.2X
+to_timestamp wholestage off                         735            746          15          1.4         734.9       1.0X
+to_timestamp wholestage on                          708            725          11          1.4         708.2       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                   1029           1040          16          1.0        1028.6       1.0X
-to_unix_timestamp wholestage on                     992           1153         175          1.0         992.3       1.0X
+to_unix_timestamp wholestage off                    718            727          12          1.4         717.9       1.0X
+to_unix_timestamp wholestage on                     739            755          12          1.4         739.1       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          164            165           2          6.1         163.5       1.0X
-to date str wholestage on                           153            155           1          6.5         153.1       1.1X
+to date str wholestage off                          124            125           1          8.0         124.4       1.0X
+to date str wholestage on                           134            138           3          7.5         133.9       0.9X
 
 Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                             1665           1718          75          0.6        1664.8       1.0X
-to_date wholestage on                              1506           1565          41          0.7        1506.1       1.1X
+to_date wholestage off                             1510           1544          48          0.7        1510.4       1.0X
+to_date wholestage on                              1544           1557          15          0.6        1544.2       1.0X
 
 
 ================================================================================================
@@ -511,14 +444,14 @@ Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 To/from Java's date-time:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Date                                  246            247           1         20.4          49.1       1.0X
-From java.time.LocalDate                            210            212           3         23.8          42.0       1.2X
-Collect java.sql.Date                               973           1058          75          5.1         194.6       0.3X
-Collect java.time.LocalDate                         913            972          78          5.5         182.6       0.3X
-From java.sql.Timestamp                             229            230           1         21.8          45.9       1.1X
-From java.time.Instant                              195            198           4         25.7          38.9       1.3X
-Collect longs                                       798            838          35          6.3         159.6       0.3X
-Collect java.sql.Timestamp                          989           1130         124          5.1         197.8       0.2X
-Collect java.time.Instant                          1070           1128          53          4.7         214.0       0.2X
+From java.sql.Date                                  269            278           9         18.6          53.7       1.0X
+From java.time.LocalDate                            227            234           7         22.0          45.4       1.2X
+Collect java.sql.Date                              1164           1272         141          4.3         232.8       0.2X
+Collect java.time.LocalDate                        1070           1130          59          4.7         214.1       0.3X
+From java.sql.Timestamp                             246            248           2         20.3          49.2       1.1X
+From java.time.Instant                              214            216           2         23.4          42.8       1.3X
+Collect longs                                       814            831          15          6.1         162.7       0.3X
+Collect java.sql.Timestamp                         1016           1096          78          4.9         203.2       0.3X
+Collect java.time.Instant                          1012           1093          86          4.9         202.4       0.3X
 
 

--- a/sql/core/benchmarks/DateTimeBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-jdk11-results.txt
@@ -1,435 +1,524 @@
 ================================================================================================
+datetime +/- interval
+================================================================================================
+
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+date + interval(m):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+date + interval(m) wholestage off                   928            943          22         10.8          92.8       1.0X
+date + interval(m) wholestage on                    880            894          16         11.4          88.0       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+date + interval(m, d):                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+date + interval(m, d) wholestage off                962            964           4         10.4          96.2       1.0X
+date + interval(m, d) wholestage on                 907            932          16         11.0          90.7       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+date + interval(m, d, ms):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+date + interval(m, d, ms) wholestage off           3854           3891          52          2.6         385.4       1.0X
+date + interval(m, d, ms) wholestage on            3774           3807          18          2.6         377.4       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+date - interval(m):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+date - interval(m) wholestage off                   912            916           6         11.0          91.2       1.0X
+date - interval(m) wholestage on                    859            880          20         11.6          85.9       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+date - interval(m, d):                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+date - interval(m, d) wholestage off                965            971           8         10.4          96.5       1.0X
+date - interval(m, d) wholestage on                 908            913           4         11.0          90.8       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+date - interval(m, d, ms):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+date - interval(m, d, ms) wholestage off           3937           3939           4          2.5         393.7       1.0X
+date - interval(m, d, ms) wholestage on            3849           3865          16          2.6         384.9       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+timestamp + interval(m):                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+timestamp + interval(m) wholestage off             1963           1978          21          5.1         196.3       1.0X
+timestamp + interval(m) wholestage on              1955           1978          22          5.1         195.5       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+timestamp + interval(m, d):               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+timestamp + interval(m, d) wholestage off           2046           2052           9          4.9         204.6       1.0X
+timestamp + interval(m, d) wholestage on           2021           2033          12          4.9         202.1       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+timestamp + interval(m, d, ms):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+timestamp + interval(m, d, ms) wholestage off           2212           2216           6          4.5         221.2       1.0X
+timestamp + interval(m, d, ms) wholestage on           2188           2210          23          4.6         218.8       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+timestamp - interval(m):                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+timestamp - interval(m) wholestage off             1970           1971           1          5.1         197.0       1.0X
+timestamp - interval(m) wholestage on              1968           1986          12          5.1         196.8       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+timestamp - interval(m, d):               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+timestamp - interval(m, d) wholestage off           2036           2049          18          4.9         203.6       1.0X
+timestamp - interval(m, d) wholestage on           2025           2038           8          4.9         202.5       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+timestamp - interval(m, d, ms):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+timestamp - interval(m, d, ms) wholestage off           2236           2279          61          4.5         223.6       1.0X
+timestamp - interval(m, d, ms) wholestage on           2197           2216          14          4.6         219.7       1.0X
+
+
+================================================================================================
 Extract components
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    434            445          17         23.1          43.4       1.0X
-cast to timestamp wholestage on                     388            429          57         25.8          38.8       1.1X
+cast to timestamp wholestage off                    184            191          10         54.3          18.4       1.0X
+cast to timestamp wholestage on                     180            186           6         55.5          18.0       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                   1363           1374          16          7.3         136.3       1.0X
-year of timestamp wholestage on                    1285           1295           9          7.8         128.5       1.1X
+year of timestamp wholestage off                    736            745          12         13.6          73.6       1.0X
+year of timestamp wholestage on                     715            730          17         14.0          71.5       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                1619           1623           6          6.2         161.9       1.0X
-quarter of timestamp wholestage on                 1590           1606          16          6.3         159.0       1.0X
+quarter of timestamp wholestage off                 976            986          15         10.2          97.6       1.0X
+quarter of timestamp wholestage on                  948            957           7         10.5          94.8       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                  1264           1269           8          7.9         126.4       1.0X
-month of timestamp wholestage on                   1277           1290          13          7.8         127.7       1.0X
+month of timestamp wholestage off                   745            748           4         13.4          74.5       1.0X
+month of timestamp wholestage on                    714            727           8         14.0          71.4       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off             1854           1865          16          5.4         185.4       1.0X
-weekofyear of timestamp wholestage on              1837           1855          24          5.4         183.7       1.0X
+weekofyear of timestamp wholestage off             1156           1166          15          8.6         115.6       1.0X
+weekofyear of timestamp wholestage on              1064           1079           8          9.4         106.4       1.1X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                    1248           1252           6          8.0         124.8       1.0X
-day of timestamp wholestage on                     1283           1288           7          7.8         128.3       1.0X
+day of timestamp wholestage off                     745            761          23         13.4          74.5       1.0X
+day of timestamp wholestage on                      721            724           2         13.9          72.1       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off              1288           1294           9          7.8         128.8       1.0X
-dayofyear of timestamp wholestage on               1312           1316           5          7.6         131.2       1.0X
+dayofyear of timestamp wholestage off               767            767           1         13.0          76.7       1.0X
+dayofyear of timestamp wholestage on                737            744           4         13.6          73.7       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off             1254           1263          13          8.0         125.4       1.0X
-dayofmonth of timestamp wholestage on              1274           1293          17          7.8         127.4       1.0X
+dayofmonth of timestamp wholestage off              760            763           4         13.2          76.0       1.0X
+dayofmonth of timestamp wholestage on               712            719           4         14.0          71.2       1.1X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off              1419           1422           5          7.0         141.9       1.0X
-dayofweek of timestamp wholestage on               1416           1425           8          7.1         141.6       1.0X
+dayofweek of timestamp wholestage off               877            880           4         11.4          87.7       1.0X
+dayofweek of timestamp wholestage on                817            824           5         12.2          81.7       1.1X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                1386           1386           0          7.2         138.6       1.0X
-weekday of timestamp wholestage on                 1348           1354           5          7.4         134.8       1.0X
+weekday of timestamp wholestage off                 844            846           2         11.8          84.4       1.0X
+weekday of timestamp wholestage on                  785            802          10         12.7          78.5       1.1X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                   1017           1020           4          9.8         101.7       1.0X
-hour of timestamp wholestage on                     996           1006           9         10.0          99.6       1.0X
+hour of timestamp wholestage off                    593            601          11         16.9          59.3       1.0X
+hour of timestamp wholestage on                     548            562          10         18.2          54.8       1.1X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  994            996           2         10.1          99.4       1.0X
-minute of timestamp wholestage on                   974            991          15         10.3          97.4       1.0X
+minute of timestamp wholestage off                  616            622           8         16.2          61.6       1.0X
+minute of timestamp wholestage on                   552            555           3         18.1          55.2       1.1X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                 1018           1022           6          9.8         101.8       1.0X
-second of timestamp wholestage on                   976            987          13         10.2          97.6       1.0X
+second of timestamp wholestage off                  607            611           6         16.5          60.7       1.0X
+second of timestamp wholestage on                   553            558           4         18.1          55.3       1.1X
 
 
 ================================================================================================
 Current date and time
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         297            299           2         33.7          29.7       1.0X
-current_date wholestage on                          315            322           7         31.8          31.5       0.9X
+current_date wholestage off                         166            169           5         60.2          16.6       1.0X
+current_date wholestage on                          147            151           4         67.9          14.7       1.1X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    293            299           9         34.2          29.3       1.0X
-current_timestamp wholestage on                     307            332          23         32.6          30.7       1.0X
+current_timestamp wholestage off                    341            341           0         29.4          34.1       1.0X
+current_timestamp wholestage on                     156            237         172         64.1          15.6       2.2X
 
 
 ================================================================================================
 Date arithmetic
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                        1083           1087           7          9.2         108.3       1.0X
-cast to date wholestage on                         1057           1078          18          9.5         105.7       1.0X
+cast to date wholestage off                         667            674           9         15.0          66.7       1.0X
+cast to date wholestage on                          637            644           6         15.7          63.7       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                            1249           1262          18          8.0         124.9       1.0X
-last_day wholestage on                             1288           1297          10          7.8         128.8       1.0X
+last_day wholestage off                             748            752           5         13.4          74.8       1.0X
+last_day wholestage on                              726            739          10         13.8          72.6       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                            1128           1133           7          8.9         112.8       1.0X
-next_day wholestage on                             1106           1115           9          9.0         110.6       1.0X
+next_day wholestage off                             685            689           6         14.6          68.5       1.0X
+next_day wholestage on                              651            665           9         15.4          65.1       1.1X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                            1062           1084          31          9.4         106.2       1.0X
-date_add wholestage on                             1079           1093          24          9.3         107.9       1.0X
+date_add wholestage off                             633            640          10         15.8          63.3       1.0X
+date_add wholestage on                              613            621           6         16.3          61.3       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                            1077           1081           5          9.3         107.7       1.0X
-date_sub wholestage on                             1086           1105          16          9.2         108.6       1.0X
+date_sub wholestage off                             633            642          13         15.8          63.3       1.0X
+date_sub wholestage on                              616            619           2         16.2          61.6       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                          1437           1440           4          7.0         143.7       1.0X
-add_months wholestage on                           1452           1459           7          6.9         145.2       1.0X
+add_months wholestage off                           870            871           2         11.5          87.0       1.0X
+add_months wholestage on                            869            878           7         11.5          86.9       1.0X
 
 
 ================================================================================================
 Formatting dates
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         5638           5653          21          1.8         563.8       1.0X
-format date wholestage on                          5464           5482          17          1.8         546.4       1.0X
+format date wholestage off                         3309           3352          60          3.0         330.9       1.0X
+format date wholestage on                          3306           3333          17          3.0         330.6       1.0X
 
 
 ================================================================================================
 Formatting timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       7394           7395           1          1.4         739.4       1.0X
-from_unixtime wholestage on                        7306           7332          27          1.4         730.6       1.0X
+from_unixtime wholestage off                       4549           4573          33          2.2         454.9       1.0X
+from_unixtime wholestage on                        4498           4567          62          2.2         449.8       1.0X
 
 
 ================================================================================================
 Convert timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                  1265           1268           4          7.9         126.5       1.0X
-from_utc_timestamp wholestage on                   1288           1300          11          7.8         128.8       1.0X
+from_utc_timestamp wholestage off                   773            786          18         12.9          77.3       1.0X
+from_utc_timestamp wholestage on                    810            818           7         12.3          81.0       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                    1760           1766           8          5.7         176.0       1.0X
-to_utc_timestamp wholestage on                     1732           1743          13          5.8         173.2       1.0X
+to_utc_timestamp wholestage off                    1054           1071          24          9.5         105.4       1.0X
+to_utc_timestamp wholestage on                     1009           1023          19          9.9         100.9       1.0X
 
 
 ================================================================================================
 Intervals
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        359            360           1         27.8          35.9       1.0X
-cast interval wholestage on                         327            337           9         30.6          32.7       1.1X
+cast interval wholestage off                        201            205           6         49.7          20.1       1.0X
+cast interval wholestage on                         178            183           3         56.0          17.8       1.1X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                            1849           1853           5          5.4         184.9       1.0X
-datediff wholestage on                             1819           1826           6          5.5         181.9       1.0X
+datediff wholestage off                            1119           1121           3          8.9         111.9       1.0X
+datediff wholestage on                             1075           1082          10          9.3         107.5       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      6061           6066           7          1.6         606.1       1.0X
-months_between wholestage on                       6022           6034          12          1.7         602.2       1.0X
+months_between wholestage off                      3573           4763        1682          2.8         357.3       1.0X
+months_between wholestage on                       3649           4046         514          2.7         364.9       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                              2249           2298          69          0.4        2249.4       1.0X
-window wholestage on                              47857          47942         130          0.0       47857.1       0.0X
+window wholestage off                              1194           1206          18          0.8        1193.8       1.0X
+window wholestage on                              17084          17444         255          0.1       17084.1       0.1X
 
 
 ================================================================================================
 Truncation
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                     2530           2535           7          4.0         253.0       1.0X
-date_trunc YEAR wholestage on                      2490           2506          18          4.0         249.0       1.0X
+date_trunc YEAR wholestage off                     1745           1770          35          5.7         174.5       1.0X
+date_trunc YEAR wholestage on                      1768           1797          23          5.7         176.8       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                     2525           2530           6          4.0         252.5       1.0X
-date_trunc YYYY wholestage on                      2484           2492           7          4.0         248.4       1.0X
+date_trunc YYYY wholestage off                     1765           1777          16          5.7         176.5       1.0X
+date_trunc YYYY wholestage on                      1706           1768          46          5.9         170.6       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                       2530           2530           0          4.0         253.0       1.0X
-date_trunc YY wholestage on                        2485           2494          11          4.0         248.5       1.0X
+date_trunc YY wholestage off                       1758           1766          12          5.7         175.8       1.0X
+date_trunc YY wholestage on                        1745           1770          18          5.7         174.5       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                      2507           2511           5          4.0         250.7       1.0X
-date_trunc MON wholestage on                       2501           2510          10          4.0         250.1       1.0X
+date_trunc MON wholestage off                      1815           1845          42          5.5         181.5       1.0X
+date_trunc MON wholestage on                       1753           1778          38          5.7         175.3       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                    2517           2521           5          4.0         251.7       1.0X
-date_trunc MONTH wholestage on                     2507           2517          15          4.0         250.7       1.0X
+date_trunc MONTH wholestage off                    1807           1827          28          5.5         180.7       1.0X
+date_trunc MONTH wholestage on                     1714           1745          43          5.8         171.4       1.1X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                       2502           2504           4          4.0         250.2       1.0X
-date_trunc MM wholestage on                        2504           2509           4          4.0         250.4       1.0X
+date_trunc MM wholestage off                       1785           1786           3          5.6         178.5       1.0X
+date_trunc MM wholestage on                        1710           1751          36          5.8         171.0       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                      2343           2344           3          4.3         234.3       1.0X
-date_trunc DAY wholestage on                       2308           2328          22          4.3         230.8       1.0X
+date_trunc DAY wholestage off                      1511           1522          16          6.6         151.1       1.0X
+date_trunc DAY wholestage on                       1461           1485          15          6.8         146.1       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                       2344           2349           7          4.3         234.4       1.0X
-date_trunc DD wholestage on                        2312           2326          16          4.3         231.2       1.0X
+date_trunc DD wholestage off                       1547           1571          34          6.5         154.7       1.0X
+date_trunc DD wholestage on                        1465           1544          47          6.8         146.5       1.1X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                     2330           2332           2          4.3         233.0       1.0X
-date_trunc HOUR wholestage on                      2269           2273           4          4.4         226.9       1.0X
+date_trunc HOUR wholestage off                     1620           1637          24          6.2         162.0       1.0X
+date_trunc HOUR wholestage on                      1464           1531          48          6.8         146.4       1.1X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    396            397           1         25.2          39.6       1.0X
-date_trunc MINUTE wholestage on                     371            379           5         27.0          37.1       1.1X
+date_trunc MINUTE wholestage off                    265            270           6         37.7          26.5       1.0X
+date_trunc MINUTE wholestage on                     264            268           3         37.9          26.4       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    364            376          18         27.5          36.4       1.0X
-date_trunc SECOND wholestage on                     373            376           2         26.8          37.3       1.0X
+date_trunc SECOND wholestage off                    267            271           6         37.5          26.7       1.0X
+date_trunc SECOND wholestage on                     232            241           5         43.1          23.2       1.2X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                     2433           2437           6          4.1         243.3       1.0X
-date_trunc WEEK wholestage on                      2402           2418          21          4.2         240.2       1.0X
+date_trunc WEEK wholestage off                     1705           1744          55          5.9         170.5       1.0X
+date_trunc WEEK wholestage on                      1685           1747          43          5.9         168.5       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                  3304           3310           9          3.0         330.4       1.0X
-date_trunc QUARTER wholestage on                   3283           3289           5          3.0         328.3       1.0X
+date_trunc QUARTER wholestage off                  2251           2252           2          4.4         225.1       1.0X
+date_trunc QUARTER wholestage on                   2314           2323          11          4.3         231.4       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           323            324           1         30.9          32.3       1.0X
-trunc year wholestage on                            344            349          10         29.1          34.4       0.9X
+trunc year wholestage off                           216            219           4         46.2          21.6       1.0X
+trunc year wholestage on                            231            243           7         43.2          23.1       0.9X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           333            337           6         30.0          33.3       1.0X
-trunc yyyy wholestage on                            345            351           7         29.0          34.5       1.0X
+trunc yyyy wholestage off                           214            215           2         46.7          21.4       1.0X
+trunc yyyy wholestage on                            222            233          10         45.0          22.2       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             315            317           3         31.7          31.5       1.0X
-trunc yy wholestage on                              340            345           6         29.4          34.0       0.9X
+trunc yy wholestage off                             223            229           9         44.9          22.3       1.0X
+trunc yy wholestage on                              226            241          11         44.2          22.6       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            314            314           1         31.9          31.4       1.0X
-trunc mon wholestage on                             342            343           1         29.3          34.2       0.9X
+trunc mon wholestage off                            221            223           3         45.3          22.1       1.0X
+trunc mon wholestage on                             238            271          49         42.0          23.8       0.9X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          311            316           8         32.2          31.1       1.0X
-trunc month wholestage on                           341            343           1         29.3          34.1       0.9X
+trunc month wholestage off                          240            261          29         41.6          24.0       1.0X
+trunc month wholestage on                           237            254          14         42.2          23.7       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             309            311           3         32.4          30.9       1.0X
-trunc mm wholestage on                              342            347           4         29.3          34.2       0.9X
+trunc mm wholestage off                             228            231           4         43.9          22.8       1.0X
+trunc mm wholestage on                              320            346          25         31.2          32.0       0.7X
 
 
 ================================================================================================
 Parsing
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                     175            179           6          5.7         175.3       1.0X
-to timestamp str wholestage on                      170            177          13          5.9         169.6       1.0X
+to timestamp str wholestage off                     158            162           6          6.3         157.9       1.0X
+to timestamp str wholestage on                      154            176          16          6.5         154.4       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                        1563           1577          20          0.6        1563.1       1.0X
-to_timestamp wholestage on                         1587           1591           3          0.6        1587.1       1.0X
+to_timestamp wholestage off                        1060           1100          57          0.9        1060.1       1.0X
+to_timestamp wholestage on                          891           1218         369          1.1         891.0       1.2X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                   1646           1647           2          0.6        1646.1       1.0X
-to_unix_timestamp wholestage on                    1602           1609           8          0.6        1602.3       1.0X
+to_unix_timestamp wholestage off                   1029           1040          16          1.0        1028.6       1.0X
+to_unix_timestamp wholestage on                     992           1153         175          1.0         992.3       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          216            217           1          4.6         216.0       1.0X
-to date str wholestage on                           222            226           3          4.5         221.9       1.0X
+to date str wholestage off                          164            165           2          6.1         163.5       1.0X
+to date str wholestage on                           153            155           1          6.5         153.1       1.1X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                             3800           3806           8          0.3        3800.1       1.0X
-to_date wholestage on                              3796           3808          10          0.3        3795.5       1.0X
+to_date wholestage off                             1665           1718          75          0.6        1664.8       1.0X
+to_date wholestage on                              1506           1565          41          0.7        1506.1       1.1X
 
 
 ================================================================================================
 Conversion from/to external types
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 To/from Java's date-time:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Date                                  427            436          12         11.7          85.3       1.0X
-From java.time.LocalDate                            359            363           6         13.9          71.9       1.2X
-Collect java.sql.Date                              2131           2482         403          2.3         426.1       0.2X
-Collect java.time.LocalDate                        1457           1871         495          3.4         291.4       0.3X
-From java.sql.Timestamp                             369            371           1         13.5          73.8       1.2X
-From java.time.Instant                              325            330           6         15.4          65.0       1.3X
-Collect longs                                      1370           1388          20          3.6         274.1       0.3X
-Collect java.sql.Timestamp                         1701           1721          17          2.9         340.2       0.3X
-Collect java.time.Instant                          1817           1959         159          2.8         363.4       0.2X
+From java.sql.Date                                  246            247           1         20.4          49.1       1.0X
+From java.time.LocalDate                            210            212           3         23.8          42.0       1.2X
+Collect java.sql.Date                               973           1058          75          5.1         194.6       0.3X
+Collect java.time.LocalDate                         913            972          78          5.5         182.6       0.3X
+From java.sql.Timestamp                             229            230           1         21.8          45.9       1.1X
+From java.time.Instant                              195            198           4         25.7          38.9       1.3X
+Collect longs                                       798            838          35          6.3         159.6       0.3X
+Collect java.sql.Timestamp                          989           1130         124          5.1         197.8       0.2X
+Collect java.time.Instant                          1070           1128          53          4.7         214.0       0.2X
 
 

--- a/sql/core/benchmarks/DateTimeBenchmark-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-results.txt
@@ -1,435 +1,524 @@
 ================================================================================================
+datetime +/- interval
+================================================================================================
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+date + interval(m):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+date + interval(m) wholestage off                  1349           1417          96          7.4         134.9       1.0X
+date + interval(m) wholestage on                   1226           1388         246          8.2         122.6       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+date + interval(m, d):                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+date + interval(m, d) wholestage off               1491           1520          41          6.7         149.1       1.0X
+date + interval(m, d) wholestage on                1262           1318          36          7.9         126.2       1.2X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+date + interval(m, d, ms):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+date + interval(m, d, ms) wholestage off           4120           4292         243          2.4         412.0       1.0X
+date + interval(m, d, ms) wholestage on            3657           3708          30          2.7         365.7       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+date - interval(m):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+date - interval(m) wholestage off                   900            913          19         11.1          90.0       1.0X
+date - interval(m) wholestage on                    848            876          17         11.8          84.8       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+date - interval(m, d):                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+date - interval(m, d) wholestage off               1087           1106          27          9.2         108.7       1.0X
+date - interval(m, d) wholestage on                1022           1056          25          9.8         102.2       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+date - interval(m, d, ms):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+date - interval(m, d, ms) wholestage off           4093           4107          21          2.4         409.3       1.0X
+date - interval(m, d, ms) wholestage on            3863           3925          75          2.6         386.3       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+timestamp + interval(m):                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+timestamp + interval(m) wholestage off             2144           3097        1348          4.7         214.4       1.0X
+timestamp + interval(m) wholestage on              2214           2280          47          4.5         221.4       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+timestamp + interval(m, d):               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+timestamp + interval(m, d) wholestage off           2508           2939         610          4.0         250.8       1.0X
+timestamp + interval(m, d) wholestage on           2540           3211         948          3.9         254.0       1.0X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+timestamp + interval(m, d, ms):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+timestamp + interval(m, d, ms) wholestage off           3109           3492         541          3.2         310.9       1.0X
+timestamp + interval(m, d, ms) wholestage on           2694           2860         222          3.7         269.4       1.2X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+timestamp - interval(m):                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+timestamp - interval(m) wholestage off             2041           2474         612          4.9         204.1       1.0X
+timestamp - interval(m) wholestage on              1792           1836          54          5.6         179.2       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+timestamp - interval(m, d):               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+timestamp - interval(m, d) wholestage off           2049           2063          19          4.9         204.9       1.0X
+timestamp - interval(m, d) wholestage on           1863           1915          51          5.4         186.3       1.1X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+timestamp - interval(m, d, ms):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+timestamp - interval(m, d, ms) wholestage off           2135           2145          14          4.7         213.5       1.0X
+timestamp - interval(m, d, ms) wholestage on           2071           2142          57          4.8         207.1       1.0X
+
+
+================================================================================================
 Extract components
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    422            452          43         23.7          42.2       1.0X
-cast to timestamp wholestage on                     366            382          16         27.3          36.6       1.2X
+cast to timestamp wholestage off                    193            194           2         51.9          19.3       1.0X
+cast to timestamp wholestage on                     155            161           5         64.3          15.5       1.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                   1298           1324          37          7.7         129.8       1.0X
-year of timestamp wholestage on                    1201           1214          13          8.3         120.1       1.1X
+year of timestamp wholestage off                    752            774          30         13.3          75.2       1.0X
+year of timestamp wholestage on                     723            760          29         13.8          72.3       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                1443           1444           1          6.9         144.3       1.0X
-quarter of timestamp wholestage on                 1401           1415           8          7.1         140.1       1.0X
+quarter of timestamp wholestage off                 928            931           3         10.8          92.8       1.0X
+quarter of timestamp wholestage on                  840            875          25         11.9          84.0       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                  1230           1240          13          8.1         123.0       1.0X
-month of timestamp wholestage on                   1252           1262           8          8.0         125.2       1.0X
+month of timestamp wholestage off                   812            820          11         12.3          81.2       1.0X
+month of timestamp wholestage on                    695            734          39         14.4          69.5       1.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off             2122           2123           2          4.7         212.2       1.0X
-weekofyear of timestamp wholestage on              2398           2413          13          4.2         239.8       0.9X
+weekofyear of timestamp wholestage off             1169           1220          72          8.6         116.9       1.0X
+weekofyear of timestamp wholestage on              1136           1191          42          8.8         113.6       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                    1225           1226           2          8.2         122.5       1.0X
-day of timestamp wholestage on                     1249           1259           8          8.0         124.9       1.0X
+day of timestamp wholestage off                     824            826           4         12.1          82.4       1.0X
+day of timestamp wholestage on                      727            748          26         13.7          72.7       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off              1274           1279           6          7.8         127.4       1.0X
-dayofyear of timestamp wholestage on               1278           1294          25          7.8         127.8       1.0X
+dayofyear of timestamp wholestage off               811            822          17         12.3          81.1       1.0X
+dayofyear of timestamp wholestage on                752           1125         521         13.3          75.2       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off             1221           1222           0          8.2         122.1       1.0X
-dayofmonth of timestamp wholestage on              1233           1243           8          8.1         123.3       1.0X
+dayofmonth of timestamp wholestage off              872            933          87         11.5          87.2       1.0X
+dayofmonth of timestamp wholestage on               792            824          30         12.6          79.2       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off              1411           1422          16          7.1         141.1       1.0X
-dayofweek of timestamp wholestage on               1393           1398           5          7.2         139.3       1.0X
+dayofweek of timestamp wholestage off               925            926           2         10.8          92.5       1.0X
+dayofweek of timestamp wholestage on                893           1050         262         11.2          89.3       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                1351           1352           1          7.4         135.1       1.0X
-weekday of timestamp wholestage on                 1335           1342           5          7.5         133.5       1.0X
+weekday of timestamp wholestage off                 929            941          17         10.8          92.9       1.0X
+weekday of timestamp wholestage on                  846            874          23         11.8          84.6       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                    998            999           1         10.0          99.8       1.0X
-hour of timestamp wholestage on                     975            989          15         10.3          97.5       1.0X
+hour of timestamp wholestage off                    652            657           7         15.3          65.2       1.0X
+hour of timestamp wholestage on                     565            575           7         17.7          56.5       1.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                 1005           1012          10         10.0         100.5       1.0X
-minute of timestamp wholestage on                   978           1003          35         10.2          97.8       1.0X
+minute of timestamp wholestage off                  607            618          15         16.5          60.7       1.0X
+minute of timestamp wholestage on                   528            533           7         18.9          52.8       1.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  963            965           4         10.4          96.3       1.0X
-second of timestamp wholestage on                   977            988          16         10.2          97.7       1.0X
+second of timestamp wholestage off                  592            597           7         16.9          59.2       1.0X
+second of timestamp wholestage on                   528            540          11         18.9          52.8       1.1X
 
 
 ================================================================================================
 Current date and time
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         289            295           8         34.6          28.9       1.0X
-current_date wholestage on                          304            314           9         32.9          30.4       1.0X
+current_date wholestage off                         162            165           4         61.6          16.2       1.0X
+current_date wholestage on                          150            154           7         66.8          15.0       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    296            300           7         33.8          29.6       1.0X
-current_timestamp wholestage on                     302            311          11         33.1          30.2       1.0X
+current_timestamp wholestage off                    173            178           8         57.8          17.3       1.0X
+current_timestamp wholestage on                     144            148           5         69.3          14.4       1.2X
 
 
 ================================================================================================
 Date arithmetic
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                        1071           1078          10          9.3         107.1       1.0X
-cast to date wholestage on                         1018           1027           7          9.8         101.8       1.1X
+cast to date wholestage off                         617            624           9         16.2          61.7       1.0X
+cast to date wholestage on                          584            597           7         17.1          58.4       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                            1261           1264           5          7.9         126.1       1.0X
-last_day wholestage on                             1259           1271           9          7.9         125.9       1.0X
+last_day wholestage off                             729            746          25         13.7          72.9       1.0X
+last_day wholestage on                              720            732          11         13.9          72.0       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                            1119           1147          41          8.9         111.9       1.0X
-next_day wholestage on                             1076           1082           8          9.3         107.6       1.0X
+next_day wholestage off                             644            651           9         15.5          64.4       1.0X
+next_day wholestage on                              621            633          13         16.1          62.1       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                            1062           1070          12          9.4         106.2       1.0X
-date_add wholestage on                             1058           1060           2          9.5         105.8       1.0X
+date_add wholestage off                             627            630           5         15.9          62.7       1.0X
+date_add wholestage on                              615            643          22         16.3          61.5       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                            1048           1080          45          9.5         104.8       1.0X
-date_sub wholestage on                             1060           1066           8          9.4         106.0       1.0X
+date_sub wholestage off                             641            682          59         15.6          64.1       1.0X
+date_sub wholestage on                              635            652          20         15.8          63.5       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                          1368           1371           4          7.3         136.8       1.0X
-add_months wholestage on                           1423           1429           7          7.0         142.3       1.0X
+add_months wholestage off                           895            923          40         11.2          89.5       1.0X
+add_months wholestage on                            808            843          23         12.4          80.8       1.1X
 
 
 ================================================================================================
 Formatting dates
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         5865           5898          47          1.7         586.5       1.0X
-format date wholestage on                          5778           5788           8          1.7         577.8       1.0X
+format date wholestage off                         3643           3685          59          2.7         364.3       1.0X
+format date wholestage on                          3421           3470          36          2.9         342.1       1.1X
 
 
 ================================================================================================
 Formatting timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       8886           8899          18          1.1         888.6       1.0X
-from_unixtime wholestage on                        8831           8841           7          1.1         883.1       1.0X
+from_unixtime wholestage off                       4930           5364         615          2.0         493.0       1.0X
+from_unixtime wholestage on                        5360           5821         464          1.9         536.0       0.9X
 
 
 ================================================================================================
 Convert timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                  1093           1103          14          9.1         109.3       1.0X
-from_utc_timestamp wholestage on                   1136           1147          11          8.8         113.6       1.0X
+from_utc_timestamp wholestage off                   749            753           6         13.4          74.9       1.0X
+from_utc_timestamp wholestage on                    705            710           8         14.2          70.5       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                    1640           1646           8          6.1         164.0       1.0X
-to_utc_timestamp wholestage on                     1626           1641          12          6.1         162.6       1.0X
+to_utc_timestamp wholestage off                    1015           1020           8          9.9         101.5       1.0X
+to_utc_timestamp wholestage on                      965            968           6         10.4          96.5       1.1X
 
 
 ================================================================================================
 Intervals
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        338            348          14         29.6          33.8       1.0X
-cast interval wholestage on                         318            323           4         31.4          31.8       1.1X
+cast interval wholestage off                        222            231          11         44.9          22.2       1.0X
+cast interval wholestage on                         164            172           5         61.0          16.4       1.4X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                            1826           1829           4          5.5         182.6       1.0X
-datediff wholestage on                             1785           1797          11          5.6         178.5       1.0X
+datediff wholestage off                            1128           1137          14          8.9         112.8       1.0X
+datediff wholestage on                             1077           1084           8          9.3         107.7       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      4795           4801           9          2.1         479.5       1.0X
-months_between wholestage on                       4752           4766          19          2.1         475.2       1.0X
+months_between wholestage off                      3317           3374          81          3.0         331.7       1.0X
+months_between wholestage on                       3064           3187         133          3.3         306.4       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                              2452           2590         195          0.4        2452.1       1.0X
-window wholestage on                              42821          42877          54          0.0       42820.7       0.1X
+window wholestage off                              1030           1034           5          1.0        1030.5       1.0X
+window wholestage on                              14493          14541          40          0.1       14492.8       0.1X
 
 
 ================================================================================================
 Truncation
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                     2408           2413           7          4.2         240.8       1.0X
-date_trunc YEAR wholestage on                      2311           2318           6          4.3         231.1       1.0X
+date_trunc YEAR wholestage off                     1551           1562          15          6.4         155.1       1.0X
+date_trunc YEAR wholestage on                      1509           1521          10          6.6         150.9       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                     2404           2414          15          4.2         240.4       1.0X
-date_trunc YYYY wholestage on                      2317           2343          17          4.3         231.7       1.0X
+date_trunc YYYY wholestage off                     1566           1567           2          6.4         156.6       1.0X
+date_trunc YYYY wholestage on                      1504           1515          12          6.7         150.4       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                       2403           2415          17          4.2         240.3       1.0X
-date_trunc YY wholestage on                        2298           2316          13          4.4         229.8       1.0X
+date_trunc YY wholestage off                       1587           1683         136          6.3         158.7       1.0X
+date_trunc YY wholestage on                        1550           1592          46          6.5         155.0       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                      2370           2378          10          4.2         237.0       1.0X
-date_trunc MON wholestage on                       2329           2343          13          4.3         232.9       1.0X
+date_trunc MON wholestage off                      1686           1694          11          5.9         168.6       1.0X
+date_trunc MON wholestage on                       1590           1643          52          6.3         159.0       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                    2370           2376           7          4.2         237.0       1.0X
-date_trunc MONTH wholestage on                     2329           2347          15          4.3         232.9       1.0X
+date_trunc MONTH wholestage off                    1695           1714          27          5.9         169.5       1.0X
+date_trunc MONTH wholestage on                     1548           1589          37          6.5         154.8       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                       2363           2364           2          4.2         236.3       1.0X
-date_trunc MM wholestage on                        2323           2342          15          4.3         232.3       1.0X
+date_trunc MM wholestage off                       1660           1664           5          6.0         166.0       1.0X
+date_trunc MM wholestage on                        1555           1582          18          6.4         155.5       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                      2222           2226           7          4.5         222.2       1.0X
-date_trunc DAY wholestage on                       2162           2169           6          4.6         216.2       1.0X
+date_trunc DAY wholestage off                      1321           1328          10          7.6         132.1       1.0X
+date_trunc DAY wholestage on                       1286           1351          59          7.8         128.6       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                       2228           2232           5          4.5         222.8       1.0X
-date_trunc DD wholestage on                        2164           2171           6          4.6         216.4       1.0X
+date_trunc DD wholestage off                       1405           1422          24          7.1         140.5       1.0X
+date_trunc DD wholestage on                        1266           1281          10          7.9         126.6       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                     2236           2242           9          4.5         223.6       1.0X
-date_trunc HOUR wholestage on                      2212           2227          16          4.5         221.2       1.0X
+date_trunc HOUR wholestage off                     1713           1788         107          5.8         171.3       1.0X
+date_trunc HOUR wholestage on                      1295           1325          27          7.7         129.5       1.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    368            371           4         27.2          36.8       1.0X
-date_trunc MINUTE wholestage on                     331            335           4         30.2          33.1       1.1X
+date_trunc MINUTE wholestage off                    225            226           2         44.5          22.5       1.0X
+date_trunc MINUTE wholestage on                     195            200           5         51.2          19.5       1.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    383            383           0         26.1          38.3       1.0X
-date_trunc SECOND wholestage on                     328            335           8         30.5          32.8       1.2X
+date_trunc SECOND wholestage off                    246            249           3         40.6          24.6       1.0X
+date_trunc SECOND wholestage on                     190            195           5         52.5          19.0       1.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                     2259           2277          26          4.4         225.9       1.0X
-date_trunc WEEK wholestage on                      2201           2227          18          4.5         220.1       1.0X
+date_trunc WEEK wholestage off                     1522           1522           0          6.6         152.2       1.0X
+date_trunc WEEK wholestage on                      1472           1496          16          6.8         147.2       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                  3168           3183          22          3.2         316.8       1.0X
-date_trunc QUARTER wholestage on                   3130           3139          10          3.2         313.0       1.0X
+date_trunc QUARTER wholestage off                  2320           2337          24          4.3         232.0       1.0X
+date_trunc QUARTER wholestage on                   2089           2203         127          4.8         208.9       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           326            330           5         30.7          32.6       1.0X
-trunc year wholestage on                            295            298           3         33.8          29.5       1.1X
+trunc year wholestage off                           225            228           5         44.5          22.5       1.0X
+trunc year wholestage on                            185            190           4         54.0          18.5       1.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           322            323           0         31.0          32.2       1.0X
-trunc yyyy wholestage on                            295            297           2         33.9          29.5       1.1X
+trunc yyyy wholestage off                           221            228          10         45.2          22.1       1.0X
+trunc yyyy wholestage on                            177            182           5         56.5          17.7       1.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             324            325           2         30.9          32.4       1.0X
-trunc yy wholestage on                              295            300           4         33.9          29.5       1.1X
+trunc yy wholestage off                             239            245           8         41.8          23.9       1.0X
+trunc yy wholestage on                              181            188           6         55.2          18.1       1.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            323            336          19         31.0          32.3       1.0X
-trunc mon wholestage on                             294            297           3         34.0          29.4       1.1X
+trunc mon wholestage off                            221            221           0         45.3          22.1       1.0X
+trunc mon wholestage on                             179            191          11         55.8          17.9       1.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          322            322           0         31.1          32.2       1.0X
-trunc month wholestage on                           295            297           4         33.9          29.5       1.1X
+trunc month wholestage off                          218            223           8         45.9          21.8       1.0X
+trunc month wholestage on                           179            183           5         56.0          17.9       1.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             322            324           2         31.0          32.2       1.0X
-trunc mm wholestage on                              297            306           6         33.7          29.7       1.1X
+trunc mm wholestage off                             217            220           4         46.0          21.7       1.0X
+trunc mm wholestage on                              179            185           6         55.8          17.9       1.2X
 
 
 ================================================================================================
 Parsing
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                     214            215           1          4.7         214.1       1.0X
-to timestamp str wholestage on                      212            217           4          4.7         212.1       1.0X
+to timestamp str wholestage off                     149            149           0          6.7         149.0       1.0X
+to timestamp str wholestage on                      128            133           4          7.8         127.6       1.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                        1543           1545           3          0.6        1542.8       1.0X
-to_timestamp wholestage on                         1541           1550          12          0.6        1541.0       1.0X
+to_timestamp wholestage off                         913            915           3          1.1         912.7       1.0X
+to_timestamp wholestage on                          837            873          27          1.2         836.6       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                   1590           1592           2          0.6        1590.4       1.0X
-to_unix_timestamp wholestage on                    1527           1531           4          0.7        1527.0       1.0X
+to_unix_timestamp wholestage off                    848            852           5          1.2         848.4       1.0X
+to_unix_timestamp wholestage on                     888            900          19          1.1         887.7       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          264            267           4          3.8         264.0       1.0X
-to date str wholestage on                           261            263           3          3.8         261.2       1.0X
+to date str wholestage off                          171            174           3          5.8         171.5       1.0X
+to date str wholestage on                           167            178          10          6.0         167.4       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                             3578           3590          16          0.3        3578.2       1.0X
-to_date wholestage on                              3495           3504           9          0.3        3495.4       1.0X
+to_date wholestage off                             1718           1741          33          0.6        1717.7       1.0X
+to_date wholestage on                              1546           1610          76          0.6        1546.1       1.1X
 
 
 ================================================================================================
 Conversion from/to external types
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 To/from Java's date-time:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Date                                  414            424          12         12.1          82.9       1.0X
-From java.time.LocalDate                            350            355           4         14.3          69.9       1.2X
-Collect java.sql.Date                              2064           2709        1101          2.4         412.8       0.2X
-Collect java.time.LocalDate                        1467           1493          31          3.4         293.5       0.3X
-From java.sql.Timestamp                             396            401           4         12.6          79.3       1.0X
-From java.time.Instant                              260            266           7         19.2          52.0       1.6X
-Collect longs                                      1336           1475         178          3.7         267.2       0.3X
-Collect java.sql.Timestamp                         2175           2887        1226          2.3         435.0       0.2X
-Collect java.time.Instant                          1679           1917         228          3.0         335.7       0.2X
+From java.sql.Date                                  263            271          10         19.0          52.6       1.0X
+From java.time.LocalDate                            207            213           5         24.2          41.3       1.3X
+Collect java.sql.Date                              1148           1329         283          4.4         229.5       0.2X
+Collect java.time.LocalDate                        1021           1071          44          4.9         204.2       0.3X
+From java.sql.Timestamp                             229            234           6         21.9          45.7       1.2X
+From java.time.Instant                              160            169          10         31.2          32.1       1.6X
+Collect longs                                       828            916          77          6.0         165.5       0.3X
+Collect java.sql.Timestamp                         1241           1331         126          4.0         248.2       0.2X
+Collect java.time.Instant                          1207           1269          88          4.1         241.4       0.2X
 
 

--- a/sql/core/benchmarks/DateTimeBenchmark-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-results.txt
@@ -4,87 +4,20 @@ datetime +/- interval
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
-date + interval(m):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+datetime +/- interval:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date + interval(m) wholestage off                  1349           1417          96          7.4         134.9       1.0X
-date + interval(m) wholestage on                   1226           1388         246          8.2         122.6       1.1X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
-date + interval(m, d):                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------
-date + interval(m, d) wholestage off               1491           1520          41          6.7         149.1       1.0X
-date + interval(m, d) wholestage on                1262           1318          36          7.9         126.2       1.2X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
-date + interval(m, d, ms):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------
-date + interval(m, d, ms) wholestage off           4120           4292         243          2.4         412.0       1.0X
-date + interval(m, d, ms) wholestage on            3657           3708          30          2.7         365.7       1.1X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
-date - interval(m):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------
-date - interval(m) wholestage off                   900            913          19         11.1          90.0       1.0X
-date - interval(m) wholestage on                    848            876          17         11.8          84.8       1.1X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
-date - interval(m, d):                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------
-date - interval(m, d) wholestage off               1087           1106          27          9.2         108.7       1.0X
-date - interval(m, d) wholestage on                1022           1056          25          9.8         102.2       1.1X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
-date - interval(m, d, ms):                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------
-date - interval(m, d, ms) wholestage off           4093           4107          21          2.4         409.3       1.0X
-date - interval(m, d, ms) wholestage on            3863           3925          75          2.6         386.3       1.1X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
-timestamp + interval(m):                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------
-timestamp + interval(m) wholestage off             2144           3097        1348          4.7         214.4       1.0X
-timestamp + interval(m) wholestage on              2214           2280          47          4.5         221.4       1.0X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
-timestamp + interval(m, d):               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------
-timestamp + interval(m, d) wholestage off           2508           2939         610          4.0         250.8       1.0X
-timestamp + interval(m, d) wholestage on           2540           3211         948          3.9         254.0       1.0X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
-timestamp + interval(m, d, ms):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------
-timestamp + interval(m, d, ms) wholestage off           3109           3492         541          3.2         310.9       1.0X
-timestamp + interval(m, d, ms) wholestage on           2694           2860         222          3.7         269.4       1.2X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
-timestamp - interval(m):                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------
-timestamp - interval(m) wholestage off             2041           2474         612          4.9         204.1       1.0X
-timestamp - interval(m) wholestage on              1792           1836          54          5.6         179.2       1.1X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
-timestamp - interval(m, d):               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------
-timestamp - interval(m, d) wholestage off           2049           2063          19          4.9         204.9       1.0X
-timestamp - interval(m, d) wholestage on           1863           1915          51          5.4         186.3       1.1X
-
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
-timestamp - interval(m, d, ms):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------
-timestamp - interval(m, d, ms) wholestage off           2135           2145          14          4.7         213.5       1.0X
-timestamp - interval(m, d, ms) wholestage on           2071           2142          57          4.8         207.1       1.0X
+date + interval(m)                                 1003           1012          13          0.0   334353721.7       1.0X
+date + interval(m, d)                              1154           1174          29          0.0   384575202.7       0.9X
+date + interval(m, d, ms)                          4338           4366          40          0.0  1446002701.3       0.2X
+date - interval(m)                                  850            858           8          0.0   283424914.7       1.2X
+date - interval(m, d)                              1017           1031          19          0.0   339034354.7       1.0X
+date - interval(m, d, ms)                          4699           4717          25          0.0  1566218686.3       0.2X
+timestamp + interval(m)                            2044           2046           3          0.0   681382301.0       0.5X
+timestamp + interval(m, d)                         2215           2249          48          0.0   738464286.7       0.5X
+timestamp + interval(m, d, ms)                     2053           2063          13          0.0   684393366.0       0.5X
+timestamp - interval(m)                            1668           1677          12          0.0   556138256.7       0.6X
+timestamp - interval(m, d)                         1865           1882          25          0.0   621574795.3       0.5X
+timestamp - interval(m, d, ms)                     2075           2077           3          0.0   691569937.3       0.5X
 
 
 ================================================================================================
@@ -95,92 +28,92 @@ Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    193            194           2         51.9          19.3       1.0X
-cast to timestamp wholestage on                     155            161           5         64.3          15.5       1.2X
+cast to timestamp wholestage off                    192            192           0         52.2          19.2       1.0X
+cast to timestamp wholestage on                     163            166           3         61.3          16.3       1.2X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                    752            774          30         13.3          75.2       1.0X
-year of timestamp wholestage on                     723            760          29         13.8          72.3       1.0X
+year of timestamp wholestage off                    743            745           4         13.5          74.3       1.0X
+year of timestamp wholestage on                     708            715           5         14.1          70.8       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                 928            931           3         10.8          92.8       1.0X
-quarter of timestamp wholestage on                  840            875          25         11.9          84.0       1.1X
+quarter of timestamp wholestage off                 848            857          12         11.8          84.8       1.0X
+quarter of timestamp wholestage on                  803            813           6         12.5          80.3       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                   812            820          11         12.3          81.2       1.0X
-month of timestamp wholestage on                    695            734          39         14.4          69.5       1.2X
+month of timestamp wholestage off                   740            745           7         13.5          74.0       1.0X
+month of timestamp wholestage on                    703            710           5         14.2          70.3       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off             1169           1220          72          8.6         116.9       1.0X
-weekofyear of timestamp wholestage on              1136           1191          42          8.8         113.6       1.0X
+weekofyear of timestamp wholestage off             1162           1182          28          8.6         116.2       1.0X
+weekofyear of timestamp wholestage on              1093           1102           9          9.2         109.3       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                     824            826           4         12.1          82.4       1.0X
-day of timestamp wholestage on                      727            748          26         13.7          72.7       1.1X
+day of timestamp wholestage off                     742            748           9         13.5          74.2       1.0X
+day of timestamp wholestage on                      703            713           7         14.2          70.3       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off               811            822          17         12.3          81.1       1.0X
-dayofyear of timestamp wholestage on                752           1125         521         13.3          75.2       1.1X
+dayofyear of timestamp wholestage off               791            799          11         12.6          79.1       1.0X
+dayofyear of timestamp wholestage on                732            744           9         13.7          73.2       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off              872            933          87         11.5          87.2       1.0X
-dayofmonth of timestamp wholestage on               792            824          30         12.6          79.2       1.1X
+dayofmonth of timestamp wholestage off              738            752          20         13.6          73.8       1.0X
+dayofmonth of timestamp wholestage on               695            712           9         14.4          69.5       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off               925            926           2         10.8          92.5       1.0X
-dayofweek of timestamp wholestage on                893           1050         262         11.2          89.3       1.0X
+dayofweek of timestamp wholestage off               854            856           3         11.7          85.4       1.0X
+dayofweek of timestamp wholestage on                819            839          16         12.2          81.9       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                 929            941          17         10.8          92.9       1.0X
-weekday of timestamp wholestage on                  846            874          23         11.8          84.6       1.1X
+weekday of timestamp wholestage off                 816            821           7         12.3          81.6       1.0X
+weekday of timestamp wholestage on                  788            800           8         12.7          78.8       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                    652            657           7         15.3          65.2       1.0X
-hour of timestamp wholestage on                     565            575           7         17.7          56.5       1.2X
+hour of timestamp wholestage off                    595            595           1         16.8          59.5       1.0X
+hour of timestamp wholestage on                     533            541          10         18.8          53.3       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  607            618          15         16.5          60.7       1.0X
-minute of timestamp wholestage on                   528            533           7         18.9          52.8       1.2X
+minute of timestamp wholestage off                  585            588           4         17.1          58.5       1.0X
+minute of timestamp wholestage on                   532            545          11         18.8          53.2       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  592            597           7         16.9          59.2       1.0X
-second of timestamp wholestage on                   528            540          11         18.9          52.8       1.1X
+second of timestamp wholestage off                  579            589          13         17.3          57.9       1.0X
+second of timestamp wholestage on                   529            537           6         18.9          52.9       1.1X
 
 
 ================================================================================================
@@ -191,15 +124,15 @@ Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         162            165           4         61.6          16.2       1.0X
-current_date wholestage on                          150            154           7         66.8          15.0       1.1X
+current_date wholestage off                         171            174           4         58.4          17.1       1.0X
+current_date wholestage on                          152            155           3         65.6          15.2       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    173            178           8         57.8          17.3       1.0X
-current_timestamp wholestage on                     144            148           5         69.3          14.4       1.2X
+current_timestamp wholestage off                    178            181           4         56.2          17.8       1.0X
+current_timestamp wholestage on                     138            149           7         72.6          13.8       1.3X
 
 
 ================================================================================================
@@ -210,43 +143,43 @@ Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                         617            624           9         16.2          61.7       1.0X
-cast to date wholestage on                          584            597           7         17.1          58.4       1.1X
+cast to date wholestage off                         630            640          14         15.9          63.0       1.0X
+cast to date wholestage on                          591            594           5         16.9          59.1       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                             729            746          25         13.7          72.9       1.0X
-last_day wholestage on                              720            732          11         13.9          72.0       1.0X
+last_day wholestage off                             759            778          26         13.2          75.9       1.0X
+last_day wholestage on                              727            736           9         13.8          72.7       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                             644            651           9         15.5          64.4       1.0X
-next_day wholestage on                              621            633          13         16.1          62.1       1.0X
+next_day wholestage off                             649            659          15         15.4          64.9       1.0X
+next_day wholestage on                              628            629           1         15.9          62.8       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                             627            630           5         15.9          62.7       1.0X
-date_add wholestage on                              615            643          22         16.3          61.5       1.0X
+date_add wholestage off                             621            622           1         16.1          62.1       1.0X
+date_add wholestage on                              600            606           6         16.7          60.0       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                             641            682          59         15.6          64.1       1.0X
-date_sub wholestage on                              635            652          20         15.8          63.5       1.0X
+date_sub wholestage off                             611            626          21         16.4          61.1       1.0X
+date_sub wholestage on                              588            600           7         17.0          58.8       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                           895            923          40         11.2          89.5       1.0X
-add_months wholestage on                            808            843          23         12.4          80.8       1.1X
+add_months wholestage off                           843            845           2         11.9          84.3       1.0X
+add_months wholestage on                            818            831          11         12.2          81.8       1.0X
 
 
 ================================================================================================
@@ -257,8 +190,8 @@ Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         3643           3685          59          2.7         364.3       1.0X
-format date wholestage on                          3421           3470          36          2.9         342.1       1.1X
+format date wholestage off                         3557           3569          18          2.8         355.7       1.0X
+format date wholestage on                          3564           3588          17          2.8         356.4       1.0X
 
 
 ================================================================================================
@@ -269,8 +202,8 @@ Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       4930           5364         615          2.0         493.0       1.0X
-from_unixtime wholestage on                        5360           5821         464          1.9         536.0       0.9X
+from_unixtime wholestage off                       4875           4887          17          2.1         487.5       1.0X
+from_unixtime wholestage on                        4845           4870          16          2.1         484.5       1.0X
 
 
 ================================================================================================
@@ -281,15 +214,15 @@ Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                   749            753           6         13.4          74.9       1.0X
-from_utc_timestamp wholestage on                    705            710           8         14.2          70.5       1.1X
+from_utc_timestamp wholestage off                   665            671           8         15.0          66.5       1.0X
+from_utc_timestamp wholestage on                    654            672          14         15.3          65.4       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                    1015           1020           8          9.9         101.5       1.0X
-to_utc_timestamp wholestage on                      965            968           6         10.4          96.5       1.1X
+to_utc_timestamp wholestage off                     982            983           1         10.2          98.2       1.0X
+to_utc_timestamp wholestage on                      877            889           9         11.4          87.7       1.1X
 
 
 ================================================================================================
@@ -300,29 +233,29 @@ Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        222            231          11         44.9          22.2       1.0X
-cast interval wholestage on                         164            172           5         61.0          16.4       1.4X
+cast interval wholestage off                        200            206           9         50.1          20.0       1.0X
+cast interval wholestage on                         157            163           5         63.6          15.7       1.3X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                            1128           1137          14          8.9         112.8       1.0X
-datediff wholestage on                             1077           1084           8          9.3         107.7       1.0X
+datediff wholestage off                            1065           1068           4          9.4         106.5       1.0X
+datediff wholestage on                             1028           1047          15          9.7         102.8       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      3317           3374          81          3.0         331.7       1.0X
-months_between wholestage on                       3064           3187         133          3.3         306.4       1.1X
+months_between wholestage off                      3102           3111          13          3.2         310.2       1.0X
+months_between wholestage on                       2970           3028          46          3.4         297.0       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                              1030           1034           5          1.0        1030.5       1.0X
-window wholestage on                              14493          14541          40          0.1       14492.8       0.1X
+window wholestage off                              1142           1154          16          0.9        1142.2       1.0X
+window wholestage on                              14817          15049         257          0.1       14816.5       0.1X
 
 
 ================================================================================================
@@ -333,134 +266,134 @@ Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                     1551           1562          15          6.4         155.1       1.0X
-date_trunc YEAR wholestage on                      1509           1521          10          6.6         150.9       1.0X
+date_trunc YEAR wholestage off                     1516           1518           2          6.6         151.6       1.0X
+date_trunc YEAR wholestage on                      1458           1468           9          6.9         145.8       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                     1566           1567           2          6.4         156.6       1.0X
-date_trunc YYYY wholestage on                      1504           1515          12          6.7         150.4       1.0X
+date_trunc YYYY wholestage off                     1535           1535           1          6.5         153.5       1.0X
+date_trunc YYYY wholestage on                      1453           1461           7          6.9         145.3       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                       1587           1683         136          6.3         158.7       1.0X
-date_trunc YY wholestage on                        1550           1592          46          6.5         155.0       1.0X
+date_trunc YY wholestage off                       1561           1567           9          6.4         156.1       1.0X
+date_trunc YY wholestage on                        1452           1467          16          6.9         145.2       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                      1686           1694          11          5.9         168.6       1.0X
-date_trunc MON wholestage on                       1590           1643          52          6.3         159.0       1.1X
+date_trunc MON wholestage off                      1522           1531          13          6.6         152.2       1.0X
+date_trunc MON wholestage on                       1458           1467           7          6.9         145.8       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                    1695           1714          27          5.9         169.5       1.0X
-date_trunc MONTH wholestage on                     1548           1589          37          6.5         154.8       1.1X
+date_trunc MONTH wholestage off                    1518           1519           0          6.6         151.8       1.0X
+date_trunc MONTH wholestage on                     1452           1465          16          6.9         145.2       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                       1660           1664           5          6.0         166.0       1.0X
-date_trunc MM wholestage on                        1555           1582          18          6.4         155.5       1.1X
+date_trunc MM wholestage off                       1531           1532           1          6.5         153.1       1.0X
+date_trunc MM wholestage on                        1453           1463           8          6.9         145.3       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                      1321           1328          10          7.6         132.1       1.0X
-date_trunc DAY wholestage on                       1286           1351          59          7.8         128.6       1.0X
+date_trunc DAY wholestage off                      1287           1309          31          7.8         128.7       1.0X
+date_trunc DAY wholestage on                       1310           1337          16          7.6         131.0       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                       1405           1422          24          7.1         140.5       1.0X
-date_trunc DD wholestage on                        1266           1281          10          7.9         126.6       1.1X
+date_trunc DD wholestage off                       1322           1328           9          7.6         132.2       1.0X
+date_trunc DD wholestage on                        1282           1324          28          7.8         128.2       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                     1713           1788         107          5.8         171.3       1.0X
-date_trunc HOUR wholestage on                      1295           1325          27          7.7         129.5       1.3X
+date_trunc HOUR wholestage off                     1379           1393          20          7.3         137.9       1.0X
+date_trunc HOUR wholestage on                      1288           1302          11          7.8         128.8       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    225            226           2         44.5          22.5       1.0X
-date_trunc MINUTE wholestage on                     195            200           5         51.2          19.5       1.2X
+date_trunc MINUTE wholestage off                    243            245           2         41.2          24.3       1.0X
+date_trunc MINUTE wholestage on                     213            219           8         47.0          21.3       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    246            249           3         40.6          24.6       1.0X
-date_trunc SECOND wholestage on                     190            195           5         52.5          19.0       1.3X
+date_trunc SECOND wholestage off                    238            245          11         42.1          23.8       1.0X
+date_trunc SECOND wholestage on                     201            210           9         49.7          20.1       1.2X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                     1522           1522           0          6.6         152.2       1.0X
-date_trunc WEEK wholestage on                      1472           1496          16          6.8         147.2       1.0X
+date_trunc WEEK wholestage off                     1443           1477          49          6.9         144.3       1.0X
+date_trunc WEEK wholestage on                      1491           1516          17          6.7         149.1       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                  2320           2337          24          4.3         232.0       1.0X
-date_trunc QUARTER wholestage on                   2089           2203         127          4.8         208.9       1.1X
+date_trunc QUARTER wholestage off                  2017           2039          32          5.0         201.7       1.0X
+date_trunc QUARTER wholestage on                   1966           2005          36          5.1         196.6       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           225            228           5         44.5          22.5       1.0X
-trunc year wholestage on                            185            190           4         54.0          18.5       1.2X
+trunc year wholestage off                           206            206           1         48.6          20.6       1.0X
+trunc year wholestage on                            175            178           2         57.2          17.5       1.2X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           221            228          10         45.2          22.1       1.0X
-trunc yyyy wholestage on                            177            182           5         56.5          17.7       1.3X
+trunc yyyy wholestage off                           188            189           2         53.2          18.8       1.0X
+trunc yyyy wholestage on                            176            180           4         56.9          17.6       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             239            245           8         41.8          23.9       1.0X
-trunc yy wholestage on                              181            188           6         55.2          18.1       1.3X
+trunc yy wholestage off                             191            191           0         52.4          19.1       1.0X
+trunc yy wholestage on                              175            180           4         57.0          17.5       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            221            221           0         45.3          22.1       1.0X
-trunc mon wholestage on                             179            191          11         55.8          17.9       1.2X
+trunc mon wholestage off                            203            205           3         49.3          20.3       1.0X
+trunc mon wholestage on                             183            186           2         54.8          18.3       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          218            223           8         45.9          21.8       1.0X
-trunc month wholestage on                           179            183           5         56.0          17.9       1.2X
+trunc month wholestage off                          199            199           0         50.3          19.9       1.0X
+trunc month wholestage on                           177            179           2         56.4          17.7       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             217            220           4         46.0          21.7       1.0X
-trunc mm wholestage on                              179            185           6         55.8          17.9       1.2X
+trunc mm wholestage off                             198            198           1         50.5          19.8       1.0X
+trunc mm wholestage on                              180            183           3         55.7          18.0       1.1X
 
 
 ================================================================================================
@@ -471,36 +404,36 @@ Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                     149            149           0          6.7         149.0       1.0X
-to timestamp str wholestage on                      128            133           4          7.8         127.6       1.2X
+to timestamp str wholestage off                     138            139           2          7.2         138.2       1.0X
+to timestamp str wholestage on                      129            138           7          7.8         128.9       1.1X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                         913            915           3          1.1         912.7       1.0X
-to_timestamp wholestage on                          837            873          27          1.2         836.6       1.1X
+to_timestamp wholestage off                         885            889           5          1.1         885.3       1.0X
+to_timestamp wholestage on                          854            866          10          1.2         854.0       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                    848            852           5          1.2         848.4       1.0X
-to_unix_timestamp wholestage on                     888            900          19          1.1         887.7       1.0X
+to_unix_timestamp wholestage off                    848            856          12          1.2         848.1       1.0X
+to_unix_timestamp wholestage on                     826            850          18          1.2         826.4       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          171            174           3          5.8         171.5       1.0X
-to date str wholestage on                           167            178          10          6.0         167.4       1.0X
+to date str wholestage off                          167            171           5          6.0         167.2       1.0X
+to date str wholestage on                           165            173           4          6.1         165.0       1.0X
 
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                             1718           1741          33          0.6        1717.7       1.0X
-to_date wholestage on                              1546           1610          76          0.6        1546.1       1.1X
+to_date wholestage off                             1612           1633          31          0.6        1611.7       1.0X
+to_date wholestage on                              1588           1605          19          0.6        1588.2       1.0X
 
 
 ================================================================================================
@@ -511,14 +444,14 @@ Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.4
 Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 To/from Java's date-time:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Date                                  263            271          10         19.0          52.6       1.0X
-From java.time.LocalDate                            207            213           5         24.2          41.3       1.3X
-Collect java.sql.Date                              1148           1329         283          4.4         229.5       0.2X
-Collect java.time.LocalDate                        1021           1071          44          4.9         204.2       0.3X
-From java.sql.Timestamp                             229            234           6         21.9          45.7       1.2X
-From java.time.Instant                              160            169          10         31.2          32.1       1.6X
-Collect longs                                       828            916          77          6.0         165.5       0.3X
-Collect java.sql.Timestamp                         1241           1331         126          4.0         248.2       0.2X
-Collect java.time.Instant                          1207           1269          88          4.1         241.4       0.2X
+From java.sql.Date                                  245            247           1         20.4          49.0       1.0X
+From java.time.LocalDate                            228            233           4         21.9          45.6       1.1X
+Collect java.sql.Date                              1239           1361         209          4.0         247.9       0.2X
+Collect java.time.LocalDate                        1049           1107          54          4.8         209.8       0.2X
+From java.sql.Timestamp                             247            252           4         20.2          49.5       1.0X
+From java.time.Instant                              156            158           3         32.1          31.2       1.6X
+Collect longs                                       854            910          59          5.9         170.8       0.3X
+Collect java.sql.Timestamp                         1133           1140          12          4.4         226.6       0.2X
+Collect java.time.Instant                          1108           1159          74          4.5         221.7       0.2X
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
@@ -60,6 +60,22 @@ object DateTimeBenchmark extends SqlBasedBenchmark {
     withDefaultTimeZone(LA) {
       withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> LA.getId) {
         val N = 10000000
+        runBenchmark("datetime +/- interval") {
+          val ts = "cast(id as timestamp)"
+          val dt = s"cast($ts as date)"
+          run(N, "date + interval(m)", s"$dt + interval 1 month")
+          run(N, "date + interval(m, d)", s"$dt + interval 1 month 2 day")
+          run(N, "date + interval(m, d, ms)", s"$dt + interval 1 month 2 day 5 hour")
+          run(N, "date - interval(m)", s"$dt - interval 1 month")
+          run(N, "date - interval(m, d)", s"$dt - interval 1 month 2 day")
+          run(N, "date - interval(m, d, ms)", s"$dt - interval 1 month 2 day 5 hour")
+          run(N, "timestamp + interval(m)", s"$ts + interval 1 month")
+          run(N, "timestamp + interval(m, d)", s"$ts + interval 1 month 2 day")
+          run(N, "timestamp + interval(m, d, ms)", s"$ts + interval 1 month 2 day 5 hour")
+          run(N, "timestamp - interval(m)", s"$ts - interval 1 month")
+          run(N, "timestamp - interval(m, d)", s"$ts - interval 1 month 2 day")
+          run(N, "timestamp - interval(m, d, ms)", s"$ts - interval 1 month 2 day 5 hour")
+        }
         runBenchmark("Extract components") {
           run(N, "cast to timestamp", "cast(id as timestamp)")
           run(N, "year")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
@@ -61,20 +61,46 @@ object DateTimeBenchmark extends SqlBasedBenchmark {
       withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> LA.getId) {
         val N = 10000000
         runBenchmark("datetime +/- interval") {
+          val benchmark = new Benchmark("datetime +/- interval", 3, output = output)
           val ts = "cast(id as timestamp)"
           val dt = s"cast($ts as date)"
-          run(N, "date + interval(m)", s"$dt + interval 1 month")
-          run(N, "date + interval(m, d)", s"$dt + interval 1 month 2 day")
-          run(N, "date + interval(m, d, ms)", s"$dt + interval 1 month 2 day 5 hour")
-          run(N, "date - interval(m)", s"$dt - interval 1 month")
-          run(N, "date - interval(m, d)", s"$dt - interval 1 month 2 day")
-          run(N, "date - interval(m, d, ms)", s"$dt - interval 1 month 2 day 5 hour")
-          run(N, "timestamp + interval(m)", s"$ts + interval 1 month")
-          run(N, "timestamp + interval(m, d)", s"$ts + interval 1 month 2 day")
-          run(N, "timestamp + interval(m, d, ms)", s"$ts + interval 1 month 2 day 5 hour")
-          run(N, "timestamp - interval(m)", s"$ts - interval 1 month")
-          run(N, "timestamp - interval(m, d)", s"$ts - interval 1 month 2 day")
-          run(N, "timestamp - interval(m, d, ms)", s"$ts - interval 1 month 2 day 5 hour")
+          benchmark.addCase("date + interval(m)") { _ =>
+            doBenchmark(N, s"$dt + interval 1 month")
+          }
+          benchmark.addCase("date + interval(m, d)") { _ =>
+            doBenchmark(N, s"$dt + interval 1 month 2 day")
+          }
+          benchmark.addCase("date + interval(m, d, ms)") { _ =>
+            doBenchmark(N, s"$dt + interval 1 month 2 day 5 hour")
+          }
+          benchmark.addCase("date - interval(m)") { _ =>
+            doBenchmark(N, s"$dt - interval 1 month")
+          }
+          benchmark.addCase("date - interval(m, d)") { _ =>
+            doBenchmark(N, s"$dt - interval 1 month 2 day")
+          }
+          benchmark.addCase("date - interval(m, d, ms)") { _ =>
+            doBenchmark(N, s"$dt - interval 1 month 2 day 5 hour")
+          }
+          benchmark.addCase("timestamp + interval(m)") { _ =>
+            doBenchmark(N, s"$ts + interval 1 month")
+          }
+          benchmark.addCase("timestamp + interval(m, d)") { _ =>
+            doBenchmark(N, s"$ts + interval 1 month 2 day")
+          }
+          benchmark.addCase("timestamp + interval(m, d, ms)") { _ =>
+            doBenchmark(N, s"$ts + interval 1 month 2 day 5 hour")
+          }
+          benchmark.addCase("timestamp - interval(m)") { _ =>
+            doBenchmark(N, s"$ts - interval 1 month")
+          }
+          benchmark.addCase("timestamp - interval(m, d)") { _ =>
+            doBenchmark(N, s"$ts - interval 1 month 2 day")
+          }
+          benchmark.addCase("timestamp - interval(m, d, ms)") { _ =>
+            doBenchmark(N, s"$ts - interval 1 month 2 day 5 hour")
+          }
+          benchmark.run()
         }
         runBenchmark("Extract components") {
           run(N, "cast to timestamp", "cast(id as timestamp)")


### PR DESCRIPTION
### What changes were proposed in this pull request?
With https://github.com/apache/spark/pull/28310, the operation of date +/- interval(m, d, 0) has been improved a lot.

According to the benchmark results, about 75% time cost is reduced because of no casting date to timestamp back and forth.

In this PR, we add a benchmark for these operations, and timestamp +/- interval operations as accessories.

### Why are the changes needed?

Performance test coverage, since these operations are missing in the DateTimeBenchmark.

### Does this PR introduce any user-facing change?

No, just test


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
regenerated benchmark results