### PR TITLE
[SPARK-31587][R][INFRA] Uses R 4.0.0 in Github Actions

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -105,7 +105,7 @@ jobs:
         java-version: '11'
     - name: install R
       run: |
-        echo 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/' | sudo tee -a /etc/apt/sources.list
+        echo 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran40/' | sudo tee -a /etc/apt/sources.list
         curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xE298A3A825C0D65DFD57CBB651716619E084DAB9" | sudo apt-key add
         sudo apt-get update
         sudo apt-get install -y r-base r-base-dev libcurl4-openssl-dev
@@ -141,7 +141,7 @@ jobs:
         ruby-version: '2.7'
     - name: Install R
       run: |
-        echo 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/' | sudo tee -a /etc/apt/sources.list
+        echo 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran40/' | sudo tee -a /etc/apt/sources.list
         curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xE298A3A825C0D65DFD57CBB651716619E084DAB9" | sudo apt-key add
         sudo apt-get update
         sudo apt-get install -y r-base r-base-dev libcurl4-openssl-dev pandoc

--- a/dev/create-release/spark-rm/Dockerfile
+++ b/dev/create-release/spark-rm/Dockerfile
@@ -43,7 +43,7 @@ ARG GEM_PKGS="jekyll:4.0.0 jekyll-redirect-from:0.16.0 rouge:3.15.0"
 # This is all in a single "RUN" command so that if anything changes, "apt update" is run to fetch
 # the most current package versions (instead of potentially using old versions cached by docker).
 RUN apt-get clean && apt-get update && $APT_INSTALL gnupg ca-certificates && \
-  echo 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/' >> /etc/apt/sources.list && \
+  echo 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran40/' >> /etc/apt/sources.list && \
   gpg --keyserver keyserver.ubuntu.com --recv-key E298A3A825C0D65DFD57CBB651716619E084DAB9 && \
   gpg -a --export E084DAB9 | apt-key add - && \
   apt-get clean && \


### PR DESCRIPTION
### What changes were proposed in this pull request?

Currently R installation seems being failed in Github Actions:

```
Get:61 https://dl.bintray.com/sbt/debian  Packages [4174 B]
Get:62 http://ppa.launchpad.net/apt-fast/stable/ubuntu bionic/main amd64 Packages [532 B]
Get:63 http://ppa.launchpad.net/git-core/ppa/ubuntu bionic/main amd64 Packages [3036 B]
Get:64 http://ppa.launchpad.net/ondrej/php/ubuntu bionic/main amd64 Packages [52.0 kB]
Get:65 http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic/main amd64 Packages [33.9 kB]
Get:66 http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic/main Translation-en [10.1 kB]
Reading package lists...
E: The repository 'https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/ Release' does not have a Release file.
##[error]Process completed with exit code 100.
```


### Why are the changes needed?

To fix the broken builds in Github Actions.

### Does this PR introduce any user-facing change?

No, it's dev-only change.

### How was this patch tested?

Github Actions build will test it out.
