### PR TITLE
[SPARK-31590][SQL] Metadata-only queries should not include subquery in partition filters

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/OptimizeMetadataOnlyQuery.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/OptimizeMetadataOnlyQuery.scala
@@ -119,6 +119,10 @@ case class OptimizeMetadataOnlyQuery(catalog: SessionCatalog) extends Rule[Logic
       }
     }
 
+    if (normalizedFilters.exists(_.find(_.isInstanceOf[Unevaluable]).isDefined)) {
+      return child
+    }
+
     child transform {
       case plan if plan eq relation =>
         relation match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/OptimizeMetadataOnlyQuery.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/OptimizeMetadataOnlyQuery.scala
@@ -117,11 +117,7 @@ case class OptimizeMetadataOnlyQuery(catalog: SessionCatalog) extends Rule[Logic
         case a: AttributeReference =>
           a.withName(relation.output.find(_.semanticEquals(a)).get.name)
       }
-    }
-
-    if (normalizedFilters.exists(_.find(_.isInstanceOf[Unevaluable]).isDefined)) {
-      return child
-    }
+    }.filterNot(SubqueryExpression.hasSubquery)
 
     child transform {
       case plan if plan eq relation =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/OptimizeMetadataOnlyQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/OptimizeMetadataOnlyQuerySuite.scala
@@ -104,8 +104,7 @@ class OptimizeMetadataOnlyQuerySuite extends QueryTest with SharedSparkSession {
     "select max(c1) from (select partcol1 + 1 as c1 from srcpart where partcol1 = 0) t")
 
   testMetadataOnly(
-    "SPARK-31590 " +
-      "The filter used by Metadata-only queries should filter out all the unevaluable expr",
+    "SPARK-31590 Metadata-only queries should not include subquery in partition filters",
     """
       |SELECT partcol1, MAX(partcol2) AS partcol2
       |FROM srcpart

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/OptimizeMetadataOnlyQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/OptimizeMetadataOnlyQuerySuite.scala
@@ -152,27 +152,27 @@ class OptimizeMetadataOnlyQuerySuite extends QueryTest with SharedSparkSession {
   }
 
   test("SPARK-31590 The filter used by Metadata-only queries should not have Unevaluable") {
-    withTable("test_tbl") {
-      withSQLConf(OPTIMIZER_METADATA_ONLY.key -> "true") {
-        sql("CREATE TABLE test_tbl (a INT,d STRING,h STRING) USING PARQUET PARTITIONED BY (d ,h)")
-        sql("""
-            |INSERT OVERWRITE TABLE test_tbl PARTITION(d,h)
-            |SELECT 1,'2020-01-01','23'
-            |UNION ALL
-            |SELECT 2,'2020-01-02','01'
-            |UNION ALL
-            |SELECT 3,'2020-01-02','02'
-            """.stripMargin)
-        sql(
-          s"""
-             |SELECT d, MAX(h) AS h
-             |FROM test_tbl
-             |WHERE d= (
-             |  SELECT MAX(d) AS d
-             |  FROM test_tbl
-             |)
-             |GROUP BY d
-        """.stripMargin).collect()
+    Seq(true, false).foreach { enableOptimizeMetadataOnlyQuery =>
+      withSQLConf(OPTIMIZER_METADATA_ONLY.key -> enableOptimizeMetadataOnlyQuery.toString) {
+        val df = sql(
+          """
+            |SELECT partcol1, MAX(partcol2) AS partcol2
+            |FROM srcpart
+            |WHERE partcol1 = (
+            |  SELECT MAX(partcol1)
+            |  FROM srcpart
+            |)
+            |GROUP BY partcol1
+          """.stripMargin)
+        val localRelations = df.queryExecution.optimizedPlan.collect {
+          case l@LocalRelation(_, _, _) => l
+        }
+        if (enableOptimizeMetadataOnlyQuery) {
+          assert(localRelations.size == 1)
+        } else {
+          assert(localRelations.size == 0)
+        }
+        df.collect()
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/OptimizeMetadataOnlyQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/OptimizeMetadataOnlyQuerySuite.scala
@@ -104,7 +104,8 @@ class OptimizeMetadataOnlyQuerySuite extends QueryTest with SharedSparkSession {
     "select max(c1) from (select partcol1 + 1 as c1 from srcpart where partcol1 = 0) t")
 
   testMetadataOnly(
-    "SPARK-31590 The filter used by Metadata-only queries should not have Unevaluable",
+    "SPARK-31590 " +
+      "The filter used by Metadata-only queries should filter out all the unevaluable expr",
     """
       |SELECT partcol1, MAX(partcol2) AS partcol2
       |FROM srcpart
@@ -112,7 +113,7 @@ class OptimizeMetadataOnlyQuerySuite extends QueryTest with SharedSparkSession {
       |  SELECT MAX(partcol1)
       |  FROM srcpart
       |)
-      |AND partcol2= 'event'
+      |AND partcol2 = 'event'
       |GROUP BY partcol1
       |""".stripMargin
   )

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/OptimizeMetadataOnlyQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/OptimizeMetadataOnlyQuerySuite.scala
@@ -113,7 +113,7 @@ class OptimizeMetadataOnlyQuerySuite extends QueryTest with SharedSparkSession {
       |  SELECT MAX(partcol1)
       |  FROM srcpart
       |)
-      |AND partcol2 = 'event'
+      |AND partcol2 = 'even'
       |GROUP BY partcol1
       |""".stripMargin
   )


### PR DESCRIPTION
### What changes were proposed in this pull request?
Metadata-only queries should not include subquery in partition filters.

### Why are the changes needed?

Apply the `OptimizeMetadataOnlyQuery` rule again, will get the exception `Cannot evaluate expression: scalar-subquery`.

### Does this PR introduce any user-facing change?
Yes. When `spark.sql.optimizer.metadataOnly` is enabled, it succeeds when the queries include subquery in partition filters.

### How was this patch tested?

add UT