### PR TITLE
[SPARK-31589][INFRA][2.4] Use `r-lib/actions/setup-r` in GitHub Action

### DIFF
--- a/.github/workflows/branch-2.4.yml
+++ b/.github/workflows/branch-2.4.yml
@@ -88,12 +88,12 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: '1.8'
-    - name: install R
+    - uses: r-lib/actions/setup-r@v1
+      with:
+        r-version: '3.6.2'
+    - name: install lib
       run: |
-        echo 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/' | sudo tee -a /etc/apt/sources.list
-        curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xE298A3A825C0D65DFD57CBB651716619E084DAB9" | sudo apt-key add
-        sudo apt-get update
-        sudo apt-get install -y r-base r-base-dev libcurl4-openssl-dev
+        sudo apt-get install -y libcurl4-openssl-dev
     - name: install R packages
       run: |
         sudo Rscript -e "install.packages(c('curl', 'xml2', 'httr', 'devtools', 'testthat', 'knitr', 'rmarkdown', 'roxygen2', 'e1071', 'survival'), repos='https://cloud.r-project.org/')"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `r-lib/actions/setup-r` because it's more stable and maintained by 3rd party.

### Why are the changes needed?

This will recover the current outage. In addition, this will be more robust in the future.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Pass the GitHub Actions, especially `Linter R` and `Generate Documents`.