### PR TITLE
[SPARK-31591][CORE] Fix null name prefix when create directory

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -293,7 +293,7 @@ private[spark] object Utils extends Logging {
    * Create a directory inside the given parent directory. The directory is guaranteed to be
    * newly created, and is not marked for automatic deletion.
    */
-  def createDirectory(root: String, namePrefix: String = null): File = {
+  def createDirectory(root: String, namePrefix: String = "spark"): File = {
     var attempts = 0
     val maxAttempts = MAX_DIR_CREATION_ATTEMPTS
     var dir: File = null

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -293,7 +293,7 @@ private[spark] object Utils extends Logging {
    * Create a directory inside the given parent directory. The directory is guaranteed to be
    * newly created, and is not marked for automatic deletion.
    */
-  def createDirectory(root: String, namePrefix: String = "spark"): File = {
+  def createDirectory(root: String, namePrefix: String = null): File = {
     var attempts = 0
     val maxAttempts = MAX_DIR_CREATION_ATTEMPTS
     var dir: File = null
@@ -304,7 +304,8 @@ private[spark] object Utils extends Logging {
           maxAttempts + " attempts!")
       }
       try {
-        dir = new File(root, namePrefix + "-" + UUID.randomUUID.toString)
+        dir = new File(root,
+          Option(namePrefix).getOrElse("spark") + "-" + UUID.randomUUID.toString)
         if (dir.exists() || !dir.mkdirs()) {
           dir = null
         }

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -1297,6 +1297,16 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
       assert(Utils.trimExceptCRLF(s"b${s}b") === s"b${s}b")
     }
   }
+
+  test("Fix null name prefix when create directory") {
+    val tempDir = Utils.createTempDir()
+    try{
+      val withoutNull = Utils.createDirectory(tempDir.getCanonicalPath, null).getName
+      assert(!withoutNull.contains("null"))
+    } finally {
+      Utils.deleteRecursively(tempDir)
+    }
+  }
 }
 
 private class SimpleExtension


### PR DESCRIPTION
### What changes were proposed in this pull request?
In our production, we find that many shuffle files could be located in
```
1.9G    /hadoop/2/yarn/local/usercache/b_carmel/appcache/application_1586487864336_4602/null-107d4e9c-d3c7-419e-9743-a21dc4eaeb3f/37
2.4G    /hadoop/2/yarn/local/usercache/b_carmel/appcache/application_1586487864336_4602/null-107d4e9c-d3c7-419e-9743-a21dc4eaeb3f/38
659M    /hadoop/2/yarn/local/usercache/b_carmel/appcache/application_1586487864336_4602/null-107d4e9c-d3c7-419e-9743-a21dc4eaeb3f/39
577M    /hadoop/2/yarn/local/usercache/b_carmel/appcache/application_1586487864336_4602/null-107d4e9c-d3c7-419e-9743-a21dc4eaeb3f/3a
2.2G    /hadoop/2/yarn/local/usercache/b_carmel/appcache/application_1586487864336_4602/null-107d4e9c-d3c7-419e-9743-a21dc4eaeb3f/3b
```

The Util.createDirectory() uses a default parameter "spark"
```
  def createDirectory(root: String, namePrefix: String = "spark"): File
```
But in some cases, the actual namePrefix is null. If the method is called with null, then the default value would not be applied.

### Does this PR introduce any user-facing change?
No


### How was this patch tested?
Add a UT.
