### PR TITLE
[SPARK-31594][SQL] Do not display the seed of rand/randn with no argument in output schema

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/randomExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/randomExpressions.scala
@@ -102,6 +102,8 @@ case class Rand(child: Expression) extends RDG with ExpressionWithRandomSeed {
   }
 
   override def freshCopy(): Rand = Rand(child)
+
+  override def sql: String = "rand()"
 }
 
 object Rand {
@@ -145,6 +147,8 @@ case class Randn(child: Expression) extends RDG with ExpressionWithRandomSeed {
   }
 
   override def freshCopy(): Randn = Randn(child)
+
+  override def sql: String = "randn()"
 }
 
 object Randn {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/randomExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/randomExpressions.scala
@@ -83,9 +83,12 @@ trait ExpressionWithRandomSeed {
   """,
   since = "1.5.0")
 // scalastyle:on line.size.limit
-case class Rand(child: Expression) extends RDG with ExpressionWithRandomSeed {
+case class Rand(child: Expression, useRandSeed: Boolean = false)
+  extends RDG with ExpressionWithRandomSeed {
 
-  def this() = this(Literal(Utils.random.nextLong(), LongType))
+  def this() = this(Literal(Utils.random.nextLong(), LongType), true)
+
+  def this(child: Expression) = this(child, false)
 
   override def withNewSeed(seed: Long): Rand = Rand(Literal(seed, LongType))
 
@@ -103,7 +106,10 @@ case class Rand(child: Expression) extends RDG with ExpressionWithRandomSeed {
 
   override def freshCopy(): Rand = Rand(child)
 
-  override def sql: String = "rand()"
+  override def flatArguments: Iterator[Any] = Iterator(child)
+  override def sql: String = {
+    s"rand(${if (useRandSeed) "" else child.sql})"
+  }
 }
 
 object Rand {
@@ -128,9 +134,12 @@ object Rand {
   """,
   since = "1.5.0")
 // scalastyle:on line.size.limit
-case class Randn(child: Expression) extends RDG with ExpressionWithRandomSeed {
+case class Randn(child: Expression, useRandSeed: Boolean = false)
+  extends RDG with ExpressionWithRandomSeed {
 
-  def this() = this(Literal(Utils.random.nextLong(), LongType))
+  def this() = this(Literal(Utils.random.nextLong(), LongType), true)
+
+  def this(child: Expression) = this(child, false)
 
   override def withNewSeed(seed: Long): Randn = Randn(Literal(seed, LongType))
 
@@ -148,7 +157,10 @@ case class Randn(child: Expression) extends RDG with ExpressionWithRandomSeed {
 
   override def freshCopy(): Randn = Randn(child)
 
-  override def sql: String = "randn()"
+  override def flatArguments: Iterator[Any] = Iterator(child)
+  override def sql: String = {
+    s"randn(${if (useRandSeed) "" else child.sql})"
+  }
 }
 
 object Randn {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/randomExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/randomExpressions.scala
@@ -83,7 +83,7 @@ trait ExpressionWithRandomSeed {
   """,
   since = "1.5.0")
 // scalastyle:on line.size.limit
-case class Rand(child: Expression, useRandSeed: Boolean = false)
+case class Rand(child: Expression, hideSeed: Boolean = false)
   extends RDG with ExpressionWithRandomSeed {
 
   def this() = this(Literal(Utils.random.nextLong(), LongType), true)
@@ -104,11 +104,11 @@ case class Rand(child: Expression, useRandSeed: Boolean = false)
       isNull = FalseLiteral)
   }
 
-  override def freshCopy(): Rand = Rand(child)
+  override def freshCopy(): Rand = Rand(child, hideSeed)
 
   override def flatArguments: Iterator[Any] = Iterator(child)
   override def sql: String = {
-    s"rand(${if (useRandSeed) "" else child.sql})"
+    s"rand(${if (hideSeed) "" else child.sql})"
   }
 }
 
@@ -134,7 +134,7 @@ object Rand {
   """,
   since = "1.5.0")
 // scalastyle:on line.size.limit
-case class Randn(child: Expression, useRandSeed: Boolean = false)
+case class Randn(child: Expression, hideSeed: Boolean = false)
   extends RDG with ExpressionWithRandomSeed {
 
   def this() = this(Literal(Utils.random.nextLong(), LongType), true)
@@ -155,11 +155,11 @@ case class Randn(child: Expression, useRandSeed: Boolean = false)
       isNull = FalseLiteral)
   }
 
-  override def freshCopy(): Randn = Randn(child)
+  override def freshCopy(): Randn = Randn(child, hideSeed)
 
   override def flatArguments: Iterator[Any] = Iterator(child)
   override def sql: String = {
-    s"randn(${if (useRandSeed) "" else child.sql})"
+    s"randn(${if (hideSeed) "" else child.sql})"
   }
 }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/RandomSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/RandomSuite.scala
@@ -34,4 +34,11 @@ class RandomSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(Rand(5419823303878592871L), 0.7145363364564755)
     checkEvaluation(Randn(5419823303878592871L), 0.7816815274533012)
   }
+
+  test("Do not display the seed of rand/randn with no argument in output schema") {
+    assert(Rand(Literal(1L), true).sql === "rand()")
+    assert(Randn(Literal(1L), true).sql === "randn()")
+    assert(Rand(Literal(1L), false).sql === "rand(1L)")
+    assert(Randn(Literal(1L), false).sql === "randn(1L)")
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/RandomSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/RandomSuite.scala
@@ -35,7 +35,7 @@ class RandomSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(Randn(5419823303878592871L), 0.7816815274533012)
   }
 
-  test("Do not display the seed of rand/randn with no argument in output schema") {
+  test("SPARK-31594: Do not display the seed of rand/randn with no argument in output schema") {
     assert(Rand(Literal(1L), true).sql === "rand()")
     assert(Randn(Literal(1L), true).sql === "randn()")
     assert(Rand(Literal(1L), false).sql === "rand(1L)")

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3426,7 +3426,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     }
   }
 
-  test("Do not display the seed of rand/randn with no argument in output schema") {
+  test("SPARK-31594: Do not display the seed of rand/randn with no argument in output schema") {
     def checkIfSeedExistsInExplain(df: DataFrame): Unit = {
       val output = new java.io.ByteArrayOutputStream()
       Console.withOut(output) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3432,7 +3432,8 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
       Console.withOut(output) {
         df.explain()
       }
-      output.toString.matches("""randn?\(-?[0-9]+\)""")
+      val projectExplainOutput = output.toString.split("\n").find(_.contains("Project")).get
+      assert(projectExplainOutput.matches(""".*randn?\(-?[0-9]+\).*"""))
     }
     val df1 = sql("SELECT rand()")
     assert(df1.schema.head.name === "rand()")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR intends to update `sql` in `Rand`/`Randn` with no argument to make a column name deterministic.

Before this PR (a column name changes run-by-run):
```
scala> sql("select rand()").show()
+-------------------------+
|rand(7986133828002692830)|
+-------------------------+
|       0.9524061403696937|
+-------------------------+
```
After this PR (a column name fixed):
```
scala> sql("select rand()").show()
+------------------+                                                            
|            rand()|
+------------------+
|0.7137935639522275|
+------------------+

// If a seed given, it is still shown in a column name
// (the same with the current behaviour)
scala> sql("select rand(1)").show()
+------------------+                                                            
|           rand(1)|
+------------------+
|0.6363787615254752|
+------------------+

// We can still check a seed in explain output:
scala> sql("select rand()").explain()
== Physical Plan ==
*(1) Project [rand(-2282124938778456838) AS rand()#0]
+- *(1) Scan OneRowRelation[]
```

Note: This fix comes from #28194; the ongoing PR tests the output schema of expressions, so their schemas must be deterministic for the tests.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To make output schema deterministic.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added unit tests.