### PR TITLE
[SPARK-31549][PYSPARK] Add a develop API invoking collect on Python RDD with user-specified job group

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -172,8 +172,6 @@ private[spark] object PythonRDD extends Logging {
    * A helper function to collect an RDD as an iterator, then serve it via socket.
    * This method is similar with `PythonRDD.collectAndServe`, but user can specify job group id,
    * job description, and interruptOnCancel option.
-   *
-   * Note: This method are temporary, might be removed in future.
    */
   def collectAndServeWithJobGroup[T](
       rdd: RDD[T],

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -169,6 +169,23 @@ private[spark] object PythonRDD extends Logging {
   }
 
   /**
+   * A helper function to collect an RDD as an iterator, then serve it via socket.
+   * This method is similar with `PythonRDD.collectAndServe`, but user can specify job group id,
+   * job description, and interruptOnCancel option.
+   *
+   * Note: This method are temporary, might be removed in future.
+   */
+  def collectAndServeWithJobGroup[T](
+      rdd: RDD[T],
+      groupId: String,
+      description: String,
+      interruptOnCancel: Boolean): Array[Any] = {
+    val sc = rdd.sparkContext
+    sc.setJobGroup(groupId, description, interruptOnCancel)
+    serveIterator(rdd.collect().iterator, s"serve RDD ${rdd.id}")
+  }
+
+  /**
    * A helper function to create a local RDD iterator and serve it via socket. Partitions are
    * are collected as separate jobs, by order of index. Partition data is first requested by a
    * non-zero integer to start a collection job. The response is prefaced by an integer with 1

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -877,6 +877,17 @@ class RDD(object):
             sock_info = self.ctx._jvm.PythonRDD.collectAndServe(self._jrdd.rdd())
         return list(_load_from_socket(sock_info, self._jrdd_deserializer))
 
+    def collectWithJobGroup(self, groupId, description, interruptOnCancel=False):
+        """
+        When collect rdd, use this method to specify job group.
+
+        .. note:: This method are temporary, might be removed in future.
+        """
+        with SCCallSiteSync(self.context) as css:
+            sock_info = self.ctx._jvm.PythonRDD.collectAndServeWithJobGroup(
+                self._jrdd.rdd(), groupId, description, interruptOnCancel)
+        return list(_load_from_socket(sock_info, self._jrdd_deserializer))
+
     def reduce(self, f):
         """
         Reduces the elements of this RDD using the specified commutative and

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -883,7 +883,6 @@ class RDD(object):
 
         When collect rdd, use this method to specify job group.
 
-        .. note:: This method are temporary, might be removed in future.
         .. versionadded:: 3.0.0
         """
         with SCCallSiteSync(self.context) as css:

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -879,9 +879,12 @@ class RDD(object):
 
     def collectWithJobGroup(self, groupId, description, interruptOnCancel=False):
         """
+        .. note:: Experimental
+
         When collect rdd, use this method to specify job group.
 
         .. note:: This method are temporary, might be removed in future.
+        .. versionadded:: 3.0.0
         """
         with SCCallSiteSync(self.context) as css:
             sock_info = self.ctx._jvm.PythonRDD.collectAndServeWithJobGroup(

--- a/python/pyspark/tests/test_rdd.py
+++ b/python/pyspark/tests/test_rdd.py
@@ -834,9 +834,8 @@ class RDDTests(ReusedPySparkTestCase):
             and then exits.
             """
             try:
-                self.sc.setJobGroup(job_group, "test rdd collect with setting job group")
-                self.sc.parallelize([15]).map(lambda x: time.sleep(x)).collect(
-                    job_group, "test rdd collect with setting job group")
+                self.sc.parallelize([15]).map(lambda x: time.sleep(x)) \
+                    .collectWithJobGroup(job_group, "test rdd collect with setting job group")
                 is_job_cancelled[index] = False
             except Exception:
                 # Assume that exception means job cancellation.

--- a/python/pyspark/tests/test_rdd.py
+++ b/python/pyspark/tests/test_rdd.py
@@ -814,6 +814,63 @@ class RDDTests(ReusedPySparkTestCase):
         rddWithoutRp = self.sc.parallelize(range(10))
         self.assertEqual(rddWithoutRp.getResourceProfile(), None)
 
+    def test_collect_with_job_group(self):
+        import time
+        import threading
+
+        group_A_name = "group_A"
+        group_B_name = "group_B"
+
+        def map_func(x):
+            time.sleep(3)
+            return x + 1
+
+        num_threads = 4
+        thread_list = []
+        # an array which record whether job is cancelled.
+        # the index of the array is the thread index which job run in.
+        is_job_cancelled = [False for x in range(num_threads)]
+
+        def run_job(job_group, index):
+            try:
+                result = self.sc.parallelize([3]).map(map_func).collectWithJobGroup(
+                    job_group, "test rdd collect with setting job group")
+                is_job_cancelled[index] = False
+                return result
+            except Exception as e:
+                is_job_cancelled[index] = True
+                return None
+
+        def launch_job_thread(job_group, index):
+            thread = threading.Thread(target=run_job, args=(job_group, index))
+            thread.start()
+            return thread
+
+        # test job succeeded when not cancelled.
+        run_job(group_A_name, 0)
+        self.assertFalse(is_job_cancelled[0], "job didn't succeeded.")
+
+        # launch spark job in multiple threads and cancel half of them.
+        for i in range(num_threads):
+            if i % 2 == 0:
+                thread = launch_job_thread(group_A_name, i)
+            else:
+                thread = launch_job_thread(group_B_name, i)
+            thread_list.append(thread)
+
+        time.sleep(1)
+        self.sc.cancelJobGroup(group_A_name)
+
+        for i in range(num_threads):
+            thread_list[i].join()
+            if i % 2 == 0:
+                # make sure group A job being cancelled.
+                self.assertTrue(is_job_cancelled[i], "Job in group A wasn't cancelled.")
+            else:
+                # make sure group B job succeeded.
+                self.assertFalse(is_job_cancelled[i], "Job in group B didn't succeeded.")
+
+
 if __name__ == "__main__":
     import unittest
     from pyspark.tests.test_rdd import *

--- a/python/pyspark/tests/test_rdd.py
+++ b/python/pyspark/tests/test_rdd.py
@@ -835,7 +835,8 @@ class RDDTests(ReusedPySparkTestCase):
             """
             try:
                 self.sc.setJobGroup(job_group, "test rdd collect with setting job group")
-                self.sc.parallelize([15]).map(lambda x: time.sleep(x)).collect()
+                self.sc.parallelize([15]).map(lambda x: time.sleep(x)).collect(
+                    job_group, "test rdd collect with setting job group")
                 is_job_cancelled[index] = False
             except Exception:
                 # Assume that exception means job cancellation.


### PR DESCRIPTION
### What changes were proposed in this pull request?
I add a new API in pyspark RDD class:

def collectWithJobGroup(self, groupId, description, interruptOnCancel=False)

This API do the same thing with `rdd.collect`, but it can specify the job group when do collect.
The purpose of adding this API is, if we use:

```
sc.setJobGroup("group-id...")
rdd.collect()
```
The `setJobGroup` API in pyspark won't work correctly. This related to a bug discussed in 
https://issues.apache.org/jira/browse/SPARK-31549

Note:

This PR is a rather temporary workaround for `PYSPARK_PIN_THREAD`, and as a step to migrate to  `PYSPARK_PIN_THREAD` smoothly. It targets Spark 3.0.

- `PYSPARK_PIN_THREAD` is unstable at this moment that affects whole PySpark applications.
- It is impossible to make it runtime configuration as it has to be set before JVM is launched.
- There is a thread leak issue between Python and JVM. We should address but it's not a release blocker for Spark 3.0 since the feature is experimental. I plan to handle this after Spark 3.0 due to stability.

Once `PYSPARK_PIN_THREAD` is enabled by default, we should remove this API out ideally. I will target to deprecate this API in Spark 3.1.

### Why are the changes needed?
Fix bug.


### Does this PR introduce any user-facing change?
A develop API in pyspark: `pyspark.RDD. collectWithJobGroup`


### How was this patch tested?
Unit test.
