### PR TITLE
[SPARK-31557][SQL][TESTS][FOLLOWUP] Check rebasing in all legacy formatters

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/util/DateFormatterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/util/DateFormatterSuite.scala
@@ -50,23 +50,29 @@ class DateFormatterSuite extends SparkFunSuite with SQLHelper {
   test("roundtrip date -> days -> date") {
     LegacyBehaviorPolicy.values.foreach { parserPolicy =>
       withSQLConf(SQLConf.LEGACY_TIME_PARSER_POLICY.key -> parserPolicy.toString) {
-        Seq(
-          "0050-01-01",
-          "0953-02-02",
-          "1423-03-08",
-          "1582-10-15",
-          "1969-12-31",
-          "1972-08-25",
-          "1975-09-26",
-          "2018-12-12",
-          "2038-01-01",
-          "5010-11-17").foreach { date =>
-          DateTimeTestUtils.outstandingTimezonesIds.foreach { timeZone =>
-            withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> timeZone) {
-              val formatter = DateFormatter(getZoneId(timeZone))
-              val days = formatter.parse(date)
-              val formatted = formatter.format(days)
-              assert(date === formatted)
+        LegacyDateFormats.values.foreach { legacyFormat =>
+          Seq(
+            "0050-01-01",
+            "0953-02-02",
+            "1423-03-08",
+            "1582-10-15",
+            "1969-12-31",
+            "1972-08-25",
+            "1975-09-26",
+            "2018-12-12",
+            "2038-01-01",
+            "5010-11-17").foreach { date =>
+            DateTimeTestUtils.outstandingTimezonesIds.foreach { timeZone =>
+              withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> timeZone) {
+                val formatter = DateFormatter(
+                  DateFormatter.defaultPattern,
+                  getZoneId(timeZone),
+                  DateFormatter.defaultLocale,
+                  legacyFormat)
+                val days = formatter.parse(date)
+                val formatted = formatter.format(days)
+                assert(date === formatted)
+              }
             }
           }
         }
@@ -77,23 +83,29 @@ class DateFormatterSuite extends SparkFunSuite with SQLHelper {
   test("roundtrip days -> date -> days") {
     LegacyBehaviorPolicy.values.foreach { parserPolicy =>
       withSQLConf(SQLConf.LEGACY_TIME_PARSER_POLICY.key -> parserPolicy.toString) {
-        Seq(
-          -701265,
-          -371419,
-          -199722,
-          -1,
-          0,
-          967,
-          2094,
-          17877,
-          24837,
-          1110657).foreach { days =>
-          DateTimeTestUtils.outstandingTimezonesIds.foreach { timeZone =>
-            withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> timeZone) {
-              val formatter = DateFormatter(getZoneId(timeZone))
-              val date = formatter.format(days)
-              val parsed = formatter.parse(date)
-              assert(days === parsed)
+        LegacyDateFormats.values.foreach { legacyFormat =>
+          Seq(
+            -701265,
+            -371419,
+            -199722,
+            -1,
+            0,
+            967,
+            2094,
+            17877,
+            24837,
+            1110657).foreach { days =>
+            DateTimeTestUtils.outstandingTimezonesIds.foreach { timeZone =>
+              withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> timeZone) {
+                val formatter = DateFormatter(
+                  DateFormatter.defaultPattern,
+                  getZoneId(timeZone),
+                  DateFormatter.defaultLocale,
+                  legacyFormat)
+                val date = formatter.format(days)
+                val parsed = formatter.parse(date)
+                assert(days === parsed)
+              }
             }
           }
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Check all available legacy formats in the tests added by https://github.com/apache/spark/pull/28345
- Check dates rebasing in legacy parsers for only one direction either days -> string or string -> days.

### Why are the changes needed?
Round trip tests can hide issues in dates rebasing. For example, if we remove rebasing from legacy parsers (from `parse()` and `format()`) the tests will pass.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
By running `DateFormatterSuite`.