### PR TITLE
[SPARK-31610][SPARK-31668][ML] Address hashingTF saving&loading bug and expose hashFunc property in HashingTF

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/HashingTF.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/HashingTF.scala
@@ -42,7 +42,7 @@ import org.apache.spark.util.VersionUtils.majorMinorVersion
  * otherwise the features will not be mapped evenly to the columns.
  */
 @Since("1.2.0")
-class HashingTF @Since("3.0.0") private[m] (
+class HashingTF @Since("3.0.0") private[ml] (
     @Since("1.4.0") override val uid: String,
     @Since("3.1.0") val hashFuncVersion: Int)
   extends Transformer with HasInputCol with HasOutputCol with HasNumFeatures

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/HashingTF.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/HashingTF.scala
@@ -48,7 +48,7 @@ class HashingTF @Since("3.0.0") (
   extends Transformer with HasInputCol with HasOutputCol with HasNumFeatures
     with DefaultParamsWritable {
 
-  @transient lazy val hashFunc = hashFuncVersion match {
+  lazy val hashFunc = hashFuncVersion match {
     case HashingTF.SPARK_2_MURMUR3_HASH => OldHashingTF.murmur3Hash _
     case HashingTF.SPARK_3_MURMUR3_HASH => FeatureHasher.murmur3Hash _
     case _ => throw new IllegalArgumentException("Illegal hash function version setting.")
@@ -140,6 +140,13 @@ class HashingTF @Since("3.0.0") (
   @Since("3.0.0")
   override def toString: String = {
     s"HashingTF: uid=$uid, binary=${$(binary)}, numFeatures=${$(numFeatures)}"
+  }
+
+  @Since("3.0.0")
+  override def save(path: String): Unit = {
+    require(hashFuncVersion == HashingTF.SPARK_3_MURMUR3_HASH,
+      "Cannot save model which is loaded from lower version spark saved model.")
+    super.save(path)
   }
 }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/HashingTF.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/HashingTF.scala
@@ -44,21 +44,21 @@ import org.apache.spark.util.VersionUtils.majorMinorVersion
 @Since("1.2.0")
 class HashingTF @Since("3.0.0") (
     @Since("1.4.0") override val uid: String,
-    private[ml] val hashFuncVersion: Int)
+    @Since("3.0.0") val hashFuncVersion: Int)
   extends Transformer with HasInputCol with HasOutputCol with HasNumFeatures
     with DefaultParamsWritable {
 
   @transient lazy val hashFunc = hashFuncVersion match {
-    case HashingTF.HASH_FUNC_VERSION_1 => OldHashingTF.murmur3Hash _
-    case HashingTF.HASH_FUNC_VERSION_2 => FeatureHasher.murmur3Hash _
+    case HashingTF.SPARK_2_MURMUR3_HASH => OldHashingTF.murmur3Hash _
+    case HashingTF.SPARK_3_MURMUR3_HASH => FeatureHasher.murmur3Hash _
     case _ => throw new IllegalArgumentException("Illegal hash function version setting.")
   }
 
   @Since("1.2.0")
-  def this() = this(Identifiable.randomUID("hashingTF"), HashingTF.HASH_FUNC_VERSION_2)
+  def this() = this(Identifiable.randomUID("hashingTF"), HashingTF.SPARK_3_MURMUR3_HASH)
 
   @Since("1.4.0")
-  def this(uid: String) = this(uid, hashFuncVersion = HashingTF.HASH_FUNC_VERSION_2)
+  def this(uid: String) = this(uid, hashFuncVersion = HashingTF.SPARK_3_MURMUR3_HASH)
 
   /** @group setParam */
   @Since("1.4.0")
@@ -146,8 +146,8 @@ class HashingTF @Since("3.0.0") (
 @Since("1.6.0")
 object HashingTF extends DefaultParamsReadable[HashingTF] {
 
-  private[ml] val HASH_FUNC_VERSION_1 = 1
-  private[ml] val HASH_FUNC_VERSION_2 = 2
+  private[ml] val SPARK_2_MURMUR3_HASH = 1
+  private[ml] val SPARK_3_MURMUR3_HASH = 2
 
   private class HashingTFReader extends MLReader[HashingTF] {
 
@@ -161,9 +161,9 @@ object HashingTF extends DefaultParamsReadable[HashingTF] {
       // `ml.Feature.FeatureHasher.murmur3Hash`.
       val (majorVersion, _) = majorMinorVersion(metadata.sparkVersion)
       val hashFuncVersion = if (majorVersion < 3) {
-        HASH_FUNC_VERSION_1
+        SPARK_2_MURMUR3_HASH
       } else {
-        HASH_FUNC_VERSION_2
+        SPARK_3_MURMUR3_HASH
       }
       val hashingTF = new HashingTF(metadata.uid, hashFuncVersion = hashFuncVersion)
       metadata.getAndSetParams(hashingTF)

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/HashingTF.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/HashingTF.scala
@@ -48,12 +48,6 @@ class HashingTF @Since("3.0.0") private[ml] (
   extends Transformer with HasInputCol with HasOutputCol with HasNumFeatures
     with DefaultParamsWritable {
 
-  lazy val hashFunc = hashFuncVersion match {
-    case HashingTF.SPARK_2_MURMUR3_HASH => OldHashingTF.murmur3Hash _
-    case HashingTF.SPARK_3_MURMUR3_HASH => FeatureHasher.murmur3Hash _
-    case _ => throw new IllegalArgumentException("Illegal hash function version setting.")
-  }
-
   @Since("1.2.0")
   def this() = this(Identifiable.randomUID("hashingTF"), HashingTF.SPARK_3_MURMUR3_HASH)
 
@@ -131,7 +125,12 @@ class HashingTF @Since("3.0.0") private[ml] (
    */
   @Since("3.0.0")
   def indexOf(term: Any): Int = {
-    Utils.nonNegativeMod(hashFunc(term), $(numFeatures))
+    val hashValue = hashFuncVersion match {
+      case HashingTF.SPARK_2_MURMUR3_HASH => OldHashingTF.murmur3Hash(term)
+      case HashingTF.SPARK_3_MURMUR3_HASH => FeatureHasher.murmur3Hash(term)
+      case _ => throw new IllegalArgumentException("Illegal hash function version setting.")
+    }
+    Utils.nonNegativeMod(hashValue, $(numFeatures))
   }
 
   @Since("1.4.1")

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/HashingTF.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/HashingTF.scala
@@ -42,9 +42,9 @@ import org.apache.spark.util.VersionUtils.majorMinorVersion
  * otherwise the features will not be mapped evenly to the columns.
  */
 @Since("1.2.0")
-class HashingTF @Since("3.0.0") (
+class HashingTF @Since("3.0.0") private[m] (
     @Since("1.4.0") override val uid: String,
-    @Since("3.0.0") val hashFuncVersion: Int)
+    @Since("3.1.0") val hashFuncVersion: Int)
   extends Transformer with HasInputCol with HasOutputCol with HasNumFeatures
     with DefaultParamsWritable {
 
@@ -145,7 +145,9 @@ class HashingTF @Since("3.0.0") (
   @Since("3.0.0")
   override def save(path: String): Unit = {
     require(hashFuncVersion == HashingTF.SPARK_3_MURMUR3_HASH,
-      "Cannot save model which is loaded from lower version spark saved model.")
+      "Cannot save model which is loaded from lower version spark saved model. We can address " +
+      "it by (1) use old spark version to save the model, or (2) use new version spark to " +
+      "re-train the pipeline.")
     super.save(path)
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/HashingTFSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/HashingTFSuite.scala
@@ -100,6 +100,10 @@ class HashingTFSuite extends MLTest with DefaultReadWriteTest {
     val metadata = spark.read.json(s"$hashingTFPath/metadata")
     val sparkVersionStr = metadata.select("sparkVersion").first().getString(0)
     assert(sparkVersionStr == "2.4.4")
+
+    intercept[IllegalArgumentException] {
+      loadedHashingTF.save(hashingTFPath)
+    }
   }
 
   test("read/write") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Expose hashFunc property in HashingTF

Some third-party library such as mleap need to access it.
See background description here:
https://github.com/combust/mleap/pull/665#issuecomment-621258623


### Why are the changes needed?
See https://github.com/combust/mleap/pull/665#issuecomment-621258623

### Does this PR introduce any user-facing change?
No. Only add a package private constructor.

### How was this patch tested?
N/A