### PR TITLE
[SPARK-31611][YARN] Register NettyMemoryMetrics into Node Manager's metrics system

### DIFF
--- a/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
+++ b/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
@@ -198,6 +198,7 @@ public class YarnShuffleService extends AuxiliaryService {
       // register metrics on the block handler into the Node Manager's metrics system.
       blockHandler.getAllMetrics().getMetrics().put("numRegisteredConnections",
           shuffleServer.getRegisteredConnections());
+      blockHandler.getAllMetrics().getMetrics().putAll(shuffleServer.getAllMetrics().getMetrics());
       YarnShuffleServiceMetrics serviceMetrics =
           new YarnShuffleServiceMetrics(blockHandler.getAllMetrics());
 

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceSuite.scala
@@ -402,7 +402,9 @@ class YarnShuffleServiceSuite extends SparkFunSuite with Matchers with BeforeAnd
       "numRegisteredConnections",
       "openBlockRequestLatencyMillis",
       "registeredExecutorsSize",
-      "registerExecutorRequestLatencyMillis"
+      "registerExecutorRequestLatencyMillis",
+      "shuffle-server.usedDirectMemory",
+      "shuffle-server.usedHeapMemory"
     ))
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Register `NettyMemoryMetrics` into Node Manager's metrics system through `YarnShuffleServiceMetrics`.

- usedDirectMemory
- usedHeapMemory

### Why are the changes needed?

Such that `NettyMemoryMetrics` can be exposed through Node Manager's JMX.

### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Update UT to ensure NettyMemoryMetrics are registered into Node Manager's metrics system.
