### PR TITLE
[SPARK-31612][SQL][DOCS] SQL Reference clean up

### DIFF
--- a/docs/sql-ref-syntax-aux-describe-database.md
+++ b/docs/sql-ref-syntax-aux-describe-database.md
@@ -42,7 +42,7 @@ interchangeable.
   </dd>
 </dl>
 
-### Example
+### Examples
 
 {% highlight sql %}
 -- Create employees DATABASE

--- a/docs/sql-ref-syntax-aux-show-tables.md
+++ b/docs/sql-ref-syntax-aux-show-tables.md
@@ -52,7 +52,7 @@ SHOW TABLES [ { FROM | IN } database_name ] [ LIKE 'regex_pattern' ]
   </dd>
 </dl>
 
-### Example
+### Examples
 
 {% highlight sql %}
 -- List all tables in default database

--- a/docs/sql-ref-syntax-aux-show-views.md
+++ b/docs/sql-ref-syntax-aux-show-views.md
@@ -51,7 +51,7 @@ SHOW VIEWS [ { FROM | IN } database_name ] [ LIKE 'regex_pattern' ]
   </dd>
 </dl>
 
-### Example
+### Examples
 {% highlight sql %}
 -- Create views in different databases, also create global/local temp views.
 CREATE VIEW sam AS SELECT id, salary FROM employee WHERE name = 'sam';

--- a/docs/sql-ref-syntax-ddl-alter-database.md
+++ b/docs/sql-ref-syntax-ddl-alter-database.md
@@ -31,7 +31,7 @@ for a database and may be used for auditing purposes.
 
 {% highlight sql %}
 ALTER { DATABASE | SCHEMA } database_name
-    SET DBPROPERTIES ( property_name = property_value, ... )
+    SET DBPROPERTIES ( property_name = property_value [ , ... ] )
 {% endhighlight %}
 
 ### Parameters

--- a/docs/sql-ref-syntax-ddl-alter-table.md
+++ b/docs/sql-ref-syntax-ddl-alter-table.md
@@ -66,7 +66,7 @@ ALTER TABLE table_identifier partition_spec RENAME TO partition_spec
 #### Syntax
 
 {% highlight sql %}
-ALTER TABLE table_identifier ADD COLUMNS ( col_spec [ , col_spec ... ] )
+ALTER TABLE table_identifier ADD COLUMNS ( col_spec [ , ... ] )
 {% endhighlight %}
 
 #### Parameters
@@ -84,7 +84,7 @@ ALTER TABLE table_identifier ADD COLUMNS ( col_spec [ , col_spec ... ] )
 
 <dl>
   <dt><code><em>COLUMNS ( col_spec )</em></code></dt>
-  <dd>Specifies the columns to be added to be renamed.</dd>
+  <dd>Specifies the columns to be added.</dd>
 </dl>
 
 ### ALTER OR CHANGE COLUMN

--- a/docs/sql-ref-syntax-ddl-alter-view.md
+++ b/docs/sql-ref-syntax-ddl-alter-view.md
@@ -105,7 +105,7 @@ ALTER VIEW view_identifier UNSET TBLPROPERTIES [ IF EXISTS ]  ( property_key [ ,
 </dl>
 
 #### ALTER View AS SELECT
-`ALTER VIEW view_identifier AS SELECT` statement changes the definition of a view, the `SELECT` statement must be valid,
+`ALTER VIEW view_identifier AS SELECT` statement changes the definition of a view. The `SELECT` statement must be valid,
 and the `view_identifier` must exist.
 
 #### Syntax
@@ -127,7 +127,7 @@ Note that `ALTER VIEW` statement does not support `SET SERDE` or `SET SERDEPROPE
   </dd>
   <dt><code><em>select_statement</em></code></dt>
   <dd>
-    Specifies the definition of the view, detail check <a href="sql-ref-syntax-qry-select.html">select_statement</a>
+    Specifies the definition of the view. Check <a href="sql-ref-syntax-qry-select.html">select_statement</a> for details.
   </dd>
 </dl>
 
@@ -136,7 +136,7 @@ Note that `ALTER VIEW` statement does not support `SET SERDE` or `SET SERDEPROPE
 {% highlight sql %}
 -- Rename only changes the view name.
 -- The source and target databases of the view have to be the same.
--- Use qualified or unqualified name for the source and target view  
+-- Use qualified or unqualified name for the source and target view.
 ALTER VIEW tempdb1.v1 RENAME TO tempdb1.v2;
 
 -- Verify that the new view is created.

--- a/docs/sql-ref-syntax-ddl-create-function.md
+++ b/docs/sql-ref-syntax-ddl-create-function.md
@@ -28,8 +28,8 @@ all sessions. The resources specified in the `USING` clause are made available
 to all executors when they are executed for the first time. In addition to the
 SQL interface, spark allows users to create custom user defined scalar and
 aggregate functions using Scala, Python and Java APIs. Please refer to 
-[scalar_functions](sql-getting-started.html#scalar-functions) and 
-[aggregate functions](sql-getting-started#aggregations) for more information.
+[Scalar UDFs](sql-ref-functions-udf-scalar.html) and
+[UDAFs](sql-ref-functions-udf-aggregate.html) for more information.
 
 ### Syntax
 

--- a/docs/sql-ref-syntax-ddl-create-table-datasource.md
+++ b/docs/sql-ref-syntax-ddl-create-table-datasource.md
@@ -28,7 +28,7 @@ The `CREATE TABLE` statement defines a new table using a Data Source.
 {% highlight sql %}
 CREATE TABLE [ IF NOT EXISTS ] table_identifier
     [ ( col_name1 col_type1 [ COMMENT col_comment1 ], ... ) ]
-    [USING data_source]
+    [ USING data_source ]
     [ OPTIONS ( key1=val1, key2=val2, ... ) ]
     [ PARTITIONED BY ( col_name1, col_name2, ... ) ]
     [ CLUSTERED BY ( col_name3, col_name4, ... ) 

--- a/docs/sql-ref-syntax-ddl-create-view.md
+++ b/docs/sql-ref-syntax-ddl-create-view.md
@@ -42,7 +42,7 @@ CREATE [ OR REPLACE ] [ [ GLOBAL ] TEMPORARY ] VIEW [ IF NOT EXISTS ] view_ident
   <dt><code><em>[ GLOBAL ] TEMPORARY</em></code></dt>
   <dd>TEMPORARY views are session-scoped and will be dropped when session ends 
       because it skips persisting the definition in the underlying metastore, if any.
-      GLOBAL TEMPORARY views are tied to a system preserved temporary database `global_temp`.</dd>
+      GLOBAL TEMPORARY views are tied to a system preserved temporary database <code>global_temp</code>.</dd>
 </dl>
 <dl>
   <dt><code><em>IF NOT EXISTS</em></code></dt>
@@ -64,7 +64,7 @@ CREATE [ OR REPLACE ] [ [ GLOBAL ] TEMPORARY ] VIEW [ IF NOT EXISTS ] view_ident
     <ul>
       <li><code>[ ( column_name [ COMMENT column_comment ], ... ) ]</code> to specify column-level comments.</li>
       <li><code>[ COMMENT view_comment ]</code> to specify view-level comments.</li>
-      <li><code>[ TBLPROPERTIES ( property_name = property_value, ... ) ]</code> to add metadata key-value pairs.</li>
+      <li><code>[ TBLPROPERTIES ( property_name = property_value [ , ... ] ) ]</code> to add metadata key-value pairs.</li>
     </ul>  
   </dd>
 </dl>

--- a/docs/sql-ref-syntax-ddl-drop-database.md
+++ b/docs/sql-ref-syntax-ddl-drop-database.md
@@ -27,14 +27,14 @@ exception will be thrown if the database does not exist in the system.
 ### Syntax
 
 {% highlight sql %}
-DROP ( DATABASE | SCHEMA ) [ IF EXISTS ] dbname [ RESTRICT | CASCADE ]
+DROP { DATABASE | SCHEMA } [ IF EXISTS ] dbname [ RESTRICT | CASCADE ]
 {% endhighlight %}
 
 ### Parameters
 
 <dl>
   <dt><code><em>DATABASE | SCHEMA</em></code></dt>
-  <dd>`DATABASE` and `SCHEMA` mean the same thing, either of them can be used.</dd>
+  <dd><code>DATABASE</code> and <code>SCHEMA</code> mean the same thing, either of them can be used.</dd>
 </dl>
 
 <dl>
@@ -52,7 +52,7 @@ DROP ( DATABASE | SCHEMA ) [ IF EXISTS ] dbname [ RESTRICT | CASCADE ]
   <dd>If specified, will drop all the associated tables and functions.</dd>
 </dl>
 
-### Example
+### Examples
 
 {% highlight sql %}
 -- Create `inventory_db` Database

--- a/docs/sql-ref-syntax-ddl-drop-function.md
+++ b/docs/sql-ref-syntax-ddl-drop-function.md
@@ -27,19 +27,26 @@ be thrown if the function does not exist.
 ### Syntax
 
 {% highlight sql %}
-DROP [ TEMPORARY ] FUNCTION [ IF EXISTS ] [ db_name. ] function_name
+DROP [ TEMPORARY ] FUNCTION [ IF EXISTS ] function_name
 {% endhighlight %}
 
 ### Parameters
 
 <dl>
   <dt><code><em>function_name</em></code></dt>
-  <dd>The name of an existing function.</dd>
+  <dd>
+    Specifies the name of an existing function. The function name may be
+    optionally qualified with a database name. <br><br>
+    <b>Syntax:</b>
+      <code>
+        [ database_name. ] function_name
+      </code>
+  </dd>
 </dl>
 
 <dl>
   <dt><code><em>TEMPORARY</em></code></dt>
-  <dd>Should be used to delete the `temporary` function.</dd>
+  <dd>Should be used to delete the <code>TEMPORARY</code> function.</dd>
 </dl>
 
 <dl>
@@ -47,7 +54,7 @@ DROP [ TEMPORARY ] FUNCTION [ IF EXISTS ] [ db_name. ] function_name
   <dd>If specified, no exception is thrown when the function does not exist.</dd>
 </dl>
 
-### Example
+### Examples
 
 {% highlight sql %}
 -- Create a permanent function `test_avg`
@@ -62,7 +69,8 @@ SHOW USER FUNCTIONS;
   +----------------+
 
 -- Create Temporary function `test_avg`
-CREATE TEMPORARY FUNCTION test_avg as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDAFAverage';
+CREATE TEMPORARY FUNCTION test_avg AS
+    'org.apache.hadoop.hive.ql.udf.generic.GenericUDAFAverage';
 
 -- List user functions
 SHOW USER FUNCTIONS;

--- a/docs/sql-ref-syntax-ddl-drop-table.md
+++ b/docs/sql-ref-syntax-ddl-drop-table.md
@@ -49,7 +49,7 @@ DROP TABLE [ IF EXISTS ] table_identifier
   </dd>
 </dl>
 
-### Example
+### Examples
 
 {% highlight sql %}
 -- Assumes a table named `employeetable` exists.

--- a/docs/sql-ref-syntax-ddl-drop-view.md
+++ b/docs/sql-ref-syntax-ddl-drop-view.md
@@ -46,7 +46,7 @@ DROP VIEW [ IF EXISTS ] view_identifier
   </dd>
 </dl>
 
-### Example
+### Examples
 
 {% highlight sql %}
 -- Assumes a view named `employeeView` exists.

--- a/docs/sql-ref-syntax-ddl-truncate-table.md
+++ b/docs/sql-ref-syntax-ddl-truncate-table.md
@@ -61,7 +61,7 @@ TRUNCATE TABLE table_identifier [ partition_spec ]
 -- Create table Student with partition
 CREATE TABLE Student (name STRING, rollno INT) PARTITIONED BY (age INT);
 
-SELECT * from Student;
+SELECT * FROM Student;
   +----+------+---+
   |name|rollno|age|
   +----+------+---+
@@ -74,7 +74,7 @@ SELECT * from Student;
 TRUNCATE TABLE Student partition(age=10);
 
 -- After truncate execution, records belonging to partition age=10 are removed
-SELECT * from Student;
+SELECT * FROM Student;
   +----+------+---+
   |name|rollno|age|
   +----+------+---+
@@ -84,7 +84,7 @@ SELECT * from Student;
 -- Removes all rows from the table from all partitions
 TRUNCATE TABLE Student;
 
-SELECT * from Student;
+SELECT * FROM Student;
   +----+------+---+
   |name|rollno|age|
   +----+------+---+

--- a/docs/sql-ref-syntax-dml-insert-into.md
+++ b/docs/sql-ref-syntax-dml-insert-into.md
@@ -27,7 +27,7 @@ The `INSERT INTO` statement inserts new rows into a table. The inserted rows can
 
 {% highlight sql %}
 INSERT INTO [ TABLE ] table_identifier [ partition_spec ]
-    { { VALUES ( { value | NULL } [ , ... ] ) [ , ( ... ) ] } | query }
+    { VALUES ( { value | NULL } [ , ... ] ) [ , ( ... ) ] | query }
 {% endhighlight %}
 
 ### Parameters
@@ -50,7 +50,7 @@ INSERT INTO [ TABLE ] table_identifier [ partition_spec ]
     for partitions.<br><br>
     <b>Syntax:</b>
       <code>
-        PARTITION (partition_col_name  = partition_col_val [ , ... ])
+        PARTITION ( partition_col_name  = partition_col_val [ , ... ] )
       </code>
   </dd>
 </dl>

--- a/docs/sql-ref-syntax-dml-insert-overwrite-directory-hive.md
+++ b/docs/sql-ref-syntax-dml-insert-overwrite-directory-hive.md
@@ -29,7 +29,7 @@ Hive support must be enabled to use this command. The inserted rows can be speci
 {% highlight sql %}
 INSERT OVERWRITE [ LOCAL ] DIRECTORY directory_path
     [ ROW FORMAT row_format ] [ STORED AS file_format ]
-    { { VALUES ( { value | NULL } [ , ... ] ) [ , ( ... ) ] } | query }
+    { VALUES ( { value | NULL } [ , ... ] ) [ , ( ... ) ] | query }
 {% endhighlight %}
 
 ### Parameters

--- a/docs/sql-ref-syntax-dml-insert-overwrite-directory.md
+++ b/docs/sql-ref-syntax-dml-insert-overwrite-directory.md
@@ -28,7 +28,7 @@ The `INSERT OVERWRITE DIRECTORY` statement overwrites the existing data in the d
 {% highlight sql %}
 INSERT OVERWRITE [ LOCAL ] DIRECTORY [ directory_path ]
     USING file_format [ OPTIONS ( key = val [ , ... ] ) ]
-    { { VALUES ( { value | NULL } [ , ... ] ) [ , ( ... ) ] } | query }
+    { VALUES ( { value | NULL } [ , ... ] ) [ , ( ... ) ] | query }
 {% endhighlight %}
 
 ### Parameters

--- a/docs/sql-ref-syntax-dml-insert-overwrite-table.md
+++ b/docs/sql-ref-syntax-dml-insert-overwrite-table.md
@@ -27,7 +27,7 @@ The `INSERT OVERWRITE` statement overwrites the existing data in the table using
 
 {% highlight sql %}
 INSERT OVERWRITE [ TABLE ] table_identifier [ partition_spec [ IF NOT EXISTS ] ]
-    { { VALUES ( { value | NULL } [ , ... ] ) [ , ( ... ) ] } | query }
+    { VALUES ( { value | NULL } [ , ... ] ) [ , ( ... ) ] | query }
 {% endhighlight %}
 
 ### Parameters

--- a/docs/sql-ref-syntax-qry-select-usedb.md
+++ b/docs/sql-ref-syntax-qry-select-usedb.md
@@ -41,7 +41,7 @@ USE database_name
   </dd>
 </dl>
 
-### Example
+### Examples
 
 {% highlight sql %}
 -- Use the 'userdb' which exists.

--- a/docs/sql-ref-syntax-qry.md
+++ b/docs/sql-ref-syntax-qry.md
@@ -22,7 +22,8 @@ license: |
 Spark supports <code>SELECT</code> statement that is used to retrieve rows
 from one or more tables according to the specified clauses. The full syntax
 and brief description of supported clauses are explained in
-[SELECT](sql-ref-syntax-qry-select.html) section. Spark also provides the
+[SELECT](sql-ref-syntax-qry-select.html) section. The SQL statements related
+to SELECT are also included in this section. Spark also provides the
 ability to generate logical and physical plan for a given query using
 [EXPLAIN](sql-ref-syntax-qry-explain.html) statement.
 
@@ -34,4 +35,12 @@ ability to generate logical and physical plan for a given query using
  * [CLUSTER BY Clause](sql-ref-syntax-qry-select-clusterby.html)
  * [DISTRIBUTE BY Clause](sql-ref-syntax-qry-select-distribute-by.html)
  * [LIMIT Clause](sql-ref-syntax-qry-select-limit.html)
+ * [JOIN](sql-ref-syntax-qry-select-join.html)
+ * [Join Hints](sql-ref-syntax-qry-select-hints.html)
+ * [Set Operators](sql-ref-syntax-qry-select-setops.html)
+ * [TABLESAMPLE](sql-ref-syntax-qry-sampling.html)
+ * [Table-valued Function](sql-ref-syntax-qry-select-tvf.html)
+ * [Inline Table](sql-ref-syntax-qry-select-inline-table.html)
+ * [Common Table Expression](sql-ref-syntax-qry-select-cte.html)
+ * [Window Function](sql-ref-syntax-qry-window.html)
  * [EXPLAIN Statement](sql-ref-syntax-qry-explain.html)


### PR DESCRIPTION
### What changes were proposed in this pull request?
SQL Reference cleanup

### Why are the changes needed?
To complete SQL Reference


### Does this PR introduce _any_ user-facing change?
Fix the following stuff:

- Example -> Examples
- SET DBPROPERTIES ( property_name = property_value, ... ) -> SET DBPROPERTIES ( property_name = property_value [ , ... ] )  
// be consistent with format. brackets [ and ] indicate optional parts, and dots ... mean that the 
// preceding element can be repeated.
- col_spec [ , col_spec ... ] -> col_spec [ , ... ] // same as above, be consistent with format.
- [USING data_source] -> [ USING data_source ] // be consistent with format. space between [ and text
- change function_name format to make it consistent with others
- from -> FROM // uppercase keyword
- { { VALUES ( { value | NULL } [ , ... ] ) [ , ( ... ) ] } | query } ->  { VALUES ( { value | NULL } [ , ... ] ) [ , ( ... ) ] | query } // remove unnecessary { } 
- DROP ( DATABASE | SCHEMA ) -> DROP { DATABASE | SCHEMA } 
// Braces { and } and vertical lines | indicate that you must choose one alternative
- fix a few link and typo too. 

Also updated sql-ref-syntax-qry.html

before
<img width="1100" alt="Screen Shot 2020-04-29 at 11 08 25 PM" src="https://user-images.githubusercontent.com/13592258/80677799-70b27280-8a6e-11ea-8e3f-a768f29d0377.png">

after
<img width="1100" alt="Screen Shot 2020-04-29 at 11 05 55 PM" src="https://user-images.githubusercontent.com/13592258/80677803-74de9000-8a6e-11ea-880c-aa05c53254a6.png">



### How was this patch tested?
Manually build and check
