### PR TITLE
[SPARK-31616][SQL] Add partition event listener in ExternalCatalogWithListener

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogWithListener.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogWithListener.scala
@@ -175,8 +175,12 @@ class ExternalCatalogWithListener(delegate: ExternalCatalog)
       isOverwrite: Boolean,
       inheritTableSpecs: Boolean,
       isSrcLocal: Boolean): Unit = {
+    postToAll(LoadPartitionPreEvent(
+      db, table, loadPath, partition, isOverwrite, inheritTableSpecs, isSrcLocal))
     delegate.loadPartition(
       db, table, loadPath, partition, isOverwrite, inheritTableSpecs, isSrcLocal)
+    postToAll(LoadPartitionEvent(
+      db, table, loadPath, partition, isOverwrite, inheritTableSpecs, isSrcLocal))
   }
 
   override def loadDynamicPartitions(
@@ -186,7 +190,11 @@ class ExternalCatalogWithListener(delegate: ExternalCatalog)
       partition: TablePartitionSpec,
       replace: Boolean,
       numDP: Int): Unit = {
+    postToAll(LoadDynamicPartitionsPreEvent(
+      db, table, loadPath, partition, replace, numDP))
     delegate.loadDynamicPartitions(db, table, loadPath, partition, replace, numDP)
+    postToAll(LoadDynamicPartitionsEvent(
+      db, table, loadPath, partition, replace, numDP))
   }
 
   // --------------------------------------------------------------------------
@@ -198,7 +206,9 @@ class ExternalCatalogWithListener(delegate: ExternalCatalog)
       table: String,
       parts: Seq[CatalogTablePartition],
       ignoreIfExists: Boolean): Unit = {
+    postToAll(CreatePartitionsPreEvent(db, table, parts, ignoreIfExists))
     delegate.createPartitions(db, table, parts, ignoreIfExists)
+    postToAll(CreatePartitionsEvent(db, table, parts, ignoreIfExists))
   }
 
   override def dropPartitions(
@@ -208,7 +218,9 @@ class ExternalCatalogWithListener(delegate: ExternalCatalog)
       ignoreIfNotExists: Boolean,
       purge: Boolean,
       retainData: Boolean): Unit = {
+    postToAll(DropPartitionsPreEvent(db, table, partSpecs, ignoreIfNotExists, purge, retainData))
     delegate.dropPartitions(db, table, partSpecs, ignoreIfNotExists, purge, retainData)
+    postToAll(DropPartitionsEvent(db, table, partSpecs, ignoreIfNotExists, purge, retainData))
   }
 
   override def renamePartitions(
@@ -216,14 +228,18 @@ class ExternalCatalogWithListener(delegate: ExternalCatalog)
       table: String,
       specs: Seq[TablePartitionSpec],
       newSpecs: Seq[TablePartitionSpec]): Unit = {
+    postToAll(RenamePartitionsPreEvent(db, table, specs, newSpecs))
     delegate.renamePartitions(db, table, specs, newSpecs)
+    postToAll(RenamePartitionsEvent(db, table, specs, newSpecs))
   }
 
   override def alterPartitions(
       db: String,
       table: String,
       parts: Seq[CatalogTablePartition]): Unit = {
+    postToAll(AlterPartitionsPreEvent(db, table, parts))
     delegate.alterPartitions(db, table, parts)
+    postToAll(AlterPartitionsEvent(db, table, parts))
   }
 
   override def getPartition(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogWithListener.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogWithListener.scala
@@ -199,9 +199,10 @@ class ExternalCatalogWithListener(delegate: ExternalCatalog)
     postToAll(LoadDynamicPartitionsEvent(db, table, loadPath, partitions, replace, numDP))
   }
 
-  def calculateDynamicPartitions(loadPath: Path,
-                                 partitionSpec: TablePartitionSpec,
-                                 numDP: Int): Array[TablePartitionSpec] = {
+  def calculateDynamicPartitions(
+      loadPath: Path,
+      partitionSpec: TablePartitionSpec,
+      numDP: Int): Array[TablePartitionSpec] = {
     assert(numDP > 0)
     try {
       val fs = loadPath.getFileSystem(new Configuration())

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/events.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/events.scala
@@ -188,7 +188,7 @@ case class LoadDynamicPartitionsPreEvent(
     database: String,
     table: String,
     loadPath: String,
-    partition: TablePartitionSpec,
+    partitions: Seq[TablePartitionSpec],
     replace: Boolean,
     numDP: Int) extends PartitionEvent
 
@@ -199,7 +199,7 @@ case class LoadDynamicPartitionsEvent(
    database: String,
    table: String,
    loadPath: String,
-   partition: TablePartitionSpec,
+   partitions: Seq[TablePartitionSpec],
    replace: Boolean,
    numDP: Int) extends PartitionEvent
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/events.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/events.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.catalyst.catalog
 
 import org.apache.spark.scheduler.SparkListenerEvent
+import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 
 /**
  * Event emitted by the external catalog when it is modified. Events are either fired before or
@@ -144,6 +145,137 @@ case class AlterTableEvent(
     database: String,
     name: String,
     kind: String) extends TableEvent
+
+/**
+ * Event fired when a partition is created, dropped or renamed.
+ */
+trait PartitionEvent extends DatabaseEvent {
+
+  /**
+   * table name
+   */
+  val table: String
+}
+
+/**
+ * Event fired before a partition is loaded.
+ */
+case class LoadPartitionPreEvent(
+    database: String,
+    table: String,
+    loadPath: String,
+    partition: TablePartitionSpec,
+    isOverwrite: Boolean,
+    inheritTableSpecs: Boolean,
+    isSrcLocal: Boolean) extends PartitionEvent
+
+/**
+ * Event fired after a partition is loaded.
+ */
+case class LoadPartitionEvent(
+    database: String,
+    table: String,
+    loadPath: String,
+    partition: TablePartitionSpec,
+    isOverwrite: Boolean,
+    inheritTableSpecs: Boolean,
+    isSrcLocal: Boolean) extends PartitionEvent
+
+/**
+ * Event fired before load dynamic partitions.
+ */
+case class LoadDynamicPartitionsPreEvent(
+    database: String,
+    table: String,
+    loadPath: String,
+    partition: TablePartitionSpec,
+    replace: Boolean,
+    numDP: Int) extends PartitionEvent
+
+/**
+ * Event fired after load dynamic partitions.
+ */
+case class LoadDynamicPartitionsEvent(
+   database: String,
+   table: String,
+   loadPath: String,
+   partition: TablePartitionSpec,
+   replace: Boolean,
+   numDP: Int) extends PartitionEvent
+
+/**
+ * Event fired before a partition is created.
+ */
+case class CreatePartitionsPreEvent(
+    database: String,
+    table: String,
+    parts: Seq[CatalogTablePartition],
+    ignoreIfExists: Boolean) extends PartitionEvent
+
+/**
+ * Event fired after a partition is created.
+ */
+case class CreatePartitionsEvent(
+    database: String,
+    table: String,
+    parts: Seq[CatalogTablePartition],
+    ignoreIfExists: Boolean) extends PartitionEvent
+
+/**
+ * Event fired before a partition is dropped.
+ */
+case class DropPartitionsPreEvent(
+    database: String,
+    table: String,
+    partSpecs: Seq[TablePartitionSpec],
+    ignoreIfNotExists: Boolean,
+    purge: Boolean,
+    retainData: Boolean) extends PartitionEvent
+
+/**
+ * Event fired after a partition is dropped.
+ */
+case class DropPartitionsEvent(
+    database: String,
+    table: String,
+    partSpecs: Seq[TablePartitionSpec],
+    ignoreIfNotExists: Boolean,
+    purge: Boolean,
+    retainData: Boolean) extends PartitionEvent
+
+/**
+ * Event fired before a partition is renamed.
+ */
+case class RenamePartitionsPreEvent(
+    database: String,
+    table: String,
+    specs: Seq[TablePartitionSpec],
+    newSpecs: Seq[TablePartitionSpec]) extends PartitionEvent
+
+/**
+ * Event fired after a partition is renamed.
+ */
+case class RenamePartitionsEvent(
+    database: String,
+    table: String,
+    specs: Seq[TablePartitionSpec],
+    newSpecs: Seq[TablePartitionSpec]) extends PartitionEvent
+
+/**
+ * Event fired before a partition is altered.
+ */
+case class AlterPartitionsPreEvent(
+    database: String,
+    table: String,
+    parts: Seq[CatalogTablePartition]) extends PartitionEvent
+
+/**
+ * Event fired after a partition is altered.
+ */
+case class AlterPartitionsEvent(
+    database: String,
+    table: String,
+    parts: Seq[CatalogTablePartition]) extends PartitionEvent
 
 /**
  * Event fired when a function is created, dropped, altered or renamed.


### PR DESCRIPTION

### What changes were proposed in this pull request?
For a partition is changed through external catalog , we can get the event by adding custom external catalog listener. 

### Why are the changes needed?

There are many partitioned table in our data warehouse.
We can get and analyze these  partition change events  by adding custom external catalog listener.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Use exists tests
