### PR TITLE
[SPARK-17604][SS] FileStreamSource: provide a new option to have retention on input files

### DIFF
--- a/docs/structured-streaming-programming-guide.md
+++ b/docs/structured-streaming-programming-guide.md
@@ -547,6 +547,12 @@ Here are the details of all the sources in Spark.
         <br/>
         <code>maxFileAge</code>: Maximum age of a file that can be found in this directory, before it is ignored. For the first batch all files will be considered valid. If <code>latestFirst</code> is set to `true` and <code>maxFilesPerTrigger</code> is set, then this parameter will be ignored, because old files that are valid, and should be processed, may be ignored. The max age is specified with respect to the timestamp of the latest file, and not the timestamp of the current system.(default: 1 week)
         <br/>
+        <code>inputRetention</code>: Maximum age of a file that can be found in this directory, before it is ignored. (e.g. 14d, default: None)<br/>
+        This is the "hard" limit of input data retention - input files older than the max age will be ignored regardless of source options (while `maxFileAgeMs` depends on the condition), as well as entries in checkpoint metadata will be purged based on this.<br/>
+        Unlike `maxFileAgeMs`, the max age is specified with respect to the timestamp of the current system, to provide consistent behavior regardless of metadata entries.<br/>
+        NOTE 1: Please be careful to set the value if the query replays from the old input files.<br/>
+        NOTE 2: Please make sure the timestamp is in sync between nodes which run the query.<br/>
+        <br/>
         <code>cleanSource</code>: option to clean up completed files after processing.<br/>
         Available options are "archive", "delete", "off". If the option is not provided, the default value is "off".<br/>
         When "archive" is provided, additional option <code>sourceArchiveDir</code> must be provided as well. The value of "sourceArchiveDir" must not match with source pattern in depth (the number of directories from the root directory), where the depth is minimum of depth on both paths. This will ensure archived files are never included as new source files.<br/>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamOptions.scala
@@ -77,6 +77,21 @@ class FileStreamOptions(parameters: CaseInsensitiveMap[String]) extends Logging 
   val fileNameOnly: Boolean = withBooleanParameter("fileNameOnly", false)
 
   /**
+   * Maximum age of a file that can be found in this directory, before it is ignored.
+   *
+   * This is the "hard" limit of input data retention - input files older than the max age will be
+   * ignored regardless of source options (while `maxFileAgeMs` depends on the condition), as well
+   * as entries in checkpoint metadata will be purged based on this.
+   *
+   * Unlike `maxFileAgeMs`, the max age is specified with respect to the timestamp of the current
+   * system, to provide consistent behavior regardless of metadata entries.
+   *
+   * NOTE 1: Please be careful to set the value if the query replays from the old input files.
+   * NOTE 2: Please make sure the timestamp is in sync between nodes which run the query.
+   */
+  val inputRetentionMs = parameters.get("inputRetention").map(Utils.timeStringAsMs)
+
+  /**
    * The archive directory to move completed files. The option will be only effective when
    * "cleanSource" is set to "archive".
    *

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -42,7 +42,7 @@ import org.apache.spark.sql.streaming.util.StreamManualClock
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.types.{StructType, _}
-import org.apache.spark.util.Utils
+import org.apache.spark.util.{ManualClock, SystemClock, Utils}
 
 abstract class FileStreamSourceTest
   extends StreamTest with SharedSparkSession with PrivateMethodTester {
@@ -1461,7 +1461,8 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
 
   private def readLogFromResource(dir: String): Seq[FileEntry] = {
     val input = getClass.getResource(s"/structured-streaming/$dir")
-    val log = new FileStreamSourceLog(FileStreamSourceLog.VERSION, spark, input.toString)
+    val log = new FileStreamSourceLog(FileStreamSourceLog.VERSION, spark, input.toString,
+      new SystemClock, Long.MaxValue)
     log.allFiles()
   }
 
@@ -1614,7 +1615,8 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
       // add the metadata entries as a pre-req
       val dir = new File(temp, "dir") // use non-existent directory to test whether log make the dir
     val metadataLog =
-      new FileStreamSourceLog(FileStreamSourceLog.VERSION, spark, dir.getAbsolutePath)
+      new FileStreamSourceLog(FileStreamSourceLog.VERSION, spark, dir.getAbsolutePath,
+        new SystemClock, Long.MaxValue)
       assert(metadataLog.add(0, Array(FileEntry(s"$scheme:///file1", 100L, 0))))
       assert(metadataLog.add(1, Array(FileEntry(s"$scheme:///file2", 200L, 0))))
 
@@ -1622,6 +1624,87 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
         dir.getAbsolutePath, Map.empty)
       // this method should throw an exception if `fs.exists` is called during resolveRelation
       newSource.getBatch(None, FileStreamSourceOffset(1))
+    }
+  }
+
+  test("old files should not be included as input files if input retention is specified") {
+    withTempDir { dir =>
+      /** Create a text file with a single data item */
+      def createFile(data: Int, timestamp: Long): File = {
+        val file = stringToFile(new File(dir, s"$data.txt"), data.toString)
+        file.setLastModified(timestamp)
+        file
+      }
+
+      def validate(
+          files: Seq[File],
+          inputRetention: Long,
+          timeToAdvance: Long,
+          limit: ReadLimit,
+          expectedFiles: Seq[File]): Unit = {
+        val df = createFileStream("text", dir.getAbsolutePath,
+          options = Map("inputRetention" -> inputRetention.toString, "maxFileAge" -> "7d"))
+        val fileSource = getSourceFromFileStream(df)
+        val _metadataLog = PrivateMethod[FileStreamSourceLog](Symbol("metadataLog"))
+        val metadataLog = fileSource invokePrivate _metadataLog()
+
+        val clock = new ManualClock
+        fileSource.clockForRetention = clock
+        clock.advance(timeToAdvance)
+
+        val offset = fileSource.latestOffset(FileStreamSourceOffset(-1L), limit)
+          .asInstanceOf[FileStreamSourceOffset]
+
+        val inputFiles = metadataLog.get(offset.logOffset)
+        assert(inputFiles.nonEmpty)
+
+        val inputFileNames = inputFiles.get.map { f => new File(f.path).getName }.toSet
+        val expectedFileNames = expectedFiles.map(_.getName).toSet
+        assert(inputFileNames === expectedFileNames)
+      }
+
+      // files will have various modified times between 1000 to 10000
+      val files = (1 to 10).map { idx =>
+        createFile(idx, 1000 * idx)
+      }
+
+      // we initialize FileStreamSource per case as the test will be affected by SeenFilesMap
+      validate(files, 5000, 10000, ReadLimit.allAvailable(),
+        files.filter(_.lastModified() >= 5000))
+      validate(files, 5000, 10000, ReadLimit.maxFiles(2),
+        files.filter(_.lastModified() >= 5000).take(2))
+    }
+  }
+
+  test("filter out outdated entries in file stream source log when compacting") {
+    withTempDir { dir =>
+      val clock = new ManualClock
+      val metadataLog =
+        new FileStreamSourceLog(FileStreamSourceLog.VERSION, spark, dir.getAbsolutePath,
+          clock, 10000)
+
+      val files1 = (1 to 3).map { idx =>
+        FileEntry(s"1_$idx", idx * 1000, 1)
+      }
+
+      clock.advance(4000) // clock time = 4000
+
+      files1.foreach { f => assert(metadataLog.shouldRetain(f)) }
+
+      val files2 = (1 to 3).map { idx =>
+        FileEntry(s"2_$idx", 10000 + idx * 1000, 2)
+      }
+
+      val allFiles = files1 ++ files2
+
+      allFiles.foreach { f => assert(metadataLog.shouldRetain(f)) }
+
+      clock.advance(10000) // clock time = 14000
+
+      // only files in batch 1 will be evicted
+
+      files1.foreach { f => assert(!metadataLog.shouldRetain(f)) }
+      files2.foreach { f => assert(metadataLog.shouldRetain(f)) }
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR introduces a new option, `inputRetention` to provide a way to specify retention on input files.

`maxAgeMs` plays as `soft` limit (it doesn't apply for some conditions like first batch, as well as it's applied relatively to the modified time of input files). Given it's not consistently applied across the matrix of configurations, Spark cannot purge the entries based on the configuration. (Streaming query can change the configurations and be relaunched.)

`inputRetention` plays as `hard` limit - Spark will not include files older than the retention as input files, as well as tries to exclude file entries older than the retention (it actually happens on compaction, as it's the only phase to remove entries).

`inputRetention` is relative to the system timestamp unlike `maxAgeMs`, which is easier for end users to reason about. This would require end users to correctly set the nodes' timestamp, but in most cases they would do it in other reasons as well. Also, this would filter out old files when the query intends to replay from input files, hence this should be considered as well.

### Why are the changes needed?

This has been a pain to deal with metadata growing in both file stream source and file stream sink. For file stream source, all processed input files are tracked which size is continuously growing, and there's no approach on reducing the size/entries. In compact batch, it reads all previous input files to write new compact file, which brings major latency. 

### Does this PR introduce _any_ user-facing change?

This doesn't bring any change "by default", as the new configuration is optional. (The default value is set to unrealistic one making it effectively none.)

This adds a new configuration - previous sections described the behavior.

### How was this patch tested?

New UTs verifying two behaviors per test. 

1) old files should not be included as input files if input retention is specified
2) when compacting, outdated entries should be filtered out 

I've manually tested with above two behaviors as well.