### PR TITLE
[SPARK-31625][YARN] Unregister application from YARN RM outside the shutdown hook if it succeeds

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -152,7 +152,7 @@ private[spark] class ApplicationMaster(
   // In cluster mode, used to tell the AM when the user's SparkContext has been initialized.
   private val sparkContextPromise = Promise[SparkContext]()
 
-  private val defaultStagingDir = new Path(System.getenv("SPARK_YARN_STAGING_DIR"))
+  private lazy val defaultStagingDir = new Path(System.getenv("SPARK_YARN_STAGING_DIR"))
 
   /**
    * Load the list of localized files set by the client, used when launching executors. This should

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -89,7 +89,7 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
   }
 
   test("run Spark in yarn-client mode with unmanaged am") {
-    // testBasicYarnApp(true, Map(YARN_UNMANAGED_AM.key -> "true"))
+    testBasicYarnApp(true, Map(YARN_UNMANAGED_AM.key -> "true"))
   }
 
   test("run Spark in yarn-client mode with different configurations, ensuring redaction") {

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -238,6 +238,13 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
     testExecutorEnv(false)
   }
 
+  test("spark context is not stopped by user application in cluster mode") {
+    val result = File.createTempFile("result", null, tempDir)
+    val finalState = runSpark(false, mainClassName(SparkContextNotStoppedTestApp.getClass),
+      appArgs = Seq(result.getAbsolutePath()))
+    checkResult(finalState, result)
+  }
+
   private def testBasicYarnApp(clientMode: Boolean, conf: Map[String, String] = Map()): Unit = {
     val result = File.createTempFile("result", null, tempDir)
     val finalState = runSpark(clientMode, mainClassName(YarnClusterDriver.getClass),
@@ -582,6 +589,18 @@ private object ExecutorEnvTestApp {
 
     Files.write(result.toString, new File(status), StandardCharsets.UTF_8)
     sc.stop()
+  }
+
+}
+
+private object SparkContextNotStoppedTestApp {
+
+  def main(args: Array[String]): Unit = {
+    val status = args(0)
+    val sparkConf = new SparkConf()
+    val sc = new SparkContext(sparkConf)
+    sc.parallelize(Seq(1)).collect
+    Files.write("success", new File(status), StandardCharsets.UTF_8)
   }
 
 }

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -89,7 +89,7 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
   }
 
   test("run Spark in yarn-client mode with unmanaged am") {
-    testBasicYarnApp(true, Map(YARN_UNMANAGED_AM.key -> "true"))
+    // testBasicYarnApp(true, Map(YARN_UNMANAGED_AM.key -> "true"))
   }
 
   test("run Spark in yarn-client mode with different configurations, ensuring redaction") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Currently, an application is unregistered from YARN RM in a shutdown hook. In the scenario where the shutdown hook does not run (e.g., timeouts, etc.), the application is not unregistered, resulting in YARN RM resubmitting the application even if it succeeded.

For example, you could see the following on the driver log:
```
20/04/30 06:20:29 INFO SparkContext: Successfully stopped SparkContext
20/04/30 06:20:29 INFO ApplicationMaster: Final app status: SUCCEEDED, exitCode: 0
20/04/30 06:20:59 WARN ShutdownHookManager: ShutdownHook '$anon$2' timeout, java.util.concurrent.TimeoutException
java.util.concurrent.TimeoutException
	at java.util.concurrent.FutureTask.get(FutureTask.java:205)
	at org.apache.hadoop.util.ShutdownHookManager.executeShutdown(ShutdownHookManager.java:124)
	at org.apache.hadoop.util.ShutdownHookManager$1.run(ShutdownHookManager.java:95)
```
You can see that the final app status is `SUCCEEDED`. However, on the YARN RM side:
```
020-04-30 06:21:25,083 INFO RMContainerImpl: container_1588227360159_0001_01_000001 Container Transitioned from RUNNING to COMPLETED
2020-04-30 06:21:25,085 INFO RMAppAttemptImpl: Updating application attempt appattempt_1588227360159_0001_000001 with final state: FAILED, and exit status: 0
2020-04-30 06:21:25,085 INFO RMAppAttemptImpl: appattempt_1588227360159_0001_000001 State change from RUNNING to FINAL_SAVING on event = CONTAINER_FINISHED
```

You see that the final state of the application becomes `FAILED` since the container is finished before the application is unregistered.

This could be misleading and this PR proposes to unregister the application right away if it succeeds.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To fix a bug where application is not unregistered even if it succeeds.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. If the application succeeds, it will be unregistered even if the shutdown hook doesn't get run.

The following is YARN RM log when there was a timeout on the shutdown hook after the fix:
```
2020-05-02 02:13:02,222 INFO RMContainerImpl: container_1588385278256_0001_01_000001 Container Transitioned from RUNNING to COMPLETED
2020-05-02 02:13:02,222 INFO ApplicationMasterService: Unregistering app attempt : appattempt_1588385278256_0001_000001
2020-05-02 02:13:02,224 INFO RMAppAttemptImpl: appattempt_1588385278256_0001_000001 State change from FINISHING to FINISHED on event = CONTAINER_FINISHED
2020-05-02 02:13:02,226 INFO RMAppImpl: application_1588385278256_0001 State change from FINISHING to FINISHED on event = ATTEMPT_FINISHED
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added a test that covers the scenario where spark context is not stopped by the user application.

The scenario where shutdown hook timeouts is manually tested.