### PR TITLE
[SPARK-31212][SQL][WIP] Fix Failure of casting the '1000-02-29' string to the date type

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -21,7 +21,7 @@ import java.nio.charset.StandardCharsets
 import java.sql.{Date, Timestamp}
 import java.time._
 import java.time.temporal.{ChronoField, ChronoUnit, IsoFields}
-import java.util.{Locale, TimeZone}
+import java.util.{GregorianCalendar, Locale, TimeZone}
 import java.util.concurrent.TimeUnit._
 
 import scala.util.control.NonFatal
@@ -203,6 +203,20 @@ object DateTimeUtils {
     val day = julian_us / MICROS_PER_DAY
     val micros = julian_us % MICROS_PER_DAY
     (day.toInt, MICROSECONDS.toNanos(micros))
+  }
+
+  /**
+   *Returns Gregorian days since epoch
+   */
+  def toGregorianDays(
+      year: Int,
+      month: Byte = 1,
+      day: Byte = 1,
+      hour: Byte = 0,
+      minute: Byte = 0,
+      sec: Byte = 0): SQLDate = {
+    val calendar = new GregorianCalendar(year, month - 1, day, hour, minute, sec)
+    MILLISECONDS.toDays(calendar.getTimeInMillis).toInt
   }
 
   /*
@@ -485,10 +499,9 @@ object DateTimeUtils {
     }
     segments(i) = currentSegmentValue
     try {
-      val localDate = LocalDate.of(segments(0), segments(1), segments(2))
-      Some(localDateToDays(localDate))
+      Some(toGregorianDays(segments(0), segments(1).toByte, segments(2).toByte))
     } catch {
-      case NonFatal(_) => None
+      case NonFatal(e) => None
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -21,7 +21,7 @@ import java.nio.charset.StandardCharsets
 import java.sql.{Date, Timestamp}
 import java.time._
 import java.time.temporal.{ChronoField, ChronoUnit, IsoFields}
-import java.util.{GregorianCalendar, Locale, TimeZone}
+import java.util.{Calendar, GregorianCalendar, Locale, TimeZone}
 import java.util.concurrent.TimeUnit._
 
 import scala.util.control.NonFatal
@@ -216,7 +216,16 @@ object DateTimeUtils {
       minute: Byte = 0,
       sec: Byte = 0): SQLDate = {
     val calendar = new GregorianCalendar(year, month - 1, day, hour, minute, sec)
+    calendar.setTimeZone(TimeZoneUTC)
+    calendar.setLenient(false)
     MILLISECONDS.toDays(calendar.getTimeInMillis).toInt
+  }
+
+  def fromGregorianDays(date: SQLDate): GregorianCalendar = {
+    val calendar = new GregorianCalendar(TimeZoneUTC)
+    calendar.setLenient(false)
+    calendar.setTimeInMillis(DAYS.toMillis(date))
+    calendar
   }
 
   /*
@@ -553,7 +562,7 @@ object DateTimeUtils {
    * since 1.1.1970.
    */
   def getDayInYear(date: SQLDate): Int = {
-    LocalDate.ofEpochDay(date).getDayOfYear
+    fromGregorianDays(date).get(Calendar.DAY_OF_YEAR)
   }
 
   /**
@@ -561,7 +570,7 @@ object DateTimeUtils {
    * since 1.1.1970.
    */
   def getYear(date: SQLDate): Int = {
-    LocalDate.ofEpochDay(date).getYear
+    fromGregorianDays(date).get(Calendar.YEAR)
   }
 
   /**
@@ -594,7 +603,7 @@ object DateTimeUtils {
    * since 1.1.1970. January is month 1.
    */
   def getMonth(date: SQLDate): Int = {
-    LocalDate.ofEpochDay(date).getMonthValue
+    fromGregorianDays(date).get(Calendar.MONTH) + 1
   }
 
   /**
@@ -602,7 +611,8 @@ object DateTimeUtils {
    * since 1.1.1970.
    */
   def getDayOfMonth(date: SQLDate): Int = {
-    LocalDate.ofEpochDay(date).getDayOfMonth
+    val calendar = fromGregorianDays(date)
+    calendar.get(Calendar.DAY_OF_MONTH)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -206,7 +206,7 @@ object DateTimeUtils {
   }
 
   /**
-   *Returns Gregorian days since epoch
+   * Returns Gregorian days since epoch in UTC timezone
    */
   def toGregorianDays(
       year: Int,
@@ -221,6 +221,9 @@ object DateTimeUtils {
     MILLISECONDS.toDays(calendar.getTimeInMillis).toInt
   }
 
+  /**
+   * Returns a GregorianCalendar set to the provided days since epoch in UTC timezone
+   */
   def fromGregorianDays(date: SQLDate): GregorianCalendar = {
     val calendar = new GregorianCalendar(TimeZoneUTC)
     calendar.setLenient(false)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -501,7 +501,7 @@ object DateTimeUtils {
     try {
       Some(toGregorianDays(segments(0), segments(1).toByte, segments(2).toByte))
     } catch {
-      case NonFatal(e) => None
+      case NonFatal(_) => None
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeTestUtils.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeTestUtils.scala
@@ -91,7 +91,8 @@ object DateTimeTestUtils {
       day: Byte = 1,
       hour: Byte = 0,
       minute: Byte = 0,
-      sec: Byte = 0): Int = toGregorianDays(year, month, day, hour, minute, sec)
+      sec: Byte = 0): Int =
+    toGregorianDays(year, month, day, hour, minute, sec)
 
   // Returns microseconds since epoch for current date and give time
   def time(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeTestUtils.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeTestUtils.scala
@@ -18,13 +18,13 @@
 package org.apache.spark.sql.catalyst.util
 
 import java.time.{LocalDate, LocalDateTime, LocalTime, ZoneId, ZoneOffset}
-import java.util.TimeZone
+import java.util.{GregorianCalendar, TimeZone}
 import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.catalyst.util.DateTimeConstants._
-import org.apache.spark.sql.catalyst.util.DateTimeUtils.getZoneId
+import org.apache.spark.sql.catalyst.util.DateTimeUtils.{getZoneId, toGregorianDays}
 
 /**
  * Helper functions for testing date and time functionality.
@@ -91,10 +91,7 @@ object DateTimeTestUtils {
       day: Byte = 1,
       hour: Byte = 0,
       minute: Byte = 0,
-      sec: Byte = 0): Int = {
-    val micros = date(year, month, day, hour, minute, sec)
-    TimeUnit.MICROSECONDS.toDays(micros).toInt
-  }
+      sec: Byte = 0): Int = toGregorianDays(year, month, day, hour, minute, sec)
 
   // Returns microseconds since epoch for current date and give time
   def time(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -125,7 +125,7 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
     stringToDate(UTF8String.fromString(s), zoneId)
   }
 
-  test("SPARK-31212 string to date for leap year before and after 1582-10-15") {
+  test("SPARK-31212: string to date for leap year before and after 1582-10-15") {
     assert(toDate("1000-02-29").get === days(1000, 2, 29))
     assert(toDate("2000-02-29").get === days(2000, 2, 29))
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -125,6 +125,11 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
     stringToDate(UTF8String.fromString(s), zoneId)
   }
 
+  test("SPARK-31212 string to date for leap year before and after 1582-10-15") {
+    assert(toDate("1000-02-29").get === days(1000, 2, 29))
+    assert(toDate("2000-02-29").get === days(2000, 2, 29))
+  }
+
   test("string to date") {
     assert(toDate("2015-01-28").get === days(2015, 1, 28))
     assert(toDate("2015").get === days(2015, 1, 1))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Use GregogianCalendar to replace LocalDate when computing days from epoch. This solves a problem where some date before the Gregogian cutover date (1582-10-15) can't be recognized due to different leap year rules. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix a bug where dates such as `1000-02-29` can't be recognized as a valid date.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I added a unit test that would fail in master right now.