### PR TITLE
[SPARK-31633][BUILD] Upgrade SLF4J from 1.7.16 to 1.7.30

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.7-hive-1.2
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-1.2
@@ -112,7 +112,7 @@ javax.servlet-api/3.1.0//javax.servlet-api-3.1.0.jar
 javolution/5.5.1//javolution-5.5.1.jar
 jaxb-api/2.2.2//jaxb-api-2.2.2.jar
 jaxb-runtime/2.3.2//jaxb-runtime-2.3.2.jar
-jcl-over-slf4j/1.7.16//jcl-over-slf4j-1.7.16.jar
+jcl-over-slf4j/1.7.30//jcl-over-slf4j-1.7.30.jar
 jdo-api/3.0.1//jdo-api-3.0.1.jar
 jersey-client/2.30//jersey-client-2.30.jar
 jersey-common/2.30//jersey-common-2.30.jar
@@ -135,7 +135,7 @@ json4s-scalap_2.12/3.6.6//json4s-scalap_2.12-3.6.6.jar
 jsp-api/2.1//jsp-api-2.1.jar
 jsr305/3.0.0//jsr305-3.0.0.jar
 jta/1.1//jta-1.1.jar
-jul-to-slf4j/1.7.16//jul-to-slf4j-1.7.16.jar
+jul-to-slf4j/1.7.30//jul-to-slf4j-1.7.30.jar
 kryo-shaded/4.0.2//kryo-shaded-4.0.2.jar
 kubernetes-client/4.7.1//kubernetes-client-4.7.1.jar
 kubernetes-model-common/4.7.1//kubernetes-model-common-4.7.1.jar
@@ -184,8 +184,8 @@ scala-reflect/2.12.10//scala-reflect-2.12.10.jar
 scala-xml_2.12/1.2.0//scala-xml_2.12-1.2.0.jar
 shapeless_2.12/2.3.3//shapeless_2.12-2.3.3.jar
 shims/0.7.45//shims-0.7.45.jar
-slf4j-api/1.7.16//slf4j-api-1.7.16.jar
-slf4j-log4j12/1.7.16//slf4j-log4j12-1.7.16.jar
+slf4j-api/1.7.30//slf4j-api-1.7.30.jar
+slf4j-log4j12/1.7.30//slf4j-log4j12-1.7.30.jar
 snakeyaml/1.24//snakeyaml-1.24.jar
 snappy-java/1.1.7.3//snappy-java-1.1.7.3.jar
 snappy/0.2//snappy-0.2.jar

--- a/dev/deps/spark-deps-hadoop-2.7-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-2.3
@@ -126,7 +126,7 @@ javax.servlet-api/3.1.0//javax.servlet-api-3.1.0.jar
 javolution/5.5.1//javolution-5.5.1.jar
 jaxb-api/2.2.2//jaxb-api-2.2.2.jar
 jaxb-runtime/2.3.2//jaxb-runtime-2.3.2.jar
-jcl-over-slf4j/1.7.16//jcl-over-slf4j-1.7.16.jar
+jcl-over-slf4j/1.7.30//jcl-over-slf4j-1.7.30.jar
 jdo-api/3.0.1//jdo-api-3.0.1.jar
 jersey-client/2.30//jersey-client-2.30.jar
 jersey-common/2.30//jersey-common-2.30.jar
@@ -150,7 +150,7 @@ json4s-scalap_2.12/3.6.6//json4s-scalap_2.12-3.6.6.jar
 jsp-api/2.1//jsp-api-2.1.jar
 jsr305/3.0.0//jsr305-3.0.0.jar
 jta/1.1//jta-1.1.jar
-jul-to-slf4j/1.7.16//jul-to-slf4j-1.7.16.jar
+jul-to-slf4j/1.7.30//jul-to-slf4j-1.7.30.jar
 kryo-shaded/4.0.2//kryo-shaded-4.0.2.jar
 kubernetes-client/4.7.1//kubernetes-client-4.7.1.jar
 kubernetes-model-common/4.7.1//kubernetes-model-common-4.7.1.jar
@@ -198,8 +198,8 @@ scala-reflect/2.12.10//scala-reflect-2.12.10.jar
 scala-xml_2.12/1.2.0//scala-xml_2.12-1.2.0.jar
 shapeless_2.12/2.3.3//shapeless_2.12-2.3.3.jar
 shims/0.7.45//shims-0.7.45.jar
-slf4j-api/1.7.16//slf4j-api-1.7.16.jar
-slf4j-log4j12/1.7.16//slf4j-log4j12-1.7.16.jar
+slf4j-api/1.7.30//slf4j-api-1.7.30.jar
+slf4j-log4j12/1.7.30//slf4j-log4j12-1.7.30.jar
 snakeyaml/1.24//snakeyaml-1.24.jar
 snappy-java/1.1.7.3//snappy-java-1.1.7.3.jar
 spire-macros_2.12/0.17.0-M1//spire-macros_2.12-0.17.0-M1.jar

--- a/dev/deps/spark-deps-hadoop-3.2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3.2-hive-2.3
@@ -126,7 +126,7 @@ javolution/5.5.1//javolution-5.5.1.jar
 jaxb-api/2.2.11//jaxb-api-2.2.11.jar
 jaxb-runtime/2.3.2//jaxb-runtime-2.3.2.jar
 jcip-annotations/1.0-1//jcip-annotations-1.0-1.jar
-jcl-over-slf4j/1.7.16//jcl-over-slf4j-1.7.16.jar
+jcl-over-slf4j/1.7.30//jcl-over-slf4j-1.7.30.jar
 jdo-api/3.0.1//jdo-api-3.0.1.jar
 jersey-client/2.30//jersey-client-2.30.jar
 jersey-common/2.30//jersey-common-2.30.jar
@@ -148,7 +148,7 @@ json4s-scalap_2.12/3.6.6//json4s-scalap_2.12-3.6.6.jar
 jsp-api/2.1//jsp-api-2.1.jar
 jsr305/3.0.0//jsr305-3.0.0.jar
 jta/1.1//jta-1.1.jar
-jul-to-slf4j/1.7.16//jul-to-slf4j-1.7.16.jar
+jul-to-slf4j/1.7.30//jul-to-slf4j-1.7.30.jar
 kerb-admin/1.0.1//kerb-admin-1.0.1.jar
 kerb-client/1.0.1//kerb-client-1.0.1.jar
 kerb-common/1.0.1//kerb-common-1.0.1.jar
@@ -214,8 +214,8 @@ scala-reflect/2.12.10//scala-reflect-2.12.10.jar
 scala-xml_2.12/1.2.0//scala-xml_2.12-1.2.0.jar
 shapeless_2.12/2.3.3//shapeless_2.12-2.3.3.jar
 shims/0.7.45//shims-0.7.45.jar
-slf4j-api/1.7.16//slf4j-api-1.7.16.jar
-slf4j-log4j12/1.7.16//slf4j-log4j12-1.7.16.jar
+slf4j-api/1.7.30//slf4j-api-1.7.30.jar
+slf4j-log4j12/1.7.30//slf4j-log4j12-1.7.30.jar
 snakeyaml/1.24//snakeyaml-1.24.jar
 snappy-java/1.1.7.3//snappy-java-1.1.7.3.jar
 spire-macros_2.12/0.17.0-M1//spire-macros_2.12-0.17.0-M1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <maven.version>3.6.3</maven.version>
     <sbt.project.name>spark</sbt.project.name>
-    <slf4j.version>1.7.16</slf4j.version>
+    <slf4j.version>1.7.30</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
     <hadoop.version>2.7.4</hadoop.version>
     <protobuf.version>2.5.0</protobuf.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade SLF4J from 1.7.16 to 1.7.30.

### Why are the changes needed?

SLF4J 1.7.23+ is required to enable `slf4j-log4j12` with MDC feature to run under Java 9. Also, this will bring all latest bug fixes.
- http://www.slf4j.org/news.html

> When running under Java 9, log4j version 1.2.x is unable to correctly parse the "java.version" system property. Assuming an inccorect Java version, it proceeded to disable its MDC functionality. The slf4j-log4j12 module shipping in this release fixes the issue by tweaking MDC internals by reflection, allowing log4j to run under Java 9. See also SLF4J-393.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the Jenkins with the existing tests.