### PR TITLE
[SPARK-31235][FOLLOWUP][TESTS][test-hadoop3.2] Fix test "specify a more specific type for the ap…

### DIFF
--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
@@ -224,10 +224,10 @@ class ClientSuite extends SparkFunSuite with Matchers {
 
     // Mock yarn submit application
     val yarnClient = mock(classOf[YarnClient])
-    val map = new ConcurrentHashMap[ApplicationId, RMApp]()
+    val rmApps = new ConcurrentHashMap[ApplicationId, RMApp]()
     val rmContext = mock(classOf[RMContext])
     val conf = mock(classOf[Configuration])
-    when(rmContext.getRMApps).thenReturn(map)
+    when(rmContext.getRMApps).thenReturn(rmApps)
     val dispatcher = mock(classOf[Dispatcher])
     when(rmContext.getDispatcher).thenReturn(dispatcher)
     when[EventHandler[_]](dispatcher.getEventHandler).thenReturn(
@@ -276,7 +276,7 @@ class ClientSuite extends SparkFunSuite with Matchers {
         containerLaunchContext)
 
       yarnClient.submitApplication(context)
-      assert(map.get(appId).getApplicationType === targetType)
+      assert(rmApps.get(appId).getApplicationType === targetType)
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Update the input parameters for instantiating `RMAppManager` and `ClientRMService`


### Why are the changes needed?
For hadoop3.2, if `RMAppManager` is not created correctly, the following exception will occur:
```
java.lang.RuntimeException: java.lang.NullPointerException
	at org.apache.hadoop.util.ReflectionUtils.newInstance(ReflectionUtils.java:135)
	at org.apache.hadoop.yarn.security.YarnAuthorizationProvider.getInstance(YarnAuthorizationProvider.java:55)
	at org.apache.hadoop.yarn.server.resourcemanager.RMAppManager.<init>(RMAppManager.java:117)
```

### How was this patch tested?
UTs