### PR TITLE
[SPARK-31361][SQL][FOLLOWUP] Use LEGACY_PARQUET_REBASE_DATETIME_IN_READ instead of avro config in ParquetIOSuite

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
@@ -955,7 +955,7 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
             // The file metadata indicates if it needs rebase or not, so we can always get the
             // correct result regardless of the "rebaseInRead" config.
             Seq(true, false).foreach { rebase =>
-              withSQLConf(SQLConf.LEGACY_AVRO_REBASE_DATETIME_IN_READ.key -> rebase.toString) {
+              withSQLConf(SQLConf.LEGACY_PARQUET_REBASE_DATETIME_IN_READ.key -> rebase.toString) {
                 checkAnswer(spark.read.parquet(path), Row(Timestamp.valueOf(tsStr)))
               }
             }
@@ -984,7 +984,7 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
       // The file metadata indicates if it needs rebase or not, so we can always get the correct
       // result regardless of the "rebaseInRead" config.
       Seq(true, false).foreach { rebase =>
-        withSQLConf(SQLConf.LEGACY_AVRO_REBASE_DATETIME_IN_READ.key -> rebase.toString) {
+        withSQLConf(SQLConf.LEGACY_PARQUET_REBASE_DATETIME_IN_READ.key -> rebase.toString) {
           checkAnswer(spark.read.parquet(path), Row(Date.valueOf("1001-01-01")))
         }
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Replace the Avro SQL config `LEGACY_AVRO_REBASE_DATETIME_IN_READ ` by `LEGACY_PARQUET_REBASE_DATETIME_IN_READ ` in `ParquetIOSuite`. 

### Why are the changes needed?
Avro config is not relevant to the parquet tests.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
By running `ParquetIOSuite` via
```
./build/sbt "test:testOnly *ParquetIOSuite"
```