### PR TITLE
[SPARK-30168] [SQL]Changing deprecated api s used in parquet to minimise warning

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetInteroperabilitySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetInteroperabilitySuite.scala
@@ -22,8 +22,8 @@ import java.time.ZoneOffset
 
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.fs.{FileSystem, Path, PathFilter}
-import org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER
 import org.apache.parquet.hadoop.ParquetFileReader
+import org.apache.parquet.hadoop.util.HadoopInputFile
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
 
 import org.apache.spark.sql.Row
@@ -174,7 +174,8 @@ class ParquetInteroperabilitySuite extends ParquetCompatibilityTest with SharedS
               assert(parts.size == 2)
               parts.foreach { part =>
                 val oneFooter =
-                  ParquetFileReader.readFooter(hadoopConf, part.getPath, NO_FILTER)
+                  ParquetFileReader.open(
+                    HadoopInputFile.fromPath(part.getPath, hadoopConf)).getFooter
                 assert(oneFooter.getFileMetaData.getSchema.getColumns.size === 1)
                 val typeName = oneFooter
                   .getFileMetaData.getSchema.getColumns.get(0).getPrimitiveType.getPrimitiveTypeName

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -21,8 +21,8 @@ import java.io.File
 import java.net.URI
 
 import org.apache.hadoop.fs.Path
-import org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER
 import org.apache.parquet.hadoop.ParquetFileReader
+import org.apache.parquet.hadoop.util.HadoopInputFile
 import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.SparkException
@@ -2370,8 +2370,8 @@ class HiveDDLSuite
         OrcFileOperator.getFileReader(maybeFile.get.toPath.toString).get.getCompression.name
 
       case "parquet" =>
-        val footer = ParquetFileReader.readFooter(
-          sparkContext.hadoopConfiguration, new Path(maybeFile.get.getPath), NO_FILTER)
+        val footer = ParquetFileReader.open(HadoopInputFile.fromPath(
+          new Path(maybeFile.get.getPath), sparkContext.hadoopConfiguration)).getFooter
         footer.getBlocks.get(0).getColumns.get(0).getCodec.toString
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
**ParquetInputSplit, ParquetFileReader.readFooter , ParquetFileReader.readAllFootersInParallel**
The above api s have become deprecated and their support will be removed in parquet 2.0 .
These Api s have been changed as per the suggestions given in the doc release by parquet, using the alternative
[https://www.javadoc.io/doc/org.apache.parquet/parquet-hadoop/1.8.3/org/apache/parquet/hadoop/ParquetFileReader.html](url)
[https://www.javadoc.io/doc/org.apache.parquet/parquet-hadoop/1.10.1/org/apache/parquet/hadoop/ParquetInputSplit.html](url)
 
### Why are the changes needed?
To use alternative api s inplace of the deprecated api s 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
UT cases where run.                     
