### PR TITLE
[SPARK-29083][CORE] Prefetch elements in rdd.toLocalIterator

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/java/JavaRDDLike.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaRDDLike.scala
@@ -368,6 +368,9 @@ trait JavaRDDLike[T, This <: JavaRDDLike[T, This]] extends Serializable {
   def toLocalIterator(): JIterator[T] =
      asJavaIteratorConverter(rdd.toLocalIterator).asJava
 
+  def toLocalIterator(prefetchPartitions: Boolean): JIterator[T] =
+    asJavaIteratorConverter(rdd.toLocalIterator(prefetchPartitions)).asJava
+
   /**
    * Return an array that contains all of the elements in a specific partition of this RDD.
    */

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -205,7 +205,6 @@ private[spark] object PythonRDD extends Logging {
 
         // Collects a partition on each iteration
         val prefetchIter = new PrefetchingIterator(rdd, prefetchPartitions)
-        if (prefetchPartitions) prefetchIter.hasNext
 
         // Write data until iteration is complete, client stops iteration, or error occurs
         var complete = false

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -20,17 +20,19 @@ package org.apache.spark.rdd
 import java.util.Random
 import java.util.concurrent.locks.ReentrantLock
 
-import scala.collection.{Map, mutable}
+import scala.collection.{mutable, Map}
 import scala.collection.mutable.ArrayBuffer
 import scala.io.Codec
 import scala.language.implicitConversions
 import scala.ref.WeakReference
-import scala.reflect.{ClassTag, classTag}
+import scala.reflect.{classTag, ClassTag}
 import scala.util.hashing
+
 import com.clearspring.analytics.stream.cardinality.HyperLogLogPlus
 import org.apache.hadoop.io.{BytesWritable, NullWritable, Text}
 import org.apache.hadoop.io.compress.CompressionCodec
 import org.apache.hadoop.mapred.TextOutputFormat
+
 import org.apache.spark._
 import org.apache.spark.Partitioner._
 import org.apache.spark.annotation.{DeveloperApi, Experimental, Since}
@@ -45,9 +47,10 @@ import org.apache.spark.partial.PartialResult
 import org.apache.spark.resource.ResourceProfile
 import org.apache.spark.storage.{RDDBlockId, StorageLevel}
 import org.apache.spark.util.{BoundedPriorityQueue, Utils}
-import org.apache.spark.util.collection.{ExternalAppendOnlyMap, OpenHashMap, Utils => collectionUtils}
-import org.apache.spark.util.random.{BernoulliCellSampler, BernoulliSampler, PoissonSampler, SamplingUtils}
-
+import org.apache.spark.util.collection.{ExternalAppendOnlyMap, OpenHashMap,
+  Utils => collectionUtils}
+import org.apache.spark.util.random.{BernoulliCellSampler, BernoulliSampler, PoissonSampler,
+  SamplingUtils}
 /**
  * A Resilient Distributed Dataset (RDD), the basic abstraction in Spark. Represents an immutable,
  * partitioned collection of elements that can be operated on in parallel. This class contains the

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1048,9 +1048,7 @@ abstract class RDD[T: ClassTag](
    * recomputing the input RDD should be cached first.
    */
   def toLocalIterator(prefetchPartitions: Boolean = false): Iterator[T] = withScope {
-    val iterator = new PrefetchingIterator(this, prefetchPartitions)
-    if (prefetchPartitions) iterator.hasNext
-    iterator.flatMap(data => data)
+    new PrefetchingIterator(this, prefetchPartitions).flatMap(data => data)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -20,30 +20,33 @@ package org.apache.spark.rdd
 import java.util.Random
 import java.util.concurrent.locks.ReentrantLock
 
-import com.clearspring.analytics.stream.cardinality.HyperLogLogPlus
-import org.apache.hadoop.io.compress.CompressionCodec
-import org.apache.hadoop.io.{BytesWritable, NullWritable, Text}
-import org.apache.hadoop.mapred.TextOutputFormat
-import org.apache.spark.Partitioner._
-import org.apache.spark._
-import org.apache.spark.annotation.{DeveloperApi, Experimental, Since}
-import org.apache.spark.api.java.JavaRDD
-import org.apache.spark.internal.Logging
-import org.apache.spark.internal.config.{RDD_LIMIT_SCALE_UP_FACTOR, _}
-import org.apache.spark.partial.{BoundedDouble, CountEvaluator, GroupedCountEvaluator, PartialResult}
-import org.apache.spark.resource.ResourceProfile
-import org.apache.spark.storage.{RDDBlockId, StorageLevel}
-import org.apache.spark.util.collection.{ExternalAppendOnlyMap, OpenHashMap, Utils => collectionUtils}
-import org.apache.spark.util.random.{BernoulliCellSampler, BernoulliSampler, PoissonSampler, SamplingUtils}
-import org.apache.spark.util.{BoundedPriorityQueue, Utils}
-
-import scala.collection.mutable.ArrayBuffer
 import scala.collection.{Map, mutable}
+import scala.collection.mutable.ArrayBuffer
 import scala.io.Codec
 import scala.language.implicitConversions
 import scala.ref.WeakReference
 import scala.reflect.{ClassTag, classTag}
 import scala.util.hashing
+import com.clearspring.analytics.stream.cardinality.HyperLogLogPlus
+import org.apache.hadoop.io.{BytesWritable, NullWritable, Text}
+import org.apache.hadoop.io.compress.CompressionCodec
+import org.apache.hadoop.mapred.TextOutputFormat
+import org.apache.spark._
+import org.apache.spark.Partitioner._
+import org.apache.spark.annotation.{DeveloperApi, Experimental, Since}
+import org.apache.spark.api.java.JavaRDD
+import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config._
+import org.apache.spark.internal.config.RDD_LIMIT_SCALE_UP_FACTOR
+import org.apache.spark.partial.BoundedDouble
+import org.apache.spark.partial.CountEvaluator
+import org.apache.spark.partial.GroupedCountEvaluator
+import org.apache.spark.partial.PartialResult
+import org.apache.spark.resource.ResourceProfile
+import org.apache.spark.storage.{RDDBlockId, StorageLevel}
+import org.apache.spark.util.{BoundedPriorityQueue, Utils}
+import org.apache.spark.util.collection.{ExternalAppendOnlyMap, OpenHashMap, Utils => collectionUtils}
+import org.apache.spark.util.random.{BernoulliCellSampler, BernoulliSampler, PoissonSampler, SamplingUtils}
 
 /**
  * A Resilient Distributed Dataset (RDD), the basic abstraction in Spark. Represents an immutable,

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -51,6 +51,7 @@ import org.apache.spark.util.collection.{ExternalAppendOnlyMap, OpenHashMap,
   Utils => collectionUtils}
 import org.apache.spark.util.random.{BernoulliCellSampler, BernoulliSampler, PoissonSampler,
   SamplingUtils}
+
 /**
  * A Resilient Distributed Dataset (RDD), the basic abstraction in Spark. Represents an immutable,
  * partitioned collection of elements that can be operated on in parallel. This class contains the

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1047,15 +1047,12 @@ abstract class RDD[T: ClassTag](
    * recomputing the input RDD should be cached first.
    */
   def toLocalIterator(prefetchPartitions: Boolean = false): Iterator[T] = withScope {
-
     if (!prefetchPartitions || partitions.indices.isEmpty) {
       def collectPartition(p: Int): Array[T] = {
         sc.runJob(this, (iter: Iterator[T]) => iter.toArray, Seq(p)).head
       }
       partitions.indices.iterator.flatMap(i => collectPartition(i))
-
     } else {
-
       val iterator: Iterator[Array[T]] = prefetchingIterator
       iterator.hasNext
       iterator.flatMap(data => data)
@@ -1101,7 +1098,6 @@ abstract class RDD[T: ClassTag](
       })
 
       private def initPrefetch(p: Int): Unit = {
-
         fetchInProgress = true
 
         sc.submitJob(
@@ -1113,7 +1109,6 @@ abstract class RDD[T: ClassTag](
       }
 
       private def rememberResultAndSignal(value: Array[T]): Unit = withLock(() => {
-
         nextResult = value
         fetchInProgress = false
 

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.rdd
 
 import java.util.Random
-import java.util.concurrent.locks.ReentrantLock
 
 import scala.collection.{mutable, Map}
 import scala.collection.mutable.ArrayBuffer

--- a/core/src/main/scala/org/apache/spark/rdd/util/PrefetchingIterator.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/util/PrefetchingIterator.scala
@@ -29,8 +29,9 @@ import org.apache.spark.rdd.RDD
 /**
  * Iterator that optionally prefetches next partition asynchronously
  */
-class PrefetchingIterator[T : ClassTag](rdd: RDD[T],
-                                        prefetch: Boolean)
+private[spark] class PrefetchingIterator[T : ClassTag](
+    rdd: RDD[T],
+    prefetch: Boolean)
   extends Iterator[Array[T]]
     with Serializable {
 

--- a/core/src/main/scala/org/apache/spark/rdd/util/PrefetchingIterator.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/util/PrefetchingIterator.scala
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.rdd.util
+
+import java.util.concurrent.locks.ReentrantLock
+
+import scala.reflect.ClassTag
+
+import org.apache.spark.rdd.RDD
+
+/**
+ * Iterator that optionally prefetches next partition asynchronously
+ */
+class PrefetchingIterator[T : ClassTag](rdd: RDD[T],
+                                        prefetch: Boolean)
+  extends Iterator[Array[T]]
+    with Serializable {
+
+  private val partitionIterator = rdd.partitions.indices.iterator
+
+  private val lock = new ReentrantLock()
+  private val ready = lock.newCondition()
+
+  private var nextResult: Array[T] = _
+  private var fetchInProgress = false
+
+  /**
+   * In addition, it prefetches next element, if it exists
+   */
+  override def hasNext: Boolean = withLock(() => {
+    if (fetchInProgress) true
+    else if (nextResult == null) {
+      if (partitionIterator.hasNext) {
+        initPrefetch(partitionIterator.next())
+        true
+      } else false
+    } else true
+  })
+
+  override def next(): Array[T] = withLock(() => {
+    while (fetchInProgress) ready.await()
+
+    val partitionArray = nextResult
+
+    nextResult = null
+    fetchInProgress = false
+
+    if (prefetch && partitionIterator.hasNext) initPrefetch(partitionIterator.next())
+
+    partitionArray
+  })
+
+  private def initPrefetch(p: Int): Unit = {
+    fetchInProgress = true
+
+    rdd.sparkContext.submitJob(
+      rdd,
+      (iter: Iterator[T]) => iter.toArray,
+      Seq(p),
+      (_, value: Array[T]) => rememberResultAndSignal(value),
+      nextResult)
+  }
+
+  private def rememberResultAndSignal(value: Array[T]): Unit = withLock(() => {
+    nextResult = value
+    fetchInProgress = false
+
+    ready.signal()
+  })
+
+  private def withLock[A](fn: () => A): A = {
+    lock.lock()
+    try fn()
+    finally lock.unlock()
+  }
+}

--- a/core/src/test/java/test/org/apache/spark/JavaAPISuite.java
+++ b/core/src/test/java/test/org/apache/spark/JavaAPISuite.java
@@ -17,11 +17,38 @@
 
 package test.org.apache.spark;
 
-import com.google.common.base.Throwables;
+import java.io.*;
+import java.nio.channels.FileChannel;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.apache.spark.Partitioner;
+import org.apache.spark.SparkConf;
+import org.apache.spark.TaskContext;
+import org.apache.spark.TaskContext$;
+import scala.Tuple2;
+import scala.Tuple3;
+import scala.Tuple4;
+import scala.collection.JavaConverters;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
+import com.google.common.base.Throwables;
 import com.google.common.io.Files;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.IntWritable;
@@ -30,15 +57,18 @@ import org.apache.hadoop.io.compress.DefaultCodec;
 import org.apache.hadoop.mapred.SequenceFileInputFormat;
 import org.apache.hadoop.mapred.SequenceFileOutputFormat;
 import org.apache.hadoop.mapreduce.Job;
-import org.apache.spark.Partitioner;
-import org.apache.spark.SparkConf;
-import org.apache.spark.TaskContext;
-import org.apache.spark.TaskContext$;
+import org.junit.After;
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.spark.api.java.JavaDoubleRDD;
+import org.apache.spark.api.java.JavaFutureAction;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.Optional;
-import org.apache.spark.api.java.*;
-import org.apache.spark.api.java.function.FlatMapFunction2;
-import org.apache.spark.api.java.function.Function;
-import org.apache.spark.api.java.function.Function2;
+import org.apache.spark.api.java.function.*;
 import org.apache.spark.input.PortableDataStream;
 import org.apache.spark.partial.BoundedDouble;
 import org.apache.spark.partial.PartialResult;
@@ -51,26 +81,6 @@ import org.apache.spark.serializer.KryoSerializer;
 import org.apache.spark.storage.StorageLevel;
 import org.apache.spark.util.LongAccumulator;
 import org.apache.spark.util.StatCounter;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import scala.Tuple2;
-import scala.Tuple3;
-import scala.Tuple4;
-import scala.collection.JavaConverters;
-
-import java.io.*;
-import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
-import java.nio.charset.StandardCharsets;
-import java.util.*;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-import static org.junit.Assert.*;
 
 // The test suite itself is Serializable so that anonymous Function implementations can be
 // serialized, as an alternative to converting these anonymous classes to static inner classes;

--- a/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
@@ -27,10 +27,12 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable.{ArrayBuffer, HashMap}
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
+
 import com.esotericsoftware.kryo.KryoException
 import org.apache.hadoop.io.{LongWritable, Text}
 import org.apache.hadoop.mapred.{FileSplit, TextInputFormat}
 import org.scalatest.concurrent.Eventually
+
 import org.apache.spark._
 import org.apache.spark.api.java.{JavaRDD, JavaSparkContext}
 import org.apache.spark.internal.config.RDD_PARALLEL_LISTING_THRESHOLD

--- a/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
@@ -64,6 +64,9 @@ class RDDSuite extends SparkFunSuite with SharedSparkContext with Eventually {
     assert(sc.makeRDD(Array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 5)
       .toLocalIterator(prefetchPartitions = true).toList === List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
 
+    assert(sc.makeRDD(Array.empty[Int], 5)
+      .toLocalIterator(prefetchPartitions = true).toList === List())
+
     val dups = sc.makeRDD(Array(1, 1, 2, 2, 3, 3, 4, 4), 2)
     assert(dups.distinct().count() === 4)
     assert(dups.distinct().count === 4)  // Can distinct and count be called without parentheses?


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
This PR allows Scala toLocalIterator to prefetch the next partition while the first partition is being collected. 
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
A new param is added to toLocalIterator


<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Added consistency and parallelism tests as in the parent ticket [SPARK-27659](https://issues.apache.org/jira/browse/SPARK-27659)
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
