### PR TITLE
[SPARK-30267][SQL] Interoperability tests with Avro records generated by Avro4s

### DIFF
--- a/external/avro/pom.xml
+++ b/external/avro/pom.xml
@@ -70,6 +70,11 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-tags_${scala.binary.version}</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.sksamuel.avro4s</groupId>
+      <artifactId>avro4s-core_${scala.binary.version}</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/Avro4sInteroperSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/Avro4sInteroperSuite.scala
@@ -44,7 +44,7 @@ class Avro4sInteroperSuite extends SparkFunSuite
                            string: String
                          )
 
-  test("Case class with scalar types") {
+  test("SPARK-30267: Case class with scalar types") {
     val sample = ScalarSample(
       int = 2000,
       long = 100000L,
@@ -71,7 +71,7 @@ class Avro4sInteroperSuite extends SparkFunSuite
                         seq: Seq[String]
                       )
 
-  test("Case class with Seq type") {
+  test("SPARK-30267: Case class with Seq type") {
     val sample = SeqSample(
       "str",
       Seq("a", "b", "c")
@@ -98,7 +98,7 @@ class Avro4sInteroperSuite extends SparkFunSuite
                         innerSeq: Seq[String]
                         )
 
-  test("Inner class with Seq type") {
+  test("SPARK-30267: Inner class with Seq type") {
     val sample = OuterSample(
       "outer",
       InnerSample(

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/Avro4sInteroperSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/Avro4sInteroperSuite.scala
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.avro
+
+import com.sksamuel.avro4s.{Record, RecordFormat}
+import org.scalatest.Matchers
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.InternalRow
+
+class Avro4sInteroperSuite extends SparkFunSuite
+  with Matchers {
+
+  private def doConvert(avroRecord: Record): InternalRow = {
+    val avroSchema = avroRecord.getSchema
+    val sqlDataType = SchemaConverters.toSqlType(avroSchema)
+      .dataType
+    val deserializer = new AvroDeserializer(avroSchema, sqlDataType, rebaseDateTime = false)
+    deserializer.deserialize(avroRecord)
+      .asInstanceOf[InternalRow]
+  }
+
+  case class ScalarSample(
+                           int: Int,
+                           long: Long,
+                           float: Float,
+                           double: Double,
+                           boolean: Boolean,
+                           string: String
+                         )
+
+  test("Case class with scalar types") {
+    val sample = ScalarSample(
+      int = 2000,
+      long = 100000L,
+      float = 0.5f,
+      double = 0.123,
+      boolean = true,
+      string = "str"
+    )
+    val sampleRecord: Record = RecordFormat[ScalarSample].to(sample)
+
+    val result = doConvert(sampleRecord)
+
+    result.numFields shouldBe 6
+    result.getInt(0) shouldBe 2000
+    result.getLong(1) shouldBe 100000L
+    result.getFloat(2) shouldBe 0.5f
+    result.getDouble(3) shouldBe 0.123
+    result.getBoolean(4) shouldBe true
+    result.getString(5) shouldBe "str"
+  }
+
+  case class SeqSample(
+                        string: String,
+                        seq: Seq[String]
+                      )
+
+  test("Case class with Seq type") {
+    val sample = SeqSample(
+      "str",
+      Seq("a", "b", "c")
+    )
+    val sampleRecord = RecordFormat[SeqSample].to(sample)
+
+    val result = doConvert(sampleRecord)
+
+    result.numFields shouldBe 2
+    result.getString(0) shouldBe "str"
+    val resultSeq = result.getArray(1)
+    resultSeq.numElements() shouldBe 3
+    resultSeq.getUTF8String(0).toString shouldBe "a"
+    resultSeq.getUTF8String(1).toString shouldBe "b"
+    resultSeq.getUTF8String(2).toString shouldBe "c"
+  }
+
+  case class OuterSample(
+                        outerString: String,
+                        inner: InnerSample
+                           )
+  case class InnerSample(
+                        innerString: String,
+                        innerSeq: Seq[String]
+                        )
+
+  test("Inner class with Seq type") {
+    val sample = OuterSample(
+      "outer",
+      InnerSample(
+        "inner",
+        Seq("a", "b", "c")
+      )
+    )
+    val sampleRecord = RecordFormat[OuterSample].to(sample)
+
+    val result = doConvert(sampleRecord)
+
+    result.numFields shouldBe 2
+    result.getString(0) shouldBe "outer"
+    val innerResult = result.getStruct(1, 2)
+    innerResult.numFields shouldBe 2
+    innerResult.getString(0) shouldBe "inner"
+    val resultSeq = innerResult.getArray(1)
+    resultSeq.numElements() shouldBe 3
+    resultSeq.getUTF8String(0).toString shouldBe "a"
+    resultSeq.getUTF8String(1).toString shouldBe "b"
+    resultSeq.getUTF8String(2).toString shouldBe "c"
+  }
+
+}
+

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,7 @@
     <codahale.metrics.version>4.1.1</codahale.metrics.version>
     <avro.version>1.8.2</avro.version>
     <avro.mapred.classifier>hadoop2</avro.mapred.classifier>
+    <avro4s.version>2.0.4</avro4s.version>
     <aws.kinesis.client.version>1.12.0</aws.kinesis.client.version>
     <!-- Should be consistent with Kinesis client dependency -->
     <aws.java.sdk.version>1.11.655</aws.java.sdk.version>
@@ -1170,6 +1171,11 @@
             <artifactId>velocity</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.sksamuel.avro4s</groupId>
+        <artifactId>avro4s-core_${scala.binary.version}</artifactId>
+        <version>${avro4s.version}</version>
       </dependency>
       <!-- See SPARK-23654 for info on this dependency;
       It is used to keep javax.activation at v1.1.1 after dropping


### PR DESCRIPTION
### What changes were proposed in this pull request?

Tests to ensure interoperability with [Avro4s](https://github.com/sksamuel/avro4s).
These tests check, that Avro records generated by Avro4s can be successfully deserealized to Spark SQL records.

Avro4s version 2.0.4 is used - the latest version compatible with Avro 1.8 (used by Spark).

### Why are the changes needed?

Avro4s is a popular library to make conversions between Avro records and Scala case classes.
I faced the issue with ClassCastException https://issues.apache.org/jira/browse/SPARK-30267 when using Avro records generated by Avro4s.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New tests: Avro4sInteroperSuite.
