### PR TITLE
[SPARK-27249][ML] Developers API for Transformers beyond UnaryTransformer

### DIFF
--- a/examples/src/main/scala/org/apache/spark/examples/ml/MultiTransformerExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/MultiTransformerExample.scala
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// scalastyle:off println
+package org.apache.spark.examples.ml
+
+// $example on$
+import org.apache.spark.examples.ml.UnaryTransformerExample.MyTransformer
+import org.apache.spark.ml.UnaryTransformer
+import org.apache.spark.ml.param.DoubleParam
+import org.apache.spark.ml.util.{DefaultParamsReadable, DefaultParamsWritable, Identifiable}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.types.{DataType, DataTypes}
+import org.apache.spark.util.Utils
+// $example off$
+
+/**
+ * An example demonstrating creating a custom [[org.apache.spark.ml.Transformer]] using
+ * the [[UnaryTransformer]] abstraction.
+ *
+ * Run with
+ * {{{
+ * bin/run-example ml.MultiTransformerExample
+ * }}}
+ */
+object MultiTransformerExample {
+
+  // $example on$
+  /**
+   * Simple Transformer which adds a constant value to input Doubles.
+   *
+   * [[MultiTransformerExample]] can be used to create a stage usable within Pipelines.
+   * It defines parameters for specifying input and output columns:
+   * [[UnaryTransformer.inputCol]] and [[UnaryTransformer.outputCol]].
+   * It can optionally handle schema validation.
+   *
+   * [[DefaultParamsWritable]] provides a default implementation for persisting instances
+   * of this Transformer.
+   */
+  class MyTransformer(override val uid: String)
+    extends UnaryTransformer[Double, Double, MyTransformer] with DefaultParamsWritable {
+
+    final val shift: DoubleParam = new DoubleParam(this, "shift", "Value added to input")
+
+    def getShift: Double = $(shift)
+
+    def setShift(value: Double): this.type = set(shift, value)
+
+    def this() = this(Identifiable.randomUID("myT"))
+
+    override protected def createTransformFunc: Double => Double = (input: Double) => {
+      input + $(shift)
+    }
+
+    override protected def outputDataType: DataType = DataTypes.DoubleType
+
+    override protected def validateInputType(inputType: DataType): Unit = {
+      require(inputType == DataTypes.DoubleType, s"Bad input type: $inputType. Requires Double.")
+    }
+  }
+
+  /**
+   * Companion object for our simple Transformer.
+   *
+   * [[DefaultParamsReadable]] provides a default implementation for loading instances
+   * of this Transformer which were persisted using [[DefaultParamsWritable]].
+   */
+  object MyTransformer extends DefaultParamsReadable[MyTransformer]
+  // $example off$
+
+  def main(args: Array[String]): Unit = {
+    println("Hello there")
+    val spark = SparkSession
+      .builder()
+      .appName("UnaryTransformerExample")
+      .getOrCreate()
+
+    // $example on$
+    val myTransformer1 = new MyTransformer()
+      .setShift(0.5)
+      .setInputCol("input")
+      .setOutputCol("output1")
+
+    // $example on$
+    val myTransformer2 = new MyTransformer()
+      .setShift(1.5)
+      .setInputCol("output1")
+      .setOutputCol("output2")
+
+    val multiTransformer = myTransformer1.compose(myTransformer2)
+
+    // Create data, transform, and display it.
+    val data = spark.range(0, 5).toDF("input")
+      .select(col("input").cast("double").as("input"))
+
+    val result = multiTransformer.transform(data)
+    println("Transformed by adding constant value")
+
+    result.show()
+
+    // Save and load the Transformer.
+    val tmpDir = Utils.createTempDir()
+    val dirName = tmpDir.getCanonicalPath
+    // myTransformer.write.overwrite().save(dirName)
+    val sameTransformer = MyTransformer.load(dirName)
+
+    // Transform the data to show the results are identical.
+    println("Same transform applied from loaded model")
+    val sameResult = sameTransformer.transform(data)
+    sameResult.show()
+
+    Utils.deleteRecursively(tmpDir)
+    // $example off$
+
+    spark.stop()
+  }
+
+}
+// scalastyle:on println
+

--- a/examples/src/main/scala/org/apache/spark/examples/ml/MultiTransformerExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/MultiTransformerExample.scala
@@ -78,7 +78,6 @@ object MultiTransformerExample {
   // $example off$
 
   def main(args: Array[String]): Unit = {
-    println("Hello there")
     val spark = SparkSession
       .builder()
       .appName("MultiTransformerExample")
@@ -96,15 +95,17 @@ object MultiTransformerExample {
       .setInputCol("output1")
       .setOutputCol("output2")
 
-    val multiTransformer = new MultiTransformer(List(myTransformer1, myTransformer2))
+    val multiTransformer = new MultiTransformer(List(myTransformer1))
+
+    val multiTransformer2 = multiTransformer.composeTransformers(List(myTransformer2))
 
     // Create data, transform, and display it.
     val data = spark.range(0, 5).toDF("input")
       .select(col("input").cast("double").as("input"))
 
-    val result = multiTransformer.transform(data)
+    val result = multiTransformer2.transform(data)
 
-    println("Two transforms adding constant value")
+    println("Apply transforms adding constant value")
 
     result.show()
 

--- a/examples/src/main/scala/org/apache/spark/examples/ml/MultiTransformerExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/MultiTransformerExample.scala
@@ -19,7 +19,6 @@
 package org.apache.spark.examples.ml
 
 // $example on$
-import org.apache.spark.examples.ml.UnaryTransformerExample.MyTransformer
 import org.apache.spark.ml.MultiTransformer
 import org.apache.spark.ml.UnaryTransformer
 import org.apache.spark.ml.param.DoubleParam
@@ -27,12 +26,11 @@ import org.apache.spark.ml.util.{DefaultParamsReadable, DefaultParamsWritable, I
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.{DataType, DataTypes}
-import org.apache.spark.util.Utils
 // $example off$
 
 /**
  * An example demonstrating creating a custom [[org.apache.spark.ml.Transformer]] using
- * the [[UnaryTransformer]] abstraction.
+ * the [[MultiTransformer]] abstraction.
  *
  * Run with
  * {{{
@@ -46,12 +44,7 @@ object MultiTransformerExample {
    * Simple Transformer which adds a constant value to input Doubles.
    *
    * [[MultiTransformerExample]] can be used to create a stage usable within Pipelines.
-   * It defines parameters for specifying input and output columns:
-   * [[UnaryTransformer.inputCol]] and [[UnaryTransformer.outputCol]].
-   * It can optionally handle schema validation.
    *
-   * [[DefaultParamsWritable]] provides a default implementation for persisting instances
-   * of this Transformer.
    */
   class MyTransformer(override val uid: String)
     extends UnaryTransformer[Double, Double, MyTransformer] with DefaultParamsWritable {
@@ -88,7 +81,7 @@ object MultiTransformerExample {
     println("Hello there")
     val spark = SparkSession
       .builder()
-      .appName("UnaryTransformerExample")
+      .appName("MultiTransformerExample")
       .getOrCreate()
 
     // $example on$
@@ -103,11 +96,17 @@ object MultiTransformerExample {
       .setInputCol("output1")
       .setOutputCol("output2")
 
-    val multiTransformer = new MultiTransformer(Nil)
+    val multiTransformer = new MultiTransformer(List(myTransformer1, myTransformer2))
 
     // Create data, transform, and display it.
     val data = spark.range(0, 5).toDF("input")
       .select(col("input").cast("double").as("input"))
+
+    val result = multiTransformer.transform(data)
+
+    println("Two transforms adding constant value")
+
+    result.show()
 
     spark.stop()
   }

--- a/examples/src/main/scala/org/apache/spark/examples/ml/MultiTransformerExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/MultiTransformerExample.scala
@@ -20,6 +20,7 @@ package org.apache.spark.examples.ml
 
 // $example on$
 import org.apache.spark.examples.ml.UnaryTransformerExample.MyTransformer
+import org.apache.spark.ml.MultiTransformer
 import org.apache.spark.ml.UnaryTransformer
 import org.apache.spark.ml.param.DoubleParam
 import org.apache.spark.ml.util.{DefaultParamsReadable, DefaultParamsWritable, Identifiable}
@@ -102,30 +103,11 @@ object MultiTransformerExample {
       .setInputCol("output1")
       .setOutputCol("output2")
 
-    val multiTransformer = myTransformer1.compose(myTransformer2)
+    val multiTransformer = new MultiTransformer(Nil)
 
     // Create data, transform, and display it.
     val data = spark.range(0, 5).toDF("input")
       .select(col("input").cast("double").as("input"))
-
-    val result = multiTransformer.transform(data)
-    println("Transformed by adding constant value")
-
-    result.show()
-
-    // Save and load the Transformer.
-    val tmpDir = Utils.createTempDir()
-    val dirName = tmpDir.getCanonicalPath
-    // myTransformer.write.overwrite().save(dirName)
-    val sameTransformer = MyTransformer.load(dirName)
-
-    // Transform the data to show the results are identical.
-    println("Same transform applied from loaded model")
-    val sameResult = sameTransformer.transform(data)
-    sameResult.show()
-
-    Utils.deleteRecursively(tmpDir)
-    // $example off$
 
     spark.stop()
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/Transformer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Transformer.scala
@@ -122,3 +122,27 @@ abstract class UnaryTransformer[IN: TypeTag, OUT: TypeTag, T <: UnaryTransformer
 
   override def copy(extra: ParamMap): T = defaultCopy(extra)
 }
+
+/**
+ * A MultiTransformer is a transformer that will chain together a sequence of UnaryTransformers
+ *
+ * @param transformers
+ */
+class MultiTransformer(transformers: List[UnaryTransformer[_, _, _]]) {
+
+  def composeTransformers(otherTransformers: List[UnaryTransformer[_, _, _]]): Unit = {
+    new MultiTransformer(transformers ++ otherTransformers) }
+
+  def transform(dataSet: Dataset[_]): Dataset[_] = {
+    def transform2(dataSet: Dataset[_], xFormers: List[UnaryTransformer[_, _, _]]): Dataset[_] = {
+      xFormers match {
+        case Nil => dataSet
+        case head::tail => transform2(head.transform(dataSet), tail)
+      }
+    }
+
+    transform2(dataSet, transformers)
+  }
+}
+
+

--- a/mllib/src/main/scala/org/apache/spark/ml/Transformer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Transformer.scala
@@ -130,9 +130,21 @@ abstract class UnaryTransformer[IN: TypeTag, OUT: TypeTag, T <: UnaryTransformer
  */
 class MultiTransformer(transformers: List[UnaryTransformer[_, _, _]]) {
 
+  /**
+   * Add additional transformers to the sequence.
+   *
+   * @param otherTransformers
+   */
   def composeTransformers(otherTransformers: List[UnaryTransformer[_, _, _]]): Unit = {
     new MultiTransformer(transformers ++ otherTransformers) }
 
+  /**
+   * Transform the dataSet by applying all of the transformers.
+   *
+   * @param dataSet
+   *
+   * @return The result of applying the transformers in sequence.
+   */
   def transform(dataSet: Dataset[_]): Dataset[_] = {
     def transform2(dataSet: Dataset[_], xFormers: List[UnaryTransformer[_, _, _]]): Dataset[_] = {
       xFormers match {

--- a/mllib/src/main/scala/org/apache/spark/ml/Transformer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Transformer.scala
@@ -135,7 +135,7 @@ class MultiTransformer(transformers: List[UnaryTransformer[_, _, _]]) {
    *
    * @param otherTransformers
    */
-  def composeTransformers(otherTransformers: List[UnaryTransformer[_, _, _]]): Unit = {
+  def composeTransformers(otherTransformers: List[UnaryTransformer[_, _, _]]): MultiTransformer = {
     new MultiTransformer(transformers ++ otherTransformers) }
 
   /**


### PR DESCRIPTION
 
### What changes were proposed in this pull request?

Adding class `MultiTransformer` to allow encapsulation of a sequence of transforms.
### Why are the changes needed?

Requested in SPARK-2749 as the current API is limiting.

### Does this PR introduce _any_ user-facing change?

No
 
### How was this patch tested?

By running the new example

```
bin/run-example ml.MultiTransformerExample
```