### PR TITLE
[SPARK-31620][SQL] Fix reference binding failure in case of an final agg contains subquery

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
@@ -402,11 +402,11 @@ abstract class DeclarativeAggregate
   final lazy val inputAggBufferAttributes: Seq[AttributeReference] = {
     // SPARK-31620: inputAggBufferAttributes from a partial agg can be referenced by a final agg
     // in order to merge agg values. However, in case of an aggregate function contains a subquery,
-    // the aggregate function will be transformed to new copy during `PlanSubqueries` and lost
-    // original attributes because `TreeNode` does not preserve "lazy val" during `makeCopy`. As a
-    // result, the final agg could fail to resolve references through partial agg. So we use the
-    // tag to save the original attributes to let the new copy node share the same attributes with
-    // old node.
+    // the aggregate function will be transformed to a new copied node during `PlanSubqueries` and
+    // lost original attributes because `TreeNode` does not preserve "lazy val" during `makeCopy`.
+    // As a result, the final agg could fail to resolve references through partial agg. So we use
+    // the tag to save the original attributes to let the new copy node share the same attributes
+    // with old node.
     getTagValue(inputAggBufferAttributeTag).getOrElse {
       val attrs = aggBufferAttributes.map(_.newInstance())
       setTagValue(inputAggBufferAttributeTag, attrs)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
@@ -405,7 +405,7 @@ abstract class DeclarativeAggregate
     // the aggregate function will be transformed to a new copied node during `PlanSubqueries` and
     // lost original attributes because `TreeNode` does not preserve "lazy val" during `makeCopy`.
     // As a result, the final agg could fail to resolve references through partial agg. So we use
-    // the tag to save the original attributes to let the new copy node share the same attributes
+    // the tag to save the original attributes to let the new copied node share the same attributes
     // with old node.
     getTagValue(inputAggBufferAttributeTag).getOrElse {
       val attrs = aggBufferAttributes.map(_.newInstance())

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
@@ -21,7 +21,6 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
-import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.types._
 
 /** The mode of an [[AggregateFunction]]. */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
@@ -400,13 +400,15 @@ abstract class DeclarativeAggregate
   final override def aggBufferSchema: StructType = StructType.fromAttributes(aggBufferAttributes)
 
   final lazy val inputAggBufferAttributes: Seq[AttributeReference] = {
-    // SPARK-31620: inputAggBufferAttributes from a partial agg can be referenced by a final agg
-    // in order to merge agg values. However, in case of an aggregate function contains a subquery,
-    // the aggregate function will be transformed to a new copied node during `PlanSubqueries` and
-    // lost original attributes because `TreeNode` does not preserve "lazy val" during `makeCopy`.
-    // As a result, the final agg could fail to resolve references through partial agg. So we use
-    // the tag to save the original attributes to let the new copied node share the same attributes
-    // with old node.
+    // SPARK-31620: inputAggBufferAttributes from a partial aggregate can be referenced by a final
+    // aggregate in order to merge aggregate values. However, in case of an aggregate function
+    // contains a subquery, the aggregate function will be transformed to a new copied node during
+    // `PlanSubqueries` and lost original attributes because `TreeNode` does not preserve them
+    // during `makeCopy`. As a result, the final aggregate could fail to resolve references through
+    // partial aggregate's output. So, we use the tag to save the original attributes to let the
+    // new copied node share the same attributes with old node. Note, we don't save other attributes
+    // within an aggregate function and ImperativeAggregate's inputAggBufferAttributes because they
+    // will not be referenced out of the aggregate function itself.
     getTagValue(inputAggBufferAttributeTag).getOrElse {
       val attrs = aggBufferAttributes.map(_.newInstance())
       setTagValue(inputAggBufferAttributeTag, attrs)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/BaseAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/BaseAggregateExec.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.aggregate
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, NamedExpression}
-import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
+import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, Final, PartialMerge}
 import org.apache.spark.sql.execution.{ExplainUtils, UnaryExecNode}
 
 /**
@@ -39,5 +39,29 @@ trait BaseAggregateExec extends UnaryExecNode {
        |${ExplainUtils.generateFieldString("Aggregate Attributes", aggregateAttributes)}
        |${ExplainUtils.generateFieldString("Results", resultExpressions)}
        |""".stripMargin
+  }
+
+  protected def inputAttributes: Seq[Attribute] = {
+    val modes = aggregateExpressions.map(_.mode).distinct
+    if (modes.contains(Final) || modes.contains(PartialMerge)) {
+      // SPARK-31620: when planning aggregates, the partial aggregate uses aggregate function's
+      // `inputAggBufferAttributes` as its output. And Final and PartialMerge aggregate rely on the
+      // output to bind references for `DeclarativeAggregate.mergeExpressions`. But if we copy the
+      // aggregate function somehow after aggregate planning, like `PlanSubqueries`, the
+      // `DeclarativeAggregate` will be replaced by a new instance with new
+      // `inputAggBufferAttributes` and `mergeExpressions`. Then Final and PartialMerge aggregate
+      // can't bind the `mergeExpressions` with the output of the partial aggregate, as they use
+      // the `inputAggBufferAttributes` of the original `DeclarativeAggregate` before copy. Instead,
+      // we shall use `inputAggBufferAttributes` after copy to match the new `mergeExpressions`.
+      val aggAttrs = aggregateExpressions
+        // there're exactly four cases needs `inputAggBufferAttributes` from child according to the
+        // agg planning in `AggUtils`: Partial -> Final, PartialMerge -> Final,
+        // Partial -> PartialMerge, PartialMerge -> PartialMerge.
+        .filter(a => a.mode == Final || a.mode == PartialMerge).map(_.aggregateFunction)
+        .flatMap(_.inputAggBufferAttributes)
+      child.output.dropRight(aggAttrs.length) ++ aggAttrs
+    } else {
+      child.output
+    }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -343,7 +343,10 @@ case class HashAggregateExec(
       // the `inputAggBufferAttributes` of the original `DeclarativeAggregate` before copy. Instead,
       // we shall use `inputAggBufferAttributes` after copy to match the new `mergeExpressions`.
       val aggAttrs = aggregateExpressions
-        .filter(a => a.mode == Final || !a.isDistinct).map(_.aggregateFunction)
+        // there're exactly four cases needs `inputAggBufferAttributes` from child according to the
+        // agg planning in `AggUtils`: Partial -> Final, PartialMerge -> Final,
+        // Partial -> PartialMerge, PartialMerge -> PartialMerge.
+        .filter(a => a.mode == Final || a.mode == PartialMerge).map(_.aggregateFunction)
         .flatMap(_.inputAggBufferAttributes)
       child.output.dropRight(aggAttrs.length) ++ aggAttrs
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -331,29 +331,6 @@ case class HashAggregateExec(
     }
   }
 
-  private def inputAttributes: Seq[Attribute] = {
-    if (modes.contains(Final) || modes.contains(PartialMerge)) {
-      // SPARK-31620: when planning aggregates, the partial aggregate uses aggregate function's
-      // `inputAggBufferAttributes` as its output. And Final and PartialMerge aggregate rely on the
-      // output to bind references for `DeclarativeAggregate.mergeExpressions`. But if we copy the
-      // aggregate function somehow after aggregate planning, like `PlanSubqueries`, the
-      // `DeclarativeAggregate` will be replaced by a new instance with new
-      // `inputAggBufferAttributes` and `mergeExpressions`. Then Final and PartialMerge aggregate
-      // can't bind the `mergeExpressions` with the output of the partial aggregate, as they use
-      // the `inputAggBufferAttributes` of the original `DeclarativeAggregate` before copy. Instead,
-      // we shall use `inputAggBufferAttributes` after copy to match the new `mergeExpressions`.
-      val aggAttrs = aggregateExpressions
-        // there're exactly four cases needs `inputAggBufferAttributes` from child according to the
-        // agg planning in `AggUtils`: Partial -> Final, PartialMerge -> Final,
-        // Partial -> PartialMerge, PartialMerge -> PartialMerge.
-        .filter(a => a.mode == Final || a.mode == PartialMerge).map(_.aggregateFunction)
-        .flatMap(_.inputAggBufferAttributes)
-      child.output.dropRight(aggAttrs.length) ++ aggAttrs
-    } else {
-      child.output
-    }
-  }
-
   private def doConsumeWithoutKeys(ctx: CodegenContext, input: Seq[ExprCode]): String = {
     // only have DeclarativeAggregate
     val functions = aggregateExpressions.map(_.aggregateFunction.asInstanceOf[DeclarativeAggregate])

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectHashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectHashAggregateExec.scala
@@ -123,7 +123,7 @@ case class ObjectHashAggregateExec(
             resultExpressions,
             (expressions, inputSchema) =>
               MutableProjection.create(expressions, inputSchema),
-            child.output,
+            inputAttributes,
             iter,
             fallbackCountThreshold,
             numOutputRows)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortAggregateExec.scala
@@ -88,7 +88,7 @@ case class SortAggregateExec(
         val outputIter = new SortBasedAggregationIterator(
           partIndex,
           groupingExpressions,
-          child.output,
+          inputAttributes,
           iter,
           aggregateExpressions,
           aggregateAttributes,

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -973,4 +973,13 @@ class DataFrameAggregateSuite extends QueryTest
       assert(error.message.contains("function count_if requires boolean type"))
     }
   }
+
+  test("SPARK-31620: agg with subquery") {
+    withTempView("t1", "t2") {
+      sql("create temporary view t1 as select * from values (1, 2) as t1(a, b)")
+      sql("create temporary view t2 as select * from values (3, 4) as t2(c, d)")
+      checkAnswer(sql("select sum(if(c > (select a from t1), d, 0)) as csum from t2"),
+        Row(4) :: Nil)
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -996,6 +996,14 @@ class DataFrameAggregateSuite extends QueryTest
           // test subquery with agg
           checkAnswer(sql("select sum(distinct(if(c > (select sum(distinct(a)) from t1)," +
             " d, 0))) as csum from t2 group by c"), Row(4) :: Nil)
+
+          // test SortAggregateExec
+          checkAnswer(sql("select max(if(c > (select a from t1), 'str1', 'str2')) as csum from t2"),
+            Row("str1") :: Nil)
+
+          // test ObjectHashAggregateExec
+          checkAnswer(sql("select collect_list(d), sum(if(c > (select a from t1), d, 0)) as csum" +
+            " from t2"), Row(Array(4), 4) :: Nil)
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -980,12 +980,22 @@ class DataFrameAggregateSuite extends QueryTest
         withTempView("t1", "t2") {
           sql("create temporary view t1 as select * from values (1, 2) as t1(a, b)")
           sql("create temporary view t2 as select * from values (3, 4) as t2(c, d)")
+
           // test without grouping keys
           checkAnswer(sql("select sum(if(c > (select a from t1), d, 0)) as csum from t2"),
             Row(4) :: Nil)
+
           // test with grouping keys
           checkAnswer(sql("select c, sum(if(c > (select a from t1), d, 0)) as csum from " +
             "t2 group by c"), Row(3, 4) :: Nil)
+
+          // test with distinct
+          checkAnswer(sql("select avg(distinct(d)), sum(distinct(if(c > (select a from t1)," +
+            " d, 0))) as csum from t2 group by c"), Row(4, 4) :: Nil)
+
+          // test subquery with agg
+          checkAnswer(sql("select sum(distinct(if(c > (select sum(distinct(a)) from t1)," +
+            " d, 0))) as csum from t2 group by c"), Row(4) :: Nil)
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -975,7 +975,7 @@ class DataFrameAggregateSuite extends QueryTest
   }
 
   Seq(true, false).foreach { value =>
-    test(s"SPARK-31620: agg with subquery (codegen = $value)") {
+    test(s"SPARK-31620: agg with subquery (whole-stage-codegen = $value)") {
       withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> value.toString) {
         withTempView("t1", "t2") {
           sql("create temporary view t1 as select * from values (1, 2) as t1(a, b)")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Instead of using `child.output` directly, we should use `inputAggBufferAttributes` from the current agg expression  for `Final` and `PartialMerge` aggregates to bind references for their `mergeExpression`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

When planning aggregates, the partial aggregate uses agg fucs' `inputAggBufferAttributes` as its output, see https://github.com/apache/spark/blob/v3.0.0-rc1/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggUtils.scala#L105

For final `HashAggregateExec`, we need to bind the `DeclarativeAggregate.mergeExpressions` with the output of the partial aggregate operator, see https://github.com/apache/spark/blob/v3.0.0-rc1/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala#L348

This is usually fine. However, if we copy the agg func somehow after agg planning, like `PlanSubqueries`, the `DeclarativeAggregate` will be replaced by a new instance with new `inputAggBufferAttributes` and `mergeExpressions`. Then we can't bind the `mergeExpressions` with the output of the partial aggregate operator, as it uses the `inputAggBufferAttributes` of the original `DeclarativeAggregate` before copy.

Note that, `ImperativeAggregate` doesn't have this problem, as we don't need to bind its `mergeExpressions`. It has a different mechanism to access buffer values, via `mutableAggBufferOffset` and `inputAggBufferOffset`.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, user hit error previously but run query successfully after this change.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Added a regression test.
