### PR TITLE
[SPARK-31677][SS] Use kvstore to cache stream query progress

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
@@ -25,13 +25,14 @@ import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, CurrentBatch
 import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LocalRelation, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.connector.catalog.{SupportsRead, SupportsWrite, Table, TableCapability}
-import org.apache.spark.sql.connector.read.streaming.{MicroBatchStream, Offset => OffsetV2, ReadLimit, SparkDataStream, SupportsAdmissionControl}
+import org.apache.spark.sql.connector.read.streaming.{MicroBatchStream, ReadLimit, SparkDataStream, SupportsAdmissionControl, Offset => OffsetV2}
 import org.apache.spark.sql.execution.SQLExecution
-import org.apache.spark.sql.execution.datasources.v2.{StreamingDataSourceV2Relation, StreamWriterCommitProgress, WriteToDataSourceV2Exec}
+import org.apache.spark.sql.execution.datasources.v2.{StreamWriterCommitProgress, StreamingDataSourceV2Relation, WriteToDataSourceV2Exec}
 import org.apache.spark.sql.execution.streaming.sources.WriteToMicroBatchDataSource
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.{OutputMode, Trigger}
 import org.apache.spark.util.Clock
+import org.apache.spark.util.kvstore.KVStore
 
 class MicroBatchExecution(
     sparkSession: SparkSession,
@@ -43,10 +44,11 @@ class MicroBatchExecution(
     triggerClock: Clock,
     outputMode: OutputMode,
     extraOptions: Map[String, String],
-    deleteCheckpointOnStop: Boolean)
+    deleteCheckpointOnStop: Boolean,
+    store: KVStore)
   extends StreamExecution(
     sparkSession, name, checkpointRoot, analyzedPlan, sink,
-    trigger, triggerClock, outputMode, deleteCheckpointOnStop) {
+    trigger, triggerClock, outputMode, deleteCheckpointOnStop, store) {
 
   @volatile protected var sources: Seq[SparkDataStream] = Seq.empty
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
@@ -25,9 +25,9 @@ import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, CurrentBatch
 import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LocalRelation, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.connector.catalog.{SupportsRead, SupportsWrite, Table, TableCapability}
-import org.apache.spark.sql.connector.read.streaming.{MicroBatchStream, ReadLimit, SparkDataStream, SupportsAdmissionControl, Offset => OffsetV2}
+import org.apache.spark.sql.connector.read.streaming.{MicroBatchStream, Offset => OffsetV2, ReadLimit, SparkDataStream, SupportsAdmissionControl}
 import org.apache.spark.sql.execution.SQLExecution
-import org.apache.spark.sql.execution.datasources.v2.{StreamWriterCommitProgress, StreamingDataSourceV2Relation, WriteToDataSourceV2Exec}
+import org.apache.spark.sql.execution.datasources.v2.{StreamingDataSourceV2Relation, StreamWriterCommitProgress, WriteToDataSourceV2Exec}
 import org.apache.spark.sql.execution.streaming.sources.WriteToMicroBatchDataSource
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.{OutputMode, Trigger}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -48,6 +48,7 @@ import org.apache.spark.sql.internal.connector.SupportsStreamingUpdate
 import org.apache.spark.sql.streaming._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.{Clock, UninterruptibleThread, Utils}
+import org.apache.spark.util.kvstore.KVStore
 
 /** States for [[StreamExecution]]'s lifecycle. */
 trait State
@@ -75,7 +76,8 @@ abstract class StreamExecution(
     val trigger: Trigger,
     val triggerClock: Clock,
     val outputMode: OutputMode,
-    deleteCheckpointOnStop: Boolean)
+    deleteCheckpointOnStop: Boolean,
+    override val store: KVStore)
   extends StreamingQuery with ProgressReporter with Logging {
 
   import org.apache.spark.sql.streaming.StreamingQueryListener._

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousExecution.scala
@@ -35,6 +35,7 @@ import org.apache.spark.sql.execution.datasources.v2.StreamingDataSourceV2Relati
 import org.apache.spark.sql.execution.streaming.{StreamingRelationV2, _}
 import org.apache.spark.sql.streaming.{OutputMode, Trigger}
 import org.apache.spark.util.Clock
+import org.apache.spark.util.kvstore.KVStore
 
 class ContinuousExecution(
     sparkSession: SparkSession,
@@ -46,10 +47,11 @@ class ContinuousExecution(
     triggerClock: Clock,
     outputMode: OutputMode,
     extraOptions: Map[String, String],
-    deleteCheckpointOnStop: Boolean)
+    deleteCheckpointOnStop: Boolean,
+    store: KVStore)
   extends StreamExecution(
     sparkSession, name, checkpointRoot, analyzedPlan, sink,
-    trigger, triggerClock, outputMode, deleteCheckpointOnStop) {
+    trigger, triggerClock, outputMode, deleteCheckpointOnStop, store) {
 
   @volatile protected var sources: Seq[ContinuousStream] = Seq()
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -109,16 +109,14 @@ private[sql] class SharedState(
    * A [[StreamingQueryListener]] for structured streaming ui, it contains all streaming query ui
    * data to show.
    */
-  lazy val streamingQueryStatusListener: Option[StreamingQueryStatusListener] = {
-    sparkContext.ui.flatMap { ui =>
+  lazy val streamingQueryStatusListener: StreamingQueryStatusListener = {
+    val statusListener = new StreamingQueryStatusListener(conf)
+    sparkContext.ui.foreach { ui =>
       if (conf.get(STREAMING_UI_ENABLED)) {
-        val statusListener = new StreamingQueryStatusListener(conf)
         new StreamingQueryTab(statusListener, ui)
-        Some(statusListener)
-      } else {
-        None
       }
     }
+    statusListener
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryListenerSuite.scala
@@ -225,7 +225,7 @@ class StreamingQueryListenerSuite extends StreamTest with BeforeAndAfter {
       assert(isListenerActive(listener1) === false)
       assert(isListenerActive(listener2))
     } finally {
-      spark.streams.listListeners().foreach(spark.streams.removeListener)
+      allListenerExcludeDefault(spark).foreach(spark.streams.removeListener)
     }
   }
 
@@ -366,10 +366,10 @@ class StreamingQueryListenerSuite extends StreamTest with BeforeAndAfter {
     assert(session1.streams.ne(session2.streams))
 
     withListenerAdded(collector1, session1) {
-      assert(session1.streams.listListeners().nonEmpty)
+      assert(allListenerExcludeDefault(session1).nonEmpty)
 
       withListenerAdded(collector2, session2) {
-        assert(session2.streams.listListeners().nonEmpty)
+        assert(allListenerExcludeDefault(session2).nonEmpty)
 
         // query on session1 should send events only to collector1
         runQuery(session1)
@@ -462,6 +462,10 @@ class StreamingQueryListenerSuite extends StreamTest with BeforeAndAfter {
     } finally {
       spark.streams.removeListener(listener)
     }
+  }
+
+  private def allListenerExcludeDefault(session: SparkSession): Array[StreamingQueryListener] = {
+    session.streams.listListeners().filterNot(_.isInstanceOf[StreamingQueryStatusListener])
   }
 
   private def testReplayListenerBusWithBorkenEventJsons(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Use KVStore instead to cache streaming query progress information.

### Why are the changes needed?

Streaming query progress information are cached twice in `StreamExecution` and `StreamingQueryStatusListener`. It is memory-wasting. We can make this two usage unified.


### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

update ut and manual test.
