### PR TITLE
[SPARK-31680][SQL][TESTS] Support Java 8 datetime types by Random data generator

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
@@ -19,13 +19,13 @@ package org.apache.spark.sql
 
 import java.math.MathContext
 import java.sql.{Date, Timestamp}
-import java.time.LocalDate
+import java.time.{Instant, LocalDate, LocalDateTime, ZoneId}
 
 import scala.collection.mutable
 import scala.util.{Random, Try}
 
 import org.apache.spark.sql.catalyst.CatalystTypeConverters
-import org.apache.spark.sql.catalyst.util.DateTimeConstants.MILLIS_PER_DAY
+import org.apache.spark.sql.catalyst.util.DateTimeConstants.{MICROS_PER_MILLIS, MILLIS_PER_DAY}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
@@ -204,7 +204,7 @@ object RandomDataGenerator {
             specialDates.map(java.sql.Date.valueOf))
         }
       case TimestampType =>
-        def uniformTimestampRand(rand: Random): java.sql.Timestamp = {
+        def uniformMicorsRand(rand: Random): Long = {
           var milliseconds = rand.nextLong() % 253402329599999L
           // -62135740800000L is the number of milliseconds before January 1, 1970, 00:00:00 GMT
           // for "0001-01-01 00:00:00.000000". We need to find a
@@ -214,26 +214,39 @@ object RandomDataGenerator {
             // January 1, 1970, 00:00:00 GMT for "9999-12-31 23:59:59.999999".
             milliseconds = rand.nextLong() % 253402329599999L
           }
-          // DateTimeUtils.toJavaTimestamp takes microsecond.
-          val ts = DateTimeUtils.toJavaTimestamp(milliseconds * 1000)
-          // The generated `ts` is based on the hybrid calendar Julian + Gregorian since
-          // 1582-10-15 but it should be valid in Proleptic Gregorian calendar too which is used
-          // by Spark SQL since version 3.0 (see SPARK-26651). We try to convert `ts` to
-          // a local timestamp in Proleptic Gregorian calendar to satisfy this requirement.
-          // Some years are leap years in Julian calendar but not in Proleptic Gregorian calendar.
-          // As the consequence of that, 29 February of such years might not exist in Proleptic
-          // Gregorian calendar. When this happens, we shift the timestamp `ts` by one day.
-          Try { ts.toLocalDateTime; ts }.getOrElse(new Timestamp(ts.getTime + MILLIS_PER_DAY))
+          milliseconds * MICROS_PER_MILLIS
         }
-        randomNumeric[java.sql.Timestamp](
-          rand,
-          uniformTimestampRand,
-          Seq(
-            "0001-01-01 00:00:00", // the fist timestamp of Common Era
-            "1582-10-15 23:59:59", // the cutover date from Julian to Gregorian calendar
-            "1970-01-01 00:00:00", // the epoch timestamp
-            "9999-12-31 23:59:59.999" // the last supported timestamp according to SQL standard
-          ).map(java.sql.Timestamp.valueOf))
+        val specialTs = Seq(
+          "0001-01-01 00:00:00", // the fist timestamp of Common Era
+          "1582-10-15 23:59:59", // the cutover date from Julian to Gregorian calendar
+          "1970-01-01 00:00:00", // the epoch timestamp
+          "9999-12-31 23:59:59"  // the last supported timestamp according to SQL standard
+        )
+        if (SQLConf.get.getConf(SQLConf.DATETIME_JAVA8API_ENABLED)) {
+          randomNumeric[Instant](
+            rand,
+            (rand: Random) => DateTimeUtils.microsToInstant(uniformMicorsRand(rand)),
+            specialTs.map { s =>
+              val ldt = LocalDateTime.parse(s.replace(" ", "'T'"))
+              ldt.atZone(ZoneId.systemDefault()).toInstant
+            })
+        } else {
+          randomNumeric[java.sql.Timestamp](
+            rand,
+            (rand: Random) => {
+              // DateTimeUtils.toJavaTimestamp takes microsecond.
+              val ts = DateTimeUtils.toJavaTimestamp(uniformMicorsRand(rand))
+              // The generated `ts` is based on the hybrid calendar Julian + Gregorian since
+              // 1582-10-15 but it should be valid in Proleptic Gregorian calendar too which is used
+              // by Spark SQL since version 3.0 (see SPARK-26651). We try to convert `ts` to
+              // a local timestamp in Proleptic Gregorian calendar to satisfy this requirement. Some
+              // years are leap years in Julian calendar but not in Proleptic Gregorian calendar.
+              // As the consequence of that, 29 February of such years might not exist in Proleptic
+              // Gregorian calendar. When this happens, we shift the timestamp `ts` by one day.
+              Try { ts.toLocalDateTime; ts }.getOrElse(new Timestamp(ts.getTime + MILLIS_PER_DAY))
+            },
+            specialTs.map(java.sql.Timestamp.valueOf))
+        }
       case CalendarIntervalType => Some(() => {
         val months = rand.nextInt(1000)
         val days = rand.nextInt(10000)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
@@ -227,7 +227,7 @@ object RandomDataGenerator {
             rand,
             (rand: Random) => DateTimeUtils.microsToInstant(uniformMicorsRand(rand)),
             specialTs.map { s =>
-              val ldt = LocalDateTime.parse(s.replace(" ", "'T'"))
+              val ldt = LocalDateTime.parse(s.replace(" ", "T"))
               ldt.atZone(ZoneId.systemDefault()).toInstant
             })
         } else {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/RowEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/RowEncoderSuite.scala
@@ -377,23 +377,27 @@ class RowEncoderSuite extends CodegenInterpretedPlanTest {
 
   private def encodeDecodeTest(schema: StructType): Unit = {
     test(s"encode/decode: ${schema.simpleString}") {
-      val encoder = RowEncoder(schema).resolveAndBind()
-      val inputGenerator = RandomDataGenerator.forType(schema, nullable = false).get
+      Seq(false, true).foreach { java8Api =>
+        withSQLConf(SQLConf.DATETIME_JAVA8API_ENABLED.key -> java8Api.toString) {
+          val encoder = RowEncoder(schema).resolveAndBind()
+          val inputGenerator = RandomDataGenerator.forType(schema, nullable = false).get
 
-      var input: Row = null
-      try {
-        for (_ <- 1 to 5) {
-          input = inputGenerator.apply().asInstanceOf[Row]
-          val convertedBack = roundTrip(encoder, input)
-          assert(input == convertedBack)
+          var input: Row = null
+          try {
+            for (_ <- 1 to 5) {
+              input = inputGenerator.apply().asInstanceOf[Row]
+              val convertedBack = roundTrip(encoder, input)
+              assert(input == convertedBack)
+            }
+          } catch {
+            case e: Exception =>
+              fail(
+                s"""
+                   |schema: ${schema.simpleString}
+                   |input: ${input}
+                 """.stripMargin, e)
+          }
         }
-      } catch {
-        case e: Exception =>
-          fail(
-            s"""
-               |schema: ${schema.simpleString}
-               |input: ${input}
-             """.stripMargin, e)
       }
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/HadoopFsRelationTest.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/HadoopFsRelationTest.scala
@@ -145,40 +145,49 @@ abstract class HadoopFsRelationTest extends QueryTest with SQLTestUtils with Tes
 
           val seed = System.nanoTime()
           withClue(s"Random data generated with the seed: ${seed}") {
-            val dataGenerator = RandomDataGenerator.forType(
-              dataType = dataType,
-              nullable = true,
-              new Random(seed)
-            ).getOrElse {
-              fail(s"Failed to create data generator for schema $dataType")
+            val java8ApiConfValues = if (dataType == DateType || dataType == TimestampType) {
+              Seq(false, true)
+            } else {
+              Seq(false)
             }
+            java8ApiConfValues.foreach { java8Api =>
+              withSQLConf(SQLConf.DATETIME_JAVA8API_ENABLED.key -> java8Api.toString) {
+                val dataGenerator = RandomDataGenerator.forType(
+                  dataType = dataType,
+                  nullable = true,
+                  new Random(seed)
+                ).getOrElse {
+                  fail(s"Failed to create data generator for schema $dataType")
+                }
 
-            // Create a DF for the schema with random data. The index field is used to sort the
-            // DataFrame.  This is a workaround for SPARK-10591.
-            val schema = new StructType()
-              .add("index", IntegerType, nullable = false)
-              .add("col", dataType, nullable = true)
-            val rdd =
-              spark.sparkContext.parallelize((1 to 20).map(i => Row(i, dataGenerator())))
-            val df = spark.createDataFrame(rdd, schema).orderBy("index").coalesce(1)
+                // Create a DF for the schema with random data. The index field is used to sort the
+                // DataFrame.  This is a workaround for SPARK-10591.
+                val schema = new StructType()
+                  .add("index", IntegerType, nullable = false)
+                  .add("col", dataType, nullable = true)
+                val rdd =
+                  spark.sparkContext.parallelize((1 to 20).map(i => Row(i, dataGenerator())))
+                val df = spark.createDataFrame(rdd, schema).orderBy("index").coalesce(1)
 
-            df.write
-              .mode("overwrite")
-              .format(dataSourceName)
-              .option("dataSchema", df.schema.json)
-              .options(extraOptions)
-              .save(path)
+                df.write
+                  .mode("overwrite")
+                  .format(dataSourceName)
+                  .option("dataSchema", df.schema.json)
+                  .options(extraOptions)
+                  .save(path)
 
-            val loadedDF = spark
-              .read
-              .format(dataSourceName)
-              .option("dataSchema", df.schema.json)
-              .schema(df.schema)
-              .options(extraOptions)
-              .load(path)
-              .orderBy("index")
+                val loadedDF = spark
+                  .read
+                  .format(dataSourceName)
+                  .option("dataSchema", df.schema.json)
+                  .schema(df.schema)
+                  .options(extraOptions)
+                  .load(path)
+                  .orderBy("index")
 
-            checkAnswer(loadedDF, df)
+                checkAnswer(loadedDF, df)
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Generates java.time.Instant/java.time.LocalDate for DateType/TimestampType by `RandomDataGenerator.forType` when the SQL config `spark.sql.datetime.java8API.enabled` is set to `true`.

### Why are the changes needed?
To improve test coverage, and check java.time.Instant/java.time.LocalDate types in round trip tests.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
By running modified test suites `RowEncoderSuite`, `RandomDataGeneratorSuite` and `HadoopFsRelationTest`.