### PR TITLE
[SPARK-31655][BUILD][2.4] Upgrade snappy-java to 1.1.7.5

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.6
+++ b/dev/deps/spark-deps-hadoop-2.6
@@ -179,7 +179,7 @@ shims/0.7.45//shims-0.7.45.jar
 slf4j-api/1.7.16//slf4j-api-1.7.16.jar
 slf4j-log4j12/1.7.16//slf4j-log4j12-1.7.16.jar
 snakeyaml/1.15//snakeyaml-1.15.jar
-snappy-java/1.1.7.3//snappy-java-1.1.7.3.jar
+snappy-java/1.1.7.5//snappy-java-1.1.7.5.jar
 snappy/0.2//snappy-0.2.jar
 spire-macros_2.11/0.13.0//spire-macros_2.11-0.13.0.jar
 spire_2.11/0.13.0//spire_2.11-0.13.0.jar

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -180,7 +180,7 @@ shims/0.7.45//shims-0.7.45.jar
 slf4j-api/1.7.16//slf4j-api-1.7.16.jar
 slf4j-log4j12/1.7.16//slf4j-log4j12-1.7.16.jar
 snakeyaml/1.15//snakeyaml-1.15.jar
-snappy-java/1.1.7.3//snappy-java-1.1.7.3.jar
+snappy-java/1.1.7.5//snappy-java-1.1.7.5.jar
 snappy/0.2//snappy-0.2.jar
 spire-macros_2.11/0.13.0//spire-macros_2.11-0.13.0.jar
 spire_2.11/0.13.0//spire_2.11-0.13.0.jar

--- a/dev/deps/spark-deps-hadoop-3.1
+++ b/dev/deps/spark-deps-hadoop-3.1
@@ -200,7 +200,7 @@ shims/0.7.45//shims-0.7.45.jar
 slf4j-api/1.7.16//slf4j-api-1.7.16.jar
 slf4j-log4j12/1.7.16//slf4j-log4j12-1.7.16.jar
 snakeyaml/1.15//snakeyaml-1.15.jar
-snappy-java/1.1.7.3//snappy-java-1.1.7.3.jar
+snappy-java/1.1.7.5//snappy-java-1.1.7.5.jar
 snappy/0.2//snappy-0.2.jar
 spire-macros_2.11/0.13.0//spire-macros_2.11-0.13.0.jar
 spire_2.11/0.13.0//spire_2.11-0.13.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
     <fasterxml.jackson.version>2.6.7</fasterxml.jackson.version>
     <fasterxml.jackson-module-scala.version>2.6.7.1</fasterxml.jackson-module-scala.version>
     <fasterxml.jackson.databind.version>2.6.7.3</fasterxml.jackson.databind.version>
-    <snappy.version>1.1.7.3</snappy.version>
+    <snappy.version>1.1.7.5</snappy.version>
     <netlib.java.version>1.1.2</netlib.java.version>
     <calcite.version>1.2.0-incubating</calcite.version>
     <commons-codec.version>1.10</commons-codec.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

snappy-java have release v1.1.7.5, upgrade to latest version.

Fixed in v1.1.7.4
- Caching internal buffers for SnappyFramed streams #234
- Fixed the native lib for ppc64le to work with glibc 2.17 (Previously it depended on 2.22)

Fixed in v1.1.7.5
- Fixes java.lang.NoClassDefFoundError: org/xerial/snappy/pool/DefaultPoolFactory in 1.1.7.4

https://github.com/xerial/snappy-java/compare/1.1.7.3...1.1.7.5

v 1.1.7.5 release note:
https://github.com/xerial/snappy-java/commit/edc4ec28bdb15a32b6c41ca9e8b195e635bec3a3
### Why are the changes needed?
Fix bug 


### Does this PR introduce _any_ user-facing change?
No 

### How was this patch tested?
No need
