### PR TITLE
[SPARK-27562][Shuffle] Complete the verification mechanism for shuffle transmitted data

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/buffer/DigestFileSegmentManagedBuffer.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/buffer/DigestFileSegmentManagedBuffer.java
@@ -15,34 +15,36 @@
  * limitations under the License.
  */
 
-package org.apache.spark.network.shuffle;
+package org.apache.spark.network.buffer;
 
-import java.util.Optional;
+import java.io.File;
+
+import com.google.common.base.Objects;
+
+import org.apache.spark.network.util.TransportConf;
 
 /**
- * Contains offset and length of the shuffle block data.
+ * A {@link ManagedBuffer} backed by a segment in a file with digest.
  */
-public class ShuffleIndexRecord {
-  private final long offset;
-  private final long length;
-  private final Optional<Long> digest;
+public final class DigestFileSegmentManagedBuffer extends FileSegmentManagedBuffer {
 
-  public ShuffleIndexRecord(long offset, long length, Optional<Long> digest) {
-    this.offset = offset;
-    this.length = length;
+  private final long digest;
+
+  public DigestFileSegmentManagedBuffer(TransportConf conf, File file, long offset, long length,
+    long digest) {
+    super(conf, file, offset, length);
     this.digest = digest;
   }
 
-  public long getOffset() {
-    return offset;
-  }
+  public long getDigest() { return digest; }
 
-  public long getLength() {
-    return length;
-  }
-
-  public Optional<Long> getDigest() {
-    return digest;
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+      .add("file", getFile())
+      .add("offset", getOffset())
+      .add("length", getLength())
+      .add("digest", digest)
+      .toString();
   }
 }
-

--- a/common/network-common/src/main/java/org/apache/spark/network/buffer/FileSegmentManagedBuffer.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/buffer/FileSegmentManagedBuffer.java
@@ -38,7 +38,7 @@ import org.apache.spark.network.util.TransportConf;
 /**
  * A {@link ManagedBuffer} backed by a segment in a file.
  */
-public final class FileSegmentManagedBuffer extends ManagedBuffer {
+public class FileSegmentManagedBuffer extends ManagedBuffer {
   private final TransportConf conf;
   private final File file;
   private final long offset;

--- a/common/network-common/src/main/java/org/apache/spark/network/client/ChunkReceivedCallback.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/ChunkReceivedCallback.java
@@ -36,6 +36,11 @@ public interface ChunkReceivedCallback {
    */
   void onSuccess(int chunkIndex, ManagedBuffer buffer);
 
+  /** Called with a extra digest parameter upon receipt of a particular chunk.*/
+  default void onSuccess(int chunkIndex, ManagedBuffer buffer, long digest) {
+    onSuccess(chunkIndex, buffer);
+  }
+
   /**
    * Called upon failure to fetch a particular chunk. Note that this may actually be called due
    * to failure to fetch a prior chunk in this stream.

--- a/common/network-common/src/main/java/org/apache/spark/network/client/StreamCallback.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/StreamCallback.java
@@ -35,6 +35,11 @@ public interface StreamCallback {
   /** Called when all data from the stream has been received. */
   void onComplete(String streamId) throws IOException;
 
+  /** Called with a extra digest when all data from the stream has been received. */
+  default void onComplete(String streamId, long digest) throws IOException {
+    onComplete(streamId);
+  }
+
   /** Called if there's an error reading data from the stream. */
   void onFailure(String streamId, Throwable cause) throws IOException;
 }

--- a/common/network-common/src/main/java/org/apache/spark/network/client/StreamInterceptor.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/StreamInterceptor.java
@@ -37,6 +37,7 @@ public class StreamInterceptor<T extends Message> implements TransportFrameDecod
   private final long byteCount;
   private final StreamCallback callback;
   private long bytesRead;
+  private long digest = -1L;
 
   public StreamInterceptor(
       MessageHandler<T> handler,
@@ -48,6 +49,16 @@ public class StreamInterceptor<T extends Message> implements TransportFrameDecod
     this.byteCount = byteCount;
     this.callback = callback;
     this.bytesRead = 0;
+  }
+
+  public StreamInterceptor(
+      MessageHandler<T> handler,
+      String streamId,
+      long byteCount,
+      StreamCallback callback,
+      long digest) {
+    this(handler, streamId, byteCount, callback);
+    this.digest = digest;
   }
 
   @Override
@@ -86,7 +97,11 @@ public class StreamInterceptor<T extends Message> implements TransportFrameDecod
       throw re;
     } else if (bytesRead == byteCount) {
       deactivateStream();
-      callback.onComplete(streamId);
+      if (digest < 0) {
+        callback.onComplete(streamId);
+      } else {
+        callback.onComplete(streamId, digest);
+      }
     }
 
     return bytesRead != byteCount;

--- a/common/network-common/src/main/java/org/apache/spark/network/protocol/DigestChunkFetchSuccess.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/protocol/DigestChunkFetchSuccess.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.protocol;
+
+import com.google.common.base.Objects;
+import io.netty.buffer.ByteBuf;
+import org.apache.spark.network.buffer.ManagedBuffer;
+import org.apache.spark.network.buffer.NettyManagedBuffer;
+
+/**
+ * Response to {@link ChunkFetchRequest} when a chunk exists with a digest and has been
+ * successfully fetched.
+ *
+ * Note that the server-side encoding of this messages does NOT include the buffer itself, as this
+ * may be written by Netty in a more efficient manner (i.e., zero-copy write).
+ * Similarly, the client-side decoding will reuse the Netty ByteBuf as the buffer.
+ */
+public final class DigestChunkFetchSuccess extends AbstractResponseMessage {
+  public final StreamChunkId streamChunkId;
+  public final long digest;
+
+  public DigestChunkFetchSuccess(StreamChunkId streamChunkId, ManagedBuffer buffer, long digest) {
+    super(buffer, true);
+    this.streamChunkId = streamChunkId;
+    this.digest = digest;
+  }
+
+  @Override
+  public Message.Type type() { return Type.DigestChunkFetchSuccess; }
+
+  @Override
+  public int encodedLength() {
+    return streamChunkId.encodedLength() + 8;
+  }
+
+  /** Encoding does NOT include 'buffer' itself. See {@link MessageEncoder}. */
+  @Override
+  public void encode(ByteBuf buf) {
+    streamChunkId.encode(buf);
+    buf.writeLong(digest);
+  }
+
+  @Override
+  public ResponseMessage createFailureResponse(String error) {
+    return new ChunkFetchFailure(streamChunkId, error);
+  }
+
+  /** Decoding uses the given ByteBuf as our data, and will retain() it. */
+  public static DigestChunkFetchSuccess decode(ByteBuf buf) {
+    StreamChunkId streamChunkId = StreamChunkId.decode(buf);
+    long digest = buf.readLong();
+    buf.retain();
+    NettyManagedBuffer managedBuf = new NettyManagedBuffer(buf.duplicate());
+    return new DigestChunkFetchSuccess(streamChunkId, managedBuf, digest);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(streamChunkId, body(), digest);
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other instanceof DigestChunkFetchSuccess) {
+      DigestChunkFetchSuccess o = (DigestChunkFetchSuccess) other;
+      return streamChunkId.equals(o.streamChunkId) && super.equals(o) && digest == o.digest;
+    }
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+      .add("streamChunkId", streamChunkId)
+      .add("digest", digest)
+      .add("buffer", body())
+      .toString();
+  }
+}

--- a/common/network-common/src/main/java/org/apache/spark/network/protocol/DigestStreamResponse.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/protocol/DigestStreamResponse.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.protocol;
+
+import com.google.common.base.Objects;
+import io.netty.buffer.ByteBuf;
+import org.apache.spark.network.buffer.ManagedBuffer;
+
+/**
+ * Response to {@link StreamRequest} with digest when the stream has been successfully opened.
+ * <p>
+ * Note the message itself does not contain the stream data. That is written separately by the
+ * sender. The receiver is expected to set a temporary channel handler that will consume the
+ * number of bytes this message says the stream has.
+ */
+public final class DigestStreamResponse extends AbstractResponseMessage {
+  public final String streamId;
+  public final long byteCount;
+  public final long digest;
+
+  public DigestStreamResponse(String streamId, long byteCount, ManagedBuffer buffer, long digest) {
+    super(buffer, false);
+    this.streamId = streamId;
+    this.byteCount = byteCount;
+    this.digest = digest;
+  }
+
+  @Override
+  public Message.Type type() { return Type.DigestStreamResponse; }
+
+  @Override
+  public int encodedLength() {
+    return 8 + Encoders.Strings.encodedLength(streamId) + 8;
+  }
+
+  /** Encoding does NOT include 'buffer' itself. See {@link MessageEncoder}. */
+  @Override
+  public void encode(ByteBuf buf) {
+    Encoders.Strings.encode(buf, streamId);
+    buf.writeLong(byteCount);
+    buf.writeLong(digest);
+  }
+
+  @Override
+  public ResponseMessage createFailureResponse(String error) {
+    return new StreamFailure(streamId, error);
+  }
+
+  public static DigestStreamResponse decode(ByteBuf buf) {
+    String streamId = Encoders.Strings.decode(buf);
+    long byteCount = buf.readLong();
+    long digest = buf.readLong();
+    return new DigestStreamResponse(streamId, byteCount, null, digest);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(byteCount, streamId, body(), digest);
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other instanceof DigestStreamResponse) {
+      DigestStreamResponse o = (DigestStreamResponse) other;
+      return byteCount == o.byteCount && streamId.equals(o.streamId) && digest == o.digest;
+    }
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+      .add("streamId", streamId)
+      .add("byteCount", byteCount)
+      .add("digest", digest)
+      .add("body", body())
+      .toString();
+  }
+
+}

--- a/common/network-common/src/main/java/org/apache/spark/network/protocol/Message.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/protocol/Message.java
@@ -37,7 +37,8 @@ public interface Message extends Encodable {
     ChunkFetchRequest(0), ChunkFetchSuccess(1), ChunkFetchFailure(2),
     RpcRequest(3), RpcResponse(4), RpcFailure(5),
     StreamRequest(6), StreamResponse(7), StreamFailure(8),
-    OneWayMessage(9), UploadStream(10), User(-1);
+    OneWayMessage(9), UploadStream(10), DigestChunkFetchSuccess(11),
+    DigestStreamResponse(12), User(-1);
 
     private final byte id;
 
@@ -66,6 +67,8 @@ public interface Message extends Encodable {
         case 8: return StreamFailure;
         case 9: return OneWayMessage;
         case 10: return UploadStream;
+        case 11: return DigestChunkFetchSuccess;
+        case 12: return DigestStreamResponse;
         case -1: throw new IllegalArgumentException("User type messages cannot be decoded.");
         default: throw new IllegalArgumentException("Unknown message type: " + id);
       }

--- a/common/network-common/src/main/java/org/apache/spark/network/protocol/MessageDecoder.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/protocol/MessageDecoder.java
@@ -50,6 +50,12 @@ public final class MessageDecoder extends MessageToMessageDecoder<ByteBuf> {
 
   private Message decode(Message.Type msgType, ByteBuf in) {
     switch (msgType) {
+      case DigestChunkFetchSuccess:
+        return DigestChunkFetchSuccess.decode(in);
+
+      case DigestStreamResponse:
+        return DigestStreamResponse.decode(in);
+
       case ChunkFetchRequest:
         return ChunkFetchRequest.decode(in);
 

--- a/common/network-common/src/main/java/org/apache/spark/network/server/ChunkFetchRequestHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/ChunkFetchRequestHandler.java
@@ -25,15 +25,13 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
+import org.apache.spark.network.buffer.DigestFileSegmentManagedBuffer;
+import org.apache.spark.network.protocol.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.spark.network.buffer.ManagedBuffer;
 import org.apache.spark.network.client.TransportClient;
-import org.apache.spark.network.protocol.ChunkFetchFailure;
-import org.apache.spark.network.protocol.ChunkFetchRequest;
-import org.apache.spark.network.protocol.ChunkFetchSuccess;
-import org.apache.spark.network.protocol.Encodable;
 
 import static org.apache.spark.network.util.NettyUtils.*;
 
@@ -111,8 +109,15 @@ public class ChunkFetchRequestHandler extends SimpleChannelInboundHandler<ChunkF
     }
 
     streamManager.chunkBeingSent(msg.streamChunkId.streamId);
-    respond(channel, new ChunkFetchSuccess(msg.streamChunkId, buf)).addListener(
-      (ChannelFutureListener) future -> streamManager.chunkSent(msg.streamChunkId.streamId));
+    if (buf instanceof DigestFileSegmentManagedBuffer) {
+      respond(channel, new DigestChunkFetchSuccess(msg.streamChunkId, buf,
+        ((DigestFileSegmentManagedBuffer)buf).getDigest())).addListener(
+        (ChannelFutureListener) future -> streamManager.chunkSent(msg.streamChunkId.streamId));
+    } else {
+      respond(channel, new ChunkFetchSuccess(msg.streamChunkId, buf)).addListener(
+        (ChannelFutureListener) future -> streamManager.chunkSent(msg.streamChunkId.streamId));
+    }
+
   }
 
   /**

--- a/common/network-common/src/main/java/org/apache/spark/network/server/TransportRequestHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/TransportRequestHandler.java
@@ -28,6 +28,7 @@ import io.netty.channel.ChannelFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.spark.network.buffer.DigestFileSegmentManagedBuffer;
 import org.apache.spark.network.buffer.ManagedBuffer;
 import org.apache.spark.network.buffer.NioManagedBuffer;
 import org.apache.spark.network.client.*;
@@ -143,9 +144,16 @@ public class TransportRequestHandler extends MessageHandler<RequestMessage> {
 
     if (buf != null) {
       streamManager.streamBeingSent(req.streamId);
-      respond(new StreamResponse(req.streamId, buf.size(), buf)).addListener(future -> {
-        streamManager.streamSent(req.streamId);
-      });
+      if (buf instanceof DigestFileSegmentManagedBuffer) {
+        respond(new DigestStreamResponse(req.streamId, buf.size(), buf,
+          ((DigestFileSegmentManagedBuffer) buf).getDigest())).addListener(future -> {
+          streamManager.streamSent(req.streamId);
+        });
+      } else {
+        respond(new StreamResponse(req.streamId, buf.size(), buf)).addListener(future -> {
+          streamManager.streamSent(req.streamId);
+        });
+      }
     } else {
       // org.apache.spark.repl.ExecutorClassLoader.STREAM_NOT_FOUND_REGEX should also be updated
       // when the following error message is changed.

--- a/common/network-common/src/main/java/org/apache/spark/network/util/DigestUtils.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/DigestUtils.java
@@ -36,7 +36,13 @@ public class DigestUtils {
     }
 
     public static long getDigest(InputStream data) throws IOException {
-        return updateCRC32(getCRC32(), data);
+        CRC32 crc32 = new CRC32();
+        byte[] buffer = new byte[STREAM_BUFFER_LENGTH];
+        int len;
+        while ((len = data.read(buffer)) >= 0) {
+            crc32.update(buffer, 0, len);
+        }
+        return crc32.getValue();
     }
 
     public static long getDigest(File file, long offset, long length) {
@@ -46,7 +52,7 @@ public class DigestUtils {
         try (RandomAccessFile rf = new RandomAccessFile(file, "r")) {
             MappedByteBuffer data = rf.getChannel().map(FileChannel.MapMode.READ_ONLY, offset,
               length);
-            CRC32 crc32 = getCRC32();
+            CRC32 crc32 = new CRC32();
             byte[] buffer = new byte[STREAM_BUFFER_LENGTH];
             int len;
             while ((len = Math.min(STREAM_BUFFER_LENGTH, data.remaining())) > 0) {
@@ -59,18 +65,5 @@ public class DigestUtils {
               "%s(offset:%d, length:%d)", file.getName(), offset, length ));
             return -1L;
         }
-    }
-
-    private static CRC32 getCRC32() {
-        return new CRC32();
-    }
-
-    private static long updateCRC32(CRC32 crc32, InputStream data) throws IOException {
-        byte[] buffer = new byte[STREAM_BUFFER_LENGTH];
-        int len;
-        while ((len = data.read(buffer)) >= 0) {
-            crc32.update(buffer, 0, len);
-        }
-        return crc32.getValue();
     }
 }

--- a/common/network-common/src/main/java/org/apache/spark/network/util/DigestUtils.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/DigestUtils.java
@@ -44,7 +44,8 @@ public class DigestUtils {
             return -1L;
         }
         try (RandomAccessFile rf = new RandomAccessFile(file, "r")) {
-            MappedByteBuffer data = rf.getChannel().map(FileChannel.MapMode.READ_ONLY, offset, length);
+            MappedByteBuffer data = rf.getChannel().map(FileChannel.MapMode.READ_ONLY, offset,
+              length);
             CRC32 crc32 = getCRC32();
             byte[] buffer = new byte[STREAM_BUFFER_LENGTH];
             int len;

--- a/common/network-common/src/main/java/org/apache/spark/network/util/DigestUtils.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/DigestUtils.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.util;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.CRC32;
+
+public class DigestUtils {
+    private static final int STREAM_BUFFER_LENGTH = 8192;
+    private static final int DIGEST_LENGTH = 8;
+
+    public static int getDigestLength() {
+       return DIGEST_LENGTH;
+    }
+
+    public static long getDigest(InputStream data) throws IOException {
+        return updateCRC32(getCRC32(), data);
+    }
+
+    public static long getDigest(File file, long offset, long length) {
+        if (length <= 0) {
+            return -1;
+        }
+        try {
+            LimitedInputStream inputStream = new LimitedInputStream(new FileInputStream(file),
+              offset + length, true);
+            inputStream.skip(offset);
+            return getDigest(inputStream);
+        } catch (IOException e) {
+            return -1;
+        }
+    }
+
+    public static CRC32 getCRC32() {
+        return new CRC32();
+    }
+
+    public static long updateCRC32(CRC32 crc32, InputStream data) throws IOException {
+        byte[] buffer = new byte[STREAM_BUFFER_LENGTH];
+        int len;
+        while ((len = data.read(buffer)) >= 0) {
+            crc32.update(buffer, 0, len);
+        }
+        return crc32.getValue();
+    }
+}

--- a/common/network-common/src/main/java/org/apache/spark/network/util/DigestUtils.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/DigestUtils.java
@@ -23,7 +23,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.zip.CRC32;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class DigestUtils {
+    private static final Logger LOG = LoggerFactory.getLogger(DigestUtils.class);
     private static final int STREAM_BUFFER_LENGTH = 8192;
     private static final int DIGEST_LENGTH = 8;
 
@@ -45,15 +49,17 @@ public class DigestUtils {
             inputStream.skip(offset);
             return getDigest(inputStream);
         } catch (IOException e) {
+            LOG.error(String.format("Exception while computing digest for file segment: " +
+              "%s(offset:%d, length:%d)", file.getName(), offset, length ));
             return -1;
         }
     }
 
-    public static CRC32 getCRC32() {
+    private static CRC32 getCRC32() {
         return new CRC32();
     }
 
-    public static long updateCRC32(CRC32 crc32, InputStream data) throws IOException {
+    private static long updateCRC32(CRC32 crc32, InputStream data) throws IOException {
         byte[] buffer = new byte[STREAM_BUFFER_LENGTH];
         int len;
         while ((len = data.read(buffer)) >= 0) {

--- a/common/network-common/src/main/java/org/apache/spark/network/util/DigestUtils.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/DigestUtils.java
@@ -56,7 +56,7 @@ public class DigestUtils {
         } catch (IOException e) {
             LOG.error(String.format("Exception while computing digest for file segment: " +
               "%s(offset:%d, length:%d)", file.getName(), offset, length ));
-            return -1;
+            return -1L;
         }
     }
 

--- a/common/network-common/src/test/java/org/apache/spark/network/util/DigestUtilsSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/util/DigestUtilsSuite.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.util;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.zip.CRC32;
+
+import org.junit.Test;
+
+public class DigestUtilsSuite {
+
+  @Test
+  public void testGetDigest() throws IOException {
+    File testFile = File.createTempFile("test-digest", ".txt");
+    try {
+      String testStr = "org.apache.spark.network.util.DigestUtilsSuite.testGetDigest";
+      FileOutputStream out = new FileOutputStream(testFile);
+      out.write(testStr.getBytes());
+      out.close();
+
+      CRC32 crc32 = new CRC32();
+      crc32.update(testStr.getBytes());
+      long digest = crc32.getValue();
+
+      assert(digest == DigestUtils.getDigest(new FileInputStream(testFile)));
+      assert(digest == DigestUtils.getDigest(testFile, 0, testFile.length()));
+    } finally {
+      testFile.delete();
+    }
+  }
+}

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockFetchingListener.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockFetchingListener.java
@@ -30,6 +30,15 @@ public interface BlockFetchingListener extends EventListener {
   void onBlockFetchSuccess(String blockId, ManagedBuffer data);
 
   /**
+   * Called once per successfully fetch block during shuffle, which has a parameter present the
+   * checkSum of shuffle block. Here provide a default method body for that not every
+   * blockFetchingListener need to implement one onBlockFetchSuccess method.
+   */
+  default void onBlockFetchSuccess(String blockId, ManagedBuffer data, long digest) {
+    onBlockFetchSuccess(blockId, data);
+  }
+
+  /**
    * Called at least once per block upon failures.
    */
   void onBlockFetchFailure(String blockId, Throwable exception);

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
@@ -39,7 +39,6 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.cache.Weigher;
 import com.google.common.collect.Maps;
-import org.apache.spark.network.util.*;
 import org.iq80.leveldb.DB;
 import org.iq80.leveldb.DBIterator;
 import org.slf4j.Logger;
@@ -49,7 +48,12 @@ import org.apache.spark.network.buffer.DigestFileSegmentManagedBuffer;
 import org.apache.spark.network.buffer.FileSegmentManagedBuffer;
 import org.apache.spark.network.buffer.ManagedBuffer;
 import org.apache.spark.network.shuffle.protocol.ExecutorShuffleInfo;
+import org.apache.spark.network.util.DigestUtils;
+import org.apache.spark.network.util.LevelDBProvider;
 import org.apache.spark.network.util.LevelDBProvider.StoreVersion;
+import org.apache.spark.network.util.JavaUtils;
+import org.apache.spark.network.util.NettyUtils;
+import org.apache.spark.network.util.TransportConf;
 
 /**
  * Manages converting shuffle BlockIds into physical segments of local files, from a process outside

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
@@ -166,6 +166,12 @@ public class OneForOneBlockFetcher {
     }
 
     @Override
+    public void onSuccess(int chunkIndex, ManagedBuffer buffer, long digest) {
+      // On receipt of a chunk, pass it upwards as a block.
+      listener.onBlockFetchSuccess(blockIds[chunkIndex], buffer, digest);
+    }
+
+    @Override
     public void onFailure(int chunkIndex, Throwable e) {
       // On receipt of a failure, fail every block from chunkIndex onwards.
       String[] remainingBlockIds = Arrays.copyOfRange(blockIds, chunkIndex, blockIds.length);
@@ -243,6 +249,14 @@ public class OneForOneBlockFetcher {
     @Override
     public void onComplete(String streamId) throws IOException {
       listener.onBlockFetchSuccess(blockIds[chunkIndex], channel.closeAndRead());
+      if (!downloadFileManager.registerTempFileToClean(targetFile)) {
+        targetFile.delete();
+      }
+    }
+
+    @Override
+    public void onComplete(String streamId, long digest) throws IOException {
+      listener.onBlockFetchSuccess(blockIds[chunkIndex], channel.closeAndRead(), digest);
       if (!downloadFileManager.registerTempFileToClean(targetFile)) {
         targetFile.delete();
       }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RetryingBlockFetcher.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RetryingBlockFetcher.java
@@ -189,6 +189,11 @@ public class RetryingBlockFetcher {
   private class RetryingBlockFetchListener implements BlockFetchingListener {
     @Override
     public void onBlockFetchSuccess(String blockId, ManagedBuffer data) {
+      onBlockFetchSuccess(blockId, data, -1L);
+    }
+
+    @Override
+    public void onBlockFetchSuccess(String blockId, ManagedBuffer data, long digest) {
       // We will only forward this success message to our parent listener if this block request is
       // outstanding and we are still the active listener.
       boolean shouldForwardSuccess = false;
@@ -201,7 +206,11 @@ public class RetryingBlockFetcher {
 
       // Now actually invoke the parent listener, outside of the synchronized block.
       if (shouldForwardSuccess) {
-        listener.onBlockFetchSuccess(blockId, data);
+        if (digest < 0) {
+          listener.onBlockFetchSuccess(blockId, data);
+        } else {
+          listener.onBlockFetchSuccess(blockId, data, digest);
+        }
       }
     }
 

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ShuffleIndexInformation.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ShuffleIndexInformation.java
@@ -44,10 +44,9 @@ public class ShuffleIndexInformation {
     try (DataInputStream dis = new DataInputStream(Files.newInputStream(indexFile.toPath()))) {
       dis.readFully(offsetsBuffer.array());
     }
-    /**
-     * This logic is from IndexShuffleBlockResolver, and the block id format is from
-     * ShuffleIndexDigestBlockId.
-     */
+
+    // This logic is from IndexShuffleBlockResolver, and the digest file name is from
+    // ShuffleIndexDigestBlockId.
     File digestFile = new File(indexFile.getAbsolutePath() + ".digest");
     if (digestFile.exists()) {
       hasDigest = true;

--- a/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriter.java
@@ -112,7 +112,7 @@ public class LocalDiskShuffleMapOutputWriter implements ShuffleMapOutputWriter {
     }
     cleanUp();
     File resolvedTmp = outputTempFile != null && outputTempFile.isFile() ? outputTempFile : null;
-    blockResolver.writeIndexFileAndCommit(shuffleId, mapId, partitionLengths, resolvedTmp);
+    blockResolver.writeIndexDigestFileAndCommit(shuffleId, mapId, partitionLengths, resolvedTmp);
     return partitionLengths;
   }
 

--- a/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskSingleSpillMapOutputWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskSingleSpillMapOutputWriter.java
@@ -50,6 +50,6 @@ public class LocalDiskSingleSpillMapOutputWriter
     File outputFile = blockResolver.getDataFile(shuffleId, mapId);
     File tempFile = Utils.tempFileWith(outputFile);
     Files.move(mapSpillFile.toPath(), tempFile.toPath());
-    blockResolver.writeIndexFileAndCommit(shuffleId, mapId, partitionLengths, tempFile);
+    blockResolver.writeIndexDigestFileAndCommit(shuffleId, mapId, partitionLengths, tempFile);
   }
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1840,7 +1840,7 @@ package object config {
   private[spark] val SHUFFLE_DIGEST_ENABLED =
     ConfigBuilder("spark.shuffle.digest.enabled")
       .internal()
-      .doc("The parameter to control whether check the transmitted data during shuffle.")
+      .doc("The parameter to control whether check the digest of transmitted data during shuffle.")
       .booleanConf
       .createWithDefault(false)
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1836,4 +1836,11 @@ package object config {
       .version("3.1.0")
       .booleanConf
       .createWithDefault(false)
+
+  private[spark] val SHUFFLE_DIGEST_ENABLED =
+    ConfigBuilder("spark.shuffle.digest.enabled")
+      .internal()
+      .doc("The parameter to control whether check the transmitted data during shuffle.")
+      .booleanConf
+      .createWithDefault(false)
 }

--- a/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
@@ -80,7 +80,8 @@ private[spark] class BlockStoreShuffleReader[K, C](
       SparkEnv.get.conf.get(config.SHUFFLE_DETECT_CORRUPT),
       SparkEnv.get.conf.get(config.SHUFFLE_DETECT_CORRUPT_MEMORY),
       readMetrics,
-      fetchContinuousBlocksInBatch).toCompletionIterator
+      fetchContinuousBlocksInBatch,
+      SparkEnv.get.conf.get(config.SHUFFLE_DIGEST_ENABLED)).toCompletionIterator
 
     val serializerInstance = dep.serializer.newInstance()
 

--- a/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
@@ -246,19 +246,6 @@ private[spark] class IndexShuffleBlockResolver(
             out.close()
           }
 
-          if (indexFile.exists()) {
-            indexFile.delete()
-          }
-          if (dataFile.exists()) {
-            dataFile.delete()
-          }
-          if (!indexTmp.renameTo(indexFile)) {
-            throw new IOException("fail to rename file " + indexTmp + " to " + indexFile)
-          }
-          if (dataTmp != null && dataTmp.exists() && !dataTmp.renameTo(dataFile)) {
-            throw new IOException("fail to rename file " + dataTmp + " to " + dataFile)
-          }
-
           if (digestEnable) {
             digestFile = getDigestFile(shuffleId, mapId)
             digestTmp = Utils.tempFileWith(digestFile)
@@ -270,12 +257,25 @@ private[spark] class IndexShuffleBlockResolver(
             } {
               out.close()
             }
-            if (digestFile.exists()) {
-              digestFile.delete()
-            }
-            if (!digestTmp.renameTo(digestFile)) {
-              throw new IOException("fail to rename file " + digestTmp + " to " + digestFile)
-            }
+          }
+
+          if (indexFile.exists()) {
+            indexFile.delete()
+          }
+          if (digestEnable && digestFile.exists()) {
+            digestFile.delete()
+          }
+          if (dataFile.exists()) {
+            dataFile.delete()
+          }
+          if (!indexTmp.renameTo(indexFile)) {
+            throw new IOException("fail to rename file " + indexTmp + " to " + indexFile)
+          }
+          if (digestEnable && !digestTmp.renameTo(digestFile)) {
+            throw new IOException("fail to rename file " + digestTmp + " to " + digestFile)
+          }
+          if (dataTmp != null && dataTmp.exists() && !dataTmp.renameTo(dataFile)) {
+            throw new IOException("fail to rename file " + dataTmp + " to " + dataFile)
           }
         }
       }

--- a/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
@@ -339,6 +339,7 @@ private[spark] class IndexShuffleBlockResolver(
           DigestUtils.getDigest(getDataFile(shuffleId, mapId, dirs), startOffset,
             endOffset - startOffset)
         }
+
         new DigestFileSegmentManagedBuffer(
           transportConf,
           getDataFile(shuffleId, mapId, dirs),

--- a/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
@@ -22,11 +22,12 @@ import java.nio.channels.Channels
 import java.nio.file.Files
 
 import org.apache.spark.{SparkConf, SparkEnv}
-import org.apache.spark.internal.Logging
+import org.apache.spark.internal.{config, Logging}
 import org.apache.spark.io.NioBufferedFileInputStream
-import org.apache.spark.network.buffer.{FileSegmentManagedBuffer, ManagedBuffer}
+import org.apache.spark.network.buffer.{DigestFileSegmentManagedBuffer, FileSegmentManagedBuffer, ManagedBuffer}
 import org.apache.spark.network.netty.SparkTransportConf
 import org.apache.spark.network.shuffle.ExecutorDiskUtils
+import org.apache.spark.network.util.{DigestUtils, LimitedInputStream}
 import org.apache.spark.shuffle.IndexShuffleBlockResolver.NOOP_REDUCE_ID
 import org.apache.spark.storage._
 import org.apache.spark.util.Utils
@@ -52,6 +53,9 @@ private[spark] class IndexShuffleBlockResolver(
 
   private val transportConf = SparkTransportConf.fromSparkConf(conf, "shuffle")
 
+  // The digest conf for shuffle block check
+  private final val digestEnable = conf.getBoolean(config.SHUFFLE_DIGEST_ENABLED.key, false);
+  private final val digestLength = DigestUtils.getDigestLength()
 
   def getDataFile(shuffleId: Int, mapId: Long): File = getDataFile(shuffleId, mapId, None)
 
@@ -107,12 +111,16 @@ private[spark] class IndexShuffleBlockResolver(
    * Check whether the given index and data files match each other.
    * If so, return the partition lengths in the data file. Otherwise return null.
    */
-  private def checkIndexAndDataFile(index: File, data: File, blocks: Int): Array[Long] = {
-    // the index file should have `block + 1` longs as offset.
-    if (index.length() != (blocks + 1) * 8L) {
+  private def checkIndexAndDataFile(index: File, data: File, blocks: Int, digests: Array[Long]):
+  (Array[Long], Array[Long]) = {
+    // Id digestEnable is false, the index file should have `blocks + 1` longs as offset.
+    // Otherwise, it should have a byte as flag, `blocks + 1` longs as offset and `blocks` digests
+    if ((!digestEnable && index.length() != (blocks + 1) * 8L) ||
+      (digestEnable && index.length() != blocks * (8L + digestLength) + 8L + 1L)) {
       return null
     }
     val lengths = new Array[Long](blocks)
+    val digestArr = new Array[Long](blocks)
     // Read the lengths of blocks
     val in = try {
       new DataInputStream(new NioBufferedFileInputStream(index))
@@ -133,6 +141,18 @@ private[spark] class IndexShuffleBlockResolver(
         offset = off
         i += 1
       }
+      if (digestEnable) {
+        val flag = in.readByte()
+        // the flag for digestEnable should be 1
+        if (flag != 1) {
+          return null
+        }
+        i = 0
+        while (i < blocks) {
+          digestArr(i) = in.readLong()
+          i += 1
+        }
+      }
     } catch {
       case e: IOException =>
         return null
@@ -141,8 +161,8 @@ private[spark] class IndexShuffleBlockResolver(
     }
 
     // the size of data file should match with index file
-    if (data.length() == lengths.sum) {
-      lengths
+    if (data.length() == lengths.sum && !(0 until blocks).exists(i => digests(i) != digestArr(i))) {
+      (lengths, digestArr)
     } else {
       null
     }
@@ -170,11 +190,38 @@ private[spark] class IndexShuffleBlockResolver(
       // There is only one IndexShuffleBlockResolver per executor, this synchronization make sure
       // the following check and rename are atomic.
       synchronized {
-        val existingLengths = checkIndexAndDataFile(indexFile, dataFile, lengths.length)
-        if (existingLengths != null) {
+        val digests = new Array[Long](lengths.length)
+        val dateIn = if (dataTmp != null && dataTmp.exists()) {
+          new FileInputStream(dataTmp)
+        } else {
+          null
+        }
+        Utils.tryWithSafeFinally {
+          if (digestEnable && dateIn != null) {
+            for (i <- (0 until lengths.length)) {
+              val length = lengths(i)
+              if (length == 0) {
+                digests(i) = -1L
+              } else {
+                digests(i) = DigestUtils.getDigest(new LimitedInputStream(dateIn, length))
+              }
+            }
+          }
+        } {
+          if (dateIn != null) {
+            dateIn.close()
+          }
+        }
+
+        val existingLengthsDigests =
+          checkIndexAndDataFile(indexFile, dataFile, lengths.length, digests)
+        if (existingLengthsDigests != null) {
+          val existingLengths = existingLengthsDigests._1
+          val existingDigests = existingLengthsDigests._2
           // Another attempt for the same task has already written our map outputs successfully,
           // so just use the existing partition lengths and delete our temporary map outputs.
           System.arraycopy(existingLengths, 0, lengths, 0, lengths.length)
+          System.arraycopy(existingDigests, 0, digests, 0, digests.length)
           if (dataTmp != null && dataTmp.exists()) {
             dataTmp.delete()
           }
@@ -189,6 +236,13 @@ private[spark] class IndexShuffleBlockResolver(
             for (length <- lengths) {
               offset += length
               out.writeLong(offset)
+            }
+            if (digestEnable) {
+              // we write a byte present digest enable
+              out.writeByte(1)
+              for (digest <- digests) {
+                out.writeLong(digest)
+              }
             }
           } {
             out.close()
@@ -237,6 +291,10 @@ private[spark] class IndexShuffleBlockResolver(
     // class of issue from re-occurring in the future which is why they are left here even though
     // SPARK-22982 is fixed.
     val channel = Files.newByteChannel(indexFile.toPath)
+    var blocks = (indexFile.length() - 8) / 8
+    if (digestEnable) {
+      blocks = (indexFile.length() - 8 - 1) / (8 + digestLength)
+    }
     channel.position(startReduceId * 8L)
     val in = new DataInputStream(Channels.newInputStream(channel))
     try {
@@ -249,11 +307,37 @@ private[spark] class IndexShuffleBlockResolver(
         throw new Exception(s"SPARK-22982: Incorrect channel position after index file reads: " +
           s"expected $expectedPosition but actual position was $actualPosition.")
       }
-      new FileSegmentManagedBuffer(
-        transportConf,
-        getDataFile(shuffleId, mapId, dirs),
-        startOffset,
-        endOffset - startOffset)
+
+      if (digestEnable) {
+        val digestValue = if (endReduceId - startReduceId == 1) {
+          channel.position(1 + (blocks + 1) * 8L + startReduceId * digestLength)
+          val digest = in.readLong()
+          val actualDigestPosition = channel.position()
+          val expectedDigestLength = 1 + (blocks + 1) * 8L + (startReduceId + 1) * digestLength
+          if (actualDigestPosition != expectedDigestLength) {
+            throw new Exception(s"SPARK-22982: Incorrect channel position after index file " +
+              s"reads: expected $expectedDigestLength but actual position was " +
+              s" $actualDigestPosition.")
+          }
+          digest
+        } else {
+          DigestUtils.getDigest(getDataFile(shuffleId, mapId, dirs), startOffset,
+            endOffset - startOffset)
+        }
+
+        new DigestFileSegmentManagedBuffer(
+          transportConf,
+          getDataFile(shuffleId, mapId, dirs),
+          startOffset,
+          endOffset - startOffset,
+          digestValue)
+      } else {
+        new FileSegmentManagedBuffer(
+          transportConf,
+          getDataFile(shuffleId, mapId, dirs),
+          startOffset,
+          endOffset - startOffset)
+      }
     } finally {
       in.close()
     }

--- a/core/src/main/scala/org/apache/spark/storage/BlockId.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockId.scala
@@ -79,6 +79,11 @@ case class ShuffleIndexBlockId(shuffleId: Int, mapId: Long, reduceId: Int) exten
 }
 
 @DeveloperApi
+case class ShuffleIndexDigestBlockId(shuffleId: Int, mapId: Long, reduceId: Int) extends BlockId {
+  override def name: String = ShuffleIndexBlockId(shuffleId, mapId, reduceId).name + ".digest"
+}
+
+@DeveloperApi
 case class BroadcastBlockId(broadcastId: Long, field: String = "") extends BlockId {
   override def name: String = "broadcast_" + broadcastId + (if (field == "") "" else "_" + field)
 }
@@ -119,6 +124,7 @@ object BlockId {
   val SHUFFLE_BATCH = "shuffle_([0-9]+)_([0-9]+)_([0-9]+)_([0-9]+)".r
   val SHUFFLE_DATA = "shuffle_([0-9]+)_([0-9]+)_([0-9]+).data".r
   val SHUFFLE_INDEX = "shuffle_([0-9]+)_([0-9]+)_([0-9]+).index".r
+  val SHUFFLE_DIGEST = "shuffle_([0-9]+)_([0-9]+)_([0-9]+).digest".r
   val BROADCAST = "broadcast_([0-9]+)([_A-Za-z0-9]*)".r
   val TASKRESULT = "taskresult_([0-9]+)".r
   val STREAM = "input-([0-9]+)-([0-9]+)".r
@@ -137,6 +143,8 @@ object BlockId {
       ShuffleDataBlockId(shuffleId.toInt, mapId.toLong, reduceId.toInt)
     case SHUFFLE_INDEX(shuffleId, mapId, reduceId) =>
       ShuffleIndexBlockId(shuffleId.toInt, mapId.toLong, reduceId.toInt)
+    case SHUFFLE_DIGEST(shuffleId, mapId, reduceId) =>
+      ShuffleIndexDigestBlockId(shuffleId.toInt, mapId.toLong, reduceId.toInt)
     case BROADCAST(broadcastId, field) =>
       BroadcastBlockId(broadcastId.toLong, field.stripPrefix("_"))
     case TASKRESULT(taskId) =>

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -1008,13 +1008,12 @@ object ShuffleBlockFetcherIterator {
 
   /**
    * Result of a fetch from a remote block successfully.
-   *
    * @param blockId block id
    * @param mapIndex the mapIndex for this block, which indicate the index in the map stage.
    * @param address BlockManager that the block was fetched from.
    * @param size estimated size of the block. Note that this is NOT the exact bytes.
    *             Size of remote block is used to calculate bytesInFlight.
-   * @param buf              `ManagedBuffer` for the content.
+   * @param buf `ManagedBuffer` for the content.
    * @param isNetworkReqDone Is this the last network request for this host in this fetch request.
    * @param digest Is the digest of the result, default is -1L.
    */

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -662,6 +662,7 @@ final class ShuffleBlockFetcherIterator(
                 if (in.markSupported()) {
                   in.reset()
                 } else {
+                  in.close()
                   in = buf.createInputStream()
                 }
               }

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -642,7 +642,7 @@ final class ShuffleBlockFetcherIterator(
                   throwFetchFailedException(blockId, mapIndex, address, e)
               }
               failedOnDigestCheck = digest != digestToCheck
-              if (!failedOnDigestCheck) {
+              if (failedOnDigestCheck) {
                 buf.release()
                 val e = new CheckDigestFailedException(s"The digest to check $digestToCheck " +
                 s"of $blockId is not equal with origin $digest")

--- a/core/src/test/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriterSuite.java
+++ b/core/src/test/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriterSuite.java
@@ -152,11 +152,11 @@ public class UnsafeShuffleWriterSuite {
 
     doAnswer(renameTempAnswer)
         .when(shuffleBlockResolver)
-        .writeIndexFileAndCommit(anyInt(), anyLong(), any(long[].class), any(File.class));
+        .writeIndexDigestFileAndCommit(anyInt(), anyLong(), any(long[].class), any(File.class));
 
     doAnswer(renameTempAnswer)
         .when(shuffleBlockResolver)
-        .writeIndexFileAndCommit(anyInt(), anyLong(), any(long[].class), eq(null));
+        .writeIndexDigestFileAndCommit(anyInt(), anyLong(), any(long[].class), eq(null));
 
     when(diskBlockManager.createTempShuffleBlock()).thenAnswer(invocationOnMock -> {
       TempShuffleBlockId blockId = new TempShuffleBlockId(UUID.randomUUID());

--- a/core/src/test/scala/org/apache/spark/ContextCleanerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ContextCleanerSuite.scala
@@ -535,6 +535,7 @@ class CleanerTester(
     blockManager.master.getMatchingBlockIds( _ match {
       case ShuffleBlockId(`shuffleId`, _, _) => true
       case ShuffleIndexBlockId(`shuffleId`, _, _) => true
+      case ShuffleIndexDigestBlockId(`shuffleId`, _, _) => true
       case _ => false
     }, askSlaves = true)
   }

--- a/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
@@ -30,7 +30,7 @@ import org.apache.spark.rdd.{CoGroupedRDD, OrderedRDDFunctions, RDD, ShuffledRDD
 import org.apache.spark.scheduler.{MapStatus, MyRDD, SparkListener, SparkListenerTaskEnd}
 import org.apache.spark.serializer.KryoSerializer
 import org.apache.spark.shuffle.ShuffleWriter
-import org.apache.spark.storage.{ShuffleBlockId, ShuffleDataBlockId, ShuffleIndexDigestBlockId, ShuffleIndexBlockId}
+import org.apache.spark.storage.{ShuffleBlockId, ShuffleDataBlockId, ShuffleIndexBlockId}
 import org.apache.spark.util.MutablePair
 
 abstract class ShuffleSuite extends SparkFunSuite with Matchers with LocalSparkContext {

--- a/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
@@ -419,7 +419,7 @@ abstract class ShuffleSuite extends SparkFunSuite with Matchers with LocalSparkC
     manager.unregisterShuffle(0)
   }
 
-  test("[SPARK-27562]: test shuffle with shuffle digest enabled is true") {
+  test("SPARK-27562: Test shuffle with checking digest of transmitted data") {
       conf.set(config.SHUFFLE_DIGEST_ENABLED, true)
       val sc = new SparkContext("local", "test", conf)
       val numRecords = 10000

--- a/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
@@ -30,7 +30,7 @@ import org.apache.spark.rdd.{CoGroupedRDD, OrderedRDDFunctions, RDD, ShuffledRDD
 import org.apache.spark.scheduler.{MapStatus, MyRDD, SparkListener, SparkListenerTaskEnd}
 import org.apache.spark.serializer.KryoSerializer
 import org.apache.spark.shuffle.ShuffleWriter
-import org.apache.spark.storage.{ShuffleBlockId, ShuffleDataBlockId, ShuffleIndexBlockId}
+import org.apache.spark.storage.{ShuffleBlockId, ShuffleDataBlockId, ShuffleIndexDigestBlockId, ShuffleIndexBlockId}
 import org.apache.spark.util.MutablePair
 
 abstract class ShuffleSuite extends SparkFunSuite with Matchers with LocalSparkContext {

--- a/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
@@ -418,6 +418,22 @@ abstract class ShuffleSuite extends SparkFunSuite with Matchers with LocalSparkC
 
     manager.unregisterShuffle(0)
   }
+
+  test("[SPARK-27562]: test shuffle with shuffle digest enabled is true") {
+      conf.set(config.SHUFFLE_DIGEST_ENABLED, true)
+      val sc = new SparkContext("local", "test", conf)
+      val numRecords = 10000
+
+      val wordCount = sc.parallelize(1 to numRecords, 4)
+        .map(key => (key, 1))
+        .reduceByKey(_ + _)
+        .collect()
+      val count = wordCount.length
+      val sum = wordCount.map(value => value._1).sum
+      assert(count == numRecords)
+      assert(sum == (1 to numRecords).sum)
+      sc.stop()
+    }
 }
 
 /**

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriterSuite.scala
@@ -76,7 +76,7 @@ class BypassMergeSortShuffleWriterSuite extends SparkFunSuite with BeforeAndAfte
     when(blockManager.diskBlockManager).thenReturn(diskBlockManager)
     when(taskContext.taskMemoryManager()).thenReturn(taskMemoryManager)
 
-    when(blockResolver.writeIndexFileAndCommit(
+    when(blockResolver.writeIndexDigestFileAndCommit(
       anyInt, anyLong, any(classOf[Array[Long]]), any(classOf[File])))
       .thenAnswer { invocationOnMock =>
         val tmp = invocationOnMock.getArguments()(3).asInstanceOf[File]

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/IndexShuffleBlockResolverSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/IndexShuffleBlockResolverSuite.scala
@@ -159,7 +159,7 @@ class IndexShuffleBlockResolverSuite extends SparkFunSuite with BeforeAndAfterEa
     }
   }
 
-  test("[SPARK-27562]: check the digest when shuffle digest enabled is true") {
+  test("SPARK-27562: check the digest when shuffle digest enabled is true") {
     val confClone = conf.clone
     confClone.set(config.SHUFFLE_DIGEST_ENABLED, true)
     val resolver = new IndexShuffleBlockResolver(confClone, blockManager)

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/IndexShuffleBlockResolverSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/IndexShuffleBlockResolverSuite.scala
@@ -74,7 +74,7 @@ class IndexShuffleBlockResolverSuite extends SparkFunSuite with BeforeAndAfterEa
     } {
       out.close()
     }
-    resolver.writeIndexFileAndCommit(shuffleId, mapId, lengths, dataTmp)
+    resolver.writeIndexDigestFileAndCommit(shuffleId, mapId, lengths, dataTmp)
 
     val indexFile = new File(tempDir.getAbsolutePath, idxName)
     val dataFile = resolver.getDataFile(shuffleId, mapId)
@@ -94,7 +94,7 @@ class IndexShuffleBlockResolverSuite extends SparkFunSuite with BeforeAndAfterEa
     } {
       out2.close()
     }
-    resolver.writeIndexFileAndCommit(shuffleId, mapId, lengths2, dataTmp2)
+    resolver.writeIndexDigestFileAndCommit(shuffleId, mapId, lengths2, dataTmp2)
 
     assert(indexFile.length() === (lengths.length + 1) * 8)
     assert(lengths2.toSeq === lengths.toSeq)
@@ -133,7 +133,7 @@ class IndexShuffleBlockResolverSuite extends SparkFunSuite with BeforeAndAfterEa
     } {
       out3.close()
     }
-    resolver.writeIndexFileAndCommit(shuffleId, mapId, lengths3, dataTmp3)
+    resolver.writeIndexDigestFileAndCommit(shuffleId, mapId, lengths3, dataTmp3)
     assert(indexFile.length() === (lengths3.length + 1) * 8)
     assert(lengths3.toSeq != lengths.toSeq)
     assert(dataFile.exists())
@@ -172,7 +172,7 @@ class IndexShuffleBlockResolverSuite extends SparkFunSuite with BeforeAndAfterEa
       out.close()
     }
     val digest = DigestUtils.getDigest(new ByteArrayInputStream(new Array[Byte](10)))
-    resolver.writeIndexFileAndCommit(1, 2, lengths, dataTmp)
+    resolver.writeIndexDigestFileAndCommit(1, 2, lengths, dataTmp)
     val managedBuffer = resolver.getBlockData(ShuffleBlockId(1, 2, 0))
     assert(managedBuffer.isInstanceOf[DigestFileSegmentManagedBuffer])
     assert(managedBuffer.asInstanceOf[DigestFileSegmentManagedBuffer].getDigest == digest)

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/IndexShuffleBlockResolverSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/IndexShuffleBlockResolverSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.shuffle.sort
 
-import java.io.{DataInputStream, File, FileInputStream, FileOutputStream}
+import java.io.{ByteArrayInputStream, DataInputStream, File, FileInputStream, FileOutputStream}
 
 import org.mockito.{Mock, MockitoAnnotations}
 import org.mockito.Answers.RETURNS_SMART_NULLS
@@ -27,6 +27,9 @@ import org.mockito.invocation.InvocationOnMock
 import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.internal.config
+import org.apache.spark.network.buffer.DigestFileSegmentManagedBuffer
+import org.apache.spark.network.util.DigestUtils
 import org.apache.spark.shuffle.IndexShuffleBlockResolver
 import org.apache.spark.storage._
 import org.apache.spark.util.Utils
@@ -154,5 +157,24 @@ class IndexShuffleBlockResolverSuite extends SparkFunSuite with BeforeAndAfterEa
     } {
       indexIn2.close()
     }
+  }
+
+  test("[SPARK-27562]: check the digest when shuffle digest enabled is true") {
+    val confClone = conf.clone
+    confClone.set(config.SHUFFLE_DIGEST_ENABLED, true)
+    val resolver = new IndexShuffleBlockResolver(confClone, blockManager)
+    val lengths = Array[Long](10, 0, 20)
+    val dataTmp = File.createTempFile("shuffle", null, tempDir)
+    val out = new FileOutputStream(dataTmp)
+    Utils.tryWithSafeFinally {
+      out.write(new Array[Byte](30))
+    } {
+      out.close()
+    }
+    val digest = DigestUtils.getDigest(new ByteArrayInputStream(new Array[Byte](10)))
+    resolver.writeIndexFileAndCommit(1, 2, lengths, dataTmp)
+    val managedBuffer = resolver.getBlockData(ShuffleBlockId(1, 2, 0))
+    assert(managedBuffer.isInstanceOf[DigestFileSegmentManagedBuffer])
+    assert(managedBuffer.asInstanceOf[DigestFileSegmentManagedBuffer].getDigest == digest)
   }
 }

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriterSuite.scala
@@ -74,7 +74,7 @@ class LocalDiskShuffleMapOutputWriterSuite extends SparkFunSuite with BeforeAndA
       .set("spark.app.id", "example.spark.app")
       .set("spark.shuffle.unsafe.file.output.buffer", "16k")
     when(blockResolver.getDataFile(anyInt, anyLong)).thenReturn(mergedOutputFile)
-    when(blockResolver.writeIndexFileAndCommit(
+    when(blockResolver.writeIndexDigestFileAndCommit(
       anyInt, anyLong, any(classOf[Array[Long]]), any(classOf[File])))
       .thenAnswer { invocationOnMock =>
         partitionSizesInMergedFile = invocationOnMock.getArguments()(2).asInstanceOf[Array[Long]]

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -175,6 +175,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       true,
       false,
       metrics,
+      false,
       false)
 
     // 3 local blocks fetched in initialization
@@ -251,6 +252,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       true,
       false,
       metrics,
+      false,
       false)
     intercept[FetchFailedException] { iterator.next() }
   }
@@ -285,6 +287,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       true,
       false,
       metrics,
+      false,
       false)
     // After initialize() we'll have 2 FetchRequests and each is 1000 bytes. So only the
     // first FetchRequests can be sent, and the second one will hit maxBytesInFlight so
@@ -330,6 +333,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       true,
       false,
       metrics,
+      false,
       false)
     // After initialize(), we'll have 2 FetchRequests that one has 2 blocks inside and another one
     // has only one block. So only the first FetchRequest can be sent. The second FetchRequest will
@@ -412,7 +416,8 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       true,
       false,
       metrics,
-      true)
+      true,
+      false)
 
     // 3 local blocks batch fetched in initialization
     verify(blockManager, times(1)).getLocalBlockData(any())
@@ -472,7 +477,8 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       true,
       false,
       metrics,
-      true)
+      true,
+      false)
 
     var numResults = 0
     // After initialize(), there will be 6 FetchRequests. And each of the first 5 requests
@@ -529,7 +535,8 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       true,
       false,
       metrics,
-      true)
+      true,
+      false)
     var numResults = 0
     // After initialize(), there will be 2 FetchRequests. First one has 2 merged blocks and each
     // of them is merged from 2 shuffle blocks, second one has 1 merged block which is merged from
@@ -596,6 +603,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       true,
       false,
       taskContext.taskMetrics.createTempShuffleReadMetrics(),
+      false,
       false)
 
     verify(blocks(ShuffleBlockId(0, 0, 0)), times(0)).release()
@@ -666,6 +674,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       true,
       false,
       taskContext.taskMetrics.createTempShuffleReadMetrics(),
+      false,
       false)
 
     // Continue only after the mock calls onBlockFetchFailure
@@ -756,6 +765,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       true,
       true,
       taskContext.taskMetrics.createTempShuffleReadMetrics(),
+      false,
       false)
 
     // Continue only after the mock calls onBlockFetchFailure
@@ -827,6 +837,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       true,
       true,
       taskContext.taskMetrics.createTempShuffleReadMetrics(),
+      false,
       false)
 
     // We'll get back the block which has corruption after maxBytesInFlight/3 because the other
@@ -892,6 +903,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       true,
       true,
       taskContext.taskMetrics.createTempShuffleReadMetrics(),
+      false,
       false)
     val (id, st) = iterator.next()
     // Check that the test setup is correct -- make sure we have a concatenated stream.
@@ -955,6 +967,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       true,
       false,
       taskContext.taskMetrics.createTempShuffleReadMetrics(),
+      false,
       false)
 
     // Continue only after the mock calls onBlockFetchFailure
@@ -1017,6 +1030,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
         detectCorrupt = true,
         false,
         taskContext.taskMetrics.createTempShuffleReadMetrics(),
+        false,
         false)
     }
 
@@ -1066,6 +1080,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       true,
       false,
       taskContext.taskMetrics.createTempShuffleReadMetrics(),
+      false,
       false)
 
     // All blocks fetched return zero length and should trigger a receive-side error:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -998,6 +998,13 @@ Apart from these, the following properties are also available, and may be useful
   </td>
   <td>2.3.0</td>
 </tr>
+<tr>
+  <td><code>spark.shuffle.digest.enabled</code></td>
+  <td>false</td>
+  <td>
+    The parameter to control whether check the transmitted data during shuffle.
+  </td>
+</tr>
 </table>
 
 ### Spark UI

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1002,7 +1002,7 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.shuffle.digest.enabled</code></td>
   <td>false</td>
   <td>
-    The parameter to control whether check the transmitted data during shuffle.
+    The parameter to control whether check the digest of transmitted data during shuffle.
   </td>
 </tr>
 </table>


### PR DESCRIPTION
## What changes were proposed in this pull request?

We've seen some shuffle data corruption during shuffle read phase. 

As described in SPARK-26089, spark only checks small  shuffle blocks before PR #23453, which is proposed by ankuriitg.

There are two changes/improvements that are made in PR #23453.

1. Large blocks are checked upto maxBytesInFlight/3 size in a similar way as smaller blocks, so if a
large block is corrupt in the starting, that block will be re-fetched and if that also fails,
FetchFailureException will be thrown.
2. If large blocks are corrupt after size maxBytesInFlight/3, then any IOException thrown while
reading the stream will be converted to FetchFailureException. This is slightly more aggressive
than was originally intended but since the consumer of the stream may have already read some records and processed them, we can't just re-fetch the block, we need to fail the whole task. Additionally, we also thought about maybe adding a new type of TaskEndReason, which would re-try the task couple of times before failing the previous stage, but given the complexity involved in that solution we decided to not proceed in that direction.

However, I think there still exists some problems with the current shuffle transmitted data verification mechanism:

- For a large block, it is checked upto  maxBytesInFlight/3 size when fetching shuffle data. So if a large block is corrupt after size maxBytesInFlight/3, it can not be detected in data fetch phase.  This has been described in the previous section.
- Only the compressed or wrapped blocks are checked, I think we should also check thease blocks which are not wrapped.

This pr complete the verification mechanism for shuffle transmitted data:

Firstly, crc32 is choosed for the checksum verification  of shuffle data.

Crc is also used for checksum verification in hadoop, it is simple and fast.

During shuffle write phase, after completing the partitionedFile, we compute 

the crc32 value for each partition and then write these digests with the indexs into shuffle index file.

For the sortShuffleWriter and unsafe shuffle writer, there is only one partitionedFile for a shuffleMapTask, so the compution of digests(compute the digests for each partition depend on the indexs of this partitionedFile) is  cheap.

For the bypassShuffleWriter, the reduce partitions is little than byPassMergeThreshold, so the cost of digests compution is acceptable.

During shuffle read phase, the digest value will be passed with the block data.

And we will recompute the digest of the data obtained to compare with the origin digest value.
When recomputing the digest of data obtained, it only need an additional buffer(2048Bytes) for computing crc32 value.
After recomputing, we will reset the obtained data inputStream, if it is markSupported we only need reset it, otherwise it is a fileSegmentManagerBuffer, we need recreate it.

So, I think this verification mechanism  proposed for shuffle transmitted data is efficient and complete.

## How was this patch tested?

Unit test.
