### PR TITLE
Update ChiSqSelectorExample to show import

### DIFF
--- a/examples/src/main/scala/org/apache/spark/examples/ml/ChiSqSelectorExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/ChiSqSelectorExample.scala
@@ -30,9 +30,10 @@ object ChiSqSelectorExample {
       .builder
       .appName("ChiSqSelectorExample")
       .getOrCreate()
-    import spark.implicits._
 
     // $example on$
+    import spark.implicits._
+
     val data = Seq(
       (7, Vectors.dense(0.0, 0.0, 18.0, 1.0), 1.0),
       (8, Vectors.dense(0.0, 1.0, 12.0, 0.0), 0.0),


### PR DESCRIPTION
I found this via the mailing list, a user had submitted this change to the spark-website repo and was told to submit it here.  Six times that happened.  So here is the change, just moving the import into the example block.

ref: http://apache-spark-developers-list.1001551.n3.nabble.com/Block-a-user-from-spark-website-who-repeatedly-open-the-invalid-same-PR-td28759.html

### What changes were proposed in this pull request?
Moving 1 line into an example block.

### Why are the changes needed?
To make a website example clearer.

### Does this PR introduce _any_ user-facing change?
No