### PR TITLE
[SPARK-31526][SQL][TESTS][FOLLOWUP] Make ExpressionInfo independent from local time zone

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/expressions/ExpressionInfoSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/expressions/ExpressionInfoSuite.scala
@@ -19,14 +19,14 @@ package org.apache.spark.sql.expressions
 
 import scala.collection.parallel.immutable.ParVector
 
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.expressions.ExpressionInfo
 import org.apache.spark.sql.execution.HiveResult.hiveResultString
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
-class ExpressionInfoSuite extends SparkFunSuite with SharedSparkSession {
+class ExpressionInfoSuite extends QueryTest with SharedSparkSession {
 
   test("Replace _FUNC_ in ExpressionInfo") {
     val info = spark.sessionState.catalog.lookupFunctionInfo(FunctionIdentifier("upper"))


### PR DESCRIPTION
### What changes were proposed in this pull request?
Extend QueryTest instead of SparkFunSuite in ExpressionInfoSuite as in SQLQuerySuite.

### Why are the changes needed?
After the changes https://github.com/apache/spark/pull/28308, the moved tests from SQLQuerySuite became dependent from local time zone settings. And tests from ExpressionInfoSuite fail if they run not in the `America/Los_Angeles` time zone:
```
[info] - check outputs of expression examples *** FAILED *** (7 seconds, 720 milliseconds)
[info]   Function 'from_unixtime', Expression class 'org.apache.spark.sql.catalyst.expressions.FromUnixTime' "19[70-01-01 03]:00:00" did not equal "19[69-12-31 16]:00:00" (ExpressionInfoSuite.scala:152)
```

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
By running the modified test suite locally in the `Europe/Moscow` time zone:
```
/build/sbt "test:testOnly *ExpressionInfoSuite"
```