### PR TITLE
[SPARK-31720][CORE] TaskMemoryManager allocate failed when new task coming

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -357,6 +357,12 @@ package object config {
     .doubleConf
     .createWithDefault(0.6)
 
+  private[spark] val MEMORY_ALLOCATE_WAIT_TIME = ConfigBuilder("spark.memory.allocate.waiting")
+    .doc("When TaskMemoryManager allocate 0 byte, wait for other task in this executor release")
+    .version("3.0.0")
+    .longConf
+    .createWithDefault(100)
+
   private[spark] val STORAGE_SAFETY_FRACTION = ConfigBuilder("spark.storage.safetyFraction")
     .version("1.1.0")
     .doubleConf

--- a/core/src/main/scala/org/apache/spark/memory/MemoryManager.scala
+++ b/core/src/main/scala/org/apache/spark/memory/MemoryManager.scala
@@ -45,14 +45,17 @@ private[spark] abstract class MemoryManager(
 
   // -- Methods related to memory allocation policies and bookkeeping ------------------------------
 
+  private[this] val waitingInterval: Long = conf.get(MEMORY_ALLOCATE_WAIT_TIME)
   @GuardedBy("this")
   protected val onHeapStorageMemoryPool = new StorageMemoryPool(this, MemoryMode.ON_HEAP)
   @GuardedBy("this")
   protected val offHeapStorageMemoryPool = new StorageMemoryPool(this, MemoryMode.OFF_HEAP)
   @GuardedBy("this")
-  protected val onHeapExecutionMemoryPool = new ExecutionMemoryPool(this, MemoryMode.ON_HEAP)
+  protected val onHeapExecutionMemoryPool =
+    new ExecutionMemoryPool(this, MemoryMode.ON_HEAP, waitingInterval)
   @GuardedBy("this")
-  protected val offHeapExecutionMemoryPool = new ExecutionMemoryPool(this, MemoryMode.OFF_HEAP)
+  protected val offHeapExecutionMemoryPool =
+    new ExecutionMemoryPool(this, MemoryMode.OFF_HEAP, waitingInterval)
 
   onHeapStorageMemoryPool.incrementPoolSize(onHeapStorageMemory)
   onHeapExecutionMemoryPool.incrementPoolSize(onHeapExecutionMemory)


### PR DESCRIPTION
### What changes were proposed in this pull request?
We know that when MemoryConsumer acquire memory , if got size < acquired size,
ConsumerMemory will clear and spill some size to disk, then re-acquire execution memory.
But some times still got 0. Task break and re compute. Always this kind of task is heavy.

We know that one task's memory range is `maxExecutionSize / (2 * activeTaskNum) <  size  < maxExecutionSize / activeTaskNum`, if there are new coming task when busy ,  The amount of execution memory a task can use will be lower， in ExecutionMemoryPool.acquireMemory()
```
 val maxPoolSize = computeMaxPoolSize()
      val maxMemoryPerTask = maxPoolSize / numActiveTasks
      val minMemoryPerTask = poolSize / (2 * numActiveTasks)

      // How much we can grant this task; keep its share within 0 <= X <= 1 / numActiveTasks
      val maxToGrant = math.min(numBytes, math.max(0, maxMemoryPerTask - curMem))
      // Only give it as much memory as is free, which might be none if it reached 1 / numTasks
      val toGrant = math.min(maxToGrant, memoryFree)
```
toGrant will be 0  cause task throw OOM, then retry, it's heavy always. We can wait for other small task finish an d acquire memory again.


### Why are the changes needed?
Make task stronger


### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
NO
