### PR TITLE
[SPARK-31235][TESTS][FOLLOWUP][test-maven][test-hadoop3.2] Fix Hadoop-3.2 profile UT failure

### DIFF
--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
@@ -247,7 +247,6 @@ class ClientSuite extends SparkFunSuite with Matchers {
 
         val rmContext = mock(classOf[RMContext])
         val conf = new Configuration(false)
-        conf.set("yarn.timeline-service.enabled", "false")
         val map = new ConcurrentHashMap[ApplicationId, RMApp]()
         when(rmContext.getRMApps).thenReturn(map)
         val dispatcher = mock(classOf[Dispatcher])

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
@@ -276,6 +276,7 @@ class ClientSuite extends SparkFunSuite with Matchers {
           null)
         clientRMService.init(conf)
         clientRMService.submitApplication(request)
+        clientRMService.close()
 
         assert(map.get(subContext.getApplicationId).getApplicationType === targetType)
         null

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
@@ -247,6 +247,7 @@ class ClientSuite extends SparkFunSuite with Matchers {
 
         val rmContext = mock(classOf[RMContext])
         val conf = new Configuration(false)
+        conf.set("yarn.timeline-service.enabled", "false")
         val map = new ConcurrentHashMap[ApplicationId, RMApp]()
         when(rmContext.getRMApps).thenReturn(map)
         val dispatcher = mock(classOf[Dispatcher])


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix a UT failure in `Hadoop-3.2` profile.

### Why are the changes needed?

Currently, `master` branch Hadoop-3.2 profile jobs (SBT/Maven) are broken due to the consistent UT failure.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the Jenkins with Hadoop 3.2 profile (SBT/Maven).