### PR TITLE
[SPARK-31735][SQL] Include date/timestamp in the summary report

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
@@ -264,7 +264,10 @@ object StatFunctions extends Logging {
     }
 
     val selectedCols = ds.logicalPlan.output
-      .filter(a => a.dataType.isInstanceOf[NumericType] || a.dataType.isInstanceOf[StringType])
+      .filter(a => a.dataType.isInstanceOf[NumericType]
+        || a.dataType.isInstanceOf[StringType]
+        || a.dataType.isInstanceOf[DateType]
+        || a.dataType.isInstanceOf[TimestampType])
 
     val aggExprs = statisticFns.flatMap { func =>
       selectedCols.map(c => Column(Cast(func(c), StringType)).as(c.name))

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -832,30 +832,30 @@ class DataFrameSuite extends QueryTest
   }
 
   private lazy val person2: DataFrame = Seq(
-    ("Bob", 16, 176),
-    ("Alice", 32, 164),
-    ("David", 60, 192),
-    ("Amy", 24, 180)).toDF("name", "age", "height")
+    ("Bob", 16, 176, new Date(2020, 1, 1)),
+    ("Alice", 32, 164, new Date(2020, 1, 5)),
+    ("David", 60, 192, new Date(2020, 1, 19)),
+    ("Amy", 24, 180, new Date(2020, 1, 25))).toDF("name", "age", "height", "birthday")
 
   test("describe") {
     val describeResult = Seq(
-      Row("count", "4", "4", "4"),
-      Row("mean", null, "33.0", "178.0"),
-      Row("stddev", null, "19.148542155126762", "11.547005383792516"),
-      Row("min", "Alice", "16", "164"),
-      Row("max", "David", "60", "192"))
+      Row("count", "4", "4", "4", "4"),
+      Row("mean", null, "33.0", "178.0", "2020-1-25"),
+      Row("stddev", null, "19.148542155126762", "11.547005383792516", null),
+      Row("min", "Alice", "16", "164", "2020-1-1"),
+      Row("max", "David", "60", "192", "2020-1-25"))
 
     val emptyDescribeResult = Seq(
-      Row("count", "0", "0", "0"),
-      Row("mean", null, null, null),
-      Row("stddev", null, null, null),
-      Row("min", null, null, null),
-      Row("max", null, null, null))
+      Row("count", "0", "0", "0", "0"),
+      Row("mean", null, null, null, null),
+      Row("stddev", null, null, null, null),
+      Row("min", null, null, null, null),
+      Row("max", null, null, null, null))
 
     def getSchemaAsSeq(df: DataFrame): Seq[String] = df.schema.map(_.name)
 
     val describeAllCols = person2.describe()
-    assert(getSchemaAsSeq(describeAllCols) === Seq("summary", "name", "age", "height"))
+    assert(getSchemaAsSeq(describeAllCols) === Seq("summary", "name", "age", "height", "birthday"))
     checkAnswer(describeAllCols, describeResult)
     // All aggregate value should have been cast to string
     describeAllCols.collect().foreach { row =>
@@ -875,7 +875,7 @@ class DataFrameSuite extends QueryTest
     checkAnswer(describeNoCol, describeResult.map { case Row(s, _, _, _) => Row(s)} )
 
     val emptyDescription = person2.limit(0).describe()
-    assert(getSchemaAsSeq(emptyDescription) === Seq("summary", "name", "age", "height"))
+    assert(getSchemaAsSeq(emptyDescription) === Seq("summary", "name", "age", "height", "birthday"))
     checkAnswer(emptyDescription, emptyDescribeResult)
   }
 


### PR DESCRIPTION
For example, dates are missing from the export:

```python
from datetime import datetime, timedelta, timezone
from pyspark.sql import types as T
from pyspark.sql import Row
from pyspark.sql import functions as F

START = datetime(2014, 1, 1, tzinfo=timezone.utc)

n_days = 22

date_range = [Row(date=(START + timedelta(days=n))) for n in range(0, n_days)]

schema = T.StructType([T.StructField(name="date", dataType=T.DateType(), nullable=False)])

rdd = spark.sparkContext.parallelize(date_range)

df = spark.createDataFrame(data=rdd, schema=schema)

df.agg(F.max("date")).show()

df.summary().show()
+-------+
|summary|
+-------+
|  count|
|   mean|
| stddev|
|    min|
|    25%|
|    50%|
|    75%|
|    max|
+-------+
```

Even something less common such as arrays are sortable:

```scala
elcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 2.4.5
      /_/
         
Using Scala version 2.11.12 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_172)
Type in expressions to have them evaluated.
Type :help for more information.

scala> 

scala> val singersDF = Seq(
     |   ("beatles", "help|hey jude"),
     |   ("romeo", "eres mia")
     | ).toDF("name", "hit_songs")
singersDF: org.apache.spark.sql.DataFrame = [name: string, hit_songs: string]

scala> 

scala> val actualDF = singersDF.withColumn(
     |   "hit_songs",
     |   split(col("hit_songs"), "\\|")
     | )
actualDF: org.apache.spark.sql.DataFrame = [name: string, hit_songs: array<string>]

scala> actualDF.show()
+-------+----------------+
|   name|       hit_songs|
+-------+----------------+
|beatles|[help, hey jude]|
|  romeo|      [eres mia]|
+-------+----------------+


scala> df.max("hit_songs")
<console>:24: error: not found: value df
       df.max("hit_songs")
       ^

scala> actualDF.max("hit_songs")
<console>:26: error: value max is not a member of org.apache.spark.sql.DataFrame
       actualDF.max("hit_songs")
                ^

scala> actualDF.agg(min("hit_songs"), max("hit_songs"))
res3: org.apache.spark.sql.DataFrame = [min(hit_songs): array<string>, max(hit_songs): array<string>]

scala> actualDF.agg(min("hit_songs"), max("hit_songs")).show()
+--------------+----------------+                                               
|min(hit_songs)|  max(hit_songs)|
+--------------+----------------+
|    [eres mia]|[help, hey jude]|
+--------------+----------------+
```

Signed-off-by: Fokko Driesprong <fokko@apache.org>

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?

Not filtering the columns to compute statistics on.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?

Something as simple as DateTypes are not showing up in the output.

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

### Does this PR introduce _any_ user-facing change?

Might be, as their output will change of the summary if they have columns that aren't part of the summary right now.

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

### How was this patch tested?

Existing tests.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
