### PR TITLE
[SPARK-31737][SQL] SparkSQL can't recognize the modified length of Hive varchar

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -309,10 +309,23 @@ object DataType {
         fromFields.length == toFields.length &&
           fromFields.zip(toFields).forall { case (l, r) =>
             l.name.equalsIgnoreCase(r.name) &&
-              equalsIgnoreCaseAndNullability(l.dataType, r.dataType)
+              equalsIgnoreCaseAndNullability(l.dataType, r.dataType) &&
+                equalsMetaData(l, r)
           }
 
       case (fromDataType, toDataType) => fromDataType == toDataType
+    }
+  }
+
+  /**
+   * Returns true if the two StructField have the same HIVE_TYPE_STRING,
+   * or none of them have this attribute.
+   */
+  private[sql] def equalsMetaData(from: StructField, to: StructField): Boolean = {
+    if (from.metadata.contains(HIVE_TYPE_STRING) && to.metadata.contains(HIVE_TYPE_STRING)) {
+      from.metadata.getString(HIVE_TYPE_STRING).equals(to.metadata.getString(HIVE_TYPE_STRING))
+    } else {
+      true
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -479,4 +479,42 @@ class DataTypeSuite extends SparkFunSuite {
 
     assert(result === expected)
   }
+
+  test("SPARK-31737: SparkSQL can't recognize the modified length of Hive varchar") {
+    def checkEqualsIgnoreCaseAndNullability(
+        from: DataType,
+        to: DataType,
+        expected: Boolean): Unit = {
+      assert(DataType.equalsIgnoreCaseAndNullability(from, to) === expected)
+    }
+
+    checkEqualsIgnoreCaseAndNullability(
+      from = StructType(Seq(
+        StructField("a", StringType, nullable = false, new MetadataBuilder()
+          .putString("HIVE_TYPE_STRING", "varchar(5)")
+          .build()))),
+      to = StructType(Seq(
+        StructField("a", StringType, nullable = false, new MetadataBuilder()
+          .putString("HIVE_TYPE_STRING", "varchar(10)")
+          .build()))),
+      expected = false)
+
+    checkEqualsIgnoreCaseAndNullability(
+      from = StructType(Seq(
+        StructField("a", StringType, nullable = false, new MetadataBuilder()
+          .putString("HIVE_TYPE_STRING", "varchar(10)")
+          .build()))),
+      to = StructType(Seq(
+        StructField("a", StringType, nullable = false, new MetadataBuilder()
+          .putString("HIVE_TYPE_STRING", "varchar(10)")
+          .build()))),
+      expected = true)
+
+    checkEqualsIgnoreCaseAndNullability(
+      from = StructType(Seq(
+        StructField("a", StringType, nullable = false))),
+      to = StructType(Seq(
+        StructField("a", StringType, nullable = false))),
+      expected = true)
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support Spark SQL to recognize the length modification of the varchar type field of Hive table which created in SparkSQL

### Why are the changes needed?
When the length of a varchar field of a hive table which created by SparkSQL is modified in hive, SparkSQL can't  recognize the modified length, which causes the field length read by SparkSQL to be intercepted and the user cannot obtain the latest length.


### Does this PR intrduce _any_ user-facing change?
No

### How was this patch tested?
//Create a hive table in sparksql
spark-sql> create table test_table(id varchar(5)) stored as textfile;

// Create a file under linux, the content is 1234567890

// Then load this file into this hive table
spark-sql> load data local inpath '/home/test_table' overwrite into table test_table;

// Query this table in sparksql
spark-sql> select * from test_table;
12345

// Modify the length of this field in hive
hive> alter table test_table change column id id varchar(10);

// Query this table in hive
hive> select * from test_table;
OK
1234567890

// Query this table in sparksql again without this patch
spark-sql> select * from test_table;
// The obtained id is 12345, so the length modification does not take effect in SparkSQL
12345

// Query this table in sparksql again with this patch
spark-sql> select * from test_table;
1234567890