### PR TITLE
[SPARK-31750][SQL] Eliminate UpCast if child's dataType is DecimalType

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/DeserializerBuildHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/DeserializerBuildHelper.scala
@@ -161,7 +161,10 @@ object DeserializerBuildHelper {
     case _: StructType => expr
     case _: ArrayType => expr
     case _: MapType => expr
-    case _: DecimalType => UpCast(expr, DecimalType, walkedTypePath.getPaths)
+    case _: DecimalType =>
+      // For Scala/Java `BigDecimal`, we accept decimal types of any valid precision/scale.
+      // Here we use the `DecimalType` object to indicate it.
+      UpCast(expr, DecimalType, walkedTypePath.getPaths)
     case _ => UpCast(expr, expected, walkedTypePath.getPaths)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/DeserializerBuildHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/DeserializerBuildHelper.scala
@@ -161,6 +161,7 @@ object DeserializerBuildHelper {
     case _: StructType => expr
     case _: ArrayType => expr
     case _: MapType => expr
+    case _: DecimalType => UpCast(expr, DecimalType, walkedTypePath.getPaths)
     case _ => UpCast(expr, expected, walkedTypePath.getPaths)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3071,21 +3071,22 @@ class Analyzer(
       case p => p transformExpressions {
         case u @ UpCast(child, _, _) if !child.resolved => u
 
-        case UpCast(child, dt: AtomicType, _)
+        case u @ UpCast(child, _, _)
             if SQLConf.get.getConf(SQLConf.LEGACY_LOOSE_UPCAST) &&
+              u.dataType.isInstanceOf[AtomicType] &&
               child.dataType == StringType =>
-          Cast(child, dt.asNullable)
+          Cast(child, u.dataType.asNullable)
 
-        case UpCast(child, dataType, walkedTypePath)
+        case u @ UpCast(child, _, walkedTypePath)
           if child.dataType.isInstanceOf[DecimalType]
-            && dataType.isInstanceOf[DecimalType]
+            && u.dataType.isInstanceOf[DecimalType]
             && walkedTypePath.nonEmpty =>
           child
 
-        case UpCast(child, dataType, walkedTypePath) if !Cast.canUpCast(child.dataType, dataType) =>
-          fail(child, dataType, walkedTypePath)
+        case u @ UpCast(child, _, walkedTypePath) if !Cast.canUpCast(child.dataType, u.dataType) =>
+          fail(child, u.dataType, walkedTypePath)
 
-        case UpCast(child, dataType, _) => Cast(child, dataType.asNullable)
+        case u @ UpCast(child, _, _) => Cast(child, u.dataType.asNullable)
       }
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3077,19 +3077,15 @@ class Analyzer(
               child.dataType == StringType =>
           Cast(child, u.dataType.asNullable)
 
-        case u @ UpCast(child, _, walkedTypePath)
+        case UpCast(child, target, walkedTypePath)
           if child.dataType.isInstanceOf[DecimalType]
-            && u.dataType.isInstanceOf[DecimalType]
+            && target == DecimalType
             && walkedTypePath.nonEmpty =>
-          // SPARK-31750: there are two cases: 1. for local BigDecimal collection,
-          // e.g. Seq(BigDecimal(12.34), BigDecimal(1)).toDF("a"), we will have
-          // UpCast(child, Decimal(38, 18)) where child's data type is always Decimal(38, 18).
-          // 2. for other cases where data type is explicitly known, e.g, spark.read
-          // .parquet("/tmp/file").as[BigDecimal]. We will have UpCast(child, Decimal(38, 18)),
-          // where child's data type can be, e.g. Decimal(38, 0). In this case, we actually
-          // should not do cast otherwise there will be precision lost.
-          // Thus, we eliminate the UpCast here to avoid precision lost for case 2 and do
-          // no hurt for case 1.
+          // SPARK-31750: for the case where data type is explicitly known, e.g, spark.read
+          // .parquet("/tmp/file").as[BigDecimal], we will have UpCast(child, Decimal(38, 18)),
+          // where child's data type can be, e.g. Decimal(38, 0). In this kind of case, we
+          // actually should not do cast otherwise it will cause precision lost. Thus, we should
+          // eliminate the UpCast here to avoid precision lost.
           child
 
         case u @ UpCast(child, _, walkedTypePath) if !Cast.canUpCast(child.dataType, u.dataType) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3079,8 +3079,9 @@ class Analyzer(
 
         case UpCast(child, target, walkedTypePath)
           if child.dataType.isInstanceOf[DecimalType]
-            && target == DecimalType
-            && walkedTypePath.nonEmpty =>
+            && target == DecimalType =>
+          assert(walkedTypePath.nonEmpty,
+            "object DecimalType should only be used inside ExpressionEncoder")
           // SPARK-31750: for the case where data type is explicitly known, e.g, spark.read
           // .parquet("/tmp/file").as[BigDecimal], we will have UpCast(child, Decimal(38, 18)),
           // where child's data type can be, e.g. Decimal(38, 0). In this kind of case, we

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3079,7 +3079,7 @@ class Analyzer(
         case UpCast(child, dataType, walkedTypePath)
           if child.dataType.isInstanceOf[DecimalType]
             && dataType.isInstanceOf[DecimalType]
-            && walkedTypePath.size == 1 =>
+            && walkedTypePath.nonEmpty =>
           child
 
         case UpCast(child, dataType, walkedTypePath) if !Cast.canUpCast(child.dataType, dataType) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3076,6 +3076,12 @@ class Analyzer(
               child.dataType == StringType =>
           Cast(child, dt.asNullable)
 
+        case UpCast(child, dataType, walkedTypePath)
+          if child.dataType.isInstanceOf[DecimalType]
+            && dataType.isInstanceOf[DecimalType]
+            && walkedTypePath.size == 1 =>
+          child
+
         case UpCast(child, dataType, walkedTypePath) if !Cast.canUpCast(child.dataType, dataType) =>
           fail(child, dataType, walkedTypePath)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -1738,6 +1738,12 @@ case class AnsiCast(child: Expression, dataType: DataType, timeZoneId: Option[St
  *
  * Note that UpCast will be eliminated if the child's dataType is already DecimalType and
  * target is also DecimalType.
+ *
+ * Also note we use `AbstractDataType` instead of `DataType` in order to accept both object
+ * DecimalType and a concrete DecimalType, e.g. DecimalType(5, 2). In this way, we can still
+ * keep the original semantic for `UpCast`(e.g. cast to a concrete decimal type ) but take
+ * object DecimalType as an exception for the `ExpressionEncoder` only(any other AbstractDataType
+ * will fail at analysis phase yet).
  */
 case class UpCast(child: Expression, target: AbstractDataType, walkedTypePath: Seq[String] = Nil)
   extends UnaryExpression with Unevaluable {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -1736,14 +1736,8 @@ case class AnsiCast(child: Expression, dataType: DataType, timeZoneId: Option[St
  * Cast the child expression to the target data type, but will throw error if the cast might
  * truncate, e.g. long -> int, timestamp -> data.
  *
- * Note that UpCast will be eliminated if the child's dataType is already DecimalType and
- * target is also DecimalType.
- *
- * Also note we use `AbstractDataType` instead of `DataType` in order to accept both object
- * DecimalType and a concrete DecimalType, e.g. DecimalType(5, 2). In this way, we can still
- * keep the original semantic for `UpCast`(e.g. cast to a concrete decimal type ) but take
- * object DecimalType as an exception for the `ExpressionEncoder` only(any other AbstractDataType
- * will fail at analysis phase yet).
+ * Note: `target` is `AbstractDataType`, so that we can put `object DecimalType`, which means
+ * we accept `DecimalType` with any valid precision/scale.
  */
 case class UpCast(child: Expression, target: AbstractDataType, walkedTypePath: Seq[String] = Nil)
   extends UnaryExpression with Unevaluable {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -1735,8 +1735,15 @@ case class AnsiCast(child: Expression, dataType: DataType, timeZoneId: Option[St
 /**
  * Cast the child expression to the target data type, but will throw error if the cast might
  * truncate, e.g. long -> int, timestamp -> data.
+ *
+ * Note UpCast will be eliminated if the child's dataType is already DecimalType.
  */
-case class UpCast(child: Expression, dataType: DataType, walkedTypePath: Seq[String] = Nil)
+case class UpCast(child: Expression, target: AbstractDataType, walkedTypePath: Seq[String] = Nil)
   extends UnaryExpression with Unevaluable {
   override lazy val resolved = false
+
+  def dataType: DataType = target match {
+    case DecimalType => DecimalType.SYSTEM_DEFAULT
+    case _ => target.asInstanceOf[DataType]
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -1736,7 +1736,8 @@ case class AnsiCast(child: Expression, dataType: DataType, timeZoneId: Option[St
  * Cast the child expression to the target data type, but will throw error if the cast might
  * truncate, e.g. long -> int, timestamp -> data.
  *
- * Note UpCast will be eliminated if the child's dataType is already DecimalType.
+ * Note that UpCast will be eliminated if the child's dataType is already DecimalType and
+ * target is also DecimalType.
  */
 case class UpCast(child: Expression, target: AbstractDataType, walkedTypePath: Seq[String] = Nil)
   extends UnaryExpression with Unevaluable {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/EncoderResolutionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/EncoderResolutionSuite.scala
@@ -250,7 +250,7 @@ class EncoderResolutionSuite extends PlanTest {
   test("SPARK-31750: eliminate UpCast if child's dataType is DecimalType") {
     val encoder = ExpressionEncoder[Seq[BigDecimal]]
     val attr = Seq(AttributeReference("a", ArrayType(DecimalType(38, 0)))())
-    // previously, it will fail because Decimal(38, 0) can not be casted to Decimal(38, 18)
+    // Before SPARK-31750, it will fail because Decimal(38, 0) can not be casted to Decimal(38, 18)
     testFromRow(encoder, attr, InternalRow(ArrayData.toArrayData(Array(Decimal(1.0)))))
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/EncoderResolutionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/EncoderResolutionSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
 import org.apache.spark.sql.catalyst.plans.PlanTest
-import org.apache.spark.sql.catalyst.util.GenericArrayData
+import org.apache.spark.sql.catalyst.util.{ArrayData, GenericArrayData}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -248,9 +248,9 @@ class EncoderResolutionSuite extends PlanTest {
   }
 
   test("eliminate UpCast when the output data type of the leaf node is already decimal type") {
-    val encoder = ExpressionEncoder[BigDecimal]
-    val attr = Seq(AttributeReference("a", DecimalType(38, 0))())
-    testFromRow(encoder, attr, InternalRow(Decimal(0)))
+    val encoder = ExpressionEncoder[Seq[BigDecimal]]
+    val attr = Seq(AttributeReference("a", ArrayType(DecimalType(38, 0)))())
+    testFromRow(encoder, attr, InternalRow(ArrayData.toArrayData(Array(Decimal(1.0)))))
   }
 
   // test for leaf types

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/EncoderResolutionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/EncoderResolutionSuite.scala
@@ -250,6 +250,7 @@ class EncoderResolutionSuite extends PlanTest {
   test("eliminate UpCast when the output data type of the leaf node is already decimal type") {
     val encoder = ExpressionEncoder[Seq[BigDecimal]]
     val attr = Seq(AttributeReference("a", ArrayType(DecimalType(38, 0)))())
+    // previously, it will fail because Decimal(38, 0) can not be casted to Decimal(38, 18)
     testFromRow(encoder, attr, InternalRow(ArrayData.toArrayData(Array(Decimal(1.0)))))
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/EncoderResolutionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/EncoderResolutionSuite.scala
@@ -247,7 +247,7 @@ class EncoderResolutionSuite extends PlanTest {
        """.stripMargin.trim + " of the field in the target object")
   }
 
-  test("eliminate UpCast when the output data type of the leaf node is already decimal type") {
+  test("SPARK-31750: eliminate UpCast if child's dataType is DecimalType") {
     val encoder = ExpressionEncoder[Seq[BigDecimal]]
     val attr = Seq(AttributeReference("a", ArrayType(DecimalType(38, 0)))())
     // previously, it will fail because Decimal(38, 0) can not be casted to Decimal(38, 18)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/EncoderResolutionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/EncoderResolutionSuite.scala
@@ -22,7 +22,7 @@ import scala.reflect.runtime.universe.TypeTag
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.dsl.expressions._
-import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
 import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.util.GenericArrayData
 import org.apache.spark.sql.types._
@@ -245,6 +245,12 @@ class EncoderResolutionSuite extends PlanTest {
          |- root class: "org.apache.spark.sql.catalyst.encoders.ComplexClass"
          |You can either add an explicit cast to the input data or choose a higher precision type
        """.stripMargin.trim + " of the field in the target object")
+  }
+
+  test("eliminate UpCast when the output data type of the leaf node is already decimal type") {
+    val encoder = ExpressionEncoder[BigDecimal]
+    val attr = Seq(AttributeReference("a", DecimalType(38, 0))())
+    testFromRow(encoder, attr, InternalRow(Decimal(0)))
   }
 
   // test for leaf types

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2442,8 +2442,7 @@ class DataFrameSuite extends QueryTest
 
   test("as[BigDecimal] should not lost data precision or scale") {
     withTempPath { f =>
-      sql("select 11111111111111111111111111111111111111 as d").
-        selectExpr("cast (d as decimal(38, 0))")
+      sql("select cast(11111111111111111111111111111111111111 as decimal(38, 0)) as d")
         .write.mode("overwrite")
         .parquet(f.getAbsolutePath)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2440,13 +2440,13 @@ class DataFrameSuite extends QueryTest
     checkAnswer(Seq(nestedDecArray).toDF(), Row(Array(wrapRefArray(decJava))))
   }
 
-  test("as[BigDecimal] should not lost data precision or scale") {
+  test("SPARK-31750: eliminate UpCast if child's dataType is DecimalType") {
     withTempPath { f =>
       sql("select cast(11111111111111111111111111111111111111 as decimal(38, 0)) as d")
         .write.mode("overwrite")
         .parquet(f.getAbsolutePath)
 
-      val df = spark.read.parquet("/tmp/foo").as[BigDecimal]
+      val df = spark.read.parquet(f.getAbsolutePath).as[BigDecimal]
       assert(df.schema === new StructType().add(StructField("d", DecimalType(38, 0))))
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2442,7 +2442,7 @@ class DataFrameSuite extends QueryTest
 
   test("SPARK-31750: eliminate UpCast if child's dataType is DecimalType") {
     withTempPath { f =>
-      sql("select cast(11111111111111111111111111111111111111 as decimal(38, 0)) as d")
+      sql("select cast(1 as decimal(38, 0)) as d")
         .write.mode("overwrite")
         .parquet(f.getAbsolutePath)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Eliminate the `UpCast` if it's child data type is already decimal type.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

While deserializing internal `Decimal` value to external `BigDecimal`(Java/Scala) value, Spark should also respect `Decimal`'s precision and scale, otherwise it will cause precision lost and look weird in some cases, e.g.:
 
```
sql("select cast(11111111111111111111111111111111111111 as decimal(38, 0)) as d")
  .write.mode("overwrite")
  .parquet(f.getAbsolutePath)

// can fail
spark.read.parquet(f.getAbsolutePath).as[BigDecimal]
```
```
[info]   org.apache.spark.sql.AnalysisException: Cannot up cast `d` from decimal(38,0) to decimal(38,18).
[info] The type path of the target object is:
[info] - root class: "scala.math.BigDecimal"
[info] You can either add an explicit cast to the input data or choose a higher precision type of the field in the target object;
[info]   at org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveUpCast$.org$apache$spark$sql$catalyst$analysis$Analyzer$ResolveUpCast$$fail(Analyzer.scala:3060)
[info]   at org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveUpCast$$anonfun$apply$33$$anonfun$applyOrElse$174.applyOrElse(Analyzer.scala:3087)
[info]   at org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveUpCast$$anonfun$apply$33$$anonfun$applyOrElse$174.applyOrElse(Analyzer.scala:3071)
[info]   at org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$transformDown$1(TreeNode.scala:309)
[info]   at org.apache.spark.sql.catalyst.trees.CurrentOrigin$.withOrigin(TreeNode.scala:72)
[info]   at org.apache.spark.sql.catalyst.trees.TreeNode.transformDown(TreeNode.scala:309)
[info]   at org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$transformDown$3(TreeNode.scala:314)
```


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, for cases(cause precision lost) mentioned above will fail before this change but run successfully after this change.



### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Added tests.
