### PR TITLE
[SPARK-31705][SQL] Push predicate through join by rewriting join condition to conjunctive normal form

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -544,6 +544,18 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
+  val MAX_REWRITING_CNF_DEPTH =
+    buildConf("spark.sql.maxRewritingCNFDepth")
+      .internal()
+      .doc("The maximum depth of rewriting a join condition to conjunctive normal form " +
+        "expression. The deeper, the more predicate may be found, but the optimization time " +
+        "will increase. The default is 6. By setting this value to 0 this feature can be disabled.")
+      .version("3.1.0")
+      .intConf
+      .checkValue(_ >= 0,
+        "The depth of the maximum rewriting conjunction normal form must be positive.")
+      .createWithDefault(6)
+
   val ESCAPED_STRING_LITERALS = buildConf("spark.sql.parser.escapedStringLiterals")
     .internal()
     .doc("When true, string literals (including regex patterns) remain escaped in our SQL " +
@@ -2844,6 +2856,8 @@ class SQLConf extends Serializable with Logging {
   def caseSensitiveAnalysis: Boolean = getConf(SQLConf.CASE_SENSITIVE)
 
   def constraintPropagationEnabled: Boolean = getConf(CONSTRAINT_PROPAGATION_ENABLED)
+
+  def maxRewritingCNFDepth: Int = getConf(MAX_REWRITING_CNF_DEPTH)
 
   def escapedStringLiterals: Boolean = getConf(ESCAPED_STRING_LITERALS)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -554,7 +554,7 @@ object SQLConf {
       .intConf
       .checkValue(_ >= 0,
         "The depth of the maximum rewriting conjunction normal form must be positive.")
-      .createWithDefault(6)
+      .createWithDefault(10)
 
   val ESCAPED_STRING_LITERALS = buildConf("spark.sql.parser.escapedStringLiterals")
     .internal()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -548,8 +548,8 @@ object SQLConf {
     buildConf("spark.sql.maxRewritingCNFDepth")
       .internal()
       .doc("The maximum depth of rewriting a join condition to conjunctive normal form " +
-        "expression. The deeper, the more predicate may be found, but the optimization time " +
-        "will increase. The default is 6. By setting this value to 0 this feature can be disabled.")
+        "expression. The deeper, the more predicate may be found, but the optimization time will " +
+        "increase. The default is 10. By setting this value to 0 this feature can be disabled.")
       .version("3.1.0")
       .intConf
       .checkValue(_ >= 0,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -39,7 +39,9 @@ class FilterPushdownSuite extends PlanTest {
         PushPredicateThroughNonJoin,
         BooleanSimplification,
         PushPredicateThroughJoin,
-        CollapseProject) :: Nil
+        CollapseProject) ::
+      Batch("PushPredicateThroughJoinByCNF", Once,
+        PushPredicateThroughJoinByCNF) :: Nil
   }
 
   val attrA = 'a.int
@@ -1229,5 +1231,107 @@ class FilterPushdownSuite extends PlanTest {
       condition = Some(pythonUDFJoinCond)).analyze
 
     comparePlans(Optimize.execute(query.analyze), expected)
+  }
+
+  test("inner join: rewrite filter predicates to conjunctive normal form") {
+    val x = testRelation.subquery('x)
+    val y = testRelation.subquery('y)
+
+    val originalQuery = {
+      x.join(y)
+        .where(("x.b".attr === "y.b".attr)
+          && (("x.a".attr > 3) && ("y.a".attr > 13) || ("x.a".attr > 1) && ("y.a".attr > 11)))
+    }
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+    val left = testRelation.where(('a > 3 || 'a > 1)).subquery('x)
+    val right = testRelation.where('a > 13 || 'a > 11).subquery('y)
+    val correctAnswer =
+      left.join(right, condition = Some("x.b".attr === "y.b".attr
+        && (("x.a".attr > 3) && ("y.a".attr > 13) || ("x.a".attr > 1) && ("y.a".attr > 11))))
+        .analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("inner join: rewrite join predicates to conjunctive normal form") {
+    val x = testRelation.subquery('x)
+    val y = testRelation.subquery('y)
+
+    val originalQuery = {
+      x.join(y, condition = Some(("x.b".attr === "y.b".attr)
+        && (("x.a".attr > 3) && ("y.a".attr > 13) || ("x.a".attr > 1) && ("y.a".attr > 11))))
+    }
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+    val left = testRelation.where('a > 3 || 'a > 1).subquery('x)
+    val right = testRelation.where('a > 13 || 'a > 11).subquery('y)
+    val correctAnswer =
+      left.join(right, condition = Some("x.b".attr === "y.b".attr
+        && (("x.a".attr > 3) && ("y.a".attr > 13) || ("x.a".attr > 1) && ("y.a".attr > 11))))
+        .analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("inner join: rewrite join predicates(with NOT predicate) to conjunctive normal form") {
+    val x = testRelation.subquery('x)
+    val y = testRelation.subquery('y)
+
+    val originalQuery = {
+      x.join(y, condition = Some(("x.b".attr === "y.b".attr)
+        && Not(("x.a".attr > 3)
+        && ("x.a".attr < 2 || ("y.a".attr > 13)) || ("x.a".attr > 1) && ("y.a".attr > 11))))
+    }
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+    val left = testRelation.where('a <= 3 || 'a >= 2).subquery('x)
+    val right = testRelation.subquery('y)
+    val correctAnswer =
+      left.join(right, condition = Some("x.b".attr === "y.b".attr
+        && (("x.a".attr <= 3) || (("x.a".attr >= 2) && ("y.a".attr <= 13)))
+        && (("x.a".attr <= 1) || ("y.a".attr <= 11))))
+        .analyze
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("left join: rewrite join predicates to conjunctive normal form") {
+    val x = testRelation.subquery('x)
+    val y = testRelation.subquery('y)
+
+    val originalQuery = {
+      x.join(y, joinType = LeftOuter, condition = Some(("x.b".attr === "y.b".attr)
+        && (("x.a".attr > 3) && ("y.a".attr > 13) || ("x.a".attr > 1) && ("y.a".attr > 11))))
+    }
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+    val left = testRelation.subquery('x)
+    val right = testRelation.where('a > 13 || 'a > 11).subquery('y)
+    val correctAnswer =
+      left.join(right, joinType = LeftOuter, condition = Some("x.b".attr === "y.b".attr
+        && (("x.a".attr > 3) && ("y.a".attr > 13) || ("x.a".attr > 1) && ("y.a".attr > 11))))
+        .analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("right join: rewrite join predicates to conjunctive normal form") {
+    val x = testRelation.subquery('x)
+    val y = testRelation.subquery('y)
+
+    val originalQuery = {
+      x.join(y, joinType = RightOuter, condition = Some(("x.b".attr === "y.b".attr)
+        && (("x.a".attr > 3) && ("y.a".attr > 13) || ("x.a".attr > 1) && ("y.a".attr > 11))))
+    }
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+    val left = testRelation.where('a > 3 || 'a > 1).subquery('x)
+    val right = testRelation.subquery('y)
+    val correctAnswer =
+      left.join(right, joinType = RightOuter, condition = Some("x.b".attr === "y.b".attr
+        && (("x.a".attr > 3) && ("y.a".attr > 13) || ("x.a".attr > 1) && ("y.a".attr > 11))))
+        .analyze
+
+    comparePlans(optimized, correctAnswer)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -32,6 +32,10 @@ import org.apache.spark.unsafe.types.CalendarInterval
 class FilterPushdownSuite extends PlanTest {
 
   object Optimize extends RuleExecutor[LogicalPlan] {
+
+    override protected val blacklistedOnceBatches: Set[String] =
+      Set("Push predicate through join by CNF")
+
     val batches =
       Batch("Subqueries", Once,
         EliminateSubqueryAliases) ::
@@ -41,7 +45,7 @@ class FilterPushdownSuite extends PlanTest {
         BooleanSimplification,
         PushPredicateThroughJoin,
         CollapseProject) ::
-      Batch("PushPredicateThroughJoinByCNF", Once,
+      Batch("Push predicate through join by CNF", Once,
         PushPredicateThroughJoinByCNF) :: Nil
   }
 
@@ -1336,7 +1340,7 @@ class FilterPushdownSuite extends PlanTest {
     comparePlans(optimized, correctAnswer)
   }
 
-  test("inner join: rewrite to conjunctive normal form avoid genereting too many predicates") {
+  test("inner join: rewrite to conjunctive normal form avoid generating too many predicates") {
     val x = testRelation.subquery('x)
     val y = testRelation.subquery('y)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR add a new rule to support push predicate through join by rewriting join condition to CNF(conjunctive normal form). The following example is the steps of this rule:

1. Prepare Table:

```sql
CREATE TABLE x AS SELECT * FROM (VALUES (1, 2, 3, 4)) AS x(a, b, c, d);
CREATE TABLE y AS SELECT * FROM (VALUES (1, 2, 3, 4)) AS x(a, b, c, d);
EXPLAIN SELECT x.* FROM x JOIN y ON ((x.a > 1 AND x.a < 3 AND y.b = 1) OR (x.a > 3 AND x.a < 5 AND y.b = 2));
```

2. Convert the join condition to CNF:

Step | Current condition
--- | ---
init | (x.a > 1 AND x.a < 3 AND y.b = 1) OR (x.a > 3 AND x.a < 5 AND y.b = 2)
step 1 | ((x.a > 1 AND x.a < 3) OR (x.a > 3 AND x.a < 5 AND y.b = 2)) AND ((y.b = 1) OR (x.a > 3 AND x.a < 5 AND y.b = 2))
step 2 | ((x.a > 1 AND x.a < 3) OR (x.a > 3 AND x.a < 5)) AND ((x.a > 1 AND x.a < 3) OR (y.b = 2)) AND ((y.b = 1) OR (x.a > 3 AND x.a < 5 AND y.b = 2))
step 3 | ((x.a > 1 AND x.a < 3) OR (x.a > 3 AND x.a < 5)) AND ((x.a > 1 AND x.a < 3) OR (y.b = 2)) AND ((y.b = 1) OR (x.a > 3 AND x.a < 5)) AND ((y.b = 1) OR (y.b = 2))

3. Split conjunctive predicates

Predicates
---|
((x.a > 1 AND x.a < 3) OR (x.a > 3 AND x.a < 5))
((x.a > 1 AND x.a < 3) OR (y.b = 2))
((y.b = 1) OR (x.a > 3 AND x.a < 5))
((y.b = 1) OR (y.b = 2))

4. Push predicate

Table | Predicate
--- | ---
x | ((x.a > 1 AND x.a < 3) OR (x.a > 3 AND x.a < 5))
y | ((y.b = 1) OR (y.b = 2))



### Why are the changes needed?
Improve query performance. PostgreSQL, [Impala](https://issues.apache.org/jira/browse/IMPALA-9183) and Hive support this feature.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Unit test and benchmark test.


SQL | Before this PR | After this PR
--- | --- | ---
TPCDS 5T Q13 | 84s | 21s
TPCDS 5T q85 | 66s | 34s
TPCH 1T q19 | 37s | 32s

