### PR TITLE
[SPARK-31781][ML][PySpark] Move param k (number of clusters) to shared params

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/BisectingKMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/BisectingKMeans.scala
@@ -42,20 +42,7 @@ import org.apache.spark.storage.StorageLevel
  */
 private[clustering] trait BisectingKMeansParams extends Params with HasMaxIter
   with HasFeaturesCol with HasSeed with HasPredictionCol with HasDistanceMeasure
-  with HasWeightCol {
-
-  /**
-   * The desired number of leaf clusters. Must be &gt; 1. Default: 4.
-   * The actual number could be smaller if there are no divisible leaf clusters.
-   * @group param
-   */
-  @Since("2.0.0")
-  final val k = new IntParam(this, "k", "The desired number of leaf clusters. " +
-    "Must be > 1.", ParamValidators.gt(1))
-
-  /** @group getParam */
-  @Since("2.0.0")
-  def getK: Int = $(k)
+  with HasWeightCol with HasK {
 
   /**
    * The minimum number of points (if greater than or equal to 1.0) or the minimum proportion

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
@@ -43,20 +43,7 @@ import org.apache.spark.storage.StorageLevel
  */
 private[clustering] trait GaussianMixtureParams extends Params with HasMaxIter with HasFeaturesCol
   with HasSeed with HasPredictionCol with HasWeightCol with HasProbabilityCol with HasTol
-  with HasAggregationDepth with HasBlockSize {
-
-  /**
-   * Number of independent Gaussians in the mixture model. Must be greater than 1. Default: 2.
-   *
-   * @group param
-   */
-  @Since("2.0.0")
-  final val k = new IntParam(this, "k", "Number of independent Gaussians in the mixture model. " +
-    "Must be > 1.", ParamValidators.gt(1))
-
-  /** @group getParam */
-  @Since("2.0.0")
-  def getK: Int = $(k)
+  with HasAggregationDepth with HasBlockSize with HasK{
 
   /**
    * Validates and transforms the input schema.

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -42,21 +42,8 @@ import org.apache.spark.util.VersionUtils.majorVersion
  * Common params for KMeans and KMeansModel
  */
 private[clustering] trait KMeansParams extends Params with HasMaxIter with HasFeaturesCol
-  with HasSeed with HasPredictionCol with HasTol with HasDistanceMeasure with HasWeightCol {
-
-  /**
-   * The number of clusters to create (k). Must be &gt; 1. Note that it is possible for fewer than
-   * k clusters to be returned, for example, if there are fewer than k distinct points to cluster.
-   * Default: 2.
-   * @group param
-   */
-  @Since("1.5.0")
-  final val k = new IntParam(this, "k", "The number of clusters to create. " +
-    "Must be > 1.", ParamValidators.gt(1))
-
-  /** @group getParam */
-  @Since("1.5.0")
-  def getK: Int = $(k)
+  with HasSeed with HasPredictionCol with HasTol with HasDistanceMeasure with HasWeightCol
+  with HasK {
 
   /**
    * Param for the initialization algorithm. This can be either "random" to choose random points as

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/LDA.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/LDA.scala
@@ -31,7 +31,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.ml.{Estimator, Model}
 import org.apache.spark.ml.linalg._
 import org.apache.spark.ml.param._
-import org.apache.spark.ml.param.shared.{HasCheckpointInterval, HasFeaturesCol, HasMaxIter, HasSeed}
+import org.apache.spark.ml.param.shared._
 import org.apache.spark.ml.util._
 import org.apache.spark.ml.util.DefaultParamsReader.Metadata
 import org.apache.spark.ml.util.Instrumentation.instrumented
@@ -52,20 +52,7 @@ import org.apache.spark.util.PeriodicCheckpointer
 import org.apache.spark.util.VersionUtils
 
 private[clustering] trait LDAParams extends Params with HasFeaturesCol with HasMaxIter
-  with HasSeed with HasCheckpointInterval {
-
-  /**
-   * Param for the number of topics (clusters) to infer. Must be &gt; 1. Default: 10.
-   *
-   * @group param
-   */
-  @Since("1.6.0")
-  final val k = new IntParam(this, "k", "The number of topics (clusters) to infer. " +
-    "Must be > 1.", ParamValidators.gt(1))
-
-  /** @group getParam */
-  @Since("1.6.0")
-  def getK: Int = $(k)
+  with HasSeed with HasCheckpointInterval with HasK {
 
   /**
    * Concentration parameter (commonly named "alpha") for the prior placed on documents'

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/PowerIterationClustering.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/PowerIterationClustering.scala
@@ -31,19 +31,7 @@ import org.apache.spark.sql.types._
  * Common params for PowerIterationClustering
  */
 private[clustering] trait PowerIterationClusteringParams extends Params with HasMaxIter
-  with HasWeightCol {
-
-  /**
-   * The number of clusters to create (k). Must be &gt; 1. Default: 2.
-   * @group param
-   */
-  @Since("2.4.0")
-  final val k = new IntParam(this, "k", "The number of clusters to create. " +
-    "Must be > 1.", ParamValidators.gt(1))
-
-  /** @group getParam */
-  @Since("2.4.0")
-  def getK: Int = $(k)
+  with HasWeightCol with HasK {
 
   /**
    * Param for the initialization algorithm. This can be either "random" to use a random vector

--- a/mllib/src/main/scala/org/apache/spark/ml/param/shared/SharedParamsCodeGen.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/shared/SharedParamsCodeGen.scala
@@ -108,7 +108,10 @@ private[shared] object SharedParamsCodeGen {
       ParamDesc[Int]("blockSize", "block size for stacking input data in matrices. Data is " +
         "stacked within partitions. If block size is more than remaining data in a partition " +
         "then it is adjusted to the size of this data.",
-        isValid = "ParamValidators.gt(0)", isExpertParam = true)
+        isValid = "ParamValidators.gt(0)", isExpertParam = true),
+      ParamDesc[Int]("k", "The number of clusters to create. Must be (> 1). Note that it is" +
+        " possible for fewer than k clusters to be returned",
+        isValid = "ParamValidators.gt(1)")
     )
 
     val code = genSharedParams(params)

--- a/mllib/src/main/scala/org/apache/spark/ml/param/shared/sharedParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/shared/sharedParams.scala
@@ -562,4 +562,20 @@ trait HasBlockSize extends Params {
   /** @group expertGetParam */
   final def getBlockSize: Int = $(blockSize)
 }
+
+/**
+ * Trait for shared param k. This trait may be changed or
+ * removed between minor versions.
+ */
+trait HasK extends Params {
+
+  /**
+   * Param for The number of clusters to create. Must be (&gt; 1). Note that it is possible for fewer than k clusters to be returned.
+   * @group param
+   */
+  final val k: IntParam = new IntParam(this, "k", "The number of clusters to create. Must be (> 1). Note that it is possible for fewer than k clusters to be returned", ParamValidators.gt(1))
+
+  /** @group getParam */
+  final def getK: Int = $(k)
+}
 // scalastyle:on

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -42,10 +42,23 @@ object MimaExcludes {
     // [SPARK-31127] Implement abstract Selector
     // org.apache.spark.ml.feature.ChiSqSelectorModel type hierarchy change
     // before: class ChiSqSelector extends Estimator with ChiSqSelectorParams
-    // after: class ChiSqSelector extends PSelector
+    // after: class ChiSqSelector extends Selector
     // false positive, no binary incompatibility
     ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.ml.feature.ChiSqSelectorModel"),
-    ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.ml.feature.ChiSqSelector")
+    ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.ml.feature.ChiSqSelector"),
+
+    // [SPARK-31781] Move param k (number of clusters) to shared params
+    // before change: def getK: Int = $(k)
+    // after change: final def getK: Int = $(k)
+    ProblemFilters.exclude[FinalMethodProblem]("org.apache.spark.ml.clustering.LDA.getK"),
+    ProblemFilters.exclude[FinalMethodProblem]("org.apache.spark.ml.clustering.LDAModel.getK"),
+    ProblemFilters.exclude[FinalMethodProblem]("org.apache.spark.ml.clustering.GaussianMixtureModel.getK"),
+    ProblemFilters.exclude[FinalMethodProblem]("org.apache.spark.ml.clustering.BisectingKMeansModel.getK"),
+    ProblemFilters.exclude[FinalMethodProblem]("org.apache.spark.ml.clustering.KMeansModel.getK"),
+    ProblemFilters.exclude[FinalMethodProblem]("org.apache.spark.ml.clustering.BisectingKMeans.getK"),
+    ProblemFilters.exclude[FinalMethodProblem]("org.apache.spark.ml.clustering.GaussianMixture.getK"),
+    ProblemFilters.exclude[FinalMethodProblem]("org.apache.spark.ml.clustering.KMeans.getK"),
+    ProblemFilters.exclude[FinalMethodProblem]("org.apache.spark.ml.clustering.PowerIterationClustering.getK")
   )
 
   // Exclude rules for 3.0.x

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -99,22 +99,12 @@ class ClusteringSummary(JavaWrapper):
 @inherit_doc
 class _GaussianMixtureParams(HasMaxIter, HasFeaturesCol, HasSeed, HasPredictionCol,
                              HasProbabilityCol, HasTol, HasAggregationDepth, HasWeightCol,
-                             HasBlockSize):
+                             HasBlockSize, HasK):
     """
     Params for :py:class:`GaussianMixture` and :py:class:`GaussianMixtureModel`.
 
     .. versionadded:: 3.0.0
     """
-
-    k = Param(Params._dummy(), "k", "Number of independent Gaussians in the mixture model. " +
-              "Must be > 1.", typeConverter=TypeConverters.toInt)
-
-    @since("2.0.0")
-    def getK(self):
-        """
-        Gets the value of `k`
-        """
-        return self.getOrDefault(self.k)
 
 
 class GaussianMixtureModel(JavaModel, _GaussianMixtureParams, JavaMLWritable, JavaMLReadable,
@@ -483,15 +473,13 @@ class KMeansSummary(ClusteringSummary):
 
 @inherit_doc
 class _KMeansParams(HasMaxIter, HasFeaturesCol, HasSeed, HasPredictionCol, HasTol,
-                    HasDistanceMeasure, HasWeightCol):
+                    HasDistanceMeasure, HasWeightCol, HasK):
     """
     Params for :py:class:`KMeans` and :py:class:`KMeansModel`.
 
     .. versionadded:: 3.0.0
     """
 
-    k = Param(Params._dummy(), "k", "The number of clusters to create. Must be > 1.",
-              typeConverter=TypeConverters.toInt)
     initMode = Param(Params._dummy(), "initMode",
                      "The initialization algorithm. This can be either \"random\" to " +
                      "choose random points as initial cluster centers, or \"k-means||\" " +
@@ -499,13 +487,6 @@ class _KMeansParams(HasMaxIter, HasFeaturesCol, HasSeed, HasPredictionCol, HasTo
                      typeConverter=TypeConverters.toString)
     initSteps = Param(Params._dummy(), "initSteps", "The number of steps for k-means|| " +
                       "initialization mode. Must be > 0.", typeConverter=TypeConverters.toInt)
-
-    @since("1.5.0")
-    def getK(self):
-        """
-        Gets the value of `k`
-        """
-        return self.getOrDefault(self.k)
 
     @since("1.5.0")
     def getInitMode(self):
@@ -740,26 +721,17 @@ class KMeans(JavaEstimator, _KMeansParams, JavaMLWritable, JavaMLReadable):
 
 @inherit_doc
 class _BisectingKMeansParams(HasMaxIter, HasFeaturesCol, HasSeed, HasPredictionCol,
-                             HasDistanceMeasure, HasWeightCol):
+                             HasDistanceMeasure, HasWeightCol, HasK):
     """
     Params for :py:class:`BisectingKMeans` and :py:class:`BisectingKMeansModel`.
 
     .. versionadded:: 3.0.0
     """
 
-    k = Param(Params._dummy(), "k", "The desired number of leaf clusters. Must be > 1.",
-              typeConverter=TypeConverters.toInt)
     minDivisibleClusterSize = Param(Params._dummy(), "minDivisibleClusterSize",
                                     "The minimum number of points (if >= 1.0) or the minimum " +
                                     "proportion of points (if < 1.0) of a divisible cluster.",
                                     typeConverter=TypeConverters.toFloat)
-
-    @since("2.0.0")
-    def getK(self):
-        """
-        Gets the value of `k` or its default value.
-        """
-        return self.getOrDefault(self.k)
 
     @since("2.0.0")
     def getMinDivisibleClusterSize(self):
@@ -1016,15 +988,13 @@ class BisectingKMeansSummary(ClusteringSummary):
 
 
 @inherit_doc
-class _LDAParams(HasMaxIter, HasFeaturesCol, HasSeed, HasCheckpointInterval):
+class _LDAParams(HasMaxIter, HasFeaturesCol, HasSeed, HasCheckpointInterval, HasK):
     """
     Params for :py:class:`LDA` and :py:class:`LDAModel`.
 
     .. versionadded:: 3.0.0
     """
 
-    k = Param(Params._dummy(), "k", "The number of topics (clusters) to infer. Must be > 1.",
-              typeConverter=TypeConverters.toInt)
     optimizer = Param(Params._dummy(), "optimizer",
                       "Optimizer or inference algorithm used to estimate the LDA model.  "
                       "Supported: online, em", typeConverter=TypeConverters.toString)
@@ -1062,13 +1032,6 @@ class _LDAParams(HasMaxIter, HasFeaturesCol, HasSeed, HasCheckpointInterval):
                                " deleted. Deleting the checkpoint can cause failures if a data"
                                " partition is lost, so set this bit with care.",
                                TypeConverters.toBoolean)
-
-    @since("2.0.0")
-    def getK(self):
-        """
-        Gets the value of :py:attr:`k` or its default value.
-        """
-        return self.getOrDefault(self.k)
 
     @since("2.0.0")
     def getOptimizer(self):
@@ -1565,16 +1528,13 @@ class LDA(JavaEstimator, _LDAParams, JavaMLReadable, JavaMLWritable):
 
 
 @inherit_doc
-class _PowerIterationClusteringParams(HasMaxIter, HasWeightCol):
+class _PowerIterationClusteringParams(HasMaxIter, HasWeightCol, HasK):
     """
     Params for :py:class:`PowerIterationClustering`.
 
     .. versionadded:: 3.0.0
     """
 
-    k = Param(Params._dummy(), "k",
-              "The number of clusters to create. Must be > 1.",
-              typeConverter=TypeConverters.toInt)
     initMode = Param(Params._dummy(), "initMode",
                      "The initialization algorithm. This can be either " +
                      "'random' to use a random vector as vertex properties, or 'degree' to use " +
@@ -1587,13 +1547,6 @@ class _PowerIterationClusteringParams(HasMaxIter, HasWeightCol):
     dstCol = Param(Params._dummy(), "dstCol",
                    "Name of the input column for destination vertex IDs.",
                    typeConverter=TypeConverters.toString)
-
-    @since("2.4.0")
-    def getK(self):
-        """
-        Gets the value of :py:attr:`k` or its default value.
-        """
-        return self.getOrDefault(self.k)
 
     @since("2.4.0")
     def getInitMode(self):

--- a/python/pyspark/ml/param/_shared_params_code_gen.py
+++ b/python/pyspark/ml/param/_shared_params_code_gen.py
@@ -167,7 +167,9 @@ if __name__ == "__main__":
          None, "TypeConverters.toString"),
         ("blockSize", "block size for stacking input data in matrices. Data is stacked within "
          "partitions. If block size is more than remaining data in a partition then it is "
-         "adjusted to the size of this data.", None, "TypeConverters.toInt")]
+         "adjusted to the size of this data.", None, "TypeConverters.toInt"),
+        ("k", "The number of clusters to create. Must be > 1. Note that it is possible for " +
+         "fewer than k clusters to be returned.", None, "TypeConverters.toInt")]
 
     code = []
     for name, doc, defaultValueStr, typeConverter in shared:

--- a/python/pyspark/ml/param/shared.py
+++ b/python/pyspark/ml/param/shared.py
@@ -597,3 +597,20 @@ class HasBlockSize(Params):
         Gets the value of blockSize or its default value.
         """
         return self.getOrDefault(self.blockSize)
+
+
+class HasK(Params):
+    """
+    Mixin for param k: The number of clusters to create. Must be > 1. Note that it is possible for fewer than k clusters to be returned.
+    """
+
+    k = Param(Params._dummy(), "k", "The number of clusters to create. Must be > 1. Note that it is possible for fewer than k clusters to be returned.", typeConverter=TypeConverters.toInt)
+
+    def __init__(self):
+        super(HasK, self).__init__()
+
+    def getK(self):
+        """
+        Gets the value of k or its default value.
+        """
+        return self.getOrDefault(self.k)


### PR DESCRIPTION

### What changes were proposed in this pull request?
Param k (number of clusters) is used for all the clustering algorithms, so move it to shared params.


### Why are the changes needed?
Code reuse


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
existing tests
