### PR TITLE
[SPARK-31785][SQL][TESTS] Add a helper function to test all parquet readers

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetTest.scala
@@ -162,4 +162,36 @@ private[sql] trait ParquetTest extends FileBasedDataSourceTest {
   protected def getResourceParquetFilePath(name: String): String = {
     Thread.currentThread().getContextClassLoader.getResource(name).toString
   }
+
+  def withParquetReaderFlags[T](vectorizedOSS: Boolean)
+    (code: => T): T = {
+    val sqlConfs = Seq(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> vectorizedOSS.toString)
+    var ret = null.asInstanceOf[T]
+    withSQLConf(sqlConfs: _*) { ret = code }
+    ret
+  }
+
+  def withParquetReader[T](reader: String)(code: => T): T = reader match {
+    case "parquet-mr" => withParquetReaderFlags(false)(code)
+    case "vectorized-oss" => withParquetReaderFlags(true)(code)
+    case unknown =>
+      // scalastyle:off throwerror
+      throw new NotImplementedError(s"Unsupported Parquet reader '$unknown'.")
+      // scalastyle:on throwerror
+  }
+
+  def withParquetReaders(readers: String*)(code: => Unit): Unit = for (reader <- readers) {
+    // scalastyle:off
+    println(s"with $reader reader")
+    // scalastyle:on
+    withParquetReader(reader)(code)
+  }
+
+  def withOssParquetReaders(code: => Unit): Unit = {
+    withParquetReaders("parquet-mr", "vectorized-oss")(code)
+  }
+
+  def withAllParquetReaders(code: => Unit): Unit = {
+    withOssParquetReaders(code)
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `withAllParquetReaders` to `ParquetTest`. The function allow to run a block of code for all available Parquet readers.

### Why are the changes needed?
1. It simplifies tests
2. Allow to test all parquet readers that could be available in projects based on Apache Spark.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
By running affected test suites.