### PR TITLE
[SPARK-31788][CORE][PYTHON] Fix UnionRDD of PairRDDs

### DIFF
--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -875,7 +875,7 @@ class SparkContext(object):
             else:
                 # zip could return JavaPairRDD hence we ensure `_jrdd`
                 # to be `JavaRDD` by wrapping it in a `map`
-                rdds[i] = rdds[i].map(lambda x: x)._jrdd
+                jrdds[i] = rdds[i].map(lambda x: x)._jrdd
         return RDD(self._jsc.union(jrdds), self, rdds[0]._jrdd_deserializer)
 
     def broadcast(self, value):

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -866,21 +866,16 @@ class SparkContext(object):
         if any(x._jrdd_deserializer != first_jrdd_deserializer for x in rdds):
             rdds = [x._reserialize() for x in rdds]
         gw = SparkContext._gateway
-        jvm = SparkContext._jvm
-        jrdd_cls = jvm.org.apache.spark.api.java.JavaRDD
-        pair_jrdd_cls = jvm.org.apache.spark.api.java.JavaPairRDD
-        double_jrdd_cls = jvm.org.apache.spark.api.java.JavaDoubleRDD
-        if is_instance_of(gw, rdds[0]._jrdd, jrdd_cls):
-            cls = jrdd_cls
-        elif is_instance_of(gw, rdds[0]._jrdd, pair_jrdd_cls):
-            cls = pair_jrdd_cls
-        elif is_instance_of(gw, rdds[0]._jrdd, double_jrdd_cls):
-            cls = double_jrdd_cls
-        else:
-            raise TypeError("Unsupported java rdd class %s", rdds[0]._jrdd)
+        cls = SparkContext._jvm.org.apache.spark.api.java.JavaRDD
+        is_jrdd = is_instance_of(gw, rdds[0]._jrdd, cls)
         jrdds = gw.new_array(cls, len(rdds))
         for i in range(0, len(rdds)):
-            jrdds[i] = rdds[i]._jrdd
+            if is_jrdd:
+                jrdds[i] = rdds[i]._jrdd
+            else:
+                # zip could return JavaPairRDD hence we ensure `_jrdd`
+                # to be `JavaRDD` by wrapping it in a `map`
+                rdds[i] = rdds[i].map(lambda x: x)._jrdd
         return RDD(self._jsc.union(jrdds), self, rdds[0]._jrdd_deserializer)
 
     def broadcast(self, value):

--- a/python/pyspark/tests/test_rdd.py
+++ b/python/pyspark/tests/test_rdd.py
@@ -168,6 +168,15 @@ class RDDTests(ReusedPySparkTestCase):
             set([(x, (x, x)) for x in 'abc'])
         )
 
+    def test_union_pair_rdd(self):
+       # Regression test for SPARK-31788
+        rdd1 = self.sc.parallelize([1, 2])
+        rdd2 = self.sc.parallelize([3, 4])
+        pair_rdd = rdd1.zip(rdd2)
+        expected = [(1, 3), (2, 4), (1, 3), (2, 4)]
+        actual = self.sc.union([pair_rdd, pair_rdd]).collect()
+        self.assertEqual(expected, actual)
+
     def test_deleting_input_files(self):
         # Regression test for SPARK-1025
         tempFile = tempfile.NamedTemporaryFile(delete=False)

--- a/python/pyspark/tests/test_rdd.py
+++ b/python/pyspark/tests/test_rdd.py
@@ -169,7 +169,7 @@ class RDDTests(ReusedPySparkTestCase):
         )
 
     def test_union_pair_rdd(self):
-       # Regression test for SPARK-31788
+        # Regression test for SPARK-31788
         rdd1 = self.sc.parallelize([1, 2])
         rdd2 = self.sc.parallelize([3, 4])
         pair_rdd = rdd1.zip(rdd2)

--- a/python/pyspark/tests/test_rdd.py
+++ b/python/pyspark/tests/test_rdd.py
@@ -170,12 +170,12 @@ class RDDTests(ReusedPySparkTestCase):
 
     def test_union_pair_rdd(self):
         # Regression test for SPARK-31788
-        rdd1 = self.sc.parallelize([1, 2])
-        rdd2 = self.sc.parallelize([3, 4])
-        pair_rdd = rdd1.zip(rdd2)
-        expected = [(1, 3), (2, 4), (1, 3), (2, 4)]
-        actual = self.sc.union([pair_rdd, pair_rdd]).collect()
-        self.assertEqual(expected, actual)
+        rdd = self.sc.parallelize([1, 2])
+        pair_rdd = rdd.zip(rdd)
+        self.assertEqual(
+            self.sc.union([pair_rdd, pair_rdd]).collect(),
+            [((1, 1), (2, 2)), ((1, 1), (2, 2))]
+        )
 
     def test_deleting_input_files(self):
         # Regression test for SPARK-1025


### PR DESCRIPTION
### What changes were proposed in this pull request?
UnionRDD of PairRDDs causing a bug. The fix is to check for instance type before proceeding

### Why are the changes needed?
Changes are needed to avoid users running into issues with union rdd operation with any other type other than JavaRDD.

### Does this PR introduce _any_ user-facing change?
Yes

Before:
SparkSession available as 'spark'.
>>> rdd1 = sc.parallelize([1,2,3,4,5])
>>> rdd2 = sc.parallelize([6,7,8,9,10])
>>> pairRDD1 = rdd1.zip(rdd2)
>>> unionRDD1 = sc.union([pairRDD1, pairRDD1])
Traceback (most recent call last): File "<stdin>", line 1, in <module> File "/home/gs/spark/latest/python/pyspark/context.py", line 870,
in union jrdds[i] = rdds[i]._jrdd
File "/home/gs/spark/latest/python/lib/py4j-0.10.9-src.zip/py4j/java_collections.py", line 238, in setitem File "/home/gs/spark/latest/python/lib/py4j-0.10.9-src.zip/py4j/java_collections.py", line 221,
in __set_item File "/home/gs/spark/latest/python/lib/py4j-0.10.9-src.zip/py4j/protocol.py", line 332, in get_return_value py4j.protocol.Py4JError: An error occurred while calling None.None. Trace: py4j.Py4JException: Cannot convert org.apache.spark.api.java.JavaPairRDD to org.apache.spark.api.java.JavaRDD at py4j.commands.ArrayCommand.convertArgument(ArrayCommand.java:166) at py4j.commands.ArrayCommand.setArray(ArrayCommand.java:144) at py4j.commands.ArrayCommand.execute(ArrayCommand.java:97) at py4j.GatewayConnection.run(GatewayConnection.java:238) at java.lang.Thread.run(Thread.java:748)

After:
>>> rdd2 = sc.parallelize([6,7,8,9,10])
>>> pairRDD1 = rdd1.zip(rdd2)
>>> unionRDD1 = sc.union([pairRDD1, pairRDD1])
>>> unionRDD1.collect()
[(1, 6), (2, 7), (3, 8), (4, 9), (5, 10), (1, 6), (2, 7), (3, 8), (4, 9), (5, 10)]

### How was this patch tested?
Tested with the reproduced piece of code above manually