### PR TITLE
[SPARK-31755][SQL][FOLLOWUP] Update date-time, CSV and JSON benchmark results

### DIFF
--- a/sql/core/benchmarks/CSVBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/CSVBenchmark-jdk11-results.txt
@@ -2,66 +2,66 @@
 Benchmark to measure CSV read/write performance
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Parsing quoted values:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-One quoted string                                 24907          29374         NaN          0.0      498130.5       1.0X
+One quoted string                                 46568          46683         198          0.0      931358.6       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Wide rows with 1000 columns:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Select 1000 columns                               62811          63690        1416          0.0       62811.4       1.0X
-Select 100 columns                                23839          24064         230          0.0       23839.5       2.6X
-Select one column                                 19936          20641         827          0.1       19936.4       3.2X
-count()                                            4174           4380         206          0.2        4174.4      15.0X
-Select 100 columns, one bad input field           41015          42380        1688          0.0       41015.4       1.5X
-Select 100 columns, corrupt record field          46281          46338          93          0.0       46280.5       1.4X
+Select 1000 columns                              129836         130796        1404          0.0      129836.0       1.0X
+Select 100 columns                                40444          40679         261          0.0       40443.5       3.2X
+Select one column                                 33429          33475          73          0.0       33428.6       3.9X
+count()                                            7967           8047          73          0.1        7966.7      16.3X
+Select 100 columns, one bad input field           90639          90832         266          0.0       90638.6       1.4X
+Select 100 columns, corrupt record field         109023         109084          74          0.0      109023.3       1.2X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Count a dataset with 10 columns:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Select 10 columns + count()                       10810          10997         163          0.9        1081.0       1.0X
-Select 1 column + count()                          7608           7641          47          1.3         760.8       1.4X
-count()                                            2415           2462          77          4.1         241.5       4.5X
+Select 10 columns + count()                       20685          20707          35          0.5        2068.5       1.0X
+Select 1 column + count()                         13096          13149          49          0.8        1309.6       1.6X
+count()                                            3994           4001           7          2.5         399.4       5.2X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Write dates and timestamps:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Create a dataset of timestamps                      874            914          37         11.4          87.4       1.0X
-to_csv(timestamp)                                  7051           7223         250          1.4         705.1       0.1X
-write timestamps to files                          6712           6741          31          1.5         671.2       0.1X
-Create a dataset of dates                           909            945          35         11.0          90.9       1.0X
-to_csv(date)                                       4222           4231           8          2.4         422.2       0.2X
-write dates to files                               3799           3813          14          2.6         379.9       0.2X
+Create a dataset of timestamps                     2169           2203          32          4.6         216.9       1.0X
+to_csv(timestamp)                                 14401          14591         168          0.7        1440.1       0.2X
+write timestamps to files                         13209          13276          59          0.8        1320.9       0.2X
+Create a dataset of dates                          2231           2248          17          4.5         223.1       1.0X
+to_csv(date)                                      10406          10473          68          1.0        1040.6       0.2X
+write dates to files                               7970           7976           9          1.3         797.0       0.3X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Read dates and timestamps:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-read timestamp text from files                     1342           1364          35          7.5         134.2       1.0X
-read timestamps from files                        20300          20473         247          0.5        2030.0       0.1X
-infer timestamps from files                       40705          40744          54          0.2        4070.5       0.0X
-read date text from files                          1146           1151           6          8.7         114.6       1.2X
-read date from files                              12278          12408         117          0.8        1227.8       0.1X
-infer date from files                             12734          12872         220          0.8        1273.4       0.1X
-timestamp strings                                  1467           1482          15          6.8         146.7       0.9X
-parse timestamps from Dataset[String]             21708          22234         477          0.5        2170.8       0.1X
-infer timestamps from Dataset[String]             42357          43253         922          0.2        4235.7       0.0X
-date strings                                       1512           1532          18          6.6         151.2       0.9X
-parse dates from Dataset[String]                  13436          13470          33          0.7        1343.6       0.1X
-from_csv(timestamp)                               20390          20486          95          0.5        2039.0       0.1X
-from_csv(date)                                    12592          12693         139          0.8        1259.2       0.1X
+read timestamp text from files                     2387           2391           6          4.2         238.7       1.0X
+read timestamps from files                        53503          53593         124          0.2        5350.3       0.0X
+infer timestamps from files                      107988         108668         647          0.1       10798.8       0.0X
+read date text from files                          2121           2133          12          4.7         212.1       1.1X
+read date from files                              29983          30039          48          0.3        2998.3       0.1X
+infer date from files                             30196          30436         218          0.3        3019.6       0.1X
+timestamp strings                                  3098           3109          10          3.2         309.8       0.8X
+parse timestamps from Dataset[String]             63331          63426          84          0.2        6333.1       0.0X
+infer timestamps from Dataset[String]            124003         124463         490          0.1       12400.3       0.0X
+date strings                                       3423           3429          11          2.9         342.3       0.7X
+parse dates from Dataset[String]                  34235          34314          76          0.3        3423.5       0.1X
+from_csv(timestamp)                               60829          61600         668          0.2        6082.9       0.0X
+from_csv(date)                                    33047          33173         139          0.3        3304.7       0.1X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Filters pushdown:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-w/o filters                                       12535          12606          67          0.0      125348.8       1.0X
-pushdown disabled                                 12611          12672          91          0.0      126112.9       1.0X
-w/ filters                                         1093           1099          11          0.1       10928.3      11.5X
+w/o filters                                       28752          28765          16          0.0      287516.5       1.0X
+pushdown disabled                                 28856          28880          22          0.0      288556.3       1.0X
+w/ filters                                         1714           1731          15          0.1       17137.3      16.8X
 
 

--- a/sql/core/benchmarks/CSVBenchmark-results.txt
+++ b/sql/core/benchmarks/CSVBenchmark-results.txt
@@ -2,66 +2,66 @@
 Benchmark to measure CSV read/write performance
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Parsing quoted values:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-One quoted string                                 24073          24109          33          0.0      481463.5       1.0X
+One quoted string                                 45457          45731         344          0.0      909136.8       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Wide rows with 1000 columns:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Select 1000 columns                               58415          59611        2071          0.0       58414.8       1.0X
-Select 100 columns                                22568          23020         594          0.0       22568.0       2.6X
-Select one column                                 18995          19058          99          0.1       18995.0       3.1X
-count()                                            5301           5332          30          0.2        5300.9      11.0X
-Select 100 columns, one bad input field           39736          40153         361          0.0       39736.1       1.5X
-Select 100 columns, corrupt record field          47195          47826         590          0.0       47195.2       1.2X
+Select 1000 columns                              129646         130527        1412          0.0      129646.3       1.0X
+Select 100 columns                                42444          42551         119          0.0       42444.0       3.1X
+Select one column                                 35415          35428          20          0.0       35414.6       3.7X
+count()                                           11114          11128          16          0.1       11113.6      11.7X
+Select 100 columns, one bad input field           93353          93670         275          0.0       93352.6       1.4X
+Select 100 columns, corrupt record field         113569         113952         373          0.0      113568.8       1.1X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Count a dataset with 10 columns:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Select 10 columns + count()                        9884           9904          25          1.0         988.4       1.0X
-Select 1 column + count()                          6794           6835          46          1.5         679.4       1.5X
-count()                                            2060           2065           5          4.9         206.0       4.8X
+Select 10 columns + count()                       18498          18589          87          0.5        1849.8       1.0X
+Select 1 column + count()                         11078          11095          27          0.9        1107.8       1.7X
+count()                                            3928           3950          22          2.5         392.8       4.7X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Write dates and timestamps:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Create a dataset of timestamps                      717            732          18         14.0          71.7       1.0X
-to_csv(timestamp)                                  6994           7100         121          1.4         699.4       0.1X
-write timestamps to files                          6417           6435          27          1.6         641.7       0.1X
-Create a dataset of dates                           827            855          24         12.1          82.7       0.9X
-to_csv(date)                                       4408           4438          32          2.3         440.8       0.2X
-write dates to files                               3738           3758          28          2.7         373.8       0.2X
+Create a dataset of timestamps                     1933           1940          11          5.2         193.3       1.0X
+to_csv(timestamp)                                 18078          18243         255          0.6        1807.8       0.1X
+write timestamps to files                         12668          12786         134          0.8        1266.8       0.2X
+Create a dataset of dates                          2196           2201           5          4.6         219.6       0.9X
+to_csv(date)                                       9583           9597          21          1.0         958.3       0.2X
+write dates to files                               7091           7110          20          1.4         709.1       0.3X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Read dates and timestamps:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-read timestamp text from files                     1121           1176          52          8.9         112.1       1.0X
-read timestamps from files                        21298          21366         105          0.5        2129.8       0.1X
-infer timestamps from files                       41008          41051          39          0.2        4100.8       0.0X
-read date text from files                           962            967           5         10.4          96.2       1.2X
-read date from files                              11749          11772          22          0.9        1174.9       0.1X
-infer date from files                             12426          12459          29          0.8        1242.6       0.1X
-timestamp strings                                  1508           1519           9          6.6         150.8       0.7X
-parse timestamps from Dataset[String]             21674          21997         455          0.5        2167.4       0.1X
-infer timestamps from Dataset[String]             42141          42230         105          0.2        4214.1       0.0X
-date strings                                       1694           1701           8          5.9         169.4       0.7X
-parse dates from Dataset[String]                  12929          12951          25          0.8        1292.9       0.1X
-from_csv(timestamp)                               20603          20786         166          0.5        2060.3       0.1X
-from_csv(date)                                    12325          12338          12          0.8        1232.5       0.1X
+read timestamp text from files                     2166           2177          10          4.6         216.6       1.0X
+read timestamps from files                        53212          53402         281          0.2        5321.2       0.0X
+infer timestamps from files                      109788         110372         570          0.1       10978.8       0.0X
+read date text from files                          1921           1929           8          5.2         192.1       1.1X
+read date from files                              25470          25499          25          0.4        2547.0       0.1X
+infer date from files                             27201          27342         134          0.4        2720.1       0.1X
+timestamp strings                                  3638           3653          19          2.7         363.8       0.6X
+parse timestamps from Dataset[String]             61894          62532         555          0.2        6189.4       0.0X
+infer timestamps from Dataset[String]            125171         125430         236          0.1       12517.1       0.0X
+date strings                                       3736           3749          14          2.7         373.6       0.6X
+parse dates from Dataset[String]                  30787          30829          43          0.3        3078.7       0.1X
+from_csv(timestamp)                               60842          61035         209          0.2        6084.2       0.0X
+from_csv(date)                                    30123          30196          95          0.3        3012.3       0.1X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Filters pushdown:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-w/o filters                                       12455          12474          22          0.0      124553.8       1.0X
-pushdown disabled                                 12462          12486          29          0.0      124624.9       1.0X
-w/ filters                                         1073           1092          18          0.1       10727.6      11.6X
+w/o filters                                       28985          29042          80          0.0      289852.9       1.0X
+pushdown disabled                                 29080          29146          58          0.0      290799.4       1.0X
+w/ filters                                         2072           2084          17          0.0       20722.3      14.0X
 
 

--- a/sql/core/benchmarks/DateTimeBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-jdk11-results.txt
@@ -6,18 +6,18 @@ OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-106
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 datetime +/- interval:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date + interval(m)                                 1496           1569         104          6.7         149.6       1.0X
-date + interval(m, d)                              1514           1526          17          6.6         151.4       1.0X
-date + interval(m, d, ms)                          6231           6253          30          1.6         623.1       0.2X
-date - interval(m)                                 1481           1487           9          6.8         148.1       1.0X
-date - interval(m, d)                              1550           1552           2          6.5         155.0       1.0X
-date - interval(m, d, ms)                          6269           6272           4          1.6         626.9       0.2X
-timestamp + interval(m)                            3017           3056          54          3.3         301.7       0.5X
-timestamp + interval(m, d)                         3146           3148           3          3.2         314.6       0.5X
-timestamp + interval(m, d, ms)                     3446           3460          20          2.9         344.6       0.4X
-timestamp - interval(m)                            3045           3059          19          3.3         304.5       0.5X
-timestamp - interval(m, d)                         3147           3164          25          3.2         314.7       0.5X
-timestamp - interval(m, d, ms)                     3425           3442          25          2.9         342.5       0.4X
+date + interval(m)                                 1660           1745         120          6.0         166.0       1.0X
+date + interval(m, d)                              1672           1685          19          6.0         167.2       1.0X
+date + interval(m, d, ms)                          6462           6481          27          1.5         646.2       0.3X
+date - interval(m)                                 1456           1480          35          6.9         145.6       1.1X
+date - interval(m, d)                              1501           1509          11          6.7         150.1       1.1X
+date - interval(m, d, ms)                          6457           6466          12          1.5         645.7       0.3X
+timestamp + interval(m)                            2941           2944           4          3.4         294.1       0.6X
+timestamp + interval(m, d)                         3008           3012           6          3.3         300.8       0.6X
+timestamp + interval(m, d, ms)                     3329           3333           6          3.0         332.9       0.5X
+timestamp - interval(m)                            2964           2982          26          3.4         296.4       0.6X
+timestamp - interval(m, d)                         3030           3039          13          3.3         303.0       0.5X
+timestamp - interval(m, d, ms)                     3312           3313           1          3.0         331.2       0.5X
 
 
 ================================================================================================
@@ -28,92 +28,92 @@ OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-106
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    332            336           5         30.1          33.2       1.0X
-cast to timestamp wholestage on                     333            344          10         30.0          33.3       1.0X
+cast to timestamp wholestage off                    333            334           0         30.0          33.3       1.0X
+cast to timestamp wholestage on                     349            368          12         28.6          34.9       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                   1246           1257          16          8.0         124.6       1.0X
-year of timestamp wholestage on                    1209           1218          12          8.3         120.9       1.0X
+year of timestamp wholestage off                   1229           1229           1          8.1         122.9       1.0X
+year of timestamp wholestage on                    1218           1223           5          8.2         121.8       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                1608           1616          11          6.2         160.8       1.0X
-quarter of timestamp wholestage on                 1540           1552          10          6.5         154.0       1.0X
+quarter of timestamp wholestage off                1593           1594           2          6.3         159.3       1.0X
+quarter of timestamp wholestage on                 1515           1529          14          6.6         151.5       1.1X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                  1242           1246           6          8.1         124.2       1.0X
-month of timestamp wholestage on                   1202           1212          11          8.3         120.2       1.0X
+month of timestamp wholestage off                  1222           1246          34          8.2         122.2       1.0X
+month of timestamp wholestage on                   1207           1232          31          8.3         120.7       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off             1879           1885           8          5.3         187.9       1.0X
-weekofyear of timestamp wholestage on              1832           1845          10          5.5         183.2       1.0X
+weekofyear of timestamp wholestage off             2453           2455           2          4.1         245.3       1.0X
+weekofyear of timestamp wholestage on              2357           2380          22          4.2         235.7       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                    1236           1239           4          8.1         123.6       1.0X
-day of timestamp wholestage on                     1206           1219          17          8.3         120.6       1.0X
+day of timestamp wholestage off                    1216           1219           5          8.2         121.6       1.0X
+day of timestamp wholestage on                     1205           1221          25          8.3         120.5       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off              1308           1309           1          7.6         130.8       1.0X
-dayofyear of timestamp wholestage on               1239           1255          15          8.1         123.9       1.1X
+dayofyear of timestamp wholestage off              1268           1274           9          7.9         126.8       1.0X
+dayofyear of timestamp wholestage on               1253           1268          10          8.0         125.3       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off             1259           1263           5          7.9         125.9       1.0X
-dayofmonth of timestamp wholestage on              1201           1205           5          8.3         120.1       1.0X
+dayofmonth of timestamp wholestage off             1223           1224           1          8.2         122.3       1.0X
+dayofmonth of timestamp wholestage on              1231           1246          14          8.1         123.1       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off              1406           1410           6          7.1         140.6       1.0X
-dayofweek of timestamp wholestage on               1387           1402          15          7.2         138.7       1.0X
+dayofweek of timestamp wholestage off              1398           1406          12          7.2         139.8       1.0X
+dayofweek of timestamp wholestage on               1387           1399          15          7.2         138.7       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                1355           1367          18          7.4         135.5       1.0X
-weekday of timestamp wholestage on                 1311           1321          10          7.6         131.1       1.0X
+weekday of timestamp wholestage off                1327           1333           9          7.5         132.7       1.0X
+weekday of timestamp wholestage on                 1329           1333           4          7.5         132.9       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                    996            997           2         10.0          99.6       1.0X
-hour of timestamp wholestage on                     930            936           6         10.7          93.0       1.1X
+hour of timestamp wholestage off                   1005           1016          15          9.9         100.5       1.0X
+hour of timestamp wholestage on                     934            940           4         10.7          93.4       1.1X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                 1005           1012          10          9.9         100.5       1.0X
-minute of timestamp wholestage on                   949            952           3         10.5          94.9       1.1X
+minute of timestamp wholestage off                 1003           1009           8         10.0         100.3       1.0X
+minute of timestamp wholestage on                   934            938           7         10.7          93.4       1.1X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                 1013           1014           1          9.9         101.3       1.0X
-second of timestamp wholestage on                   933            934           2         10.7          93.3       1.1X
+second of timestamp wholestage off                  997            998           2         10.0          99.7       1.0X
+second of timestamp wholestage on                   925            935           8         10.8          92.5       1.1X
 
 
 ================================================================================================
@@ -124,15 +124,15 @@ OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-106
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         291            293           2         34.3          29.1       1.0X
-current_date wholestage on                          280            284           3         35.7          28.0       1.0X
+current_date wholestage off                         297            297           0         33.7          29.7       1.0X
+current_date wholestage on                          280            282           2         35.7          28.0       1.1X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    311            324          18         32.1          31.1       1.0X
-current_timestamp wholestage on                     275            364          85         36.3          27.5       1.1X
+current_timestamp wholestage off                    307            337          43         32.6          30.7       1.0X
+current_timestamp wholestage on                     260            284          29         38.4          26.0       1.2X
 
 
 ================================================================================================
@@ -143,43 +143,43 @@ OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-106
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                        1077           1079           3          9.3         107.7       1.0X
-cast to date wholestage on                         1018           1030          14          9.8         101.8       1.1X
+cast to date wholestage off                        1066           1073          10          9.4         106.6       1.0X
+cast to date wholestage on                          997           1003           6         10.0          99.7       1.1X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                            1257           1260           4          8.0         125.7       1.0X
-last_day wholestage on                             1218           1227          14          8.2         121.8       1.0X
+last_day wholestage off                            1238           1242           6          8.1         123.8       1.0X
+last_day wholestage on                             1259           1272          12          7.9         125.9       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                            1140           1141           1          8.8         114.0       1.0X
-next_day wholestage on                             1067           1076          11          9.4         106.7       1.1X
+next_day wholestage off                            1116           1138          32          9.0         111.6       1.0X
+next_day wholestage on                             1052           1063          11          9.5         105.2       1.1X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                            1062           1064           3          9.4         106.2       1.0X
-date_add wholestage on                             1046           1055          11          9.6         104.6       1.0X
+date_add wholestage off                            1048           1049           1          9.5         104.8       1.0X
+date_add wholestage on                             1035           1039           3          9.7         103.5       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                            1082           1083           1          9.2         108.2       1.0X
-date_sub wholestage on                             1047           1056          12          9.6         104.7       1.0X
+date_sub wholestage off                            1119           1127          11          8.9         111.9       1.0X
+date_sub wholestage on                             1028           1039           7          9.7         102.8       1.1X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                          1430           1431           1          7.0         143.0       1.0X
-add_months wholestage on                           1441           1446           8          6.9         144.1       1.0X
+add_months wholestage off                          1421           1421           0          7.0         142.1       1.0X
+add_months wholestage on                           1423           1434          11          7.0         142.3       1.0X
 
 
 ================================================================================================
@@ -190,8 +190,8 @@ OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-106
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         5442           5549         150          1.8         544.2       1.0X
-format date wholestage on                          5529           5655         236          1.8         552.9       1.0X
+format date wholestage off                         5293           5296           5          1.9         529.3       1.0X
+format date wholestage on                          5143           5157          19          1.9         514.3       1.0X
 
 
 ================================================================================================
@@ -202,8 +202,8 @@ OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-106
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       7416           7440          34          1.3         741.6       1.0X
-from_unixtime wholestage on                        7372           7391          17          1.4         737.2       1.0X
+from_unixtime wholestage off                       7136           7136           1          1.4         713.6       1.0X
+from_unixtime wholestage on                        7049           7068          29          1.4         704.9       1.0X
 
 
 ================================================================================================
@@ -214,15 +214,15 @@ OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-106
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                  1316           1320           6          7.6         131.6       1.0X
-from_utc_timestamp wholestage on                   1268           1272           4          7.9         126.8       1.0X
+from_utc_timestamp wholestage off                  1325           1329           6          7.5         132.5       1.0X
+from_utc_timestamp wholestage on                   1269           1273           4          7.9         126.9       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                    1653           1657           6          6.0         165.3       1.0X
-to_utc_timestamp wholestage on                     1594           1599           4          6.3         159.4       1.0X
+to_utc_timestamp wholestage off                    1684           1691          10          5.9         168.4       1.0X
+to_utc_timestamp wholestage on                     1641           1648           9          6.1         164.1       1.0X
 
 
 ================================================================================================
@@ -233,29 +233,29 @@ OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-106
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        341            343           3         29.4          34.1       1.0X
-cast interval wholestage on                         279            282           1         35.8          27.9       1.2X
+cast interval wholestage off                        343            346           4         29.1          34.3       1.0X
+cast interval wholestage on                         281            282           1         35.6          28.1       1.2X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                            1862           1865           4          5.4         186.2       1.0X
-datediff wholestage on                             1769           1783          15          5.7         176.9       1.1X
+datediff wholestage off                            1831           1840          13          5.5         183.1       1.0X
+datediff wholestage on                             1759           1769          15          5.7         175.9       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      5594           5599           7          1.8         559.4       1.0X
-months_between wholestage on                       5498           5508          11          1.8         549.8       1.0X
+months_between wholestage off                      5729           5747          25          1.7         572.9       1.0X
+months_between wholestage on                       5710           5720           9          1.8         571.0       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                              2044           2127         117          0.5        2044.3       1.0X
-window wholestage on                              48057          48109          54          0.0       48056.9       0.0X
+window wholestage off                              2183           2189           9          0.5        2182.6       1.0X
+window wholestage on                              46835          46944          88          0.0       46834.8       0.0X
 
 
 ================================================================================================
@@ -266,134 +266,134 @@ OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-106
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                     2540           2542           3          3.9         254.0       1.0X
-date_trunc YEAR wholestage on                      2486           2507          29          4.0         248.6       1.0X
+date_trunc YEAR wholestage off                     2668           2672           5          3.7         266.8       1.0X
+date_trunc YEAR wholestage on                      2719           2731           9          3.7         271.9       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                     2542           2543           3          3.9         254.2       1.0X
-date_trunc YYYY wholestage on                      2491           2498           9          4.0         249.1       1.0X
+date_trunc YYYY wholestage off                     2672           2677           8          3.7         267.2       1.0X
+date_trunc YYYY wholestage on                      2710           2726          12          3.7         271.0       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                       2545           2569          35          3.9         254.5       1.0X
-date_trunc YY wholestage on                        2487           2493           4          4.0         248.7       1.0X
+date_trunc YY wholestage off                       2670           2673           4          3.7         267.0       1.0X
+date_trunc YY wholestage on                        2711           2720           7          3.7         271.1       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                      2590           2590           1          3.9         259.0       1.0X
-date_trunc MON wholestage on                       2506           2520          12          4.0         250.6       1.0X
+date_trunc MON wholestage off                      2674           2674           0          3.7         267.4       1.0X
+date_trunc MON wholestage on                       2667           2677          10          3.7         266.7       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                    2595           2603          11          3.9         259.5       1.0X
-date_trunc MONTH wholestage on                     2505           2516          12          4.0         250.5       1.0X
+date_trunc MONTH wholestage off                    2675           2686          16          3.7         267.5       1.0X
+date_trunc MONTH wholestage on                     2667           2674           6          3.7         266.7       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                       2605           2612          10          3.8         260.5       1.0X
-date_trunc MM wholestage on                        2501           2515          11          4.0         250.1       1.0X
+date_trunc MM wholestage off                       2673           2674           1          3.7         267.3       1.0X
+date_trunc MM wholestage on                        2664           2669           4          3.8         266.4       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                      2225           2229           5          4.5         222.5       1.0X
-date_trunc DAY wholestage on                       2184           2196           9          4.6         218.4       1.0X
+date_trunc DAY wholestage off                      2281           2288          10          4.4         228.1       1.0X
+date_trunc DAY wholestage on                       2302           2312           8          4.3         230.2       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                       2232           2236           6          4.5         223.2       1.0X
-date_trunc DD wholestage on                        2183           2190           6          4.6         218.3       1.0X
+date_trunc DD wholestage off                       2281           2283           3          4.4         228.1       1.0X
+date_trunc DD wholestage on                        2291           2302          11          4.4         229.1       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                     2194           2199           7          4.6         219.4       1.0X
-date_trunc HOUR wholestage on                      2160           2166           5          4.6         216.0       1.0X
+date_trunc HOUR wholestage off                     2331           2332           1          4.3         233.1       1.0X
+date_trunc HOUR wholestage on                      2290           2304          11          4.4         229.0       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    390            396           9         25.7          39.0       1.0X
-date_trunc MINUTE wholestage on                     331            337           7         30.2          33.1       1.2X
+date_trunc MINUTE wholestage off                    379            385           9         26.4          37.9       1.0X
+date_trunc MINUTE wholestage on                     371            376           5         27.0          37.1       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    375            381           8         26.7          37.5       1.0X
-date_trunc SECOND wholestage on                     332            346          14         30.1          33.2       1.1X
+date_trunc SECOND wholestage off                    375            376           1         26.7          37.5       1.0X
+date_trunc SECOND wholestage on                     370            376           8         27.0          37.0       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                     2439           2443           6          4.1         243.9       1.0X
-date_trunc WEEK wholestage on                      2390           2409          32          4.2         239.0       1.0X
+date_trunc WEEK wholestage off                     2597           2604          10          3.9         259.7       1.0X
+date_trunc WEEK wholestage on                      2591           2605          13          3.9         259.1       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                  3290           3292           4          3.0         329.0       1.0X
-date_trunc QUARTER wholestage on                   3214           3218           3          3.1         321.4       1.0X
+date_trunc QUARTER wholestage off                  3501           3511          14          2.9         350.1       1.0X
+date_trunc QUARTER wholestage on                   3477           3489           9          2.9         347.7       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           308            310           3         32.5          30.8       1.0X
-trunc year wholestage on                            289            293           6         34.7          28.9       1.1X
+trunc year wholestage off                           332            334           3         30.1          33.2       1.0X
+trunc year wholestage on                            332            346          17         30.1          33.2       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           309            311           3         32.4          30.9       1.0X
-trunc yyyy wholestage on                            289            294           7         34.6          28.9       1.1X
+trunc yyyy wholestage off                           331            331           0         30.2          33.1       1.0X
+trunc yyyy wholestage on                            336            339           4         29.8          33.6       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             311            311           0         32.2          31.1       1.0X
-trunc yy wholestage on                              288            294           7         34.7          28.8       1.1X
+trunc yy wholestage off                             330            342          17         30.3          33.0       1.0X
+trunc yy wholestage on                              333            337           3         30.0          33.3       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            313            313           0         32.0          31.3       1.0X
-trunc mon wholestage on                             287            290           2         34.8          28.7       1.1X
+trunc mon wholestage off                            334            335           1         30.0          33.4       1.0X
+trunc mon wholestage on                             333            347           9         30.0          33.3       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          310            310           0         32.3          31.0       1.0X
-trunc month wholestage on                           287            290           2         34.8          28.7       1.1X
+trunc month wholestage off                          332            333           1         30.1          33.2       1.0X
+trunc month wholestage on                           333            340           7         30.0          33.3       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             311            312           1         32.1          31.1       1.0X
-trunc mm wholestage on                              287            296           9         34.8          28.7       1.1X
+trunc mm wholestage off                             328            336          11         30.5          32.8       1.0X
+trunc mm wholestage on                              333            343          11         30.0          33.3       1.0X
 
 
 ================================================================================================
@@ -404,36 +404,36 @@ OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-106
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                     169            170           1          5.9         168.9       1.0X
-to timestamp str wholestage on                      161            168          11          6.2         161.0       1.0X
+to timestamp str wholestage off                     170            171           1          5.9         170.1       1.0X
+to timestamp str wholestage on                      172            174           2          5.8         171.6       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                        1360           1361           1          0.7        1359.6       1.0X
-to_timestamp wholestage on                         1362           1366           6          0.7        1362.0       1.0X
+to_timestamp wholestage off                        1437           1439           3          0.7        1437.0       1.0X
+to_timestamp wholestage on                         1288           1292           5          0.8        1288.1       1.1X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                   1343           1346           4          0.7        1342.6       1.0X
-to_unix_timestamp wholestage on                    1356           1359           2          0.7        1356.2       1.0X
+to_unix_timestamp wholestage off                   1352           1353           2          0.7        1352.0       1.0X
+to_unix_timestamp wholestage on                    1314           1319           5          0.8        1314.4       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          227            230           4          4.4         227.0       1.0X
-to date str wholestage on                           299            302           3          3.3         299.0       0.8X
+to date str wholestage off                          211            215           6          4.7         210.7       1.0X
+to date str wholestage on                           217            217           1          4.6         216.5       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                             3413           3440          38          0.3        3413.0       1.0X
-to_date wholestage on                              3392           3402          12          0.3        3392.3       1.0X
+to_date wholestage off                             3281           3295          20          0.3        3280.9       1.0X
+to_date wholestage on                              3223           3239          17          0.3        3222.8       1.0X
 
 
 ================================================================================================
@@ -444,14 +444,14 @@ OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-106
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 To/from Java's date-time:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Date                                  410            415           7         12.2          82.0       1.0X
-From java.time.LocalDate                            332            333           1         15.1          66.4       1.2X
-Collect java.sql.Date                              1891           2542         829          2.6         378.1       0.2X
-Collect java.time.LocalDate                        1630           2138         441          3.1         326.0       0.3X
-From java.sql.Timestamp                             254            259           6         19.7          50.9       1.6X
-From java.time.Instant                              302            306           4         16.6          60.3       1.4X
-Collect longs                                      1134           1265         117          4.4         226.8       0.4X
-Collect java.sql.Timestamp                         1441           1458          16          3.5         288.1       0.3X
-Collect java.time.Instant                          1680           1928         253          3.0         336.0       0.2X
+From java.sql.Date                                  446            447           1         11.2          89.1       1.0X
+From java.time.LocalDate                            354            356           1         14.1          70.8       1.3X
+Collect java.sql.Date                              2722           3091         495          1.8         544.4       0.2X
+Collect java.time.LocalDate                        1786           1836          60          2.8         357.2       0.2X
+From java.sql.Timestamp                             275            287          19         18.2          55.0       1.6X
+From java.time.Instant                              325            328           3         15.4          65.0       1.4X
+Collect longs                                      1300           1321          25          3.8         260.0       0.3X
+Collect java.sql.Timestamp                         1450           1557         102          3.4         290.0       0.3X
+Collect java.time.Instant                          1499           1599          87          3.3         299.9       0.3X
 
 

--- a/sql/core/benchmarks/DateTimeBenchmark-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-results.txt
@@ -6,18 +6,18 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 datetime +/- interval:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date + interval(m)                                 1638           1701          89          6.1         163.8       1.0X
-date + interval(m, d)                              1785           1790           7          5.6         178.5       0.9X
-date + interval(m, d, ms)                          6229           6270          58          1.6         622.9       0.3X
-date - interval(m)                                 1500           1503           4          6.7         150.0       1.1X
-date - interval(m, d)                              1764           1766           3          5.7         176.4       0.9X
-date - interval(m, d, ms)                          6428           6446          25          1.6         642.8       0.3X
-timestamp + interval(m)                            2719           2722           4          3.7         271.9       0.6X
-timestamp + interval(m, d)                         3011           3021          14          3.3         301.1       0.5X
-timestamp + interval(m, d, ms)                     3405           3412           9          2.9         340.5       0.5X
-timestamp - interval(m)                            2759           2764           7          3.6         275.9       0.6X
-timestamp - interval(m, d)                         3094           3112          25          3.2         309.4       0.5X
-timestamp - interval(m, d, ms)                     3388           3392           5          3.0         338.8       0.5X
+date + interval(m)                                 1555           1634         113          6.4         155.5       1.0X
+date + interval(m, d)                              1774           1797          33          5.6         177.4       0.9X
+date + interval(m, d, ms)                          6293           6335          59          1.6         629.3       0.2X
+date - interval(m)                                 1461           1468          10          6.8         146.1       1.1X
+date - interval(m, d)                              1741           1741           0          5.7         174.1       0.9X
+date - interval(m, d, ms)                          6503           6518          21          1.5         650.3       0.2X
+timestamp + interval(m)                            2384           2385           1          4.2         238.4       0.7X
+timestamp + interval(m, d)                         2683           2684           2          3.7         268.3       0.6X
+timestamp + interval(m, d, ms)                     2987           3001          19          3.3         298.7       0.5X
+timestamp - interval(m)                            2391           2395           5          4.2         239.1       0.7X
+timestamp - interval(m, d)                         2674           2684          14          3.7         267.4       0.6X
+timestamp - interval(m, d, ms)                     3005           3007           3          3.3         300.5       0.5X
 
 
 ================================================================================================
@@ -28,92 +28,92 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    319            323           6         31.4          31.9       1.0X
-cast to timestamp wholestage on                     304            311           8         32.9          30.4       1.0X
+cast to timestamp wholestage off                    313            320          10         31.9          31.3       1.0X
+cast to timestamp wholestage on                     325            341          18         30.8          32.5       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                   1234           1239           6          8.1         123.4       1.0X
-year of timestamp wholestage on                    1229           1244          22          8.1         122.9       1.0X
+year of timestamp wholestage off                   1216           1216           1          8.2         121.6       1.0X
+year of timestamp wholestage on                    1226           1243          13          8.2         122.6       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                1440           1445           7          6.9         144.0       1.0X
-quarter of timestamp wholestage on                 1358           1361           3          7.4         135.8       1.1X
+quarter of timestamp wholestage off                1417           1421           5          7.1         141.7       1.0X
+quarter of timestamp wholestage on                 1358           1365           8          7.4         135.8       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                  1239           1240           1          8.1         123.9       1.0X
-month of timestamp wholestage on                   1221           1239          26          8.2         122.1       1.0X
+month of timestamp wholestage off                  1219           1220           1          8.2         121.9       1.0X
+month of timestamp wholestage on                   1222           1227           7          8.2         122.2       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off             1926           1934          11          5.2         192.6       1.0X
-weekofyear of timestamp wholestage on              1901           1911          10          5.3         190.1       1.0X
+weekofyear of timestamp wholestage off             1950           1950           0          5.1         195.0       1.0X
+weekofyear of timestamp wholestage on              1890           1899           8          5.3         189.0       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                    1225           1229           6          8.2         122.5       1.0X
-day of timestamp wholestage on                     1217           1225           7          8.2         121.7       1.0X
+day of timestamp wholestage off                    1212           1213           2          8.3         121.2       1.0X
+day of timestamp wholestage on                     1216           1227          13          8.2         121.6       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off              1290           1295           7          7.8         129.0       1.0X
-dayofyear of timestamp wholestage on               1262           1270           7          7.9         126.2       1.0X
+dayofyear of timestamp wholestage off              1282           1284           3          7.8         128.2       1.0X
+dayofyear of timestamp wholestage on               1269           1274           5          7.9         126.9       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off             1239           1239           1          8.1         123.9       1.0X
-dayofmonth of timestamp wholestage on              1215           1222           8          8.2         121.5       1.0X
+dayofmonth of timestamp wholestage off             1214           1219           7          8.2         121.4       1.0X
+dayofmonth of timestamp wholestage on              1216           1224           6          8.2         121.6       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off              1421           1422           2          7.0         142.1       1.0X
-dayofweek of timestamp wholestage on               1379           1388           8          7.3         137.9       1.0X
+dayofweek of timestamp wholestage off              1403           1430          39          7.1         140.3       1.0X
+dayofweek of timestamp wholestage on               1378           1386           8          7.3         137.8       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                1349           1351           2          7.4         134.9       1.0X
-weekday of timestamp wholestage on                 1320           1327           8          7.6         132.0       1.0X
+weekday of timestamp wholestage off                1344           1353          13          7.4         134.4       1.0X
+weekday of timestamp wholestage on                 1316           1322           5          7.6         131.6       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                   1024           1024           0          9.8         102.4       1.0X
-hour of timestamp wholestage on                     921            929          11         10.9          92.1       1.1X
+hour of timestamp wholestage off                    992           1000          10         10.1          99.2       1.0X
+hour of timestamp wholestage on                     960            962           3         10.4          96.0       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  977            982           6         10.2          97.7       1.0X
-minute of timestamp wholestage on                   927            929           2         10.8          92.7       1.1X
+minute of timestamp wholestage off                  989           1000          16         10.1          98.9       1.0X
+minute of timestamp wholestage on                   965            974          13         10.4          96.5       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  987            989           3         10.1          98.7       1.0X
-second of timestamp wholestage on                   923            926           5         10.8          92.3       1.1X
+second of timestamp wholestage off                  974            977           5         10.3          97.4       1.0X
+second of timestamp wholestage on                   959            966           8         10.4          95.9       1.0X
 
 
 ================================================================================================
@@ -124,15 +124,15 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         303            311          12         33.0          30.3       1.0X
-current_date wholestage on                          266            271           5         37.5          26.6       1.1X
+current_date wholestage off                         281            282           2         35.6          28.1       1.0X
+current_date wholestage on                          294            300           5         34.0          29.4       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    297            297           1         33.7          29.7       1.0X
-current_timestamp wholestage on                     264            272           7         37.8          26.4       1.1X
+current_timestamp wholestage off                    282            296          19         35.4          28.2       1.0X
+current_timestamp wholestage on                     304            331          31         32.9          30.4       0.9X
 
 
 ================================================================================================
@@ -143,43 +143,43 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                        1062           1063           2          9.4         106.2       1.0X
-cast to date wholestage on                         1007           1021          20          9.9         100.7       1.1X
+cast to date wholestage off                        1060           1061           1          9.4         106.0       1.0X
+cast to date wholestage on                         1021           1026          10          9.8         102.1       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                            1262           1265           5          7.9         126.2       1.0X
-last_day wholestage on                             1244           1256          14          8.0         124.4       1.0X
+last_day wholestage off                            1278           1280           3          7.8         127.8       1.0X
+last_day wholestage on                             1560           1566           6          6.4         156.0       0.8X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                            1119           1121           2          8.9         111.9       1.0X
-next_day wholestage on                             1057           1063           6          9.5         105.7       1.1X
+next_day wholestage off                            1091           1093           3          9.2         109.1       1.0X
+next_day wholestage on                             1070           1076           9          9.3         107.0       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                            1054           1059           7          9.5         105.4       1.0X
-date_add wholestage on                             1037           1069          52          9.6         103.7       1.0X
+date_add wholestage off                            1041           1047           8          9.6         104.1       1.0X
+date_add wholestage on                             1044           1050           4          9.6         104.4       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                            1054           1056           4          9.5         105.4       1.0X
-date_sub wholestage on                             1036           1040           4          9.7         103.6       1.0X
+date_sub wholestage off                            1038           1040           3          9.6         103.8       1.0X
+date_sub wholestage on                             1057           1061           4          9.5         105.7       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                          1408           1421          19          7.1         140.8       1.0X
-add_months wholestage on                           1434           1440           7          7.0         143.4       1.0X
+add_months wholestage off                          1401           1401           1          7.1         140.1       1.0X
+add_months wholestage on                           1438           1442           4          7.0         143.8       1.0X
 
 
 ================================================================================================
@@ -190,8 +190,8 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         5937           6169         328          1.7         593.7       1.0X
-format date wholestage on                          5836           5878          74          1.7         583.6       1.0X
+format date wholestage off                         5482           5803         454          1.8         548.2       1.0X
+format date wholestage on                          5502           5518           9          1.8         550.2       1.0X
 
 
 ================================================================================================
@@ -202,8 +202,8 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       8904           8914          14          1.1         890.4       1.0X
-from_unixtime wholestage on                        8918           8936          13          1.1         891.8       1.0X
+from_unixtime wholestage off                       8538           8553          22          1.2         853.8       1.0X
+from_unixtime wholestage on                        8545           8552           6          1.2         854.5       1.0X
 
 
 ================================================================================================
@@ -214,15 +214,15 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                  1110           1112           3          9.0         111.0       1.0X
-from_utc_timestamp wholestage on                   1115           1119           3          9.0         111.5       1.0X
+from_utc_timestamp wholestage off                  1094           1099           8          9.1         109.4       1.0X
+from_utc_timestamp wholestage on                   1109           1114           5          9.0         110.9       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                    1524           1525           1          6.6         152.4       1.0X
-to_utc_timestamp wholestage on                     1450           1458          14          6.9         145.0       1.1X
+to_utc_timestamp wholestage off                    1466           1469           4          6.8         146.6       1.0X
+to_utc_timestamp wholestage on                     1401           1408           7          7.1         140.1       1.0X
 
 
 ================================================================================================
@@ -233,29 +233,29 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        341            342           1         29.3          34.1       1.0X
-cast interval wholestage on                         285            294           7         35.1          28.5       1.2X
+cast interval wholestage off                        332            332           0         30.1          33.2       1.0X
+cast interval wholestage on                         315            324          10         31.7          31.5       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                            1874           1881          10          5.3         187.4       1.0X
-datediff wholestage on                             1785           1791           3          5.6         178.5       1.0X
+datediff wholestage off                            1796           1802           8          5.6         179.6       1.0X
+datediff wholestage on                             1758           1764          10          5.7         175.8       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      5038           5042           5          2.0         503.8       1.0X
-months_between wholestage on                       4979           4987           8          2.0         497.9       1.0X
+months_between wholestage off                      4833           4836           4          2.1         483.3       1.0X
+months_between wholestage on                       4777           4780           2          2.1         477.7       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                              1716           1841         177          0.6        1716.2       1.0X
-window wholestage on                              46024          46063          27          0.0       46024.1       0.0X
+window wholestage off                              1812           1908         136          0.6        1811.7       1.0X
+window wholestage on                              46279          46376          74          0.0       46278.8       0.0X
 
 
 ================================================================================================
@@ -266,134 +266,134 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                     2428           2429           2          4.1         242.8       1.0X
-date_trunc YEAR wholestage on                      2451           2469          12          4.1         245.1       1.0X
+date_trunc YEAR wholestage off                     2367           2368           1          4.2         236.7       1.0X
+date_trunc YEAR wholestage on                      2321           2334          22          4.3         232.1       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                     2423           2426           3          4.1         242.3       1.0X
-date_trunc YYYY wholestage on                      2454           2462           8          4.1         245.4       1.0X
+date_trunc YYYY wholestage off                     2330           2334           5          4.3         233.0       1.0X
+date_trunc YYYY wholestage on                      2326           2332           5          4.3         232.6       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                       2421           2441          28          4.1         242.1       1.0X
-date_trunc YY wholestage on                        2453           2461           9          4.1         245.3       1.0X
+date_trunc YY wholestage off                       2334           2335           1          4.3         233.4       1.0X
+date_trunc YY wholestage on                        2315           2324           6          4.3         231.5       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                      2425           2427           3          4.1         242.5       1.0X
-date_trunc MON wholestage on                       2431           2438           9          4.1         243.1       1.0X
+date_trunc MON wholestage off                      2327           2330           4          4.3         232.7       1.0X
+date_trunc MON wholestage on                       2279           2289          12          4.4         227.9       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                    2427           2433           8          4.1         242.7       1.0X
-date_trunc MONTH wholestage on                     2429           2435           4          4.1         242.9       1.0X
+date_trunc MONTH wholestage off                    2330           2332           2          4.3         233.0       1.0X
+date_trunc MONTH wholestage on                     2277           2284           6          4.4         227.7       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                       2425           2431           9          4.1         242.5       1.0X
-date_trunc MM wholestage on                        2430           2435           4          4.1         243.0       1.0X
+date_trunc MM wholestage off                       2328           2329           2          4.3         232.8       1.0X
+date_trunc MM wholestage on                        2279           2284           4          4.4         227.9       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                      2117           2119           4          4.7         211.7       1.0X
-date_trunc DAY wholestage on                       2036           2118         174          4.9         203.6       1.0X
+date_trunc DAY wholestage off                      1974           1984          14          5.1         197.4       1.0X
+date_trunc DAY wholestage on                       1914           1922           7          5.2         191.4       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                       2116           2119           5          4.7         211.6       1.0X
-date_trunc DD wholestage on                        2035           2043          10          4.9         203.5       1.0X
+date_trunc DD wholestage off                       1967           1976          12          5.1         196.7       1.0X
+date_trunc DD wholestage on                        1913           1917           4          5.2         191.3       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                     2013           2014           2          5.0         201.3       1.0X
-date_trunc HOUR wholestage on                      2077           2088          13          4.8         207.7       1.0X
+date_trunc HOUR wholestage off                     1970           1970           0          5.1         197.0       1.0X
+date_trunc HOUR wholestage on                      1945           1946           2          5.1         194.5       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    363            368           8         27.6          36.3       1.0X
-date_trunc MINUTE wholestage on                     321            326           7         31.2          32.1       1.1X
+date_trunc MINUTE wholestage off                    361            361           1         27.7          36.1       1.0X
+date_trunc MINUTE wholestage on                     331            336           4         30.2          33.1       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    365            366           0         27.4          36.5       1.0X
-date_trunc SECOND wholestage on                     319            332          16         31.4          31.9       1.1X
+date_trunc SECOND wholestage off                    360            361           1         27.8          36.0       1.0X
+date_trunc SECOND wholestage on                     335            348          15         29.8          33.5       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                     2371           2376           7          4.2         237.1       1.0X
-date_trunc WEEK wholestage on                      2314           2322           8          4.3         231.4       1.0X
+date_trunc WEEK wholestage off                     2232           2236           6          4.5         223.2       1.0X
+date_trunc WEEK wholestage on                      2225           2232           6          4.5         222.5       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                  3334           3335           1          3.0         333.4       1.0X
-date_trunc QUARTER wholestage on                   3286           3291           7          3.0         328.6       1.0X
+date_trunc QUARTER wholestage off                  3083           3086           4          3.2         308.3       1.0X
+date_trunc QUARTER wholestage on                   3073           3086          16          3.3         307.3       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           303            304           2         33.0          30.3       1.0X
-trunc year wholestage on                            283            291           5         35.3          28.3       1.1X
+trunc year wholestage off                           321            321           0         31.1          32.1       1.0X
+trunc year wholestage on                            299            303           5         33.5          29.9       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           324            330           8         30.9          32.4       1.0X
-trunc yyyy wholestage on                            283            291           9         35.3          28.3       1.1X
+trunc yyyy wholestage off                           323            327           5         30.9          32.3       1.0X
+trunc yyyy wholestage on                            299            302           3         33.4          29.9       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             304            305           3         32.9          30.4       1.0X
-trunc yy wholestage on                              283            302          28         35.3          28.3       1.1X
+trunc yy wholestage off                             315            315           1         31.8          31.5       1.0X
+trunc yy wholestage on                              299            304           4         33.4          29.9       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            315            319           6         31.7          31.5       1.0X
-trunc mon wholestage on                             284            287           5         35.3          28.4       1.1X
+trunc mon wholestage off                            320            321           1         31.2          32.0       1.0X
+trunc mon wholestage on                             299            307          10         33.4          29.9       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          305            314          13         32.8          30.5       1.0X
-trunc month wholestage on                           283            292          14         35.3          28.3       1.1X
+trunc month wholestage off                          316            317           1         31.6          31.6       1.0X
+trunc month wholestage on                           299            302           5         33.5          29.9       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             301            301           0         33.2          30.1       1.0X
-trunc mm wholestage on                              285            290           7         35.1          28.5       1.1X
+trunc mm wholestage off                             313            313           1         32.0          31.3       1.0X
+trunc mm wholestage on                              298            302           4         33.5          29.8       1.0X
 
 
 ================================================================================================
@@ -404,36 +404,36 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                     218            220           3          4.6         218.4       1.0X
-to timestamp str wholestage on                      213            216           6          4.7         212.5       1.0X
+to timestamp str wholestage off                     217            217           0          4.6         217.3       1.0X
+to timestamp str wholestage on                      209            212           2          4.8         209.5       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                        1838           1842           5          0.5        1838.1       1.0X
-to_timestamp wholestage on                         1952           1971          11          0.5        1952.2       0.9X
+to_timestamp wholestage off                        1676           1677           2          0.6        1675.6       1.0X
+to_timestamp wholestage on                         1599           1606           8          0.6        1599.5       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                   1987           1988           1          0.5        1986.9       1.0X
-to_unix_timestamp wholestage on                    1944           1948           3          0.5        1944.2       1.0X
+to_unix_timestamp wholestage off                   1582           1589           9          0.6        1582.1       1.0X
+to_unix_timestamp wholestage on                    1634           1637           3          0.6        1633.8       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          263            264           0          3.8         263.5       1.0X
-to date str wholestage on                           263            265           2          3.8         262.6       1.0X
+to date str wholestage off                          275            282           9          3.6         275.0       1.0X
+to date str wholestage on                           264            265           2          3.8         263.5       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                             3560           3567          11          0.3        3559.7       1.0X
-to_date wholestage on                              3525           3534          10          0.3        3524.8       1.0X
+to_date wholestage off                             3170           3188          25          0.3        3170.1       1.0X
+to_date wholestage on                              3134           3143          10          0.3        3134.3       1.0X
 
 
 ================================================================================================
@@ -444,14 +444,14 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 To/from Java's date-time:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Date                                  405            416          16         12.3          81.0       1.0X
-From java.time.LocalDate                            344            352          14         14.5          68.8       1.2X
-Collect java.sql.Date                              1622           2553        1372          3.1         324.4       0.2X
-Collect java.time.LocalDate                        1464           1482          20          3.4         292.8       0.3X
-From java.sql.Timestamp                             248            258          15         20.2          49.6       1.6X
-From java.time.Instant                              237            243           7         21.1          47.4       1.7X
-Collect longs                                      1252           1341         109          4.0         250.5       0.3X
-Collect java.sql.Timestamp                         1515           1516           2          3.3         302.9       0.3X
-Collect java.time.Instant                          1379           1490          96          3.6         275.8       0.3X
+From java.sql.Date                                  407            413           7         12.3          81.5       1.0X
+From java.time.LocalDate                            340            344           5         14.7          68.1       1.2X
+Collect java.sql.Date                              1700           2658        1422          2.9         340.0       0.2X
+Collect java.time.LocalDate                        1473           1494          30          3.4         294.6       0.3X
+From java.sql.Timestamp                             252            266          13         19.8          50.5       1.6X
+From java.time.Instant                              236            243           7         21.1          47.3       1.7X
+Collect longs                                      1280           1337          79          3.9         256.1       0.3X
+Collect java.sql.Timestamp                         1485           1501          15          3.4         297.0       0.3X
+Collect java.time.Instant                          1441           1465          37          3.5         288.1       0.3X
 
 

--- a/sql/core/benchmarks/JsonBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/JsonBenchmark-jdk11-results.txt
@@ -3,110 +3,110 @@ Benchmark for performance of JSON parsing
 ================================================================================================
 
 Preparing data for benchmarking ...
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 JSON schema inferring:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                       46010          46118         113          2.2         460.1       1.0X
-UTF-8 is set                                      54407          55427        1718          1.8         544.1       0.8X
+No encoding                                       68879          68993         116          1.5         688.8       1.0X
+UTF-8 is set                                     115270         115602         455          0.9        1152.7       0.6X
 
 Preparing data for benchmarking ...
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 count a short column:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                       26614          28220        1461          3.8         266.1       1.0X
-UTF-8 is set                                      42765          43400         550          2.3         427.6       0.6X
+No encoding                                       47452          47538         113          2.1         474.5       1.0X
+UTF-8 is set                                      77330          77354          30          1.3         773.3       0.6X
 
 Preparing data for benchmarking ...
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 count a wide column:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                       35696          35821         113          0.3        3569.6       1.0X
-UTF-8 is set                                      55441          56176        1037          0.2        5544.1       0.6X
+No encoding                                       60470          60900         534          0.2        6047.0       1.0X
+UTF-8 is set                                     104733         104931         189          0.1       10473.3       0.6X
 
 Preparing data for benchmarking ...
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 select wide row:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                       61514          62968         NaN          0.0      123027.2       1.0X
-UTF-8 is set                                      72096          72933        1162          0.0      144192.7       0.9X
+No encoding                                      130302         131072         976          0.0      260604.6       1.0X
+UTF-8 is set                                     150860         151284         377          0.0      301720.1       0.9X
 
 Preparing data for benchmarking ...
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Select a subset of 10 columns:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Select 10 columns                                  9859           9913          79          1.0         985.9       1.0X
-Select 1 column                                   10981          11003          36          0.9        1098.1       0.9X
+Select 10 columns                                 18619          18684          99          0.5        1861.9       1.0X
+Select 1 column                                   24227          24270          38          0.4        2422.7       0.8X
 
 Preparing data for benchmarking ...
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 creation of JSON parser per line:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Short column without encoding                      3555           3579          27          2.8         355.5       1.0X
-Short column with UTF-8                            5204           5227          35          1.9         520.4       0.7X
-Wide column without encoding                      60458          60637         164          0.2        6045.8       0.1X
-Wide column with UTF-8                            77544          78111         551          0.1        7754.4       0.0X
+Short column without encoding                      7947           7971          21          1.3         794.7       1.0X
+Short column with UTF-8                           12700          12753          58          0.8        1270.0       0.6X
+Wide column without encoding                      92632          92955         463          0.1        9263.2       0.1X
+Wide column with UTF-8                           147013         147170         188          0.1       14701.3       0.1X
 
 Preparing data for benchmarking ...
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 JSON functions:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Text read                                           342            346           3         29.2          34.2       1.0X
-from_json                                          7123           7318         179          1.4         712.3       0.0X
-json_tuple                                         9843           9957         132          1.0         984.3       0.0X
-get_json_object                                    7827           8046         194          1.3         782.7       0.0X
+Text read                                           713            734          19         14.0          71.3       1.0X
+from_json                                         22019          22429         456          0.5        2201.9       0.0X
+json_tuple                                        27987          28047          74          0.4        2798.7       0.0X
+get_json_object                                   21468          21870         350          0.5        2146.8       0.0X
 
 Preparing data for benchmarking ...
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Dataset of json strings:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Text read                                          1856           1884          32         26.9          37.1       1.0X
-schema inferring                                  16734          16900         153          3.0         334.7       0.1X
-parsing                                           14884          15203         470          3.4         297.7       0.1X
+Text read                                          2887           2910          24         17.3          57.7       1.0X
+schema inferring                                  31793          31843          43          1.6         635.9       0.1X
+parsing                                           36791          37104         294          1.4         735.8       0.1X
 
 Preparing data for benchmarking ...
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Json files in the per-line mode:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Text read                                          5932           6148         228          8.4         118.6       1.0X
-Schema inferring                                  20836          21938        1086          2.4         416.7       0.3X
-Parsing without charset                           18134          18661         457          2.8         362.7       0.3X
-Parsing with UTF-8                                27734          28069         378          1.8         554.7       0.2X
+Text read                                         10570          10611          45          4.7         211.4       1.0X
+Schema inferring                                  48729          48763          41          1.0         974.6       0.2X
+Parsing without charset                           35490          35648         141          1.4         709.8       0.3X
+Parsing with UTF-8                                63853          63994         163          0.8        1277.1       0.2X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Write dates and timestamps:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Create a dataset of timestamps                      889            914          28         11.2          88.9       1.0X
-to_json(timestamp)                                 7920           8172         353          1.3         792.0       0.1X
-write timestamps to files                          6726           6822         129          1.5         672.6       0.1X
-Create a dataset of dates                           953            963          12         10.5          95.3       0.9X
-to_json(date)                                      5370           5705         320          1.9         537.0       0.2X
-write dates to files                               4109           4166          52          2.4         410.9       0.2X
+Create a dataset of timestamps                     2187           2190           5          4.6         218.7       1.0X
+to_json(timestamp)                                16262          16503         323          0.6        1626.2       0.1X
+write timestamps to files                         11679          11692          12          0.9        1167.9       0.2X
+Create a dataset of dates                          2297           2310          12          4.4         229.7       1.0X
+to_json(date)                                     10904          10956          46          0.9        1090.4       0.2X
+write dates to files                               6610           6645          35          1.5         661.0       0.3X
 
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Read dates and timestamps:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-read timestamp text from files                     1614           1675          55          6.2         161.4       1.0X
-read timestamps from files                        16640          16858         209          0.6        1664.0       0.1X
-infer timestamps from files                       33239          33388         227          0.3        3323.9       0.0X
-read date text from files                          1310           1340          44          7.6         131.0       1.2X
-read date from files                               9470           9513          41          1.1         947.0       0.2X
-timestamp strings                                  1303           1342          47          7.7         130.3       1.2X
-parse timestamps from Dataset[String]             17650          18073         380          0.6        1765.0       0.1X
-infer timestamps from Dataset[String]             32623          34065        1330          0.3        3262.3       0.0X
-date strings                                       1864           1871           7          5.4         186.4       0.9X
-parse dates from Dataset[String]                  10914          11316         482          0.9        1091.4       0.1X
-from_json(timestamp)                              21102          21990         929          0.5        2110.2       0.1X
-from_json(date)                                   15275          15961         598          0.7        1527.5       0.1X
+read timestamp text from files                     2524           2530           9          4.0         252.4       1.0X
+read timestamps from files                        41002          41052          59          0.2        4100.2       0.1X
+infer timestamps from files                       84621          84939         526          0.1        8462.1       0.0X
+read date text from files                          2292           2302           9          4.4         229.2       1.1X
+read date from files                              16954          16976          21          0.6        1695.4       0.1X
+timestamp strings                                  3067           3077          13          3.3         306.7       0.8X
+parse timestamps from Dataset[String]             48690          48971         243          0.2        4869.0       0.1X
+infer timestamps from Dataset[String]             97463          97786         338          0.1        9746.3       0.0X
+date strings                                       3952           3956           3          2.5         395.2       0.6X
+parse dates from Dataset[String]                  24210          24241          30          0.4        2421.0       0.1X
+from_json(timestamp)                              71710          72242         629          0.1        7171.0       0.0X
+from_json(date)                                   42465          42481          13          0.2        4246.5       0.1X
 
 

--- a/sql/core/benchmarks/JsonBenchmark-results.txt
+++ b/sql/core/benchmarks/JsonBenchmark-results.txt
@@ -3,110 +3,110 @@ Benchmark for performance of JSON parsing
 ================================================================================================
 
 Preparing data for benchmarking ...
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 JSON schema inferring:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                       38998          41002         NaN          2.6         390.0       1.0X
-UTF-8 is set                                      61231          63282        1854          1.6         612.3       0.6X
+No encoding                                       63981          64044          56          1.6         639.8       1.0X
+UTF-8 is set                                     112672         113350         962          0.9        1126.7       0.6X
 
 Preparing data for benchmarking ...
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 count a short column:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                       28272          28338          70          3.5         282.7       1.0X
-UTF-8 is set                                      58681          62243        1517          1.7         586.8       0.5X
+No encoding                                       51256          51449         180          2.0         512.6       1.0X
+UTF-8 is set                                      83694          83859         148          1.2         836.9       0.6X
 
 Preparing data for benchmarking ...
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 count a wide column:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                       44026          51829        1329          0.2        4402.6       1.0X
-UTF-8 is set                                      65839          68596         500          0.2        6583.9       0.7X
+No encoding                                       58440          59097         569          0.2        5844.0       1.0X
+UTF-8 is set                                     102746         102883         198          0.1       10274.6       0.6X
 
 Preparing data for benchmarking ...
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 select wide row:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                       72144          74820         NaN          0.0      144287.6       1.0X
-UTF-8 is set                                      69571          77888         NaN          0.0      139142.3       1.0X
+No encoding                                      128982         129304         356          0.0      257965.0       1.0X
+UTF-8 is set                                     147247         147415         231          0.0      294494.1       0.9X
 
 Preparing data for benchmarking ...
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Select a subset of 10 columns:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Select 10 columns                                  9502           9604         106          1.1         950.2       1.0X
-Select 1 column                                   11861          11948         109          0.8        1186.1       0.8X
+Select 10 columns                                 18837          19048         331          0.5        1883.7       1.0X
+Select 1 column                                   24707          24723          14          0.4        2470.7       0.8X
 
 Preparing data for benchmarking ...
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 creation of JSON parser per line:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Short column without encoding                      3830           3846          15          2.6         383.0       1.0X
-Short column with UTF-8                            5538           5543           7          1.8         553.8       0.7X
-Wide column without encoding                      66899          69158         NaN          0.1        6689.9       0.1X
-Wide column with UTF-8                            90052          93235         NaN          0.1        9005.2       0.0X
+Short column without encoding                      8218           8234          17          1.2         821.8       1.0X
+Short column with UTF-8                           12374          12438         107          0.8        1237.4       0.7X
+Wide column without encoding                     136918         137298         345          0.1       13691.8       0.1X
+Wide column with UTF-8                           176961         177142         257          0.1       17696.1       0.0X
 
 Preparing data for benchmarking ...
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 JSON functions:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Text read                                           659            674          13         15.2          65.9       1.0X
-from_json                                          7676           7943         405          1.3         767.6       0.1X
-json_tuple                                         9881          10172         273          1.0         988.1       0.1X
-get_json_object                                    7949           8055         119          1.3         794.9       0.1X
+Text read                                          1268           1278          12          7.9         126.8       1.0X
+from_json                                         23348          23479         176          0.4        2334.8       0.1X
+json_tuple                                        29606          30221        1024          0.3        2960.6       0.0X
+get_json_object                                   21898          22148         226          0.5        2189.8       0.1X
 
 Preparing data for benchmarking ...
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Dataset of json strings:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Text read                                          3314           3326          17         15.1          66.3       1.0X
-schema inferring                                  16549          17037         484          3.0         331.0       0.2X
-parsing                                           15138          15283         172          3.3         302.8       0.2X
+Text read                                          5887           5944          49          8.5         117.7       1.0X
+schema inferring                                  46696          47054         312          1.1         933.9       0.1X
+parsing                                           32336          32450         129          1.5         646.7       0.2X
 
 Preparing data for benchmarking ...
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Json files in the per-line mode:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Text read                                          5136           5446         268          9.7         102.7       1.0X
-Schema inferring                                  19864          20568        1191          2.5         397.3       0.3X
-Parsing without charset                           17535          17888         329          2.9         350.7       0.3X
-Parsing with UTF-8                                25609          25758         218          2.0         512.2       0.2X
+Text read                                          9756           9769          11          5.1         195.1       1.0X
+Schema inferring                                  51318          51433         108          1.0        1026.4       0.2X
+Parsing without charset                           43609          43743         118          1.1         872.2       0.2X
+Parsing with UTF-8                                60775          60844         106          0.8        1215.5       0.2X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Write dates and timestamps:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Create a dataset of timestamps                      784            790           7         12.8          78.4       1.0X
-to_json(timestamp)                                 8005           8055          50          1.2         800.5       0.1X
-write timestamps to files                          6515           6559          45          1.5         651.5       0.1X
-Create a dataset of dates                           854            881          24         11.7          85.4       0.9X
-to_json(date)                                      5187           5194           7          1.9         518.7       0.2X
-write dates to files                               3663           3684          22          2.7         366.3       0.2X
+Create a dataset of timestamps                     1998           2015          17          5.0         199.8       1.0X
+to_json(timestamp)                                18156          18317         263          0.6        1815.6       0.1X
+write timestamps to files                         12912          12917           5          0.8        1291.2       0.2X
+Create a dataset of dates                          2209           2270          53          4.5         220.9       0.9X
+to_json(date)                                      9433           9489          90          1.1         943.3       0.2X
+write dates to files                               6915           6923           8          1.4         691.5       0.3X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Read dates and timestamps:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-read timestamp text from files                     1297           1316          26          7.7         129.7       1.0X
-read timestamps from files                        16915          17723         963          0.6        1691.5       0.1X
-infer timestamps from files                       33967          34304         360          0.3        3396.7       0.0X
-read date text from files                          1095           1100           7          9.1         109.5       1.2X
-read date from files                               8376           8513         209          1.2         837.6       0.2X
-timestamp strings                                  1807           1816           8          5.5         180.7       0.7X
-parse timestamps from Dataset[String]             18189          18242          74          0.5        1818.9       0.1X
-infer timestamps from Dataset[String]             37906          38547         571          0.3        3790.6       0.0X
-date strings                                       2191           2194           4          4.6         219.1       0.6X
-parse dates from Dataset[String]                  11593          11625          33          0.9        1159.3       0.1X
-from_json(timestamp)                              22589          22650         101          0.4        2258.9       0.1X
-from_json(date)                                   16479          16619         159          0.6        1647.9       0.1X
+read timestamp text from files                     2395           2412          17          4.2         239.5       1.0X
+read timestamps from files                        47269          47334          89          0.2        4726.9       0.1X
+infer timestamps from files                       91806          91851          67          0.1        9180.6       0.0X
+read date text from files                          2118           2133          13          4.7         211.8       1.1X
+read date from files                              17267          17340         115          0.6        1726.7       0.1X
+timestamp strings                                  3906           3935          26          2.6         390.6       0.6X
+parse timestamps from Dataset[String]             52244          52534         279          0.2        5224.4       0.0X
+infer timestamps from Dataset[String]            100488         100714         198          0.1       10048.8       0.0X
+date strings                                       4572           4584          12          2.2         457.2       0.5X
+parse dates from Dataset[String]                  26749          26768          17          0.4        2674.9       0.1X
+from_json(timestamp)                              71414          71867         556          0.1        7141.4       0.0X
+from_json(date)                                   45322          45549         250          0.2        4532.2       0.1X
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Re-generate results of:
- DateTimeBenchmark
- CSVBenchmark
- JsonBenchmark

in the environment:

| Item | Description |
| ---- | ----|
| Region | us-west-2 (Oregon) |
| Instance | r3.xlarge |
| AMI | ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20190722.1 (ami-06f2f779464715dc5) |
| Java | OpenJDK 64-Bit Server VM 1.8.0_242 and OpenJDK 64-Bit Server VM 11.0.6+10 |

### Why are the changes needed?
1. The PR https://github.com/apache/spark/pull/28576 changed date-time parser. The `DateTimeBenchmark` should confirm that the PR didn't slow down date/timestamp parsing.
2. CSV/JSON datasources are affected by the above PR too. This PR updates the benchmark results in the same environment as other benchmarks to have a base line for future optimizations.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
By running benchmarks via the script:
```python
#!/usr/bin/env python3

import os
from sparktestsupport.shellutils import run_cmd

benchmarks = [
    ['sql/test', 'org.apache.spark.sql.execution.benchmark.DateTimeBenchmark'],
    ['sql/test', 'org.apache.spark.sql.execution.datasources.csv.CSVBenchmark'],
    ['sql/test', 'org.apache.spark.sql.execution.datasources.json.JsonBenchmark']
]

print('Set SPARK_GENERATE_BENCHMARK_FILES=1')
os.environ['SPARK_GENERATE_BENCHMARK_FILES'] = '1'

for b in benchmarks:
    print("Run benchmark: %s" % b[1])
    run_cmd(['build/sbt', '%s:runMain %s' % (b[0], b[1])])
```