### PR TITLE
[SPARK-31778][K8S][BUILD] Support cross-building docker images

### DIFF
--- a/bin/docker-image-tool.sh
+++ b/bin/docker-image-tool.sh
@@ -246,6 +246,7 @@ Options:
   -u uid                UID to use in the USER directive to set the user the main Spark process runs as inside the
                         resulting container
   -X                    Use docker buildx to cross build. Automatically pushes.
+                        See https://docs.docker.com/buildx/working-with-buildx/ for steps to setup buildx.
   -b arg                Build arg to build or push the image. For multiple build args, this option needs to
                         be used separately for each build arg.
 

--- a/bin/docker-image-tool.sh
+++ b/bin/docker-image-tool.sh
@@ -64,9 +64,6 @@ function docker_push {
     if [ $? -ne 0 ]; then
       error "Failed to push $image_name Docker image."
     fi
-    if [ "${CROSS_BUILD}" != "false" ]; then
-      docker buildx push "$(image_ref ${image_name})"
-    fi
   else
     echo "$(image_ref ${image_name}) image not found. Skipping push for this image."
   fi
@@ -196,12 +193,12 @@ function build {
       -t $(image_ref spark-py) \
       -f "$PYDOCKERFILE" .)
       if [ $? -ne 0 ]; then
-        error "Failed to build PySpark Docker image, please refer to Docker build output for details."
+	error "Failed to build PySpark Docker image, please refer to Docker build output for details."
       fi
       if [ "${CROSS_BUILD}" != "false" ]; then
 	(cd $(img_ctx_dir pyspark) && docker buildx build $ARCHS $NOCACHEARG "${BINDING_BUILD_ARGS[@]}" \
-          -t $(image_ref spark-py) \
-          -f "$PYDOCKERFILE" .)
+	  -t $(image_ref spark-py) \
+	  -f "$PYDOCKERFILE" .)
       fi
   fi
 
@@ -214,8 +211,8 @@ function build {
     fi
     if [ "${CROSS_BUILD}" != "false" ]; then
       (cd $(img_ctx_dir sparkr) && docker buildx build $ARCHS $NOCACHEARG "${BINDING_BUILD_ARGS[@]}" \
-        -t $(image_ref spark-r) \
-        -f "$RDOCKERFILE" .)
+	-t $(image_ref spark-r) \
+	-f "$RDOCKERFILE" .)
     fi
   fi
 }
@@ -233,24 +230,24 @@ Builds or pushes the built-in Spark Docker image.
 
 Commands:
   build       Build image. Requires a repository address to be provided if the image will be
-              pushed to a different registry.
+	      pushed to a different registry.
   push        Push a pre-built image to a registry. Requires a repository address to be provided.
 
 Options:
   -f file               Dockerfile to build for JVM based Jobs. By default builds the Dockerfile shipped with Spark.
   -p file               (Optional) Dockerfile to build for PySpark Jobs. Builds Python dependencies and ships with Spark.
-                        Skips building PySpark docker image if not specified.
+			Skips building PySpark docker image if not specified.
   -R file               (Optional) Dockerfile to build for SparkR Jobs. Builds R dependencies and ships with Spark.
-                        Skips building SparkR docker image if not specified.
+			Skips building SparkR docker image if not specified.
   -r repo               Repository address.
   -t tag                Tag to apply to the built image, or to identify the image to be pushed.
   -m                    Use minikube's Docker daemon.
   -n                    Build docker image with --no-cache
   -u uid                UID to use in the USER directive to set the user the main Spark process runs as inside the
-                        resulting container
-  -x                    Use docker buildx to cross build
+			resulting container
+  -X                    Use docker buildx to cross build. Automatically pushes.
   -b arg                Build arg to build or push the image. For multiple build args, this option needs to
-                        be used separately for each build arg.
+			be used separately for each build arg.
 
 Using minikube when building images will do so directly into minikube's Docker daemon.
 There is no need to push the images into minikube in that case, they'll be automatically
@@ -277,7 +274,8 @@ Examples:
 
   - Build and push JDK11-based image for multiple archs to docker.io/myrepo
     $0 -r docker.io/myrepo -t v3.0.0 -X -b java_image_tag=11-jre-slim build
-    $0 -r docker.io/myrepo -t v3.0.0 -X push
+    # Note: buildx, which does cross building, needs to do the push during build
+    # So there is no seperate push step with -X
 
 EOF
 }

--- a/bin/docker-image-tool.sh
+++ b/bin/docker-image-tool.sh
@@ -193,12 +193,12 @@ function build {
       -t $(image_ref spark-py) \
       -f "$PYDOCKERFILE" .)
       if [ $? -ne 0 ]; then
-	error "Failed to build PySpark Docker image, please refer to Docker build output for details."
+        error "Failed to build PySpark Docker image, please refer to Docker build output for details."
       fi
       if [ "${CROSS_BUILD}" != "false" ]; then
-	(cd $(img_ctx_dir pyspark) && docker buildx build $ARCHS $NOCACHEARG "${BINDING_BUILD_ARGS[@]}" \
-	  -t $(image_ref spark-py) \
-	  -f "$PYDOCKERFILE" .)
+        (cd $(img_ctx_dir pyspark) && docker buildx build $ARCHS $NOCACHEARG "${BINDING_BUILD_ARGS[@]}" \
+          -t $(image_ref spark-py) \
+          -f "$PYDOCKERFILE" .)
       fi
   fi
 
@@ -211,8 +211,8 @@ function build {
     fi
     if [ "${CROSS_BUILD}" != "false" ]; then
       (cd $(img_ctx_dir sparkr) && docker buildx build $ARCHS $NOCACHEARG "${BINDING_BUILD_ARGS[@]}" \
-	-t $(image_ref spark-r) \
-	-f "$RDOCKERFILE" .)
+        -t $(image_ref spark-r) \
+        -f "$RDOCKERFILE" .)
     fi
   fi
 }
@@ -230,24 +230,24 @@ Builds or pushes the built-in Spark Docker image.
 
 Commands:
   build       Build image. Requires a repository address to be provided if the image will be
-	      pushed to a different registry.
+              pushed to a different registry.
   push        Push a pre-built image to a registry. Requires a repository address to be provided.
 
 Options:
   -f file               Dockerfile to build for JVM based Jobs. By default builds the Dockerfile shipped with Spark.
   -p file               (Optional) Dockerfile to build for PySpark Jobs. Builds Python dependencies and ships with Spark.
-			Skips building PySpark docker image if not specified.
+                        Skips building PySpark docker image if not specified.
   -R file               (Optional) Dockerfile to build for SparkR Jobs. Builds R dependencies and ships with Spark.
-			Skips building SparkR docker image if not specified.
+                        Skips building SparkR docker image if not specified.
   -r repo               Repository address.
   -t tag                Tag to apply to the built image, or to identify the image to be pushed.
   -m                    Use minikube's Docker daemon.
   -n                    Build docker image with --no-cache
   -u uid                UID to use in the USER directive to set the user the main Spark process runs as inside the
-			resulting container
+                        resulting container
   -X                    Use docker buildx to cross build. Automatically pushes.
   -b arg                Build arg to build or push the image. For multiple build args, this option needs to
-			be used separately for each build arg.
+                        be used separately for each build arg.
 
 Using minikube when building images will do so directly into minikube's Docker daemon.
 There is no need to push the images into minikube in that case, they'll be automatically

--- a/bin/docker-image-tool.sh
+++ b/bin/docker-image-tool.sh
@@ -19,6 +19,8 @@
 # This script builds and pushes docker images when run from a release of Spark
 # with Kubernetes support.
 
+set -x
+
 function error {
   echo "$@" 1>&2
   exit 1
@@ -61,6 +63,9 @@ function docker_push {
     docker push "$(image_ref ${image_name})"
     if [ $? -ne 0 ]; then
       error "Failed to push $image_name Docker image."
+    fi
+    if [ "${CROSS_BUILD}" != "false" ]; then
+      docker buildx push "$(image_ref ${image_name})"
     fi
   else
     echo "$(image_ref ${image_name}) image not found. Skipping push for this image."
@@ -172,12 +177,18 @@ function build {
   local BASEDOCKERFILE=${BASEDOCKERFILE:-"kubernetes/dockerfiles/spark/Dockerfile"}
   local PYDOCKERFILE=${PYDOCKERFILE:-false}
   local RDOCKERFILE=${RDOCKERFILE:-false}
+  local ARCHS=${ARCHS:-"--platform linux/amd64,linux/arm64"}
 
   (cd $(img_ctx_dir base) && docker build $NOCACHEARG "${BUILD_ARGS[@]}" \
     -t $(image_ref spark) \
     -f "$BASEDOCKERFILE" .)
   if [ $? -ne 0 ]; then
     error "Failed to build Spark JVM Docker image, please refer to Docker build output for details."
+  fi
+  if [ "${CROSS_BUILD}" != "false" ]; then
+  (cd $(img_ctx_dir base) && docker buildx build $ARCHS $NOCACHEARG "${BUILD_ARGS[@]}" \
+    -t $(image_ref spark) \
+    -f "$BASEDOCKERFILE" .)
   fi
 
   if [ "${PYDOCKERFILE}" != "false" ]; then
@@ -187,6 +198,11 @@ function build {
       if [ $? -ne 0 ]; then
         error "Failed to build PySpark Docker image, please refer to Docker build output for details."
       fi
+      if [ "${CROSS_BUILD}" != "false" ]; then
+	(cd $(img_ctx_dir pyspark) && docker buildx build $ARCHS $NOCACHEARG "${BINDING_BUILD_ARGS[@]}" \
+          -t $(image_ref spark-py) \
+          -f "$PYDOCKERFILE" .)
+      fi
   fi
 
   if [ "${RDOCKERFILE}" != "false" ]; then
@@ -195,6 +211,11 @@ function build {
       -f "$RDOCKERFILE" .)
     if [ $? -ne 0 ]; then
       error "Failed to build SparkR Docker image, please refer to Docker build output for details."
+    fi
+    if [ "${CROSS_BUILD}" != "false" ]; then
+      (cd $(img_ctx_dir sparkr) && docker buildx build $ARCHS $NOCACHEARG "${BINDING_BUILD_ARGS[@]}" \
+        -t $(image_ref spark-r) \
+        -f "$RDOCKERFILE" .)
     fi
   fi
 }
@@ -227,6 +248,7 @@ Options:
   -n                    Build docker image with --no-cache
   -u uid                UID to use in the USER directive to set the user the main Spark process runs as inside the
                         resulting container
+  -x                    Use docker buildx to cross build
   -b arg                Build arg to build or push the image. For multiple build args, this option needs to
                         be used separately for each build arg.
 
@@ -252,6 +274,11 @@ Examples:
   - Build and push JDK11-based image with tag "v3.0.0" to docker.io/myrepo
     $0 -r docker.io/myrepo -t v3.0.0 -b java_image_tag=11-jre-slim build
     $0 -r docker.io/myrepo -t v3.0.0 push
+
+  - Build and push JDK11-based image for multiple archs to docker.io/myrepo
+    $0 -r docker.io/myrepo -t v3.0.0 -X -b java_image_tag=11-jre-slim build
+    $0 -r docker.io/myrepo -t v3.0.0 -X push
+
 EOF
 }
 
@@ -268,7 +295,8 @@ RDOCKERFILE=
 NOCACHEARG=
 BUILD_PARAMS=
 SPARK_UID=
-while getopts f:p:R:mr:t:nb:u: option
+CROSS_BUILD="false"
+while getopts f:p:R:mr:t:Xnb:u: option
 do
  case "${option}"
  in
@@ -279,6 +307,7 @@ do
  t) TAG=${OPTARG};;
  n) NOCACHEARG="--no-cache";;
  b) BUILD_PARAMS=${BUILD_PARAMS}" --build-arg "${OPTARG};;
+ X) CROSS_BUILD=1;;
  m)
    if ! which minikube 1>/dev/null; then
      error "Cannot find minikube."


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add cross build support to our docker image script using the new dockerx extension.

### Why are the changes needed?

We have a CI for Spark on ARM, we should support building images for ARM and AMD64.

### Does this PR introduce _any_ user-facing change?

Yes, a new flag is added to the docker image build script to cross-build

### How was this patch tested?
Manually ran build script & pushed to https://hub.docker.com/repository/registry-1.docker.io/holdenk/spark/tags?page=1 verified amd64 & arm64 listed.
