### PR TITLE
[SPARK-31805][SS] Exclude group.id from consumer settings when using the assign strategy

### DIFF
--- a/external/kafka-0-10-token-provider/src/main/scala/org/apache/spark/kafka010/KafkaConfigUpdater.scala
+++ b/external/kafka-0-10-token-provider/src/main/scala/org/apache/spark/kafka010/KafkaConfigUpdater.scala
@@ -45,6 +45,17 @@ private[spark] case class KafkaConfigUpdater(module: String, kafkaParams: Map[St
     this
   }
 
+  def remove(key: String): this.type = {
+    val removedValue = map.remove(key)
+    if (log.isDebugEnabled) {
+      val redactedRemovedValue = KafkaRedactionUtil
+        .redactParams(Seq(key -> removedValue))
+        .head._2
+      logDebug(s"$module: Removed $key: $redactedRemovedValue")
+    }
+    this
+  }
+
   def setIfUnset(key: String, value: Object): this.type = {
     if (!map.containsKey(key)) {
       map.put(key, value)

--- a/external/kafka-0-10-token-provider/src/test/scala/org/apache/spark/kafka010/KafkaConfigUpdaterSuite.scala
+++ b/external/kafka-0-10-token-provider/src/test/scala/org/apache/spark/kafka010/KafkaConfigUpdaterSuite.scala
@@ -44,6 +44,33 @@ class KafkaConfigUpdaterSuite extends SparkFunSuite with KafkaDelegationTokenTes
     assert(updatedParams.get(testKey) === testValue)
   }
 
+  test("remove should remove existing key") {
+    val params = Map(
+      testKey -> testValue,
+      "k2" -> "v2"
+    )
+
+    val updatedParams = KafkaConfigUpdater(testModule, params)
+      .remove(testKey)
+      .build()
+
+    assert(updatedParams.size() === 1)
+    assert(!updatedParams.containsKey(testKey))
+  }
+
+  test("remove should not modify the map if the key is missing in the map") {
+    val params = Map(
+      testKey -> testValue
+    )
+
+    val updatedParams = KafkaConfigUpdater(testModule, params)
+      .remove("k2")
+      .build()
+
+    assert(updatedParams.size() === 1)
+    assert(updatedParams.get(testKey) === testValue)
+  }
+
   test("setIfUnset without existing key should set value") {
     val params = Map.empty[String, String]
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix for [SPARK-31805](https://issues.apache.org/jira/browse/SPARK-31805): do not set the `group.id` consumer property when using the "assign" strategy.

### Why are the changes needed?

With secure Kafka blocker an application fails, because the auto-generated group id is not allowed by the broker:
```text
org.apache.kafka.common.errors.GroupAuthorizationException: Not authorized to access group: spark-kafka-relation-ecab045d-4ee6-425e-88a0-495d4100a013-driver-0
```

For the "assign" strategy, consumer group is not used. Therefore the best fix is to exclude the `group.id` property from the consumer config.

### Does this PR introduce _any_ user-facing change?

Yes. When using "assign" strategy:
1. No need to reconfigure the broker - to add the necessary group ids to ACL
1. (since Spark 3.0.0) No need to provide a custom group id ([SPARK-26350](https://issues.apache.org/jira/browse/SPARK-26350)) or a custom prefix ([SPARK-26121](https://issues.apache.org/jira/browse/SPARK-26121))


### How was this patch tested?

Manually:
1. Rebuild the module:
    ```bash
    mvn install -pl :spark-sql-kafka-0-10_2.12
    ```
1. Rebuild my application with newly built `spark-sql-kafka-0-10_2.12`. My application does the following:
    ```scala
    val kafkaDf = spark.read
      .format("kafka")
      // "kafka.bootstrap.servers" and SASL-specific options
      .options(options)
      .option("assign", topicPartitionsJson)
      .option("startingOffsets", startingOffsetsJson)
      .option("endingOffsets", "latest")
      .load()
    ```
1. Run my application with a secure Kafka broker and verify that it does not fail with "GroupAuthorizationException: ..." anymore.

I did not manage to add unit tests, because I do not know, how to set up a secure Kafka broker. Unit tests in spark-sql-kafka-0-10 use the tool `KafkaTestUtils`. I am not sure if this tool is suitable to simulate a secure Kafka broker with ACLs.
