### PR TITLE
[SPARK-31809][SQL] Infer IsNotNull from some special equality join keys

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1217,9 +1217,9 @@ object InferFiltersFromConstraints extends Rule[LogicalPlan]
 
   // Whether the result of this expression may be null. For example: CAST(strCol AS double)
   // We will infer an IsNotNull expression for this expression to avoid skew join.
-  private def resultMayBeNull(e: Expression): Boolean = e match {
-    case Cast(child, dataType, _, _) => !Cast.canUpCast(child.dataType, dataType)
-    case _: Coalesce => true
+  private def resultMayBeNull(exp: Expression): Boolean = exp match {
+    case Cast(child: Attribute, dataType, _, _) => !Cast.canUpCast(child.dataType, dataType)
+    case c: Coalesce if c.children.forall(_.isInstanceOf[Attribute]) => true
     case _ => false
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1218,6 +1218,7 @@ object InferFiltersFromConstraints extends Rule[LogicalPlan]
   // Whether the result of this expression may be null. For example: CAST(strCol AS double)
   // We will infer an IsNotNull expression for this expression to avoid skew join.
   private def resultMayBeNull(exp: Expression): Boolean = exp match {
+    case e if !e.nullable => false
     case Cast(child: Attribute, dataType, _, _) => !Cast.canUpCast(child.dataType, dataType)
     case c: Coalesce if c.children.forall(_.isInstanceOf[Attribute]) => true
     case _ => false

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1239,7 +1239,6 @@ object InferFiltersFromConstraints extends Rule[LogicalPlan]
       val rightKeys = new mutable.HashSet[Expression]
       conditionOpt.foreach { condition =>
         splitConjunctivePredicates(condition).foreach {
-          case EqualTo(l, r) if l.references.isEmpty || r.references.isEmpty =>
           case EqualTo(l, r) =>
             if (resultMayBeNull(l)) {
               if (canEvaluate(l, left)) leftKeys.add(l)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferFiltersFromConstraintsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferFiltersFromConstraintsSuite.scala
@@ -374,14 +374,23 @@ class InferFiltersFromConstraintsSuite extends PlanTest {
   }
 
   test("SPARK-31809: Infer IsNotNull for join condition") {
+    val testRelation2 = LocalRelation('a.string, 'b.int)
+
     testConstraintsAfterJoin(
       testRelation.subquery('left),
-      testRelation.subquery('right),
-      testRelation.where(IsNotNull('a.cast(StringType).cast(DoubleType)) && IsNotNull('a))
-        .subquery('left),
-      testRelation.where(IsNotNull('c)).subquery('right),
+      testRelation2.subquery('right),
+      testRelation.where(IsNotNull('a)).subquery('left),
+      testRelation2.where(IsNotNull('a.cast(IntegerType)) && IsNotNull('a)).subquery('right),
       Inner,
-      Some("left.a".attr.cast(StringType).cast(DoubleType) === "right.c".attr.cast(DoubleType)))
+      Some("left.a".attr === "right.a".attr))
+
+    testConstraintsAfterJoin(
+      testRelation.subquery('left),
+      testRelation2.subquery('right),
+      testRelation.where(IsNotNull('a)).subquery('left),
+      testRelation2.subquery('right),
+      RightOuter,
+      Some("left.a".attr === "right.a".attr))
 
     testConstraintsAfterJoin(
       testRelation.subquery('left),


### PR DESCRIPTION
### What changes were proposed in this pull request?

We can infer `IsNotNull` from some special equality join keys. For example:
```sql
CREATE TABLE t1(a string, b string, c string) using parquet;
CREATE TABLE t2(a string, b decimal(38, 18), c string) using parquet;
SELECT t1.* FROM t1 JOIN t2 ON coalesce(t1.a, t1.b)=t2.a; -- case 1
SELECT t1.* FROM t1 JOIN t2 ON CAST(t1.a AS DOUBLE)=CAST(t2.b AS DOUBLE); -- case 2
```
The `coalesce(t1.a, t1.b)` or `CAST(t1.a AS DOUBLE)` may generate a lot of null values, which will lead to skew join.
After this pr:
```
== Physical Plan ==
*(5) Project [a#5, b#6, c#7]
+- *(5) SortMergeJoin [coalesce(a#5, b#6)], [a#8], Inner
   :- *(2) Sort [coalesce(a#5, b#6) ASC NULLS FIRST], false, 0
   :  +- Exchange hashpartitioning(coalesce(a#5, b#6), 200), true, [id=#44]
   :     +- *(1) Filter isnotnull(coalesce(a#5, b#6))
   :        +- Scan hive default.t1 [a#5, b#6, c#7], HiveTableRelation `default`.`t1`, org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe, [a#5, b#6, c#7], Statistics(sizeInBytes=8.0 EiB)
   +- *(4) Sort [a#8 ASC NULLS FIRST], false, 0
      +- Exchange hashpartitioning(a#8, 200), true, [id=#52]
         +- *(3) Filter isnotnull(a#8)
            +- Scan hive default.t2 [a#8], HiveTableRelation `default`.`t2`, org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe, [a#8, b#9, c#10], Statistics(sizeInBytes=8.0 EiB)
```

### Why are the changes needed?

1. Avoid skew join in some cases.
2. [Hive support this optimization](https://github.com/apache/hive/blob/rel/release-3.1.2/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveJoinAddNotNullRule.java).


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test and benchmark test:
Case1:
Before this PR | After this PR
-- | --
![image](https://issues.apache.org/jira/secure/attachment/13003914/13003914_default.png) | ![image](https://issues.apache.org/jira/secure/attachment/13003913/13003913_infer.png)

Case2:
Before this PR | After this PR
-- | --
![image](https://user-images.githubusercontent.com/5399861/128879249-f08c0577-caf7-422f-b25c-f47113cc5793.png) | ![image](https://user-images.githubusercontent.com/5399861/128879432-eff937d2-999b-4ac8-a216-25b40e093b67.png)
