### PR TITLE
[SPARK-31762][SQL][FOLLOWUP] Avoid double formatting in legacy fractional formatter

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
@@ -137,14 +137,14 @@ class FractionTimestampFormatter(zoneId: ZoneId)
     } else {
       var nanosString = nanos.toString
       // Add leading zeros
-      nanosString = "000000000".substring(0, 9 - nanosString.length) + nanosString
+      nanosString = ".000000000".substring(0, 10 - nanosString.length) + nanosString
       // Truncate trailing zeros
-      val nanosChar = new Array[Char](nanosString.length)
-      nanosString.getChars(0, nanosString.length, nanosChar, 0)
-      var truncIndex = 8
-      while (nanosChar(truncIndex) == '0') truncIndex -= 1
-
-      formatted + "." + new String(nanosChar, 0, truncIndex + 1)
+      val charBuff = new Array[Char](formatted.length + nanosString.length)
+      formatted.getChars(0, formatted.length, charBuff, 0)
+      nanosString.getChars(0, nanosString.length, charBuff, formatted.length)
+      var truncIndex = charBuff.size - 1
+      while (charBuff(truncIndex) == '0') truncIndex -= 1
+      new String(charBuff, 0, truncIndex + 1)
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
@@ -138,7 +138,7 @@ class FractionTimestampFormatter(zoneId: ZoneId)
       // Formats non-zero seconds fraction w/o trailing zeros. For example:
       //   formatted = '2020-05:27 15:55:30'
       //   nanos = 001234000
-      // Counts trailing zeros in `nanos`: 001234000 -> 3
+      // Counts the length of the fractional part: 001234000 -> 6
       var fracLen = 9
       while (nanos % 10 == 0) {
         nanos /= 10

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
@@ -127,16 +127,14 @@ class FractionTimestampFormatter(zoneId: ZoneId)
   override protected lazy val formatter = DateTimeFormatterHelper.fractionFormatter
 
   // The new formatter will omit the trailing 0 in the timestamp string, but the legacy formatter
-  // can't. Here we borrow the code from Spark 2.4 DateTimeUtils.timestampToString to omit the
-  // trailing 0 for the legacy formatter as well.
+  // can't. Here we use toString to eliminate trailing 0 and remove '.0' explicitly.
   override def format(ts: Timestamp): String = {
-    val timestampString = ts.toString
-    val formatted = legacyFormatter.format(ts)
-
-    if (timestampString.length > 19 && timestampString.substring(19) != ".0") {
-      formatted + timestampString.substring(19)
+    val s = ts.toString
+    val i = s.length - 2
+    if (s(i) == '.' && s(i + 1) == '0') {
+      s.substring(0, i)
     } else {
-      formatted
+      s
     }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/util/TimestampFormatterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/util/TimestampFormatterSuite.scala
@@ -135,6 +135,9 @@ class TimestampFormatterSuite extends SparkFunSuite with SQLHelper with Matchers
   test("format fraction of second") {
     val formatter = TimestampFormatter.getFractionFormatter(UTC)
     Seq(
+      -999999 -> "1969-12-31 23:59:59.000001",
+      -999900 -> "1969-12-31 23:59:59.0001",
+      -1 -> "1969-12-31 23:59:59.999999",
       0 -> "1970-01-01 00:00:00",
       1 -> "1970-01-01 00:00:00.000001",
       1000 -> "1970-01-01 00:00:00.001",


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, the legacy fractional formatter is based on the implementation from Spark 2.4 which formats the input timestamp twice:
```
    val timestampString = ts.toString
    val formatted = legacyFormatter.format(ts)
```
to strip trailing zeros. This PR proposes to avoid the first formatting by forming the second fraction directly.

### Why are the changes needed?
It makes legacy fractional formatter faster.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
By existing test "format fraction of second" in `TimestampFormatterSuite` + added test for timestamps before 1970-01-01 00:00:00Z