### PR TITLE
[SPARK-31840][ML] Add instance weight support in LogisticRegressionSummary

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -41,7 +41,7 @@ import org.apache.spark.mllib.evaluation.{BinaryClassificationMetrics, Multiclas
 import org.apache.spark.mllib.util.MLUtils
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Dataset, Row}
-import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.functions.{col, lit}
 import org.apache.spark.sql.types.{DataType, DoubleType, StructType}
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util.VersionUtils
@@ -729,6 +729,7 @@ class LogisticRegression @Since("1.2.0") (
       objectiveHistory: Array[Double]): LogisticRegressionModel = {
     val model = copyValues(new LogisticRegressionModel(uid, coefficientMatrix, interceptVector,
       numClasses, checkMultinomial(numClasses)))
+    val weightColName = if (!isDefined(weightCol)) "weightCol" else $(weightCol)
 
     val (summaryModel, probabilityColName, predictionColName) = model.findSummaryModel()
     val logRegSummary = if (numClasses <= 2) {
@@ -738,6 +739,7 @@ class LogisticRegression @Since("1.2.0") (
         predictionColName,
         $(labelCol),
         $(featuresCol),
+        weightColName,
         objectiveHistory)
     } else {
       new LogisticRegressionTrainingSummaryImpl(
@@ -746,6 +748,7 @@ class LogisticRegression @Since("1.2.0") (
         predictionColName,
         $(labelCol),
         $(featuresCol),
+        weightColName,
         objectiveHistory)
     }
     model.setSummary(Some(logRegSummary))
@@ -1185,14 +1188,15 @@ class LogisticRegressionModel private[spark] (
    */
   @Since("2.0.0")
   def evaluate(dataset: Dataset[_]): LogisticRegressionSummary = {
+    val weightColName = if (!isDefined(weightCol)) "weightCol" else $(weightCol)
     // Handle possible missing or invalid prediction columns
     val (summaryModel, probabilityColName, predictionColName) = findSummaryModel()
     if (numClasses > 2) {
       new LogisticRegressionSummaryImpl(summaryModel.transform(dataset),
-        probabilityColName, predictionColName, $(labelCol), $(featuresCol))
+        probabilityColName, predictionColName, $(labelCol), $(featuresCol), weightColName)
     } else {
       new BinaryLogisticRegressionSummaryImpl(summaryModel.transform(dataset),
-        probabilityColName, predictionColName, $(labelCol), $(featuresCol))
+        probabilityColName, predictionColName, $(labelCol), $(featuresCol), weightColName)
     }
   }
 
@@ -1390,8 +1394,6 @@ object LogisticRegressionModel extends MLReadable[LogisticRegressionModel] {
 
 /**
  * Abstraction for logistic regression results for a given model.
- *
- * Currently, the summary ignores the instance weights.
  */
 sealed trait LogisticRegressionSummary extends Serializable {
 
@@ -1417,12 +1419,28 @@ sealed trait LogisticRegressionSummary extends Serializable {
   @Since("1.6.0")
   def featuresCol: String
 
+  /** Field in "predictions" which gives the weight of each instance as a vector. */
+  @Since("3.1.0")
+  def weightCol: String
+
   @transient private val multiclassMetrics = {
-    new MulticlassMetrics(
-      predictions.select(
-        col(predictionCol),
-        col(labelCol).cast(DoubleType))
-        .rdd.map { case Row(prediction: Double, label: Double) => (prediction, label) })
+    if (predictions.schema.fieldNames.contains(weightCol)) {
+      new MulticlassMetrics(
+        predictions.select(
+          col(predictionCol),
+          col(labelCol).cast(DoubleType),
+          col(weightCol).cast(DoubleType)).rdd.map {
+          case Row(prediction: Double, label: Double, weight: Double) => (prediction, label, weight)
+        })
+    } else {
+      new MulticlassMetrics(
+        predictions.select(
+          col(predictionCol),
+          col(labelCol).cast(DoubleType),
+          lit(1.0)).rdd.map {
+          case Row(prediction: Double, label: Double, weight: Double) => (prediction, label, weight)
+        })
+    }
   }
 
   /**
@@ -1538,8 +1556,6 @@ sealed trait LogisticRegressionTrainingSummary extends LogisticRegressionSummary
 
 /**
  * Abstraction for binary logistic regression results for a given model.
- *
- * Currently, the summary ignores the instance weights.
  */
 sealed trait BinaryLogisticRegressionSummary extends LogisticRegressionSummary {
 
@@ -1548,29 +1564,33 @@ sealed trait BinaryLogisticRegressionSummary extends LogisticRegressionSummary {
 
   // TODO: Allow the user to vary the number of bins using a setBins method in
   // BinaryClassificationMetrics. For now the default is set to 100.
-  @transient private val binaryMetrics = new BinaryClassificationMetrics(
-    predictions.select(col(probabilityCol), col(labelCol).cast(DoubleType)).rdd.map {
-      case Row(score: Vector, label: Double) => (score(1), label)
-    }, 100
-  )
+  @transient private val binaryMetrics = if (predictions.schema.fieldNames.contains(weightCol)) {
+    new BinaryClassificationMetrics(
+      predictions.select(col(probabilityCol), col(labelCol).cast(DoubleType),
+        col(weightCol).cast(DoubleType)).rdd.map {
+        case Row(score: Vector, label: Double, weight: Double) => (score(1), label, weight)
+      }, 100
+    )
+  } else {
+    new BinaryClassificationMetrics(
+      predictions.select(col(probabilityCol), col(labelCol).cast(DoubleType),
+        lit(1.0)).rdd.map {
+        case Row(score: Vector, label: Double, weight: Double) => (score(1), label, weight)
+      }, 100
+    )
+  }
 
   /**
    * Returns the receiver operating characteristic (ROC) curve,
    * which is a Dataframe having two fields (FPR, TPR)
    * with (0.0, 0.0) prepended and (1.0, 1.0) appended to it.
    * See http://en.wikipedia.org/wiki/Receiver_operating_characteristic
-   *
-   * @note This ignores instance weights (setting all to 1.0) from `LogisticRegression.weightCol`.
-   * This will change in later Spark versions.
    */
   @Since("1.5.0")
   @transient lazy val roc: DataFrame = binaryMetrics.roc().toDF("FPR", "TPR")
 
   /**
    * Computes the area under the receiver operating characteristic (ROC) curve.
-   *
-   * @note This ignores instance weights (setting all to 1.0) from `LogisticRegression.weightCol`.
-   * This will change in later Spark versions.
    */
   @Since("1.5.0")
   lazy val areaUnderROC: Double = binaryMetrics.areaUnderROC()
@@ -1578,18 +1598,12 @@ sealed trait BinaryLogisticRegressionSummary extends LogisticRegressionSummary {
   /**
    * Returns the precision-recall curve, which is a Dataframe containing
    * two fields recall, precision with (0.0, 1.0) prepended to it.
-   *
-   * @note This ignores instance weights (setting all to 1.0) from `LogisticRegression.weightCol`.
-   * This will change in later Spark versions.
    */
   @Since("1.5.0")
   @transient lazy val pr: DataFrame = binaryMetrics.pr().toDF("recall", "precision")
 
   /**
    * Returns a dataframe with two fields (threshold, F-Measure) curve with beta = 1.0.
-   *
-   * @note This ignores instance weights (setting all to 1.0) from `LogisticRegression.weightCol`.
-   * This will change in later Spark versions.
    */
   @Since("1.5.0")
   @transient lazy val fMeasureByThreshold: DataFrame = {
@@ -1600,9 +1614,6 @@ sealed trait BinaryLogisticRegressionSummary extends LogisticRegressionSummary {
    * Returns a dataframe with two fields (threshold, precision) curve.
    * Every possible probability obtained in transforming the dataset are used
    * as thresholds used in calculating the precision.
-   *
-   * @note This ignores instance weights (setting all to 1.0) from `LogisticRegression.weightCol`.
-   * This will change in later Spark versions.
    */
   @Since("1.5.0")
   @transient lazy val precisionByThreshold: DataFrame = {
@@ -1613,9 +1624,6 @@ sealed trait BinaryLogisticRegressionSummary extends LogisticRegressionSummary {
    * Returns a dataframe with two fields (threshold, recall) curve.
    * Every possible probability obtained in transforming the dataset are used
    * as thresholds used in calculating the recall.
-   *
-   * @note This ignores instance weights (setting all to 1.0) from `LogisticRegression.weightCol`.
-   * This will change in later Spark versions.
    */
   @Since("1.5.0")
   @transient lazy val recallByThreshold: DataFrame = {
@@ -1625,8 +1633,6 @@ sealed trait BinaryLogisticRegressionSummary extends LogisticRegressionSummary {
 
 /**
  * Abstraction for binary logistic regression training results.
- * Currently, the training summary ignores the training weights except
- * for the objective trace.
  */
 sealed trait BinaryLogisticRegressionTrainingSummary extends BinaryLogisticRegressionSummary
   with LogisticRegressionTrainingSummary
@@ -1641,6 +1647,7 @@ sealed trait BinaryLogisticRegressionTrainingSummary extends BinaryLogisticRegre
  *                      double.
  * @param labelCol field in "predictions" which gives the true label of each instance.
  * @param featuresCol field in "predictions" which gives the features of each instance as a vector.
+ * @param weightCol field in "predictions" which gives the weight of each instance as a vector.
  * @param objectiveHistory objective function (scaled loss + regularization) at each iteration.
  */
 private class LogisticRegressionTrainingSummaryImpl(
@@ -1649,9 +1656,10 @@ private class LogisticRegressionTrainingSummaryImpl(
     predictionCol: String,
     labelCol: String,
     featuresCol: String,
+    weightCol: String,
     override val objectiveHistory: Array[Double])
   extends LogisticRegressionSummaryImpl(
-    predictions, probabilityCol, predictionCol, labelCol, featuresCol)
+    predictions, probabilityCol, predictionCol, labelCol, featuresCol, weightCol)
   with LogisticRegressionTrainingSummary
 
 /**
@@ -1664,13 +1672,15 @@ private class LogisticRegressionTrainingSummaryImpl(
  *                      double.
  * @param labelCol field in "predictions" which gives the true label of each instance.
  * @param featuresCol field in "predictions" which gives the features of each instance as a vector.
+ * @param weightCol field in "predictions" which gives the weight of each instance as a vector.
  */
 private class LogisticRegressionSummaryImpl(
     @transient override val predictions: DataFrame,
     override val probabilityCol: String,
     override val predictionCol: String,
     override val labelCol: String,
-    override val featuresCol: String)
+    override val featuresCol: String,
+    override val weightCol: String)
   extends LogisticRegressionSummary
 
 /**
@@ -1683,6 +1693,7 @@ private class LogisticRegressionSummaryImpl(
  *                      double.
  * @param labelCol field in "predictions" which gives the true label of each instance.
  * @param featuresCol field in "predictions" which gives the features of each instance as a vector.
+ * @param weightCol field in "predictions" which gives the weight of each instance as a vector.
  * @param objectiveHistory objective function (scaled loss + regularization) at each iteration.
  */
 private class BinaryLogisticRegressionTrainingSummaryImpl(
@@ -1691,9 +1702,10 @@ private class BinaryLogisticRegressionTrainingSummaryImpl(
     predictionCol: String,
     labelCol: String,
     featuresCol: String,
+    weightCol: String,
     override val objectiveHistory: Array[Double])
   extends BinaryLogisticRegressionSummaryImpl(
-    predictions, probabilityCol, predictionCol, labelCol, featuresCol)
+    predictions, probabilityCol, predictionCol, labelCol, featuresCol, weightCol)
   with BinaryLogisticRegressionTrainingSummary
 
 /**
@@ -1706,13 +1718,15 @@ private class BinaryLogisticRegressionTrainingSummaryImpl(
  *                      each class as a double.
  * @param labelCol field in "predictions" which gives the true label of each instance.
  * @param featuresCol field in "predictions" which gives the features of each instance as a vector.
+ * @param weightCol field in "predictions" which gives the weight of each instance as a vector.
  */
 private class BinaryLogisticRegressionSummaryImpl(
     predictions: DataFrame,
     probabilityCol: String,
     predictionCol: String,
     labelCol: String,
-    featuresCol: String)
+    featuresCol: String,
+    weightCol: String)
   extends LogisticRegressionSummaryImpl(
-    predictions, probabilityCol, predictionCol, labelCol, featuresCol)
+    predictions, probabilityCol, predictionCol, labelCol, featuresCol, weightCol)
   with BinaryLogisticRegressionSummary

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -29,6 +29,7 @@ import org.apache.spark.SparkException
 import org.apache.spark.annotation.Since
 import org.apache.spark.internal.Logging
 import org.apache.spark.ml.feature._
+import org.apache.spark.ml.functions.checkNonNegativeWeight
 import org.apache.spark.ml.linalg._
 import org.apache.spark.ml.optim.aggregator._
 import org.apache.spark.ml.optim.loss.{L2Regularization, RDDLossFunction}
@@ -1429,7 +1430,7 @@ sealed trait LogisticRegressionSummary extends Serializable {
         predictions.select(
           col(predictionCol),
           col(labelCol).cast(DoubleType),
-          col(weightCol).cast(DoubleType)).rdd.map {
+          checkNonNegativeWeight(col(weightCol).cast(DoubleType))).rdd.map {
           case Row(prediction: Double, label: Double, weight: Double) => (prediction, label, weight)
         })
     } else {
@@ -1567,7 +1568,7 @@ sealed trait BinaryLogisticRegressionSummary extends LogisticRegressionSummary {
   @transient private val binaryMetrics = if (predictions.schema.fieldNames.contains(weightCol)) {
     new BinaryClassificationMetrics(
       predictions.select(col(probabilityCol), col(labelCol).cast(DoubleType),
-        col(weightCol).cast(DoubleType)).rdd.map {
+        checkNonNegativeWeight(col(weightCol).cast(DoubleType))).rdd.map {
         case Row(score: Vector, label: Double, weight: Double) => (score(1), label, weight)
       }, 100
     )

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -333,13 +333,13 @@ class LogisticRegressionSuite extends MLTest with DefaultReadWriteTest {
     assert(blorSummary.weightedRecall ~== blorSummary2.weightedRecall relTol 1e-6)
     assert(blorSummary.asBinary.areaUnderROC ~== blorSummary2.asBinary.areaUnderROC relTol 1e-6)
 
-    assert(blorModel2.summary.asBinary.accuracy ~==
+    assert(blorModel.summary.asBinary.accuracy ~==
       blorModel2.summary.asBinary.accuracy relTol 1e-6)
-    assert(blorModel2.summary.asBinary.weightedPrecision ~==
+    assert(blorModel.summary.asBinary.weightedPrecision ~==
       blorModel2.summary.asBinary.weightedPrecision relTol 1e-6)
-    assert(blorModel2.summary.asBinary.weightedRecall ~==
+    assert(blorModel.summary.asBinary.weightedRecall ~==
       blorModel2.summary.asBinary.weightedRecall relTol 1e-6)
-    assert(blorModel2.summary.asBinary.asBinary.areaUnderROC ~==
+    assert(blorModel.summary.asBinary.asBinary.areaUnderROC ~==
       blorModel2.summary.asBinary.areaUnderROC relTol 1e-6)
 
     assert(mlorSummary.accuracy ~== mlorSummary2.accuracy relTol 1e-6)

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -45,7 +45,11 @@ object MimaExcludes {
     // after: class ChiSqSelector extends PSelector
     // false positive, no binary incompatibility
     ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.ml.feature.ChiSqSelectorModel"),
-    ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.ml.feature.ChiSqSelector")
+    ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.ml.feature.ChiSqSelector"),
+
+    //[SPARK-31840] Add instance weight support in LogisticRegressionSummary
+    // weightCol in org.apache.spark.ml.classification.LogisticRegressionSummary is present only in current version
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.ml.classification.LogisticRegressionSummary.weightCol")
   )
 
   // Exclude rules for 3.0.x

--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -662,6 +662,8 @@ class LogisticRegression(_JavaProbabilisticClassifier, _LogisticRegressionParams
     DenseVector([-1.080..., -0.646...])
     >>> blorModel.intercept
     3.112...
+    >>> blorModel.evaluate(bdf).accuracy == blorModel.summary.accuracy
+    True
     >>> data_path = "data/mllib/sample_multiclass_classification_data.txt"
     >>> mdf = spark.read.format("libsvm").load(data_path)
     >>> mlor = LogisticRegression(regParam=0.1, elasticNetParam=1.0, family="multinomial")
@@ -987,6 +989,15 @@ class LogisticRegressionSummary(JavaWrapper):
         as a vector.
         """
         return self._call_java("featuresCol")
+
+    @property
+    @since("3.1.0")
+    def weightCol(self):
+        """
+        Field in "predictions" which gives the weight of each instance
+        as a vector.
+        """
+        return self._call_java("weightCol")
 
     @property
     @since("2.3.0")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add instance weight support in LogisticRegressionSummary

### Why are the changes needed?
LogisticRegression, MulticlassClassificationEvaluator and BinaryClassificationEvaluator support instance weight. We should support instance weight in LogisticRegressionSummary too. 


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add new tests
