### PR TITLE
[SPARK-31850][SQL]Prevent DetermineTableStats from computing stats multiple times for same table

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -135,7 +135,10 @@ class SessionCatalog(
 
   private val tableRelationCache: Cache[QualifiedTableName, LogicalPlan] = {
     val cacheSize = conf.tableRelationCacheSize
-    CacheBuilder.newBuilder().maximumSize(cacheSize).build[QualifiedTableName, LogicalPlan]()
+    CacheBuilder
+      .newBuilder()
+      .recordStats()
+      .maximumSize(cacheSize).build[QualifiedTableName, LogicalPlan]()
   }
 
   /** This method provides a way to get a cached plan. */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -24,9 +24,11 @@ import scala.collection.{GenMap, GenSeq}
 import scala.collection.parallel.ForkJoinTaskSupport
 import scala.collection.parallel.immutable.ParVector
 import scala.util.control.NonFatal
+
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs._
 import org.apache.hadoop.mapred.{FileInputFormat, JobConf}
+
 import org.apache.spark.internal.config.RDD_PARALLEL_LISTING_THRESHOLD
 import org.apache.spark.sql.{AnalysisException, Row, SparkSession}
 import org.apache.spark.sql.catalyst.{QualifiedTableName, TableIdentifier}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -263,13 +263,13 @@ class FindDataSourceTable(sparkSession: SparkSession) extends Rule[LogicalPlan] 
       i.copy(table = readDataSourceTable(tableMeta))
 
     case i @ InsertIntoStatement(UnresolvedCatalogRelation(tableMeta), _, _, _, _) =>
-      i.copy(table = DDLUtils.readHiveTable(tableMeta))
+      i.copy(table = DDLUtils.readHiveTable(sparkSession.sessionState.catalog, tableMeta))
 
     case UnresolvedCatalogRelation(tableMeta) if DDLUtils.isDatasourceTable(tableMeta) =>
       readDataSourceTable(tableMeta)
 
     case UnresolvedCatalogRelation(tableMeta) =>
-      DDLUtils.readHiveTable(tableMeta)
+      DDLUtils.readHiveTable(sparkSession.sessionState.catalog, tableMeta)
   }
 }
 

--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -37,11 +37,6 @@
   <dependencies>
     <!-- Added for Hive Parquet SerDe -->
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>${hive.parquet.group}</groupId>
       <artifactId>parquet-hadoop-bundle</artifactId>
     </dependency>

--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -37,6 +37,11 @@
   <dependencies>
     <!-- Added for Hive Parquet SerDe -->
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>${hive.parquet.group}</groupId>
       <artifactId>parquet-hadoop-bundle</artifactId>
     </dependency>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -124,8 +124,7 @@ class DetermineTableStats(session: SparkSession) extends Rule[LogicalPlan] {
         val hadoopConf = session.sessionState.newHadoopConf()
         val tablePath = new Path(table.location)
         val fs: FileSystem = tablePath.getFileSystem(hadoopConf)
-        val size = fs.getContentSummary(tablePath).getLength
-        size
+        fs.getContentSummary(tablePath).getLength
       } catch {
         case e: IOException =>
           logWarning("Failed to get table size from HDFS.", e)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -111,7 +111,7 @@ class ResolveHiveSerdeTable(session: SparkSession) extends Rule[LogicalPlan] {
   }
 }
 
-class DetermineTableStats(val session: SparkSession) extends Rule[LogicalPlan] {
+class DetermineTableStats(session: SparkSession) extends Rule[LogicalPlan] {
 
   private[hive] def hiveTableWithStats(relation: HiveTableRelation): HiveTableRelation = {
     val partitionCols = relation.partitionCols

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/CreateHiveTableAsSelectCommand.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/CreateHiveTableAsSelectCommand.scala
@@ -148,7 +148,7 @@ case class OptimizedCreateHiveTableAsSelectCommand(
       tableDesc: CatalogTable,
       tableExists: Boolean): DataWritingCommand = {
     val metastoreCatalog = catalog.asInstanceOf[HiveSessionCatalog].metastoreCatalog
-    val hiveTable = DDLUtils.readHiveTable(tableDesc)
+    val hiveTable = DDLUtils.readHiveTable(catalog, tableDesc)
 
     val hadoopRelation = metastoreCatalog.convert(hiveTable) match {
       case LogicalRelation(t: HadoopFsRelation, _, _, _) => t

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/DetermineTableStatsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/DetermineTableStatsSuite.scala
@@ -56,7 +56,8 @@ class DetermineTableStatsSuite extends QueryTest
       def getStats: CacheStats = {
         cache.stats()
       }
-      
+      spark.sql(s"select count(id) id from ${tName} group by name order by id").collect()
+
       val df = catalog.lookupRelation(TableIdentifier(tName))
       catalog.invalidateAllCachedTables()
       val baseStats: CacheStats = getStats

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/DetermineTableStatsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/DetermineTableStatsSuite.scala
@@ -49,7 +49,7 @@ class DetermineTableStatsSuite extends QueryTest
 
           val hiveRelation = DDLUtils.readHiveTable(spark.sharedState
             .externalCatalog.getTable(SessionCatalog.DEFAULT_DATABASE, tName))
-          val ident = TableIdentifier(tName)
+          val ident = TableIdentifier(tName, Some(SessionCatalog.DEFAULT_DATABASE))
           val rule: DetermineTableStats = mock(classOf[DetermineTableStats])
 
           // define the mock methods behaviour

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/DetermineTableStatsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/DetermineTableStatsSuite.scala
@@ -40,7 +40,7 @@ class DetermineTableStatsSuite extends QueryTest
     sql(s"CREATE TABLE $tName(id int, name STRING) STORED AS PARQUET".stripMargin)
   }
 
-  test("test if table size retrieved from cache") {
+  test("SPARK-31850: Test if table size retrieved from cache") {
     val flags = Seq(true, false)
     flags.foreach {
       hdfsFallbackEnabled =>
@@ -49,8 +49,7 @@ class DetermineTableStatsSuite extends QueryTest
 
           val hiveRelation = DDLUtils.readHiveTable(spark.sharedState
             .externalCatalog.getTable(SessionCatalog.DEFAULT_DATABASE, tName))
-          val tbl1 =
-            spark.sharedState.externalCatalog.getTable(SessionCatalog.DEFAULT_DATABASE, tName)
+          val ident = TableIdentifier(tName)
           val rule: DetermineTableStats = mock(classOf[DetermineTableStats])
 
           // define the mock methods behaviour
@@ -61,7 +60,7 @@ class DetermineTableStatsSuite extends QueryTest
 
           rule.apply(hiveRelation)
           assert(relationToSizeMap.nonEmpty == hdfsFallbackEnabled)
-          assert(relationToSizeMap.contains(tbl1.identifier) == hdfsFallbackEnabled)
+          assert(relationToSizeMap.contains(ident) == hdfsFallbackEnabled)
 
           // clear the map for next iteration
           relationToSizeMap.clear()

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/DetermineTableStatsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/DetermineTableStatsSuite.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.hive
+
+import scala.collection.mutable
+
+import org.mockito.Mockito._
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.SessionCatalog
+import org.apache.spark.sql.execution.command.DDLUtils
+import org.apache.spark.sql.hive.test.TestHiveSingleton
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SQLTestUtils
+
+class DetermineTableStatsSuite extends QueryTest
+  with TestHiveSingleton
+  with SQLTestUtils {
+
+  val relationToSizeMap: mutable.Map[TableIdentifier, Long] = mutable.Map.empty
+  val tName = "t1"
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    sql(s"CREATE TABLE $tName(id int, name STRING) STORED AS PARQUET".stripMargin)
+  }
+
+  test("test if table size retrieved from cache") {
+    val flags = Seq(true, false)
+    flags.foreach {
+      hdfsFallbackEnabled =>
+        withSQLConf((SQLConf.ENABLE_FALL_BACK_TO_HDFS_FOR_STATS.key,
+          hdfsFallbackEnabled.toString)) {
+
+          val hiveRelation = DDLUtils.readHiveTable(spark.sharedState
+            .externalCatalog.getTable(SessionCatalog.DEFAULT_DATABASE, tName))
+          val tbl1 =
+            spark.sharedState.externalCatalog.getTable(SessionCatalog.DEFAULT_DATABASE, tName)
+          val rule: DetermineTableStats = mock(classOf[DetermineTableStats])
+
+          // define the mock methods behaviour
+          when(rule.session).thenReturn(spark)
+          when(rule.getRelationToSizeMap).thenReturn(relationToSizeMap)
+          when(rule.hiveTableWithStats(hiveRelation)).thenCallRealMethod()
+          when(rule.apply(hiveRelation)).thenCallRealMethod()
+
+          rule.apply(hiveRelation)
+          assert(relationToSizeMap.nonEmpty == hdfsFallbackEnabled)
+          assert(relationToSizeMap.contains(tbl1.identifier) == hdfsFallbackEnabled)
+
+          // clear the map for next iteration
+          relationToSizeMap.clear()
+        }
+    }
+  }
+
+  override def afterAll(): Unit = {
+    spark.sql(s"drop table $tName")
+    super.afterAll()
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Changes to avoid stats computation for same table multiple times

Repro steps
```
spark.sql("set spark.sql.hive.convertMetastoreParquet=false")
spark.sql("create table c(id INT, name STRING) STORED AS PARQUET")
val df = spark.sql("select count(id) id from c group by name order by id " )
df.queryExecution.analyzed
```
**Stacktrace indicating that stats collection happens multiple times:**
```
  at org.apache.spark.sql.hive.DetermineTableStats.hiveTableWithStats(HiveStrategies.scala:121)
  at org.apache.spark.sql.hive.DetermineTableStats$$anonfun$apply$2.applyOrElse(HiveStrategies.scala:150)
  at org.apache.spark.sql.hive.DetermineTableStats$$anonfun$apply$2.applyOrElse(HiveStrategies.scala:147)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.$anonfun$resolveOperatorsDown$2(AnalysisHelper.scala:108)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$$Lambda$870.808816071.apply(Unknown Source:-1)
  at org.apache.spark.sql.catalyst.trees.CurrentOrigin$.withOrigin(TreeNode.scala:72)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.$anonfun$resolveOperatorsDown$1(AnalysisHelper.scala:108)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$$Lambda$869.1113025977.apply(Unknown Source:-1)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$.allowInvokingTransformsInAnalyzer(AnalysisHelper.scala:194)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.resolveOperatorsDown(AnalysisHelper.scala:106)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.resolveOperatorsDown$(AnalysisHelper.scala:104)
  at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.resolveOperatorsDown(LogicalPlan.scala:29)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.$anonfun$resolveOperatorsDown$4(AnalysisHelper.scala:113)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$$Lambda$872.1354725727.apply(Unknown Source:-1)
  at org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$mapChildren$1(TreeNode.scala:399)
  at org.apache.spark.sql.catalyst.trees.TreeNode$$Lambda$1144.1492742163.apply(Unknown Source:-1)
  at org.apache.spark.sql.catalyst.trees.TreeNode.mapProductIterator(TreeNode.scala:237)
  at org.apache.spark.sql.catalyst.trees.TreeNode.mapChildren(TreeNode.scala:397)
  at org.apache.spark.sql.catalyst.trees.TreeNode.mapChildren(TreeNode.scala:350)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.$anonfun$resolveOperatorsDown$1(AnalysisHelper.scala:113)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$$Lambda$869.1113025977.apply(Unknown Source:-1)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$.allowInvokingTransformsInAnalyzer(AnalysisHelper.scala:194)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.resolveOperatorsDown(AnalysisHelper.scala:106)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.resolveOperatorsDown$(AnalysisHelper.scala:104)
  at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.resolveOperatorsDown(LogicalPlan.scala:29)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.$anonfun$resolveOperatorsDown$4(AnalysisHelper.scala:113)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$$Lambda$872.1354725727.apply(Unknown Source:-1)
  at org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$mapChildren$1(TreeNode.scala:399)
  at org.apache.spark.sql.catalyst.trees.TreeNode$$Lambda$1144.1492742163.apply(Unknown Source:-1)
  at org.apache.spark.sql.catalyst.trees.TreeNode.mapProductIterator(TreeNode.scala:237)
  at org.apache.spark.sql.catalyst.trees.TreeNode.mapChildren(TreeNode.scala:397)
  at org.apache.spark.sql.catalyst.trees.TreeNode.mapChildren(TreeNode.scala:350)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.$anonfun$resolveOperatorsDown$1(AnalysisHelper.scala:113)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$$Lambda$869.1113025977.apply(Unknown Source:-1)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$.allowInvokingTransformsInAnalyzer(AnalysisHelper.scala:194)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.resolveOperatorsDown(AnalysisHelper.scala:106)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.resolveOperatorsDown$(AnalysisHelper.scala:104)
  at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.resolveOperatorsDown(LogicalPlan.scala:29)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.resolveOperators(AnalysisHelper.scala:73)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.resolveOperators$(AnalysisHelper.scala:72)
  at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.resolveOperators(LogicalPlan.scala:29)
  at org.apache.spark.sql.hive.DetermineTableStats.apply(HiveStrategies.scala:147)
  at org.apache.spark.sql.hive.DetermineTableStats.apply(HiveStrategies.scala:114)
  at org.apache.spark.sql.catalyst.rules.RuleExecutor.$anonfun$execute$2(RuleExecutor.scala:149)
  at org.apache.spark.sql.catalyst.rules.RuleExecutor$$Lambda$863.668742490.apply(Unknown Source:-1)
  at scala.collection.IndexedSeqOptimized.foldLeft(IndexedSeqOptimized.scala:60)
  at scala.collection.IndexedSeqOptimized.foldLeft$(IndexedSeqOptimized.scala:68)
  at scala.collection.mutable.ArrayBuffer.foldLeft(ArrayBuffer.scala:49)
  at org.apache.spark.sql.catalyst.rules.RuleExecutor.$anonfun$execute$1(RuleExecutor.scala:146)
  at org.apache.spark.sql.catalyst.rules.RuleExecutor.$anonfun$execute$1$adapted(RuleExecutor.scala:138)
  at org.apache.spark.sql.catalyst.rules.RuleExecutor$$Lambda$862.773865813.apply(Unknown Source:-1)
  at scala.collection.immutable.List.foreach(List.scala:392)
  at org.apache.spark.sql.catalyst.rules.RuleExecutor.execute(RuleExecutor.scala:138)
  at org.apache.spark.sql.catalyst.analysis.Analyzer.org$apache$spark$sql$catalyst$analysis$Analyzer$$executeSameContext(Analyzer.scala:176)
  at org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveAggregateFunctions$$anonfun$apply$20.applyOrElse(Analyzer.scala:2139)
  at org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveAggregateFunctions$$anonfun$apply$20.applyOrElse(Analyzer.scala:2116)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.$anonfun$resolveOperatorsUp$3(AnalysisHelper.scala:90)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$$Lambda$866.1662235713.apply(Unknown Source:-1)
  at org.apache.spark.sql.catalyst.trees.CurrentOrigin$.withOrigin(TreeNode.scala:72)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.$anonfun$resolveOperatorsUp$1(AnalysisHelper.scala:90)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$$Lambda$864.152426436.apply(Unknown Source:-1)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$.allowInvokingTransformsInAnalyzer(AnalysisHelper.scala:194)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.resolveOperatorsUp(AnalysisHelper.scala:86)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.resolveOperatorsUp$(AnalysisHelper.scala:84)
  at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.resolveOperatorsUp(LogicalPlan.scala:29)
  at org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveAggregateFunctions$.apply(Analyzer.scala:2116)
  at org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveAggregateFunctions$.apply(Analyzer.scala:2115)
  at org.apache.spark.sql.catalyst.rules.RuleExecutor.$anonfun$execute$2(RuleExecutor.scala:149)
  at org.apache.spark.sql.catalyst.rules.RuleExecutor$$Lambda$863.668742490.apply(Unknown Source:-1)
  at scala.collection.LinearSeqOptimized.foldLeft(LinearSeqOptimized.scala:126)
  at scala.collection.LinearSeqOptimized.foldLeft$(LinearSeqOptimized.scala:122)
  at scala.collection.immutable.List.foldLeft(List.scala:89)
  at org.apache.spark.sql.catalyst.rules.RuleExecutor.$anonfun$execute$1(RuleExecutor.scala:146)
  at org.apache.spark.sql.catalyst.rules.RuleExecutor.$anonfun$execute$1$adapted(RuleExecutor.scala:138)
  at org.apache.spark.sql.catalyst.rules.RuleExecutor$$Lambda$862.773865813.apply(Unknown Source:-1)
  at scala.collection.immutable.List.foreach(List.scala:392)
  at org.apache.spark.sql.catalyst.rules.RuleExecutor.execute(RuleExecutor.scala:138)
  at org.apache.spark.sql.catalyst.analysis.Analyzer.org$apache$spark$sql$catalyst$analysis$Analyzer$$executeSameContext(Analyzer.scala:176)
  at org.apache.spark.sql.catalyst.analysis.Analyzer.execute(Analyzer.scala:170)
```
- In the above trace we can see **DetermineTableStats** got triggered as part of executing **ResolveAggregateFunctions**.
- **ResolveAggregateFunctions** is part of a batch which has **FixedPoint** as its execution strategy, hence the computation can happen any number of times, based on when Fixed point is reached.
- This is not specific to **ResolveAggregateFunctions**, any analyzer rule which invokes _org.apache.spark.sql.catalyst.analysis.Analyzer#executeSameContext_ will face this issue.
- In best case , **DetermineTableStats** rule will run atleast **thrice** as part of analysis phase, twice as part of **ResolveAggregateFunctions**(assuming fixed point is reached in the first two attempts ) and once as past of **postHocResolutionRules#DetermineTableStats**

 **Note:** 

- There is no log line in DetermineTableStats to indicate that stats compute happened. Need to add a log line or use a debugger

- The above can be repro-ed with first query on a created table.

### Why are the changes needed?
Stats computation might be an expensive operation especially for a large table
Once stats are computed for a table, it can be re-used. 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit tests added
