### PR TITLE
[SPARK-31860][BUILD][2.4] only push release tags on success

### DIFF
--- a/dev/create-release/do-release.sh
+++ b/dev/create-release/do-release.sh
@@ -54,9 +54,6 @@ function should_build {
 if should_build "tag" && [ $SKIP_TAG = 0 ]; then
   run_silent "Creating release tag $RELEASE_TAG..." "tag.log" \
     "$SELF/release-tag.sh"
-  echo "It may take some time for the tag to be synchronized to github."
-  echo "Press enter when you've verified that the new tag ($RELEASE_TAG) is available."
-  read
 else
   echo "Skipping tag creation for $RELEASE_TAG."
 fi

--- a/dev/create-release/do-release.sh
+++ b/dev/create-release/do-release.sh
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+set -e
+
 SELF=$(cd $(dirname $0) && pwd)
 . "$SELF/release-util.sh"
 
@@ -78,4 +80,10 @@ if should_build "publish"; then
     "$SELF/release-build.sh" publish-release
 else
   echo "Skipping publish step."
+fi
+
+if should_build "tag" && [ $SKIP_TAG = 0 ]; then
+  # Push the tag after success
+  git push origin "$RELEASE_TAG"
+  git push origin "HEAD:$GIT_BRANCH"
 fi

--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -92,9 +92,12 @@ BASE_DIR=$(pwd)
 init_java
 init_maven_sbt
 
-rm -rf spark
-git clone "$ASF_REPO"
+# Only clone the repo fresh when not present, otherwise use checkout
+if [ ! -d spark ]; then
+  git clone "$ASF_REPO"
+fi
 cd spark
+git fetch
 git checkout $GIT_REF
 git_hash=`git rev-parse --short HEAD`
 echo "Checked out Spark git hash $git_hash"

--- a/dev/create-release/release-tag.sh
+++ b/dev/create-release/release-tag.sh
@@ -101,7 +101,6 @@ sed -i".tmp7" 's/SPARK_VERSION_SHORT:.*$/SPARK_VERSION_SHORT: '"$R_NEXT_VERSION"
 
 git commit -a -m "Preparing development version $NEXT_VERSION"
 
-cd ..
 if is_dry_run; then
   cd ..
   mv spark spark.tag

--- a/dev/create-release/release-tag.sh
+++ b/dev/create-release/release-tag.sh
@@ -24,7 +24,7 @@ function exit_with_usage {
   local NAME=$(basename $0)
   cat << EOF
 usage: $NAME
-Tags a Spark release on a particular branch.
+Tags a Spark release on a particular branch. Must push after
 
 Inputs are specified with the following environment variables:
 ASF_USERNAME - Apache Username
@@ -102,9 +102,6 @@ sed -i".tmp7" 's/SPARK_VERSION_SHORT:.*$/SPARK_VERSION_SHORT: '"$R_NEXT_VERSION"
 git commit -a -m "Preparing development version $NEXT_VERSION"
 
 if ! is_dry_run; then
-  # Push changes
-  git push origin $RELEASE_TAG
-  git push origin HEAD:$GIT_BRANCH
 
   cd ..
   rm -rf spark

--- a/dev/create-release/release-tag.sh
+++ b/dev/create-release/release-tag.sh
@@ -101,11 +101,8 @@ sed -i".tmp7" 's/SPARK_VERSION_SHORT:.*$/SPARK_VERSION_SHORT: '"$R_NEXT_VERSION"
 
 git commit -a -m "Preparing development version $NEXT_VERSION"
 
-if ! is_dry_run; then
-
-  cd ..
-  rm -rf spark
-else
+cd ..
+if is_dry_run; then
   cd ..
   mv spark spark.tag
   echo "Clone with version changes and tag available as spark.tag in the output directory."


### PR DESCRIPTION
### What changes were proposed in this pull request?

Only push the release tag after the build has finished.

### Why are the changes needed?

If the build fails we don't need a release tag.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Running locally with a fake user
