### PR TITLE
[SPARK-31875][SQL] Provide a option to disable user supplied Hints

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -200,6 +200,8 @@ class Analyzer(
   val postHocResolutionRules: Seq[Rule[LogicalPlan]] = Nil
 
   lazy val batches: Seq[Batch] = Seq(
+    Batch("Disable Hints", Once,
+      new ResolveHints.DisableHints(conf)),
     Batch("Hints", fixedPoint,
       new ResolveHints.ResolveJoinStrategyHints(conf),
       new ResolveHints.ResolveCoalesceHints(conf)),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
@@ -286,7 +286,7 @@ object ResolveHints {
    */
   class DisableHints(conf: SQLConf) extends RemoveAllHints(conf: SQLConf) {
     override def apply(plan: LogicalPlan): LogicalPlan = {
-      if (conf.optimizerIgnoreHints) super.apply(plan) else plan
+      if (conf.getConf(SQLConf.OPTIMIZER_IGNORE_HINTS)) super.apply(plan) else plan
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
@@ -144,7 +144,7 @@ object ResolveHints {
     }
 
     def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperatorsUp {
-      case h: UnresolvedHint if conf.optimizerHintsEnabled &&
+      case h: UnresolvedHint if !conf.optimizerIgnoreHints &&
           STRATEGY_HINT_NAMES.contains(h.name.toUpperCase(Locale.ROOT)) =>
         if (h.parameters.isEmpty) {
           // If there is no table alias specified, apply the hint on the entire subtree.
@@ -249,7 +249,7 @@ object ResolveHints {
     }
 
     def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperators {
-      case hint @ UnresolvedHint(hintName, _, _) if conf.optimizerHintsEnabled =>
+      case hint @ UnresolvedHint(hintName, _, _) if !conf.optimizerIgnoreHints =>
         hintName.toUpperCase(Locale.ROOT) match {
           case "REPARTITION" =>
             createRepartition(shuffle = true, hint)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
@@ -144,7 +144,8 @@ object ResolveHints {
     }
 
     def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperatorsUp {
-      case h: UnresolvedHint if STRATEGY_HINT_NAMES.contains(h.name.toUpperCase(Locale.ROOT)) =>
+      case h: UnresolvedHint if conf.optimizerHintsEnabled &&
+          STRATEGY_HINT_NAMES.contains(h.name.toUpperCase(Locale.ROOT)) =>
         if (h.parameters.isEmpty) {
           // If there is no table alias specified, apply the hint on the entire subtree.
           ResolvedHint(h.child, createHintInfo(h.name))
@@ -248,7 +249,8 @@ object ResolveHints {
     }
 
     def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperators {
-      case hint @ UnresolvedHint(hintName, _, _) => hintName.toUpperCase(Locale.ROOT) match {
+      case hint @ UnresolvedHint(hintName, _, _) if conf.optimizerHintsEnabled =>
+        hintName.toUpperCase(Locale.ROOT) match {
           case "REPARTITION" =>
             createRepartition(shuffle = true, hint)
           case "COALESCE" =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
@@ -286,7 +286,7 @@ object ResolveHints {
    */
   class DisableHints(conf: SQLConf) extends RemoveAllHints(conf: SQLConf) {
     override def apply(plan: LogicalPlan): LogicalPlan = {
-      if (conf.getConf(SQLConf.IGNORE_HINTS)) super.apply(plan) else plan
+      if (conf.getConf(SQLConf.DISABLE_HINTS)) super.apply(plan) else plan
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
@@ -280,7 +280,7 @@ object ResolveHints {
   }
 
   /**
-   * Removes all the hints when `spark.sql.ignorePlanHints` is set.
+   * Removes all the hints when `spark.sql.optimizer.disableHints` is set.
    * This is executed at the very beginning of the Analyzer to disable
    * the hint functionality.
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
@@ -280,13 +280,13 @@ object ResolveHints {
   }
 
   /**
-   * Removes all the hints when `spark.sql.optimizer.ignoreHints` is set.
+   * Removes all the hints when `spark.sql.ignorePlanHints` is set.
    * This is executed at the very beginning of the Analyzer to disable
    * the hint functionality.
    */
   class DisableHints(conf: SQLConf) extends RemoveAllHints(conf: SQLConf) {
     override def apply(plan: LogicalPlan): LogicalPlan = {
-      if (conf.getConf(SQLConf.OPTIMIZER_IGNORE_HINTS)) super.apply(plan) else plan
+      if (conf.getConf(SQLConf.IGNORE_HINTS)) super.apply(plan) else plan
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2106,6 +2106,16 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val OPTIMIZER_HINTS_ENABLED =
+    buildConf("spark.sql.optimizer.hints.enabled")
+      .internal()
+      .doc("Hints are additional directives that aids optimizer in better planning of a query. " +
+        "This configuration when set to `false`, disables the application of user " +
+        "specified hints.")
+      .version("3.1.0")
+      .booleanConf
+      .createWithDefault(true)
+
   val NESTED_PREDICATE_PUSHDOWN_FILE_SOURCE_LIST =
     buildConf("spark.sql.optimizer.nestedPredicatePushdown.supportedFileSources")
       .internal()
@@ -3193,6 +3203,8 @@ class SQLConf extends Serializable with Logging {
   def ansiEnabled: Boolean = getConf(ANSI_ENABLED)
 
   def nestedSchemaPruningEnabled: Boolean = getConf(NESTED_SCHEMA_PRUNING_ENABLED)
+
+  def optimizerHintsEnabled: Boolean = getConf(OPTIMIZER_HINTS_ENABLED)
 
   def serializerNestedSchemaPruningEnabled: Boolean =
     getConf(SERIALIZER_NESTED_SCHEMA_PRUNING_ENABLED)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2109,9 +2109,8 @@ object SQLConf {
   val OPTIMIZER_HINTS_ENABLED =
     buildConf("spark.sql.optimizer.hints.enabled")
       .internal()
-      .doc("Hints are additional directives that aids optimizer in better planning of a query. " +
-        "This configuration when set to `false`, disables the application of user " +
-        "specified hints.")
+      .doc("When false, the optimizer will ignore user-specified hints that are additional " +
+        "directives for better planning of a query.")
       .version("3.1.0")
       .booleanConf
       .createWithDefault(true)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3203,8 +3203,6 @@ class SQLConf extends Serializable with Logging {
 
   def nestedSchemaPruningEnabled: Boolean = getConf(NESTED_SCHEMA_PRUNING_ENABLED)
 
-  def optimizerIgnoreHints: Boolean = getConf(OPTIMIZER_IGNORE_HINTS)
-
   def serializerNestedSchemaPruningEnabled: Boolean =
     getConf(SERIALIZER_NESTED_SCHEMA_PRUNING_ENABLED)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2106,10 +2106,10 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
-  val IGNORE_HINTS =
+  val DISABLE_HINTS =
     buildConf("spark.sql.optimizer.disableHints")
       .internal()
-      .doc("When true, the optimizer will ignore user-specified hints that are additional " +
+      .doc("When true, the optimizer will disable user-specified hints that are additional " +
         "directives for better planning of a query.")
       .version("3.1.0")
       .booleanConf

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2106,8 +2106,8 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
-  val OPTIMIZER_IGNORE_HINTS =
-    buildConf("spark.sql.optimizer.ignoreHints")
+  val IGNORE_HINTS =
+    buildConf("spark.sql.ignorePlanHints")
       .internal()
       .doc("When true, the optimizer will ignore user-specified hints that are additional " +
         "directives for better planning of a query.")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2106,14 +2106,14 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
-  val OPTIMIZER_HINTS_ENABLED =
-    buildConf("spark.sql.optimizer.hints.enabled")
+  val OPTIMIZER_IGNORE_HINTS =
+    buildConf("spark.sql.optimizer.ignoreHints")
       .internal()
-      .doc("When false, the optimizer will ignore user-specified hints that are additional " +
+      .doc("When true, the optimizer will ignore user-specified hints that are additional " +
         "directives for better planning of a query.")
       .version("3.1.0")
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(false)
 
   val NESTED_PREDICATE_PUSHDOWN_FILE_SOURCE_LIST =
     buildConf("spark.sql.optimizer.nestedPredicatePushdown.supportedFileSources")
@@ -3203,7 +3203,7 @@ class SQLConf extends Serializable with Logging {
 
   def nestedSchemaPruningEnabled: Boolean = getConf(NESTED_SCHEMA_PRUNING_ENABLED)
 
-  def optimizerHintsEnabled: Boolean = getConf(OPTIMIZER_HINTS_ENABLED)
+  def optimizerIgnoreHints: Boolean = getConf(OPTIMIZER_IGNORE_HINTS)
 
   def serializerNestedSchemaPruningEnabled: Boolean =
     getConf(SERIALIZER_NESTED_SCHEMA_PRUNING_ENABLED)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2107,7 +2107,7 @@ object SQLConf {
       .createWithDefault(true)
 
   val IGNORE_HINTS =
-    buildConf("spark.sql.ignorePlanHints")
+    buildConf("spark.sql.optimizer.disableHints")
       .internal()
       .doc("When true, the optimizer will ignore user-specified hints that are additional " +
         "directives for better planning of a query.")

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3522,7 +3522,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     }
   }
 
-  test("disable hint resolution when spark.sql.optimizer.ignoreHints = true") {
+  test("SPARK-31875: disable hint resolution when spark.sql.optimizer.ignoreHints = true") {
     withSQLConf(SQLConf.OPTIMIZER_IGNORE_HINTS.key -> "true") {
       withTempView("t1", "t2") {
         Seq[Integer](1, 2).toDF("c1").createOrReplaceTempView("t1")

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3522,8 +3522,8 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     }
   }
 
-  test("disable hint resolution when spark.sql.optimizer.hints.enabled = false") {
-    withSQLConf("spark.sql.optimizer.hints.enabled" -> "false") {
+  test("disable hint resolution when spark.sql.optimizer.ignoreHints = true") {
+    withSQLConf(SQLConf.OPTIMIZER_IGNORE_HINTS.key -> "true") {
       withTempView("t1", "t2") {
         Seq[Integer](1, 2).toDF("c1").createOrReplaceTempView("t1")
         Seq[Integer](1, 2).toDF("c1").createOrReplaceTempView("t2")

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3521,6 +3521,45 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
             |""".stripMargin), Row(1))
     }
   }
+
+  test("disable hint resolution when spark.sql.optimizer.hints.enabled = false") {
+    withSQLConf("spark.sql.optimizer.hints.enabled" -> "false") {
+      withTempView("t1", "t2") {
+        Seq[Integer](1, 2).toDF("c1").createOrReplaceTempView("t1")
+        Seq[Integer](1, 2).toDF("c1").createOrReplaceTempView("t2")
+        val repartitionHints = Seq(
+          "COALESCE(2)",
+          "REPARTITION(c1)",
+          "REPARTITION(c1, 2)",
+          "REPARTITION_BY_RANGE(c1, 2)",
+          "REPARTITION_BY_RANGE(c1)"
+        )
+        val joinHints = Seq(
+          "BROADCASTJOIN (t1)",
+          "MAPJOIN(t1)",
+          "SHUFFLE_MERGE(t1)",
+          "MERGEJOIN(t1)",
+          "SHUFFLE_REPLICATE_NL(t1)"
+        )
+
+        repartitionHints.foreach { hintName =>
+          val sqlText = s"SELECT /*+ $hintName */ * FROM t1"
+          val sqlTextWithoutHint = "SELECT * FROM t1"
+          val expectedPlan = sql(sqlTextWithoutHint)
+          val actualPlan = sql(sqlText)
+          comparePlans(actualPlan.queryExecution.analyzed, expectedPlan.queryExecution.analyzed)
+        }
+
+        joinHints.foreach { hintName =>
+          val sqlText = s"SELECT /*+ $hintName */ * FROM t1 INNER JOIN t2 ON t1.c1 = t2.c1"
+          val sqlTextWithoutHint = "SELECT * FROM t1 INNER JOIN t2 ON t1.c1 = t2.c1"
+          val expectedPlan = sql(sqlTextWithoutHint)
+          val actualPlan = sql(sqlText)
+          comparePlans(actualPlan.queryExecution.analyzed, expectedPlan.queryExecution.analyzed)
+        }
+      }
+    }
+  }
 }
 
 case class Foo(bar: Option[String])

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3522,7 +3522,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     }
   }
 
-  test("SPARK-31875: remove hints from plan when spark.sql.ignorePlanHints = true") {
+  test("SPARK-31875: remove hints from plan when spark.sql.optimizer.disableHints = true") {
     withSQLConf(SQLConf.IGNORE_HINTS.key -> "true") {
       withTempView("t1", "t2") {
         Seq[Integer](1, 2).toDF("c1").createOrReplaceTempView("t1")

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3523,7 +3523,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
   }
 
   test("SPARK-31875: remove hints from plan when spark.sql.optimizer.disableHints = true") {
-    withSQLConf(SQLConf.IGNORE_HINTS.key -> "true") {
+    withSQLConf(SQLConf.DISABLE_HINTS.key -> "true") {
       withTempView("t1", "t2") {
         Seq[Integer](1, 2).toDF("c1").createOrReplaceTempView("t1")
         Seq[Integer](1, 2).toDF("c1").createOrReplaceTempView("t2")

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3522,8 +3522,8 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     }
   }
 
-  test("SPARK-31875: disable hint resolution when spark.sql.optimizer.ignoreHints = true") {
-    withSQLConf(SQLConf.OPTIMIZER_IGNORE_HINTS.key -> "true") {
+  test("SPARK-31875: remove hints from plan when spark.sql.ignorePlanHints = true") {
+    withSQLConf(SQLConf.IGNORE_HINTS.key -> "true") {
       withTempView("t1", "t2") {
         Seq[Integer](1, 2).toDF("c1").createOrReplaceTempView("t1")
         Seq[Integer](1, 2).toDF("c1").createOrReplaceTempView("t2")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Introduce a new SQL config `spark.sql.optimizer.ignoreHints`. When this is set to true
application of hints are disabled. This is similar to Oracle's OPTIMIZER_IGNORE_HINTS.
This can be helpful to study the impact of performance difference when hints are applied vs when they are not.

### Why are the changes needed?
Can be helpful to study the impact of performance difference when hints are applied vs when they are not.

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
New tests added in ResolveHintsSuite.