### PR TITLE
[SPARK-31877][SQL]Avoid stats computation for Hive table

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -654,8 +654,7 @@ case class HiveTableRelation(
     tableMeta: CatalogTable,
     dataCols: Seq[AttributeReference],
     partitionCols: Seq[AttributeReference],
-    tableStats: Option[Statistics] = Option(Statistics(sizeInBytes
-      = SQLConf.get.defaultSizeInBytes)),
+    tableStats: Statistics = Statistics(sizeInBytes = SQLConf.get.defaultSizeInBytes),
     @transient prunedPartitions: Option[Seq[CatalogTablePartition]] = None)
   extends LeafNode with MultiInstanceRelation {
   assert(tableMeta.identifier.database.isDefined)
@@ -681,10 +680,9 @@ case class HiveTableRelation(
   )
 
   override def computeStats(): Statistics = {
-    tableMeta.stats.map(_.toPlanStats(output, conf.cboEnabled || conf.planStatsEnabled))
-      .orElse(tableStats)
-      .getOrElse {
-      throw new IllegalStateException("table stats must be specified.")
+    tableMeta.stats.map(_.toPlanStats(output, conf.cboEnabled || conf.planStatsEnabled)) match {
+      case Some(stats) => stats
+      case _ => tableStats
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -654,7 +654,7 @@ case class HiveTableRelation(
     tableMeta: CatalogTable,
     dataCols: Seq[AttributeReference],
     partitionCols: Seq[AttributeReference],
-    tableStats: Option[Statistics] = None,
+    tableStats: Option[Statistics] = Some(Statistics(sizeInBytes = SQLConf.get.defaultSizeInBytes)),
     @transient prunedPartitions: Option[Seq[CatalogTablePartition]] = None)
   extends LeafNode with MultiInstanceRelation {
   assert(tableMeta.identifier.database.isDefined)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -654,7 +654,7 @@ case class HiveTableRelation(
     tableMeta: CatalogTable,
     dataCols: Seq[AttributeReference],
     partitionCols: Seq[AttributeReference],
-    tableStats: Option[Statistics] = Some(Statistics(sizeInBytes = SQLConf.get.defaultSizeInBytes)),
+    tableStats: Option[Statistics] = Option(Statistics(sizeInBytes = SQLConf.get.defaultSizeInBytes)),
     @transient prunedPartitions: Option[Seq[CatalogTablePartition]] = None)
   extends LeafNode with MultiInstanceRelation {
   assert(tableMeta.identifier.database.isDefined)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -654,7 +654,8 @@ case class HiveTableRelation(
     tableMeta: CatalogTable,
     dataCols: Seq[AttributeReference],
     partitionCols: Seq[AttributeReference],
-    tableStats: Option[Statistics] = Option(Statistics(sizeInBytes = SQLConf.get.defaultSizeInBytes)),
+    tableStats: Option[Statistics] = Option(Statistics(sizeInBytes
+      = SQLConf.get.defaultSizeInBytes)),
     @transient prunedPartitions: Option[Seq[CatalogTablePartition]] = None)
   extends LeafNode with MultiInstanceRelation {
   assert(tableMeta.identifier.database.isDefined)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
@@ -82,8 +82,8 @@ class HiveSessionStateBuilder(session: SparkSession, parentState: Option[Session
 
     override val postHocResolutionRules: Seq[Rule[LogicalPlan]] =
       new DetectAmbiguousSelfJoin(conf) +:
-        new DetermineTableStats(session) +:
         RelationConversions(conf, catalog) +:
+        new DetermineTableStats(session) +:
         PreprocessTableCreation(session) +:
         PreprocessTableInsertion(conf) +:
         DataSourceAnalysis(conf) +:

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -133,7 +133,7 @@ class DetermineTableStats(session: SparkSession) extends Rule[LogicalPlan] {
       conf.defaultSizeInBytes
     }
 
-    val stats = Some(Statistics(sizeInBytes = BigInt(sizeInBytes)))
+    val stats = Statistics(sizeInBytes = BigInt(sizeInBytes))
     relation.copy(tableStats = stats)
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -24,8 +24,8 @@ import org.apache.hadoop.fs.Path
 import org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER
 import org.apache.parquet.hadoop.ParquetFileReader
 import org.scalatest.BeforeAndAfterEach
+
 import org.apache.spark.SparkException
-import org.apache.spark.sql.catalyst.QueryPlanningTracker.RuleSummary
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row, SaveMode}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{NoSuchPartitionException, TableAlreadyExistsException}

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveExplainSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveExplainSuite.scala
@@ -62,13 +62,15 @@ class HiveExplainSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
     }
 
     // No statistics information if "cost" is not specified
-    checkKeywordsNotExist(sql("EXPLAIN  SELECT * FROM src "), "sizeInBytes", "rowCount")
+    checkKeywordsExist(sql("EXPLAIN  SELECT * FROM src "), "sizeInBytes=8.0 EiB")
+    checkKeywordsNotExist(sql("EXPLAIN  SELECT * FROM src "), "rowCount")
   }
 
   test("explain extended command") {
     checkKeywordsExist(sql(" explain   select * from src where key=123 "),
                    "== Physical Plan ==",
-                   "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe")
+                   "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
+                   "Statistics(sizeInBytes=8.0 EiB)")
 
     checkKeywordsNotExist(sql(" explain   select * from src where key=123 "),
                    "== Parsed Logical Plan ==",
@@ -81,7 +83,6 @@ class HiveExplainSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
                    "Type",
                    "Provider",
                    "Properties",
-                   "Statistics",
                    "Location",
                    "Serde Library",
                    "InputFormat",


### PR DESCRIPTION

### What changes were proposed in this pull request?
As part of **DetermineTableStats** rule we compute the stats for a HiveTableRelation, whcih can b an expensive operation. And it could happen multiple times for a query(SPARK-31850).

In most cases(the flag for converting Parquet and Orc table to datasource table is enabled by default in master branch), **RelationConversion** rule converts the HiveTableRelation to LogicalRelation.
When the conversion happens, the stats computed as part of Hive Table relation does not get used.

In this change,  stats compute is avoided by performing the conversion before computing stats.

### Why are the changes needed?
With the change, stats for Hive table will not be computed unnecessarily.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
It was tested on local machine and  behaviour verified.
