### PR TITLE
[SPARK-31878][SQL] Create date formatter only once in `HiveResult`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/HiveResult.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/HiveResult.scala
@@ -73,7 +73,13 @@ object HiveResult {
   }
 
   private def zoneId = DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone)
-  private def dateFormatter = DateFormatter(zoneId)
+  // Date formatting does not depend on time zone ID because it converts local days
+  // since the epoch to local date string. Time zone id does matter only in parsing
+  // when the parser has to handle special values like `now`, `yesterday` and etc.
+  // Here, `dateFormatter` is used only for formatting, so, we can initialize it by
+  // any time zone once, for instance, by the current session time zone. And we can
+  // reuse it even when the session time zone might be changed.
+  private val dateFormatter = DateFormatter(zoneId)
   private def timestampFormatter = TimestampFormatter.getFractionFormatter(zoneId)
 
   /** Formats a datum (based on the given data type) and returns the string representation. */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/HiveResult.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/HiveResult.scala
@@ -72,7 +72,6 @@ object HiveResult {
     }
   }
 
-  private def zoneId = DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone)
   // Date formatting does not depend on time zone ID because it converts local days
   // since the epoch to local date string. Time zone id does matter only in parsing
   // when the parser has to handle special values like `now`, `yesterday` and etc.
@@ -85,7 +84,8 @@ object HiveResult {
     locale = DateFormatter.defaultLocale,
     // Use `FastDateFormat` as the legacy formatter because it is thread-safe.
     legacyFormat = LegacyDateFormats.FAST_DATE_FORMAT)
-  private def timestampFormatter = TimestampFormatter.getFractionFormatter(zoneId)
+  private def timestampFormatter = TimestampFormatter.getFractionFormatter(
+    DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone))
 
   /** Formats a datum (based on the given data type) and returns the string representation. */
   def toHiveString(a: (Any, DataType), nested: Boolean = false): String = a match {


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Replace `def dateFormatter` to `val dateFormatter`.
2. Modify the `date formatting in hive result` test in `HiveResultSuite` to check modified code on various time zones.

### Why are the changes needed?
To avoid creation of `DateFormatter` per every incoming date in `HiveResult.toHiveString`. This should eliminate unnecessary creation of `SimpleDateFormat` instances and compilation of the default pattern `yyyy-MM-dd`. The changes can speed up processing of legacy date values of the `java.sql.Date` type which is collected by default.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Modified a test in `HiveResultSuite`.