### PR TITLE
[SPARK-29880][CORE][YARN] Handle submit exception when submit to federation cluster 

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -171,8 +171,13 @@ private[spark] class Client(
       yarnClient.init(hadoopConf)
       yarnClient.start()
 
-      logInfo("Requesting a new application from cluster with %d NodeManagers"
-        .format(yarnClient.getYarnClusterMetrics.getNumNodeManagers))
+      try {
+        logInfo("Requesting a new application from cluster with %d NodeManagers"
+          .format(yarnClient.getYarnClusterMetrics.getNumNodeManagers))
+      } catch {
+        case NonFatal(e) =>
+          logWarning(s"Yarn client may not implement given API $e")
+      }
 
       // Get a new application from our RM
       val newApp = yarnClient.createApplication()

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -173,11 +173,14 @@ private[spark] class Client(
 
       try {
         logInfo(s"Requesting a new application from cluster" +
-          s" ${hadoopConf.get(YarnConfiguration.RM_ADDRESS, YarnConfiguration.DEFAULT_RM_ADDRESS)}" +
+          s" ${hadoopConf.get(YarnConfiguration.RM_ADDRESS,
+            YarnConfiguration.DEFAULT_RM_ADDRESS)}" +
           s" with %d NodeManagers.".format(yarnClient.getYarnClusterMetrics.getNumNodeManagers))
       } catch {
         case NonFatal(e) =>
-          logWarning(s"Yarn client may not implement the given API $e")
+          logWarning(s"Failed to request YARN cluster information from cluster " +
+            s"${hadoopConf.get(YarnConfiguration.RM_ADDRESS,
+              YarnConfiguration.DEFAULT_RM_ADDRESS)}" + " with excepation: $e")
       }
 
       // Get a new application from our RM

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -172,11 +172,12 @@ private[spark] class Client(
       yarnClient.start()
 
       try {
-        logInfo("Requesting a new application from cluster with %d NodeManagers"
-          .format(yarnClient.getYarnClusterMetrics.getNumNodeManagers))
+        logInfo(s"Requesting a new application from cluster" +
+          s" ${hadoopConf.get(YarnConfiguration.RM_ADDRESS, YarnConfiguration.DEFAULT_RM_ADDRESS)}" +
+          s" with %d NodeManagers.".format(yarnClient.getYarnClusterMetrics.getNumNodeManagers))
       } catch {
         case NonFatal(e) =>
-          logWarning(s"Yarn client may not implement given API $e")
+          logWarning(s"Yarn client may not implement the given API $e")
       }
 
       // Get a new application from our RM


### PR DESCRIPTION
When we submit application to federation yarn cluster. Since getYarnClusterMetrics is not implemented. The submission will exit with failure.

    ResourceRequestHelper.validateResources(sparkConf)
    var appId: ApplicationId = null
    try {
      launcherBackend.connect()
      yarnClient.init(hadoopConf)
      yarnClient.start()

     logInfo("Requesting a new application from cluster with %d NodeManagers"
          .format(yarnClient.getYarnClusterMetrics.getNumNodeManagers))`
### Why are the changes needed?
Since hadoop federation cluster was deployed, spark application will submit with failure if we do not handle the exception.
### How was this patch tested?
UT
