### PR TITLE
SPARK-29897 Add implicit cast for SubtractTimestamps

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -2322,7 +2322,7 @@ case class Extract(field: Expression, source: Expression, child: Expression)
  * between the given timestamps.
  */
 case class SubtractTimestamps(endTimestamp: Expression, startTimestamp: Expression)
-  extends BinaryExpression with ExpectsInputTypes with NullIntolerant {
+  extends BinaryExpression with ImplicitCastInputTypes with NullIntolerant {
 
   override def left: Expression = endTimestamp
   override def right: Expression = startTimestamp

--- a/sql/core/src/test/resources/sql-tests/inputs/datetime.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/datetime.sql
@@ -59,6 +59,8 @@ select date'2020-01-01' - timestamp'2019-10-06 10:11:12.345678';
 select timestamp'2019-10-06 10:11:12.345678' - date'2020-01-01';
 select timestamp'2019-10-06 10:11:12.345678' - null;
 select null - timestamp'2019-10-06 10:11:12.345678';
+select timestamp'2019-10-06 10:11:12.345678' - '2019-10-05 10:11:12.345678';
+select '2019-10-06 10:11:12.345678' - timestamp'2019-10-05 10:11:12.345678';
 
 -- date add/sub
 select date_add('2011-11-11', 1Y);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add implicit cast option for SubtractTimestamps expression


### Why are the changes needed?
Currently, this statement is failing because timestamp is passed as string. By adding implicit cast trait, it will be casted to timestamp data type automatically. 
SELECT EXTRACT(DAY FROM NOW() - '2014-08-02 08:10:56');


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
SQL statements added to sql-tests