### PR TITLE
[SPARK-31897][SQL] Enable codegen for GenerateExec

### DIFF
--- a/sql/core/benchmarks/GenerateExecBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/GenerateExecBenchmark-jdk11-results.txt
@@ -1,0 +1,12 @@
+================================================================================================
+GenerateExec benchmark
+================================================================================================
+
+OpenJDK 64-Bit Server VM 11.0.9+11-LTS on Mac OS X 10.16
+Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
+GenerateExec Benchmark:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+GenerateExec Benchmark wholestage off             72694          72900         292          1.4         726.9       1.0X
+GenerateExec Benchmark wholestage on              29207          30182         562          3.4         292.1       2.5X
+
+

--- a/sql/core/benchmarks/GenerateExecBenchmark-results.txt
+++ b/sql/core/benchmarks/GenerateExecBenchmark-results.txt
@@ -1,0 +1,12 @@
+================================================================================================
+GenerateExec benchmark
+================================================================================================
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_271-b09 on Mac OS X 10.16
+Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
+GenerateExec Benchmark:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+GenerateExec Benchmark wholestage off             88194          88334         199          1.1         881.9       1.0X
+GenerateExec Benchmark wholestage on              43805          44271         326          2.3         438.0       2.0X
+
+

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/GenerateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/GenerateExec.scala
@@ -124,7 +124,7 @@ case class GenerateExec(
     }
   }
 
-  override def supportCodegen: Boolean = true
+  override def supportCodegen: Boolean = super.supportCodegen && generator.supportCodegen
 
   override def inputRDDs(): Seq[RDD[InternalRow]] = {
     child.asInstanceOf[CodegenSupport].inputRDDs()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/GenerateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/GenerateExec.scala
@@ -226,11 +226,9 @@ case class GenerateExec(
       "0"
     }
     val numOutput = metricTerm(ctx, "numOutputRows")
-    val requiredInput = {
-      input.zipWithIndex.flatMap { case (ev, i) =>
-        if ((parent.inputSet).contains(child.output(i))) Seq(ev) else Seq()
-      }
-    } ++ position ++ values
+    val requiredInput = input.zip(child.output).filter {
+      case(_, output) => parent.inputSet.contains(output)
+    }.map(_._1) ++ position ++ values
     s"""
        |${data.code}
        |$initMapData

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/GenerateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/GenerateExec.scala
@@ -226,9 +226,11 @@ case class GenerateExec(
       "0"
     }
     val numOutput = metricTerm(ctx, "numOutputRows")
-    val requiredInput =
-      evaluateRequiredVariablesExpr(child.output,
-        input, parent.inputSet) ++ position ++ values
+    val requiredInput = {
+      input.zipWithIndex.flatMap { case (ev, i) =>
+        if ((parent.inputSet).contains(child.output(i))) Seq(ev) else Seq()
+      }
+    } ++ position ++ values
     s"""
        |${data.code}
        |$initMapData
@@ -239,18 +241,6 @@ case class GenerateExec(
        |  ${consume(ctx, requiredInput)}
        |}
      """.stripMargin
-  }
-
-  /**
-   * Returns [ExprCode] for required attributes
-   */
-  private def evaluateRequiredVariablesExpr(
-    attributes: Seq[Attribute],
-    variables: Seq[ExprCode],
-    required: AttributeSet): Seq[ExprCode] = {
-    variables.zipWithIndex.flatMap { case (ev, i) =>
-      if (required.contains(attributes(i))) Seq(ev) else Seq()
-    }
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/GenerateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/GenerateExec.scala
@@ -248,7 +248,6 @@ case class GenerateExec(
     attributes: Seq[Attribute],
     variables: Seq[ExprCode],
     required: AttributeSet): Seq[ExprCode] = {
-    assert(attributes.size == variables.size)
     variables.zipWithIndex.flatMap { case (ev, i) =>
       if (required.contains(attributes(i))) Seq(ev) else Seq()
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/GenerateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/GenerateExec.scala
@@ -124,7 +124,7 @@ case class GenerateExec(
     }
   }
 
-  override def supportCodegen: Boolean = false
+  override def supportCodegen: Boolean = true
 
   override def inputRDDs(): Seq[RDD[InternalRow]] = {
     child.asInstanceOf[CodegenSupport].inputRDDs()
@@ -233,7 +233,7 @@ case class GenerateExec(
        |for (int $index = $init; $index < $numElements; $index++) {
        |  $numOutput.add(1);
        |  $updateRowData
-       |  ${consume(ctx, input ++ position ++ values)}
+       |  ${consume(ctx, input.filterNot(_ == data) ++ position ++ values)}
        |}
      """.stripMargin
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/GenerateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/GenerateExec.scala
@@ -144,9 +144,12 @@ case class GenerateExec(
       Seq.empty
     }
 
+    val requiredInput = input.zip(child.output).filter {
+      case(_, output) => parent.inputSet.contains(output)
+    }.map(_._1)
     boundGenerator match {
-      case e: CollectionGenerator => codeGenCollection(ctx, e, values, row)
-      case g => codeGenTraversableOnce(ctx, g, values, row)
+      case e: CollectionGenerator => codeGenCollection(ctx, e, requiredInput, row)
+      case g => codeGenTraversableOnce(ctx, g, requiredInput, row)
     }
   }
 
@@ -226,9 +229,7 @@ case class GenerateExec(
       "0"
     }
     val numOutput = metricTerm(ctx, "numOutputRows")
-    val requiredInput = input.zip(child.output).filter {
-      case(_, output) => parent.inputSet.contains(output)
-    }.map(_._1) ++ position ++ values
+    val requiredInput = input ++ position ++ values
     s"""
        |${data.code}
        |$initMapData

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/GenerateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/GenerateExec.scala
@@ -124,7 +124,7 @@ case class GenerateExec(
     }
   }
 
-  override def supportCodegen: Boolean = super.supportCodegen && generator.supportCodegen
+  override def supportCodegen: Boolean = generator.supportCodegen
 
   override def inputRDDs(): Seq[RDD[InternalRow]] = {
     child.asInstanceOf[CodegenSupport].inputRDDs()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/GenerateExecBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/GenerateExecBenchmark.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import org.apache.spark.sql.execution.benchmark.SqlBasedBenchmark
+import org.apache.spark.sql.functions.explode
+
+case class Data(value1: Float, value2: Map[String, String], value3: String)
+
+class GenerateExecBenchmark extends SqlBasedBenchmark {
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    runBenchmark("GenerateExec benchmark") {
+      import spark.implicits._
+      val numRecords = 100000000
+      codegenBenchmark("GenerateExec Benchmark", numRecords) {
+            val srcDF = spark.range(numRecords).map {
+              x => Data(x.toFloat, Map(x.toString -> x.toString ), s"value3$x")
+            }.select($"value1", explode($"value2"), $"value3")
+            srcDF.noop()
+      }
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/GenerateExecBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/GenerateExecBenchmark.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.execution.benchmark.SqlBasedBenchmark
 import org.apache.spark.sql.functions.explode
 
 /**
- * Benchmark to measure performance for generate exec operator(with codegen).
+ * Benchmark to measure performance for generate exec operator.
  * To run this benchmark:
  * {{{
  *   1. without sbt: bin/spark-submit --class <this class> <spark sql test jar>
@@ -39,10 +39,10 @@ object GenerateExecBenchmark extends SqlBasedBenchmark {
       import spark.implicits._
       val numRecords = 100000000
       codegenBenchmark("GenerateExec Benchmark", numRecords) {
-            val srcDF = spark.range(numRecords).map {
-              x => Data(x.toFloat, Map(x.toString -> x.toString ), s"value3$x")
-            }.select($"value1", explode($"value2"), $"value3")
-            srcDF.noop()
+        val srcDF = spark.range(numRecords).map {
+          x => Data(x.toFloat, Map(x.toString -> x.toString), s"value3$x")
+        }.select($"value1", explode($"value2"), $"value3")
+        srcDF.noop()
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/GenerateExecBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/GenerateExecBenchmark.scala
@@ -20,9 +20,19 @@ package org.apache.spark.sql.execution
 import org.apache.spark.sql.execution.benchmark.SqlBasedBenchmark
 import org.apache.spark.sql.functions.explode
 
+/**
+ * Benchmark to measure performance for aggregate primitives.
+ * To run this benchmark:
+ * {{{
+ *   1. without sbt: bin/spark-submit --class <this class> <spark sql test jar>
+ *   2. build/sbt "sql/test:runMain <this class>"
+ *   3. generate result: SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/test:runMain <this class>"
+ *      Results will be written to "benchmarks/AggregateBenchmark-results.txt".
+ * }}}
+ */
 case class Data(value1: Float, value2: Map[String, String], value3: String)
 
-class GenerateExecBenchmark extends SqlBasedBenchmark {
+object GenerateExecBenchmark extends SqlBasedBenchmark {
 
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
     runBenchmark("GenerateExec benchmark") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/GenerateExecBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/GenerateExecBenchmark.scala
@@ -21,13 +21,13 @@ import org.apache.spark.sql.execution.benchmark.SqlBasedBenchmark
 import org.apache.spark.sql.functions.explode
 
 /**
- * Benchmark to measure performance for aggregate primitives.
+ * Benchmark to measure performance for generate exec operator(with codegen).
  * To run this benchmark:
  * {{{
  *   1. without sbt: bin/spark-submit --class <this class> <spark sql test jar>
  *   2. build/sbt "sql/test:runMain <this class>"
  *   3. generate result: SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/test:runMain <this class>"
- *      Results will be written to "benchmarks/AggregateBenchmark-results.txt".
+ *      Results will be written to "benchmarks/GenerateExecBenchmark-results.txt".
  * }}}
  */
 case class Data(value1: Float, value2: Map[String, String], value3: String)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -50,7 +50,7 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
     assert(df.collect() === Array(Row(9, 4.5)))
   }
 
-  test("SPARK-31897: GenerateExec should be included in WholeStageCodegen") {
+  test("GenerateExec should be included in WholeStageCodegen") {
     import testImplicits._
     val arrayData = Seq(("James", Seq("Java", "Scala"), Map("hair" -> "black", "eye" -> "brown")))
     val df = arrayData.toDF("name", "knownLanguages", "properties")
@@ -65,7 +65,6 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
     }.isDefined)
     checkAnswer(expDF, Array(Row("James", "Java", Map("hair" -> "black", "eye" -> "brown")),
       Row("James", "Scala", Map("hair" -> "black", "eye" -> "brown"))))
-
 
     // Map - explode
     expDF = df.select($"name", $"knownLanguages", explode($"properties"))
@@ -100,7 +99,6 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
     }.isDefined)
     checkAnswer(expDF,
       Array(Row("James", 0, "hair", "black"), Row("James", 1, "eye", "brown")))
-
 
     // Array - explode , selecting all columns
     expDF = df.select($"*", explode($"knownLanguages"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -68,6 +68,7 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
       Array(Row("James", "Java", Map("hair" -> "black", "eye" -> "brown")),
         Row("James", "Scala", Map("hair" -> "black", "eye" -> "brown"))))
 
+
     // Map - explode
     expDF = df.select($"name", $"knownLanguages", explode($"properties"))
     plan = expDF.queryExecution.executedPlan
@@ -104,6 +105,34 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
     results = expDF.collect()
     assert(results ===
       Array(Row("James", 0, "hair", "black"), Row("James", 1, "eye", "brown")))
+
+
+    // Array - explode , selecting all columns
+    expDF = df.select($"*", explode($"knownLanguages"))
+    plan = expDF.queryExecution.executedPlan
+    assert(plan.find {
+      case stage: WholeStageCodegenExec =>
+        stage.find(_.isInstanceOf[GenerateExec]).isDefined
+      case _ => false
+    }.isDefined)
+    results = expDF.collect()
+    assert(results ===
+      Array(Row("James", Seq("Java", "Scala"), Map("hair" -> "black", "eye" -> "brown"), "Java"),
+        Row("James", Seq("Java", "Scala"), Map("hair" -> "black", "eye" -> "brown"), "Scala")))
+
+    // Map - explode, selecting all columns
+    expDF = df.select($"*", explode($"properties"))
+    plan = expDF.queryExecution.executedPlan
+    assert(plan.find {
+      case stage: WholeStageCodegenExec =>
+        stage.find(_.isInstanceOf[GenerateExec]).isDefined
+      case _ => false
+    }.isDefined)
+    results = expDF.collect()
+    assert(results ===
+      Array(
+        Row("James", List("Java", "Scala"), Map("hair" -> "black", "eye" -> "brown"), "hair", "black"),
+        Row("James", List("Java", "Scala"), Map("hair" -> "black", "eye" -> "brown"), "eye", "brown")))
   }
 
   test("Aggregate with grouping keys should be included in WholeStageCodegen") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -131,8 +131,10 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
     results = expDF.collect()
     assert(results ===
       Array(
-        Row("James", List("Java", "Scala"), Map("hair" -> "black", "eye" -> "brown"), "hair", "black"),
-        Row("James", List("Java", "Scala"), Map("hair" -> "black", "eye" -> "brown"), "eye", "brown")))
+        Row("James", List("Java", "Scala"),
+          Map("hair" -> "black", "eye" -> "brown"), "hair", "black"),
+        Row("James", List("Java", "Scala"),
+          Map("hair" -> "black", "eye" -> "brown"), "eye", "brown")))
   }
 
   test("Aggregate with grouping keys should be included in WholeStageCodegen") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -50,7 +50,7 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
     assert(df.collect() === Array(Row(9, 4.5)))
   }
 
-  test("GenerateExec should be included in WholeStageCodegen") {
+  test("SPARK-31897: GenerateExec should be included in WholeStageCodegen") {
     import testImplicits._
     val arrayData = Seq(("James", Seq("Java", "Scala"), Map("hair" -> "black", "eye" -> "brown")))
     val df = arrayData.toDF("name", "knownLanguages", "properties")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -52,7 +52,7 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
 
   test("GenerateExec should be included in WholeStageCodegen") {
     val arrayData1 = Seq(
-      Row("James", List("Java", "Scala"), Map("hair" -> "black", "eye" -> "brown")),
+      Row("James", List("Java", "Scala"), Map("hair" -> "black", "eye" -> "brown"))
     )
 
     val arraySchema1 = new StructType()
@@ -63,7 +63,7 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
     val df = spark.createDataFrame(spark.sparkContext.parallelize(arrayData1), arraySchema1)
 
     // Array - explode
-    var expDF = df.select($"name",explode($"knownLanguages"), $"properties")
+    var expDF = df.select($"name", explode($"knownLanguages"), $"properties")
     var plan = expDF.queryExecution.executedPlan
     assert(plan.find {
       case stage: WholeStageCodegenExec =>
@@ -71,13 +71,13 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
       case _ =>
         false
     }.isDefined)
-    var results  = expDF.collect()
+    var results = expDF.collect()
     assert(results.size ==2 && results ===
       Array(Row("James", "Java", Map("hair" -> "black", "eye" -> "brown")),
         Row("James", "Scala", Map("hair" -> "black", "eye" -> "brown"))))
 
     // Map - explode
-    expDF = df.select($"name",$"knownLanguages", explode($"properties"))
+    expDF = df.select($"name", $"knownLanguages", explode($"properties"))
     plan = expDF.queryExecution.executedPlan
     assert(plan.find {
       case stage: WholeStageCodegenExec =>
@@ -91,7 +91,7 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
         Row("James", List("Java", "Scala"), "eye", "brown")))
 
     // Array - posexplode
-    expDF = df.select($"name",posexplode($"knownLanguages"))
+    expDF = df.select($"name", posexplode($"knownLanguages"))
     plan = expDF.queryExecution.executedPlan
     assert(plan.find {
       case stage: WholeStageCodegenExec =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -63,10 +63,8 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
         stage.find(_.isInstanceOf[GenerateExec]).isDefined
       case _ => false
     }.isDefined)
-    var results = expDF.collect()
-    assert(results ===
-      Array(Row("James", "Java", Map("hair" -> "black", "eye" -> "brown")),
-        Row("James", "Scala", Map("hair" -> "black", "eye" -> "brown"))))
+    checkAnswer(expDF, Array(Row("James", "Java", Map("hair" -> "black", "eye" -> "brown")),
+      Row("James", "Scala", Map("hair" -> "black", "eye" -> "brown"))))
 
 
     // Map - explode
@@ -77,8 +75,7 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
         stage.find(_.isInstanceOf[GenerateExec]).isDefined
       case _ => false
     }.isDefined)
-    results = expDF.collect()
-    assert(results ===
+    checkAnswer(expDF,
       Array(Row("James", List("Java", "Scala"), "hair", "black"),
         Row("James", List("Java", "Scala"), "eye", "brown")))
 
@@ -90,8 +87,7 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
         stage.find(_.isInstanceOf[GenerateExec]).isDefined
       case _ => false
     }.isDefined)
-    results = expDF.collect()
-    assert(results ===
+    checkAnswer(expDF,
       Array(Row("James", 0, "Java"), Row("James", 1, "Scala")))
 
     // Map - posexplode
@@ -102,8 +98,7 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
         stage.find(_.isInstanceOf[GenerateExec]).isDefined
       case _ => false
     }.isDefined)
-    results = expDF.collect()
-    assert(results ===
+    checkAnswer(expDF,
       Array(Row("James", 0, "hair", "black"), Row("James", 1, "eye", "brown")))
 
 
@@ -115,8 +110,7 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
         stage.find(_.isInstanceOf[GenerateExec]).isDefined
       case _ => false
     }.isDefined)
-    results = expDF.collect()
-    assert(results ===
+    checkAnswer(expDF,
       Array(Row("James", Seq("Java", "Scala"), Map("hair" -> "black", "eye" -> "brown"), "Java"),
         Row("James", Seq("Java", "Scala"), Map("hair" -> "black", "eye" -> "brown"), "Scala")))
 
@@ -128,8 +122,7 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
         stage.find(_.isInstanceOf[GenerateExec]).isDefined
       case _ => false
     }.isDefined)
-    results = expDF.collect()
-    assert(results ===
+    checkAnswer(expDF,
       Array(
         Row("James", List("Java", "Scala"),
           Map("hair" -> "black", "eye" -> "brown"), "hair", "black"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, ShuffledHash
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.{ArrayType, IntegerType, MapType, StringType, StructType}
+import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
 
 // Disable AQE because the WholeStageCodegenExec is added when running QueryStageExec
 class WholeStageCodegenSuite extends QueryTest with SharedSparkSession

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -50,7 +50,8 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
     assert(df.collect() === Array(Row(9, 4.5)))
   }
 
-  test("GenerateExec should be included in WholeStageCodegen") {
+  testWithWholeStageCodegenOnAndOff("GenerateExec should be" +
+    " included in WholeStageCodegen") { codegenEnabled =>
     import testImplicits._
     val arrayData = Seq(("James", Seq("Java", "Scala"), Map("hair" -> "black", "eye" -> "brown")))
     val df = arrayData.toDF("name", "knownLanguages", "properties")
@@ -61,7 +62,7 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
     assert(plan.find {
       case stage: WholeStageCodegenExec =>
         stage.find(_.isInstanceOf[GenerateExec]).isDefined
-      case _ => false
+      case _ => !codegenEnabled.toBoolean
     }.isDefined)
     checkAnswer(expDF, Array(Row("James", "Java", Map("hair" -> "black", "eye" -> "brown")),
       Row("James", "Scala", Map("hair" -> "black", "eye" -> "brown"))))
@@ -72,7 +73,7 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
     assert(plan.find {
       case stage: WholeStageCodegenExec =>
         stage.find(_.isInstanceOf[GenerateExec]).isDefined
-      case _ => false
+      case _ => !codegenEnabled.toBoolean
     }.isDefined)
     checkAnswer(expDF,
       Array(Row("James", List("Java", "Scala"), "hair", "black"),
@@ -84,7 +85,7 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
     assert(plan.find {
       case stage: WholeStageCodegenExec =>
         stage.find(_.isInstanceOf[GenerateExec]).isDefined
-      case _ => false
+      case _ => !codegenEnabled.toBoolean
     }.isDefined)
     checkAnswer(expDF,
       Array(Row("James", 0, "Java"), Row("James", 1, "Scala")))
@@ -95,7 +96,7 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
     assert(plan.find {
       case stage: WholeStageCodegenExec =>
         stage.find(_.isInstanceOf[GenerateExec]).isDefined
-      case _ => false
+      case _ => !codegenEnabled.toBoolean
     }.isDefined)
     checkAnswer(expDF,
       Array(Row("James", 0, "hair", "black"), Row("James", 1, "eye", "brown")))
@@ -106,7 +107,7 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
     assert(plan.find {
       case stage: WholeStageCodegenExec =>
         stage.find(_.isInstanceOf[GenerateExec]).isDefined
-      case _ => false
+      case _ => !codegenEnabled.toBoolean
     }.isDefined)
     checkAnswer(expDF,
       Array(Row("James", Seq("Java", "Scala"), Map("hair" -> "black", "eye" -> "brown"), "Java"),
@@ -118,7 +119,7 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
     assert(plan.find {
       case stage: WholeStageCodegenExec =>
         stage.find(_.isInstanceOf[GenerateExec]).isDefined
-      case _ => false
+      case _ => !codegenEnabled.toBoolean
     }.isDefined)
     checkAnswer(expDF,
       Array(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/GenerateExecBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/GenerateExecBenchmark.scala
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.execution
+package org.apache.spark.sql.execution.benchmark
 
-import org.apache.spark.sql.execution.benchmark.SqlBasedBenchmark
 import org.apache.spark.sql.functions.explode
 
 /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enabling codegen for GenerateExec

### Why are the changes needed?
To leverage code generation for Generators


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- UT tests added

### Benchmark
```
case class Data(value1: Float, value2: Map[String, String], value3: String)
val path = "<path>"

val numRecords = Seq(10000000, 100000000)
numRecords.map {
  recordCount =>
    import java.util.concurrent.TimeUnit.NANOSECONDS

    val srcDF = spark.range(recordCount).map {
      x => Data(x.toFloat, Map(x.toString -> x.toString ), s"value3$x")
    }.select($"value1", explode($"value2"), $"value3")
    val start = System.nanoTime()
    srcDF
      .write
      .mode("overwrite")
      .parquet(s"$path/$recordCount")
    val end = System.nanoTime()
    val diff = end - start
    (recordCount, NANOSECONDS.toMillis(diff))
}
```
**With codegen**: 
```
res0: Seq[(Int, Long)] = List((10000000,13989), (100000000,129625))
```
**Without codegen**:
```
res0: Seq[(Int, Long)] = List((10000000,15736), (100000000,150399))
```

