### PR TITLE
[SPARK-31900][SPARK-SUBMIT] Client memory passed unvalidated to the JVM Xmx

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -259,7 +259,8 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
   }
 
   private static final Pattern JavaHeapPattern = Pattern.compile("\\p{Digit}+[kmgt]?");
-  private static String validateMemoryArg(Map.Entry<String, String> memoryKV) throws IllegalArgumentException {
+  private static String validateMemoryArg(Map.Entry<String, String> memoryKV)
+      throws IllegalArgumentException {
     final String lower = memoryKV.getValue().toLowerCase(Locale.ROOT).trim();
     if (!JavaHeapPattern.matcher(lower).matches()) {
       throw new IllegalArgumentException(memoryKV.getValue() +

--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
@@ -305,7 +305,8 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
 
   @Test
   public void testThriftServerNonDaemonMemory() {
-    // SPARK-31900: ensure that spark.driver.memory is used for thrift server w/o SPARK_DAEMON_MEMORY
+    // SPARK-31900: ensure that spark.driver.memory is used for thrift server
+    // w/o SPARK_DAEMON_MEMORY
     final List<Map.Entry<String, String>> candList = new ArrayList<>(TEST_MEM_PRECEDENCE_LIST);
     candList.set(0, kv(TEST_MEM_PRECEDENCE_LIST.get(0).getKey(), null));
     assertEquals("3g",


### PR DESCRIPTION
An example of a command that fail in the client mode but would not in the cluster mode or if the same value were used for `spark.executor.memory`
```
> $SPARK_HOME/bin/spark-shell --conf spark.driver.memory=" 4g "
Invalid maximum heap size: -Xmx 4g
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```
also note that the same message is produced by the JVM makes it hard to identify which of the configs SPARK_DAEMON_MEMORY, SPARK_DRIVER_MEMORY, etc was responsible 

### Why are the changes needed?
easier ops/diagnostics, more uniform behavior 


### Does this PR introduce _any_ user-facing change?
fix-only change


### How was this patch tested?
- unit tests
- manual testing
