### PR TITLE
[SPARK-31913][SQL] Fix StackOverflowError in FileScanRDD

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
@@ -115,7 +115,7 @@ class FileScanRDD(
         while (!hasNextInCurrentFile && files.hasNext) {
           processNextFile()
         }
-        if (!files.hasNext) {
+        if (!hasNextInCurrentFile && !files.hasNext) {
           currentFile = null
           InputFileBlockHolder.unset()
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileScanRDDSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileScanRDDSuite.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import java.io.File
+import java.nio.file.Files
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
+
+class FileScanRDDSuite extends QueryTest with SharedSparkSession {
+  import testImplicits._
+
+  test("SPARK-31913: Fix StackOverflowError in FileScanRDD") {
+    def copyFiles(numFiles: Int, dir: File): Unit = {
+      val files = dir.list().filter(_.startsWith("part-"))
+      assert(files.length > 0)
+      val fileSuffix = files.head.substring(11)
+      (1 to numFiles).foreach { id =>
+        val dst = new File(dir, s"part-$id-$fileSuffix")
+        Files.copy(new File(dir, files.head).toPath, dst.toPath)
+      }
+    }
+
+    withSQLConf(
+      "fs.file.impl" -> classOf[MockDistributedFileSystem].getName,
+      SQLConf.PARALLEL_PARTITION_DISCOVERY_THRESHOLD.key -> "2",
+      SQLConf.FILES_MAX_PARTITION_BYTES.key -> "1024MB",
+      SQLConf.FILES_OPEN_COST_IN_BYTES.key -> "102400") {
+      withTempPath { tempDir =>
+        val schema = StructType(Array(StructField("a", StringType)))
+        val data = Seq().asInstanceOf[Seq[String]].toDF("a")
+        data.write.format("parquet").save(tempDir.getCanonicalPath)
+        copyFiles(10000, tempDir)
+        val df = spark.read.schema(schema).format("parquet").load(tempDir.toURI.toString)
+        assert(df.count() == 0L)
+      }
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Resolve the recursive calls in `FileScanRDD`.

### Why are the changes needed?
`FileScanRDD` throw a `StackOverflowError` when read a mass of empty files.

There are two ways to scan a file source, i.e. `BucketedRead` and `NonBucketedRead`. When scan a file source in `NonBucketedRead` way, spark will calculate how much files will be read in each partition with two important configuration: `spark.sql.files.maxPartitionBytes` and `spark.sql.files.openCostInBytes`. With these two config, we can calculate the `maxSplitBytes` in each partition. If there are lots of input files and low parallelism, the `maxSplitBytes` will be `spark.sql.files.maxPartitionBytes`. In my failed job, I set `spark.sql.files.maxPartitionBytes` with a large number, like 5GB. It means a spark task will read 5GB files at most. But accidentally, 
a mass of empty files was produced in my environment. Then a spark task will read a mass of empty files. But the `FileScanRDD` read this files in recursive way:
```
     def hasNext: Boolean = {
        // Kill the task in case it has been marked as killed. This logic is from
        // InterruptibleIterator, but we inline it here instead of wrapping the iterator in order
        // to avoid performance overhead.
        context.killTaskIfInterrupted()
        (currentIterator != null && currentIterator.hasNext) || nextIterator()
      }

     private def nextIterator(): Boolean = {
         ...
         try {
           hasNext
         } catch {
         ...
     }
```
`(currentIterator != null && currentIterator.hasNext)` always is `false`, and finally this will trigger a `StackOverflowError`.

!!! **Have to admit**, it is a corner case as  a mass of empty files was produced in my environment accidentally.

```
java.lang.StackOverflowError
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.getSubject(Subject.java:297)
	at org.apache.hadoop.security.UserGroupInformation.getCurrentUser(UserGroupInformation.java:648)
	at org.apache.hadoop.fs.FileSystem$Cache$Key.<init>(FileSystem.java:2828)
	at org.apache.hadoop.fs.FileSystem$Cache$Key.<init>(FileSystem.java:2818)
	at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:2684)
	at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:373)
	at org.apache.hadoop.fs.Path.getFileSystem(Path.java:295)
	at org.apache.parquet.hadoop.util.HadoopInputFile.fromPath(HadoopInputFile.java:38)
	at org.apache.parquet.hadoop.ParquetFileReader.<init>(ParquetFileReader.java:640)
	at org.apache.spark.sql.execution.datasources.parquet.SpecificParquetRecordReaderBase.initialize(SpecificParquetRecordReaderBase.java:148)
	at org.apache.spark.sql.execution.datasources.parquet.VectorizedParquetRecordReader.initialize(VectorizedParquetRecordReader.java:143)
	at org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat.$anonfun$buildReaderWithPartitionValues$2(ParquetFileFormat.scala:326)
	at org.apache.spark.sql.execution.datasources.FileScanRDD$$anon$1.org$apache$spark$sql$execution$datasources$FileScanRDD$$anon$$readCurrentFile(FileScanRDD.scala:116)
	at org.apache.spark.sql.execution.datasources.FileScanRDD$$anon$1.nextIterator(FileScanRDD.scala:169)
	at org.apache.spark.sql.execution.datasources.FileScanRDD$$anon$1.hasNext(FileScanRDD.scala:93)
	at org.apache.spark.sql.execution.datasources.FileScanRDD$$anon$1.nextIterator(FileScanRDD.scala:173)
	at org.apache.spark.sql.execution.datasources.FileScanRDD$$anon$1.hasNext(FileScanRDD.scala:93)
	at org.apache.spark.sql.execution.datasources.FileScanRDD$$anon$1.nextIterator(FileScanRDD.scala:173)
```

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Add new UT.
