### PR TITLE
[SPARK-29394][SQL]Support ISO 8601 format for intervals

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/IntervalUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/IntervalUtilsSuite.scala
@@ -130,6 +130,43 @@ class IntervalUtilsSuite extends SparkFunSuite with SQLHelper {
     checkFromInvalidString("0.123456789123 seconds", "'0.123456789123' is out of range")
   }
 
+  test("string to interval: iso format") {
+    checkFromString("interval P1", new CalendarInterval(12, 0, 0))
+    checkFromString("P1", new CalendarInterval(12, 0, 0))
+    checkFromString("P1T2", new CalendarInterval(12, 0, 7200000000L))
+
+    checkFromString("P1Y2M3D", new CalendarInterval(14, 3, 0))
+    checkFromString("PT1H1M1S", new CalendarInterval(0, 0, 3661000000L))
+    checkFromString("P1Y2M3DT1H1M1S", new CalendarInterval(14, 3, 3661000000L))
+    checkFromString("P1T1S", new CalendarInterval(12, 0, 1000000L))
+    checkFromString("P1DT1", new CalendarInterval(0, 1, 3600000000L))
+
+    checkFromString("P2W", new CalendarInterval(0, 14, 0))
+
+    checkFromString("P1-2-3", new CalendarInterval(14, 3, 0))
+    checkFromString("PT1:1:1", new CalendarInterval(0, 0, 3661000000L))
+    checkFromString("P1-2-3T1:1:1", new CalendarInterval(14, 3, 3661000000L))
+    checkFromString("P1-2T1:1:1", new CalendarInterval(14, 0, 3661000000L))
+    checkFromString("P1-2T1", new CalendarInterval(14, 0, 3600000000L))
+
+    checkFromString("P1Y2M-3DT-1H-1S", new CalendarInterval(14, -3, -3601000000L))
+    checkFromString("P1--2--3T-1:0:-1", new CalendarInterval(10, -3, -3601000000L))
+
+    checkFromInvalidString("P", "cannot be empty")
+    checkFromInvalidString("PT", "cannot be empty")
+    checkFromInvalidString("P1F", "invalid unit")
+    checkFromInvalidString("P1T2G", "invalid unit")
+    checkFromInvalidString("P1YY2M", "no value before unit")
+    checkFromInvalidString("P1Y2H", "invalid ISO 8601 format with designator")
+    checkFromInvalidString("P1YT1D", "invalid ISO 8601 format with designator")
+    checkFromInvalidString("P1-2-3-4", "invalid ISO 8601 alternative format")
+    checkFromInvalidString("P1-2-T3", "invalid ISO 8601 alternative format")
+    checkFromInvalidString("P1-2-3T4:5:", "invalid ISO 8601 alternative format")
+    checkFromInvalidString("P1-2-3T4:5:6:7", "invalid ISO 8601 alternative format")
+    checkFromInvalidString("P1Y2M3DT4:5:6", "invalid ISO 8601 format with designator")
+    checkFromInvalidString("P1-2-3T4H5M6S", "invalid ISO 8601 alternative format")
+  }
+
   test("from year-month string") {
     assert(fromYearMonthString("99-10") === new CalendarInterval(99 * 12 + 10, 0, 0L))
     assert(fromYearMonthString("+99-10") === new CalendarInterval(99 * 12 + 10, 0, 0L))


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This pr is to support ISO 8601 format for intervals.
- P[n]Y[n]M[n]DT[n]H[n]M[n]S
- P[n]W
- P[YYYY]-[MM]-[DD]T[hh]:[mm]:[ss]

For example:
```
spark-sql> select interval 'P1T1';
1 years 1 hours
spark-sql> select interval 'P1Y1MT1H1S';
1 years 1 months 1 hours 1 seconds
spark-sql> select interval 'P1-1-0T1:0:1';
1 years 1 months 1 hours 1 seconds
spark-sql> select interval 'P2W';
14 days
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
For feature parity with PostgreSQL which supports that:
```
postgres=# select interval 'P1T1';
    interval
-----------------
 1 year 01:00:00
(1 row)

postgres=# select interval 'P1Y1MT1H1S';
       interval
-----------------------
 1 year 1 mon 01:00:01
(1 row)

postgres=# select interval 'P1-1-0T1:0:1';
       interval
-----------------------
 1 year 1 mon 01:00:01
(1 row)

postgres=# select interval 'P2W';
 interval
----------
 14 days
(1 row)
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
- Added tests to `IntervalUtilsSuite`