### PR TITLE
[SPARK-31929][WEBUI] Close leveldbiterator when leveldb.close

### DIFF
--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
@@ -198,10 +198,7 @@ public class LevelDB implements KVStore {
       @Override
       public Iterator<T> iterator() {
         try {
-          LevelDBIterator<T> iterator = new LevelDBIterator<>(
-                  type,
-                  LevelDB.this,
-                  this);
+          LevelDBIterator<T> iterator = new LevelDBIterator<>(type, LevelDB.this, this);
           iteratorTracker.add(iterator);
           return iterator;
         } catch (Exception e) {
@@ -275,8 +272,9 @@ public class LevelDB implements KVStore {
       DB _db = this._db.get();
       if (_db != null) {
         it.close();
-        iteratorTracker.remove(it);
       }
+
+      iteratorTracker.remove(it);
     }
   }
 

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
@@ -266,7 +266,7 @@ public class LevelDB implements KVStore {
     }
   }
 
-  public boolean isClosed() {
+  boolean isClosed() {
     return this._db.get() == null;
   }
 
@@ -274,20 +274,18 @@ public class LevelDB implements KVStore {
    * Closes the given iterator if the DB is still open. Trying to close a JNI LevelDB handle
    * with a closed DB can cause JVM crashes, so this ensures that situation does not happen.
    */
-  public void closeIterator(DBIterator it) throws IOException {
+  void closeIterator(DBIterator it) throws IOException {
+    iteratorTracker.remove(it);
     synchronized (this._db) {
       DB _db = this._db.get();
       if (_db != null) {
         it.close();
       }
     }
-    iteratorTracker.remove(it);
   }
 
-  public DBIterator createIterator() {
-    DBIterator it = db().iterator();
+  void notifyIteratorCreated(DBIterator it) {
     iteratorTracker.add(it);
-    return it;
   }
 
   /** Returns metadata about indices for the given type. */

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
@@ -66,9 +66,8 @@ public class LevelDB implements KVStore {
   private final ConcurrentMap<Class<?>, LevelDBTypeInfo> types;
 
   /**
-   * Track active level db iterators. If level db is closed, level db iterator is in invalid
-   * state and JNI resources held by it can't be released. This servers the purpose: all active
-   * iterators are correctly closed, before DB is closed.
+   * If level db is closed, level db iterator will be invalid and trying to close it will cause
+   * JVM crashes. Track active iterators to make sure they are correctly closed.
    */
   private final ConcurrentLinkedQueue<LevelDBIterator<?>> iteratorTracker;
 

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBIterator.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBIterator.java
@@ -189,17 +189,18 @@ class LevelDBIterator<T> implements KVStoreIterator<T> {
       it.close();
       closed = true;
     }
+    db.notifyIteratorClosed(this);
   }
 
   /**
    * Because it's tricky to expose closeable iterators through many internal APIs, especially
-   * when Scala wrappers are used, this makes sure that, hopefully, the JNI resources held by
-   * the iterator will eventually be released.
+   * when Scala wrappers are used. This makes sure that, if iterator is not explicitly
+   * closed, it still has chance to be closed by GC (before DB is closed).
    */
   @SuppressWarnings("deprecation")
   @Override
   protected void finalize() throws Throwable {
-    db.closeIterator(this);
+    close();
   }
 
   private byte[] loadNext() {

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBIterator.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBIterator.java
@@ -48,7 +48,8 @@ class LevelDBIterator<T> implements KVStoreIterator<T> {
   LevelDBIterator(Class<T> type, LevelDB db, KVStoreView<T> params) throws Exception {
     this.db = db;
     this.ascending = params.ascending;
-    this.it = db.createIterator();
+    this.it = db.db().iterator();
+    db.notifyIteratorCreated(it);
     this.type = type;
     this.ti = db.getTypeInfo(type);
     this.index = ti.index(params.index);

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBIterator.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBIterator.java
@@ -192,17 +192,6 @@ class LevelDBIterator<T> implements KVStoreIterator<T> {
     db.notifyIteratorClosed(this);
   }
 
-  /**
-   * Because it's tricky to expose closeable iterators through many internal APIs, especially
-   * when Scala wrappers are used. This makes sure that, if iterator is not explicitly
-   * closed, it still has chance to be closed by GC (before DB is closed).
-   */
-  @SuppressWarnings("deprecation")
-  @Override
-  protected void finalize() throws Throwable {
-    close();
-  }
-
   private byte[] loadNext() {
     if (count >= max) {
       return null;

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
@@ -310,7 +310,7 @@ public class LevelDBSuite {
     }
     assertTrue(!dbpathForCloseTest.exists());
   }
-  
+
   private CustomType1 createCustomType1(int i) {
     CustomType1 t = new CustomType1();
     t.key = "key" + i;

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
@@ -281,9 +281,9 @@ public class LevelDBSuite {
     // SPARK-31929: test when LevelDB.close() is called, related LevelDBIterators
     // are closed. And files opened by iterators are also closed.
     File dbpathForCloseTest = File
-            .createTempFile(
-                    "test_db_close.",
-                    ".ldb");
+      .createTempFile(
+        "test_db_close.",
+        ".ldb");
     dbpathForCloseTest.delete();
     LevelDB dbForCloseTest = new LevelDB(dbpathForCloseTest);
     for (int i = 0; i < 8192; i++) {
@@ -291,15 +291,15 @@ public class LevelDBSuite {
     }
 
     KVStoreIterator<CustomType1> it = dbForCloseTest
-                    .view(CustomType1.class).closeableIterator();
+      .view(CustomType1.class).closeableIterator();
     assertEquals("key0", it.next().key);
     KVStoreIterator<CustomType1> it1 = dbForCloseTest
-            .view(CustomType1.class).closeableIterator();
+      .view(CustomType1.class).closeableIterator();
     assertEquals("key0", it1.next().key);
     try(KVStoreIterator<CustomType1> it2 = dbForCloseTest
-                        .view(CustomType1.class).closeableIterator();
+      .view(CustomType1.class).closeableIterator();
         KVStoreIterator<CustomType1> it3 = dbForCloseTest
-                        .view(CustomType1.class).closeableIterator();) {
+          .view(CustomType1.class).closeableIterator();) {
       assertEquals("key0", it2.next().key);
       assertEquals("key0", it3.next().key);
     }

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
@@ -279,7 +279,7 @@ public class LevelDBSuite {
   @Test
   public void testCloseLevelDBIterator() throws Exception {
     // SPARK-31929: test when LevelDB.close() is called, related LevelDBIterators
-    // are also closed. So no file handle for level DB files are opened.
+    // are closed. And files opened by iterators are also closed.
     File dbpathForCloseTest = File
             .createTempFile(
                     "test_db_close.",

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
@@ -310,8 +310,7 @@ public class LevelDBSuite {
     }
     assertTrue(!dbpathForCloseTest.exists());
   }
-
-
+  
   private CustomType1 createCustomType1(int i) {
     CustomType1 t = new CustomType1();
     t.key = "key" + i;

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
@@ -299,9 +299,7 @@ public class LevelDBSuite {
     }
     dbForCloseTest.close();
     assertTrue(dbpathForCloseTest.exists());
-    if (dbpathForCloseTest != null) {
-      FileUtils.deleteQuietly(dbpathForCloseTest);
-    }
+    FileUtils.deleteQuietly(dbpathForCloseTest);
     assertTrue(!dbpathForCloseTest.exists());
   }
 

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
@@ -19,6 +19,7 @@ package org.apache.spark.util.kvstore;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
@@ -290,18 +291,15 @@ public class LevelDBSuite {
       dbForCloseTest.write(createCustomType1(i));
     }
 
-    KVStoreIterator<CustomType1> it = dbForCloseTest
-      .view(CustomType1.class).closeableIterator();
-    assertEquals("key0", it.next().key);
-    KVStoreIterator<CustomType1> it1 = dbForCloseTest
-      .view(CustomType1.class).closeableIterator();
+    String key = dbForCloseTest.view(CustomType1.class).iterator().next().key;
+    assertEquals("key0", key);
+    System.gc(); // Make a best effort to trigger gc.
+    Iterator<CustomType1> it1 = dbForCloseTest
+      .view(CustomType1.class).iterator();
     assertEquals("key0", it1.next().key);
     try(KVStoreIterator<CustomType1> it2 = dbForCloseTest
-      .view(CustomType1.class).closeableIterator();
-        KVStoreIterator<CustomType1> it3 = dbForCloseTest
-          .view(CustomType1.class).closeableIterator();) {
+      .view(CustomType1.class).closeableIterator()) {
       assertEquals("key0", it2.next().key);
-      assertEquals("key0", it3.next().key);
     }
     dbForCloseTest.close();
     assertTrue(dbpathForCloseTest.exists());

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
@@ -295,14 +295,14 @@ public class LevelDBSuite {
     assertEquals("key0", key);
     Iterator<CustomType1> it0 = dbForCloseTest
       .view(CustomType1.class).max(1).iterator();
-    while(it0.hasNext()) {
+    while (it0.hasNext()) {
       it0.next();
     }
     System.gc();
     Iterator<CustomType1> it1 = dbForCloseTest
       .view(CustomType1.class).iterator();
     assertEquals("key0", it1.next().key);
-    try(KVStoreIterator<CustomType1> it2 = dbForCloseTest
+    try (KVStoreIterator<CustomType1> it2 = dbForCloseTest
       .view(CustomType1.class).closeableIterator()) {
       assertEquals("key0", it2.next().key);
     }

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
@@ -290,10 +290,6 @@ public class LevelDBSuite {
     for (int i = 0; i < 8192; i++) {
       dbForCloseTest.write(createCustomType1(i));
     }
-
-    String key = dbForCloseTest.view(CustomType1.class).iterator().next().key;
-    assertEquals("key0", key);
-    System.gc(); // Make a best effort to trigger gc.
     Iterator<CustomType1> it1 = dbForCloseTest
       .view(CustomType1.class).iterator();
     assertEquals("key0", it1.next().key);

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
@@ -281,15 +281,24 @@ public class LevelDBSuite {
   public void testCloseLevelDBIterator() throws Exception {
     // SPARK-31929: test when LevelDB.close() is called, related LevelDBIterators
     // are closed. And files opened by iterators are also closed.
-    File dbpathForCloseTest = File
+    File dbPathForCloseTest = File
       .createTempFile(
         "test_db_close.",
         ".ldb");
-    dbpathForCloseTest.delete();
-    LevelDB dbForCloseTest = new LevelDB(dbpathForCloseTest);
+    dbPathForCloseTest.delete();
+    LevelDB dbForCloseTest = new LevelDB(dbPathForCloseTest);
     for (int i = 0; i < 8192; i++) {
       dbForCloseTest.write(createCustomType1(i));
     }
+    String key = dbForCloseTest
+      .view(CustomType1.class).iterator().next().key;
+    assertEquals("key0", key);
+    Iterator<CustomType1> it0 = dbForCloseTest
+      .view(CustomType1.class).max(1).iterator();
+    while(it0.hasNext()) {
+      it0.next();
+    }
+    System.gc();
     Iterator<CustomType1> it1 = dbForCloseTest
       .view(CustomType1.class).iterator();
     assertEquals("key0", it1.next().key);
@@ -298,9 +307,9 @@ public class LevelDBSuite {
       assertEquals("key0", it2.next().key);
     }
     dbForCloseTest.close();
-    assertTrue(dbpathForCloseTest.exists());
-    FileUtils.deleteQuietly(dbpathForCloseTest);
-    assertTrue(!dbpathForCloseTest.exists());
+    assertTrue(dbPathForCloseTest.exists());
+    FileUtils.deleteQuietly(dbPathForCloseTest);
+    assertTrue(!dbPathForCloseTest.exists());
   }
 
   private CustomType1 createCustomType1(int i) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Close LevelDBIterator when LevelDB.close() is called.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This pull request would prevent JNI resources leaking from Level DB instance and its' iterators. In before implementation JNI resources from LevelDBIterator are cleaned by finalize() function. This behavior is also mentioned in comments of ["LevelDBIterator.java"](https://github.com/apache/spark/blob/master/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBIterator.java) by @squito . But if DB instance is already closed, then iterator's close method would be ignored. LevelDB's iterator would keep level db files opened (for the case table cache is filled up), till iterator.close() is called. Then these JNI resources (file handle) would be leaked.
This JNI resource leaking issue would cause the problem described in [SPARK-31929](https://issues.apache.org/jira/browse/SPARK-31929) on Windows: in spark history server, leaked file handle for level db files would trigger "IOException" when HistoryServerDiskManager try to remove them for releasing disk space.
![IOException](https://user-images.githubusercontent.com/10524738/84134659-7c388680-aa7b-11ea-807f-04dcfa7886a0.JPG)


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Add unit test and manually tested it.