### PR TITLE
[SPARK-31952][SQL]Fix incorrect memory spill metric when doing Aggregate

### DIFF
--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java
@@ -104,11 +104,13 @@ public final class UnsafeExternalSorter extends MemoryConsumer {
       int initialSize,
       long pageSizeBytes,
       int numElementsForSpillThreshold,
-      UnsafeInMemorySorter inMemorySorter) throws IOException {
+      UnsafeInMemorySorter inMemorySorter,
+      long existingMemoryConsumption) throws IOException {
     UnsafeExternalSorter sorter = new UnsafeExternalSorter(taskMemoryManager, blockManager,
       serializerManager, taskContext, recordComparatorSupplier, prefixComparator, initialSize,
         pageSizeBytes, numElementsForSpillThreshold, inMemorySorter, false /* ignored */);
     sorter.spill(Long.MAX_VALUE, sorter);
+    taskContext.taskMetrics().incMemoryBytesSpilled(existingMemoryConsumption);
     // The external sorter will be used to insert records, in-memory sorter is not needed.
     sorter.inMemSorter = null;
     return sorter;

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeKVExternalSorter.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeKVExternalSorter.java
@@ -165,7 +165,8 @@ public final class UnsafeKVExternalSorter {
         (int) (long) SparkEnv.get().conf().get(package$.MODULE$.SHUFFLE_SORT_INIT_BUFFER_SIZE()),
         pageSizeBytes,
         numElementsForSpillThreshold,
-        inMemSorter);
+        inMemSorter,
+        map.getTotalMemoryConsumption());
 
       // reset the map, so we can re-use it to insert new records. the inMemSorter will not used
       // anymore, so the underline array could be used by map again.


### PR DESCRIPTION
### What changes were proposed in this pull request?
It happends when hash aggregate downgrades to sort based aggregate. 
`UnsafeExternalSorter.createWithExistingInMemorySorter` calls `spill` on an `InMemorySorter` immediately, but the memory pointed by InMemorySorter is acquired by outside `BytesToBytesMap`, instead the `allocatedPages` in `UnsafeExternalSorter`. So the memory spill bytes metric is always 0, but disk bytes spill metric is right. 

Related code is at https://github.com/apache/spark/blob/master/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java#L232.

It can be reproduced by following step.
```
bin/spark-shell --driver-memory 512m --executor-memory 512m --executor-cores 1 --conf "spark.default.parallelism=1"
scala> sql("select id, count(1) from range(10000000) group by id").write.csv("/tmp/result.json")
```

Before this patch, the metric is
![image](https://user-images.githubusercontent.com/1312321/84248141-99cd2500-ab3b-11ea-8821-f78cf483557d.png)

After this patch, the metric is
![image](https://user-images.githubusercontent.com/1312321/84248156-a18cc980-ab3b-11ea-86d3-fff85d239ed0.png)


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Test manually
