### PR TITLE
[SPARK-31959][SQL][test-java11] Fix Gregorian-Julian micros rebasing while switching standard time zone offset

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/RebaseDateTimeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/RebaseDateTimeSuite.scala
@@ -410,7 +410,7 @@ class RebaseDateTimeSuite extends SparkFunSuite with Matchers with SQLHelper {
     }
   }
 
-  test("JST -> HKT at Asia/Hong_Kong in 1945") {
+  test("SPARK-31959: JST -> HKT at Asia/Hong_Kong in 1945") {
     // The 'Asia/Hong_Kong' time zone switched from 'Japan Standard Time' (JST = UTC+9)
     // to 'Hong Kong Time' (HKT = UTC+8). After Sunday, 18 November, 1945 01:59:59 AM,
     // clocks were moved backward to become Sunday, 18 November, 1945 01:00:00 AM.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/RebaseDateTimeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/RebaseDateTimeSuite.scala
@@ -428,6 +428,11 @@ class RebaseDateTimeSuite extends SparkFunSuite with Matchers with SQLHelper {
       assert(toTsStr(rebasedEarlierMicros) === expected)
       assert(toTsStr(rebasedLaterMicros) === expected)
       assert(rebasedEarlierMicros + MICROS_PER_HOUR === rebasedLaterMicros)
+      // Check optimized rebasing
+      val optRebasedEarlierMicros = rebaseGregorianToJulianMicros(earlierMicros)
+      assert(optRebasedEarlierMicros === rebasedEarlierMicros)
+      val optRebasedLaterMicros = rebaseGregorianToJulianMicros(laterMicros)
+      assert(optRebasedLaterMicros === rebasedLaterMicros)
     }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/RebaseDateTimeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/RebaseDateTimeSuite.scala
@@ -429,10 +429,11 @@ class RebaseDateTimeSuite extends SparkFunSuite with Matchers with SQLHelper {
       assert(toTsStr(rebasedLaterMicros) === expected)
       assert(rebasedEarlierMicros + MICROS_PER_HOUR === rebasedLaterMicros)
       // Check optimized rebasing
-      val optRebasedEarlierMicros = rebaseGregorianToJulianMicros(earlierMicros)
-      assert(optRebasedEarlierMicros === rebasedEarlierMicros)
-      val optRebasedLaterMicros = rebaseGregorianToJulianMicros(laterMicros)
-      assert(optRebasedLaterMicros === rebasedLaterMicros)
+      assert(rebaseGregorianToJulianMicros(earlierMicros) === rebasedEarlierMicros)
+      assert(rebaseGregorianToJulianMicros(laterMicros) === rebasedLaterMicros)
+      // Check reverse rebasing
+      assert(rebaseJulianToGregorianMicros(rebasedEarlierMicros) === earlierMicros)
+      assert(rebaseJulianToGregorianMicros(rebasedLaterMicros) === laterMicros)
     }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/RebaseDateTimeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/RebaseDateTimeSuite.scala
@@ -409,4 +409,25 @@ class RebaseDateTimeSuite extends SparkFunSuite with Matchers with SQLHelper {
       }
     }
   }
+
+  test("JST -> HKT at Asia/Hong_Kong in 1945") {
+    // The 'Asia/Hong_Kong' time zone switched from 'Japan Standard Time' (JST = UTC+9)
+    // to 'Hong Kong Time' (HKT = UTC+8). After Sunday, 18 November, 1945 01:59:59 AM,
+    // clocks were moved backward to become Sunday, 18 November, 1945 01:00:00 AM.
+    // In this way, the overlap happened w/o Daylight Saving Time.
+    val hkZid = getZoneId("Asia/Hong_Kong")
+    withDefaultTimeZone(hkZid) {
+      val ldt = LocalDateTime.of(1945, 11, 18, 1, 30, 0)
+      val earlierMicros = instantToMicros(ldt.atZone(hkZid).withEarlierOffsetAtOverlap().toInstant)
+      val laterMicros = instantToMicros(ldt.atZone(hkZid).withLaterOffsetAtOverlap().toInstant)
+      assert(earlierMicros + MICROS_PER_HOUR === laterMicros)
+      val rebasedEarlierMicros = rebaseGregorianToJulianMicros(hkZid, earlierMicros)
+      val rebasedLaterMicros = rebaseGregorianToJulianMicros(hkZid, laterMicros)
+      def toTsStr(micros: Long): String = toJavaTimestamp(micros).toString
+      val expected = "1945-11-18 01:30:00.0"
+      assert(toTsStr(rebasedEarlierMicros) === expected)
+      assert(toTsStr(rebasedLaterMicros) === expected)
+      assert(rebasedEarlierMicros + MICROS_PER_HOUR === rebasedLaterMicros)
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix the bug in microseconds rebasing during transitions from one standard time zone offset to another one. In the PR, I propose to change the implementation of `rebaseGregorianToJulianMicros` which performs rebasing via local timestamps. In the case of overlapping:
1. Check that the original instant belongs to earlier or later instant of overlapped local timestamp.
2. If it is an earlier instant, take zone and DST offsets from the previous day otherwise
3. Set time zone offsets to Julian timestamp from the next day.

Note: The fix assumes that transitions cannot happen more often than once per 2 days.

### Why are the changes needed?
Current implementation handles timestamps overlapping only during daylight saving time but overlapping can happen also during transition from one standard time zone to another one. For example in the case of `Asia/Hong_Kong`, the time zone switched from `Japan Standard Time` (UTC+9) to `Hong Kong Time` (UTC+8) on _Sunday, 18 November, 1945 01:59:59 AM_. The changes allow to handle the special case as well.

### Does this PR introduce _any_ user-facing change?
It might affect micros rebasing in before common era when not-optimised version of `rebaseGregorianToJulianMicros()` is used directly.

### How was this patch tested?
1. By existing tests in `DateTimeUtilsSuite`, `RebaseDateTimeSuite`, `DateFunctionsSuite`, `DateExpressionsSuite` and `TimestampFormatterSuite`.
2. Added new test to `RebaseDateTimeSuite`
3. Regenerated `gregorian-julian-rebase-micros.json` with the step of 30 minutes, and got the same JSON file. The JSON file isn't affected because previously it was generated with the step of 1 week. And the spike in diffs/switch points during 1 hour of timestamp overlapping wasn't detected.