### PR TITLE
[SPARK-31935][SQL][TESTS][FOLLOWUP] Fix the test case for Hadoop2/3

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
@@ -849,15 +849,15 @@ class FileBasedDataSourceSuite extends QueryTest
         withTempDir { dir =>
           val path = dir.getCanonicalPath
           val defaultFs = "nonexistFS://nonexistFS"
-          val expectMessage = "No FileSystem for scheme: nonexistFS"
+          val expectMessage = "No FileSystem for scheme nonexistFS"
           val message1 = intercept[java.io.IOException] {
             spark.range(10).write.option("fs.defaultFS", defaultFs).parquet(path)
           }.getMessage
-          assert(message1 == expectMessage)
+          assert(message1.filterNot(Set(':', '"').contains) == expectMessage)
           val message2 = intercept[java.io.IOException] {
             spark.read.option("fs.defaultFS", defaultFs).parquet(path)
           }.getMessage
-          assert(message2 == expectMessage)
+          assert(message2.filterNot(Set(':', '"').contains) == expectMessage)
         }
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the test case to accept Hadoop 2/3 error message correctly.

### Why are the changes needed?

SPARK-31935(https://github.com/apache/spark/pull/28760) breaks Hadoop 3.2 UT because Hadoop 2 and Hadoop 3 have different exception messages.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the Jenkins with both Hadoop 2/3 or do the following manually.

**Hadoop 2.7**
```
$ build/sbt "sql/testOnly *.FileBasedDataSourceSuite -- -z SPARK-31935"
...
[info] All tests passed.
```

**Hadoop 3.2**
```
$ build/sbt "sql/testOnly *.FileBasedDataSourceSuite -- -z SPARK-31935" -Phadoop-3.2
...
[info] All tests passed.
```