### PR TITLE
[SPARK-31950][SQL][TESTS] Extract SQL keywords from the SqlBase.g4 file

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -1009,6 +1009,7 @@ alterColumnAction
 // You can find the full keywords list by searching "Start of the keywords list" in this file.
 // The non-reserved keywords are listed below. Keywords not in this list are reserved keywords.
 ansiNonReserved
+//--ANSI-NON-RESERVED-START
     : ADD
     | AFTER
     | ALTER
@@ -1185,6 +1186,7 @@ ansiNonReserved
     | VIEW
     | VIEWS
     | WINDOW
+//--ANSI-NON-RESERVED-END
     ;
 
 // When `SQL_standard_keyword_behavior=false`, there are 2 kinds of keywords in Spark SQL.
@@ -1197,6 +1199,7 @@ ansiNonReserved
 // The non-reserved keywords are listed in `nonReserved`.
 // These 2 together contain all the keywords.
 strictNonReserved
+//--ANSI-STRICT-NON-RESERVED-START
     : ANTI
     | CROSS
     | EXCEPT
@@ -1212,6 +1215,7 @@ strictNonReserved
     | SETMINUS
     | UNION
     | USING
+//--ANSI-STRICT-NON-RESERVED-END
     ;
 
 nonReserved
@@ -1462,6 +1466,7 @@ nonReserved
 //============================
 // Start of the keywords list
 //============================
+//--SPARK-KEYWORD-LIST-START
 ADD: 'ADD';
 AFTER: 'AFTER';
 ALL: 'ALL';
@@ -1714,6 +1719,7 @@ WHERE: 'WHERE';
 WINDOW: 'WINDOW';
 WITH: 'WITH';
 YEAR: 'YEAR';
+//--SPARK-KEYWORD-LIST-END
 //============================
 // End of the keywords list
 //============================

--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -1199,7 +1199,6 @@ ansiNonReserved
 // The non-reserved keywords are listed in `nonReserved`.
 // These 2 together contain all the keywords.
 strictNonReserved
-//--ANSI-STRICT-NON-RESERVED-START
     : ANTI
     | CROSS
     | EXCEPT
@@ -1215,7 +1214,6 @@ strictNonReserved
     | SETMINUS
     | UNION
     | USING
-//--ANSI-STRICT-NON-RESERVED-END
     ;
 
 nonReserved

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/TableIdentifierParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/TableIdentifierParserSuite.scala
@@ -367,7 +367,7 @@ class TableIdentifierParserSuite extends SparkFunSuite with SQLHelper {
   test("check # of reserved keywords") {
     val numReservedKeywords = 77
     assert(reservedKeywordsInAnsiMode.size == 77,
-      s"The expected number of reserved keywords is $numReservedKeywords, " +
+      s"The expected number of reserved keywords is $numReservedKeywords, but " +
         s"${reservedKeywordsInAnsiMode.size} found.")
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/TableIdentifierParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/TableIdentifierParserSuite.scala
@@ -363,7 +363,7 @@ class TableIdentifierParserSuite extends SparkFunSuite with SQLHelper {
 
   test("check # of reserved keywords") {
     val numReservedKeywords = 77
-    assert(reservedKeywordsInAnsiMode.size == 77,
+    assert(reservedKeywordsInAnsiMode.size == numReservedKeywords,
       s"The expected number of reserved keywords is $numReservedKeywords, but " +
         s"${reservedKeywordsInAnsiMode.size} found.")
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/TableIdentifierParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/TableIdentifierParserSuite.scala
@@ -340,14 +340,6 @@ class TableIdentifierParserSuite extends SparkFunSuite with SQLHelper {
     keywords.map(_.trim.toLowerCase(Locale.ROOT)).toSet
   }
 
-  private def parseSyntax(startTag: String, endTag: String): Set[String] = {
-    val kwDef = """\s*[\|:]\s*([A-Z_]+)\s*""".r
-    parseAntlrGrammars(startTag, endTag) {
-      // Parses a pattern, e.g., `    | AFTER`
-      case kwDef(symbol) => Some(symbol)
-    }
-  }
-
   // All the SQL keywords defined in `SqlBase.g4`
   val allCandidateKeywords = {
     val kwDef = """([A-Z_]+):.+;""".r
@@ -359,8 +351,13 @@ class TableIdentifierParserSuite extends SparkFunSuite with SQLHelper {
     keywords
   }
 
-  val nonReservedKeywordsInAnsiMode = parseSyntax(
-    "//--ANSI-NON-RESERVED-START", "//--ANSI-NON-RESERVED-END")
+  val nonReservedKeywordsInAnsiMode = {
+    val kwDef = """\s*[\|:]\s*([A-Z_]+)\s*""".r
+    parseAntlrGrammars("//--ANSI-NON-RESERVED-START", "//--ANSI-NON-RESERVED-END") {
+      // Parses a pattern, e.g., `    | AFTER`
+      case kwDef(symbol) => Some(symbol)
+    }
+  }
 
   val reservedKeywordsInAnsiMode = allCandidateKeywords -- nonReservedKeywordsInAnsiMode
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR intends to extract SQL reserved/non-reserved keywords from the ANTLR grammar file (`SqlBase.g4`) directly.

This approach is based on the @cloud-fan suggestion: https://github.com/apache/spark/pull/28779#issuecomment-642033217

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
It is hard to maintain a full set of the keywords in `TableIdentifierParserSuite`, so it would be nice if we could extract them from the `SqlBase.g4` file directly. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Existing tests.