### PR TITLE
[SPARK-31973][SQL] Skip partial aggregates if grouping keys have high cardinality

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2196,6 +2196,13 @@ object SQLConf {
       .checkValue(bit => bit >= 10 && bit <= 30, "The bit value must be in [10, 30].")
       .createWithDefault(16)
 
+  val SPILL_PARTIAL_AGGREGATE_DISABLED =
+    buildConf("spark.sql.aggregate.spill.partialaggregate.disabled")
+      .internal()
+      .doc("Avoid sort/spill to disk during partial aggregation")
+      .booleanConf
+      .createWithDefault(false)
+
   val AVRO_COMPRESSION_CODEC = buildConf("spark.sql.avro.compression.codec")
     .doc("Compression codec used in writing of AVRO files. Supported codecs: " +
       "uncompressed, deflate, snappy, bzip2 and xz. Default codec is snappy.")
@@ -2921,6 +2928,8 @@ class SQLConf extends Serializable with Logging {
   def topKSortFallbackThreshold: Int = getConf(TOP_K_SORT_FALLBACK_THRESHOLD)
 
   def fastHashAggregateRowMaxCapacityBit: Int = getConf(FAST_HASH_AGGREGATE_MAX_ROWS_CAPACITY_BIT)
+
+  def spillInPartialAggregationDisabled: Boolean = getConf(SPILL_PARTIAL_AGGREGATE_DISABLED)
 
   def datetimeJava8ApiEnabled: Boolean = getConf(DATETIME_JAVA8API_ENABLED)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2197,7 +2197,7 @@ object SQLConf {
       .createWithDefault(16)
 
   val SKIP_PARTIAL_AGGREGATE_ENABLED =
-    buildConf("spark.sql.aggregate.partialaggregate.skip.enabled")
+      buildConf("spark.sql.aggregate.partialaggregate.skip.enabled")
       .internal()
       .doc("Avoid sort/spill to disk during partial aggregation")
       .booleanConf
@@ -2929,7 +2929,7 @@ class SQLConf extends Serializable with Logging {
 
   def fastHashAggregateRowMaxCapacityBit: Int = getConf(FAST_HASH_AGGREGATE_MAX_ROWS_CAPACITY_BIT)
 
-  def spillInPartialAggregationDisabled: Boolean = getConf(SKIP_PARTIAL_AGGREGATE_ENABLED)
+  def skipPartialAggregate: Boolean = getConf(SKIP_PARTIAL_AGGREGATE_ENABLED)
 
   def datetimeJava8ApiEnabled: Boolean = getConf(DATETIME_JAVA8API_ENABLED)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2203,6 +2203,18 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val SKIP_PARTIAL_AGGREGATE_THRESHOLD =
+    buildConf("spark.sql.aggregate.partialaggregate.skip.threshold")
+      .internal()
+      .longConf
+      .createWithDefault(100000)
+
+  val SKIP_PARTIAL_AGGREGATE_RATIO =
+    buildConf("spark.sql.aggregate.partialaggregate.skip.ratio")
+      .internal()
+      .doubleConf
+      .createWithDefault(0.5)
+
   val AVRO_COMPRESSION_CODEC = buildConf("spark.sql.avro.compression.codec")
     .doc("Compression codec used in writing of AVRO files. Supported codecs: " +
       "uncompressed, deflate, snappy, bzip2 and xz. Default codec is snappy.")
@@ -2930,6 +2942,10 @@ class SQLConf extends Serializable with Logging {
   def fastHashAggregateRowMaxCapacityBit: Int = getConf(FAST_HASH_AGGREGATE_MAX_ROWS_CAPACITY_BIT)
 
   def skipPartialAggregate: Boolean = getConf(SKIP_PARTIAL_AGGREGATE_ENABLED)
+
+  def skipPartialAggregateThreshold: Long = getConf(SKIP_PARTIAL_AGGREGATE_THRESHOLD)
+
+  def skipPartialAggregateRatio: Double = getConf(SKIP_PARTIAL_AGGREGATE_RATIO)
 
   def datetimeJava8ApiEnabled: Boolean = getConf(DATETIME_JAVA8API_ENABLED)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2197,7 +2197,7 @@ object SQLConf {
       .createWithDefault(16)
 
   val SKIP_PARTIAL_AGGREGATE_ENABLED =
-      buildConf("spark.sql.aggregate.partialaggregate.skip.enabled")
+    buildConf("spark.sql.aggregate.partialaggregate.skip.enabled")
       .internal()
       .doc("Avoid sort/spill to disk during partial aggregation")
       .booleanConf

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2201,7 +2201,7 @@ object SQLConf {
       .internal()
       .doc("Avoid sort/spill to disk during partial aggregation")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
   val AVRO_COMPRESSION_CODEC = buildConf("spark.sql.avro.compression.codec")
     .doc("Compression codec used in writing of AVRO files. Supported codecs: " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2196,8 +2196,8 @@ object SQLConf {
       .checkValue(bit => bit >= 10 && bit <= 30, "The bit value must be in [10, 30].")
       .createWithDefault(16)
 
-  val SPILL_PARTIAL_AGGREGATE_DISABLED =
-    buildConf("spark.sql.aggregate.spill.partialaggregate.disabled")
+  val SKIP_PARTIAL_AGGREGATE_ENABLED =
+    buildConf("spark.sql.aggregate.partialaggregate.skip.enabled")
       .internal()
       .doc("Avoid sort/spill to disk during partial aggregation")
       .booleanConf
@@ -2929,7 +2929,7 @@ class SQLConf extends Serializable with Logging {
 
   def fastHashAggregateRowMaxCapacityBit: Int = getConf(FAST_HASH_AGGREGATE_MAX_ROWS_CAPACITY_BIT)
 
-  def spillInPartialAggregationDisabled: Boolean = getConf(SPILL_PARTIAL_AGGREGATE_DISABLED)
+  def spillInPartialAggregationDisabled: Boolean = getConf(SKIP_PARTIAL_AGGREGATE_ENABLED)
 
   def datetimeJava8ApiEnabled: Boolean = getConf(DATETIME_JAVA8API_ENABLED)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2199,19 +2199,23 @@ object SQLConf {
   val SKIP_PARTIAL_AGGREGATE_ENABLED =
     buildConf("spark.sql.aggregate.partialaggregate.skip.enabled")
       .internal()
-      .doc("Avoid sort/spill to disk during partial aggregation")
+      .doc("Avoid sorter(sort/spill) during partial aggregation")
       .booleanConf
       .createWithDefault(true)
 
   val SKIP_PARTIAL_AGGREGATE_THRESHOLD =
     buildConf("spark.sql.aggregate.partialaggregate.skip.threshold")
       .internal()
+      .doc("Number of records after which aggregate operator checks if " +
+        "partial aggregation phase can be avoided")
       .longConf
       .createWithDefault(100000)
 
-  val SKIP_PARTIAL_AGGREGATE_RATIO =
+  val SKIP_PARTIAL_AGGREGATE_REDUCTION_RATIO =
     buildConf("spark.sql.aggregate.partialaggregate.skip.ratio")
       .internal()
+      .doc("Ratio of number of records present in map of Aggregate operator" +
+        "to the total number of records processed by the Aggregate operator")
       .doubleConf
       .createWithDefault(0.5)
 
@@ -2945,7 +2949,7 @@ class SQLConf extends Serializable with Logging {
 
   def skipPartialAggregateThreshold: Long = getConf(SKIP_PARTIAL_AGGREGATE_THRESHOLD)
 
-  def skipPartialAggregateRatio: Double = getConf(SKIP_PARTIAL_AGGREGATE_RATIO)
+  def skipPartialAggregateRatio: Double = getConf(SKIP_PARTIAL_AGGREGATE_REDUCTION_RATIO)
 
   def datetimeJava8ApiEnabled: Boolean = getConf(DATETIME_JAVA8API_ENABLED)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2196,6 +2196,23 @@ object SQLConf {
       .checkValue(bit => bit >= 10 && bit <= 30, "The bit value must be in [10, 30].")
       .createWithDefault(16)
 
+
+  val SKIP_PARTIAL_AGGREGATE_MINROWS =
+  buildConf("spark.sql.aggregate.skipPartialAggregate.minNumRows")
+      .internal()
+      .doc("Number of records after which aggregate operator checks if " +
+        "partial aggregation phase can be avoided")
+      .longConf
+      .createWithDefault(100000)
+
+  val SKIP_PARTIAL_AGGREGATE_AGGREGATE_RATIO =
+  buildConf("spark.sql.aggregate.skipPartialAggregate.aggregateRatio")
+      .internal()
+      .doc("Ratio of number of records present in map of Aggregate operator" +
+        "to the total number of records processed by the Aggregate operator")
+      .doubleConf
+      .createWithDefault(0.5)
+
   val SKIP_PARTIAL_AGGREGATE_ENABLED =
     buildConf("spark.sql.aggregate.skipPartialAggregate")
       .internal()
@@ -2206,22 +2223,6 @@ object SQLConf {
         s"${SKIP_PARTIAL_AGGREGATE_AGGREGATE_RATIO.key}")
       .booleanConf
       .createWithDefault(true)
-
-  val SKIP_PARTIAL_AGGREGATE_MINROWS =
-    buildConf("spark.sql.aggregate.skipPartialAggregate.minNumRows")
-      .internal()
-      .doc("Number of records after which aggregate operator checks if " +
-        "partial aggregation phase can be avoided")
-      .longConf
-      .createWithDefault(100000)
-
-  val SKIP_PARTIAL_AGGREGATE_AGGREGATE_RATIO =
-    buildConf("spark.sql.aggregate.skipPartialAggregate.aggregateRatio")
-      .internal()
-      .doc("Ratio of number of records present in map of Aggregate operator" +
-        "to the total number of records processed by the Aggregate operator")
-      .doubleConf
-      .createWithDefault(0.5)
 
   val AVRO_COMPRESSION_CODEC = buildConf("spark.sql.avro.compression.codec")
     .doc("Compression codec used in writing of AVRO files. Supported codecs: " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2197,22 +2197,26 @@ object SQLConf {
       .createWithDefault(16)
 
   val SKIP_PARTIAL_AGGREGATE_ENABLED =
-    buildConf("spark.sql.aggregate.partialaggregate.skip.enabled")
+    buildConf("spark.sql.aggregate.skipPartialAggregate")
       .internal()
-      .doc("Avoid sorter(sort/spill) during partial aggregation")
+      .doc("When enabled, the partial aggregation is skipped when the following" +
+        "two conditions are met. 1. When the total number of records processed is greater" +
+        s"than threshold defined by ${SKIP_PARTIAL_AGGREGATE_MINROWS.key} 2. When the ratio" +
+        "of recornd count in map to the total records is less that value defined by " +
+        s"${SKIP_PARTIAL_AGGREGATE_AGGREGATE_RATIO.key}")
       .booleanConf
       .createWithDefault(true)
 
-  val SKIP_PARTIAL_AGGREGATE_THRESHOLD =
-    buildConf("spark.sql.aggregate.partialaggregate.skip.threshold")
+  val SKIP_PARTIAL_AGGREGATE_MINROWS =
+    buildConf("spark.sql.aggregate.skipPartialAggregate.minNumRows")
       .internal()
       .doc("Number of records after which aggregate operator checks if " +
         "partial aggregation phase can be avoided")
       .longConf
       .createWithDefault(100000)
 
-  val SKIP_PARTIAL_AGGREGATE_REDUCTION_RATIO =
-    buildConf("spark.sql.aggregate.partialaggregate.skip.ratio")
+  val SKIP_PARTIAL_AGGREGATE_AGGREGATE_RATIO =
+    buildConf("spark.sql.aggregate.skipPartialAggregate.aggregateRatio")
       .internal()
       .doc("Ratio of number of records present in map of Aggregate operator" +
         "to the total number of records processed by the Aggregate operator")
@@ -2947,9 +2951,9 @@ class SQLConf extends Serializable with Logging {
 
   def skipPartialAggregate: Boolean = getConf(SKIP_PARTIAL_AGGREGATE_ENABLED)
 
-  def skipPartialAggregateThreshold: Long = getConf(SKIP_PARTIAL_AGGREGATE_THRESHOLD)
+  def skipPartialAggregateThreshold: Long = getConf(SKIP_PARTIAL_AGGREGATE_MINROWS)
 
-  def skipPartialAggregateRatio: Double = getConf(SKIP_PARTIAL_AGGREGATE_REDUCTION_RATIO)
+  def skipPartialAggregateRatio: Double = getConf(SKIP_PARTIAL_AGGREGATE_AGGREGATE_RATIO)
 
   def datetimeJava8ApiEnabled: Boolean = getConf(DATETIME_JAVA8API_ENABLED)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2202,15 +2202,22 @@ object SQLConf {
       .internal()
       .doc("Number of records after which aggregate operator checks if " +
         "partial aggregation phase can be avoided")
+      .version("3.1.0")
       .longConf
       .createWithDefault(100000)
 
   val SKIP_PARTIAL_AGGREGATE_AGGREGATE_RATIO =
   buildConf("spark.sql.aggregate.skipPartialAggregate.aggregateRatio")
       .internal()
-      .doc("Ratio of number of records present in map of Aggregate operator" +
-        "to the total number of records processed by the Aggregate operator")
+      .doc("Ratio beyond which the partial aggregation is skipped." +
+        "This is computed by taking the ratio of number of records present" +
+        " in map of Aggregate operator to the total number of records processed" +
+        " by the Aggregate operator.")
+      .version("3.1.0")
       .doubleConf
+      .checkValue(ratio => ratio > 0 && ratio < 1, "Invalid value for " +
+        "spark.sql.aggregate.skipPartialAggregate.aggregateRatio. Valid value needs" +
+        " to be between 0 and 1" )
       .createWithDefault(0.5)
 
   val SKIP_PARTIAL_AGGREGATE_ENABLED =
@@ -2219,8 +2226,9 @@ object SQLConf {
       .doc("When enabled, the partial aggregation is skipped when the following" +
         "two conditions are met. 1. When the total number of records processed is greater" +
         s"than threshold defined by ${SKIP_PARTIAL_AGGREGATE_MINROWS.key} 2. When the ratio" +
-        "of recornd count in map to the total records is less that value defined by " +
+        "of record count in map to the total records is less that value defined by " +
         s"${SKIP_PARTIAL_AGGREGATE_AGGREGATE_RATIO.key}")
+      .version("3.1.0")
       .booleanConf
       .createWithDefault(true)
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeFixedWidthAggregationMap.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeFixedWidthAggregationMap.java
@@ -67,7 +67,6 @@ public final class UnsafeFixedWidthAggregationMap {
    * Number of rows that were added to the map
    * This includes the elements that were passed on sorter
    * using {@link #destructAndCreateExternalSorter()}
-   *
    */
   private long numRowsAdded = 0L;
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeFixedWidthAggregationMap.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeFixedWidthAggregationMap.java
@@ -64,6 +64,14 @@ public final class UnsafeFixedWidthAggregationMap {
   private final UnsafeRow currentAggregationBuffer;
 
   /**
+   * Number of rows that were added to the map
+   * This includes the elements that were passed on sorter
+   * using {@link #destructAndCreateExternalSorter()}
+   *
+   */
+  private long numRowsAdded = 0L;
+
+  /**
    * @return true if UnsafeFixedWidthAggregationMap supports aggregation buffers with the given
    *         schema, false otherwise.
    */
@@ -147,6 +155,8 @@ public final class UnsafeFixedWidthAggregationMap {
       );
       if (!putSucceeded) {
         return null;
+      } else {
+        numRowsAdded = numRowsAdded + 1;
       }
     }
 
@@ -248,5 +258,9 @@ public final class UnsafeFixedWidthAggregationMap {
       (int) SparkEnv.get().conf().get(
         package$.MODULE$.SHUFFLE_SPILL_NUM_ELEMENTS_FORCE_SPILL_THRESHOLD()),
       map);
+  }
+
+  public long getNumRows() {
+    return numRowsAdded;
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggUtils.scala
@@ -354,7 +354,7 @@ object AggUtils {
     finalAndCompleteAggregate :: Nil
   }
 
-  def areAggExpressionsPartial(exprs: Seq[AggregateExpression]): Boolean = {
-    exprs.forall(e => e.mode == Partial)
+  def areAggExpressionsPartial(modes: Seq[AggregateMode]): Boolean = {
+    modes.nonEmpty && modes.forall(_ == Partial)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggUtils.scala
@@ -355,6 +355,6 @@ object AggUtils {
   }
 
   def areAggExpressionsPartial(exprs: Seq[AggregateExpression]): Boolean = {
-    exprs.forall(e => e.mode == Partial || e.mode == PartialMerge)
+    exprs.forall(e => e.mode == Partial)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggUtils.scala
@@ -353,4 +353,8 @@ object AggUtils {
 
     finalAndCompleteAggregate :: Nil
   }
+
+  def areAggExpressionsPartial(exprs: Seq[AggregateExpression]): Boolean = {
+    exprs.forall(e => e.mode == Partial || e.mode == PartialMerge)
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggUtils.scala
@@ -353,8 +353,4 @@ object AggUtils {
 
     finalAndCompleteAggregate :: Nil
   }
-
-  def areAggExpressionsPartial(modes: Seq[AggregateMode]): Boolean = {
-    modes.nonEmpty && modes.forall(_ == Partial)
-  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -899,10 +899,10 @@ case class HashAggregateExec(
          |}
          |// Can't allocate buffer from the hash map. Spill the map and fallback to sort-based
          |// aggregation after processing all input rows.
-         |if ($unsafeRowBuffer == null) {
+         |if ($unsafeRowBuffer == null && !$avoidSpillInPartialAggregateTerm) {
          |  // If sort/spill to disk is disabled, nothing is done.
          |  // Aggregation buffer is created later
-         |  if (!$avoidSpillInPartialAggregateTerm && $spillInPartialAggregateDisabled) {
+         |  if ($spillInPartialAggregateDisabled) {
          |    $avoidSpillInPartialAggregateTerm = true;
          |  } else {
          |    if ($sorterTerm == null) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -900,10 +900,10 @@ case class HashAggregateExec(
          |// Can't allocate buffer from the hash map. Spill the map and fallback to sort-based
          |// aggregation after processing all input rows.
          |if ($unsafeRowBuffer == null) {
-         |  // If sort/spill to disk is disabled, do not create the sorter
+         |  // If sort/spill to disk is disabled, nothing is done.
+         |  // Aggregation buffer is created later
          |  if (!$avoidSpillInPartialAggregateTerm && $spillInPartialAggregateDisabled) {
          |    $avoidSpillInPartialAggregateTerm = true;
-         |    $unsafeRowBuffer = (UnsafeRow) $thisPlan.getEmptyAggregationBuffer();
          |  } else {
          |    if ($sorterTerm == null) {
          |      $sorterTerm = $hashMapTerm.destructAndCreateExternalSorter();
@@ -920,6 +920,10 @@ case class HashAggregateExec(
          |      throw new $oomeClassName("No enough memory for aggregation");
          |    }
          |  }
+         |}
+         |// Create an empty aggregation buffer
+         |if ($avoidSpillInPartialAggregateTerm) {
+         |  $unsafeRowBuffer = (UnsafeRow) $thisPlan.getEmptyAggregationBuffer();
          |}
        """.stripMargin
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -835,9 +835,11 @@ case class HashAggregateExec(
 
     val aggTime = metricTerm(ctx, "aggTime")
     val beforeAgg = ctx.freshName("beforeAgg")
+    val spillInPartialAggregateDisabled = sqlContext.conf.spillInPartialAggregationDisabled
     s"""
        |if (!$initAgg) {
        |  $initAgg = true;
+       |  $avoidSpillInPartialAggregateTerm = $spillInPartialAggregateDisabled;
        |  $createFastHashMap
        |  $hashMapTerm = $thisPlan.createHashMap();
        |  long $beforeAgg = System.nanoTime();
@@ -885,7 +887,6 @@ case class HashAggregateExec(
     val oomeClassName = classOf[SparkOutOfMemoryError].getName
 
     val thisPlan = ctx.addReferenceObj("plan", this)
-    val spillInPartialAggregateDisabled = sqlContext.conf.spillInPartialAggregationDisabled
 
     val findOrInsertRegularHashMap: String =
       s"""
@@ -900,9 +901,8 @@ case class HashAggregateExec(
          |// Can't allocate buffer from the hash map. Spill the map and fallback to sort-based
          |// aggregation after processing all input rows.
          |if ($unsafeRowBuffer == null) {
-         |  // If sort/spill to disk is disabled, do not create the sorter
-         |  if (!$avoidSpillInPartialAggregateTerm && $spillInPartialAggregateDisabled) {
-         |    $avoidSpillInPartialAggregateTerm = true;
+         |  if ($avoidSpillInPartialAggregateTerm) {
+         |    // If sort/spill to disk is disabled, do not sort/spil to disk
          |    $unsafeRowBuffer = (UnsafeRow) $thisPlan.getEmptyAggregationBuffer();
          |  } else {
          |    if ($sorterTerm == null) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -74,8 +74,8 @@ case class HashAggregateExec(
     "peakMemory" -> SQLMetrics.createSizeMetric(sparkContext, "peak memory"),
     "spillSize" -> SQLMetrics.createSizeMetric(sparkContext, "spill size"),
     "aggTime" -> SQLMetrics.createTimingMetric(sparkContext, "time in aggregation build"),
-    "partialAggSkipped" -> SQLMetrics.createMetric(sparkContext, "Num records" +
-      " skipped partial aggregation skipped"),
+    "partialAggSkipped" -> SQLMetrics.createMetric(sparkContext,
+      "number of skipped records for partial aggregates"),
     "avgHashProbe" ->
       SQLMetrics.createAverageMetric(sparkContext, "avg hash probe bucket list iters"))
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -63,7 +63,7 @@ case class HashAggregateExec(
 
   require(HashAggregateExec.supportsAggregate(aggregateBufferAttributes))
 
-  override def needStopCheck: Boolean = sqlContext.conf.spillInPartialAggregationDisabled
+  override def needStopCheck: Boolean = sqlContext.conf.skipPartialAggregate
 
   override lazy val allAttributes: AttributeSeq =
     child.output ++ aggregateBufferAttributes ++ aggregateAttributes ++
@@ -413,7 +413,7 @@ case class HashAggregateExec(
   private var fastHashMapTerm: String = _
   private var isFastHashMapEnabled: Boolean = false
 
-  private val isPartial = AggUtils.areAggExpressionsPartial(aggregateExpressions)
+  private val isPartial = AggUtils.areAggExpressionsPartial(modes)
   private var avoidSpillInPartialAggregateTerm: String = _
   private var childrenConsumed: String = _
   private var outputFunc: String = _
@@ -900,7 +900,7 @@ case class HashAggregateExec(
     val oomeClassName = classOf[SparkOutOfMemoryError].getName
 
     val thisPlan = ctx.addReferenceObj("plan", this)
-    val spillInPartialAggregateDisabled = sqlContext.conf.spillInPartialAggregationDisabled
+    val spillInPartialAggregateDisabled = sqlContext.conf.skipPartialAggregate
 
     val findOrInsertRegularHashMap: String =
       s"""

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -340,7 +340,6 @@ case class HashAggregateExec(
     // only have DeclarativeAggregate
     val functions = aggregateExpressions.map(_.aggregateFunction.asInstanceOf[DeclarativeAggregate])
     val inputAttrs = functions.flatMap(_.aggBufferAttributes) ++ inputAttributes
-
     // To individually generate code for each aggregate function, an element in `updateExprs` holds
     // all the expressions for the buffer of an aggregation function.
     val updateExprs = aggregateExpressions.map { e =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -256,7 +256,6 @@ case class HashAggregateExec(
     s"""
        |while (!$initAgg) {
        |  $initAgg = true;
-       |  $avoidSpillInPartialAggregateTerm = ${Utils.isTesting} && $isPartial;
        |  long $beforeAgg = System.nanoTime();
        |  $doAggFuncName();
        |  $aggTime.add((System.nanoTime() - $beforeAgg) / $NANOS_PER_MILLIS);

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -416,7 +416,6 @@ case class HashAggregateExec(
   private var avoidSpillInPartialAggregateTerm: String = _
   private val skipPartialAggregate = sqlContext.conf.skipPartialAggregate &&
     AggUtils.areAggExpressionsPartial(modes) && find(_.isInstanceOf[ExpandExec]).isEmpty
-  private var childrenConsumed: String = _
   private var outputFunc: String = _
 
   // whether a vectorized hashmap is used instead
@@ -694,7 +693,7 @@ case class HashAggregateExec(
     val initAgg = ctx.addMutableState(CodeGenerator.JAVA_BOOLEAN, "initAgg")
     avoidSpillInPartialAggregateTerm = ctx.
       addMutableState(CodeGenerator.JAVA_BOOLEAN, "avoidPartialAggregate")
-    childrenConsumed = ctx.
+    val childrenConsumed = ctx.
       addMutableState(CodeGenerator.JAVA_BOOLEAN, "childrenConsumed")
     if (sqlContext.conf.enableTwoLevelAggMap) {
       enableTwoLevelHashMap(ctx)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -420,7 +420,7 @@ case class HashAggregateExec(
 
   private var avoidSpillInPartialAggregateTerm: String = _
   private val skipPartialAggregateEnabled = sqlContext.conf.skipPartialAggregate &&
-    modes.forall(_ == Partial) && find(_.isInstanceOf[ExpandExec]).isEmpty
+    !modes.exists(_ != Partial) && find(_.isInstanceOf[ExpandExec]).isEmpty
   private var rowCountTerm: String = _
   private var outputFunc: String = _
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -419,8 +419,10 @@ case class HashAggregateExec(
   private var isFastHashMapEnabled: Boolean = false
 
   private var avoidSpillInPartialAggregateTerm: String = _
-  private val skipPartialAggregateEnabled = sqlContext.conf.skipPartialAggregate &&
-    !modes.exists(_ != Partial) && find(_.isInstanceOf[ExpandExec]).isEmpty
+  private val skipPartialAggregateEnabled = {
+    sqlContext.conf.skipPartialAggregate &&
+      modes.nonEmpty && modes.forall(_ == Partial) && find(_.isInstanceOf[ExpandExec]).isEmpty
+  }
   private var rowCountTerm: String = _
   private var outputFunc: String = _
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -952,7 +952,8 @@ case class HashAggregateExec(
            |if (!$avoidSpillInPartialAggregateTerm) {
            |  $getAggBufferFromMap
            |  // Can't allocate buffer from the hash map.
-           |  // Check if we can avoid partial aggregation. Otherwise, Spill the map and fallback to sort-based
+           |  // Check if we can avoid partial aggregation.
+           |  //  Otherwise, Spill the map and fallback to sort-based
            |  // aggregation after processing all input rows.
            |  if ($unsafeRowBuffer == null && !$avoidSpillInPartialAggregateTerm) {
            |    $countTerm = $countTerm + $hashMapTerm.getNumRows();

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -943,7 +943,7 @@ case class HashAggregateExec(
       def getHeuristicToAvoidAgg: String = {
         s"""
           |!($rowCountTerm < $skipPartialAggregateThreshold) &&
-          |      ($countTerm/$rowCountTerm) > $skipPartialAggRatio;
+          |      ((float)$countTerm/$rowCountTerm) > $skipPartialAggRatio;
           |""".stripMargin
       }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashMapGenerator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashMapGenerator.scala
@@ -136,6 +136,14 @@ abstract class HashMapGenerator(
      """.stripMargin
   }
 
+  protected final def generateNumRows(): String = {
+    s"""
+       |public int getNumRows() {
+       |  return batch.numRows();
+       |}
+     """.stripMargin
+  }
+
   protected final def genComputeHash(
       ctx: CodegenContext,
       input: String,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashMapGenerator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashMapGenerator.scala
@@ -75,6 +75,8 @@ abstract class HashMapGenerator(
        |
        |${generateRowIterator()}
        |
+       |${generateNumRows()}
+       |
        |${generateClose()}
        |}
      """.stripMargin

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -52,7 +52,7 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
   }
 
   test(s"Avoid spill in partial aggregation" ) {
-    withSQLConf((SQLConf.SPILL_PARTIAL_AGGREGATE_DISABLED.key, "true")) {
+    withSQLConf((SQLConf.SKIP_PARTIAL_AGGREGATE_ENABLED.key, "true")) {
       // Create Dataframes
       val data = Seq(("James", 1), ("James", 1), ("Phil", 1))
       val aggDF = data.toDF("name", "values").groupBy("name").sum("values")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -65,7 +65,7 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
       assert(partAggNode.isDefined,
       "No HashAggregate node with partial aggregate expression found")
       assert(partAggNode.get.metrics("partialAggSkipped").value == data.size,
-      "Partial aggregation got triggrered in partial hash aggregate node")
+      "Partial aggregation got triggered in partial hash aggregate node")
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -166,7 +166,7 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
     }
   }
 
-  test("SPARK-: Avoid spill in partial aggregation " +
+  test("SPARK-31973: Avoid spill in partial aggregation " +
     "when spark.sql.aggregate.spill.partialaggregate.disabled is set") {
     withSQLConf((SQLConf.SPILL_PARTIAL_AGGREGATE_DISABLED.key, "true"),
       (SQLConf.ENABLE_TWOLEVEL_AGG_MAP.key, "false")) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -77,7 +77,6 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
       }
       checkAnswer(aggDF, Row(6))
       assert(aggNodes.nonEmpty)
-      Thread.sleep(1000000)
       assert(aggNodes.forall(_.metrics("partialAggSkipped").value == 0))
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -53,8 +53,8 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
   }
 
   test("Avoid spill in partial aggregation" ) {
-    withSQLConf((SQLConf.SKIP_PARTIAL_AGGREGATE_ENABLED.key, "true"),
-      (SQLConf.SKIP_PARTIAL_AGGREGATE_MINROWS.key, "2")) {
+    withSQLConf((SQLConf.SKIP_PARTIAL_AGGREGATE_ENABLED.key -> "true"),
+      (SQLConf.SKIP_PARTIAL_AGGREGATE_MINROWS.key -> "2")) {
       // Create Dataframes
       val data = Seq(("James", 1), ("James", 1), ("Phil", 1))
       val aggDF = data.toDF("name", "values").groupBy("name").sum("values")
@@ -73,9 +73,9 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
     }
   }
 
-  test(s"Distinct: Partial aggregation should happen for" +
-    s" HashAggregate nodes performing partial Aggregate operations " ) {
-    withSQLConf((SQLConf.SKIP_PARTIAL_AGGREGATE_ENABLED.key, "true")) {
+  test(s"Distinct: Partial aggregation should happen for " +
+    "HashAggregate nodes performing partial Aggregate operations " ) {
+    withSQLConf((SQLConf.SKIP_PARTIAL_AGGREGATE_ENABLED.key -> "true")) {
       val aggDF = testData2.select(sumDistinct($"a"), sum($"b"))
       val aggNodes = aggDF.queryExecution.executedPlan.collect {
         case h: HashAggregateExec => h

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -60,7 +60,8 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
       val aggDF = data.toDF("name", "values").groupBy("name").sum("values")
       val partAggNode = aggDF.queryExecution.executedPlan.find {
         case h: HashAggregateExec =>
-          !h.aggregateExpressions.map(_.mode).exists(_ != Partial)
+          val modes = h.aggregateExpressions.map(_.mode)
+          modes.nonEmpty && modes.forall(_ == Partial)
         case _ => false
       }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -17,8 +17,8 @@
 
 package org.apache.spark.sql.execution
 
-import org.apache.spark.sql.catalyst.expressions.aggregate.Partial
 import org.apache.spark.sql.{Dataset, QueryTest, Row, SaveMode}
+import org.apache.spark.sql.catalyst.expressions.aggregate.Partial
 import org.apache.spark.sql.catalyst.expressions.codegen.{ByteCodeStats, CodeAndComment, CodeGenerator}
 import org.apache.spark.sql.execution.adaptive.DisableAdaptiveExecutionSuite
 import org.apache.spark.sql.execution.aggregate.{AggUtils, HashAggregateExec}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -51,9 +51,9 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
     assert(df.collect() === Array(Row(9, 4.5)))
   }
 
-  test(s"Avoid spill in partial aggregation" ) {
+  test("Avoid spill in partial aggregation" ) {
     withSQLConf((SQLConf.SKIP_PARTIAL_AGGREGATE_ENABLED.key, "true"),
-      ("spark.sql.aggregate.partialaggregate.skip.threshold", "2")) {
+      (SQLConf.SKIP_PARTIAL_AGGREGATE_MINROWS.key, "2")) {
       // Create Dataframes
       val data = Seq(("James", 1), ("James", 1), ("Phil", 1))
       val aggDF = data.toDF("name", "values").groupBy("name").sum("values")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -52,7 +52,8 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
   }
 
   test(s"Avoid spill in partial aggregation" ) {
-    withSQLConf((SQLConf.SKIP_PARTIAL_AGGREGATE_ENABLED.key, "true")) {
+    withSQLConf((SQLConf.SKIP_PARTIAL_AGGREGATE_ENABLED.key, "true"),
+      ("spark.sql.aggregate.partialaggregate.skip.threshold", "2")) {
       // Create Dataframes
       val data = Seq(("James", 1), ("James", 1), ("Phil", 1))
       val aggDF = data.toDF("name", "values").groupBy("name").sum("values")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -60,9 +60,10 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
       val aggDF = data.toDF("name", "values").groupBy("name").sum("values")
       val partAggNode = aggDF.queryExecution.executedPlan.find {
         case h: HashAggregateExec =>
-          h.aggregateExpressions.map(_.mode).forall(_ == Partial)
+          !h.aggregateExpressions.map(_.mode).exists(_ != Partial)
         case _ => false
       }
+
       checkAnswer(aggDF, Seq(Row("James", 2), Row("Phil", 1)))
       assert(partAggNode.isDefined,
       "No HashAggregate node with partial aggregate expression found")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -142,52 +142,57 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils
   }
 
   test("Aggregate metrics: track avg probe") {
-    // The executed plan looks like:
-    // HashAggregate(keys=[a#61], functions=[count(1)], output=[a#61, count#71L])
-    // +- Exchange hashpartitioning(a#61, 5)
-    //    +- HashAggregate(keys=[a#61], functions=[partial_count(1)], output=[a#61, count#76L])
-    //       +- Exchange RoundRobinPartitioning(1)
-    //          +- LocalTableScan [a#61]
-    //
-    // Assume the execution plan with node id is:
-    // Wholestage disabled:
-    // HashAggregate(nodeId = 0)
-    //   Exchange(nodeId = 1)
-    //     HashAggregate(nodeId = 2)
-    //       Exchange (nodeId = 3)
-    //         LocalTableScan(nodeId = 4)
-    //
-    // Wholestage enabled:
-    // WholeStageCodegen(nodeId = 0)
-    //   HashAggregate(nodeId = 1)
-    //     Exchange(nodeId = 2)
-    //       WholeStageCodegen(nodeId = 3)
-    //         HashAggregate(nodeId = 4)
-    //           Exchange(nodeId = 5)
-    //             LocalTableScan(nodeId = 6)
-    Seq(true, false).foreach { enableWholeStage =>
-      val df = generateRandomBytesDF().repartition(1).groupBy('a).count()
-      val nodeIds = if (enableWholeStage) {
-        Set(4L, 1L)
-      } else {
-        Set(2L, 0L)
-      }
-      val metrics = getSparkPlanMetrics(df, 1, nodeIds, enableWholeStage).get
-      nodeIds.foreach { nodeId =>
-        val probes = metrics(nodeId)._2("avg hash probe bucket list iters").toString
-        if (!probes.contains("\n")) {
-          // It's a single metrics value
-          assert(probes.toDouble > 1.0)
+    if (spark.sessionState.conf.getConf(SQLConf.SKIP_PARTIAL_AGGREGATE_ENABLED)) {
+      logInfo("Skipping, since partial Aggregation is disabled")
+    } else {
+      // The executed plan looks like:
+      // HashAggregate(keys=[a#61], functions=[count(1)], output=[a#61, count#71L])
+      // +- Exchange hashpartitioning(a#61, 5)
+      //    +- HashAggregate(keys=[a#61], functions=[partial_count(1)], output=[a#61, count#76L])
+      //       +- Exchange RoundRobinPartitioning(1)
+      //          +- LocalTableScan [a#61]
+      //
+      // Assume the execution plan with node id is:
+      // Wholestage disabled:
+      // HashAggregate(nodeId = 0)
+      //   Exchange(nodeId = 1)
+      //     HashAggregate(nodeId = 2)
+      //       Exchange (nodeId = 3)
+      //         LocalTableScan(nodeId = 4)
+      //
+      // Wholestage enabled:
+      // WholeStageCodegen(nodeId = 0)
+      //   HashAggregate(nodeId = 1)
+      //     Exchange(nodeId = 2)
+      //       WholeStageCodegen(nodeId = 3)
+      //         HashAggregate(nodeId = 4)
+      //           Exchange(nodeId = 5)
+      //             LocalTableScan(nodeId = 6)
+      Seq(true, false).foreach { enableWholeStage =>
+        val df = generateRandomBytesDF().repartition(1).groupBy('a).count()
+        val nodeIds = if (enableWholeStage) {
+          Set(4L, 1L)
         } else {
-          val mainValue = probes.split("\n").apply(1).stripPrefix("(").stripSuffix(")")
-          // Extract min, med, max from the string and strip off everthing else.
-          val index = mainValue.indexOf(" (", 0)
-          mainValue.slice(0, index).split(", ").foreach {
-            probe => assert(probe.toDouble > 1.0)
+          Set(2L, 0L)
+        }
+        val metrics = getSparkPlanMetrics(df, 1, nodeIds, enableWholeStage).get
+        nodeIds.foreach { nodeId =>
+          val probes = metrics(nodeId)._2("avg hash probe bucket list iters").toString
+          if (!probes.contains("\n")) {
+            // It's a single metrics value
+            assert(probes.toDouble > 1.0)
+          } else {
+            val mainValue = probes.split("\n").apply(1).stripPrefix("(").stripSuffix(")")
+            // Extract min, med, max from the string and strip off everthing else.
+            val index = mainValue.indexOf(" (", 0)
+            mainValue.slice(0, index).split(", ").foreach {
+              probe => assert(probe.toDouble > 1.0)
+            }
           }
         }
       }
     }
+
   }
 
   test("ObjectHashAggregate metrics") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -192,7 +192,6 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils
         }
       }
     }
-
   }
 
   test("ObjectHashAggregate metrics") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -142,53 +142,48 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils
   }
 
   test("Aggregate metrics: track avg probe") {
-    val skipPartialAgg = spark.sessionState.conf.getConf(SQLConf.SKIP_PARTIAL_AGGREGATE_ENABLED)
-    if (skipPartialAgg) {
-      logInfo("Skipping, since partial Aggregation is disabled")
-    } else {
-      // The executed plan looks like:
-      // HashAggregate(keys=[a#61], functions=[count(1)], output=[a#61, count#71L])
-      // +- Exchange hashpartitioning(a#61, 5)
-      //    +- HashAggregate(keys=[a#61], functions=[partial_count(1)], output=[a#61, count#76L])
-      //       +- Exchange RoundRobinPartitioning(1)
-      //          +- LocalTableScan [a#61]
-      //
-      // Assume the execution plan with node id is:
-      // Wholestage disabled:
-      // HashAggregate(nodeId = 0)
-      //   Exchange(nodeId = 1)
-      //     HashAggregate(nodeId = 2)
-      //       Exchange (nodeId = 3)
-      //         LocalTableScan(nodeId = 4)
-      //
-      // Wholestage enabled:
-      // WholeStageCodegen(nodeId = 0)
-      //   HashAggregate(nodeId = 1)
-      //     Exchange(nodeId = 2)
-      //       WholeStageCodegen(nodeId = 3)
-      //         HashAggregate(nodeId = 4)
-      //           Exchange(nodeId = 5)
-      //             LocalTableScan(nodeId = 6)
-      Seq(true, false).foreach { enableWholeStage =>
-        val df = generateRandomBytesDF().repartition(1).groupBy('a).count()
-        val nodeIds = if (enableWholeStage) {
-          Set(4L, 1L)
+    // The executed plan looks like:
+    // HashAggregate(keys=[a#61], functions=[count(1)], output=[a#61, count#71L])
+    // +- Exchange hashpartitioning(a#61, 5)
+    //    +- HashAggregate(keys=[a#61], functions=[partial_count(1)], output=[a#61, count#76L])
+    //       +- Exchange RoundRobinPartitioning(1)
+    //          +- LocalTableScan [a#61]
+    //
+    // Assume the execution plan with node id is:
+    // Wholestage disabled:
+    // HashAggregate(nodeId = 0)
+    //   Exchange(nodeId = 1)
+    //     HashAggregate(nodeId = 2)
+    //       Exchange (nodeId = 3)
+    //         LocalTableScan(nodeId = 4)
+    //
+    // Wholestage enabled:
+    // WholeStageCodegen(nodeId = 0)
+    //   HashAggregate(nodeId = 1)
+    //     Exchange(nodeId = 2)
+    //       WholeStageCodegen(nodeId = 3)
+    //         HashAggregate(nodeId = 4)
+    //           Exchange(nodeId = 5)
+    //             LocalTableScan(nodeId = 6)
+    Seq(true, false).foreach { enableWholeStage =>
+      val df = generateRandomBytesDF().repartition(1).groupBy('a).count()
+      val nodeIds = if (enableWholeStage) {
+        Set(4L, 1L)
+      } else {
+        Set(2L, 0L)
+      }
+      val metrics = getSparkPlanMetrics(df, 1, nodeIds, enableWholeStage).get
+      nodeIds.foreach { nodeId =>
+        val probes = metrics(nodeId)._2("avg hash probe bucket list iters").toString
+        if (!probes.contains("\n")) {
+          // It's a single metrics value
+          assert(probes.toDouble > 1.0)
         } else {
-          Set(2L, 0L)
-        }
-        val metrics = getSparkPlanMetrics(df, 1, nodeIds, enableWholeStage).get
-        nodeIds.foreach { nodeId =>
-          val probes = metrics(nodeId)._2("avg hash probe bucket list iters").toString
-          if (!probes.contains("\n")) {
-            // It's a single metrics value
-            assert(probes.toDouble > 1.0)
-          } else {
-            val mainValue = probes.split("\n").apply(1).stripPrefix("(").stripSuffix(")")
-            // Extract min, med, max from the string and strip off everthing else.
-            val index = mainValue.indexOf(" (", 0)
-            mainValue.slice(0, index).split(", ").foreach {
-              probe => assert(probe.toDouble > 1.0)
-            }
+          val mainValue = probes.split("\n").apply(1).stripPrefix("(").stripSuffix(")")
+          // Extract min, med, max from the string and strip off everthing else.
+          val index = mainValue.indexOf(" (", 0)
+          mainValue.slice(0, index).split(", ").foreach {
+            probe => assert(probe.toDouble > 1.0)
           }
         }
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In case of HashAggregation, a partial aggregation(update) is done followed by final aggregation(merge) 

During partial aggregation we sort and spill to disk every-time       fby, when the fast Map(when enabled) and  UnsafeFixedWidthAggregationMap gets exhausted

**When the cardinality of grouping column is close to the total number of records being processed, the sorting of data spilling to disk is not required, since it is kind of no-op and we can directly use rows in Final aggregation.**

When the user is aware of nature of data, currently he has no control over disabling this sort, spill operation.

This is similar to following issues in Hive:
https://issues.apache.org/jira/browse/HIVE-223
https://issues.apache.org/jira/browse/HIVE-291

In this PR, the ability to disable sort/spill during partial aggregation is added

### Benchmark
spark.executor.memory = 12G
#### Init code
```
// init code
case class Data(name: String, value1: String, value2: String, value3: Long, random: Int)
val numRecords = Seq(60000000)
val tblName = "tbl"
```
#### Generate data

```
// init code
case class Data(name: String, value1: String, value2: String, value3: Long, random: Int)
val numRecords = Seq(30000000, 60000000)

val basePath = "s3://qubole-spar/karuppayya/SPAR-4477/benchmark/"
val rand = scala.util.Random
// write
numRecords.foreach {
  recordCount =>
    val dataLocation = s"$basePath/$recordCount"
    val dataDF = spark.range(recordCount).map {
      x =>
        if (x < 10) Data(s"name1", s"value1", s"value1", 10, rand.nextInt(100))
        else Data(s"name$x", s"value$x", s"value$x", 1, rand.nextInt(100))
    }
    // creating data to be processed by on task(aslo gzip-ing to ensure spark doesnt
    // create multiple splits )
    val randomDF = dataDF.orderBy("random")
      randomDF.drop("random").repartition(1)
      .write
      .mode("overwrite")
      .option("compression", "gzip")
      .parquet(dataLocation)
}
```
#### query
```
val query =
  s"""
    |SELECT name, value1, value2, SUM(value3) s
    |FROM $tblName
    |GROUP BY name, value1, value2
    |"""
```

#### Benchmark code
```
  .add(StructField("name", StringType))
  .add(StructField("value1", StringType))
  .add(StructField("value2", StringType))
  .add(StructField("value3", LongType))
val query =
  """
    |SELECT name, value1, value2, SUM(value3) s
    |FROM tbl
    |GROUP BY name, value1, value2
    |"""

case class Metric(recordCount: Long, partialAggregateEnabled: Boolean, timeTaken: Long)
val metrics = Seq(true, false).flatMap {
  enabled =>
    sql(s"set spark.sql.aggregate.partialaggregate.skip.enabled=$enabled").collect
    numRecords.map {
      recordCount =>
        import java.util.concurrent.TimeUnit.NANOSECONDS
        val dataLocation = s"$basePath/$recordCount"
        spark.read
          .option("inferTimestamp", "false")
          .schema(userSpecifiedSchema)
          .json(dataLocation)
          .createOrReplaceTempView("tbl")
        val start = System.nanoTime()
        spark.sql(query).filter("s > 10").collect
        val end = System.nanoTime()
        val diff = end - start
        Metric(recordCount, enabled, NANOSECONDS.toMillis(diff))
    }
}
```
### Results
```
val df = metrics.toDF
df.createOrReplaceTempView("a")
val df = sql("select * from a order by recordcount desc, partialAggregateEnabled")
df.show()
scala> df.show
+-----------+-----------------------+---------+
|recordCount|partialAggregateEnabled|timeTaken|
+-----------+-----------------------+---------+
|   90000000|                  false|   593844|
|   90000000|                   true|   412958|
|   60000000|                  false|   377054|
|   60000000|                   true|   276363|
```
### Percent improvement: 
90000000 → 30.46%, 60000000 → 26.70%

 
### Why are the changes needed?
This improvement can improve the performance of queries

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
This patch was tested manually