### PR TITLE
[SPARK-31968][SQL]Duplicate partition columns check when writing data

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -545,17 +545,8 @@ object PartitioningUtils {
       partitionColumns: Seq[String],
       caseSensitive: Boolean): Unit = {
 
-    // scalastyle:off caselocale
-    val names = if (caseSensitive) partitionColumns else partitionColumns.map(_.toLowerCase)
-    // scalastyle:on caselocale
-
-    if (names.distinct.length != names.length) {
-      val duplicateColumns = names.groupBy(identity).collect {
-        case (x, ys) if ys.length > 1 => s"`$x`"
-      }
-      throw new AnalysisException(
-        s"Found duplicate partition column(s) ${duplicateColumns.mkString(", ")}")
-    }
+    SchemaUtils.checkColumnNameDuplication(
+      partitionColumns, partitionColumns.mkString(","), caseSensitive)
 
     partitionColumnsSchema(schema, partitionColumns, caseSensitive).foreach {
       field => field.dataType match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -548,7 +548,8 @@ object PartitioningUtils {
     val existsCols = new mutable.HashSet[String]
     partitionColumns.foreach(col => {
       if (existsCols.contains(col)) {
-        throw new AnalysisException(s"partition ${col} is duplicate")
+        throw new AnalysisException(s"" +
+          s"Found partition ${col} is duplicate in ${partitionColumns}")
       } else {
         existsCols.add(col)
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -546,7 +546,7 @@ object PartitioningUtils {
       caseSensitive: Boolean): Unit = {
 
     SchemaUtils.checkColumnNameDuplication(
-      partitionColumns, partitionColumns.mkString(","), caseSensitive)
+      partitionColumns, partitionColumns.mkString(", "), caseSensitive)
 
     partitionColumnsSchema(schema, partitionColumns, caseSensitive).foreach {
       field => field.dataType match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -545,6 +545,15 @@ object PartitioningUtils {
       partitionColumns: Seq[String],
       caseSensitive: Boolean): Unit = {
 
+    val existsCols = new mutable.HashSet[String]
+    partitionColumns.foreach(col => {
+      if (existsCols.contains(col)) {
+        throw new AnalysisException(s"partition ${col} is duplicate")
+      } else {
+        existsCols.add(col)
+      }
+    })
+
     partitionColumnsSchema(schema, partitionColumns, caseSensitive).foreach {
       field => field.dataType match {
         case _: AtomicType => // OK

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
@@ -158,9 +158,11 @@ class PartitionedWriteSuite extends QueryTest with SharedSparkSession {
   }
 
   test("SPARK-31968:duplicate partition columns check") {
-    val e = intercept[AnalysisException](Seq((3, 2)).toDF("a", "b").
-      write.mode("append")
-      .partitionBy("b", "b").csv("/tmp"))
-    assert(e.getMessage.contains("Found duplicate partition column(s) `b`;"))
+    val ds = Seq((3, 2)).toDF("a", "b")
+    val e = intercept[AnalysisException](ds
+      .write.mode(org.apache.spark.sql.SaveMode.Overwrite)
+      .partitionBy("b", "b").csv("/tmp/111"))
+    assert(e.getMessage.contains(
+      "Found duplicate column(s) b,b: `b`;"))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
@@ -160,7 +160,7 @@ class PartitionedWriteSuite extends QueryTest with SharedSparkSession {
   test("SPARK-31968:duplicate partition columns check") {
     val e = intercept[AnalysisException](Seq((3, 2)).toDF("a", "b").
       write.mode("append")
-      .partitionBy("b", "b").saveAsTable("t"))
-    assert(e.getMessage.contains("partition b is duplicate"))
+      .partitionBy("b", "b").csv("/tmp"))
+    assert(e.getMessage.contains("Found partition b is duplicate in WrappedArray(b, b);"))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
@@ -161,6 +161,6 @@ class PartitionedWriteSuite extends QueryTest with SharedSparkSession {
     val e = intercept[AnalysisException](Seq((3, 2)).toDF("a", "b").
       write.mode("append")
       .partitionBy("b", "b").csv("/tmp"))
-    assert(e.getMessage.contains("Found partition b is duplicate in WrappedArray(b, b);"))
+    assert(e.getMessage.contains("Found duplicate partition column(s) `b`;"))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
@@ -157,12 +157,13 @@ class PartitionedWriteSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("SPARK-31968:duplicate partition columns check") {
-    val ds = Seq((3, 2)).toDF("a", "b")
-    val e = intercept[AnalysisException](ds
-      .write.mode(org.apache.spark.sql.SaveMode.Overwrite)
-      .partitionBy("b", "b").csv("/tmp/111"))
-    assert(e.getMessage.contains(
-      "Found duplicate column(s) b,b: `b`;"))
+  test("SPARK-31968: duplicate partition columns check") {
+    withTempPath { f =>
+      val ds = Seq((3, 2)).toDF("a", "b")
+      val e = intercept[AnalysisException](ds
+        .write.partitionBy("b", "b").csv(f.getAbsolutePath))
+      assert(e.getMessage.contains(
+        "Found duplicate column(s) b, b: `b`;"))
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
@@ -159,11 +159,9 @@ class PartitionedWriteSuite extends QueryTest with SharedSparkSession {
 
   test("SPARK-31968: duplicate partition columns check") {
     withTempPath { f =>
-      val ds = Seq((3, 2)).toDF("a", "b")
-      val e = intercept[AnalysisException](ds
-        .write.partitionBy("b", "b").csv(f.getAbsolutePath))
-      assert(e.getMessage.contains(
-        "Found duplicate column(s) b, b: `b`;"))
+      val e = intercept[AnalysisException](
+        Seq((3, 2)).toDF("a", "b").write.partitionBy("b", "b").csv(f.getAbsolutePath))
+      assert(e.getMessage.contains("Found duplicate column(s) b, b: `b`;"))
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
A unit test is added
Partition duplicate check added in `org.apache.spark.sql.execution.datasources.PartitioningUtils#validatePartitionColumn`

### Why are the changes needed?
When people write data with duplicate partition column, it will cause a `org.apache.spark.sql.AnalysisException: Found duplicate column ...` in loading data from the  writted.

### Does this PR introduce _any_ user-facing change?
Yes.
It will prevent people from using duplicate partition columns to write data.
1. Before the PR:
It will look ok at `df.write.partitionBy("b", "b").csv("file:///tmp/output")`,
but get an exception when read：
`spark.read.csv("file:///tmp/output").show()`
org.apache.spark.sql.AnalysisException: Found duplicate column(s) in the partition schema: `b`;
2. After the PR：
`df.write.partitionBy("b", "b").csv("file:///tmp/output")` will trigger the exception：
org.apache.spark.sql.AnalysisException: Found duplicate column(s) b, b: `b`;

### How was this patch tested?
Unit test.
