### PR TITLE
[SPARK-32000][CORE][TESTS] Fix the flaky testcase for partially launched task in barrier-mode.

### DIFF
--- a/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
@@ -275,7 +275,7 @@ class BarrierTaskContextSuite extends SparkFunSuite with LocalSparkContext with 
   }
 
   test("SPARK-31485: barrier stage should fail if only partial tasks are launched") {
-    val conf = new SparkConf().set(LOCALITY_WAIT_PROCESS.key, Int.MaxValue + "s")
+    val conf = new SparkConf().set(LOCALITY_WAIT_PROCESS.key, "10s")
     initLocalClusterSparkContext(2, conf)
     val rdd0 = sc.parallelize(Seq(0, 1, 2, 3), 2)
     val dep = new OneToOneDependency[Int](rdd0)


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR fixes the flaky testcase "barrier stage should fail if only partial tasks are launched" for SPARK-31485 by extending `spark.locality.wait.process`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
I noticed sometimes the testcase for SPARK-31485 fails.
[This](https://amplab.cs.berkeley.edu/jenkins/job/SparkPullRequestBuilder/124086/testReport/org.apache.spark.scheduler/BarrierTaskContextSuite/SPARK_31485__barrier_stage_should_fail_if_only_partial_tasks_are_launched/) is an one instance.
Or, you can easily reproduce by running the testcase with setting `spark.locality.wait.process` to `0s`.

The reason should be related to the locality wait. 
If the scheduler waits for a resource offer which meets the preferred location for a task until the time-limit of process-local but no resource can be offered for the locality level, the scheduler will give up the preferred location. In this case, such task can be assigned to off-preferred location.
The testcase for SPARK-31485, there are two tasks and only one task is supposed to be assigned at one schedule round but both two tasks can be assigned in that situation mentioned above and the testcase will fail.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
The modified testcase.