### PR TITLE
[SPARK-32006][SQL] Create date/timestamp formatters once before collect in `hiveResultString()`

### DIFF
--- a/sql/core/benchmarks/DateTimeBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-jdk11-results.txt
@@ -6,18 +6,18 @@ OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-106
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 datetime +/- interval:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date + interval(m)                                 1660           1745         120          6.0         166.0       1.0X
-date + interval(m, d)                              1672           1685          19          6.0         167.2       1.0X
-date + interval(m, d, ms)                          6462           6481          27          1.5         646.2       0.3X
-date - interval(m)                                 1456           1480          35          6.9         145.6       1.1X
-date - interval(m, d)                              1501           1509          11          6.7         150.1       1.1X
-date - interval(m, d, ms)                          6457           6466          12          1.5         645.7       0.3X
-timestamp + interval(m)                            2941           2944           4          3.4         294.1       0.6X
-timestamp + interval(m, d)                         3008           3012           6          3.3         300.8       0.6X
-timestamp + interval(m, d, ms)                     3329           3333           6          3.0         332.9       0.5X
-timestamp - interval(m)                            2964           2982          26          3.4         296.4       0.6X
-timestamp - interval(m, d)                         3030           3039          13          3.3         303.0       0.5X
-timestamp - interval(m, d, ms)                     3312           3313           1          3.0         331.2       0.5X
+date + interval(m)                                 1550           1609          83          6.5         155.0       1.0X
+date + interval(m, d)                              1572           1575           5          6.4         157.2       1.0X
+date + interval(m, d, ms)                          6512           6512           0          1.5         651.2       0.2X
+date - interval(m)                                 1469           1489          28          6.8         146.9       1.1X
+date - interval(m, d)                              1558           1572          19          6.4         155.8       1.0X
+date - interval(m, d, ms)                          6602           6605           4          1.5         660.2       0.2X
+timestamp + interval(m)                            2945           2961          23          3.4         294.5       0.5X
+timestamp + interval(m, d)                         3075           3083          12          3.3         307.5       0.5X
+timestamp + interval(m, d, ms)                     3421           3430          13          2.9         342.1       0.5X
+timestamp - interval(m)                            3050           3061          17          3.3         305.0       0.5X
+timestamp - interval(m, d)                         3195           3201           8          3.1         319.5       0.5X
+timestamp - interval(m, d, ms)                     3442           3450          11          2.9         344.2       0.5X
 
 
 ================================================================================================
@@ -28,92 +28,92 @@ OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-106
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    333            334           0         30.0          33.3       1.0X
-cast to timestamp wholestage on                     349            368          12         28.6          34.9       1.0X
+cast to timestamp wholestage off                    320            326           8         31.2          32.0       1.0X
+cast to timestamp wholestage on                     289            297           5         34.6          28.9       1.1X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                   1229           1229           1          8.1         122.9       1.0X
-year of timestamp wholestage on                    1218           1223           5          8.2         121.8       1.0X
+year of timestamp wholestage off                   1266           1266           1          7.9         126.6       1.0X
+year of timestamp wholestage on                    1233           1253          15          8.1         123.3       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                1593           1594           2          6.3         159.3       1.0X
-quarter of timestamp wholestage on                 1515           1529          14          6.6         151.5       1.1X
+quarter of timestamp wholestage off                1594           1600           8          6.3         159.4       1.0X
+quarter of timestamp wholestage on                 1529           1532           3          6.5         152.9       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                  1222           1246          34          8.2         122.2       1.0X
-month of timestamp wholestage on                   1207           1232          31          8.3         120.7       1.0X
+month of timestamp wholestage off                  1239           1257          25          8.1         123.9       1.0X
+month of timestamp wholestage on                   1235           1243           5          8.1         123.5       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off             2453           2455           2          4.1         245.3       1.0X
-weekofyear of timestamp wholestage on              2357           2380          22          4.2         235.7       1.0X
+weekofyear of timestamp wholestage off             2209           2216           9          4.5         220.9       1.0X
+weekofyear of timestamp wholestage on              1831           1838           9          5.5         183.1       1.2X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                    1216           1219           5          8.2         121.6       1.0X
-day of timestamp wholestage on                     1205           1221          25          8.3         120.5       1.0X
+day of timestamp wholestage off                    1238           1238           0          8.1         123.8       1.0X
+day of timestamp wholestage on                     1223           1235          12          8.2         122.3       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off              1268           1274           9          7.9         126.8       1.0X
-dayofyear of timestamp wholestage on               1253           1268          10          8.0         125.3       1.0X
+dayofyear of timestamp wholestage off              1302           1304           3          7.7         130.2       1.0X
+dayofyear of timestamp wholestage on               1269           1276           6          7.9         126.9       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off             1223           1224           1          8.2         122.3       1.0X
-dayofmonth of timestamp wholestage on              1231           1246          14          8.1         123.1       1.0X
+dayofmonth of timestamp wholestage off             1251           1253           3          8.0         125.1       1.0X
+dayofmonth of timestamp wholestage on              1225           1232           9          8.2         122.5       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off              1398           1406          12          7.2         139.8       1.0X
-dayofweek of timestamp wholestage on               1387           1399          15          7.2         138.7       1.0X
+dayofweek of timestamp wholestage off              1424           1424           1          7.0         142.4       1.0X
+dayofweek of timestamp wholestage on               1385           1389           4          7.2         138.5       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                1327           1333           9          7.5         132.7       1.0X
-weekday of timestamp wholestage on                 1329           1333           4          7.5         132.9       1.0X
+weekday of timestamp wholestage off                1366           1366           0          7.3         136.6       1.0X
+weekday of timestamp wholestage on                 1320           1325           5          7.6         132.0       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                   1005           1016          15          9.9         100.5       1.0X
-hour of timestamp wholestage on                     934            940           4         10.7          93.4       1.1X
+hour of timestamp wholestage off                    985            986           1         10.2          98.5       1.0X
+hour of timestamp wholestage on                     974            981          10         10.3          97.4       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                 1003           1009           8         10.0         100.3       1.0X
-minute of timestamp wholestage on                   934            938           7         10.7          93.4       1.1X
+minute of timestamp wholestage off                 1044           1047           5          9.6         104.4       1.0X
+minute of timestamp wholestage on                   984            994          17         10.2          98.4       1.1X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  997            998           2         10.0          99.7       1.0X
-second of timestamp wholestage on                   925            935           8         10.8          92.5       1.1X
+second of timestamp wholestage off                  999           1003           6         10.0          99.9       1.0X
+second of timestamp wholestage on                   961            974           8         10.4          96.1       1.0X
 
 
 ================================================================================================
@@ -124,15 +124,15 @@ OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-106
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         297            297           0         33.7          29.7       1.0X
-current_date wholestage on                          280            282           2         35.7          28.0       1.1X
+current_date wholestage off                         297            302           7         33.6          29.7       1.0X
+current_date wholestage on                          270            283          22         37.1          27.0       1.1X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    307            337          43         32.6          30.7       1.0X
-current_timestamp wholestage on                     260            284          29         38.4          26.0       1.2X
+current_timestamp wholestage off                    302            310          11         33.1          30.2       1.0X
+current_timestamp wholestage on                     264            351          98         37.9          26.4       1.1X
 
 
 ================================================================================================
@@ -143,43 +143,43 @@ OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-106
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                        1066           1073          10          9.4         106.6       1.0X
-cast to date wholestage on                          997           1003           6         10.0          99.7       1.1X
+cast to date wholestage off                        1083           1083           1          9.2         108.3       1.0X
+cast to date wholestage on                         1040           1044           5          9.6         104.0       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                            1238           1242           6          8.1         123.8       1.0X
-last_day wholestage on                             1259           1272          12          7.9         125.9       1.0X
+last_day wholestage off                            1258           1258           0          7.9         125.8       1.0X
+last_day wholestage on                             1244           1254           8          8.0         124.4       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                            1116           1138          32          9.0         111.6       1.0X
-next_day wholestage on                             1052           1063          11          9.5         105.2       1.1X
+next_day wholestage off                            1133           1135           3          8.8         113.3       1.0X
+next_day wholestage on                             1093           1100           7          9.1         109.3       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                            1048           1049           1          9.5         104.8       1.0X
-date_add wholestage on                             1035           1039           3          9.7         103.5       1.0X
+date_add wholestage off                            1065           1074          14          9.4         106.5       1.0X
+date_add wholestage on                             1044           1053           6          9.6         104.4       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                            1119           1127          11          8.9         111.9       1.0X
-date_sub wholestage on                             1028           1039           7          9.7         102.8       1.1X
+date_sub wholestage off                            1069           1076           9          9.4         106.9       1.0X
+date_sub wholestage on                             1047           1052           8          9.6         104.7       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                          1421           1421           0          7.0         142.1       1.0X
-add_months wholestage on                           1423           1434          11          7.0         142.3       1.0X
+add_months wholestage off                          1417           1430          18          7.1         141.7       1.0X
+add_months wholestage on                           1439           1445           5          6.9         143.9       1.0X
 
 
 ================================================================================================
@@ -190,8 +190,8 @@ OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-106
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         5293           5296           5          1.9         529.3       1.0X
-format date wholestage on                          5143           5157          19          1.9         514.3       1.0X
+format date wholestage off                         5228           5232           6          1.9         522.8       1.0X
+format date wholestage on                          5172           5193          17          1.9         517.2       1.0X
 
 
 ================================================================================================
@@ -202,8 +202,8 @@ OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-106
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       7136           7136           1          1.4         713.6       1.0X
-from_unixtime wholestage on                        7049           7068          29          1.4         704.9       1.0X
+from_unixtime wholestage off                       6941           6952          16          1.4         694.1       1.0X
+from_unixtime wholestage on                        6898           6926          32          1.4         689.8       1.0X
 
 
 ================================================================================================
@@ -214,15 +214,15 @@ OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-106
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                  1325           1329           6          7.5         132.5       1.0X
-from_utc_timestamp wholestage on                   1269           1273           4          7.9         126.9       1.0X
+from_utc_timestamp wholestage off                  1339           1342           5          7.5         133.9       1.0X
+from_utc_timestamp wholestage on                   1285           1292           5          7.8         128.5       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                    1684           1691          10          5.9         168.4       1.0X
-to_utc_timestamp wholestage on                     1641           1648           9          6.1         164.1       1.0X
+to_utc_timestamp wholestage off                    1697           1717          29          5.9         169.7       1.0X
+to_utc_timestamp wholestage on                     1656           1665          13          6.0         165.6       1.0X
 
 
 ================================================================================================
@@ -233,29 +233,29 @@ OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-106
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        343            346           4         29.1          34.3       1.0X
-cast interval wholestage on                         281            282           1         35.6          28.1       1.2X
+cast interval wholestage off                        333            344          16         30.1          33.3       1.0X
+cast interval wholestage on                         288            290           2         34.7          28.8       1.2X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                            1831           1840          13          5.5         183.1       1.0X
-datediff wholestage on                             1759           1769          15          5.7         175.9       1.0X
+datediff wholestage off                            1857           1860           4          5.4         185.7       1.0X
+datediff wholestage on                             1795           1808          10          5.6         179.5       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      5729           5747          25          1.7         572.9       1.0X
-months_between wholestage on                       5710           5720           9          1.8         571.0       1.0X
+months_between wholestage off                      5826           5834          11          1.7         582.6       1.0X
+months_between wholestage on                       5737           5763          18          1.7         573.7       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                              2183           2189           9          0.5        2182.6       1.0X
-window wholestage on                              46835          46944          88          0.0       46834.8       0.0X
+window wholestage off                              2220           2246          36          0.5        2220.4       1.0X
+window wholestage on                              46696          46794          89          0.0       46696.1       0.0X
 
 
 ================================================================================================
@@ -266,134 +266,134 @@ OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-106
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                     2668           2672           5          3.7         266.8       1.0X
-date_trunc YEAR wholestage on                      2719           2731           9          3.7         271.9       1.0X
+date_trunc YEAR wholestage off                     2658           2659           1          3.8         265.8       1.0X
+date_trunc YEAR wholestage on                      2691           2700           8          3.7         269.1       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                     2672           2677           8          3.7         267.2       1.0X
-date_trunc YYYY wholestage on                      2710           2726          12          3.7         271.0       1.0X
+date_trunc YYYY wholestage off                     2671           2679          11          3.7         267.1       1.0X
+date_trunc YYYY wholestage on                      2700           2706           6          3.7         270.0       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                       2670           2673           4          3.7         267.0       1.0X
-date_trunc YY wholestage on                        2711           2720           7          3.7         271.1       1.0X
+date_trunc YY wholestage off                       2674           2689          20          3.7         267.4       1.0X
+date_trunc YY wholestage on                        2697           2716          17          3.7         269.7       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                      2674           2674           0          3.7         267.4       1.0X
-date_trunc MON wholestage on                       2667           2677          10          3.7         266.7       1.0X
+date_trunc MON wholestage off                      2695           2700           7          3.7         269.5       1.0X
+date_trunc MON wholestage on                       2711           2722          11          3.7         271.1       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                    2675           2686          16          3.7         267.5       1.0X
-date_trunc MONTH wholestage on                     2667           2674           6          3.7         266.7       1.0X
+date_trunc MONTH wholestage off                    2682           2685           4          3.7         268.2       1.0X
+date_trunc MONTH wholestage on                     2709           2727          15          3.7         270.9       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                       2673           2674           1          3.7         267.3       1.0X
-date_trunc MM wholestage on                        2664           2669           4          3.8         266.4       1.0X
+date_trunc MM wholestage off                       2683           2693          14          3.7         268.3       1.0X
+date_trunc MM wholestage on                        2706           2722          16          3.7         270.6       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                      2281           2288          10          4.4         228.1       1.0X
-date_trunc DAY wholestage on                       2302           2312           8          4.3         230.2       1.0X
+date_trunc DAY wholestage off                      2292           2299          10          4.4         229.2       1.0X
+date_trunc DAY wholestage on                       2290           2311          14          4.4         229.0       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                       2281           2283           3          4.4         228.1       1.0X
-date_trunc DD wholestage on                        2291           2302          11          4.4         229.1       1.0X
+date_trunc DD wholestage off                       2302           2309           9          4.3         230.2       1.0X
+date_trunc DD wholestage on                        2282           2292           6          4.4         228.2       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                     2331           2332           1          4.3         233.1       1.0X
-date_trunc HOUR wholestage on                      2290           2304          11          4.4         229.0       1.0X
+date_trunc HOUR wholestage off                     2288           2288           0          4.4         228.8       1.0X
+date_trunc HOUR wholestage on                      2277           2290          14          4.4         227.7       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    379            385           9         26.4          37.9       1.0X
-date_trunc MINUTE wholestage on                     371            376           5         27.0          37.1       1.0X
+date_trunc MINUTE wholestage off                    400            419          26         25.0          40.0       1.0X
+date_trunc MINUTE wholestage on                     401            405           4         24.9          40.1       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    375            376           1         26.7          37.5       1.0X
-date_trunc SECOND wholestage on                     370            376           8         27.0          37.0       1.0X
+date_trunc SECOND wholestage off                    408            414           9         24.5          40.8       1.0X
+date_trunc SECOND wholestage on                     408            413           8         24.5          40.8       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                     2597           2604          10          3.9         259.7       1.0X
-date_trunc WEEK wholestage on                      2591           2605          13          3.9         259.1       1.0X
+date_trunc WEEK wholestage off                     2623           2631          12          3.8         262.3       1.0X
+date_trunc WEEK wholestage on                      2613           2621           8          3.8         261.3       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                  3501           3511          14          2.9         350.1       1.0X
-date_trunc QUARTER wholestage on                   3477           3489           9          2.9         347.7       1.0X
+date_trunc QUARTER wholestage off                  3518           3520           3          2.8         351.8       1.0X
+date_trunc QUARTER wholestage on                   3501           3510          11          2.9         350.1       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           332            334           3         30.1          33.2       1.0X
-trunc year wholestage on                            332            346          17         30.1          33.2       1.0X
+trunc year wholestage off                           315            333          26         31.8          31.5       1.0X
+trunc year wholestage on                            352            360           7         28.4          35.2       0.9X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           331            331           0         30.2          33.1       1.0X
-trunc yyyy wholestage on                            336            339           4         29.8          33.6       1.0X
+trunc yyyy wholestage off                           321            321           1         31.2          32.1       1.0X
+trunc yyyy wholestage on                            354            358           5         28.3          35.4       0.9X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             330            342          17         30.3          33.0       1.0X
-trunc yy wholestage on                              333            337           3         30.0          33.3       1.0X
+trunc yy wholestage off                             312            313           1         32.0          31.2       1.0X
+trunc yy wholestage on                              355            360           5         28.2          35.5       0.9X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            334            335           1         30.0          33.4       1.0X
-trunc mon wholestage on                             333            347           9         30.0          33.3       1.0X
+trunc mon wholestage off                            324            327           4         30.9          32.4       1.0X
+trunc mon wholestage on                             355            357           2         28.2          35.5       0.9X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          332            333           1         30.1          33.2       1.0X
-trunc month wholestage on                           333            340           7         30.0          33.3       1.0X
+trunc month wholestage off                          313            318           8         32.0          31.3       1.0X
+trunc month wholestage on                           354            358           5         28.3          35.4       0.9X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             328            336          11         30.5          32.8       1.0X
-trunc mm wholestage on                              333            343          11         30.0          33.3       1.0X
+trunc mm wholestage off                             314            325          15         31.8          31.4       1.0X
+trunc mm wholestage on                              353            366          17         28.4          35.3       0.9X
 
 
 ================================================================================================
@@ -404,36 +404,36 @@ OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-106
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                     170            171           1          5.9         170.1       1.0X
-to timestamp str wholestage on                      172            174           2          5.8         171.6       1.0X
+to timestamp str wholestage off                     168            169           0          5.9         168.4       1.0X
+to timestamp str wholestage on                      168            173           7          6.0         167.6       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                        1437           1439           3          0.7        1437.0       1.0X
-to_timestamp wholestage on                         1288           1292           5          0.8        1288.1       1.1X
+to_timestamp wholestage off                        1390           1390           0          0.7        1389.8       1.0X
+to_timestamp wholestage on                         1204           1215          11          0.8        1204.2       1.2X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                   1352           1353           2          0.7        1352.0       1.0X
-to_unix_timestamp wholestage on                    1314           1319           5          0.8        1314.4       1.0X
+to_unix_timestamp wholestage off                   1277           1281           4          0.8        1277.5       1.0X
+to_unix_timestamp wholestage on                    1203           1213          11          0.8        1202.6       1.1X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          211            215           6          4.7         210.7       1.0X
-to date str wholestage on                           217            217           1          4.6         216.5       1.0X
+to date str wholestage off                          218            219           1          4.6         218.2       1.0X
+to date str wholestage on                           211            214           5          4.7         210.8       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                             3281           3295          20          0.3        3280.9       1.0X
-to_date wholestage on                              3223           3239          17          0.3        3222.8       1.0X
+to_date wholestage off                             3016           3041          35          0.3        3016.1       1.0X
+to_date wholestage on                              3015           3023           9          0.3        3014.6       1.0X
 
 
 ================================================================================================
@@ -444,18 +444,18 @@ OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-106
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 To/from Java's date-time:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Date                                  446            447           1         11.2          89.1       1.0X
-From java.time.LocalDate                            354            356           1         14.1          70.8       1.3X
-Collect java.sql.Date                              2722           3091         495          1.8         544.4       0.2X
-Collect java.time.LocalDate                        1786           1836          60          2.8         357.2       0.2X
-From java.sql.Timestamp                             275            287          19         18.2          55.0       1.6X
-From java.time.Instant                              325            328           3         15.4          65.0       1.4X
-Collect longs                                      1300           1321          25          3.8         260.0       0.3X
-Collect java.sql.Timestamp                         1450           1557         102          3.4         290.0       0.3X
-Collect java.time.Instant                          1499           1599          87          3.3         299.9       0.3X
-java.sql.Date to Hive string                      17536          18367        1059          0.3        3507.2       0.0X
-java.time.LocalDate to Hive string                12089          12897         725          0.4        2417.8       0.0X
-java.sql.Timestamp to Hive string                 48014          48625         752          0.1        9602.9       0.0X
-java.time.Instant to Hive string                  37346          37445          93          0.1        7469.1       0.0X
+From java.sql.Date                                  430            442          18         11.6          86.0       1.0X
+From java.time.LocalDate                            351            354           3         14.3          70.2       1.2X
+Collect java.sql.Date                              2095           2853         733          2.4         418.9       0.2X
+Collect java.time.LocalDate                        1691           1910         209          3.0         338.3       0.3X
+From java.sql.Timestamp                             276            280           4         18.1          55.2       1.6X
+From java.time.Instant                              324            328           4         15.4          64.8       1.3X
+Collect longs                                      1348           1450         126          3.7         269.5       0.3X
+Collect java.sql.Timestamp                         1441           1478          62          3.5         288.3       0.3X
+Collect java.time.Instant                          1471           1579         100          3.4         294.3       0.3X
+java.sql.Date to Hive string                      12049          12909         862          0.4        2409.8       0.0X
+java.time.LocalDate to Hive string                12045          12130          74          0.4        2408.9       0.0X
+java.sql.Timestamp to Hive string                 12854          13376         510          0.4        2570.9       0.0X
+java.time.Instant to Hive string                  15057          15184         115          0.3        3011.4       0.0X
 
 

--- a/sql/core/benchmarks/DateTimeBenchmark-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-results.txt
@@ -6,18 +6,18 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 datetime +/- interval:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date + interval(m)                                 1555           1634         113          6.4         155.5       1.0X
-date + interval(m, d)                              1774           1797          33          5.6         177.4       0.9X
-date + interval(m, d, ms)                          6293           6335          59          1.6         629.3       0.2X
-date - interval(m)                                 1461           1468          10          6.8         146.1       1.1X
-date - interval(m, d)                              1741           1741           0          5.7         174.1       0.9X
-date - interval(m, d, ms)                          6503           6518          21          1.5         650.3       0.2X
-timestamp + interval(m)                            2384           2385           1          4.2         238.4       0.7X
-timestamp + interval(m, d)                         2683           2684           2          3.7         268.3       0.6X
-timestamp + interval(m, d, ms)                     2987           3001          19          3.3         298.7       0.5X
-timestamp - interval(m)                            2391           2395           5          4.2         239.1       0.7X
-timestamp - interval(m, d)                         2674           2684          14          3.7         267.4       0.6X
-timestamp - interval(m, d, ms)                     3005           3007           3          3.3         300.5       0.5X
+date + interval(m)                                 1636           1653          24          6.1         163.6       1.0X
+date + interval(m, d)                              1802           1818          23          5.5         180.2       0.9X
+date + interval(m, d, ms)                          6330           6348          26          1.6         633.0       0.3X
+date - interval(m)                                 1462           1484          32          6.8         146.2       1.1X
+date - interval(m, d)                              1732           1732           1          5.8         173.2       0.9X
+date - interval(m, d, ms)                          6494           6505          16          1.5         649.4       0.3X
+timestamp + interval(m)                            2446           2446           0          4.1         244.6       0.7X
+timestamp + interval(m, d)                         2670           2703          46          3.7         267.0       0.6X
+timestamp + interval(m, d, ms)                     2992           3012          29          3.3         299.2       0.5X
+timestamp - interval(m)                            2447           2449           3          4.1         244.7       0.7X
+timestamp - interval(m, d)                         2739           2739           0          3.7         273.9       0.6X
+timestamp - interval(m, d, ms)                     2977           2983           8          3.4         297.7       0.5X
 
 
 ================================================================================================
@@ -28,92 +28,92 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    313            320          10         31.9          31.3       1.0X
-cast to timestamp wholestage on                     325            341          18         30.8          32.5       1.0X
+cast to timestamp wholestage off                    312            321          13         32.1          31.2       1.0X
+cast to timestamp wholestage on                     290            311          14         34.5          29.0       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                   1216           1216           1          8.2         121.6       1.0X
-year of timestamp wholestage on                    1226           1243          13          8.2         122.6       1.0X
+year of timestamp wholestage off                   1226           1228           3          8.2         122.6       1.0X
+year of timestamp wholestage on                    1214           1222          10          8.2         121.4       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                1417           1421           5          7.1         141.7       1.0X
-quarter of timestamp wholestage on                 1358           1365           8          7.4         135.8       1.0X
+quarter of timestamp wholestage off                1437           1447          14          7.0         143.7       1.0X
+quarter of timestamp wholestage on                 1354           1359           4          7.4         135.4       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                  1219           1220           1          8.2         121.9       1.0X
-month of timestamp wholestage on                   1222           1227           7          8.2         122.2       1.0X
+month of timestamp wholestage off                  1219           1219           1          8.2         121.9       1.0X
+month of timestamp wholestage on                   1205           1211           7          8.3         120.5       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off             1950           1950           0          5.1         195.0       1.0X
-weekofyear of timestamp wholestage on              1890           1899           8          5.3         189.0       1.0X
+weekofyear of timestamp wholestage off             1849           1854           7          5.4         184.9       1.0X
+weekofyear of timestamp wholestage on              1829           1835           5          5.5         182.9       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                    1212           1213           2          8.3         121.2       1.0X
-day of timestamp wholestage on                     1216           1227          13          8.2         121.6       1.0X
+day of timestamp wholestage off                    1224           1230           8          8.2         122.4       1.0X
+day of timestamp wholestage on                     1204           1215          10          8.3         120.4       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off              1282           1284           3          7.8         128.2       1.0X
-dayofyear of timestamp wholestage on               1269           1274           5          7.9         126.9       1.0X
+dayofyear of timestamp wholestage off              1272           1275           5          7.9         127.2       1.0X
+dayofyear of timestamp wholestage on               1246           1256           7          8.0         124.6       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off             1214           1219           7          8.2         121.4       1.0X
-dayofmonth of timestamp wholestage on              1216           1224           6          8.2         121.6       1.0X
+dayofmonth of timestamp wholestage off             1226           1233          11          8.2         122.6       1.0X
+dayofmonth of timestamp wholestage on              1205           1211           5          8.3         120.5       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off              1403           1430          39          7.1         140.3       1.0X
-dayofweek of timestamp wholestage on               1378           1386           8          7.3         137.8       1.0X
+dayofweek of timestamp wholestage off              1420           1427           9          7.0         142.0       1.0X
+dayofweek of timestamp wholestage on               1375           1385          11          7.3         137.5       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                1344           1353          13          7.4         134.4       1.0X
+weekday of timestamp wholestage off                1345           1347           3          7.4         134.5       1.0X
 weekday of timestamp wholestage on                 1316           1322           5          7.6         131.6       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                    992           1000          10         10.1          99.2       1.0X
-hour of timestamp wholestage on                     960            962           3         10.4          96.0       1.0X
+hour of timestamp wholestage off                    983            984           1         10.2          98.3       1.0X
+hour of timestamp wholestage on                     942            953           8         10.6          94.2       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  989           1000          16         10.1          98.9       1.0X
-minute of timestamp wholestage on                   965            974          13         10.4          96.5       1.0X
+minute of timestamp wholestage off                 1008           1010           3          9.9         100.8       1.0X
+minute of timestamp wholestage on                   942            945           3         10.6          94.2       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  974            977           5         10.3          97.4       1.0X
-second of timestamp wholestage on                   959            966           8         10.4          95.9       1.0X
+second of timestamp wholestage off                  975            976           1         10.3          97.5       1.0X
+second of timestamp wholestage on                   938            944           4         10.7          93.8       1.0X
 
 
 ================================================================================================
@@ -124,15 +124,15 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         281            282           2         35.6          28.1       1.0X
-current_date wholestage on                          294            300           5         34.0          29.4       1.0X
+current_date wholestage off                         295            296           2         33.9          29.5       1.0X
+current_date wholestage on                          267            274           6         37.5          26.7       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    282            296          19         35.4          28.2       1.0X
-current_timestamp wholestage on                     304            331          31         32.9          30.4       0.9X
+current_timestamp wholestage off                    298            303           7         33.5          29.8       1.0X
+current_timestamp wholestage on                     261            275          12         38.2          26.1       1.1X
 
 
 ================================================================================================
@@ -143,43 +143,43 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                        1060           1061           1          9.4         106.0       1.0X
-cast to date wholestage on                         1021           1026          10          9.8         102.1       1.0X
+cast to date wholestage off                        1071           1073           3          9.3         107.1       1.0X
+cast to date wholestage on                          998           1014          31         10.0          99.8       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                            1278           1280           3          7.8         127.8       1.0X
-last_day wholestage on                             1560           1566           6          6.4         156.0       0.8X
+last_day wholestage off                            1260           1261           1          7.9         126.0       1.0X
+last_day wholestage on                             1245           1261          17          8.0         124.5       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                            1091           1093           3          9.2         109.1       1.0X
-next_day wholestage on                             1070           1076           9          9.3         107.0       1.0X
+next_day wholestage off                            1118           1120           2          8.9         111.8       1.0X
+next_day wholestage on                             1043           1047           3          9.6         104.3       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                            1041           1047           8          9.6         104.1       1.0X
-date_add wholestage on                             1044           1050           4          9.6         104.4       1.0X
+date_add wholestage off                            1046           1048           3          9.6         104.6       1.0X
+date_add wholestage on                             1040           1048          11          9.6         104.0       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                            1038           1040           3          9.6         103.8       1.0X
-date_sub wholestage on                             1057           1061           4          9.5         105.7       1.0X
+date_sub wholestage off                            1081           1081           0          9.3         108.1       1.0X
+date_sub wholestage on                             1030           1035           6          9.7         103.0       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                          1401           1401           1          7.1         140.1       1.0X
-add_months wholestage on                           1438           1442           4          7.0         143.8       1.0X
+add_months wholestage off                          1393           1400          10          7.2         139.3       1.0X
+add_months wholestage on                           1391           1396           5          7.2         139.1       1.0X
 
 
 ================================================================================================
@@ -190,8 +190,8 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         5482           5803         454          1.8         548.2       1.0X
-format date wholestage on                          5502           5518           9          1.8         550.2       1.0X
+format date wholestage off                         5424           5426           2          1.8         542.4       1.0X
+format date wholestage on                          5408           5448          37          1.8         540.8       1.0X
 
 
 ================================================================================================
@@ -202,8 +202,8 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       8538           8553          22          1.2         853.8       1.0X
-from_unixtime wholestage on                        8545           8552           6          1.2         854.5       1.0X
+from_unixtime wholestage off                       8839           8841           3          1.1         883.9       1.0X
+from_unixtime wholestage on                        8788           8826          24          1.1         878.8       1.0X
 
 
 ================================================================================================
@@ -214,15 +214,15 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                  1094           1099           8          9.1         109.4       1.0X
-from_utc_timestamp wholestage on                   1109           1114           5          9.0         110.9       1.0X
+from_utc_timestamp wholestage off                  1105           1111           8          9.0         110.5       1.0X
+from_utc_timestamp wholestage on                   1073           1081           8          9.3         107.3       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                    1466           1469           4          6.8         146.6       1.0X
-to_utc_timestamp wholestage on                     1401           1408           7          7.1         140.1       1.0X
+to_utc_timestamp wholestage off                    1462           1465           4          6.8         146.2       1.0X
+to_utc_timestamp wholestage on                     1394           1408          13          7.2         139.4       1.0X
 
 
 ================================================================================================
@@ -233,29 +233,29 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        332            332           0         30.1          33.2       1.0X
-cast interval wholestage on                         315            324          10         31.7          31.5       1.1X
+cast interval wholestage off                        325            328           4         30.8          32.5       1.0X
+cast interval wholestage on                         286            290           3         35.0          28.6       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                            1796           1802           8          5.6         179.6       1.0X
-datediff wholestage on                             1758           1764          10          5.7         175.8       1.0X
+datediff wholestage off                            1822           1824           3          5.5         182.2       1.0X
+datediff wholestage on                             1757           1761           5          5.7         175.7       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      4833           4836           4          2.1         483.3       1.0X
-months_between wholestage on                       4777           4780           2          2.1         477.7       1.0X
+months_between wholestage off                      4886           4893          10          2.0         488.6       1.0X
+months_between wholestage on                       4785           4799          12          2.1         478.5       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                              1812           1908         136          0.6        1811.7       1.0X
-window wholestage on                              46279          46376          74          0.0       46278.8       0.0X
+window wholestage off                              2024           2052          40          0.5        2023.7       1.0X
+window wholestage on                              46599          46660          45          0.0       46599.0       0.0X
 
 
 ================================================================================================
@@ -266,134 +266,134 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                     2367           2368           1          4.2         236.7       1.0X
-date_trunc YEAR wholestage on                      2321           2334          22          4.3         232.1       1.0X
+date_trunc YEAR wholestage off                     2361           2366           7          4.2         236.1       1.0X
+date_trunc YEAR wholestage on                      2325           2328           3          4.3         232.5       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                     2330           2334           5          4.3         233.0       1.0X
-date_trunc YYYY wholestage on                      2326           2332           5          4.3         232.6       1.0X
+date_trunc YYYY wholestage off                     2366           2374          12          4.2         236.6       1.0X
+date_trunc YYYY wholestage on                      2316           2328          13          4.3         231.6       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                       2334           2335           1          4.3         233.4       1.0X
-date_trunc YY wholestage on                        2315           2324           6          4.3         231.5       1.0X
+date_trunc YY wholestage off                       2359           2359           0          4.2         235.9       1.0X
+date_trunc YY wholestage on                        2315           2325           7          4.3         231.5       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                      2327           2330           4          4.3         232.7       1.0X
-date_trunc MON wholestage on                       2279           2289          12          4.4         227.9       1.0X
+date_trunc MON wholestage off                      2360           2369          12          4.2         236.0       1.0X
+date_trunc MON wholestage on                       2306           2314           9          4.3         230.6       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                    2330           2332           2          4.3         233.0       1.0X
-date_trunc MONTH wholestage on                     2277           2284           6          4.4         227.7       1.0X
+date_trunc MONTH wholestage off                    2359           2360           2          4.2         235.9       1.0X
+date_trunc MONTH wholestage on                     2304           2308           4          4.3         230.4       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                       2328           2329           2          4.3         232.8       1.0X
-date_trunc MM wholestage on                        2279           2284           4          4.4         227.9       1.0X
+date_trunc MM wholestage off                       2356           2358           2          4.2         235.6       1.0X
+date_trunc MM wholestage on                        2302           2309           6          4.3         230.2       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                      1974           1984          14          5.1         197.4       1.0X
-date_trunc DAY wholestage on                       1914           1922           7          5.2         191.4       1.0X
+date_trunc DAY wholestage off                      1962           1964           3          5.1         196.2       1.0X
+date_trunc DAY wholestage on                       1916           1921           6          5.2         191.6       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                       1967           1976          12          5.1         196.7       1.0X
-date_trunc DD wholestage on                        1913           1917           4          5.2         191.3       1.0X
+date_trunc DD wholestage off                       1956           1957           2          5.1         195.6       1.0X
+date_trunc DD wholestage on                        1916           1922           6          5.2         191.6       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                     1970           1970           0          5.1         197.0       1.0X
-date_trunc HOUR wholestage on                      1945           1946           2          5.1         194.5       1.0X
+date_trunc HOUR wholestage off                     1968           1970           3          5.1         196.8       1.0X
+date_trunc HOUR wholestage on                      1949           1961           9          5.1         194.9       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    361            361           1         27.7          36.1       1.0X
-date_trunc MINUTE wholestage on                     331            336           4         30.2          33.1       1.1X
+date_trunc MINUTE wholestage off                    368            373           7         27.2          36.8       1.0X
+date_trunc MINUTE wholestage on                     338            343           6         29.6          33.8       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    360            361           1         27.8          36.0       1.0X
-date_trunc SECOND wholestage on                     335            348          15         29.8          33.5       1.1X
+date_trunc SECOND wholestage off                    379            379           1         26.4          37.9       1.0X
+date_trunc SECOND wholestage on                     327            340          13         30.6          32.7       1.2X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                     2232           2236           6          4.5         223.2       1.0X
-date_trunc WEEK wholestage on                      2225           2232           6          4.5         222.5       1.0X
+date_trunc WEEK wholestage off                     2227           2242          21          4.5         222.7       1.0X
+date_trunc WEEK wholestage on                      2231           2241           9          4.5         223.1       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                  3083           3086           4          3.2         308.3       1.0X
-date_trunc QUARTER wholestage on                   3073           3086          16          3.3         307.3       1.0X
+date_trunc QUARTER wholestage off                  3158           3160           3          3.2         315.8       1.0X
+date_trunc QUARTER wholestage on                   3150           3163          12          3.2         315.0       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           321            321           0         31.1          32.1       1.0X
-trunc year wholestage on                            299            303           5         33.5          29.9       1.1X
+trunc year wholestage off                           321            323           3         31.2          32.1       1.0X
+trunc year wholestage on                            302            330          18         33.1          30.2       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           323            327           5         30.9          32.3       1.0X
-trunc yyyy wholestage on                            299            302           3         33.4          29.9       1.1X
+trunc yyyy wholestage off                           320            324           6         31.2          32.0       1.0X
+trunc yyyy wholestage on                            294            329          20         34.0          29.4       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             315            315           1         31.8          31.5       1.0X
-trunc yy wholestage on                              299            304           4         33.4          29.9       1.1X
+trunc yy wholestage off                             322            322           0         31.1          32.2       1.0X
+trunc yy wholestage on                              293            320          37         34.1          29.3       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            320            321           1         31.2          32.0       1.0X
-trunc mon wholestage on                             299            307          10         33.4          29.9       1.1X
+trunc mon wholestage off                            320            322           2         31.2          32.0       1.0X
+trunc mon wholestage on                             291            312          26         34.4          29.1       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          316            317           1         31.6          31.6       1.0X
-trunc month wholestage on                           299            302           5         33.5          29.9       1.1X
+trunc month wholestage off                          318            331          18         31.4          31.8       1.0X
+trunc month wholestage on                           297            329          28         33.7          29.7       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             313            313           1         32.0          31.3       1.0X
-trunc mm wholestage on                              298            302           4         33.5          29.8       1.0X
+trunc mm wholestage off                             318            319           1         31.4          31.8       1.0X
+trunc mm wholestage on                              312            335          15         32.1          31.2       1.0X
 
 
 ================================================================================================
@@ -404,36 +404,36 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                     217            217           0          4.6         217.3       1.0X
-to timestamp str wholestage on                      209            212           2          4.8         209.5       1.0X
+to timestamp str wholestage off                     217            221           5          4.6         217.5       1.0X
+to timestamp str wholestage on                      210            214           5          4.8         210.0       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                        1676           1677           2          0.6        1675.6       1.0X
-to_timestamp wholestage on                         1599           1606           8          0.6        1599.5       1.0X
+to_timestamp wholestage off                        1714           1718           5          0.6        1714.4       1.0X
+to_timestamp wholestage on                         1418           1433          14          0.7        1418.5       1.2X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                   1582           1589           9          0.6        1582.1       1.0X
-to_unix_timestamp wholestage on                    1634           1637           3          0.6        1633.8       1.0X
+to_unix_timestamp wholestage off                   1436           1441           6          0.7        1436.2       1.0X
+to_unix_timestamp wholestage on                    1421           1426           7          0.7        1420.6       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          275            282           9          3.6         275.0       1.0X
-to date str wholestage on                           264            265           2          3.8         263.5       1.0X
+to date str wholestage off                          267            267           0          3.8         266.6       1.0X
+to date str wholestage on                           260            262           2          3.8         260.1       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                             3170           3188          25          0.3        3170.1       1.0X
-to_date wholestage on                              3134           3143          10          0.3        3134.3       1.0X
+to_date wholestage off                             3419           3436          25          0.3        3419.0       1.0X
+to_date wholestage on                              3344           3352           7          0.3        3343.5       1.0X
 
 
 ================================================================================================
@@ -444,18 +444,18 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 To/from Java's date-time:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Date                                  407            413           7         12.3          81.5       1.0X
-From java.time.LocalDate                            340            344           5         14.7          68.1       1.2X
-Collect java.sql.Date                              1700           2658        1422          2.9         340.0       0.2X
-Collect java.time.LocalDate                        1473           1494          30          3.4         294.6       0.3X
-From java.sql.Timestamp                             252            266          13         19.8          50.5       1.6X
-From java.time.Instant                              236            243           7         21.1          47.3       1.7X
-Collect longs                                      1280           1337          79          3.9         256.1       0.3X
-Collect java.sql.Timestamp                         1485           1501          15          3.4         297.0       0.3X
-Collect java.time.Instant                          1441           1465          37          3.5         288.1       0.3X
-java.sql.Date to Hive string                      18745          20895        1364          0.3        3749.0       0.0X
-java.time.LocalDate to Hive string                15296          15450         143          0.3        3059.2       0.0X
-java.sql.Timestamp to Hive string                 46421          47210         946          0.1        9284.2       0.0X
-java.time.Instant to Hive string                  34747          35187         382          0.1        6949.4       0.0X
+From java.sql.Date                                  436            445           8         11.5          87.2       1.0X
+From java.time.LocalDate                            348            357          11         14.4          69.7       1.3X
+Collect java.sql.Date                              1723           1917         168          2.9         344.5       0.3X
+Collect java.time.LocalDate                        1591           1602          18          3.1         318.3       0.3X
+From java.sql.Timestamp                             248            252           4         20.2          49.6       1.8X
+From java.time.Instant                              232            238           5         21.5          46.5       1.9X
+Collect longs                                      1398           1455          99          3.6         279.5       0.3X
+Collect java.sql.Timestamp                         1469           1483          13          3.4         293.9       0.3X
+Collect java.time.Instant                          1561           1597          40          3.2         312.2       0.3X
+java.sql.Date to Hive string                      13820          14798         857          0.4        2763.9       0.0X
+java.time.LocalDate to Hive string                14374          14779         357          0.3        2874.8       0.0X
+java.sql.Timestamp to Hive string                 14872          15461         653          0.3        2974.5       0.0X
+java.time.Instant to Hive string                  17062          17789         759          0.3        3412.4       0.0X
 
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/HiveResult.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/HiveResult.scala
@@ -92,9 +92,9 @@ object HiveResult {
 
   /** Formats a datum (based on the given data type) and returns the string representation. */
   def toHiveString(
-    a: (Any, DataType),
-    nested: Boolean,
-    formatters: TimeFormatters): String = a match {
+      a: (Any, DataType),
+      nested: Boolean,
+      formatters: TimeFormatters): String = a match {
     case (null, _) => if (nested) "null" else "NULL"
     case (b, BooleanType) => b.toString
     case (d: Date, DateType) => formatters.date.format(d)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/HiveResult.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/HiveResult.scala
@@ -33,6 +33,23 @@ import org.apache.spark.unsafe.types.CalendarInterval
  * Runs a query returning the result in Hive compatible form.
  */
 object HiveResult {
+  case class TimeFormatters(date: DateFormatter, timestamp: TimestampFormatter)
+
+  def getTimeFormatters: TimeFormatters = {
+    // The date formatter does not depend on Spark's session time zone controlled by
+    // the SQL config `spark.sql.session.timeZone`. The `zoneId` parameter is used only in
+    // parsing of special date values like `now`, `yesterday` and etc. but not in date formatting.
+    // While formatting of:
+    // - `java.time.LocalDate`, zone id is not used by `DateTimeFormatter` at all.
+    // - `java.sql.Date`, the date formatter delegates formatting to the legacy formatter
+    //   which uses the default system time zone `TimeZone.getDefault`. This works correctly
+    //   due to `DateTimeUtils.toJavaDate` which is based on the system time zone too.
+    val dateFormatter = DateFormatter(ZoneOffset.UTC)
+    val timestampFormatter = TimestampFormatter.getFractionFormatter(
+      DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone))
+    TimeFormatters(dateFormatter, timestampFormatter)
+  }
+
   /**
    * Returns the result as a hive compatible sequence of strings. This is used in tests and
    * `SparkSQLDriver` for CLI applications.
@@ -55,11 +72,12 @@ object HiveResult {
     case command @ ExecutedCommandExec(_: ShowViewsCommand) =>
       command.executeCollect().map(_.getString(1))
     case other =>
+      val timeFormatters = getTimeFormatters
       val result: Seq[Seq[Any]] = other.executeCollectPublic().map(_.toSeq).toSeq
       // We need the types so we can output struct field names
       val types = executedPlan.output.map(_.dataType)
       // Reformat to match hive tab delimited output.
-      result.map(_.zip(types).map(e => toHiveString(e)))
+      result.map(_.zip(types).map(e => toHiveString(e, false, timeFormatters)))
         .map(_.mkString("\t"))
   }
 
@@ -72,47 +90,32 @@ object HiveResult {
     }
   }
 
-  // We can create the date formatter only once because it does not depend on Spark's
-  // session time zone controlled by the SQL config `spark.sql.session.timeZone`.
-  // The `zoneId` parameter is used only in parsing of special date values like `now`,
-  // `yesterday` and etc. but not in date formatting. While formatting of:
-  // - `java.time.LocalDate`, zone id is not used by `DateTimeFormatter` at all.
-  // - `java.sql.Date`, the date formatter delegates formatting to the legacy formatter
-  //   which uses the default system time zone `TimeZone.getDefault`. This works correctly
-  //   due to `DateTimeUtils.toJavaDate` which is based on the system time zone too.
-  private val dateFormatter = DateFormatter(
-    format = DateFormatter.defaultPattern,
-    // We can set any time zone id. UTC was taken for simplicity.
-    zoneId = ZoneOffset.UTC,
-    locale = DateFormatter.defaultLocale,
-    // Use `FastDateFormat` as the legacy formatter because it is thread-safe.
-    legacyFormat = LegacyDateFormats.FAST_DATE_FORMAT,
-    isParsing = false)
-  private def timestampFormatter = TimestampFormatter.getFractionFormatter(
-    DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone))
-
   /** Formats a datum (based on the given data type) and returns the string representation. */
-  def toHiveString(a: (Any, DataType), nested: Boolean = false): String = a match {
+  def toHiveString(
+    a: (Any, DataType),
+    nested: Boolean,
+    formatters: TimeFormatters): String = a match {
     case (null, _) => if (nested) "null" else "NULL"
     case (b, BooleanType) => b.toString
-    case (d: Date, DateType) => dateFormatter.format(d)
-    case (ld: LocalDate, DateType) => dateFormatter.format(ld)
-    case (t: Timestamp, TimestampType) => timestampFormatter.format(t)
-    case (i: Instant, TimestampType) => timestampFormatter.format(i)
+    case (d: Date, DateType) => formatters.date.format(d)
+    case (ld: LocalDate, DateType) => formatters.date.format(ld)
+    case (t: Timestamp, TimestampType) => formatters.timestamp.format(t)
+    case (i: Instant, TimestampType) => formatters.timestamp.format(i)
     case (bin: Array[Byte], BinaryType) => new String(bin, StandardCharsets.UTF_8)
     case (decimal: java.math.BigDecimal, DecimalType()) => decimal.toPlainString
     case (n, _: NumericType) => n.toString
     case (s: String, StringType) => if (nested) "\"" + s + "\"" else s
     case (interval: CalendarInterval, CalendarIntervalType) => interval.toString
     case (seq: Seq[_], ArrayType(typ, _)) =>
-      seq.map(v => (v, typ)).map(e => toHiveString(e, true)).mkString("[", ",", "]")
+      seq.map(v => (v, typ)).map(e => toHiveString(e, true, formatters)).mkString("[", ",", "]")
     case (m: Map[_, _], MapType(kType, vType, _)) =>
       m.map { case (key, value) =>
-        toHiveString((key, kType), true) + ":" + toHiveString((value, vType), true)
+        toHiveString((key, kType), true, formatters) + ":" +
+          toHiveString((value, vType), true, formatters)
       }.toSeq.sorted.mkString("{", ",", "}")
     case (struct: Row, StructType(fields)) =>
       struct.toSeq.zip(fields).map { case (v, t) =>
-        s""""${t.name}":${toHiveString((v, t.dataType), true)}"""
+        s""""${t.name}":${toHiveString((v, t.dataType), true, formatters)}"""
       }.mkString("{", ",", "}")
     case (other, _: UserDefinedType[_]) => other.toString
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/HiveResultSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/HiveResultSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution
 
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils
 import org.apache.spark.sql.connector.InMemoryTableCatalog
+import org.apache.spark.sql.execution.HiveResult._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.{ExamplePoint, ExamplePointUDT, SharedSparkSession}
 
@@ -31,10 +32,10 @@ class HiveResultSuite extends SharedSparkSession {
         val dates = Seq("2018-12-28", "1582-10-03", "1582-10-04", "1582-10-15")
         val df = dates.toDF("a").selectExpr("cast(a as date) as b")
         val executedPlan1 = df.queryExecution.executedPlan
-        val result = HiveResult.hiveResultString(executedPlan1)
+        val result = hiveResultString(executedPlan1)
         assert(result == dates)
         val executedPlan2 = df.selectExpr("array(b)").queryExecution.executedPlan
-        val result2 = HiveResult.hiveResultString(executedPlan2)
+        val result2 = hiveResultString(executedPlan2)
         assert(result2 == dates.map(x => s"[$x]"))
       }
     }
@@ -48,17 +49,17 @@ class HiveResultSuite extends SharedSparkSession {
       "1582-10-15 01:02:03")
     val df = timestamps.toDF("a").selectExpr("cast(a as timestamp) as b")
     val executedPlan1 = df.queryExecution.executedPlan
-    val result = HiveResult.hiveResultString(executedPlan1)
+    val result = hiveResultString(executedPlan1)
     assert(result == timestamps)
     val executedPlan2 = df.selectExpr("array(b)").queryExecution.executedPlan
-    val result2 = HiveResult.hiveResultString(executedPlan2)
+    val result2 = hiveResultString(executedPlan2)
     assert(result2 == timestamps.map(x => s"[$x]"))
   }
 
   test("toHiveString correctly handles UDTs") {
     val point = new ExamplePoint(50.0, 50.0)
     val tpe = new ExamplePointUDT()
-    assert(HiveResult.toHiveString((point, tpe)) === "(50.0, 50.0)")
+    assert(toHiveString((point, tpe), false, getTimeFormatters) === "(50.0, 50.0)")
   }
 
   test("decimal formatting in hive result") {
@@ -66,13 +67,13 @@ class HiveResultSuite extends SharedSparkSession {
     Seq(2, 6, 18).foreach { scala =>
       val executedPlan =
         df.selectExpr(s"CAST(value AS decimal(38, $scala))").queryExecution.executedPlan
-      val result = HiveResult.hiveResultString(executedPlan)
+      val result = hiveResultString(executedPlan)
       assert(result.head.split("\\.").last.length === scala)
     }
 
     val executedPlan = Seq(java.math.BigDecimal.ZERO).toDS()
       .selectExpr(s"CAST(value AS decimal(38, 8))").queryExecution.executedPlan
-    val result = HiveResult.hiveResultString(executedPlan)
+    val result = hiveResultString(executedPlan)
     assert(result.head === "0.00000000")
   }
 
@@ -84,7 +85,7 @@ class HiveResultSuite extends SharedSparkSession {
             spark.sql(s"CREATE TABLE $ns.$tbl (id bigint) USING $source")
             val df = spark.sql(s"SHOW TABLES FROM $ns")
             val executedPlan = df.queryExecution.executedPlan
-            assert(HiveResult.hiveResultString(executedPlan).head == tbl)
+            assert(hiveResultString(executedPlan).head == tbl)
           }
       }
     }
@@ -101,7 +102,7 @@ class HiveResultSuite extends SharedSparkSession {
             val expected = "id                  " +
               "\tbigint              " +
               "\tcol1                "
-            assert(HiveResult.hiveResultString(executedPlan).head == expected)
+            assert(hiveResultString(executedPlan).head == expected)
           }
       }
     }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerQueryTestSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerQueryTestSuite.scala
@@ -30,7 +30,7 @@ import org.apache.spark.SparkException
 import org.apache.spark.sql.SQLQueryTestSuite
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
 import org.apache.spark.sql.catalyst.util.fileToString
-import org.apache.spark.sql.execution.HiveResult
+import org.apache.spark.sql.execution.HiveResult.{getTimeFormatters, toHiveString, TimeFormatters}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
@@ -257,8 +257,9 @@ class ThriftServerQueryTestSuite extends SQLQueryTestSuite with SharedThriftServ
   private def getNormalizedResult(statement: Statement, sql: String): (String, Seq[String]) = {
     val rs = statement.executeQuery(sql)
     val cols = rs.getMetaData.getColumnCount
+    val timeFormatters = getTimeFormatters
     val buildStr = () => (for (i <- 1 to cols) yield {
-      getHiveResult(rs.getObject(i))
+      getHiveResult(rs.getObject(i), timeFormatters)
     }).mkString("\t")
 
     val answer = Iterator.continually(rs.next()).takeWhile(identity).map(_ => buildStr()).toSeq
@@ -280,18 +281,18 @@ class ThriftServerQueryTestSuite extends SQLQueryTestSuite with SharedThriftServ
       upperCase.startsWith("(")
   }
 
-  private def getHiveResult(obj: Object): String = {
+  private def getHiveResult(obj: Object, timeFormatters: TimeFormatters): String = {
     obj match {
       case null =>
-        HiveResult.toHiveString((null, StringType))
+        toHiveString((null, StringType), false, timeFormatters)
       case d: java.sql.Date =>
-        HiveResult.toHiveString((d, DateType))
+        toHiveString((d, DateType), false, timeFormatters)
       case t: Timestamp =>
-        HiveResult.toHiveString((t, TimestampType))
+        toHiveString((t, TimestampType), false, timeFormatters)
       case d: java.math.BigDecimal =>
-        HiveResult.toHiveString((d, DecimalType.fromDecimal(Decimal(d))))
+        toHiveString((d, DecimalType.fromDecimal(Decimal(d))), false, timeFormatters)
       case bin: Array[Byte] =>
-        HiveResult.toHiveString((bin, BinaryType))
+        toHiveString((bin, BinaryType), false, timeFormatters)
       case other =>
         other.toString
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Add method `getTimeFormatters` to `HiveResult` which creates timestamp and date formatters.
2. Move creation of `dateFormatter` and `timestampFormatter` from the constructor of the `HiveResult` object to `HiveResult. hiveResultString()` via `getTimeFormatters`. This allows to resolve time zone ID from Spark's session time zone `spark.sql.session.timeZone` and create date/timestamp formatters only once before collecting `java.sql.Timestamp`/`java.sql.Date` values.
3. Create date/timestamp formatters once in SparkExecuteStatementOperation.

### Why are the changes needed?
To fix perf regression comparing to Spark 2.4

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- By existing test suite `HiveResultSuite` and etc.
- Re-generate benchmarks results of `DateTimeBenchmark` in the environment:

| Item | Description |
| ---- | ----|
| Region | us-west-2 (Oregon) |
| Instance | r3.xlarge |
| AMI | ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20190722.1 (ami-06f2f779464715dc5) |
| Java | OpenJDK 64-Bit Server VM 1.8.0_252 and OpenJDK 64-Bit Server VM 11.0.7+10 |
