### PR TITLE
[SPARK-32009][ML][PySpark] Remove deprecated method BisectingKMeansModel.computeCost

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/BisectingKMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/BisectingKMeans.scala
@@ -137,24 +137,6 @@ class BisectingKMeansModel private[ml] (
   @Since("2.0.0")
   def clusterCenters: Array[Vector] = parentModel.clusterCenters.map(_.asML)
 
-  /**
-   * Computes the sum of squared distances between the input points and their corresponding cluster
-   * centers.
-   *
-   * @deprecated This method is deprecated and will be removed in future versions. Use
-   *             ClusteringEvaluator instead. You can also get the cost on the training dataset in
-   *             the summary.
-   */
-  @Since("2.0.0")
-  @deprecated("This method is deprecated and will be removed in future versions. Use " +
-    "ClusteringEvaluator instead. You can also get the cost on the training dataset in the " +
-    "summary.", "3.0.0")
-  def computeCost(dataset: Dataset[_]): Double = {
-    SchemaUtils.validateVectorCompatibleColumn(dataset.schema, getFeaturesCol)
-    val data = DatasetUtils.columnToOldVector(dataset, getFeaturesCol)
-    parentModel.computeCost(data)
-  }
-
   @Since("2.0.0")
   override def write: MLWriter = new BisectingKMeansModel.BisectingKMeansModelWriter(this)
 

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -55,6 +55,7 @@ object MimaExcludes {
     // [SPARK-24634] Add a new metric regarding number of inputs later than watermark plus allowed delay
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.streaming.StateOperatorProgress.<init>$default$4"),
 
+    // [SPARK-32009] Remove deprecated method BisectingKMeansModel.computeCost
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.ml.clustering.BisectingKMeansModel.computeCost")
   )
 

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -39,6 +39,7 @@ object MimaExcludes {
     // [SPARK-31077] Remove ChiSqSelector dependency on mllib.ChiSqSelectorModel
     // private constructor
     ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.spark.ml.feature.ChiSqSelectorModel.this"),
+
     // [SPARK-31127] Implement abstract Selector
     // org.apache.spark.ml.feature.ChiSqSelectorModel type hierarchy change
     // before: class ChiSqSelector extends Estimator with ChiSqSelectorParams
@@ -46,11 +47,15 @@ object MimaExcludes {
     // false positive, no binary incompatibility
     ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.ml.feature.ChiSqSelectorModel"),
     ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.ml.feature.ChiSqSelector"),
+
     //[SPARK-31840] Add instance weight support in LogisticRegressionSummary
     // weightCol in org.apache.spark.ml.classification.LogisticRegressionSummary is present only in current version
     ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.ml.classification.LogisticRegressionSummary.weightCol"),
+
     // [SPARK-24634] Add a new metric regarding number of inputs later than watermark plus allowed delay
-    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.streaming.StateOperatorProgress.<init>$default$4")
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.streaming.StateOperatorProgress.<init>$default$4"),
+
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.ml.clustering.BisectingKMeansModel.computeCost")
   )
 
   // Exclude rules for 3.0.x

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -796,21 +796,6 @@ class BisectingKMeansModel(JavaModel, _BisectingKMeansParams, JavaMLWritable, Ja
         """Get the cluster centers, represented as a list of NumPy arrays."""
         return [c.toArray() for c in self._call_java("clusterCenters")]
 
-    @since("2.0.0")
-    def computeCost(self, dataset):
-        """
-        Computes the sum of squared distances between the input points
-        and their corresponding cluster centers.
-
-        .. note:: Deprecated in 3.0.0. It will be removed in future versions. Use
-           ClusteringEvaluator instead. You can also get the cost on the training dataset in the
-           summary.
-        """
-        warnings.warn("Deprecated in 3.0.0. It will be removed in future versions. Use "
-                      "ClusteringEvaluator instead. You can also get the cost on the training "
-                      "dataset in the summary.", DeprecationWarning)
-        return self._call_java("computeCost", dataset)
-
     @property
     @since("2.1.0")
     def summary(self):
@@ -871,8 +856,6 @@ class BisectingKMeans(JavaEstimator, _BisectingKMeansParams, JavaMLWritable, Jav
     >>> centers = model.clusterCenters()
     >>> len(centers)
     2
-    >>> model.computeCost(df)
-    2.0
     >>> model.hasSummary
     True
     >>> summary = model.summary


### PR DESCRIPTION

### What changes were proposed in this pull request?
Remove deprecated method BisectingKMeansModel.computeCost in 3.1

### Why are the changes needed?
KMeansModel.computeCost was introduced in https://issues.apache.org/jira/browse/SPARK-11029 as a temporary solution. It was deprecated in 2.4 (https://issues.apache.org/jira/browse/SPARK-23451)  and removed in 3.0 (https://issues.apache.org/jira/browse/SPARK-25867). However, deprecation of BisectingKMeansModel.computeCost missed 2.4 release and was done in 3.0. BisectingKMeansModel.computeCost should be removed in 3.1 to be consistent with KMean. 


### Does this PR introduce _any_ user-facing change?
Yes, this introduced an API breaking change, unfortunately.


### How was this patch tested?
existing tests.