### PR TITLE
[SPARK-30616][SQL] Introduce TTL config option for SQL Metadata Cache

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.catalyst.catalog
 import java.net.URI
 import java.util.Locale
 import java.util.concurrent.Callable
+import java.util.concurrent.TimeUnit
 import javax.annotation.concurrent.GuardedBy
 
 import scala.collection.mutable
@@ -135,7 +136,16 @@ class SessionCatalog(
 
   private val tableRelationCache: Cache[QualifiedTableName, LogicalPlan] = {
     val cacheSize = conf.tableRelationCacheSize
-    CacheBuilder.newBuilder().maximumSize(cacheSize).build[QualifiedTableName, LogicalPlan]()
+    val cacheTTL = conf.metadataCacheTTL
+
+    var builder = CacheBuilder.newBuilder()
+      .maximumSize(cacheSize)
+
+    if (cacheTTL > 0) {
+      builder = builder.expireAfterWrite(cacheTTL, TimeUnit.SECONDS)
+    }
+
+    builder.build[QualifiedTableName, LogicalPlan]()
   }
 
   /** This method provides a way to get a cached plan. */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -837,9 +837,9 @@ object SQLConf {
 
   val HIVE_FILESOURCE_PARTITION_FILE_CACHE_TTL =
     buildConf("spark.sql.hive.filesourcePartitionFileCacheTTL")
-      .doc("When positive, it's used as a TTL (time-to-live) value for the partition file " +
-        "metadata cache. This conf only has an effect when hive filesource partition management " +
-        "is enabled.")
+      .doc("Time-to-live (TTL) value for the partition file metadata cache. This configuration " +
+           "only has an effect when this value having a positive value and setting `hive` to " +
+           s"${StaticSQLConf.CATALOG_IMPLEMENTATION}.")
       .version("3.1.0")
       .timeConf(TimeUnit.SECONDS)
       .createWithDefault(-1)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -835,6 +835,15 @@ object SQLConf {
       .longConf
       .createWithDefault(250 * 1024 * 1024)
 
+  val HIVE_FILESOURCE_PARTITION_FILE_CACHE_TTL =
+    buildConf("spark.sql.hive.filesourcePartitionFileCacheTTL")
+      .doc("When positive, it's used as a TTL (time-to-live) value for the partition file " +
+        "metadata cache. This conf only has an effect when hive filesource partition management " +
+        "is enabled.")
+      .version("3.1.0")
+      .timeConf(TimeUnit.SECONDS)
+      .createWithDefault(-1)
+
   object HiveCaseSensitiveInferenceMode extends Enumeration {
     val INFER_AND_SAVE, INFER_ONLY, NEVER_INFER = Value
   }
@@ -2899,6 +2908,8 @@ class SQLConf extends Serializable with Logging {
   def manageFilesourcePartitions: Boolean = getConf(HIVE_MANAGE_FILESOURCE_PARTITIONS)
 
   def filesourcePartitionFileCacheSize: Long = getConf(HIVE_FILESOURCE_PARTITION_FILE_CACHE_SIZE)
+
+  def filesourcePartitionFileCacheTTL: Long = getConf(HIVE_FILESOURCE_PARTITION_FILE_CACHE_TTL)
 
   def caseSensitiveInferenceMode: HiveCaseSensitiveInferenceMode.Value =
     HiveCaseSensitiveInferenceMode.withName(getConf(HIVE_CASE_SENSITIVE_INFERENCE))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2656,8 +2656,7 @@ object SQLConf {
       .checkValue(_ > 0, "The difference must be positive.")
       .createWithDefault(4)
 
-  val METADATA_CACHE_TTL =
-    buildConf("spark.sql.metadataCacheTTL")
+  val METADATA_CACHE_TTL = buildConf("spark.sql.metadataCacheTTL")
       .doc("Time-to-live (TTL) value for the metadata caches: partition file metadata cache and " +
         "session catalog cache. This configuration only has an effect when this value having " +
         "a positive value. It also requires setting `hive` to " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2656,16 +2656,6 @@ object SQLConf {
       .checkValue(_ > 0, "The difference must be positive.")
       .createWithDefault(4)
 
-  val METADATA_CACHE_TTL = buildConf("spark.sql.metadataCacheTTL")
-      .doc("Time-to-live (TTL) value for the metadata caches: partition file metadata cache and " +
-        "session catalog cache. This configuration only has an effect when this value having " +
-        "a positive value. It also requires setting `hive` to " +
-        s"${StaticSQLConf.CATALOG_IMPLEMENTATION} to be applied to the partition file " +
-        "metadata cache.")
-      .version("3.1.0")
-      .timeConf(TimeUnit.SECONDS)
-      .createWithDefault(-1)
-
   /**
    * Holds information about keys that have been deprecated.
    *
@@ -3261,7 +3251,7 @@ class SQLConf extends Serializable with Logging {
   def legacyAllowCastNumericToTimestamp: Boolean =
     getConf(SQLConf.LEGACY_ALLOW_CAST_NUMERIC_TO_TIMESTAMP)
 
-  def metadataCacheTTL: Long = getConf(METADATA_CACHE_TTL)
+  def metadataCacheTTL: Long = getConf(StaticSQLConf.METADATA_CACHE_TTL)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -835,15 +835,6 @@ object SQLConf {
       .longConf
       .createWithDefault(250 * 1024 * 1024)
 
-  val HIVE_FILESOURCE_PARTITION_FILE_CACHE_TTL =
-    buildConf("spark.sql.hive.filesourcePartitionFileCacheTTL")
-      .doc("Time-to-live (TTL) value for the partition file metadata cache. This configuration " +
-           "only has an effect when this value having a positive value and setting `hive` to " +
-           s"${StaticSQLConf.CATALOG_IMPLEMENTATION}.")
-      .version("3.1.0")
-      .timeConf(TimeUnit.SECONDS)
-      .createWithDefault(-1)
-
   object HiveCaseSensitiveInferenceMode extends Enumeration {
     val INFER_AND_SAVE, INFER_ONLY, NEVER_INFER = Value
   }
@@ -2665,6 +2656,17 @@ object SQLConf {
       .checkValue(_ > 0, "The difference must be positive.")
       .createWithDefault(4)
 
+  val METADATA_CACHE_TTL =
+    buildConf("spark.sql.metadataCacheTTL")
+      .doc("Time-to-live (TTL) value for the metadata caches: partition file metadata cache and " +
+        "session catalog cache. This configuration only has an effect when this value having " +
+        "a positive value. It also requires setting `hive` to " +
+        s"${StaticSQLConf.CATALOG_IMPLEMENTATION} to be applied to the partition file " +
+        "metadata cache.")
+      .version("3.1.0")
+      .timeConf(TimeUnit.SECONDS)
+      .createWithDefault(-1)
+
   /**
    * Holds information about keys that have been deprecated.
    *
@@ -2908,8 +2910,6 @@ class SQLConf extends Serializable with Logging {
   def manageFilesourcePartitions: Boolean = getConf(HIVE_MANAGE_FILESOURCE_PARTITIONS)
 
   def filesourcePartitionFileCacheSize: Long = getConf(HIVE_FILESOURCE_PARTITION_FILE_CACHE_SIZE)
-
-  def filesourcePartitionFileCacheTTL: Long = getConf(HIVE_FILESOURCE_PARTITION_FILE_CACHE_TTL)
 
   def caseSensitiveInferenceMode: HiveCaseSensitiveInferenceMode.Value =
     HiveCaseSensitiveInferenceMode.withName(getConf(HIVE_CASE_SENSITIVE_INFERENCE))
@@ -3261,6 +3261,8 @@ class SQLConf extends Serializable with Logging {
 
   def legacyAllowCastNumericToTimestamp: Boolean =
     getConf(SQLConf.LEGACY_ALLOW_CAST_NUMERIC_TO_TIMESTAMP)
+
+  def metadataCacheTTL: Long = getConf(METADATA_CACHE_TTL)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3251,7 +3251,7 @@ class SQLConf extends Serializable with Logging {
   def legacyAllowCastNumericToTimestamp: Boolean =
     getConf(SQLConf.LEGACY_ALLOW_CAST_NUMERIC_TO_TIMESTAMP)
 
-  def metadataCacheTTL: Long = getConf(StaticSQLConf.METADATA_CACHE_TTL)
+  def metadataCacheTTL: Long = getConf(StaticSQLConf.METADATA_CACHE_TTL_SECONDS)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -235,7 +235,7 @@ object StaticSQLConf {
       s"${StaticSQLConf.CATALOG_IMPLEMENTATION} to `hive`, setting " +
       s"${SQLConf.HIVE_FILESOURCE_PARTITION_FILE_CACHE_SIZE} > 0 and setting " +
       s"${SQLConf.HIVE_MANAGE_FILESOURCE_PARTITIONS} to `true` " +
-      s"to be applied to the partition file metadata cache.")
+      "to be applied to the partition file metadata cache.")
     .version("3.1.0")
     .timeConf(TimeUnit.SECONDS)
     .createWithDefault(-1)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.internal
 
 import java.util.Locale
+import java.util.concurrent.TimeUnit
 
 import org.apache.spark.util.Utils
 
@@ -226,4 +227,16 @@ object StaticSQLConf {
       .version("3.0.0")
       .intConf
       .createWithDefault(100)
+
+  val METADATA_CACHE_TTL = buildStaticConf("spark.sql.metadataCacheTTL")
+    .doc("Time-to-live (TTL) value for the metadata caches: partition file metadata cache and " +
+      "session catalog cache. This configuration only has an effect when this value having " +
+      "a positive value (> 0). It also requires setting " +
+      s"${StaticSQLConf.CATALOG_IMPLEMENTATION} to `hive`, setting " +
+      s"${SQLConf.HIVE_FILESOURCE_PARTITION_FILE_CACHE_SIZE} > 0 and setting " +
+      s"${SQLConf.HIVE_MANAGE_FILESOURCE_PARTITIONS} to `true` " +
+      s"to be applied to the partition file metadata cache.")
+    .version("3.1.0")
+    .timeConf(TimeUnit.SECONDS)
+    .createWithDefault(-1)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -228,7 +228,7 @@ object StaticSQLConf {
       .intConf
       .createWithDefault(100)
 
-  val METADATA_CACHE_TTL = buildStaticConf("spark.sql.metadataCacheTTL")
+  val METADATA_CACHE_TTL_SECONDS = buildStaticConf("spark.sql.metadataCacheTTLSeconds")
     .doc("Time-to-live (TTL) value for the metadata caches: partition file metadata cache and " +
       "session catalog cache. This configuration only has an effect when this value having " +
       "a positive value (> 0). It also requires setting " +

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -17,15 +17,19 @@
 
 package org.apache.spark.sql.catalyst.catalog
 
+import scala.concurrent.duration._
+
+import org.scalatest.concurrent.Eventually
+
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
+import org.apache.spark.sql.catalyst.{FunctionIdentifier, QualifiedTableName, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
-import org.apache.spark.sql.catalyst.plans.logical.{Range, SubqueryAlias, View}
+import org.apache.spark.sql.catalyst.plans.logical.{Command, Range, SubqueryAlias, View}
 import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.connector.catalog.SupportsNamespaces.PROP_OWNER
-import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
 import org.apache.spark.sql.types._
 
 class InMemorySessionCatalogSuite extends SessionCatalogSuite {
@@ -45,7 +49,7 @@ class InMemorySessionCatalogSuite extends SessionCatalogSuite {
  * signatures but do not extend a common parent. This is largely by design but
  * unfortunately leads to very similar test code in two places.
  */
-abstract class SessionCatalogSuite extends AnalysisTest {
+abstract class SessionCatalogSuite extends AnalysisTest with Eventually {
   protected val utils: CatalogTestUtils
 
   protected val isHiveExternalCatalog = false
@@ -63,6 +67,16 @@ abstract class SessionCatalogSuite extends AnalysisTest {
 
   private def withEmptyCatalog(f: SessionCatalog => Unit): Unit = {
     val catalog = new SessionCatalog(newEmptyCatalog())
+    catalog.createDatabase(newDb("default"), ignoreIfExists = true)
+    try {
+      f(catalog)
+    } finally {
+      catalog.reset()
+    }
+  }
+
+  private def withConfAndEmptyCatalog(conf: SQLConf)(f: SessionCatalog => Unit): Unit = {
+    val catalog = new SessionCatalog(newEmptyCatalog(), new SimpleFunctionRegistry(), conf)
     catalog.createDatabase(newDb("default"), ignoreIfExists = true)
     try {
       f(catalog)
@@ -1639,6 +1653,29 @@ abstract class SessionCatalogSuite extends AnalysisTest {
       // override in `AnalysisException`,so here we get the root cause
       // exception message for check.
       assert(cause.cause.get.getMessage.contains("Actual error"))
+    }
+  }
+
+  test("expire table relation cache if TTL is configured") {
+    case class TestCommand() extends Command
+
+    val conf = new SQLConf()
+    conf.setConf(StaticSQLConf.METADATA_CACHE_TTL, 1L)
+
+    withConfAndEmptyCatalog(conf) { catalog =>
+      val table = QualifiedTableName(catalog.getCurrentDatabase, "test")
+
+      // First, make sure the test table is not cached.
+      assert(catalog.getCachedTable(table) === null)
+
+      catalog.cacheTable(table, TestCommand())
+      assert(catalog.getCachedTable(table) !== null)
+
+      // Wait until the cache expiration.
+      eventually(timeout(3.seconds)) {
+        // And the cache is gone.
+        assert(catalog.getCachedTable(table) === null)
+      }
     }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -1660,7 +1660,7 @@ abstract class SessionCatalogSuite extends AnalysisTest with Eventually {
     case class TestCommand() extends Command
 
     val conf = new SQLConf()
-    conf.setConf(StaticSQLConf.METADATA_CACHE_TTL, 1L)
+    conf.setConf(StaticSQLConf.METADATA_CACHE_TTL_SECONDS, 1L)
 
     withConfAndEmptyCatalog(conf) { catalog =>
       val table = QualifiedTableName(catalog.getCurrentDatabase, "test")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileStatusCache.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileStatusCache.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources
 
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.collection.JavaConverters._
@@ -44,7 +45,9 @@ object FileStatusCache {
       session.sqlContext.conf.filesourcePartitionFileCacheSize > 0) {
       if (sharedCache == null) {
         sharedCache = new SharedInMemoryCache(
-          session.sqlContext.conf.filesourcePartitionFileCacheSize)
+          session.sqlContext.conf.filesourcePartitionFileCacheSize,
+          session.sqlContext.conf.filesourcePartitionFileCacheTTL
+        )
       }
       sharedCache.createForNewClient()
     } else {
@@ -89,7 +92,7 @@ abstract class FileStatusCache {
  *
  * @param maxSizeInBytes max allowable cache size before entries start getting evicted
  */
-private class SharedInMemoryCache(maxSizeInBytes: Long) extends Logging {
+private class SharedInMemoryCache(maxSizeInBytes: Long, cacheTTL: Long) extends Logging {
 
   // Opaque object that uniquely identifies a shared cache user
   private type ClientId = Object
@@ -129,11 +132,17 @@ private class SharedInMemoryCache(maxSizeInBytes: Long) extends Logging {
         }
       }
     }
-    CacheBuilder.newBuilder()
+
+    var builder = CacheBuilder.newBuilder()
       .weigher(weigher)
       .removalListener(removalListener)
       .maximumWeight(maxSizeInBytes / weightScale)
-      .build[(ClientId, Path), Array[FileStatus]]()
+
+    if (cacheTTL > 0) {
+      builder = builder.expireAfterWrite(cacheTTL, TimeUnit.SECONDS)
+    }
+
+    builder.build[(ClientId, Path), Array[FileStatus]]()
   }
 
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileStatusCache.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileStatusCache.scala
@@ -46,7 +46,7 @@ object FileStatusCache {
       if (sharedCache == null) {
         sharedCache = new SharedInMemoryCache(
           session.sqlContext.conf.filesourcePartitionFileCacheSize,
-          session.sqlContext.conf.filesourcePartitionFileCacheTTL
+          session.sqlContext.conf.metadataCacheTTL
         )
       }
       sharedCache.createForNewClient()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
@@ -31,7 +31,6 @@ import org.mockito.Mockito.{mock, when}
 
 import org.apache.spark.SparkException
 import org.apache.spark.metrics.source.HiveCatalogMetrics
-import org.apache.spark.sql.LocalSparkSession.withSparkSession
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.functions.col
@@ -492,9 +491,7 @@ class FileIndexSuite extends SharedSparkSession {
   }
 
   test("expire FileStatusCache if TTL is configured") {
-    val sparkConfWithTTl = sparkConf.set(SQLConf.METADATA_CACHE_TTL.key, "1")
-
-    withSparkSession(SparkSession.builder.config(sparkConfWithTTl).getOrCreate()) { spark =>
+    withSQLConf(SQLConf.METADATA_CACHE_TTL.key -> "1") {
       val path = new Path("/tmp", "abc")
       val files = (1 to 3).map(_ => new FileStatus())
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
@@ -21,6 +21,7 @@ import java.io.{File, FileNotFoundException}
 import java.net.URI
 
 import scala.collection.mutable
+import scala.concurrent.duration._
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{BlockLocation, FileStatus, LocatedFileStatus, Path, RawLocalFileSystem, RemoteIterator}
@@ -504,9 +505,10 @@ class FileIndexSuite extends SharedSparkSession {
       // Exactly 3 files are cached.
       assert(fileStatusCache.getLeafFiles(path).get.length === 3)
       // Wait until the cache expiration.
-      Thread.sleep(1500) // 1.5 seconds > 1 second
-      // And the cache is gone.
-      assert(fileStatusCache.getLeafFiles(path) === None)
+      eventually(timeout(2.seconds)) {
+        // And the cache is gone.
+        assert(fileStatusCache.getLeafFiles(path).isEmpty === true)
+      }
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
@@ -491,9 +491,10 @@ class FileIndexSuite extends SharedSparkSession {
   }
 
   test("expire FileStatusCache if TTL is configured") {
-    val previousValue = SQLConf.get.getConf(StaticSQLConf.METADATA_CACHE_TTL)
+    val previousValue = SQLConf.get.getConf(StaticSQLConf.METADATA_CACHE_TTL_SECONDS)
     try {
-      SQLConf.get.setConf(StaticSQLConf.METADATA_CACHE_TTL, 1L)
+      // using 'SQLConf.get.setConf' instead of 'withSQLConf' to set a static config at runtime
+      SQLConf.get.setConf(StaticSQLConf.METADATA_CACHE_TTL_SECONDS, 1L)
 
       val path = new Path("/dummy_tmp", "abc")
       val files = (1 to 3).map(_ => new FileStatus())
@@ -510,7 +511,7 @@ class FileIndexSuite extends SharedSparkSession {
         assert(fileStatusCache.getLeafFiles(path).isEmpty === true)
       }
     } finally {
-      SQLConf.get.setConf(StaticSQLConf.METADATA_CACHE_TTL, previousValue)
+      SQLConf.get.setConf(StaticSQLConf.METADATA_CACHE_TTL_SECONDS, previousValue)
     }
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveMetadataCacheSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveMetadataCacheSuite.scala
@@ -19,8 +19,11 @@ package org.apache.spark.sql.hive
 
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.SparkException
-import org.apache.spark.sql.QueryTest
+import org.apache.spark.{SparkConf, SparkException}
+import org.apache.spark.sql.{QueryTest, SparkSession}
+import org.apache.spark.sql.LocalSparkSession.withSparkSession
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.hive.test.TestHiveSingleton
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SQLTestUtils
@@ -125,5 +128,40 @@ class HiveMetadataCacheSuite extends QueryTest with SQLTestUtils with TestHiveSi
 
   for (pruningEnabled <- Seq(true, false)) {
     testCaching(pruningEnabled)
+  }
+
+  test("cache TTL") {
+    val sparkConfWithTTl = new SparkConf().set(SQLConf.METADATA_CACHE_TTL.key, "1")
+    val newSession = SparkSession.builder.config(sparkConfWithTTl).getOrCreate().cloneSession()
+
+    withSparkSession(newSession) { implicit spark =>
+      withTable("test_ttl") {
+        withTempDir { dir =>
+          spark.sql(s"""
+            |create external table test_ttl (id long)
+            |partitioned by (f1 int, f2 int)
+            |stored as parquet
+            |location "${dir.toURI}"""".stripMargin)
+
+          val tableIdentifier = TableIdentifier("test_ttl", Some("default"))
+
+          // First, make sure the test table is not cached.
+          assert(getCachedDataSourceTable(tableIdentifier) === null)
+          // This query will make the table cached.
+          spark.sql("select * from test_ttl")
+          assert(getCachedDataSourceTable(tableIdentifier) !== null)
+          // Wait until the cache expiration.
+          Thread.sleep(1500L) // 1.5 seconds > 1 second.
+          // And the cache is gone.
+          assert(getCachedDataSourceTable(tableIdentifier) === null)
+        }
+      }
+    }
+  }
+
+  private def getCachedDataSourceTable(table: TableIdentifier)
+                                      (implicit spark: SparkSession): LogicalPlan = {
+    spark.sessionState.catalog.asInstanceOf[HiveSessionCatalog].metastoreCatalog
+      .getCachedDataSourceTable(table)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
New `spark.sql.metadataCacheTTLSeconds` option that adds time-to-live cache behaviour to the existing caches in `FileStatusCache` and `SessionCatalog`.

### Why are the changes needed?
Currently Spark [caches file listing for tables](https://spark.apache.org/docs/2.4.4/sql-data-sources-parquet.html#metadata-refreshing) and requires issuing `REFRESH TABLE` any time the file listing has changed outside of Spark. Unfortunately, simply submitting `REFRESH TABLE` commands could be very cumbersome. Assuming frequently added files, hundreds of tables and dozens of users querying the data (and expecting up-to-date results), manually refreshing metadata for each table is not a solution. 

This is a pretty common use-case for streaming ingestion of data, which can be done outside of Spark (with tools like Kafka Connect, etc.).

A similar feature exists in Presto: `hive.file-status-cache-expire-time` can be found [here](https://prestosql.io/docs/current/connector/hive.html#hive-configuration-properties).

### Does this PR introduce _any_ user-facing change?
Yes, it's controlled with the new `spark.sql.metadataCacheTTLSeconds` option.

When it's set to `-1` (by default), the behaviour of caches doesn't change, so it stays _backwards-compatible_.

Otherwise, you can specify a value in seconds, for example `spark.sql.metadataCacheTTLSeconds: 60` means 1-minute cache TTL.

### How was this patch tested?

Added new tests in:

- FileIndexSuite
- SessionCatalogSuite
