### PR TITLE
[SPARK-32019][SQL] Add spark.sql.files.minPartitionNum config

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1177,8 +1177,8 @@ object SQLConf {
     .createWithDefault(4 * 1024 * 1024)
 
   val FILES_MIN_PARTITION_NUM = buildConf("spark.sql.files.minPartitionNum")
-    .doc("The suggested (not guaranteed) minimum number of file split partitions. If not set, " +
-      "the default value is the default parallelism of the Spark cluster. This configuration is " +
+    .doc("The suggested (not guaranteed) minimum number of splitting file partitions. " +
+      "If not set, the default value is `spark.default.parallelism`. This configuration is " +
       "effective only when using file-based sources such as Parquet, JSON and ORC.")
     .version("3.1.0")
     .intConf

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1177,7 +1177,7 @@ object SQLConf {
     .createWithDefault(4 * 1024 * 1024)
 
   val FILES_MIN_PARTITION_NUM = buildConf("spark.sql.files.minPartitionNum")
-    .doc("The suggested (not guaranteed) minimum number of splitting file partitions. " +
+    .doc("The suggested (not guaranteed) minimum number of split file partitions. " +
       "If not set, the default value is `spark.default.parallelism`. This configuration is " +
       "effective only when using file-based sources such as Parquet, JSON and ORC.")
     .version("3.1.0")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1176,6 +1176,14 @@ object SQLConf {
     .longConf
     .createWithDefault(4 * 1024 * 1024)
 
+  val FILES_MIN_PARTITION_NUM = buildConf("spark.sql.files.minPartitionNum")
+    .doc("The suggested (not guaranteed) minimum number of file split partitions. If not set, " +
+      "the default value is the default parallelism of the Spark cluster. This configuration is " +
+      "effective only when using file-based sources such as Parquet, JSON and ORC.")
+    .version("3.1.0")
+    .intConf
+    .createOptional
+
   val IGNORE_CORRUPT_FILES = buildConf("spark.sql.files.ignoreCorruptFiles")
     .doc("Whether to ignore corrupt files. If true, the Spark jobs will continue to run when " +
       "encountering corrupted files and the contents that have been read will still be returned. " +
@@ -2781,6 +2789,8 @@ class SQLConf extends Serializable with Logging {
   def filesMaxPartitionBytes: Long = getConf(FILES_MAX_PARTITION_BYTES)
 
   def filesOpenCostInBytes: Long = getConf(FILES_OPEN_COST_IN_BYTES)
+
+  def filesMinPartitionNum: Option[Int] = getConf(FILES_MIN_PARTITION_NUM)
 
   def ignoreCorruptFiles: Boolean = getConf(IGNORE_CORRUPT_FILES)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1182,6 +1182,7 @@ object SQLConf {
       "effective only when using file-based sources such as Parquet, JSON and ORC.")
     .version("3.1.0")
     .intConf
+    .checkValue(v => v > 0, "The min partition number must be a positive integer.")
     .createOptional
 
   val IGNORE_CORRUPT_FILES = buildConf("spark.sql.files.ignoreCorruptFiles")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FilePartition.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FilePartition.scala
@@ -88,9 +88,10 @@ object FilePartition extends Logging {
       selectedPartitions: Seq[PartitionDirectory]): Long = {
     val defaultMaxSplitBytes = sparkSession.sessionState.conf.filesMaxPartitionBytes
     val openCostInBytes = sparkSession.sessionState.conf.filesOpenCostInBytes
-    val defaultParallelism = sparkSession.sparkContext.defaultParallelism
+    val minPartitionNum = sparkSession.sessionState.conf.filesMinPartitionNum
+      .getOrElse(sparkSession.sparkContext.defaultParallelism)
     val totalBytes = selectedPartitions.flatMap(_.files.map(_.getLen + openCostInBytes)).sum
-    val bytesPerCore = totalBytes / defaultParallelism
+    val bytesPerCore = totalBytes / minPartitionNum
 
     Math.min(defaultMaxSplitBytes, Math.max(openCostInBytes, bytesPerCore))
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -552,11 +552,12 @@ class FileSourceStrategySuite extends QueryTest with SharedSparkSession with Pre
     withSQLConf(SQLConf.FILES_MIN_PARTITION_NUM.key -> "16") {
       val partitions = (1 to 100).map(i => s"file$i" -> 128*1024*1024)
       val table = createTable(files = partitions)
-      assert(table.rdd.partitions.length == 16)
+      // partition is limit by filesMaxPartitionBytes(128MB)
+      assert(table.rdd.partitions.length == 100)
     }
 
     withSQLConf(SQLConf.FILES_MIN_PARTITION_NUM.key -> "32") {
-      val partitions = (1 to 500).map(i => s"file$i" -> 4*1024*1024)
+      val partitions = (1 to 800).map(i => s"file$i" -> 4*1024*1024)
       val table = createTable(files = partitions)
       assert(table.rdd.partitions.length == 32)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -526,17 +526,17 @@ class FileSourceStrategySuite extends QueryTest with SharedSparkSession with Pre
         assert(scan.head.scan.readSchema() == StructType(StructField("key", LongType) :: Nil))
       }
     }
+  }
 
-    test("Add spark.sql.files.minPartitionNum config") {
-      withSQLConf(SQLConf.FILES_MIN_PARTITION_NUM.key -> "1") {
-        val table =
-          createTable(files = Seq(
-            "file1" -> 1,
-            "file2" -> 1,
-            "file3" -> 1,
-          ))
-        assert(table.rdd.partitions.length == 1)
-      }
+  test("Add spark.sql.files.minPartitionNum config") {
+    withSQLConf(SQLConf.FILES_MIN_PARTITION_NUM.key -> "1") {
+      val table =
+        createTable(files = Seq(
+          "file1" -> 1,
+          "file2" -> 1,
+          "file3" -> 1,
+        ))
+      assert(table.rdd.partitions.length == 1)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -550,14 +550,14 @@ class FileSourceStrategySuite extends QueryTest with SharedSparkSession with Pre
     }
 
     withSQLConf(SQLConf.FILES_MIN_PARTITION_NUM.key -> "16") {
-      val partitions = (1 to 100).map(i => s"file$i" -> 128*1024*1024)
+      val partitions = (1 to 100).map(i => s"file$i" -> 128 * 1024 * 1024)
       val table = createTable(files = partitions)
-      // partition is limit by filesMaxPartitionBytes(128MB)
+      // partition is limited by filesMaxPartitionBytes(128MB)
       assert(table.rdd.partitions.length == 100)
     }
 
     withSQLConf(SQLConf.FILES_MIN_PARTITION_NUM.key -> "32") {
-      val partitions = (1 to 800).map(i => s"file$i" -> 4*1024*1024)
+      val partitions = (1 to 800).map(i => s"file$i" -> 4 * 1024 * 1024)
       val table = createTable(files = partitions)
       assert(table.rdd.partitions.length == 50)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -528,7 +528,7 @@ class FileSourceStrategySuite extends QueryTest with SharedSparkSession with Pre
     }
   }
 
-  test("Add spark.sql.files.minPartitionNum config") {
+  test("SPARK-32019: Add spark.sql.files.minPartitionNum config") {
     withSQLConf(SQLConf.FILES_MIN_PARTITION_NUM.key -> "1") {
       val table =
         createTable(files = Seq(
@@ -547,6 +547,18 @@ class FileSourceStrategySuite extends QueryTest with SharedSparkSession with Pre
           "file3" -> 1
         ))
       assert(table.rdd.partitions.length == 3)
+    }
+
+    withSQLConf(SQLConf.FILES_MIN_PARTITION_NUM.key -> "16") {
+      val partitions = (1 to 100).map(i => s"file$i" -> 128*1024*1024)
+      val table = createTable(files = partitions)
+      assert(table.rdd.partitions.length == 16)
+    }
+
+    withSQLConf(SQLConf.FILES_MIN_PARTITION_NUM.key -> "32") {
+      val partitions = (1 to 500).map(i => s"file$i" -> 4*1024*1024)
+      val table = createTable(files = partitions)
+      assert(table.rdd.partitions.length == 32)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -534,7 +534,7 @@ class FileSourceStrategySuite extends QueryTest with SharedSparkSession with Pre
         createTable(files = Seq(
           "file1" -> 1,
           "file2" -> 1,
-          "file3" -> 1,
+          "file3" -> 1
         ))
       assert(table.rdd.partitions.length == 1)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -526,6 +526,18 @@ class FileSourceStrategySuite extends QueryTest with SharedSparkSession with Pre
         assert(scan.head.scan.readSchema() == StructType(StructField("key", LongType) :: Nil))
       }
     }
+
+    test("Add spark.sql.files.minPartitionNum config") {
+      withSQLConf(SQLConf.FILES_MIN_PARTITION_NUM.key -> "1") {
+        val table =
+          createTable(files = Seq(
+            "file1" -> 1,
+            "file2" -> 1,
+            "file3" -> 1,
+          ))
+        assert(table.rdd.partitions.length == 1)
+      }
+    }
   }
 
   // Helpers for checking the arguments passed to the FileFormat.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -559,7 +559,7 @@ class FileSourceStrategySuite extends QueryTest with SharedSparkSession with Pre
     withSQLConf(SQLConf.FILES_MIN_PARTITION_NUM.key -> "32") {
       val partitions = (1 to 800).map(i => s"file$i" -> 4*1024*1024)
       val table = createTable(files = partitions)
-      assert(table.rdd.partitions.length == 32)
+      assert(table.rdd.partitions.length == 50)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -538,6 +538,16 @@ class FileSourceStrategySuite extends QueryTest with SharedSparkSession with Pre
         ))
       assert(table.rdd.partitions.length == 1)
     }
+
+    withSQLConf(SQLConf.FILES_MIN_PARTITION_NUM.key -> "10") {
+      val table =
+        createTable(files = Seq(
+          "file1" -> 1,
+          "file2" -> 1,
+          "file3" -> 1
+        ))
+      assert(table.rdd.partitions.length == 3)
+    }
   }
 
   // Helpers for checking the arguments passed to the FileFormat.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add a new config `spark.sql.files.minPartitionNum` to control file split partition in local session.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Aims to control file split partitions in session level.
More details see discuss in [PR-28778](https://github.com/apache/spark/pull/28778).

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, new config.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Add UT.