### PR TITLE
[SPARK-31982][SQL]Function sequence doesn't handle date increments that cross DST

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -2631,8 +2631,8 @@ object Sequence {
           (num.toLong(start), num.toLong(stop))
         }
         else {
-          (DateTimeUtils.epochDaysToMicros(num.toInt(start), zoneId),
-            DateTimeUtils.epochDaysToMicros(num.toInt(stop), zoneId))
+          (daysToMicros(num.toInt(start), zoneId),
+            daysToMicros(num.toInt(stop), zoneId))
         }
 
         val maxEstimatedArrayLength =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -2636,7 +2636,7 @@ object Sequence {
 
         while (t < exclusiveItem ^ stepSign < 0) {
           arr(i) = if (scale == 1) {
-            fromLong(t / scale)
+            fromLong(t)
           } else {
             fromLong(Math.round(t / scale.toFloat))
           }
@@ -2703,7 +2703,7 @@ object Sequence {
          |
          |  while ($t < $exclusiveItem ^ $stepSign < 0) {
          |    if (${scale}L == 1L) {
-         |      $arr[$i] = ($elemType) ($t / ${scale}L);
+         |      $arr[$i] = ($elemType) $t;
          |    } else {
          |      $arr[$i] = ($elemType) (Math.round($t / (float)${scale}L));
          |    }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -2589,6 +2589,8 @@ object Sequence {
     }
   }
 
+  // To generate time sequences, we use scale 1 in TemporalSequenceImpl
+  // for `TimestampType`, while MICROS_PER_DAY for `DateType`
   private class TemporalSequenceImpl[T: ClassTag]
       (dt: IntegralType, scale: Long, fromLong: Long => T, zoneId: ZoneId)
       (implicit num: Integral[T]) extends SequenceImpl {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -2635,7 +2635,7 @@ object Sequence {
         var i = 0
 
         while (t < exclusiveItem ^ stepSign < 0) {
-          arr(i) = fromLong(t / scale)
+          arr(i) = fromLong(Math.round(t / scale.toFloat))
           i += 1
           t = timestampAddInterval(
             startMicros, i * stepMonths, i * stepDays, i * stepMicros, zoneId)
@@ -2698,7 +2698,7 @@ object Sequence {
          |  int $i = 0;
          |
          |  while ($t < $exclusiveItem ^ $stepSign < 0) {
-         |    $arr[$i] = ($elemType) ($t / ${scale}L);
+         |    $arr[$i] = ($elemType) (Math.round($t / (float)${scale}L));
          |    $i += 1;
          |    $t = org.apache.spark.sql.catalyst.util.DateTimeUtils.timestampAddInterval(
          |       $startMicros, $i * $stepMonths, $i * $stepDays, $i * $stepMicros, $zid);

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -2635,7 +2635,11 @@ object Sequence {
         var i = 0
 
         while (t < exclusiveItem ^ stepSign < 0) {
-          arr(i) = fromLong(Math.round(t / scale.toFloat))
+          arr(i) = if (scale == 1) {
+            fromLong(t / scale)
+          } else {
+            fromLong(Math.round(t / scale.toFloat))
+          }
           i += 1
           t = timestampAddInterval(
             startMicros, i * stepMonths, i * stepDays, i * stepMicros, zoneId)
@@ -2698,7 +2702,11 @@ object Sequence {
          |  int $i = 0;
          |
          |  while ($t < $exclusiveItem ^ $stepSign < 0) {
-         |    $arr[$i] = ($elemType) (Math.round($t / (float)${scale}L));
+         |    if (${scale}L == 1L) {
+         |      $arr[$i] = ($elemType) ($t / ${scale}L);
+         |    } else {
+         |      $arr[$i] = ($elemType) (Math.round($t / (float)${scale}L));
+         |    }
          |    $i += 1;
          |    $t = org.apache.spark.sql.catalyst.util.DateTimeUtils.timestampAddInterval(
          |       $startMicros, $i * $stepMonths, $i * $stepDays, $i * $stepMicros, $zid);

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -2623,8 +2623,6 @@ object Sequence {
         // about a month length in days and a day length in microseconds
         val intervalStepInMicros =
           stepMicros + stepMonths * microsPerMonth + stepDays * microsPerDay
-        val startMicros: Long = num.toLong(start) * scale
-        val stopMicros: Long = num.toLong(stop) * scale
 
         // Date to timestamp is not equal from GMT and Chicago timezones
         val (startMicros, stopMicros) = if (scale == 1) {
@@ -2699,8 +2697,19 @@ object Sequence {
          |} else if ($stepMonths == 0 && $stepDays == 0 && ${scale}L == 1) {
          |  ${backedSequenceImpl.genCode(ctx, start, stop, stepMicros, arr, elemType)};
          |} else {
-         |  final long $startMicros = $start * ${scale}L;
-         |  final long $stopMicros = $stop * ${scale}L;
+         |  long $startMicros;
+         |  long $stopMicros;
+         |  if (${scale}L == 1L) {
+         |    $startMicros = $start;
+         |    $stopMicros = $stop;
+         |  } else {
+         |    $startMicros =
+         |      org.apache.spark.sql.catalyst.util.DateTimeUtils.daysToMicros(
+         |        (int)$start, $zid);
+         |    $stopMicros =
+         |      org.apache.spark.sql.catalyst.util.DateTimeUtils.daysToMicros(
+         |        (int)$stop, $zid);
+         |  }
          |
          |  $sequenceLengthCode
          |

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -2625,6 +2625,16 @@ object Sequence {
           stepMicros + stepMonths * microsPerMonth + stepDays * microsPerDay
         val startMicros: Long = num.toLong(start) * scale
         val stopMicros: Long = num.toLong(stop) * scale
+
+        // Date to timestamp is not equal from GMT and Chicago timezones
+        val (startMicros, stopMicros) = if (scale == 1) {
+          (num.toLong(start), num.toLong(stop))
+        }
+        else {
+          (DateTimeUtils.epochDaysToMicros(num.toInt(start), zoneId),
+            DateTimeUtils.epochDaysToMicros(num.toInt(stop), zoneId))
+        }
+
         val maxEstimatedArrayLength =
           getSequenceLength(startMicros, stopMicros, intervalStepInMicros)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -1854,17 +1854,18 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
       Literal(Date.valueOf("2018-01-01")),
       Literal(stringToInterval("interval 1 year"))),
       Seq(Date.valueOf("2018-01-01")))
-=======
+
   test("SPARK-31982: sequence doesn't handle date increments that cross DST") {
     Array("America/Chicago", "GMT", "Asia/Shanghai").foreach(tz => {
-      checkEvaluation(Sequence(
-        Cast(Literal("2011-03-01"), DateType),
-        Cast(Literal("2011-04-01"), DateType),
-        Option(Literal(stringToInterval("interval 1 month"))),
-        Option(tz)),
-        Seq(
-          Date.valueOf("2011-03-01"), Date.valueOf("2011-04-01")))
+      DateTimeTestUtils.withDefaultTimeZone(DateTimeUtils.getTimeZone(tz).toZoneId) {
+        checkEvaluation(Sequence(
+          Cast(Literal("2011-03-01"), DateType),
+          Cast(Literal("2011-04-01"), DateType),
+          Option(Literal(stringToInterval("interval 1 month"))),
+          Option(tz)),
+          Seq(
+            Date.valueOf("2011-03-01"), Date.valueOf("2011-04-01")))
+      }
     })
->>>>>>> Asia timezone fix
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -1856,14 +1856,15 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
   }
 
   test("SPARK-31982: sequence doesn't handle date increments that cross DST") {
-    Array("America/Chicago", "GMT").foreach(tz => {
-      checkEvaluation(Sequence(
-        Cast(Literal("2011-03-01"), DateType),
-        Cast(Literal("2011-04-01"), DateType),
-        Option(Literal(stringToInterval("interval 1 month"))),
-        Option(tz)),
-        Seq(
-          Date.valueOf("2011-03-01"), Date.valueOf("2011-04-01")))
+    Array("America/Chicago", "GMT", "Asia/Shanghai").foreach(tz => {
+      DateTimeTestUtils.withDefaultTimeZone(DateTimeUtils.getZoneId(tz)) {
+        checkEvaluation(Sequence(
+          Cast(Literal("2011-03-01"), DateType),
+          Cast(Literal("2011-04-01"), DateType),
+          Option(Literal(stringToInterval("interval 1 month"))),
+          Option(tz)),
+          Seq(Date.valueOf("2011-03-01"), Date.valueOf("2011-04-01")))
+      }
     })
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -1837,6 +1837,7 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
     checkEvaluation(ArrayIntersect(oneNull, empty), Seq.empty)
   }
 
+<<<<<<< HEAD
   test("SPARK-31980: Start and end equal in month range") {
     checkEvaluation(new Sequence(
       Literal(Date.valueOf("2018-01-01")),
@@ -1853,5 +1854,17 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
       Literal(Date.valueOf("2018-01-01")),
       Literal(stringToInterval("interval 1 year"))),
       Seq(Date.valueOf("2018-01-01")))
+=======
+  test("SPARK-31982: sequence doesn't handle date increments that cross DST") {
+    Array("America/Chicago", "GMT", "Asia/Shanghai").foreach(tz => {
+      checkEvaluation(Sequence(
+        Cast(Literal("2011-03-01"), DateType),
+        Cast(Literal("2011-04-01"), DateType),
+        Option(Literal(stringToInterval("interval 1 month"))),
+        Option(tz)),
+        Seq(
+          Date.valueOf("2011-03-01"), Date.valueOf("2011-04-01")))
+    })
+>>>>>>> Asia timezone fix
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -1837,7 +1837,6 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
     checkEvaluation(ArrayIntersect(oneNull, empty), Seq.empty)
   }
 
-<<<<<<< HEAD
   test("SPARK-31980: Start and end equal in month range") {
     checkEvaluation(new Sequence(
       Literal(Date.valueOf("2018-01-01")),
@@ -1854,17 +1853,17 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
       Literal(Date.valueOf("2018-01-01")),
       Literal(stringToInterval("interval 1 year"))),
       Seq(Date.valueOf("2018-01-01")))
+  }
 
   test("SPARK-31982: sequence doesn't handle date increments that cross DST") {
-    Array("America/Chicago", "GMT", "Asia/Shanghai").foreach(tz => {
-      DateTimeTestUtils.withDefaultTimeZone(DateTimeUtils.getTimeZone(tz).toZoneId) {
-        checkEvaluation(Sequence(
-          Cast(Literal("2011-03-01"), DateType),
-          Cast(Literal("2011-04-01"), DateType),
-          Option(Literal(stringToInterval("interval 1 month"))),
-          Option(tz)),
-          Seq(Date.valueOf("2011-03-01"), Date.valueOf("2011-04-01")))
-      }
+    Array("America/Chicago", "GMT").foreach(tz => {
+      checkEvaluation(Sequence(
+        Cast(Literal("2011-03-01"), DateType),
+        Cast(Literal("2011-04-01"), DateType),
+        Option(Literal(stringToInterval("interval 1 month"))),
+        Option(tz)),
+        Seq(
+          Date.valueOf("2011-03-01"), Date.valueOf("2011-04-01")))
     })
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -1863,8 +1863,7 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
           Cast(Literal("2011-04-01"), DateType),
           Option(Literal(stringToInterval("interval 1 month"))),
           Option(tz)),
-          Seq(
-            Date.valueOf("2011-03-01"), Date.valueOf("2011-04-01")))
+          Seq(Date.valueOf("2011-03-01"), Date.valueOf("2011-04-01")))
       }
     })
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a unit test.
Logical bug fix in `org.apache.spark.sql.catalyst.expressions.Sequence.TemporalSequenceImpl`

### Why are the changes needed?
Spark sequence doesn't handle date increments that cross DST

### Does this PR introduce _any_ user-facing change?
Before the PR, people will not get a correct result：
`set spark.sql.session.timeZone` to `Asia/Shanghai, America/Chicago, GMT`, 
Before execute 
`sql("select sequence(cast('2011-03-01' as date), cast('2011-05-01' as date), interval 1 month)").show(false)`, People will get `[2011-03-01, 2011-04-01, 2011-05-01]`, **`[2011-03-01, 2011-03-28, 2011-04-28]`**, `[2011-03-01, 2011-04-01, 2011-05-01]`.

After the PR, sequence date conversion is corrected：
We will get `[2011-03-01, 2011-04-01, 2011-05-01]` from the former three conditions.

### How was this patch tested?
Unit test.