### PR TITLE
[SPARK-32002][SQL]Support ExtractValue from nested ArrayStruct

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SelectedFieldSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SelectedFieldSuite.scala
@@ -378,12 +378,6 @@ class SelectedFieldSuite extends AnalysisTest {
         StructField("subfield1", IntegerType, nullable = false) :: Nil)) :: Nil)))
   }
 
-  testSelect(arrayWithMultipleFields, "col7.field3.subfield1") {
-    StructField("col7", ArrayType(StructType(
-      StructField("field3", ArrayType(StructType(
-        StructField("subfield1", IntegerType, nullable = false) :: Nil))) :: Nil)))
-  }
-
   // Array with a nested int array
   //  |-- col1: string (nullable = false)
   //  |-- col8: array (nullable = true)

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3524,7 +3524,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     }
   }
 
-  test("SPARK-32002: Support Extract valve from nested ArrayStruct") {
+  test("SPARK-32002: Support Extract value from nested ArrayStruct") {
     withTempView("rows") {
       val df = spark.read
         .json(Seq(

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -22,11 +22,9 @@ import java.net.{MalformedURLException, URL}
 import java.sql.{Date, Timestamp}
 import java.util.concurrent.atomic.AtomicBoolean
 
-import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.{AccumulatorSuite, SparkException}
-
 import org.apache.spark.scheduler.{SparkListener, SparkListenerJobStart}
 import org.apache.spark.sql.catalyst.expressions.GenericRow
 import org.apache.spark.sql.catalyst.expressions.aggregate.{Complete, Partial}

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3526,7 +3526,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     }
   }
 
-  test("SPARK-32002: Support Extract valve from nested Array(a:Struct(Array(b:Struct)))") {
+  test("SPARK-32002: Support Extract valve from nested ArrayStruct") {
     withTempView("rows") {
       val df = spark.read
         .json(Seq(


### PR DESCRIPTION
### What changes were proposed in this pull request?

For data `nest.json`

```json
{"a": [{"b": [{"c": [1,2]}]}]}
{"a": [{"b": [{"c": [1]}, {"c": [2]}]}]}
```
run with 

```scala
val df: DataFrame = spark.read.json(testFile("nest-data.json"))
df.createTempView("nest_table")
sql("select a.b.c from nest_table").show()
```

will got error 

```
org.apache.spark.sql.AnalysisException: cannot resolve 'nest_table.`a`.`b`['c']' due to data type mismatch: argument 2 requires integral type, however, ''c'' is of string type.; line 1 pos 7;
'Project [a#6.b[c] AS c#8|#6.b[c] AS c#8]
+- SubqueryAlias `nest_table`
+- Relationa#6 json
```

This is because after resolve `a.b`, it construct `GetArrayStructField` from `a#`
result with type `ArrayType(ArrayType(StructType))`, then it can't be extract through current `ExtractValue` method.

Support extract `StructField` form nested Array-Struct combination

### Why are the changes needed?

Support more use case 


### Does this PR introduce _any_ user-facing change?

Yes, users will be able to select from nested array and structs.

### How was this patch tested?

Added UT
