### PR TITLE
[SPARK-32039][YARN][WEBUI][2.4] Adding Check to not to set UI port (spark.ui.port) property if mentioned explicitly

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -254,9 +254,11 @@ private[spark] class ApplicationMaster(args: ApplicationMasterArguments) extends
       var attemptID: Option[String] = None
 
       if (isClusterMode) {
-        // Set the web ui port to be ephemeral for yarn so we don't conflict with
-        // other spark processes running on the same box
-        System.setProperty("spark.ui.port", "0")
+        // Set the web ui port to be ephemeral for yarn if not set explicitly
+        // so we don't conflict with other spark processes running on the same box
+        if (System.getProperty("spark.ui.port") != null) {
+          System.setProperty("spark.ui.port", "0")
+        }
 
         // Set the master and deploy mode property to match the requested mode.
         System.setProperty("spark.master", "yarn")

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -254,9 +254,10 @@ private[spark] class ApplicationMaster(args: ApplicationMasterArguments) extends
       var attemptID: Option[String] = None
 
       if (isClusterMode) {
-        // Set the web ui port to be ephemeral for yarn so we don't conflict with
+        // Set the web ui port to be ephemeral for yarn if not set explicitly so we don't conflict with
         // other spark processes running on the same box
-        System.setProperty("spark.ui.port", "0")
+        if (System.getProperty("spark.ui.port") != null)
+          System.setProperty("spark.ui.port", "0")
 
         // Set the master and deploy mode property to match the requested mode.
         System.setProperty("spark.master", "yarn")


### PR DESCRIPTION
**What changes were proposed in this pull request?**
When a Spark Job launched in Cluster mode with Yarn, Application Master sets `spark.ui.port` port to 0 which means Driver's web UI gets any random port even if we want to explicitly set the Port range for Driver's Web UI

**Why are the changes needed?**
We access Spark Web UI via Knox Proxy, and there are firewall restrictions due to which we can not access Spark Web UI since Web UI port range gets random port even if we set explicitly. 

This Change will check if there is a specified port range explicitly mentioned so that it does not assign a random port. 

**Does this PR introduce any user-facing change?**
No

**How was this patch tested?**
Local Tested.