### PR TITLE
[SPARK-29465][YARN][WEBUI] Adding Check to not to set UI port (spark.ui.port) property if mentioned explicitly

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -211,9 +211,11 @@ private[spark] class ApplicationMaster(
   final def run(): Int = {
     try {
       val attemptID = if (isClusterMode) {
-        // Set the web ui port to be ephemeral for yarn so we don't conflict with
-        // other spark processes running on the same box
-        System.setProperty(UI_PORT.key, "0")
+        // Set the web ui port to be ephemeral for yarn if not set explicitly
+        // so we don't conflict with other spark processes running on the same box
+        if (System.getProperty(UI_PORT.key) != null) {
+          System.setProperty(UI_PORT.key, "0")
+        }
 
         // Set the master and deploy mode property to match the requested mode.
         System.setProperty("spark.master", "yarn")

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -213,6 +213,8 @@ private[spark] class ApplicationMaster(
       val attemptID = if (isClusterMode) {
         // Set the web ui port to be ephemeral for yarn if not set explicitly
         // so we don't conflict with other spark processes running on the same box
+        // If set explicitly, Web UI will attempt to run on UI_PORT and try 
+        // incrementally until UI_PORT + `spark.port.maxRetries`
         if (System.getProperty(UI_PORT.key) == null) {
           System.setProperty(UI_PORT.key, "0")
         }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -213,6 +213,8 @@ private[spark] class ApplicationMaster(
       val attemptID = if (isClusterMode) {
         // Set the web ui port to be ephemeral for yarn if not set explicitly
         // so we don't conflict with other spark processes running on the same box
+        // If set explicitly, Web UI will attempt to run on UI_PORT and try
+        // incrementally until UI_PORT + `spark.port.maxRetries`
         if (System.getProperty(UI_PORT.key) == null) {
           System.setProperty(UI_PORT.key, "0")
         }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -213,7 +213,7 @@ private[spark] class ApplicationMaster(
       val attemptID = if (isClusterMode) {
         // Set the web ui port to be ephemeral for yarn if not set explicitly
         // so we don't conflict with other spark processes running on the same box
-        if (System.getProperty(UI_PORT.key) != null) {
+        if (System.getProperty(UI_PORT.key) == null) {
           System.setProperty(UI_PORT.key, "0")
         }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
When a Spark Job launched in Cluster mode with Yarn, Application Master sets spark.ui.port port to 0 which means Driver's web UI gets any random port even if we want to explicitly set the Port range for Driver's Web UI

## Why are the changes needed?
We access Spark Web UI via Knox Proxy, and there are firewall restrictions due to which we can not access Spark Web UI since Web UI port range gets random port even if we set explicitly.

This Change will check if there is a specified port range explicitly mentioned so that it does not assign a random port.

## Does this PR introduce any user-facing change?
No

## How was this patch tested?
Local Tested.