### PR TITLE
[SPARK-32041][SQL] Fix Exchange reuse issues when subqueries are involved

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.catalyst.util.StringUtils.PlanStringConcat
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.execution.adaptive.{AdaptiveExecutionContext, InsertAdaptiveSparkPlan}
 import org.apache.spark.sql.execution.dynamicpruning.PlanDynamicPruningFilters
-import org.apache.spark.sql.execution.exchange.{EnsureRequirements, ReuseExchange}
+import org.apache.spark.sql.execution.exchange.{EnsureRequirements, ReuseExchangeAndSubquery}
 import org.apache.spark.sql.execution.streaming.{IncrementalExecution, OffsetSeqMetadata}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.OutputMode
@@ -337,8 +337,7 @@ object QueryExecution {
       ApplyColumnarRulesAndInsertTransitions(sparkSession.sessionState.conf,
         sparkSession.sessionState.columnarRules),
       CollapseCodegenStages(sparkSession.sessionState.conf),
-      ReuseExchange(sparkSession.sessionState.conf),
-      ReuseSubquery(sparkSession.sessionState.conf)
+      ReuseExchangeAndSubquery(sparkSession.sessionState.conf)
     )
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/ReuseExchangeAndSubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ReuseExchangeAndSubquerySuite.scala
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import scala.collection.mutable
+
+import org.apache.spark.sql.execution._
+import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, Exchange, ReusedExchangeExec, ShuffleExchangeExec}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+
+class ReuseExchangeAndSubquerySuite extends QueryTest with SharedSparkSession {
+
+  import testImplicits._
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    val factData = (0 to 100).map(i => (i%5, i%20, i))
+    factData.toDF("store_id", "product_id", "units_sold")
+      .write
+      .partitionBy("store_id")
+      .format("parquet")
+      .saveAsTable("fact_stats")
+
+    val dimData = Seq[(Int, String, String)](
+      (1, "AU", "US"),
+      (2, "CA", "US"),
+      (3, "KA", "IN"),
+      (4, "DL", "IN"),
+      (5, "GA", "PA")
+    )
+    dimData.toDF("store_id", "state_province", "country")
+      .write
+      .format("parquet")
+      .saveAsTable("dim_stats")
+    sql("ANALYZE TABLE fact_stats COMPUTE STATISTICS FOR COLUMNS store_id")
+    sql("ANALYZE TABLE dim_stats COMPUTE STATISTICS FOR COLUMNS store_id")
+  }
+
+  override def afterAll(): Unit = {
+    sql("DROP TABLE IF EXISTS fact_stats")
+    sql("DROP TABLE IF EXISTS dim_stats")
+    super.afterAll()
+  }
+
+  private def getAllExchangesAndSubqueries(plan: SparkPlan): Seq[SparkPlan] = {
+    val allExchangesAndSubqueries = new mutable.ListBuffer[SparkPlan]
+    allExchangesAndSubqueries ++= plan.collect {
+      case re: ReusedExchangeExec => re
+      case rs: ReusedSubqueryExec => rs
+      case e: Exchange => e
+      case e: BaseSubqueryExec => e
+    }
+    plan.transformAllExpressions {
+      case e: ExecSubqueryExpression =>
+        allExchangesAndSubqueries ++= getAllExchangesAndSubqueries(e.plan)
+        e
+    }
+    allExchangesAndSubqueries
+  }
+
+  private def validateReuseExchangesAndReuseSubqueries(
+      plan: SparkPlan,
+      expectedReuseBroadcastExchanges: Int,
+      expectedReuseShuffleExchanges: Int,
+      expectedReuseSubqueries: Int): Unit = {
+    val plans = getAllExchangesAndSubqueries(plan)
+    val shuffleExchangeIds = plans.filter(_.isInstanceOf[ShuffleExchangeExec]).map(_.id)
+    val broadcastExchangeIds = plans.filter(_.isInstanceOf[BroadcastExchangeExec]).map(_.id)
+    val referencedShuffleExchangeIds = plans.flatMap {
+      case r: ReusedExchangeExec if r.child.isInstanceOf[ShuffleExchangeExec] => Some(r.child.id)
+      case _ => None
+    }
+    val referencedBroadcastExchangeIds = plans.flatMap {
+      case r: ReusedExchangeExec if r.child.isInstanceOf[BroadcastExchangeExec] => Some(r.child.id)
+      case _ => None
+    }
+    val subqueryIds = plans.filter(_.isInstanceOf[BaseSubqueryExec]).map(_.id)
+    val referencedSubqueryIds = plans.flatMap {
+      case r: ReusedSubqueryExec => Some(r.child.id)
+      case _ => None
+    }
+
+    val missingBroadcastExchangeIds = referencedBroadcastExchangeIds.toSet.diff(
+      broadcastExchangeIds.toSet)
+    assert(missingBroadcastExchangeIds.isEmpty, "ReusedExchangeExec pointing to incorrect " +
+      s"BroadcastExchangeExec IDs [${missingBroadcastExchangeIds.mkString(",")}] in plan:\n $plan")
+
+    val missingShuffleExchangeIds = referencedShuffleExchangeIds.toSet.diff(
+      shuffleExchangeIds.toSet)
+    assert(missingShuffleExchangeIds.isEmpty, "ReusedExchangeExec pointing to incorrect " +
+      s"ShuffleExchangeExec IDs [${missingShuffleExchangeIds.mkString(",")}] in plan:\n $plan")
+
+    val missingSubqueryExchanges = referencedSubqueryIds.toSet.diff(subqueryIds.toSet)
+    assert(missingSubqueryExchanges.isEmpty, "ReusedSubqueryExec pointing to incorrect" +
+      s" Subquery [${missingSubqueryExchanges.mkString(",")}] in plan:\n $plan")
+
+    assert(referencedSubqueryIds.size == expectedReuseSubqueries, s"Expected " +
+      s"$expectedReuseSubqueries ReusedSubqueryExec in Plan, " +
+      s"found - ${referencedSubqueryIds.size}. Plan:\n $plan")
+
+    assert(referencedBroadcastExchangeIds.size == expectedReuseBroadcastExchanges, s"Expected " +
+      s"$expectedReuseBroadcastExchanges ReusedExchangeExec over BroadcastExchangeExec in Plan, " +
+      s"found - ${referencedBroadcastExchangeIds.size}. Plan:\n $plan")
+
+    assert(referencedShuffleExchangeIds.size == expectedReuseShuffleExchanges, s"Expected " +
+      s"$expectedReuseShuffleExchanges ReusedExchangeExec over BroadcastExchangeExec in Plan, " +
+      s"found - ${referencedShuffleExchangeIds.size}. Plan:\n $plan")
+  }
+
+  test("Inner ReusedExchangeExec inside InSubqueryExec should not make reference issues to " +
+    "outer Exchange operators") {
+    withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> "true") {
+      withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "500") {
+        val df = sql(
+          """
+            | With view1 as (
+            |   SELECT product_id, f.store_id
+            |   FROM fact_stats f JOIN dim_stats
+            |   ON f.store_id = dim_stats.store_id WHERE dim_stats.country = 'IN')
+            |
+            | SELECT * FROM view1 v1 join view1 v2 WHERE v1.product_id = v2.product_id
+      """.stripMargin)
+        // Here we are doing: `v1 join v1` where v1 = fact_stats join dim_stats
+        // So v1 should be computed only once and We should have a ReusedExchangeExec
+        // for ShuffleExchangeExec. Also DPP will trigger inside v1. So we should have
+        // ReusedExchangeExec for BroadcastExchangeExec
+        validateReuseExchangesAndReuseSubqueries(df.queryExecution.executedPlan, 1, 1, 0)
+      }
+    }
+  }
+
+  test("test reuse exchange inside a reuse subquery") {
+    withSQLConf(SQLConf.EXCHANGE_REUSE_ENABLED.key -> "true") {
+      withSQLConf(SQLConf.SUBQUERY_REUSE_ENABLED.key -> "true") {
+        withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+          val df = sql(
+            """
+              | With v1 as (
+              |   SELECT f1.store_id
+              |   FROM fact_stats f1 join fact_stats f2
+              |   WHERE f1.store_id = f2.store_id
+              | )
+              | SELECT (SELECT max(store_id) from v1), (SELECT max(store_id) from v1)
+            """.stripMargin)
+          validateReuseExchangesAndReuseSubqueries(df.queryExecution.executedPlan, 0, 1, 1)
+        }
+      }
+    }
+  }
+
+  Seq(true, false).foreach { broadcastJoin =>
+    test("test reuse exchange when child of reuse exchange contains " +
+      s"reusable subquery (broadcast join: $broadcastJoin)") {
+      withSQLConf(SQLConf.EXCHANGE_REUSE_ENABLED.key -> "true") {
+        withSQLConf(SQLConf.SUBQUERY_REUSE_ENABLED.key -> "true") {
+          // withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "false") {
+          val autoBroadcastJoinThreshold = if (broadcastJoin) 1024 * 1024 * 1024 else -1
+          withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> s"$autoBroadcastJoinThreshold") {
+            val df = sql(
+              """
+                | With view1 as (
+                |   SELECT product_id, units_sold
+                |   FROM fact_stats
+                |   WHERE store_id = (SELECT max(store_id) FROM dim_stats)
+                |         and units_sold = 2
+                | ), view2 as (
+                |   SELECT product_id, units_sold
+                |   FROM fact_stats
+                |   WHERE store_id = (SELECT max(store_id) FROM dim_stats)
+                |         and units_sold = 1
+                | )
+                |
+                | SELECT *
+                | FROM view1 v1 join view2 v2 join view2 v3
+                | WHERE v1.product_id = v2.product_id and v2.product_id = v3.product_id
+      """.stripMargin)
+            // view2 is self joined. So one of them should be Exchange and other should
+            // be ReusedExchangeExec.
+            // Also the subquery is repeated thrice. But one of them is inside ReusedExchangeExec.
+            // So out of remaining two, one will be ReusedSubqueryExec
+            if (broadcastJoin) {
+              validateReuseExchangesAndReuseSubqueries(df.queryExecution.executedPlan, 1, 0, 1)
+            } else {
+              validateReuseExchangesAndReuseSubqueries(df.queryExecution.executedPlan, 0, 1, 1)
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper, DisableAdaptiveExecution}
 import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
 import org.apache.spark.sql.execution.columnar.{InMemoryRelation, InMemoryTableScanExec}
-import org.apache.spark.sql.execution.exchange.{EnsureRequirements, ReusedExchangeExec, ReuseExchange, ShuffleExchangeExec}
+import org.apache.spark.sql.execution.exchange.{EnsureRequirements, ReusedExchangeExec, ReuseExchangeAndSubquery, ShuffleExchangeExec}
 import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, SortMergeJoinExec}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
@@ -476,7 +476,7 @@ class PlannerSuite extends SharedSparkSession with AdaptiveSparkPlanHelper {
       shuffle,
       shuffle)
 
-    val outputPlan = ReuseExchange(spark.sessionState.conf).apply(inputPlan)
+    val outputPlan = ReuseExchangeAndSubquery(spark.sessionState.conf).apply(inputPlan)
     if (outputPlan.collect { case e: ReusedExchangeExec => true }.size != 1) {
       fail(s"Should re-use the shuffle:\n$outputPlan")
     }
@@ -493,7 +493,7 @@ class PlannerSuite extends SharedSparkSession with AdaptiveSparkPlanHelper {
       ShuffleExchangeExec(finalPartitioning, inputPlan),
       ShuffleExchangeExec(finalPartitioning, inputPlan))
 
-    val outputPlan2 = ReuseExchange(spark.sessionState.conf).apply(inputPlan2)
+    val outputPlan2 = ReuseExchangeAndSubquery(spark.sessionState.conf).apply(inputPlan2)
     if (outputPlan2.collect { case e: ReusedExchangeExec => true }.size != 2) {
       fail(s"Should re-use the two shuffles:\n$outputPlan2")
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Create a single post-order rule for ReuseExchange and ReuseSubquery which traverses the plan in 1 single post order and replaces duplicated nodes with ReusedExchangeExec, ReuseSubqueryExec.

This fixes the `ReusedExchangeExec Reference issue` where a ReusedExchangeExec points to an Exchange which doesn't exist in entire query plan.


### Why are the changes needed?

Currently Spark do 3 iterations on plan to identify and replace nodes which can be ReusedExchangeExec and ReusedSubqueryExec:
Phase-1: First one is done in ReuseExchange rule to replace Exchange with ReusedExchangeExec. 
Phase-2: Seconds one is introduces by DPP in ReuseExchange rule to find out all the InSubqueryExec and traverse the plans inside it and replace relevant Exchange with ReusedSubqueryExec. 
Phase-3: Third we do in ReuseSubquery rule to identify ExecSubqueryExpression which are reusable and replace them with ReuseSubqueryExec.

When any change is done by Phase-2/Phase-3 in a subtree of Exchange, then the id of exchange will change. and sometimes this leads to another ReusedExchangeExec pointing to Exchange which doesn't exist in plan.

Example: Suppose this is the plan after Phase-1 when we try to do self join of a view.

                                     SORTMERGEJOIN         
           Exchange (id=1234)                          ReusedExchangeExec (points-to-id=1234)
                          |
                     ChildSubtree

Suppose ChildSubtree has DPP applied inside it. So Phase-2 will try to convert plan inside InSubqueryExec to use ReuseBroadcast and in that process, complete hierarchy of ChildSubtree will also change. i.e.

                                     SORTMERGEJOIN         
           Exchange (id=1878)                        ReusedExchangeExec (points-to-id=1234)
                          |
                    NewChildSubtree

But the `ReusedExchangeExec (points-to-id=1234)` is still pointing to id 1234 and so no reuse will happen.

This PR fixes this issue by merging Phase1,Phase2 and Phase3 into a single post order traversal.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added UTs.

Also tried the fix on TPCDS 1000 scale with Spark 2.4.5 + DPP backported.

  | Time taken before | Time taken after | Improvement
-- | -- | -- | --
query14a | 166991 | 129895 | 22.21
query14b | 168852 | 114782 | 32.02
query23a | 656295 | 495019 | 24.57
query23b | 604754 | 414849 | 31.4
query47 | 53506 | 39816 | 25.59
query57 | 37825 | 29619 | 21.69

