### PR TITLE
[SPARK-32042][SQL] Support UTF8String literals

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -700,6 +700,7 @@ object ScalaReflection extends ScalaReflection {
         val Schema(dataType, nullable) = schemaFor(elementType)
         Schema(ArrayType(dataType, containsNull = nullable), nullable = true)
       case t if isSubtype(t, localTypeOf[String]) => Schema(StringType, nullable = true)
+      case t if isSubtype(t, localTypeOf[UTF8String]) => Schema(StringType, nullable = true)
       case t if isSubtype(t, localTypeOf[java.time.Instant]) =>
         Schema(TimestampType, nullable = true)
       case t if isSubtype(t, localTypeOf[java.sql.Timestamp]) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -62,6 +62,7 @@ object Literal {
     case s: Short => Literal(s, ShortType)
     case s: String => Literal(UTF8String.fromString(s), StringType)
     case c: Char => Literal(UTF8String.fromString(c.toString), StringType)
+    case u: UTF8String => Literal(u, StringType)
     case b: Boolean => Literal(b, BooleanType)
     case d: BigDecimal =>
       val decimal = Decimal(d)
@@ -120,6 +121,7 @@ object Literal {
 
     // other scala classes
     case _ if clz == classOf[String] => StringType
+    case _ if clz == classOf[UTF8String] => StringType
     case _ if clz == classOf[BigInt] => DecimalType.SYSTEM_DEFAULT
     case _ if clz == classOf[BigDecimal] => DecimalType.SYSTEM_DEFAULT
     case _ if clz == classOf[CalendarInterval] => CalendarIntervalType

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.catalyst.util.DateTimeConstants._
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
-import org.apache.spark.unsafe.types.CalendarInterval
+import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 
 class LiteralExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
 
@@ -138,6 +138,14 @@ class LiteralExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(Literal.create(""), "")
     checkEvaluation(Literal.create("test"), "test")
     checkEvaluation(Literal.create("\u0000"), "\u0000")
+
+    checkEvaluation(Literal(UTF8String.fromString("")), "")
+    checkEvaluation(Literal(UTF8String.fromString("test")), "test")
+    checkEvaluation(Literal(UTF8String.fromString("\u0000")), "\u0000")
+
+    checkEvaluation(Literal.create(UTF8String.fromString("")), "")
+    checkEvaluation(Literal.create(UTF8String.fromString("test")), "test")
+    checkEvaluation(Literal.create(UTF8String.fromString("\u0000")), "\u0000")
   }
 
   test("sum two literals") {
@@ -190,6 +198,7 @@ class LiteralExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkArrayLiteral(Array(MICROS_PER_DAY, MICROS_PER_HOUR))
     val arr = collection.mutable.WrappedArray.make(Array(1.0, 4.0))
     checkEvaluation(Literal(arr), toCatalyst(arr))
+    checkArrayLiteral(Array(UTF8String.fromString("y"), UTF8String.fromString("t")))
   }
 
   test("seq") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pr add Support `UTF8String` literals.


### Why are the changes needed?

To fix `Unsupported literal type` for the following use case:

```scala
val min = spark.sql("select min(concat('a', id)) from range(10)").queryExecution.executedPlan.executeCollect().head
assert(Literal(min.get(0, StringType)) === Literal("a0"))
```

```
Unsupported literal type class org.apache.spark.unsafe.types.UTF8String a0
java.lang.RuntimeException: Unsupported literal type class org.apache.spark.unsafe.types.UTF8String a0
	at org.apache.spark.sql.catalyst.expressions.Literal$.apply(literals.scala:89)
```


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Unit test.
