### PR TITLE
[SPARK-32071][SQL][TESTS] Add `make_interval` benchmark

### DIFF
--- a/sql/core/benchmarks/IntervalBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/IntervalBenchmark-jdk11-results.txt
@@ -2,39 +2,39 @@ OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-106
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast strings to intervals:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-prepare string w/ interval                          708            817         107          1.4         707.7       1.0X
-prepare string w/o interval                         671            673           2          1.5         670.7       1.1X
-1 units w/ interval                                 515            525          11          1.9         514.6       1.4X
-1 units w/o interval                                497            508          11          2.0         497.2       1.4X
-2 units w/ interval                                 748            756          10          1.3         747.6       0.9X
-2 units w/o interval                                713            722          12          1.4         713.0       1.0X
-3 units w/ interval                                1467           1470           6          0.7        1466.7       0.5X
-3 units w/o interval                               1435           1439           4          0.7        1435.0       0.5X
-4 units w/ interval                                1717           1730          11          0.6        1717.2       0.4X
-4 units w/o interval                               1696           1701           5          0.6        1696.4       0.4X
-5 units w/ interval                                1936           1945          13          0.5        1935.6       0.4X
-5 units w/o interval                               1897           1901           6          0.5        1897.1       0.4X
-6 units w/ interval                                2086           2105          23          0.5        2086.2       0.3X
-6 units w/o interval                               2067           2070           3          0.5        2067.4       0.3X
-7 units w/ interval                                2538           2548          16          0.4        2537.9       0.3X
-7 units w/o interval                               2515           2518           5          0.4        2514.9       0.3X
-8 units w/ interval                                2728           2735           6          0.4        2727.8       0.3X
-8 units w/o interval                               2727           2736          14          0.4        2726.7       0.3X
-9 units w/ interval                                2906           2932          24          0.3        2906.0       0.2X
-9 units w/o interval                               2923           2930          10          0.3        2922.9       0.2X
-10 units w/ interval                               3276           3280           4          0.3        3276.4       0.2X
-10 units w/o interval                              3266           3272           5          0.3        3266.0       0.2X
-11 units w/ interval                               3493           3497           7          0.3        3493.1       0.2X
-11 units w/o interval                              3444           3451           7          0.3        3443.9       0.2X
+prepare string w/ interval                          708            829         110          1.4         708.0       1.0X
+prepare string w/o interval                         660            672          14          1.5         660.3       1.1X
+1 units w/ interval                                 514            543          33          1.9         514.2       1.4X
+1 units w/o interval                                476            492          20          2.1         475.9       1.5X
+2 units w/ interval                                 751            767          14          1.3         751.0       0.9X
+2 units w/o interval                                709            716          11          1.4         709.0       1.0X
+3 units w/ interval                                1541           1551          15          0.6        1540.9       0.5X
+3 units w/o interval                               1531           1532           1          0.7        1531.5       0.5X
+4 units w/ interval                                1764           1768           5          0.6        1763.5       0.4X
+4 units w/o interval                               1737           1745           8          0.6        1736.6       0.4X
+5 units w/ interval                                1920           1930          10          0.5        1919.7       0.4X
+5 units w/o interval                               1928           1936          11          0.5        1927.9       0.4X
+6 units w/ interval                                2124           2127           4          0.5        2124.2       0.3X
+6 units w/o interval                               2124           2125           1          0.5        2123.7       0.3X
+7 units w/ interval                                2525           2541          15          0.4        2525.5       0.3X
+7 units w/o interval                               2512           2518          11          0.4        2511.5       0.3X
+8 units w/ interval                                2578           2597          19          0.4        2578.1       0.3X
+8 units w/o interval                               2558           2562           6          0.4        2558.1       0.3X
+9 units w/ interval                                2742           2750           9          0.4        2741.8       0.3X
+9 units w/o interval                               2752           2762          11          0.4        2751.8       0.3X
+10 units w/ interval                               3112           3123          10          0.3        3111.9       0.2X
+10 units w/o interval                              3116           3130          14          0.3        3115.7       0.2X
+11 units w/ interval                               3255           3273          20          0.3        3255.3       0.2X
+11 units w/o interval                              3294           3305          14          0.3        3293.6       0.2X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
-make_interval():                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------
-prepare make_interval()                            3402           3419          20          0.3        3401.6       1.0X
-make_interval(0, 1, 2, 3, 4, 5, 50.123456)             91            100           8         11.0          91.1      37.3X
-make_interval(*, *, 2, 3, 4, 5, 50.123456)            164            165           1          6.1         163.8      20.8X
-make_interval(0, 1, *, *, 4, 5, 50.123456)            165            170           7          6.1         165.0      20.6X
-make_interval(0, 1, 2, 3, *, *, *)                 3435           3441           7          0.3        3435.0       1.0X
-make_interval(*, *, *, *, *, *, *)                 3457           3475          24          0.3        3456.9       1.0X
+make_interval():                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------
+prepare make_interval()                              3395           3410          16          0.3        3395.0       1.0X
+make_interval(0, 1, 2, 3, 4, 5, 50.123456)             94            102           9         10.7          93.8      36.2X
+make_interval(*, *, 2, 3, 4, 5, 50.123456)            136            139           4          7.3         136.5      24.9X
+make_interval(0, 1, *, *, 4, 5, 50.123456)            115            119           4          8.7         114.8      29.6X
+make_interval(0, 1, 2, 3, *, *, *)                   3359           3382          37          0.3        3358.7       1.0X
+make_interval(*, *, *, *, *, *, *)                   3382           3388           9          0.3        3382.3       1.0X
 

--- a/sql/core/benchmarks/IntervalBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/IntervalBenchmark-jdk11-results.txt
@@ -2,38 +2,39 @@ OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-106
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast strings to intervals:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-prepare string w/ interval                          812            897          75          1.2         811.7       1.0X
-prepare string w/o interval                         660            667           6          1.5         660.3       1.2X
-1 units w/ interval                                 549            590          66          1.8         548.7       1.5X
-1 units w/o interval                                474            484          10          2.1         473.5       1.7X
-2 units w/ interval                                 723            728           7          1.4         723.5       1.1X
-2 units w/o interval                                685            688           3          1.5         684.5       1.2X
-3 units w/ interval                                1405           1420          14          0.7        1405.1       0.6X
-3 units w/o interval                               1368           1373           4          0.7        1367.8       0.6X
-4 units w/ interval                                1777           1782           7          0.6        1777.3       0.5X
-4 units w/o interval                               1770           1772           3          0.6        1769.7       0.5X
-5 units w/ interval                                1983           1997          21          0.5        1983.4       0.4X
-5 units w/o interval                               1952           1964          15          0.5        1951.6       0.4X
-6 units w/ interval                                2161           2167           9          0.5        2160.7       0.4X
-6 units w/o interval                               2147           2147           1          0.5        2146.6       0.4X
-7 units w/ interval                                2356           2365           8          0.4        2356.2       0.3X
-7 units w/o interval                               2329           2335           6          0.4        2329.0       0.3X
-8 units w/ interval                                2567           2574           8          0.4        2566.5       0.3X
-8 units w/o interval                               2569           2580          12          0.4        2569.1       0.3X
-9 units w/ interval                                2735           2747          19          0.4        2734.8       0.3X
-9 units w/o interval                               2732           2739           7          0.4        2732.4       0.3X
-10 units w/ interval                               2940           2947          13          0.3        2939.6       0.3X
-10 units w/o interval                              2945           2948           3          0.3        2944.5       0.3X
-11 units w/ interval                               3215           3227          16          0.3        3215.3       0.3X
-11 units w/o interval                              3243           3247           3          0.3        3242.7       0.3X
+prepare string w/ interval                          708            817         107          1.4         707.7       1.0X
+prepare string w/o interval                         671            673           2          1.5         670.7       1.1X
+1 units w/ interval                                 515            525          11          1.9         514.6       1.4X
+1 units w/o interval                                497            508          11          2.0         497.2       1.4X
+2 units w/ interval                                 748            756          10          1.3         747.6       0.9X
+2 units w/o interval                                713            722          12          1.4         713.0       1.0X
+3 units w/ interval                                1467           1470           6          0.7        1466.7       0.5X
+3 units w/o interval                               1435           1439           4          0.7        1435.0       0.5X
+4 units w/ interval                                1717           1730          11          0.6        1717.2       0.4X
+4 units w/o interval                               1696           1701           5          0.6        1696.4       0.4X
+5 units w/ interval                                1936           1945          13          0.5        1935.6       0.4X
+5 units w/o interval                               1897           1901           6          0.5        1897.1       0.4X
+6 units w/ interval                                2086           2105          23          0.5        2086.2       0.3X
+6 units w/o interval                               2067           2070           3          0.5        2067.4       0.3X
+7 units w/ interval                                2538           2548          16          0.4        2537.9       0.3X
+7 units w/o interval                               2515           2518           5          0.4        2514.9       0.3X
+8 units w/ interval                                2728           2735           6          0.4        2727.8       0.3X
+8 units w/o interval                               2727           2736          14          0.4        2726.7       0.3X
+9 units w/ interval                                2906           2932          24          0.3        2906.0       0.2X
+9 units w/o interval                               2923           2930          10          0.3        2922.9       0.2X
+10 units w/ interval                               3276           3280           4          0.3        3276.4       0.2X
+10 units w/o interval                              3266           3272           5          0.3        3266.0       0.2X
+11 units w/ interval                               3493           3497           7          0.3        3493.1       0.2X
+11 units w/o interval                              3444           3451           7          0.3        3443.9       0.2X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 make_interval():                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-prepare make_interval()                            3399           3415          14          0.3        3398.9       1.0X
-make_interval(0,1,2,3,4,5,50.123456)                 91             96           7         11.0          91.3      37.2X
-make_interval(*,*,*,3,4,5,50.123456)                185            186           0          5.4         185.5      18.3X
-make_interval(0,1,2,*,4,5,50.123456)                161            164           4          6.2         161.2      21.1X
-make_interval(0, 1, 2, 3, *, *, *)                 3419           3423           3          0.3        3419.0       1.0X
+prepare make_interval()                            3402           3419          20          0.3        3401.6       1.0X
+make_interval(0, 1, 2, 3, 4, 5, 50.123456)             91            100           8         11.0          91.1      37.3X
+make_interval(*, *, 2, 3, 4, 5, 50.123456)            164            165           1          6.1         163.8      20.8X
+make_interval(0, 1, *, *, 4, 5, 50.123456)            165            170           7          6.1         165.0      20.6X
+make_interval(0, 1, 2, 3, *, *, *)                 3435           3441           7          0.3        3435.0       1.0X
+make_interval(*, *, *, *, *, *, *)                 3457           3475          24          0.3        3456.9       1.0X
 

--- a/sql/core/benchmarks/IntervalBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/IntervalBenchmark-jdk11-results.txt
@@ -2,38 +2,38 @@ OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-106
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast strings to intervals:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-prepare string w/ interval                          744            823          81          1.3         744.3       1.0X
-prepare string w/o interval                         612            620          12          1.6         611.9       1.2X
-1 units w/ interval                                 518            525           8          1.9         517.5       1.4X
-1 units w/o interval                                475            477           2          2.1         475.0       1.6X
-2 units w/ interval                                 681            727          76          1.5         680.9       1.1X
-2 units w/o interval                                654            660          10          1.5         653.5       1.1X
-3 units w/ interval                                1319           1325          10          0.8        1318.6       0.6X
-3 units w/o interval                               1330           1332           3          0.8        1329.7       0.6X
-4 units w/ interval                                1723           1725           4          0.6        1722.8       0.4X
-4 units w/o interval                               1723           1725           2          0.6        1723.1       0.4X
-5 units w/ interval                                1906           1921          15          0.5        1906.4       0.4X
-5 units w/o interval                               1902           1918          20          0.5        1901.9       0.4X
-6 units w/ interval                                2109           2118           8          0.5        2108.8       0.4X
-6 units w/o interval                               2102           2105           4          0.5        2102.3       0.4X
-7 units w/ interval                                2324           2325           1          0.4        2324.5       0.3X
-7 units w/o interval                               2381           2384           3          0.4        2380.9       0.3X
-8 units w/ interval                                2460           2483          21          0.4        2459.6       0.3X
-8 units w/o interval                               2452           2459          10          0.4        2452.3       0.3X
-9 units w/ interval                                2714           2720           9          0.4        2714.3       0.3X
-9 units w/o interval                               2707           2719          10          0.4        2707.4       0.3X
-10 units w/ interval                               2860           2863           3          0.3        2859.8       0.3X
-10 units w/o interval                              2853           2863          11          0.4        2852.9       0.3X
-11 units w/ interval                               3156           3160           7          0.3        3155.5       0.2X
-11 units w/o interval                              3169           3179          10          0.3        3168.8       0.2X
+prepare string w/ interval                          812            897          75          1.2         811.7       1.0X
+prepare string w/o interval                         660            667           6          1.5         660.3       1.2X
+1 units w/ interval                                 549            590          66          1.8         548.7       1.5X
+1 units w/o interval                                474            484          10          2.1         473.5       1.7X
+2 units w/ interval                                 723            728           7          1.4         723.5       1.1X
+2 units w/o interval                                685            688           3          1.5         684.5       1.2X
+3 units w/ interval                                1405           1420          14          0.7        1405.1       0.6X
+3 units w/o interval                               1368           1373           4          0.7        1367.8       0.6X
+4 units w/ interval                                1777           1782           7          0.6        1777.3       0.5X
+4 units w/o interval                               1770           1772           3          0.6        1769.7       0.5X
+5 units w/ interval                                1983           1997          21          0.5        1983.4       0.4X
+5 units w/o interval                               1952           1964          15          0.5        1951.6       0.4X
+6 units w/ interval                                2161           2167           9          0.5        2160.7       0.4X
+6 units w/o interval                               2147           2147           1          0.5        2146.6       0.4X
+7 units w/ interval                                2356           2365           8          0.4        2356.2       0.3X
+7 units w/o interval                               2329           2335           6          0.4        2329.0       0.3X
+8 units w/ interval                                2567           2574           8          0.4        2566.5       0.3X
+8 units w/o interval                               2569           2580          12          0.4        2569.1       0.3X
+9 units w/ interval                                2735           2747          19          0.4        2734.8       0.3X
+9 units w/o interval                               2732           2739           7          0.4        2732.4       0.3X
+10 units w/ interval                               2940           2947          13          0.3        2939.6       0.3X
+10 units w/o interval                              2945           2948           3          0.3        2944.5       0.3X
+11 units w/ interval                               3215           3227          16          0.3        3215.3       0.3X
+11 units w/o interval                              3243           3247           3          0.3        3242.7       0.3X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 make_interval():                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-prepare make_interval()                            3396           3410          13          0.3        3395.6       1.0X
-make_interval(0,1,2,3,4,5,50.123456)                132            141           8          7.6         132.3      25.7X
-make_interval(*,*,*,3,4,5,50.123456)                170            180          13          5.9         170.4      19.9X
-make_interval(0,1,2,*,4,5,50.123456)                159            167           9          6.3         158.8      21.4X
-make_interval(0, 1, 2, 3, *, *, *)                 3426           3439          15          0.3        3426.2       1.0X
+prepare make_interval()                            3399           3415          14          0.3        3398.9       1.0X
+make_interval(0,1,2,3,4,5,50.123456)                 91             96           7         11.0          91.3      37.2X
+make_interval(*,*,*,3,4,5,50.123456)                185            186           0          5.4         185.5      18.3X
+make_interval(0,1,2,*,4,5,50.123456)                161            164           4          6.2         161.2      21.1X
+make_interval(0, 1, 2, 3, *, *, *)                 3419           3423           3          0.3        3419.0       1.0X
 

--- a/sql/core/benchmarks/IntervalBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/IntervalBenchmark-jdk11-results.txt
@@ -1,29 +1,39 @@
-Java HotSpot(TM) 64-Bit Server VM 11.0.5+10-LTS on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast strings to intervals:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-prepare string w/ interval                          448            469          20          2.2         447.6       1.0X
-prepare string w/o interval                         405            409           4          2.5         404.6       1.1X
-1 units w/ interval                                 321            328           6          3.1         321.4       1.4X
-1 units w/o interval                                303            307           4          3.3         303.1       1.5X
-2 units w/ interval                                 445            458          12          2.2         444.6       1.0X
-2 units w/o interval                                416            424          10          2.4         416.2       1.1X
-3 units w/ interval                                1006           1012           8          1.0        1006.4       0.4X
-3 units w/o interval                               1240           1249           8          0.8        1239.6       0.4X
-4 units w/ interval                                1295           1418         106          0.8        1295.4       0.3X
-4 units w/o interval                               1172           1188          15          0.9        1171.6       0.4X
-5 units w/ interval                                1326           1335          11          0.8        1325.6       0.3X
-5 units w/o interval                               1309           1336          44          0.8        1308.7       0.3X
-6 units w/ interval                                1441           1464          29          0.7        1441.0       0.3X
-6 units w/o interval                               1350           1369          17          0.7        1350.1       0.3X
-7 units w/ interval                                1606           1669          99          0.6        1605.6       0.3X
-7 units w/o interval                               1546           1557          12          0.6        1546.3       0.3X
-8 units w/ interval                                1771           1875         120          0.6        1770.6       0.3X
-8 units w/o interval                               1775           1789          13          0.6        1775.2       0.3X
-9 units w/ interval                                2126           2757         849          0.5        2126.4       0.2X
-9 units w/o interval                               2053           2070          21          0.5        2053.3       0.2X
-10 units w/ interval                               2209           2243          30          0.5        2209.1       0.2X
-10 units w/o interval                              2400           2702         365          0.4        2400.2       0.2X
-11 units w/ interval                               2616           2699          72          0.4        2616.5       0.2X
-11 units w/o interval                              3218           3380         195          0.3        3218.4       0.1X
+prepare string w/ interval                          744            823          81          1.3         744.3       1.0X
+prepare string w/o interval                         612            620          12          1.6         611.9       1.2X
+1 units w/ interval                                 518            525           8          1.9         517.5       1.4X
+1 units w/o interval                                475            477           2          2.1         475.0       1.6X
+2 units w/ interval                                 681            727          76          1.5         680.9       1.1X
+2 units w/o interval                                654            660          10          1.5         653.5       1.1X
+3 units w/ interval                                1319           1325          10          0.8        1318.6       0.6X
+3 units w/o interval                               1330           1332           3          0.8        1329.7       0.6X
+4 units w/ interval                                1723           1725           4          0.6        1722.8       0.4X
+4 units w/o interval                               1723           1725           2          0.6        1723.1       0.4X
+5 units w/ interval                                1906           1921          15          0.5        1906.4       0.4X
+5 units w/o interval                               1902           1918          20          0.5        1901.9       0.4X
+6 units w/ interval                                2109           2118           8          0.5        2108.8       0.4X
+6 units w/o interval                               2102           2105           4          0.5        2102.3       0.4X
+7 units w/ interval                                2324           2325           1          0.4        2324.5       0.3X
+7 units w/o interval                               2381           2384           3          0.4        2380.9       0.3X
+8 units w/ interval                                2460           2483          21          0.4        2459.6       0.3X
+8 units w/o interval                               2452           2459          10          0.4        2452.3       0.3X
+9 units w/ interval                                2714           2720           9          0.4        2714.3       0.3X
+9 units w/o interval                               2707           2719          10          0.4        2707.4       0.3X
+10 units w/ interval                               2860           2863           3          0.3        2859.8       0.3X
+10 units w/o interval                              2853           2863          11          0.4        2852.9       0.3X
+11 units w/ interval                               3156           3160           7          0.3        3155.5       0.2X
+11 units w/o interval                              3169           3179          10          0.3        3168.8       0.2X
+
+OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+make_interval():                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+prepare make_interval()                            3396           3410          13          0.3        3395.6       1.0X
+make_interval(0,1,2,3,4,5,50.123456)                132            141           8          7.6         132.3      25.7X
+make_interval(*,*,*,3,4,5,50.123456)                170            180          13          5.9         170.4      19.9X
+make_interval(0,1,2,*,4,5,50.123456)                159            167           9          6.3         158.8      21.4X
+make_interval(0, 1, 2, 3, *, *, *)                 3426           3439          15          0.3        3426.2       1.0X
 

--- a/sql/core/benchmarks/IntervalBenchmark-results.txt
+++ b/sql/core/benchmarks/IntervalBenchmark-results.txt
@@ -2,39 +2,39 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast strings to intervals:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-prepare string w/ interval                          659            710          64          1.5         659.0       1.0X
-prepare string w/o interval                         581            592          14          1.7         581.2       1.1X
-1 units w/ interval                                 567            585          27          1.8         567.5       1.2X
-1 units w/o interval                                538            550          12          1.9         537.7       1.2X
-2 units w/ interval                                 741            754          13          1.3         741.1       0.9X
-2 units w/o interval                                716            735          18          1.4         716.0       0.9X
-3 units w/ interval                                1449           1462          13          0.7        1448.9       0.5X
-3 units w/o interval                               1435           1444          11          0.7        1434.7       0.5X
-4 units w/ interval                                1654           1660           6          0.6        1653.6       0.4X
-4 units w/o interval                               1628           1635           7          0.6        1628.0       0.4X
-5 units w/ interval                                1822           1830           8          0.5        1822.5       0.4X
-5 units w/o interval                               1800           1807           8          0.6        1800.2       0.4X
-6 units w/ interval                                1997           2009          14          0.5        1996.9       0.3X
-6 units w/o interval                               1981           1989          13          0.5        1980.6       0.3X
-7 units w/ interval                                2346           2360          14          0.4        2345.6       0.3X
-7 units w/o interval                               2314           2317           5          0.4        2313.7       0.3X
-8 units w/ interval                                2573           2577           4          0.4        2573.1       0.3X
-8 units w/o interval                               2570           2573           5          0.4        2569.6       0.3X
-9 units w/ interval                                2775           2781           8          0.4        2775.2       0.2X
-9 units w/o interval                               2769           2772           4          0.4        2769.0       0.2X
-10 units w/ interval                               3016           3026          11          0.3        3015.9       0.2X
-10 units w/o interval                              3127           3135          11          0.3        3127.3       0.2X
-11 units w/ interval                               3371           3378           6          0.3        3370.7       0.2X
-11 units w/o interval                              3359           3374          16          0.3        3359.4       0.2X
+prepare string w/ interval                          677            718          40          1.5         677.2       1.0X
+prepare string w/o interval                         602            624          19          1.7         602.2       1.1X
+1 units w/ interval                                 582            598          20          1.7         581.8       1.2X
+1 units w/o interval                                549            591          64          1.8         549.1       1.2X
+2 units w/ interval                                 758            773          14          1.3         758.2       0.9X
+2 units w/o interval                                723            738          14          1.4         722.6       0.9X
+3 units w/ interval                                1442           1450          11          0.7        1441.8       0.5X
+3 units w/o interval                               1426           1429           3          0.7        1426.4       0.5X
+4 units w/ interval                                1645           1652          11          0.6        1645.1       0.4X
+4 units w/o interval                               1618           1626          10          0.6        1617.6       0.4X
+5 units w/ interval                                1794           1803          13          0.6        1794.4       0.4X
+5 units w/o interval                               1783           1793           9          0.6        1783.2       0.4X
+6 units w/ interval                                1976           1984          11          0.5        1976.2       0.3X
+6 units w/o interval                               1948           1959          10          0.5        1947.9       0.3X
+7 units w/ interval                                2394           2408          18          0.4        2393.7       0.3X
+7 units w/o interval                               2387           2392           8          0.4        2386.8       0.3X
+8 units w/ interval                                2578           2588          15          0.4        2577.5       0.3X
+8 units w/o interval                               2572           2578           5          0.4        2571.8       0.3X
+9 units w/ interval                                2812           2829          19          0.4        2811.7       0.2X
+9 units w/o interval                               2811           2816           4          0.4        2810.7       0.2X
+10 units w/ interval                               3108           3116          10          0.3        3107.8       0.2X
+10 units w/o interval                              3107           3109           3          0.3        3106.8       0.2X
+11 units w/ interval                               3386           3392           8          0.3        3386.3       0.2X
+11 units w/o interval                              3374           3377           4          0.3        3374.0       0.2X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
-make_interval():                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------
-prepare make_interval()                            3675           3701          31          0.3        3674.7       1.0X
-make_interval(0, 1, 2, 3, 4, 5, 50.123456)             85             91           5         11.7          85.3      43.1X
-make_interval(*, *, 2, 3, 4, 5, 50.123456)            162            173          11          6.2         162.5      22.6X
-make_interval(0, 1, *, *, 4, 5, 50.123456)            165            169           4          6.1         164.7      22.3X
-make_interval(0, 1, 2, 3, *, *, *)                 3664           3667           4          0.3        3664.5       1.0X
-make_interval(*, *, *, *, *, *, *)                 3699           3715          24          0.3        3698.5       1.0X
+make_interval():                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------
+prepare make_interval()                              3634           3684          47          0.3        3634.1       1.0X
+make_interval(0, 1, 2, 3, 4, 5, 50.123456)             90            100          12         11.1          90.0      40.4X
+make_interval(*, *, 2, 3, 4, 5, 50.123456)            114            119           5          8.8         114.3      31.8X
+make_interval(0, 1, *, *, 4, 5, 50.123456)            121            138          21          8.3         120.7      30.1X
+make_interval(0, 1, 2, 3, *, *, *)                   3615           3621           9          0.3        3614.7       1.0X
+make_interval(*, *, *, *, *, *, *)                   3638           3657          21          0.3        3637.7       1.0X
 

--- a/sql/core/benchmarks/IntervalBenchmark-results.txt
+++ b/sql/core/benchmarks/IntervalBenchmark-results.txt
@@ -1,29 +1,39 @@
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.3
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast strings to intervals:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-prepare string w/ interval                          389            410          21          2.6         388.7       1.0X
-prepare string w/o interval                         340            360          18          2.9         340.5       1.1X
-1 units w/ interval                                 378            389          16          2.6         377.8       1.0X
-1 units w/o interval                                346            350           5          2.9         346.2       1.1X
-2 units w/ interval                                 444            457          11          2.3         444.2       0.9X
-2 units w/o interval                                455            464          12          2.2         455.1       0.9X
-3 units w/ interval                                 942            964          20          1.1         941.5       0.4X
-3 units w/o interval                                927           1020          93          1.1         927.3       0.4X
-4 units w/ interval                                1114           1127          17          0.9        1113.9       0.3X
-4 units w/o interval                               1100           1105           4          0.9        1100.3       0.4X
-5 units w/ interval                                1180           1244          57          0.8        1180.1       0.3X
-5 units w/o interval                               1135           1141           6          0.9        1135.2       0.3X
-6 units w/ interval                                1284           1316          48          0.8        1284.0       0.3X
-6 units w/o interval                               1276           1357         122          0.8        1276.1       0.3X
-7 units w/ interval                                1609           1636          32          0.6        1609.1       0.2X
-7 units w/o interval                               1551           1578          36          0.6        1550.9       0.3X
-8 units w/ interval                                1787           1874         129          0.6        1787.1       0.2X
-8 units w/o interval                               1751           1767          15          0.6        1750.6       0.2X
-9 units w/ interval                                1960           2065         141          0.5        1959.7       0.2X
-9 units w/o interval                               1885           1908          39          0.5        1885.1       0.2X
-10 units w/ interval                               2178           2185          11          0.5        2177.9       0.2X
-10 units w/o interval                              2150           2255         164          0.5        2150.1       0.2X
-11 units w/ interval                               2457           2542         139          0.4        2456.7       0.2X
-11 units w/o interval                              2557           2770         188          0.4        2556.7       0.2X
+prepare string w/ interval                          659            753         128          1.5         658.7       1.0X
+prepare string w/o interval                         594            612          20          1.7         594.1       1.1X
+1 units w/ interval                                 579            599          18          1.7         578.7       1.1X
+1 units w/o interval                                537            553          21          1.9         536.7       1.2X
+2 units w/ interval                                 775            778           3          1.3         774.9       0.8X
+2 units w/o interval                                735            742          10          1.4         735.2       0.9X
+3 units w/ interval                                1440           1444           8          0.7        1439.5       0.5X
+3 units w/o interval                               1412           1422           8          0.7        1412.1       0.5X
+4 units w/ interval                                1647           1652           7          0.6        1647.0       0.4X
+4 units w/o interval                               1624           1635          12          0.6        1624.1       0.4X
+5 units w/ interval                                1810           1812           2          0.6        1810.5       0.4X
+5 units w/o interval                               1788           1794           7          0.6        1787.7       0.4X
+6 units w/ interval                                1974           1980          10          0.5        1973.8       0.3X
+6 units w/o interval                               1957           1968          13          0.5        1956.5       0.3X
+7 units w/ interval                                2392           2405          14          0.4        2391.7       0.3X
+7 units w/o interval                               2375           2379           3          0.4        2375.3       0.3X
+8 units w/ interval                                2694           2701           7          0.4        2694.2       0.2X
+8 units w/o interval                               2646           2651           5          0.4        2646.2       0.2X
+9 units w/ interval                                2816           2827          13          0.4        2816.0       0.2X
+9 units w/o interval                               2818           2824           7          0.4        2818.2       0.2X
+10 units w/ interval                               3128           3135          12          0.3        3127.6       0.2X
+10 units w/o interval                              3132           3135           4          0.3        3132.0       0.2X
+11 units w/ interval                               3300           3307           6          0.3        3299.7       0.2X
+11 units w/o interval                              3299           3301           3          0.3        3298.8       0.2X
+
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+make_interval():                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+prepare make_interval()                            3645           3692          40          0.3        3645.3       1.0X
+make_interval(0,1,2,3,4,5,50.123456)                 89             99          10         11.3          88.9      41.0X
+make_interval(*,*,*,3,4,5,50.123456)                156            176          17          6.4         156.5      23.3X
+make_interval(0,1,2,*,4,5,50.123456)                142            144           2          7.0         142.2      25.6X
+make_interval(0, 1, 2, 3, *, *, *)                 3669           3678          16          0.3        3669.1       1.0X
 

--- a/sql/core/benchmarks/IntervalBenchmark-results.txt
+++ b/sql/core/benchmarks/IntervalBenchmark-results.txt
@@ -2,38 +2,39 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast strings to intervals:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-prepare string w/ interval                          659            753         128          1.5         658.7       1.0X
-prepare string w/o interval                         594            612          20          1.7         594.1       1.1X
-1 units w/ interval                                 579            599          18          1.7         578.7       1.1X
-1 units w/o interval                                537            553          21          1.9         536.7       1.2X
-2 units w/ interval                                 775            778           3          1.3         774.9       0.8X
-2 units w/o interval                                735            742          10          1.4         735.2       0.9X
-3 units w/ interval                                1440           1444           8          0.7        1439.5       0.5X
-3 units w/o interval                               1412           1422           8          0.7        1412.1       0.5X
-4 units w/ interval                                1647           1652           7          0.6        1647.0       0.4X
-4 units w/o interval                               1624           1635          12          0.6        1624.1       0.4X
-5 units w/ interval                                1810           1812           2          0.6        1810.5       0.4X
-5 units w/o interval                               1788           1794           7          0.6        1787.7       0.4X
-6 units w/ interval                                1974           1980          10          0.5        1973.8       0.3X
-6 units w/o interval                               1957           1968          13          0.5        1956.5       0.3X
-7 units w/ interval                                2392           2405          14          0.4        2391.7       0.3X
-7 units w/o interval                               2375           2379           3          0.4        2375.3       0.3X
-8 units w/ interval                                2694           2701           7          0.4        2694.2       0.2X
-8 units w/o interval                               2646           2651           5          0.4        2646.2       0.2X
-9 units w/ interval                                2816           2827          13          0.4        2816.0       0.2X
-9 units w/o interval                               2818           2824           7          0.4        2818.2       0.2X
-10 units w/ interval                               3128           3135          12          0.3        3127.6       0.2X
-10 units w/o interval                              3132           3135           4          0.3        3132.0       0.2X
-11 units w/ interval                               3300           3307           6          0.3        3299.7       0.2X
-11 units w/o interval                              3299           3301           3          0.3        3298.8       0.2X
+prepare string w/ interval                          659            710          64          1.5         659.0       1.0X
+prepare string w/o interval                         581            592          14          1.7         581.2       1.1X
+1 units w/ interval                                 567            585          27          1.8         567.5       1.2X
+1 units w/o interval                                538            550          12          1.9         537.7       1.2X
+2 units w/ interval                                 741            754          13          1.3         741.1       0.9X
+2 units w/o interval                                716            735          18          1.4         716.0       0.9X
+3 units w/ interval                                1449           1462          13          0.7        1448.9       0.5X
+3 units w/o interval                               1435           1444          11          0.7        1434.7       0.5X
+4 units w/ interval                                1654           1660           6          0.6        1653.6       0.4X
+4 units w/o interval                               1628           1635           7          0.6        1628.0       0.4X
+5 units w/ interval                                1822           1830           8          0.5        1822.5       0.4X
+5 units w/o interval                               1800           1807           8          0.6        1800.2       0.4X
+6 units w/ interval                                1997           2009          14          0.5        1996.9       0.3X
+6 units w/o interval                               1981           1989          13          0.5        1980.6       0.3X
+7 units w/ interval                                2346           2360          14          0.4        2345.6       0.3X
+7 units w/o interval                               2314           2317           5          0.4        2313.7       0.3X
+8 units w/ interval                                2573           2577           4          0.4        2573.1       0.3X
+8 units w/o interval                               2570           2573           5          0.4        2569.6       0.3X
+9 units w/ interval                                2775           2781           8          0.4        2775.2       0.2X
+9 units w/o interval                               2769           2772           4          0.4        2769.0       0.2X
+10 units w/ interval                               3016           3026          11          0.3        3015.9       0.2X
+10 units w/o interval                              3127           3135          11          0.3        3127.3       0.2X
+11 units w/ interval                               3371           3378           6          0.3        3370.7       0.2X
+11 units w/o interval                              3359           3374          16          0.3        3359.4       0.2X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 make_interval():                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-prepare make_interval()                            3645           3692          40          0.3        3645.3       1.0X
-make_interval(0,1,2,3,4,5,50.123456)                 89             99          10         11.3          88.9      41.0X
-make_interval(*,*,*,3,4,5,50.123456)                156            176          17          6.4         156.5      23.3X
-make_interval(0,1,2,*,4,5,50.123456)                142            144           2          7.0         142.2      25.6X
-make_interval(0, 1, 2, 3, *, *, *)                 3669           3678          16          0.3        3669.1       1.0X
+prepare make_interval()                            3675           3701          31          0.3        3674.7       1.0X
+make_interval(0, 1, 2, 3, 4, 5, 50.123456)             85             91           5         11.7          85.3      43.1X
+make_interval(*, *, 2, 3, 4, 5, 50.123456)            162            173          11          6.2         162.5      22.6X
+make_interval(0, 1, *, *, 4, 5, 50.123456)            165            169           4          6.1         164.7      22.3X
+make_interval(0, 1, 2, 3, *, *, *)                 3664           3667           4          0.3        3664.5       1.0X
+make_interval(*, *, *, *, *, *, *)                 3699           3715          24          0.3        3698.5       1.0X
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/IntervalBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/IntervalBenchmark.scala
@@ -123,27 +123,27 @@ object IntervalBenchmark extends SqlBasedBenchmark {
     val benchmark = new Benchmark("make_interval()", cardinality, output = output)
     val hmExprs = Seq("id % 24", "id % 60")
     val hmsExprs = hmExprs ++ Seq("cast((id % 500000000) / 1000000.0 as decimal(18, 6))")
-    val ymwExprs = Seq("(2000 + (id % 30))", "((id % 12) + 1)", "((id % 54) + 1)")
-    val dayExpr = Seq("((id % 1000) + 1)")
-    val args = ymwExprs ++ dayExpr ++ hmsExprs
+    val ymExprs = Seq("(2000 + (id % 30))", "((id % 12) + 1)")
+    val wdExpr = Seq("((id % 54) + 1)", "((id % 1000) + 1)")
+    val args = ymExprs ++ wdExpr ++ hmsExprs
 
     addCaseExpr(
       benchmark,
       cardinality,
       "prepare make_interval()",
       args: _*)
-    val foldableExpr = "make_interval(0,1,2,3,4,5,50.123456)"
+    val foldableExpr = "make_interval(0, 1, 2, 3, 4, 5, 50.123456)"
     addCaseExpr(benchmark, cardinality, foldableExpr, foldableExpr)
     addCaseExpr(
       benchmark,
       cardinality,
-      "make_interval(*,*,*,3,4,5,50.123456)",
-      s"make_interval(${ymwExprs.mkString(",")}, 3, 4, 5, 50.123456)")
+      "make_interval(*, *, 2, 3, 4, 5, 50.123456)",
+      s"make_interval(${ymExprs.mkString(",")}, 2, 3, 4, 5, 50.123456)")
     addCaseExpr(
       benchmark,
       cardinality,
-      "make_interval(0,1,2,*,4,5,50.123456)",
-      s"make_interval(0, 1, 2, ${dayExpr.mkString(",")}, 4, 5, 50.123456)")
+      "make_interval(0, 1, *, *, 4, 5, 50.123456)",
+      s"make_interval(0, 1, ${wdExpr.mkString(",")}, 4, 5, 50.123456)")
     addCaseExpr(
       benchmark,
       cardinality,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/IntervalBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/IntervalBenchmark.scala
@@ -149,6 +149,11 @@ object IntervalBenchmark extends SqlBasedBenchmark {
       cardinality,
       "make_interval(0, 1, 2, 3, *, *, *)",
       s"make_interval(0, 1, 2, 3, ${hmsExprs.mkString(",")})")
+    addCaseExpr(
+      benchmark,
+      cardinality,
+      "make_interval(*, *, *, *, *, *, *)",
+      s"make_interval(${args.mkString(",")})")
 
     benchmark.run()
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/IntervalBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/IntervalBenchmark.scala
@@ -39,11 +39,11 @@ import org.apache.spark.sql.internal.SQLConf
 object IntervalBenchmark extends SqlBasedBenchmark {
   import spark.implicits._
 
-  private def doBenchmark(cardinality: Long, exprs: Column*): Unit = {
+  private def doBenchmark(cardinality: Long, columns: Column*): Unit = {
     withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "true") {
       spark
         .range(0, cardinality, 1, 1)
-        .select(exprs: _*)
+        .select(columns: _*)
         .queryExecution
         .toRdd
         .foreach(_ => ())
@@ -59,6 +59,26 @@ object IntervalBenchmark extends SqlBasedBenchmark {
       doBenchmark(cardinality, exprs: _*)
     }
   }
+
+  private def doBenchmarkExpr(cardinality: Long, exprs: String*): Unit = {
+    withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "true") {
+      spark
+        .range(0, cardinality, 1, 1)
+        .selectExpr(exprs: _*)
+        .queryExecution
+        .toRdd
+        .foreach(_ => ())
+    }
+  }
+
+  private def addCaseExpr(
+      benchmark: Benchmark,
+      cardinality: Long,
+      name: String,
+      exprs: String*): Unit = {
+    benchmark.addCase(name, numIters = 3) { _ => doBenchmarkExpr(cardinality, exprs: _*) }
+  }
+
 
   private def buildString(withPrefix: Boolean, units: Seq[String] = Seq.empty): Column = {
     val init = lit(if (withPrefix) "interval" else "") ::
@@ -78,25 +98,63 @@ object IntervalBenchmark extends SqlBasedBenchmark {
     }
   }
 
-  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
-    val N = 1000000
+  private def benchmarkIntervalStringParsing(cardinality: Long): Unit = {
     val timeUnits = Seq(
       "13 months", "                      1                     months",
       "100 weeks", "9 days", "12 hours", "-                    3 hours",
       "5 minutes", "45 seconds", "123 milliseconds", "567 microseconds")
     val intervalToTest = ListBuffer[String]()
 
-    val benchmark = new Benchmark("cast strings to intervals", N, output = output)
+    val benchmark = new Benchmark("cast strings to intervals", cardinality, output = output)
     // The first 2 cases are used to show the overhead of preparing the interval string.
-    addCase(benchmark, N, "prepare string w/ interval", buildString(true, timeUnits))
-    addCase(benchmark, N, "prepare string w/o interval", buildString(false, timeUnits))
-    addCase(benchmark, N, intervalToTest) // Only years
+    addCase(benchmark, cardinality, "prepare string w/ interval", buildString(true, timeUnits))
+    addCase(benchmark, cardinality, "prepare string w/o interval", buildString(false, timeUnits))
+    addCase(benchmark, cardinality, intervalToTest) // Only years
 
     for (unit <- timeUnits) {
       intervalToTest.append(unit)
-      addCase(benchmark, N, intervalToTest)
+      addCase(benchmark, cardinality, intervalToTest)
     }
 
     benchmark.run()
+  }
+
+  private def benchmarkMakeInterval(cardinality: Long): Unit = {
+    val benchmark = new Benchmark("make_interval()", cardinality, output = output)
+    val hmExprs = Seq("id % 24", "id % 60")
+    val hmsExprs = hmExprs ++ Seq("cast((id % 500000000) / 1000000.0 as decimal(18, 6))")
+    val ymwExprs = Seq("(2000 + (id % 30))", "((id % 12) + 1)", "((id % 54) + 1)")
+    val dayExpr = Seq("((id % 1000) + 1)")
+    val args = ymwExprs ++ dayExpr ++ hmsExprs
+
+    addCaseExpr(
+      benchmark,
+      cardinality,
+      "prepare make_interval()",
+      args: _*)
+    val foldableExpr = "make_interval(0,1,2,3,4,5,50.123456)"
+    addCaseExpr(benchmark, cardinality, foldableExpr, foldableExpr)
+    addCaseExpr(
+      benchmark,
+      cardinality,
+      "make_interval(*,*,*,3,4,5,50.123456)",
+      s"make_interval(${ymwExprs.mkString(",")}, 3, 4, 5, 50.123456)")
+    addCaseExpr(
+      benchmark,
+      cardinality,
+      "make_interval(0,1,2,*,4,5,50.123456)",
+      s"make_interval(0, 1, 2, ${dayExpr.mkString(",")}, 4, 5, 50.123456)")
+    addCaseExpr(
+      benchmark,
+      cardinality,
+      "make_interval(0, 1, 2, 3, *, *, *)",
+      s"make_interval(0, 1, 2, 3, ${hmsExprs.mkString(",")})")
+
+    benchmark.run()
+  }
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    benchmarkIntervalStringParsing(1000000)
+    benchmarkMakeInterval(1000000)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add benchmarks for interval constructor `make_interval` and measure perf of 4 cases:
1. Constant (year, month)
2. Constant (week, day)
3. Constant (hour, minute, second, second fraction)
4. All fields are NOT constant.

The benchmark results are generated in the environment:

| Item | Description |
| ---- | ----|
| Region | us-west-2 (Oregon) |
| Instance | r3.xlarge |
| AMI | ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20190722.1 (ami-06f2f779464715dc5) |
| Java | OpenJDK 64-Bit Server VM 1.8.0_252 and OpenJDK 64-Bit Server VM 11.0.7+10 |

### Why are the changes needed?
To have a base line for future perf improvements of `make_interval`, and to prevent perf regressions in the future.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
By running `IntervalBenchmark` via:
```
$ SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/test:runMain org.apache.spark.sql.execution.benchmark.IntervalBenchmark"
```