### PR TITLE
[SPARK-32083][SQL] Coalesce to one partition when all partitions are empty in AQE

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ShufflePartitionsUtil.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ShufflePartitionsUtil.scala
@@ -92,9 +92,10 @@ object ShufflePartitionsUtil extends Logging {
     var coalescedSize = 0L
     var i = 0
 
-    def createPartitionSpec(): Unit = {
-      // Skip empty inputs, as it is a waste to launch an empty task.
-      if (coalescedSize > 0) {
+    def createPartitionSpec(last: Boolean = false): Unit = {
+      // Skip empty inputs, as it is a waste to launch an empty task
+      // unless all inputs are empty
+      if (coalescedSize > 0 || (last && partitionSpecs.isEmpty)) {
         partitionSpecs += CoalescedPartitionSpec(latestSplitPoint, i)
       }
     }
@@ -120,7 +121,7 @@ object ShufflePartitionsUtil extends Logging {
       }
       i += 1
     }
-    createPartitionSpec()
+    createPartitionSpec(last = true)
     partitionSpecs
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ShufflePartitionsUtilSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ShufflePartitionsUtilSuite.scala
@@ -200,7 +200,7 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
       val bytesByPartitionId2 = Array[Long](0, 0, 0, 0, 0)
       checkEstimation(
         Array(bytesByPartitionId1, bytesByPartitionId2),
-        Seq.empty, targetSize, minNumPartitions)
+        Array(CoalescedPartitionSpec(0, 5)), targetSize, minNumPartitions)
     }
 
 
@@ -243,21 +243,23 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
     }
   }
 
-  test("do not create partition spec for 0-size partitions") {
+  test("do not create partition spec for 0-size partitions except all partitions are empty") {
     val targetSize = 100
     val minNumPartitions = 2
+    val expectedPartitionSpecs = Array(CoalescedPartitionSpec(0, 5))
 
     {
       // 1 shuffle: All bytes per partition are 0, no partition spec created.
       val bytesByPartitionId = Array[Long](0, 0, 0, 0, 0)
-      checkEstimation(Array(bytesByPartitionId), Seq.empty, targetSize)
+      checkEstimation(Array(bytesByPartitionId), expectedPartitionSpecs, targetSize)
     }
 
     {
       // 2 shuffles: All bytes per partition are 0, no partition spec created.
       val bytesByPartitionId1 = Array[Long](0, 0, 0, 0, 0)
       val bytesByPartitionId2 = Array[Long](0, 0, 0, 0, 0)
-      checkEstimation(Array(bytesByPartitionId1, bytesByPartitionId2), Seq.empty, targetSize)
+      checkEstimation(Array(bytesByPartitionId1, bytesByPartitionId2),
+        expectedPartitionSpecs, targetSize)
     }
 
     {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR creates one partition spec in `ShufflePartitionsUtil` if all inputs are empty, which avoids launching as many unnecessary tasks as the number of shuffle partitions for following stages.

### Why are the changes needed?

For SQL like 

```
SELECT b, COUNT(t1.a) as cnt
FROM t1
INNER JOIN t2
ON t1.id = t2.id
WHERE t1.id > 10
GROUP BY b
```

when all ids of t1 are smaller than 10. No tasks are launched for join since empty input is coalesced to 0 partition. However, many unnecessary tasks could be launched for the following aggregate execution. Hence, I'm proposing coalescing to one partition when all partitions are empty.

#### Before

![image](https://user-images.githubusercontent.com/1191767/86062434-47788780-ba9b-11ea-8623-4c00612f6d15.png)

#### After

![image](https://user-images.githubusercontent.com/1191767/86062484-6414bf80-ba9b-11ea-9378-f2f7aae3ab27.png)

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
updated tests.