### PR TITLE
[SPARK-32068][WEBUI] Correct task lauchtime show issue due to timezone in stage tab

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/utils.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/utils.js
@@ -161,7 +161,15 @@ function setDataTableDefaults() {
 
 function formatDate(date) {
   if (date <= 0) return "-";
-  else return date.split(".")[0].replace("T", " ");
+  else return {
+     var d = new Date(date.replace("GMT","Z"))
+     return d.getFullYear() + '-' +
+            (d.getMonth() + 1) + '-' +
+            d.getDate() + " " +
+            d.getHours() + ":" +
+            d.getMinutes() + ":" +
+            d.getSeconds();
+  }
 }
 
 function createRESTEndPointForExecutorsPage(appId) {

--- a/core/src/main/resources/org/apache/spark/ui/static/utils.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/utils.js
@@ -161,8 +161,8 @@ function setDataTableDefaults() {
 
 function formatDate(date) {
   if (date <= 0) return "-";
-  else return {
-     var d = new Date(date.replace("GMT","Z"))
+  else {
+     var d = new Date(date.replace("GMT", "Z"))
      return d.getFullYear() + '-' +
             (d.getMonth() + 1) + '-' +
             d.getDate() + " " +

--- a/core/src/main/resources/org/apache/spark/ui/static/utils.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/utils.js
@@ -56,13 +56,17 @@ function formatTimeMillis(timeMillis) {
     return "-";
   } else {
     var dt = new Date(timeMillis);
+    return formatDateString(dt);
+  }
+}
+
+function formatDateString(dt) {
     return dt.getFullYear() + "-" +
       padZeroes(dt.getMonth() + 1) + "-" +
       padZeroes(dt.getDate()) + " " +
       padZeroes(dt.getHours()) + ":" +
       padZeroes(dt.getMinutes()) + ":" +
       padZeroes(dt.getSeconds());
-  }
 }
 
 function getTimeZone() {
@@ -162,13 +166,8 @@ function setDataTableDefaults() {
 function formatDate(date) {
   if (date <= 0) return "-";
   else {
-     var d = new Date(date.replace("GMT", "Z"))
-     return d.getFullYear() + '-' +
-            (d.getMonth() + 1) + '-' +
-            d.getDate() + " " +
-            d.getHours() + ":" +
-            d.getMinutes() + ":" +
-            d.getSeconds();
+     var dt = new Date(date.replace("GMT", "Z"))
+     return formatDateString(dt);
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
`formatDate` in utils.js `org/apache/spark/ui/static/utils.js` is partly refactored.

### Why are the changes needed?
In branch-2.4，task launch time is returned as html string from driver, 
while in branch-3.x，this is returned in JSON Object as`Date`type  from `org.apache.spark.status.api.v1.TaskData`
Due to：
LaunchTime from jersey server in spark driver is correct, which will be converted to date string like `2020-06-28T02:57:42.605GMT` in json object, then the formatDate in utils.js treat it as date.split(".")[0].replace("T", " ").
So `2020-06-28T02:57:42.605GMT` will be converted to `2020-06-28 02:57:42`, but correct is `2020-06-28 10:57:42` in GMT+8 timezone.
![选区_071](https://user-images.githubusercontent.com/7149304/85937186-b6d36780-b933-11ea-8382-80a3891f1c2a.png)
![选区_070](https://user-images.githubusercontent.com/7149304/85937190-bcc94880-b933-11ea-8860-2083c97ea269.png)

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manual test.