### PR TITLE
[SPARK-32086][YARN]Bug fix for RemoveBroadcast RPC failed after executor is shutdown

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
@@ -154,6 +154,7 @@ private[spark] abstract class YarnSchedulerBackend(
    * Request that the ApplicationMaster kill the specified executors.
    */
   override def doKillExecutors(executorIds: Seq[String]): Future[Boolean] = {
+    executorIds.foreach(sc.env.blockManager.master.removeExecutor)
     yarnSchedulerEndpointRef.ask[Boolean](KillExecutors(executorIds))
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bug fix for yarn Dynamic Resource Allocation.

### Why are the changes needed?

There are some exceptions when RemoveBroadcast RPC are called from BlockManagerMaster to BlockManagers on executors.

It seems that `blockManagerInfo.values` in `BlockManagerMaster` has not been updated after the executor is closed

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?
Using Exists patch
