### PR TITLE
[SPARK-32133][SQL] Forbid time field steps for date start/end in Sequence 

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -2612,6 +2612,9 @@ object Sequence {
       val stepDays = step.days
       val stepMicros = step.microseconds
 
+      require(scale != MICROS_PER_DAY || stepMonths != 0 || stepDays != 0,
+        "sequence step must be a day interval if start and end values are dates")
+
       if (stepMonths == 0 && stepMicros == 0 && scale == MICROS_PER_DAY) {
         backedSequenceImpl.eval(start, stop, fromLong(stepDays))
 
@@ -2678,6 +2681,11 @@ object Sequence {
          |final int $stepMonths = $step.months;
          |final int $stepDays = $step.days;
          |final long $stepMicros = $step.microseconds;
+         |
+         |if (${scale}L == ${MICROS_PER_DAY}L && $stepMonths == 0 && $stepDays == 0) {
+         |  throw new IllegalArgumentException(
+         |    "sequence step must be a day interval if start and end values are dates");
+         |}
          |
          |if ($stepMonths == 0 && $stepMicros == 0 && ${scale}L == ${MICROS_PER_DAY}L) {
          |  ${backedSequenceImpl.genCode(ctx, start, stop, stepDays, arr, elemType)};

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -2612,7 +2612,7 @@ object Sequence {
       val stepDays = step.days
       val stepMicros = step.microseconds
 
-      if(scale == MICROS_PER_DAY && stepMonths == 0 && stepDays == 0) {
+      if (scale == MICROS_PER_DAY && stepMonths == 0 && stepDays == 0) {
         throw new IllegalArgumentException(
           "sequence step must be a day interval if start and end values are dates")
       }
@@ -2682,13 +2682,13 @@ object Sequence {
       val check = if (scale == MICROS_PER_DAY) {
         s"""
            if ($stepMonths == 0 && $stepDays == 0) {
-            throw new IllegalArgumentException(
-               "sequence step must be a day interval if start and end values are dates");
+              throw new IllegalArgumentException(
+                "sequence step must be a day interval if start and end values are dates");
            }
          """
-      } else {
-        ""
-      }
+        } else {
+          ""
+        }
 
       s"""
          |final int $stepMonths = $step.months;

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -2682,8 +2682,8 @@ object Sequence {
       val check = if (scale == MICROS_PER_DAY) {
         s"""
            |if ($stepMonths == 0 && $stepDays == 0) {
-           |   throw new IllegalArgumentException(
-           |     "sequence step must be a day interval if start and end values are dates");
+           |  throw new IllegalArgumentException(
+           |    "sequence step must be a day interval if start and end values are dates");
            |}
           """.stripMargin
         } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -2681,11 +2681,11 @@ object Sequence {
 
       val check = if (scale == MICROS_PER_DAY) {
         s"""
-           if ($stepMonths == 0 && $stepDays == 0) {
-              throw new IllegalArgumentException(
-                "sequence step must be a day interval if start and end values are dates");
-           }
-         """
+           |if ($stepMonths == 0 && $stepDays == 0) {
+           |   throw new IllegalArgumentException(
+           |     "sequence step must be a day interval if start and end values are dates");
+           |}
+          """.stripMargin
         } else {
           ""
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -2695,7 +2695,7 @@ object Sequence {
          |final int $stepDays = $step.days;
          |final long $stepMicros = $step.microseconds;
          |
-         |  $check
+         |$check
          |
          |if ($stepMonths == 0 && $stepMicros == 0 && ${scale}L == ${MICROS_PER_DAY}L) {
          |  ${backedSequenceImpl.genCode(ctx, start, stop, stepDays, arr, elemType)};

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -2695,7 +2695,7 @@ object Sequence {
          |final int $stepDays = $step.days;
          |final long $stepMicros = $step.microseconds;
          |
-         |$check
+         |  $check
          |
          |if ($stepMonths == 0 && $stepMicros == 0 && ${scale}L == ${MICROS_PER_DAY}L) {
          |  ${backedSequenceImpl.genCode(ctx, start, stop, stepDays, arr, elemType)};

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -2618,9 +2618,11 @@ object Sequence {
       }
 
       if (stepMonths == 0 && stepMicros == 0 && scale == MICROS_PER_DAY) {
+        // Adding pure days to date start/end
         backedSequenceImpl.eval(start, stop, fromLong(stepDays))
 
       } else if (stepMonths == 0 && stepDays == 0 && scale == 1) {
+        // Adding pure microseconds to timestamp start/end
         backedSequenceImpl.eval(start, stop, fromLong(stepMicros))
 
       } else {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -1854,4 +1854,16 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
       Literal(stringToInterval("interval 1 year"))),
       Seq(Date.valueOf("2018-01-01")))
   }
+
+  test("SPARK-31982: Sequence step must be a day interval " +
+    "if start and end values are dates") {
+    val e = intercept[Exception](
+      checkEvaluation(Sequence(
+        Cast(Literal("2011-03-01"), DateType),
+        Cast(Literal("2011-04-01"), DateType),
+        Option(Literal(stringToInterval("interval 1 hour")))),
+        Seq(Date.valueOf("2011-03-01"), Date.valueOf("2011-04-01"))))
+    assert(e.getCause.getMessage.contains(
+      "sequence step must be a day interval if start and end values are dates"))
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -1855,7 +1855,7 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
       Seq(Date.valueOf("2018-01-01")))
   }
 
-  test("SPARK-31982: Sequence step must be a day interval " +
+  test("SPARK-32133: Sequence step must be a day interval " +
     "if start and end values are dates") {
     val e = intercept[Exception](
       checkEvaluation(Sequence(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -1857,13 +1857,15 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
 
   test("SPARK-32133: Sequence step must be a day interval " +
     "if start and end values are dates") {
-    val e = intercept[Exception](
-      checkEvaluation(Sequence(
-        Cast(Literal("2011-03-01"), DateType),
-        Cast(Literal("2011-04-01"), DateType),
-        Option(Literal(stringToInterval("interval 1 hour")))),
-        Seq(Date.valueOf("2011-03-01"), Date.valueOf("2011-04-01"))))
-    assert(e.getCause.getMessage.contains(
-      "sequence step must be a day interval if start and end values are dates"))
+    checkExceptionInExpression[IllegalArgumentException](Sequence(
+      Cast(Literal("2011-03-01"), DateType),
+      Cast(Literal("2011-04-01"), DateType),
+      Option(Literal(stringToInterval("interval 1 hour")))), null,
+      "sequence step must be a day interval if start and end values are dates")
+    checkEvaluation(Sequence(
+      Cast(Literal("2011-03-01"), DateType),
+      Cast(Literal("2011-03-02"), DateType),
+      Option(Literal(stringToInterval("interval 1 day")))),
+      Seq(Date.valueOf("2011-03-01"), Date.valueOf("2011-03-02")))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -933,6 +933,13 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
           Literal(negateExact(stringToInterval("interval 1 month")))),
         EmptyRow,
         s"sequence boundaries: 0 to 2678400000000 by -${28 * MICROS_PER_DAY}")
+
+      // SPARK-32133: Sequence step must be a day interval if start and end values are dates
+      checkExceptionInExpression[IllegalArgumentException](Sequence(
+        Cast(Literal("2011-03-01"), DateType),
+        Cast(Literal("2011-04-01"), DateType),
+        Option(Literal(stringToInterval("interval 1 hour")))), null,
+        "sequence step must be a day interval if start and end values are dates")
     }
   }
 
@@ -1853,19 +1860,5 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
       Literal(Date.valueOf("2018-01-01")),
       Literal(stringToInterval("interval 1 year"))),
       Seq(Date.valueOf("2018-01-01")))
-  }
-
-  test("SPARK-32133: Sequence step must be a day interval " +
-    "if start and end values are dates") {
-    checkExceptionInExpression[IllegalArgumentException](Sequence(
-      Cast(Literal("2011-03-01"), DateType),
-      Cast(Literal("2011-04-01"), DateType),
-      Option(Literal(stringToInterval("interval 1 hour")))), null,
-      "sequence step must be a day interval if start and end values are dates")
-    checkEvaluation(Sequence(
-      Cast(Literal("2011-03-01"), DateType),
-      Cast(Literal("2011-03-02"), DateType),
-      Option(Literal(stringToInterval("interval 1 day")))),
-      Seq(Date.valueOf("2011-03-01"), Date.valueOf("2011-03-02")))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
1.Add time field steps check for date start/end in Sequence at `org.apache.spark.sql.catalyst.expressions.Sequence.TemporalSequenceImpl`
2.Add a UT：`SPARK-32133: Sequence step must be a day interval if start and end values are dates` at `org.apache.spark.sql.catalyst.expressions.CollectionExpressionsSuite`

### Why are the changes needed?
**Sequence time field steps for date start/end looks strange in spark as follows:**
```
scala> sql("select explode(sequence(cast('2011-03-01' as date), cast('2011-03-02' as date), interval 1 hour))").head(3)
res0: Array[org.apache.spark.sql.Row] = _Array([2011-03-01], [2011-03-01], [2011-03-01])_ **<- strange result.**

scala> sql("select explode(sequence(cast('2011-03-01' as date), cast('2011-03-02' as date), interval 1 day))").head(3)
res1: Array[org.apache.spark.sql.Row] = Array([2011-03-01], [2011-03-02])
```

**While this behavior in Prosto make sense：** 
```
presto> select sequence(date('2011-03-01'),date('2011-03-02'),interval '1' hour);
Query 20200624_122744_00002_pehix failed: sequence step must be a day interval if start and end values are dates
presto> select sequence(date('2011-03-01'),date('2011-03-02'),interval '1' day);
_col0
[2011-03-01, 2011-03-02]
```

### Does this PR introduce _any_ user-facing change?
Yes, after this patch, users will get informed `sequence step must be a day interval if start and end values are dates` when 
use time field steps for date start/end in Sequence.

### How was this patch tested?
Unit test.