### PR TITLE
[SPARK-32104][SQL]Avoid full outer join OOM on skewed dataset

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/FileBasedAppendOnlyUnsafeRowArray.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/FileBasedAppendOnlyUnsafeRowArray.scala
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import java.io.{BufferedOutputStream, File, FileOutputStream, OutputStream, RandomAccessFile}
+import java.nio.ByteBuffer
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.{SparkEnv, TaskContext}
+import org.apache.spark.internal.Logging
+import org.apache.spark.serializer.SerializerInstance
+import org.apache.spark.sql.catalyst.expressions.UnsafeRow
+
+/**
+ * An append-only array for [[UnsafeRow]]s that strictly keeps content in an in-memory array
+ * until [[numRowsInMemoryBufferThreshold]] is reached post which it will switch to a mode which
+ * would flush to disk.
+ *
+ * Unlike [[ExternalAppendOnlyUnsafeRowArray]], the current implementation can quickly
+ * locate the corresponding data according to the given index.
+ *
+ * This class is suitable for scenarios where data is written once and
+ * read multiple times according to the index position.
+ */
+private[sql] class FileBasedAppendOnlyUnsafeRowArray(
+    numRowsInMemoryBufferThreshold: Int) extends Logging {
+
+  private val diskBlockManager = SparkEnv.get.blockManager.diskBlockManager
+  private val taskContext = TaskContext.get()
+
+  private var inMemoryRows: ArrayBuffer[UnsafeRow] = new ArrayBuffer[UnsafeRow]
+
+  private var diskOffsets: ArrayBuffer[Long] = _
+  private var diskFile: File = _
+  private var diskFileReader: RandomAccessFile = _
+  private var diskFileWriter: OutputStream = _
+  private var serializer: SerializerInstance = _
+  private val fileBufferSize =
+    SparkEnv.get.conf.getSizeAsKb("spark.shuffle.file.buffer", "32k").toInt * 1024
+
+  private var writeLength: Long = 0L
+  private var numRows = 0
+  private var isWriting: Boolean = true
+
+  def length: Int = numRows
+
+  def isEmpty: Boolean = numRows == 0
+
+  def add(unsafeRow: UnsafeRow): Unit = {
+    if (!isWriting) {
+      throw new IllegalAccessException("Already write completed.")
+    }
+    if (numRows < numRowsInMemoryBufferThreshold) {
+      inMemoryRows += unsafeRow
+    } else {
+      if (diskOffsets == null) {
+        logInfo(s"Reached spill threshold of $numRowsInMemoryBufferThreshold rows," +
+          s" switching to disk.")
+        diskOffsets = new ArrayBuffer[Long](numRows)
+        diskFile = diskBlockManager.createTempLocalBlock()._2
+        diskFileWriter = new BufferedOutputStream(new FileOutputStream(diskFile), fileBufferSize)
+        serializer = SparkEnv.get.serializer.newInstance()
+
+        // populate with existing in-memory buffered rows
+        inMemoryRows.foreach(writeFile)
+        inMemoryRows.clear()
+      }
+      writeFile(unsafeRow)
+    }
+    numRows += 1
+  }
+
+  def get(index: Int): UnsafeRow = {
+    if (index >= numRows) {
+      throw new ArrayIndexOutOfBoundsException(index)
+    }
+    if (isWriting) {
+      throw new IllegalAccessException("Not write complete, call writeComplete() first.")
+    }
+    if (diskOffsets != null) {
+      getRowFromFile(index)
+    } else {
+      inMemoryRows(index)
+    }
+  }
+
+  def writeComplete(): Unit = {
+    if (diskOffsets != null) {
+      logInfo(s"Wrote $numRows rows on disk.")
+      diskFileWriter.close()
+    }
+    isWriting = false
+  }
+
+  /**
+   * Clear memory/disk resources
+   */
+  def clear(): Unit = {
+    if (diskOffsets != null) {
+      diskOffsets.clear()
+      diskOffsets = null
+      diskFileReader.close()
+      diskFileReader = null
+      logInfo("Removing temporary unsafe row file: " + diskFile.getCanonicalPath)
+      diskFile.delete()
+    } else if (inMemoryRows.nonEmpty) {
+      inMemoryRows.clear()
+    }
+    numRows = 0
+    writeLength = 0L
+    isWriting = true
+  }
+
+  private def writeFile(unsafeRow: UnsafeRow): Unit = {
+    val bytes = serializer.serialize(unsafeRow).array()
+    diskFileWriter.write(bytes)
+    writeLength += bytes.length
+    diskOffsets += writeLength
+
+    taskContext.taskMetrics().incMemoryBytesSpilled(bytes.length)
+  }
+
+  private def getRowFromFile(index: Int): UnsafeRow = {
+    if (diskFileReader == null) {
+      diskFileReader = new RandomAccessFile(diskFile, "r")
+    }
+    // compute position and length
+    val (position, length) = if (index == 0) {
+      (0L, diskOffsets(0))
+    } else {
+      (diskOffsets(index - 1), diskOffsets(index) - diskOffsets(index - 1))
+    }
+    diskFileReader.seek(position)
+    val bytes = new Array[Byte](length.toInt)
+    diskFileReader.readFully(bytes)
+    serializer.deserialize[UnsafeRow](ByteBuffer.wrap(bytes))
+  }
+
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -791,9 +791,8 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
         )
       }
 
-      // FULL OUTER JOIN still does not use [[ExternalAppendOnlyUnsafeRowArray]]
-      // so should not cause any spill
-      assertNotSpilled(sparkContext, "full outer join") {
+      // use [[FileBasedAppendOnlyUnsafeRowArray]]
+      assertSpilled(sparkContext, "full outer join") {
         checkAnswer(
           sql(
             """


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
In the case of Full Outer Joins of large tables, in the presence of data skew around the join keys for either of the joined tables, OOMs exceptions occur. While its possible to increase the heap size to workaround, Spark should be resilient to such issues as skews can happen arbitrarily.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
[SPARK-24985](https://issues.apache.org/jira/browse/SPARK-24985) changed `SortMergeJoinExec` to use `ExternalAppendOnlyUnsafeRowArray` on `SortMergeFullOuterJoinScanner`. But its performance is very poor, because when matching the key, you need to constantly get the element at the specified position according to the index.
This PR add a `FileBasedAppendOnlyUnsafeRowArray`. It can quickly locate the corresponding data according to the given index because of the offsets array in memory. And in memory buffer rows can be limited by `spark.sql.sortMergeJoinExec.buffer.in.memory.threshold`.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
`JoinSuite` and `OuterJoinSuite`