### PR TITLE
[SPARK-32113][SQL] Avoid coalescing shuffle partitions if join condition has inequality predicate

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -326,6 +326,10 @@ trait JoinSelectionHelper {
       hint.rightHint.exists(_.strategy.contains(SHUFFLE_REPLICATE_NL))
   }
 
+  def hintToNotCoalesceShufflePartitions(hint: JoinHint): Boolean = {
+    hint.rightHint.exists(_.strategy.contains(NO_COALESCE_SHUFFLE_PARTITIONS_JOIN))
+  }
+
   private def getBuildSide(
       canBuildLeft: Boolean,
       canBuildRight: Boolean,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/hints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/hints.scala
@@ -168,6 +168,15 @@ case object NO_BROADCAST_HASH extends JoinStrategyHint {
 }
 
 /**
+ * An internal hint to discourage coalesce shuffle partitions for sort merge join,
+ * used by adaptive query execution.
+ */
+case object NO_COALESCE_SHUFFLE_PARTITIONS_JOIN extends JoinStrategyHint {
+  override def displayName: String = "no_coalesce_shuffle_partitions_join"
+  override def hintAliases: Set[String] = Set.empty
+}
+
+/**
  * The callback for implementing customized strategies of handling hint errors.
  */
 trait HintErrorHandler {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -191,7 +191,8 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         def createSortMergeJoin() = {
           if (RowOrdering.isOrderable(leftKeys)) {
             Some(Seq(joins.SortMergeJoinExec(
-              leftKeys, rightKeys, joinType, condition, planLater(left), planLater(right))))
+              leftKeys, rightKeys, joinType, condition, planLater(left), planLater(right),
+              isCoalesceShufflePartitions = !hintToNotCoalesceShufflePartitions(hint))))
           } else {
             None
           }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
@@ -159,7 +159,7 @@ case class OptimizeSkewedJoin(conf: SQLConf) extends Rule[SparkPlan] {
   def optimizeSkewJoin(plan: SparkPlan): SparkPlan = plan.transformUp {
     case smj @ SortMergeJoinExec(_, _, joinType, _,
         s1 @ SortExec(_, _, ShuffleStage(left: ShuffleStageInfo), _),
-        s2 @ SortExec(_, _, ShuffleStage(right: ShuffleStageInfo), _), _)
+        s2 @ SortExec(_, _, ShuffleStage(right: ShuffleStageInfo), _), _, _)
         if supportedJoinTypes.contains(joinType) =>
       assert(left.partitionsWithSizes.length == right.partitionsWithSizes.length)
       val numPartitions = left.partitionsWithSizes.length

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -41,7 +41,8 @@ case class SortMergeJoinExec(
     condition: Option[Expression],
     left: SparkPlan,
     right: SparkPlan,
-    isSkewJoin: Boolean = false) extends BaseJoinExec with CodegenSupport {
+    isSkewJoin: Boolean = false,
+    isCoalesceShufflePartitions: Boolean = true) extends BaseJoinExec with CodegenSupport {
 
   override lazy val metrics = Map(
     "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -693,7 +693,7 @@ class PlannerSuite extends SharedSparkSession with AdaptiveSparkPlanHelper {
 
     val outputPlan = EnsureRequirements(spark.sessionState.conf).apply(smjExec)
     outputPlan match {
-      case SortMergeJoinExec(leftKeys, rightKeys, _, _, _, _, _) =>
+      case SortMergeJoinExec(leftKeys, rightKeys, _, _, _, _, _, _) =>
         assert(leftKeys == Seq(exprA, exprA))
         assert(rightKeys == Seq(exprB, exprC))
       case _ => fail()
@@ -718,7 +718,7 @@ class PlannerSuite extends SharedSparkSession with AdaptiveSparkPlanHelper {
                ShuffleExchangeExec(HashPartitioning(leftPartitioningExpressions, _), _, _), _),
              SortExec(_, _,
                ShuffleExchangeExec(HashPartitioning(rightPartitioningExpressions, _),
-               _, _), _), _) =>
+               _, _), _), _, _) =>
         assert(leftKeys === smjExec.leftKeys)
         assert(rightKeys === smjExec.rightKeys)
         assert(leftKeys === leftPartitioningExpressions)


### PR DESCRIPTION
### What changes were proposed in this pull request?

The data usually expand if joining event-based table(Chinese named 拉链表). This PR makes it avoid coalescing shuffle partitions if joining event-based table(join condition has inequality predicate).



Default | Avoid coalescing shuffle partitions
--- | ---
<img src="https://user-images.githubusercontent.com/5399861/85926502-87d8d980-b8d2-11ea-816b-c44c0216c3f2.png" width="410"> | <img src="https://user-images.githubusercontent.com/5399861/85926505-8d362400-b8d2-11ea-82e9-7120a0b0aa0c.png" width="410">


### Why are the changes needed?

Improve query performance.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Unit test
