### PR TITLE
[SPARK-32121][SHUFFLE] Support Windows OS in ExecutorDiskUtils

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExecutorDiskUtils.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExecutorDiskUtils.java
@@ -23,13 +23,14 @@ import java.util.regex.Pattern;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.spark.network.util.JavaUtils;
 
 public class ExecutorDiskUtils {
 
   private static final Pattern MULTIPLE_SEPARATORS;
   static {
-    if (isWindows()) {
+    if (SystemUtils.IS_OS_WINDOWS) {
       MULTIPLE_SEPARATORS = Pattern.compile("[/\\\\]+");
     } else {
       MULTIPLE_SEPARATORS = Pattern.compile("/{2,}");
@@ -46,13 +47,6 @@ public class ExecutorDiskUtils {
     int subDirId = (hash / localDirs.length) % subDirsPerLocalDir;
     return new File(createNormalizedInternedPathname(
         localDir, String.format("%02x", subDirId), filename));
-  }
-
-  /** Returns whether the OS is Windows. */
-  @VisibleForTesting
-  static boolean isWindows() {
-    String os = System.getProperty("os.name");
-    return os.startsWith("Windows");
   }
 
   /**

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExecutorDiskUtils.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExecutorDiskUtils.java
@@ -29,10 +29,11 @@ public class ExecutorDiskUtils {
 
   private static final Pattern MULTIPLE_SEPARATORS;
   static {
-    if (isWindows())
-      MULTIPLE_SEPARATORS= Pattern.compile("[/\\\\]+");
-    else
+    if (isWindows()) {
+      MULTIPLE_SEPARATORS = Pattern.compile("[/\\\\]+");
+    } else {
       MULTIPLE_SEPARATORS = Pattern.compile("/{2,}");
+    }
   }
 
   /**

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExecutorDiskUtils.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExecutorDiskUtils.java
@@ -61,7 +61,7 @@ public class ExecutorDiskUtils {
    *
    * On Windows, separator "\" is used instead of "/".
    *
-   * "\\" is legal character in path name on Unix like OS, but illegal on Windows.
+   * "\\" is a legal character in path name on Unix-like OS, but illegal on Windows.
    */
   @VisibleForTesting
   static String createNormalizedInternedPathname(String dir1, String dir2, String fname) {

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExecutorDiskUtils.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExecutorDiskUtils.java
@@ -69,7 +69,7 @@ public class ExecutorDiskUtils {
     Matcher m = MULTIPLE_SEPARATORS.matcher(pathname);
     pathname = m.replaceAll(Matcher.quoteReplacement(File.separator));
     // A single trailing slash needs to be taken care of separately
-    if (pathname.length() > 1 && pathname.endsWith(File.separator)) {
+    if (pathname.length() > 1 && pathname.charAt(pathname.length() - 1) == File.separatorChar) {
       pathname = pathname.substring(0, pathname.length() - 1);
     }
     return pathname.intern();

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExecutorDiskUtils.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExecutorDiskUtils.java
@@ -59,7 +59,7 @@ public class ExecutorDiskUtils {
    * String copy. Unfortunately, we cannot just reuse the normalization code that java.io.File
    * uses, since it is in the package-private class java.io.FileSystem.
    *
-   * On Windows, separator "/" should be "\".
+   * On Windows, separator "\" is used instead of "/".
    *
    * "\\" is legal character in path name on Unix like OS, but illegal on Windows.
    */

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExecutorDiskUtils.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExecutorDiskUtils.java
@@ -27,7 +27,7 @@ import org.apache.spark.network.util.JavaUtils;
 
 public class ExecutorDiskUtils {
 
-  private static final Pattern MULTIPLE_SEPARATORS = Pattern.compile(File.separator + "{2,}");
+  private static final Pattern MULTIPLE_SEPARATORS = Pattern.compile("[/\\\\]+");
 
   /**
    * Hashes a filename into the corresponding local directory, in a manner consistent with
@@ -50,14 +50,15 @@ public class ExecutorDiskUtils {
    * the internal code in java.io.File would normalize it later, creating a new "foo/bar"
    * String copy. Unfortunately, we cannot just reuse the normalization code that java.io.File
    * uses, since it is in the package-private class java.io.FileSystem.
+   * On Windows, separator / should be \.
    */
   @VisibleForTesting
   static String createNormalizedInternedPathname(String dir1, String dir2, String fname) {
     String pathname = dir1 + File.separator + dir2 + File.separator + fname;
     Matcher m = MULTIPLE_SEPARATORS.matcher(pathname);
-    pathname = m.replaceAll("/");
+    pathname = m.replaceAll(Matcher.quoteReplacement(File.separator));
     // A single trailing slash needs to be taken care of separately
-    if (pathname.length() > 1 && pathname.endsWith("/")) {
+    if (pathname.length() > 1 && pathname.endsWith(File.separator)) {
       pathname = pathname.substring(0, pathname.length() - 1);
     }
     return pathname.intern();

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolverSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolverSuite.java
@@ -147,22 +147,20 @@ public class ExternalShuffleBlockResolverSuite {
 
   @Test
   public void testNormalizeAndInternPathname() {
-    assertPathsMatch("/foo", "bar", "baz",
-      File.separator + "foo" + File.separator + "bar" + File.separator + "baz");
-    assertPathsMatch("//foo/", "bar/", "//baz",
-      File.separator + "foo" + File.separator + "bar" + File.separator + "baz");
-    assertPathsMatch("foo", "bar", "baz///",
-      "foo" + File.separator + "bar" + File.separator + "baz");
-    assertPathsMatch("/foo/", "/bar//", "/baz",
-      File.separator + "foo" + File.separator + "bar" + File.separator + "baz");
-    assertPathsMatch("/", "", "", File.separator);
-    assertPathsMatch("/", "/", "/", File.separator);
+    String sep = File.separator;
+    String expectedPathname1 = sep + "foo" + sep + "bar" + sep + "baz";
+    String expectedPathname2 = "foo" + sep + "bar" + sep + "baz";
+    String expectedPathname3 = sep + "foo\\" + sep + "bar" + sep + "baz";
+    assertPathsMatch("/foo", "bar", "baz", expectedPathname1);
+    assertPathsMatch("//foo/", "bar/", "//baz", expectedPathname1);
+    assertPathsMatch("foo", "bar", "baz///", expectedPathname2);
+    assertPathsMatch("/foo/", "/bar//", "/baz", expectedPathname1);
+    assertPathsMatch("/", "", "", sep);
+    assertPathsMatch("/", "/", "/", sep);
     if (SystemUtils.IS_OS_WINDOWS) {
-      assertPathsMatch("/foo\\/", "bar", "baz",
-        File.separator + "foo" + File.separator + "bar" + File.separator + "baz");
+      assertPathsMatch("/foo\\/", "bar", "baz", expectedPathname1);
     } else {
-      assertPathsMatch("/foo\\/", "bar", "baz",
-        File.separator + "foo\\" + File.separator + "bar" + File.separator + "baz");
+      assertPathsMatch("/foo\\/", "bar", "baz", expectedPathname3);
     }
   }
 

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolverSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolverSuite.java
@@ -148,19 +148,17 @@ public class ExternalShuffleBlockResolverSuite {
   @Test
   public void testNormalizeAndInternPathname() {
     String sep = File.separator;
-    String expectedPathname1 = sep + "foo" + sep + "bar" + sep + "baz";
-    String expectedPathname2 = "foo" + sep + "bar" + sep + "baz";
-    String expectedPathname3 = sep + "foo\\" + sep + "bar" + sep + "baz";
-    assertPathsMatch("/foo", "bar", "baz", expectedPathname1);
-    assertPathsMatch("//foo/", "bar/", "//baz", expectedPathname1);
-    assertPathsMatch("foo", "bar", "baz///", expectedPathname2);
-    assertPathsMatch("/foo/", "/bar//", "/baz", expectedPathname1);
+    String expectedPathname = sep + "foo" + sep + "bar" + sep + "baz";
+    assertPathsMatch("/foo", "bar", "baz", expectedPathname);
+    assertPathsMatch("//foo/", "bar/", "//baz", expectedPathname);
+    assertPathsMatch("/foo/", "/bar//", "/baz", expectedPathname);
+    assertPathsMatch("foo", "bar", "baz///", "foo" + sep + "bar" + sep + "baz");
     assertPathsMatch("/", "", "", sep);
     assertPathsMatch("/", "/", "/", sep);
     if (SystemUtils.IS_OS_WINDOWS) {
-      assertPathsMatch("/foo\\/", "bar", "baz", expectedPathname1);
+      assertPathsMatch("/foo\\/", "bar", "baz", expectedPathname);
     } else {
-      assertPathsMatch("/foo\\/", "bar", "baz", expectedPathname3);
+      assertPathsMatch("/foo\\/", "bar", "baz", sep + "foo\\" + sep + "bar" + sep + "baz");
     }
   }
 

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolverSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolverSuite.java
@@ -146,12 +146,12 @@ public class ExternalShuffleBlockResolverSuite {
 
   @Test
   public void testNormalizeAndInternPathname() {
-    assertPathsMatch("/foo", "bar", "baz", "/foo/bar/baz");
-    assertPathsMatch("//foo/", "bar/", "//baz", "/foo/bar/baz");
-    assertPathsMatch("foo", "bar", "baz///", "foo/bar/baz");
-    assertPathsMatch("/foo/", "/bar//", "/baz", "/foo/bar/baz");
-    assertPathsMatch("/", "", "", "/");
-    assertPathsMatch("/", "/", "/", "/");
+    assertPathsMatch("/foo", "bar", "baz", File.separator + "foo" + File.separator + "bar" + File.separator + "baz");
+    assertPathsMatch("//foo/", "bar/", "//baz", File.separator + "foo" + File.separator + "bar" + File.separator + "baz");
+    assertPathsMatch("foo", "bar", "baz///", "foo" + File.separator + "bar" + File.separator + "baz");
+    assertPathsMatch("/foo/", "/bar//", "/baz", File.separator + "foo" + File.separator + "bar" + File.separator + "baz");
+    assertPathsMatch("/", "", "", File.separator);
+    assertPathsMatch("/", "/", "/", File.separator);
   }
 
   private void assertPathsMatch(String p1, String p2, String p3, String expectedPathname) {
@@ -160,6 +160,6 @@ public class ExternalShuffleBlockResolverSuite {
     assertEquals(expectedPathname, normPathname);
     File file = new File(normPathname);
     String returnedPath = file.getPath();
-    assertTrue(normPathname == returnedPath);
+    assertEquals(normPathname, returnedPath);
   }
 }

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolverSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolverSuite.java
@@ -25,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.CharStreams;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.spark.network.shuffle.protocol.ExecutorShuffleInfo;
 import org.apache.spark.network.util.MapConfigProvider;
 import org.apache.spark.network.util.TransportConf;
@@ -156,7 +157,7 @@ public class ExternalShuffleBlockResolverSuite {
       File.separator + "foo" + File.separator + "bar" + File.separator + "baz");
     assertPathsMatch("/", "", "", File.separator);
     assertPathsMatch("/", "/", "/", File.separator);
-    if (ExecutorDiskUtils.isWindows()) {
+    if (SystemUtils.IS_OS_WINDOWS) {
       assertPathsMatch("/foo\\/", "bar", "baz",
         File.separator + "foo" + File.separator + "bar" + File.separator + "baz");
     } else {

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolverSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolverSuite.java
@@ -158,6 +158,13 @@ public class ExternalShuffleBlockResolverSuite {
             File.separator);
     assertPathsMatch("/", "/", "/",
             File.separator);
+    if (ExecutorDiskUtils.isWindows()) {
+      assertPathsMatch("/foo\\/", "bar", "baz",
+              File.separator + "foo" + File.separator + "bar" + File.separator + "baz");
+    } else {
+      assertPathsMatch("/foo\\/", "bar", "baz",
+              File.separator + "foo\\" + File.separator + "bar" + File.separator + "baz");
+    }
   }
 
   private void assertPathsMatch(String p1, String p2, String p3, String expectedPathname) {

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolverSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolverSuite.java
@@ -147,23 +147,21 @@ public class ExternalShuffleBlockResolverSuite {
   @Test
   public void testNormalizeAndInternPathname() {
     assertPathsMatch("/foo", "bar", "baz",
-            File.separator + "foo" + File.separator + "bar" + File.separator + "baz");
+      File.separator + "foo" + File.separator + "bar" + File.separator + "baz");
     assertPathsMatch("//foo/", "bar/", "//baz",
-            File.separator + "foo" + File.separator + "bar" + File.separator + "baz");
+      File.separator + "foo" + File.separator + "bar" + File.separator + "baz");
     assertPathsMatch("foo", "bar", "baz///",
-            "foo" + File.separator + "bar" + File.separator + "baz");
+      "foo" + File.separator + "bar" + File.separator + "baz");
     assertPathsMatch("/foo/", "/bar//", "/baz",
-            File.separator + "foo" + File.separator + "bar" + File.separator + "baz");
-    assertPathsMatch("/", "", "",
-            File.separator);
-    assertPathsMatch("/", "/", "/",
-            File.separator);
+      File.separator + "foo" + File.separator + "bar" + File.separator + "baz");
+    assertPathsMatch("/", "", "", File.separator);
+    assertPathsMatch("/", "/", "/", File.separator);
     if (ExecutorDiskUtils.isWindows()) {
       assertPathsMatch("/foo\\/", "bar", "baz",
-              File.separator + "foo" + File.separator + "bar" + File.separator + "baz");
+        File.separator + "foo" + File.separator + "bar" + File.separator + "baz");
     } else {
       assertPathsMatch("/foo\\/", "bar", "baz",
-              File.separator + "foo\\" + File.separator + "bar" + File.separator + "baz");
+        File.separator + "foo\\" + File.separator + "bar" + File.separator + "baz");
     }
   }
 

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolverSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolverSuite.java
@@ -146,12 +146,18 @@ public class ExternalShuffleBlockResolverSuite {
 
   @Test
   public void testNormalizeAndInternPathname() {
-    assertPathsMatch("/foo", "bar", "baz", File.separator + "foo" + File.separator + "bar" + File.separator + "baz");
-    assertPathsMatch("//foo/", "bar/", "//baz", File.separator + "foo" + File.separator + "bar" + File.separator + "baz");
-    assertPathsMatch("foo", "bar", "baz///", "foo" + File.separator + "bar" + File.separator + "baz");
-    assertPathsMatch("/foo/", "/bar//", "/baz", File.separator + "foo" + File.separator + "bar" + File.separator + "baz");
-    assertPathsMatch("/", "", "", File.separator);
-    assertPathsMatch("/", "/", "/", File.separator);
+    assertPathsMatch("/foo", "bar", "baz",
+            File.separator + "foo" + File.separator + "bar" + File.separator + "baz");
+    assertPathsMatch("//foo/", "bar/", "//baz",
+            File.separator + "foo" + File.separator + "bar" + File.separator + "baz");
+    assertPathsMatch("foo", "bar", "baz///",
+            "foo" + File.separator + "bar" + File.separator + "baz");
+    assertPathsMatch("/foo/", "/bar//", "/baz",
+            File.separator + "foo" + File.separator + "bar" + File.separator + "baz");
+    assertPathsMatch("/", "", "",
+            File.separator);
+    assertPathsMatch("/", "/", "/",
+            File.separator);
   }
 
   private void assertPathsMatch(String p1, String p2, String p3, String expectedPathname) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Correct file seprate use in `ExecutorDiskUtils.createNormalizedInternedPathname` on Windows

### Why are the changes needed?
`ExternalShuffleBlockResolverSuite` failed on Windows, see detail at: 
https://issues.apache.org/jira/browse/SPARK-32121

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
The existed test suite.
