### PR TITLE
[SPARK-32128][SQL]import SQLConf.PARTITION_OVERWRITE_VERIFY_PATH config

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2035,6 +2035,16 @@ object SQLConf {
       .checkValues(PartitionOverwriteMode.values.map(_.toString))
       .createWithDefault(PartitionOverwriteMode.STATIC.toString)
 
+  val PARTITION_OVERWRITE_VERIFY_PATH =
+    buildConf("spark.sql.sources.partitionOverwriteVerifyPath")
+      .doc("When INSERT OVERWRITE a partitioned data source table, spark will verify input " +
+        "and output paths by default. Set to false to skip the verify in some cases. " +
+        "(eg. INSERT OVERWRITE t partition(dt=a) SELECT * FROM t WHERE dt=b)"
+      )
+      .version("3.1.0")
+      .booleanConf
+      .createWithDefault(true)
+
   object StoreAssignmentPolicy extends Enumeration {
     val ANSI, LEGACY, STRICT = Value
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -222,7 +222,8 @@ case class DataSourceAnalysis(conf: SQLConf) extends Rule[LogicalPlan] with Cast
       // For dynamic partition overwrite, we do not delete partition directories ahead.
       // We write to staging directories and move to final partition directories after writing
       // job is done. So it is ok to have outputPath try to overwrite inputpath.
-      if (overwrite && !insertCommand.dynamicPartitionOverwrite) {
+      if (overwrite && !insertCommand.dynamicPartitionOverwrite &&
+        conf.getConf(SQLConf.PARTITION_OVERWRITE_VERIFY_PATH)) {
         DDLUtils.verifyNotReadPath(actualQuery, outputPath)
       }
       insertCommand

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -334,7 +334,7 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
           checkAnswer(spark.table("insertTable"), Row(1, 1))
           val testSql =
             """
-              |INSERT OVERWRITE TABLE insertTable PARTITION(part1=2)
+              |INSERT OVERWRITE TABLE insertTable PARTITION(part=2)
               |SELECT i + 1 FROM insertTable
               |WHERE part=1
               """.stripMargin
@@ -348,7 +348,7 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
               "INSERT OVERWRITE to a table while querying it should not be allowed.")
           } else {
             sql(testSql)
-            checkAnswer(spark.table("insertTable"), Row(1, 1, 1) :: Row(2, 2) :: Nil)
+            checkAnswer(spark.table("insertTable"), Row(1, 1) :: Row(2, 2) :: Nil)
           }
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -320,7 +320,7 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
     }
   }
 
-  test("SPARK-320128: skip verify the input and output paths") {
+  test("SPARK-32128: skip verify the input and output paths") {
     Seq(true, false).foreach { verityPath =>
       withSQLConf(SQLConf.PARTITION_OVERWRITE_VERIFY_PATH.key -> verityPath.toString) {
         withTable("insertTable") {
@@ -340,15 +340,15 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
               """.stripMargin
 
           if (verityPath) {
-            sql(testSql)
-            checkAnswer(spark.table("insertTable"), Row(1, 1, 1) :: Row(2, 2) :: Nil)
-          } else {
             val message = intercept[AnalysisException] {
               sql(testSql)
             }.getMessage
             assert(
               message.contains("Cannot overwrite a path that is also being read from."),
               "INSERT OVERWRITE to a table while querying it should not be allowed.")
+          } else {
+            sql(testSql)
+            checkAnswer(spark.table("insertTable"), Row(1, 1, 1) :: Row(2, 2) :: Nil)
           }
         }
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

When INSERT OVERWRITE a partitioned data source table, spark will verify input and output paths by default. Set to false to skip the verify in some cases.  (eg. INSERT OVERWRITE t partition(dt=a) SELECT * FROM t WHERE dt=b)

### Why are the changes needed?

Without this parameter , SQL like ` INSERT OVERWRITE t partition(dt=a) SELECT * FROM t WHERE dt=b` will throw `AnalysisException` exception.

```
Exception in thread "main" org.apache.spark.sql.AnalysisException: Cannot overwrite a path that is also being read from.;
	at org.apache.spark.sql.execution.command.DDLUtils$.verifyNotReadPath(ddl.scala:940)
	at org.apache.spark.sql.execution.datasources.DataSourceAnalysis$$anonfun$apply$1.applyOrElse(DataSourceStrategy.scala:226)
	at org.apache.spark.sql.execution.datasources.DataSourceAnalysis$$anonfun$apply$1.applyOrElse(DataSourceStrategy.scala:146)
```
 

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

Add new test case.