### PR TITLE
[SPARK-32143][SQL] Prevent a skewed join from producing too many partition splits

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -507,6 +507,15 @@ object SQLConf {
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("256MB")
 
+  val SKEW_JOIN_MAX_PARTITION_SPLITS =
+    buildConf("spark.sql.adaptive.skewJoin.maxPartitionSplits")
+      .doc("The max partition number produced in a skewed join. Generate the plan with too many " +
+        "split partitions will take a long time and may lead to OOM in execution.")
+      .version("3.1.0")
+      .intConf
+      .checkValue(_ > 0, "The max split number in skew join must be positive.")
+      .createWithDefault(10000000)
+
   val NON_EMPTY_PARTITION_RATIO_FOR_BROADCAST_JOIN =
     buildConf("spark.sql.adaptive.nonEmptyPartitionRatioForBroadcastJoin")
       .internal()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -509,12 +509,12 @@ object SQLConf {
 
   val SKEW_JOIN_MAX_PARTITION_SPLITS =
     buildConf("spark.sql.adaptive.skewJoin.maxPartitionSplits")
-      .doc("The max partition number produced in a skewed join. Generate the plan with too many " +
-        "split partitions will take a long time and may lead to OOM in execution.")
+      .doc("The max number of partitions produced in a skewed join. Generate the plan with too " +
+        "many split partitions will take a long time and may lead to OOM in execution.")
       .version("3.1.0")
       .intConf
       .checkValue(_ > 0, "The max split number in skew join must be positive.")
-      .createWithDefault(10000000)
+      .createWithDefault(1000000)
 
   val NON_EMPTY_PARTITION_RATIO_FOR_BROADCAST_JOIN =
     buildConf("spark.sql.adaptive.nonEmptyPartitionRatioForBroadcastJoin")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
@@ -238,7 +238,11 @@ case class OptimizeSkewedJoin(conf: SQLConf) extends Rule[SparkPlan] {
           rightSidePartitions += rightSidePartition
           if (leftSidePartitions.length > conf.getConf(SQLConf.SKEW_JOIN_MAX_PARTITION_SPLITS)) {
             throw new SparkException(s"Too many partition splits produced in handling data skew." +
-              s" The threshold is ${conf.getConf(SQLConf.SKEW_JOIN_MAX_PARTITION_SPLITS)}")
+              s" Current limitation is ${conf.getConf(SQLConf.SKEW_JOIN_MAX_PARTITION_SPLITS)}. " +
+              s"Increasing the threshold ${SQLConf.SKEW_JOIN_MAX_PARTITION_SPLITS.key} as a " +
+              s"workaround may lead to OOM which is depended on the cluster settings. Another " +
+              s"approach is to increase ${SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES.key} which " +
+              s"could help to reduce the number of partition splits.")
           }
         }
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
@@ -20,8 +20,7 @@ package org.apache.spark.sql.execution.adaptive
 import scala.collection.mutable
 
 import org.apache.commons.io.FileUtils
-
-import org.apache.spark.{MapOutputStatistics, MapOutputTrackerMaster, SparkEnv}
+import org.apache.spark.{MapOutputStatistics, MapOutputTrackerMaster, SparkEnv, SparkException}
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution._
@@ -236,6 +235,10 @@ case class OptimizeSkewedJoin(conf: SQLConf) extends Rule[SparkPlan] {
         } {
           leftSidePartitions += leftSidePartition
           rightSidePartitions += rightSidePartition
+          if (leftSidePartitions.length > conf.getConf(SQLConf.SKEW_JOIN_MAX_PARTITION_SPLITS)) {
+            throw new SparkException(s"Too many partition splits produced in handling data skew." +
+              s" The threshold is ${conf.getConf(SQLConf.SKEW_JOIN_MAX_PARTITION_SPLITS)}")
+          }
         }
       }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution.adaptive
 import scala.collection.mutable
 
 import org.apache.commons.io.FileUtils
+
 import org.apache.spark.{MapOutputStatistics, MapOutputTrackerMaster, SparkEnv, SparkException}
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.rules.Rule

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -21,7 +21,7 @@ import java.io.File
 import java.net.URI
 
 import org.apache.log4j.Level
-
+import org.apache.spark.SparkException
 import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent, SparkListenerJobStart}
 import org.apache.spark.sql.{QueryTest, Row, SparkSession, Strategy}
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight}
@@ -1035,6 +1035,35 @@ class AdaptiveQueryExecSuite
           assert(partitionsNum === 6)
         }
       }
+    }
+  }
+
+  test("SPARK-32143: Prevent a skewed join from producing too many partition splits") {
+    withSQLConf(
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
+      SQLConf.SKEW_JOIN_ENABLED.key -> "true",
+      SQLConf.SKEW_JOIN_SKEWED_PARTITION_THRESHOLD.key -> "600",
+      SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES.key -> "600",
+      SQLConf.SKEW_JOIN_MAX_PARTITION_SPLITS.key -> "4") {
+
+      val df1 = spark.range(0, 10, 1, 2)
+        .selectExpr("id % 5 as key1", "id as value1")
+
+      val df2 = spark.range(0, 1000, 1, 10)
+        .selectExpr("id % 1 as key2", "id as value2")
+
+      val join = df1.join(df2, col("key1") === col("key2"))
+        .select(col("key1"), col("value2"))
+
+      val smjBeforeExecution = join.queryExecution.sparkPlan.collect {
+        case smj: SortMergeJoinExec => smj
+      }
+      assert(smjBeforeExecution.length === 1)
+      val e = intercept[SparkException] {
+        join.collect()
+      }.getMessage
+      assert(e.contains("Too many partition splits produced in handling data skew"))
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -21,6 +21,7 @@ import java.io.File
 import java.net.URI
 
 import org.apache.log4j.Level
+
 import org.apache.spark.SparkException
 import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent, SparkListenerJobStart}
 import org.apache.spark.sql.{QueryTest, Row, SparkSession, Strategy}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a configuration `spark.sql.adaptive.skewJoin.maxPartitionSplits` to prevent a skewed join from producing too many partition splits.

### Why are the changes needed?
In handling skewed SortMergeJoin, when matching partitions from the left side and the right side both have skew and split too many partitions, the plan generation may take a very long time and finally OOM.

Even fallback to normal SMJ, the query cannot success either. So we should fast fail this query.

In below logs we can see that it took over 1 hour to generate the plan in AQE when handle a skewed join which produced too many splits.
```
20/06/30 12:31:26,271 INFO [HiveServer2-Background-Pool: Thread-821384] adaptive.OptimizeSkewedJoin:54 :
 20/06/30 12:31:26,299 INFO [HiveServer2-Background-Pool: Thread-821384] adaptive.OptimizeSkewedJoin:54 : Left side partition 1 (3 TB) is skewed, split it into *39150* parts.
 20/06/30 12:31:26,315 INFO [HiveServer2-Background-Pool: Thread-821384] adaptive.OptimizeSkewedJoin:54 : Right side partition 1 (11 TB) is skewed, split it into *17022* parts.
 20/06/30 12:32:24,952 INFO [HiveServer2-Background-Pool: Thread-821384] adaptive.OptimizeSkewedJoin:54 : Right side partition 8 (1 GB) is skewed, split it into 17 parts.

...
 20/06/30 13:27:25,158 INFO [HiveServer2-Background-Pool: Thread-821384] adaptive.AdaptiveSparkPlanExec:54 : Final plan: CollectLimit 1000
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add a ut
