### PR TITLE
[SPARK-32144][SQL] Retain EXTERNAL property in hive table properties

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -1053,7 +1053,7 @@ private[hive] object HiveClientImpl extends Logging {
     // For EXTERNAL_TABLE, we also need to set EXTERNAL field in the table properties.
     // Otherwise, Hive metastore will change the table to a MANAGED_TABLE.
     // (metastore/src/java/org/apache/hadoop/hive/metastore/ObjectStore.java#L1095-L1105)
-    if (table.tableType == CatalogTableType.EXTERNAL) {
+    if (table.properties.get("EXTERNAL").isEmpty && table.tableType == CatalogTableType.EXTERNAL) {
       hiveTable.setProperty("EXTERNAL", "TRUE")
     }
     // Note: In Hive the schema and partition columns must be disjoint sets

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -483,7 +483,6 @@ private[hive] class HiveClientImpl(
       "comment"
     )
     // We should match case 2
-    // List the case:
     // 1. MANAGED && TRUE => EXTERNAL
     // 2. MANAGED && true => MANAGED (EXTERNAL behavior)
     // 3. MANAGED && FALSE => MANAGED

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -2733,31 +2733,35 @@ class HiveDDLSuite
 
   test("SPARK-32144: Retain EXTERNAL property in hive table properties") {
     val catalog = spark.sessionState.catalog
-    withTable("t0", "t1") {
-      Seq(true, false).zipWithIndex.foreach { case (isExternalTable, i) =>
-        val tbl = s"t$i"
-        val external = if (isExternalTable) {
-          "external"
-        } else {
-          ""
-        }
-        sql(s"create $external table $tbl(c int)")
-        val table = catalog.getTableMetadata(TableIdentifier(tbl))
-        val alter1 = table.copy(properties = table.properties ++ Map("EXTERNAL" -> "true"))
-        // spark cann't modify EXTERNAL property so we have to use hive client
-        hiveClient.alterTable(alter1)
-        val table1 = catalog.getTableMetadata(TableIdentifier(tbl))
-        val alter2 = table.copy(properties = table.properties ++ Map("EXTERNAL" -> "false"))
-        hiveClient.alterTable(alter2)
-        val table2 = catalog.getTableMetadata(TableIdentifier(tbl))
+    withTempDir { tempDir =>
+      withTable("t0", "t1") {
+        // external table need a location
+        spark.range(1).write.mode(SaveMode.Overwrite).parquet(tempDir.toURI.toString)
+        Seq(true, false).zipWithIndex.foreach { case (isExternalTable, i) =>
+          val tbl = s"t$i"
+          val external = if (isExternalTable) {
+            "external"
+          } else {
+            ""
+          }
+          sql(s"create $external table $tbl(c int) location '${tempDir.toURI}'")
+          val table = catalog.getTableMetadata(TableIdentifier(tbl))
+          val alter1 = table.copy(properties = table.properties ++ Map("EXTERNAL" -> "true"))
+          // spark cann't modify EXTERNAL property so we have to use hive client
+          hiveClient.alterTable(alter1)
+          val table1 = catalog.getTableMetadata(TableIdentifier(tbl))
+          val alter2 = table.copy(properties = table.properties ++ Map("EXTERNAL" -> "false"))
+          hiveClient.alterTable(alter2)
+          val table2 = catalog.getTableMetadata(TableIdentifier(tbl))
 
-        assert(table.properties.get("EXTERNAL").isEmpty)
-        if (isExternalTable) {
-          assert(table1.properties.get("EXTERNAL").isEmpty)
-          assert(table2.properties("EXTERNAL") == "false")
-        } else {
-          assert(table1.properties("EXTERNAL") == "true")
-          assert(table2.properties.get("EXTERNAL").isEmpty)
+          assert(table.properties.get("EXTERNAL").isEmpty)
+          if (isExternalTable) {
+            assert(table1.properties.get("EXTERNAL").isEmpty)
+            assert(table2.properties("EXTERNAL") == "false")
+          } else {
+            assert(table1.properties("EXTERNAL") == "true")
+            assert(table2.properties.get("EXTERNAL").isEmpty)
+          }
         }
       }
     }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -2753,11 +2753,11 @@ class HiveDDLSuite
 
         assert(table.properties.get("EXTERNAL").isEmpty)
         if (isExternalTable) {
-          assert(table1.properties("EXTERNAL") == "false")
-          assert(table2.properties("EXTERNAL").isEmpty)
+          assert(table1.properties.get("EXTERNAL").isEmpty)
+          assert(table2.properties("EXTERNAL") == "false")
         } else {
           assert(table1.properties("EXTERNAL") == "true")
-          assert(table2.properties("EXTERNAL").isEmpty)
+          assert(table2.properties.get("EXTERNAL").isEmpty)
         }
       }
     }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -2740,10 +2740,12 @@ class HiveDDLSuite
       val alter1 = table.copy(properties = table.properties ++ Map("EXTERNAL" -> "true"))
       // spark cann't modify EXTERNAL property so we have to use hive client
       hiveClient.alterTable(alter1)
-      assert(table.properties.get("EXTERNAL").isEmpty)
+      val table1 = catalog.getTableMetadata(TableIdentifier("t1"))
+      assert(table1.properties("EXTERNAL") == "true")
       val alter2 = table.copy(properties = table.properties ++ Map("EXTERNAL" -> "false"))
       hiveClient.alterTable(alter2)
-      assert(table.properties("EXTERNAL") == "false")
+      val table2 = catalog.getTableMetadata(TableIdentifier("t1"))
+      assert(table2.properties("EXTERNAL").isEmpty)
     }
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -2750,7 +2750,6 @@ class HiveDDLSuite
           hiveClient.alterTable(alter1)
           val table1 = catalog.getTableMetadata(TableIdentifier(tbl))
           val alter2 = table.copy(properties = table.properties ++ Map("EXTERNAL" -> "TRUE"))
-          // spark cann't modify EXTERNAL property so we have to use hive client
           hiveClient.alterTable(alter2)
           val table2 = catalog.getTableMetadata(TableIdentifier(tbl))
 
@@ -2760,14 +2759,14 @@ class HiveDDLSuite
             assert(table1.tableType == CatalogTableType.MANAGED)
             assert(table1.properties("EXTERNAL") == "true")
             assert(table2.tableType == CatalogTableType.EXTERNAL)
-            assert(table2.properties("EXTERNAL").isEmpty)
+            assert(table2.properties.get("EXTERNAL").isEmpty)
           } else {
             assert(table.tableType == CatalogTableType.MANAGED)
             assert(table.properties.get("EXTERNAL").isEmpty)
             assert(table1.tableType == CatalogTableType.MANAGED)
             assert(table1.properties("EXTERNAL") == "true")
             assert(table2.tableType == CatalogTableType.EXTERNAL)
-            assert(table2.properties("EXTERNAL").isEmpty)
+            assert(table2.properties.get("EXTERNAL").isEmpty)
           }
         }
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Retain `EXTERNAL` property in table properties so that we can get it through `CatalogTable`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Hive support alter `EXTERNAL` using `alter table tbl set tblproperties('EXTERNAL'='true')`, the result is a managed table can be changed to an external table. Unfortunately spark excluded this property then we cann't get the `EXTERNAL` property.

Note that, hive change table type to EXTERNAL when value is `TRUE`, and not change table type but keep EXTERNAL behavior when value ignoreCaseEqual `true`. Below is all case, and we make error at case 2.

```
    // We should match case 2
    // 1. MANAGED && TRUE => EXTERNAL
    // 2. MANAGED && true => MANAGED (EXTERNAL behavior)
    // 3. MANAGED && FALSE => MANAGED
    // 4. MANAGED && false => MANAGED
    // 5. EXTERNAL && TRUE => EXTERNAL
    // 6. EXTERNAL && true => MANAGED
    // 7. EXTERNAL && FALSE => MANAGED
    // 8. EXTERNAL && false => MANAGED
```

Otherhand, it is a bug. Try this step to reproduce:
1. create a managed table t1.
2. use hive client `set tblproperties('EXTERNAL'='true')` (if we drop table t1 here, data will not be deleted.)
3. use spark `set tblproperties('k'='v')`
4. `drop table t1` will drop data since t1 tblproperties will not contains `EXTERNAL`

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, if `EXTERNAL` is useful user can get it.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Add ut.