### PR TITLE
[SPARK-31976][ML][PYSPARK] LinearSVC use MemoryUsage to control the size of block

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/param/shared/SharedParamsCodeGen.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/shared/SharedParamsCodeGen.scala
@@ -107,8 +107,10 @@ private[shared] object SharedParamsCodeGen {
         "validation."),
       ParamDesc[Int]("blockSize", "block size for stacking input data in matrices. Data is " +
         "stacked within partitions. If block size is more than remaining data in a partition " +
-        "then it is adjusted to the size of this data.",
-        isValid = "ParamValidators.gt(0)", isExpertParam = true)
+        "then it is adjusted to the size of this data",
+        isValid = "ParamValidators.gt(0)", isExpertParam = true),
+      ParamDesc[Int]("maxBlockMemoryInMB", "Maximum memory in MB allocated to stack instances " +
+        "to a block", isValid = "ParamValidators.gtEq(0)", isExpertParam = true)
     )
 
     val code = genSharedParams(params)

--- a/mllib/src/main/scala/org/apache/spark/ml/param/shared/sharedParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/shared/sharedParams.scala
@@ -554,12 +554,28 @@ trait HasValidationIndicatorCol extends Params {
 trait HasBlockSize extends Params {
 
   /**
-   * Param for block size for stacking input data in matrices. Data is stacked within partitions. If block size is more than remaining data in a partition then it is adjusted to the size of this data..
+   * Param for block size for stacking input data in matrices. Data is stacked within partitions. If block size is more than remaining data in a partition then it is adjusted to the size of this data.
    * @group expertParam
    */
-  final val blockSize: IntParam = new IntParam(this, "blockSize", "block size for stacking input data in matrices. Data is stacked within partitions. If block size is more than remaining data in a partition then it is adjusted to the size of this data.", ParamValidators.gt(0))
+  final val blockSize: IntParam = new IntParam(this, "blockSize", "block size for stacking input data in matrices. Data is stacked within partitions. If block size is more than remaining data in a partition then it is adjusted to the size of this data", ParamValidators.gt(0))
 
   /** @group expertGetParam */
   final def getBlockSize: Int = $(blockSize)
+}
+
+/**
+ * Trait for shared param maxBlockMemoryInMB. This trait may be changed or
+ * removed between minor versions.
+ */
+trait HasMaxBlockMemoryInMB extends Params {
+
+  /**
+   * Param for Maximum memory in MB allocated to stack instances to a block.
+   * @group expertParam
+   */
+  final val maxBlockMemoryInMB: IntParam = new IntParam(this, "maxBlockMemoryInMB", "Maximum memory in MB allocated to stack instances to a block", ParamValidators.gtEq(0))
+
+  /** @group expertGetParam */
+  final def getMaxBlockMemoryInMB: Int = $(maxBlockMemoryInMB)
 }
 // scalastyle:on

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LinearSVCSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LinearSVCSuite.scala
@@ -214,8 +214,8 @@ class LinearSVCSuite extends MLTest with DefaultReadWriteTest {
         .setFitIntercept(fitIntercept)
         .setMaxIter(5)
       val model = lsvc.fit(dataset)
-      Seq(4, 16, 64).foreach { blockSize =>
-        val model2 = lsvc.setBlockSize(blockSize).fit(dataset)
+      Seq(0, 1).foreach { memUsage =>
+        val model2 = lsvc.setMaxBlockMemoryInMB(memUsage).fit(dataset)
         assert(model.intercept ~== model2.intercept relTol 1e-9)
         assert(model.coefficients ~== model2.coefficients relTol 1e-9)
       }

--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -499,7 +499,7 @@ class _BinaryClassificationSummary(_ClassificationSummary):
 
 class _LinearSVCParams(_ClassifierParams, HasRegParam, HasMaxIter, HasFitIntercept, HasTol,
                        HasStandardization, HasWeightCol, HasAggregationDepth, HasThreshold,
-                       HasBlockSize):
+                       HasMaxBlockMemoryInMB):
     """
     Params for :py:class:`LinearSVC` and :py:class:`LinearSVCModel`.
 
@@ -548,8 +548,8 @@ class LinearSVC(_JavaClassifier, _LinearSVCParams, JavaMLWritable, JavaMLReadabl
     LinearSVCModel...
     >>> model.getThreshold()
     0.5
-    >>> model.getBlockSize()
-    1
+    >>> model.getMaxBlockMemoryInMB()
+    0
     >>> model.coefficients
     DenseVector([0.0, -0.2792, -0.1833])
     >>> model.intercept
@@ -588,19 +588,19 @@ class LinearSVC(_JavaClassifier, _LinearSVCParams, JavaMLWritable, JavaMLReadabl
     def __init__(self, featuresCol="features", labelCol="label", predictionCol="prediction",
                  maxIter=100, regParam=0.0, tol=1e-6, rawPredictionCol="rawPrediction",
                  fitIntercept=True, standardization=True, threshold=0.0, weightCol=None,
-                 aggregationDepth=2, blockSize=1):
+                 aggregationDepth=2, maxBlockMemoryInMB=0):
         """
         __init__(self, featuresCol="features", labelCol="label", predictionCol="prediction", \
                  maxIter=100, regParam=0.0, tol=1e-6, rawPredictionCol="rawPrediction", \
                  fitIntercept=True, standardization=True, threshold=0.0, weightCol=None, \
-                 aggregationDepth=2, blockSize=1):
+                 aggregationDepth=2, maxBlockMemoryInMB=0):
         """
         super(LinearSVC, self).__init__()
         self._java_obj = self._new_java_obj(
             "org.apache.spark.ml.classification.LinearSVC", self.uid)
         self._setDefault(maxIter=100, regParam=0.0, tol=1e-6, fitIntercept=True,
                          standardization=True, threshold=0.0, aggregationDepth=2,
-                         blockSize=1)
+                         maxBlockMemoryInMB=0)
         kwargs = self._input_kwargs
         self.setParams(**kwargs)
 
@@ -609,12 +609,12 @@ class LinearSVC(_JavaClassifier, _LinearSVCParams, JavaMLWritable, JavaMLReadabl
     def setParams(self, featuresCol="features", labelCol="label", predictionCol="prediction",
                   maxIter=100, regParam=0.0, tol=1e-6, rawPredictionCol="rawPrediction",
                   fitIntercept=True, standardization=True, threshold=0.0, weightCol=None,
-                  aggregationDepth=2, blockSize=1):
+                  aggregationDepth=2, maxBlockMemoryInMB=0):
         """
         setParams(self, featuresCol="features", labelCol="label", predictionCol="prediction", \
                   maxIter=100, regParam=0.0, tol=1e-6, rawPredictionCol="rawPrediction", \
                   fitIntercept=True, standardization=True, threshold=0.0, weightCol=None, \
-                  aggregationDepth=2, blockSize=1):
+                  aggregationDepth=2, maxBlockMemoryInMB=0):
         Sets params for Linear SVM Classifier.
         """
         kwargs = self._input_kwargs
@@ -680,11 +680,11 @@ class LinearSVC(_JavaClassifier, _LinearSVCParams, JavaMLWritable, JavaMLReadabl
         return self._set(aggregationDepth=value)
 
     @since("3.1.0")
-    def setBlockSize(self, value):
+    def setMaxBlockMemoryInMB(self, value):
         """
-        Sets the value of :py:attr:`blockSize`.
+        Sets the value of :py:attr:`maxBlockMemoryInMB`.
         """
-        return self._set(blockSize=value)
+        return self._set(maxBlockMemoryInMB=value)
 
 
 class LinearSVCModel(_JavaClassificationModel, _LinearSVCParams, JavaMLWritable, JavaMLReadable,

--- a/python/pyspark/ml/param/_shared_params_code_gen.py
+++ b/python/pyspark/ml/param/_shared_params_code_gen.py
@@ -167,7 +167,9 @@ if __name__ == "__main__":
          None, "TypeConverters.toString"),
         ("blockSize", "block size for stacking input data in matrices. Data is stacked within "
          "partitions. If block size is more than remaining data in a partition then it is "
-         "adjusted to the size of this data.", None, "TypeConverters.toInt")]
+         "adjusted to the size of this data.", None, "TypeConverters.toInt"),
+        ("maxBlockMemoryInMB", "Maximum memory in MB allocated to stack instances to a block.",
+         None, "TypeConverters.toInt")]
 
     code = []
     for name, doc, defaultValueStr, typeConverter in shared:

--- a/python/pyspark/ml/param/shared.py
+++ b/python/pyspark/ml/param/shared.py
@@ -597,3 +597,20 @@ class HasBlockSize(Params):
         Gets the value of blockSize or its default value.
         """
         return self.getOrDefault(self.blockSize)
+
+
+class HasMaxBlockMemoryInMB(Params):
+    """
+    Mixin for param maxBlockMemoryInMB: Maximum memory in MB allocated to stack instances to a block.
+    """
+
+    maxBlockMemoryInMB = Param(Params._dummy(), "maxBlockMemoryInMB", "Maximum memory in MB allocated to stack instances to a block.", typeConverter=TypeConverters.toInt)
+
+    def __init__(self):
+        super(HasMaxBlockMemoryInMB, self).__init__()
+
+    def getMaxBlockMemoryInMB(self):
+        """
+        Gets the value of maxBlockMemoryInMB or its default value.
+        """
+        return self.getOrDefault(self.maxBlockMemoryInMB)


### PR DESCRIPTION
### What changes were proposed in this pull request?
in LinearSVC, use `maxBlockMemoryInMB` instead of `blockSize`

### Why are the changes needed?
According to the performance test in https://issues.apache.org/jira/browse/SPARK-31783, the performance gain is mainly related to the nnz of block.


### Does this PR introduce _any_ user-facing change?
yes, `blockSize` is changed to `maxBlockMemoryInMB`


### How was this patch tested?
added testsuites
