### PR TITLE
[SPARK-32389][TESTS] Add all hive.execution suite in the parallel test group

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -490,7 +490,7 @@ object SparkParallelTestGrouping {
   private def testNameToTestGroup(name: String): String = name match {
     case _ if testsWhichShouldRunInTheirOwnDedicatedJvm.contains(name) => name
     // Different with the cases in testsWhichShouldRunInTheirOwnDedicatedJvm, here we are grouping
-    // all tests of `org.apache.spark.sql.hive.execution.*` into a single group, instead of
+    // all suites of `org.apache.spark.sql.hive.execution.*` into a single group, instead of
     // launching one JVM per suite.
     case _ if name.contains("org.apache.spark.sql.hive.execution") => HIVE_EXECUTION_TEST_GROUP
     case _ => DEFAULT_TEST_GROUP

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -489,7 +489,7 @@ object SparkParallelTestGrouping {
 
   private def testNameToTestGroup(name: String): String = name match {
     case _ if testsWhichShouldRunInTheirOwnDedicatedJvm.contains(name) => name
-    case _ if name.contains("org.apache.spark.sql.hive.execution") => VirtualMachineError
+    case _ if name.contains("org.apache.spark.sql.hive.execution") => HIVE_EXECUTION_TEST_GROUP
     case _ => DEFAULT_TEST_GROUP
   }
 

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -482,8 +482,8 @@ object SparkParallelTestGrouping {
     "org.apache.spark.sql.hive.thriftserver.ui.ThriftServerPageSuite",
     "org.apache.spark.sql.hive.thriftserver.ui.HiveThriftServer2ListenerSuite",
     "org.apache.spark.sql.kafka010.KafkaDelegationTokenSuite",
-    // For all hive.execution suites
-    "org.apache.spark.sql.hive.execution"
+    "org.apache.spark.sql.hive.execution.HashAggregationQueryWithControlledFallbackSuite",
+    "org.apache.spark.sql.hive.execution.HiveCompatibilitySuite"
   )
 
   private val DEFAULT_TEST_GROUP = "default_test_group"

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -469,7 +469,6 @@ object SparkParallelTestGrouping {
     "org.apache.spark.sql.catalyst.expressions.MathExpressionsSuite",
     "org.apache.spark.sql.hive.HiveExternalCatalogSuite",
     "org.apache.spark.sql.hive.StatisticsSuite",
-    "org.apache.spark.sql.hive.execution.HiveCompatibilitySuite",
     "org.apache.spark.sql.hive.client.VersionsSuite",
     "org.apache.spark.sql.hive.client.HiveClientVersions",
     "org.apache.spark.sql.hive.HiveExternalCatalogVersionsSuite",
@@ -482,7 +481,9 @@ object SparkParallelTestGrouping {
     "org.apache.spark.sql.hive.thriftserver.SparkSQLEnvSuite",
     "org.apache.spark.sql.hive.thriftserver.ui.ThriftServerPageSuite",
     "org.apache.spark.sql.hive.thriftserver.ui.HiveThriftServer2ListenerSuite",
-    "org.apache.spark.sql.kafka010.KafkaDelegationTokenSuite"
+    "org.apache.spark.sql.kafka010.KafkaDelegationTokenSuite",
+    // For all hive.execution suites
+    "org.apache.spark.sql.hive.execution"
   )
 
   private val DEFAULT_TEST_GROUP = "default_test_group"

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -481,15 +481,15 @@ object SparkParallelTestGrouping {
     "org.apache.spark.sql.hive.thriftserver.SparkSQLEnvSuite",
     "org.apache.spark.sql.hive.thriftserver.ui.ThriftServerPageSuite",
     "org.apache.spark.sql.hive.thriftserver.ui.HiveThriftServer2ListenerSuite",
-    "org.apache.spark.sql.kafka010.KafkaDelegationTokenSuite",
-    "org.apache.spark.sql.hive.execution.HashAggregationQueryWithControlledFallbackSuite",
-    "org.apache.spark.sql.hive.execution.HiveCompatibilitySuite"
+    "org.apache.spark.sql.kafka010.KafkaDelegationTokenSuite"
   )
 
   private val DEFAULT_TEST_GROUP = "default_test_group"
+  private val HIVE_EXECUTION_TEST_GROUP = "hive_execution_test_group"
 
   private def testNameToTestGroup(name: String): String = name match {
     case _ if testsWhichShouldRunInTheirOwnDedicatedJvm.contains(name) => name
+    case _ if name.contains("org.apache.spark.sql.hive.execution") => VirtualMachineError
     case _ => DEFAULT_TEST_GROUP
   }
 

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -489,6 +489,9 @@ object SparkParallelTestGrouping {
 
   private def testNameToTestGroup(name: String): String = name match {
     case _ if testsWhichShouldRunInTheirOwnDedicatedJvm.contains(name) => name
+    // Different with the cases in testsWhichShouldRunInTheirOwnDedicatedJvm, here we are grouping
+    // all tests of `org.apache.spark.sql.hive.execution.*` into a single group, instead of
+    // launching one JVM per suite.
     case _ if name.contains("org.apache.spark.sql.hive.execution") => HIVE_EXECUTION_TEST_GROUP
     case _ => DEFAULT_TEST_GROUP
   }

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -469,7 +469,6 @@ object SparkParallelTestGrouping {
     "org.apache.spark.sql.catalyst.expressions.MathExpressionsSuite",
     "org.apache.spark.sql.hive.HiveExternalCatalogSuite",
     "org.apache.spark.sql.hive.StatisticsSuite",
-    "org.apache.spark.sql.hive.execution.HiveCompatibilitySuite",
     "org.apache.spark.sql.hive.client.VersionsSuite",
     "org.apache.spark.sql.hive.client.HiveClientVersions",
     "org.apache.spark.sql.hive.HiveExternalCatalogVersionsSuite",
@@ -490,7 +489,7 @@ object SparkParallelTestGrouping {
 
   private def testNameToTestGroup(name: String): String = name match {
     case _ if testsWhichShouldRunInTheirOwnDedicatedJvm.contains(name) => name
-    case _ if name.contains("org.apache.spark.sql.hive.execution") => DEFAULT_TEST_GROUP
+    case _ if name.contains("org.apache.spark.sql.hive.execution") => HIVE_EXECUTION_TEST_GROUP
     case _ => DEFAULT_TEST_GROUP
   }
 

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -469,6 +469,7 @@ object SparkParallelTestGrouping {
     "org.apache.spark.sql.catalyst.expressions.MathExpressionsSuite",
     "org.apache.spark.sql.hive.HiveExternalCatalogSuite",
     "org.apache.spark.sql.hive.StatisticsSuite",
+    "org.apache.spark.sql.hive.execution.HiveCompatibilitySuite",
     "org.apache.spark.sql.hive.client.VersionsSuite",
     "org.apache.spark.sql.hive.client.HiveClientVersions",
     "org.apache.spark.sql.hive.HiveExternalCatalogVersionsSuite",
@@ -489,7 +490,7 @@ object SparkParallelTestGrouping {
 
   private def testNameToTestGroup(name: String): String = name match {
     case _ if testsWhichShouldRunInTheirOwnDedicatedJvm.contains(name) => name
-    case _ if name.contains("org.apache.spark.sql.hive.execution") => HIVE_EXECUTION_TEST_GROUP
+    case _ if name.contains("org.apache.spark.sql.hive.execution") => DEFAULT_TEST_GROUP
     case _ => DEFAULT_TEST_GROUP
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a new parallel test group for all `hive.execution` suites.

### Why are the changes needed?

Base on the tests, it can reduce the Jenkins testing time.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing tests.