### PR TITLE
[SPARK-32156][TESTS][SQL] Refactor two similar test cases from SPARK-31061 in HiveExternalCatalogSuite

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
@@ -183,18 +183,18 @@ class HiveExternalCatalogSuite extends ExternalCatalogSuite {
 
   test("SPARK-31061: alterTable should be able to change table provider/hive") {
     val catalog = newBasicCatalog()
-    Seq("parquet", "hive").foreach(i => {
+    Seq("parquet", "hive").foreach( provider => {
       val tableDDL = CatalogTable(
         identifier = TableIdentifier("parq_tbl", Some("db1")),
         tableType = CatalogTableType.MANAGED,
         storage = storageFormat,
         schema = new StructType().add("col1", "int"),
-        provider = Some(i))
+        provider = Some(provider))
       catalog.dropTable("db1", "parq_tbl", true, true)
       catalog.createTable(tableDDL, ignoreIfExists = false)
 
       val rawTable = externalCatalog.getTable("db1", "parq_tbl")
-      assert(rawTable.provider === Some(i))
+      assert(rawTable.provider === Some(provider))
 
       val fooTable = rawTable.copy(provider = Some("foo"))
       catalog.alterTable(fooTable)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
@@ -184,14 +184,14 @@ class HiveExternalCatalogSuite extends ExternalCatalogSuite {
   test("SPARK-31061: alterTable should be able to change table provider/hive") {
     val catalog = newBasicCatalog()
     Seq("parquet", "hive").foreach(i => {
-      val parquetTable = CatalogTable(
+      val tableDDL = CatalogTable(
         identifier = TableIdentifier("parq_tbl", Some("db1")),
         tableType = CatalogTableType.MANAGED,
         storage = storageFormat,
         schema = new StructType().add("col1", "int"),
         provider = Some(i))
       catalog.dropTable("db1", "parq_tbl", true, true)
-      catalog.createTable(parquetTable, ignoreIfExists = false)
+      catalog.createTable(tableDDL, ignoreIfExists = false)
 
       val rawTable = externalCatalog.getTable("db1", "parq_tbl")
       assert(rawTable.provider === Some(i))

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
@@ -182,40 +182,23 @@ class HiveExternalCatalogSuite extends ExternalCatalogSuite {
   }
 
   test("SPARK-31061: alterTable should be able to change table provider") {
-    val catalog = newBasicCatalog()
-    val parquetTable = CatalogTable(
-      identifier = TableIdentifier("parq_tbl", Some("db1")),
-      tableType = CatalogTableType.MANAGED,
-      storage = storageFormat.copy(locationUri = Some(new URI("file:/some/path"))),
-      schema = new StructType().add("col1", "int").add("col2", "string"),
-      provider = Some("parquet"))
-    catalog.createTable(parquetTable, ignoreIfExists = false)
+    Seq("parquet", "hive").foreach(i => {
+      val catalog = newBasicCatalog()
+      val parquetTable = CatalogTable(
+        identifier = TableIdentifier("parq_tbl", Some("db1")),
+        tableType = CatalogTableType.MANAGED,
+        storage = storageFormat,
+        schema = new StructType().add("col1", "int"),
+        provider = Some(i))
+      catalog.createTable(parquetTable, ignoreIfExists = false)
 
-    val rawTable = externalCatalog.getTable("db1", "parq_tbl")
-    assert(rawTable.provider === Some("parquet"))
+      val rawTable = externalCatalog.getTable("db1", "parq_tbl")
+      assert(rawTable.provider === Some(i))
 
-    val fooTable = parquetTable.copy(provider = Some("foo"))
-    catalog.alterTable(fooTable)
-    val alteredTable = externalCatalog.getTable("db1", "parq_tbl")
-    assert(alteredTable.provider === Some("foo"))
-  }
-
-  test("SPARK-31061: alterTable should be able to change table provider from hive") {
-    val catalog = newBasicCatalog()
-    val hiveTable = CatalogTable(
-      identifier = TableIdentifier("parq_tbl", Some("db1")),
-      tableType = CatalogTableType.MANAGED,
-      storage = storageFormat,
-      schema = new StructType().add("col1", "int").add("col2", "string"),
-      provider = Some("hive"))
-    catalog.createTable(hiveTable, ignoreIfExists = false)
-
-    val rawTable = externalCatalog.getTable("db1", "parq_tbl")
-    assert(rawTable.provider === Some("hive"))
-
-    val fooTable = rawTable.copy(provider = Some("foo"))
-    catalog.alterTable(fooTable)
-    val alteredTable = externalCatalog.getTable("db1", "parq_tbl")
-    assert(alteredTable.provider === Some("foo"))
+      val fooTable = parquetTable.copy(provider = Some("foo"))
+      catalog.alterTable(fooTable)
+      val alteredTable = externalCatalog.getTable("db1", "parq_tbl")
+      assert(alteredTable.provider === Some("foo"))
+    })
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
@@ -181,21 +181,22 @@ class HiveExternalCatalogSuite extends ExternalCatalogSuite {
       "INSERT overwrite directory \"fs://localhost/tmp\" select 1 as a"))
   }
 
-  test("SPARK-31061: alterTable should be able to change table provider") {
+  test("SPARK-31061: alterTable should be able to change table provider/hive") {
+    val catalog = newBasicCatalog()
     Seq("parquet", "hive").foreach(i => {
-      val catalog = newBasicCatalog()
       val parquetTable = CatalogTable(
         identifier = TableIdentifier("parq_tbl", Some("db1")),
         tableType = CatalogTableType.MANAGED,
         storage = storageFormat,
         schema = new StructType().add("col1", "int"),
         provider = Some(i))
+      catalog.dropTable("db1", "parq_tbl", true, true)
       catalog.createTable(parquetTable, ignoreIfExists = false)
 
       val rawTable = externalCatalog.getTable("db1", "parq_tbl")
       assert(rawTable.provider === Some(i))
 
-      val fooTable = parquetTable.copy(provider = Some("foo"))
+      val fooTable = rawTable.copy(provider = Some("foo"))
       catalog.alterTable(fooTable)
       val alteredTable = externalCatalog.getTable("db1", "parq_tbl")
       assert(alteredTable.provider === Some("foo"))


### PR DESCRIPTION
### What changes were proposed in this pull request?
1.Merge two similar tests for SPARK-31061 and make the code clean.
2.Fix table alter issue due to lose path.

### Why are the changes needed?
Because this two tests for SPARK-31061 is very similar and could be merged.
And the first test case should use `rawTable` instead of `parquetTable` to alter.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit test.