### PR TITLE
Backport patches / PRs #22323 and #24879 to Spark 2.4

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -225,6 +225,15 @@ private[spark] object Config extends Logging {
         "Ensure that major Python version is either Python2 or Python3")
       .createWithDefault("2")
 
+  val KUBERNETES_LOCAL_DIRS_TMPFS =
+    ConfigBuilder("spark.kubernetes.local.dirs.tmpfs")
+      .doc("If set to true then emptyDir volumes created to back SPARK_LOCAL_DIRS will have " +
+        "their medium set to Memory so that they will be created as tmpfs (i.e. RAM) backed " +
+        "volumes. This may improve performance but scratch space usage will count towards " +
+        "your pods memory limit so you may wish to request more memory.")
+      .booleanConf
+      .createWithDefault(false)
+
   val APP_RESOURCE_TYPE =
     ConfigBuilder("spark.kubernetes.resource.type")
       .doc("This sets the resource type internally")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStep.scala
@@ -16,10 +16,13 @@
  */
 package org.apache.spark.deploy.k8s.features
 
-import java.nio.file.Paths
 import java.util.UUID
 
-import org.apache.spark.deploy.k8s.{KubernetesConf, KubernetesDriverSpecificConf, KubernetesRoleSpecificConf, SparkPod}
+import scala.collection.JavaConverters._
+
+import io.fabric8.kubernetes.api.model._
+
+import org.apache.spark.deploy.k8s.{KubernetesConf, KubernetesRoleSpecificConf, SparkPod}
 import org.apache.spark.deploy.k8s.Config._
 
 private[spark] class LocalDirsFeatureStep(
@@ -27,7 +30,7 @@ private[spark] class LocalDirsFeatureStep(
     defaultLocalDir: String = s"/var/data/spark-${UUID.randomUUID}")
   extends KubernetesFeatureConfigStep {
 
-  private val useLocalDirTmpFs = conf.get(Config.KUBERNETES_LOCAL_DIRS_TMPFS)
+  private val useLocalDirTmpFs = conf.get(KUBERNETES_LOCAL_DIRS_TMPFS)
 
   override def configurePod(pod: SparkPod): SparkPod = {
     var localDirs = pod.container.getVolumeMounts.asScala

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStep.scala
@@ -76,7 +76,7 @@ private[spark] class LocalDirsFeatureStep(
     val containerWithLocalDirVolumeMounts = new ContainerBuilder(pod.container)
       .addNewEnv()
         .withName("SPARK_LOCAL_DIRS")
-        .withValue(resolvedLocalDirs.mkString(","))
+        .withValue(localDirs.mkString(","))
         .endEnv()
       .addToVolumeMounts(localDirVolumeMounts: _*)
       .build()

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStep.scala
@@ -19,43 +19,55 @@ package org.apache.spark.deploy.k8s.features
 import java.nio.file.Paths
 import java.util.UUID
 
-import io.fabric8.kubernetes.api.model.{ContainerBuilder, HasMetadata, PodBuilder, VolumeBuilder, VolumeMountBuilder}
-
 import org.apache.spark.deploy.k8s.{KubernetesConf, KubernetesDriverSpecificConf, KubernetesRoleSpecificConf, SparkPod}
+import org.apache.spark.deploy.k8s.Config._
 
 private[spark] class LocalDirsFeatureStep(
     conf: KubernetesConf[_ <: KubernetesRoleSpecificConf],
     defaultLocalDir: String = s"/var/data/spark-${UUID.randomUUID}")
   extends KubernetesFeatureConfigStep {
 
-  // Cannot use Utils.getConfiguredLocalDirs because that will default to the Java system
-  // property - we want to instead default to mounting an emptydir volume that doesn't already
-  // exist in the image.
-  // We could make utils.getConfiguredLocalDirs opinionated about Kubernetes, as it is already
-  // a bit opinionated about YARN and Mesos.
-  private val resolvedLocalDirs = Option(conf.sparkConf.getenv("SPARK_LOCAL_DIRS"))
-    .orElse(conf.getOption("spark.local.dir"))
-    .getOrElse(defaultLocalDir)
-    .split(",")
+  private val useLocalDirTmpFs = conf.get(Config.KUBERNETES_LOCAL_DIRS_TMPFS)
 
   override def configurePod(pod: SparkPod): SparkPod = {
-    val localDirVolumes = resolvedLocalDirs
-      .zipWithIndex
-      .map { case (localDir, index) =>
-        new VolumeBuilder()
-          .withName(s"spark-local-dir-${index + 1}")
-          .withNewEmptyDir()
-          .endEmptyDir()
-          .build()
-      }
-    val localDirVolumeMounts = localDirVolumes
-      .zip(resolvedLocalDirs)
-      .map { case (localDirVolume, localDirPath) =>
-        new VolumeMountBuilder()
-          .withName(localDirVolume.getName)
-          .withMountPath(localDirPath)
-          .build()
-      }
+    var localDirs = pod.container.getVolumeMounts.asScala
+      .filter(_.getName.startsWith("spark-local-dir-"))
+      .map(_.getMountPath)
+    var localDirVolumes : Seq[Volume] = Seq()
+    var localDirVolumeMounts : Seq[VolumeMount] = Seq()
+
+    if (localDirs.isEmpty) {
+      // Cannot use Utils.getConfiguredLocalDirs because that will default to the Java system
+      // property - we want to instead default to mounting an emptydir volume that doesn't already
+      // exist in the image.
+      // We could make utils.getConfiguredLocalDirs opinionated about Kubernetes, as it is already
+      // a bit opinionated about YARN and Mesos.
+      val resolvedLocalDirs = Option(conf.sparkConf.getenv("SPARK_LOCAL_DIRS"))
+        .orElse(conf.getOption("spark.local.dir"))
+        .getOrElse(defaultLocalDir)
+        .split(",")
+      localDirs = resolvedLocalDirs.toBuffer
+      localDirVolumes = resolvedLocalDirs
+        .zipWithIndex
+        .map { case (_, index) =>
+          new VolumeBuilder()
+            .withName(s"spark-local-dir-${index + 1}")
+            .withNewEmptyDir()
+            .withMedium(if (useLocalDirTmpFs) "Memory" else null)
+            .endEmptyDir()
+            .build()
+        }
+
+      localDirVolumeMounts = localDirVolumes
+        .zip(resolvedLocalDirs)
+        .map { case (localDirVolume, localDirPath) =>
+          new VolumeMountBuilder()
+            .withName(localDirVolume.getName)
+            .withMountPath(localDirPath)
+            .build()
+        }
+    }
+
     val podWithLocalDirVolumes = new PodBuilder(pod.pod)
       .editSpec()
         .addToVolumes(localDirVolumes: _*)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesDriverBuilder.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesDriverBuilder.scala
@@ -58,8 +58,7 @@ private[spark] class KubernetesDriverBuilder(
     val baseFeatures = Seq(
       provideBasicStep(kubernetesConf),
       provideCredentialsStep(kubernetesConf),
-      provideServiceStep(kubernetesConf),
-      provideLocalDirsStep(kubernetesConf))
+      provideServiceStep(kubernetesConf))
 
     val secretFeature = if (kubernetesConf.roleSecretNamesToMountPaths.nonEmpty) {
       Seq(provideSecretsStep(kubernetesConf))
@@ -70,6 +69,7 @@ private[spark] class KubernetesDriverBuilder(
     val volumesFeature = if (kubernetesConf.roleVolumes.nonEmpty) {
       Seq(provideVolumesStep(kubernetesConf))
     } else Nil
+    val localDirsFeature = Seq(provideLocalDirsStep(kubernetesConf))
 
     val bindingsStep = kubernetesConf.roleSpecificConf.mainAppResource.map {
         case JavaMainAppResource(_) =>
@@ -81,7 +81,7 @@ private[spark] class KubernetesDriverBuilder(
       .getOrElse(provideJavaStep(kubernetesConf))
 
     val allFeatures = (baseFeatures :+ bindingsStep) ++
-      secretFeature ++ envSecretFeature ++ volumesFeature
+      secretFeature ++ envSecretFeature ++ volumesFeature ++ localDirsFeature
 
     var spec = KubernetesDriverSpec.initialSpec(kubernetesConf.sparkConf.getAll.toMap)
     for (feature <- allFeatures) {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
@@ -40,7 +40,7 @@ private[spark] class KubernetesExecutorBuilder(
   def buildFromFeatures(
     kubernetesConf: KubernetesConf[KubernetesExecutorSpecificConf]): SparkPod = {
 
-    val baseFeatures = Seq(provideBasicStep(kubernetesConf), provideLocalDirsStep(kubernetesConf))
+    val baseFeatures = Seq(provideBasicStep(kubernetesConf))
     val secretFeature = if (kubernetesConf.roleSecretNamesToMountPaths.nonEmpty) {
       Seq(provideSecretsStep(kubernetesConf))
     } else Nil
@@ -50,8 +50,9 @@ private[spark] class KubernetesExecutorBuilder(
     val volumesFeature = if (kubernetesConf.roleVolumes.nonEmpty) {
       Seq(provideVolumesStep(kubernetesConf))
     } else Nil
+    val localDirsFeature = Seq(provideLocalDirsStep(kubernetesConf))
 
-    val allFeatures = baseFeatures ++ secretFeature ++ secretEnvFeature ++ volumesFeature
+    val allFeatures = baseFeatures ++ secretFeature ++ secretEnvFeature ++ volumesFeature ++ localDirsFeature
 
     var executorPod = SparkPod.initialPod()
     for (feature <- allFeatures) {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
@@ -52,7 +52,8 @@ private[spark] class KubernetesExecutorBuilder(
     } else Nil
     val localDirsFeature = Seq(provideLocalDirsStep(kubernetesConf))
 
-    val allFeatures = baseFeatures ++ secretFeature ++ secretEnvFeature ++ volumesFeature ++ localDirsFeature
+    val allFeatures = baseFeatures ++ secretFeature ++ secretEnvFeature ++ volumesFeature ++
+      localDirsFeature
 
     var executorPod = SparkPod.initialPod()
     for (feature <- allFeatures) {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStepSuite.scala
@@ -22,6 +22,7 @@ import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.deploy.k8s._
+import org.apache.spark.deploy.k8s.Config._
 
 class LocalDirsFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
   private val defaultLocalDir = "/var/data/default-local-dir"
@@ -144,14 +145,13 @@ class LocalDirsFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
     val volumeConf = KubernetesVolumeSpec(
       "spark-local-dir-test",
       "/tmp",
-      "",
       false,
       KubernetesHostPathVolumeConf("/hostPath/tmp")
     )
-    val kubernetesConf = KubernetesTestConf.createDriverConf(volumes = Seq(volumeConf))
-    val mountVolumeStep = new MountVolumesFeatureStep(kubernetesConf)
+    val kubernetesTestConf = kubernetesConf.copy(roleVolumes = Seq(volumeConf))
+    val mountVolumeStep = new MountVolumesFeatureStep(kubernetesTestConf)
     val configuredPod = mountVolumeStep.configurePod(SparkPod.initialPod())
-    val localDirStep = new LocalDirsFeatureStep(kubernetesConf, defaultLocalDir)
+    val localDirStep = new LocalDirsFeatureStep(kubernetesTestConf, defaultLocalDir)
     val newConfiguredPod = localDirStep.configurePod(configuredPod)
 
     assert(newConfiguredPod.pod.getSpec.getVolumes.size() === 1)


### PR DESCRIPTION
### What changes were proposed in this pull request?
We should backport the fixes for local dirs on Kubernetes to Spark 2.4. 


### Why are the changes needed?
Running Spark on Kubernetes and not being able to use mounted NVME drives as local storage causes issues on services such as AWS EKS. Upgrading to 3.0 just to fix this bug is more hassle than it's worth for some organizations.


### Does this PR introduce _any_ user-facing change?
Technically, yes. This adds the `spark.kubernetes.local.dirs.tmpfs` back to Spark 2.4 from Spark 3. However, there's no "breaking changes" per se.


### How was this patch tested?
The tests were backported. Also, we've been running our own custom Spark 2.4.5 build with this patch applied at my org for the past few months.
