### PR TITLE
[SPARK-32158] [SQL] Add options to toJSON function

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -1209,7 +1209,12 @@ abstract class JsonSuite extends QueryTest with SharedSparkSession with TestJson
       )
     }
   }
-
+  test("toJSON with Options") {
+    val df = spark.sparkContext.parallelize(Seq("1", "2", null)).toDF("col1")
+    val result = df.toJSON(Map("ignoreNullFields" -> "false")).collect().mkString(",")
+    val expected = """{"col1":"1"},{"col1":"2"},{"col1":null}"""
+    assert(result == expected)
+  }
   test("SPARK-4228 DataFrame to JSON") {
     withTempView("applySchema1", "applySchema2", "primitiveTable", "complexTable") {
       val schema1 = StructType(
@@ -1335,6 +1340,7 @@ abstract class JsonSuite extends QueryTest with SharedSparkSession with TestJson
       )
     }
   }
+
 
   test("Dataset toJSON doesn't construct rdd") {
     val containsRDD = spark.emptyDataFrame.toJSON.queryExecution.logical.find {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -1209,12 +1209,14 @@ abstract class JsonSuite extends QueryTest with SharedSparkSession with TestJson
       )
     }
   }
+
   test("toJSON with Options") {
     val df = spark.sparkContext.parallelize(Seq("1", "2", null)).toDF("col1")
     val result = df.toJSON(Map("ignoreNullFields" -> "false")).collect().mkString(",")
     val expected = """{"col1":"1"},{"col1":"2"},{"col1":null}"""
     assert(result == expected)
   }
+
   test("SPARK-4228 DataFrame to JSON") {
     withTempView("applySchema1", "applySchema2", "primitiveTable", "complexTable") {
       val schema1 = StructType(
@@ -1340,7 +1342,6 @@ abstract class JsonSuite extends QueryTest with SharedSparkSession with TestJson
       )
     }
   }
-
 
   test("Dataset toJSON doesn't construct rdd") {
     val containsRDD = spark.emptyDataFrame.toJSON.queryExecution.logical.find {


### PR DESCRIPTION

Now there is a `toJSON` function and I added `toJSON(options)` . I duplicated code now but the idea would be to have `toJSON()` and `toJSON(options)` so we could reuse all the code. The only problem is that adding the `()` to `toJSON` is a breaking change and I want to see what do you think about this.

For reference see  https://issues.apache.org/jira/browse/SPARK-23772.
### What changes were proposed in this pull request?
Adding JSON Option for `toJSON` 


### Why are the changes needed?
In order to be consistent with `to_json` and to be able to print null values when calling `toJSON`


### Does this PR introduce _any_ user-facing change?
Depends, the idea would be to use the original `toJSON` but the function doesn`t accept parameters, and if I add them, could be a break change.

### How was this patch tested?
Just added a test to show the use case. The idea is to reuse all the existing test cases plus some with null values.

Jira issue -> https://issues.apache.org/jira/browse/SPARK-32158
