### PR TITLE
 [SPARK-32170][CORE] Improve the speculation for the inefficient tasks by the task metrics.

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkStatusTracker.scala
+++ b/core/src/main/scala/org/apache/spark/SparkStatusTracker.scala
@@ -122,4 +122,8 @@ class SparkStatusTracker private[spark] (sc: SparkContext, store: AppStatusStore
         exec.memoryMetrics.map(_.totalOnHeapStorageMemory).getOrElse(0L))
     }.toArray
   }
+
+  def getAppStatusStore: AppStatusStore = {
+    store
+  }
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1828,6 +1828,22 @@ package object config {
       .doubleConf
       .createWithDefault(0.75)
 
+  private[spark] val SPECULATION_TASK_MIN_DURATION =
+    ConfigBuilder("spark.speculation.task.min.duration")
+      .doc("The minimum duration of a task can be speculatived.")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("0s")
+
+  private[spark] val SPECULATION_TASK_PROGRESS_MULTIPLIER =
+    ConfigBuilder("spark.speculation.task.progress.multiplier")
+      .doubleConf
+      .createWithDefault(1.0)
+
+  private[spark] val SPECULATION_TASK_DURATION_FACTOR =
+    ConfigBuilder("spark.speculation.task.duration.factor")
+      .doubleConf
+      .createWithDefault(2.0)
+
   private[spark] val SPECULATION_TASK_DURATION_THRESHOLD =
     ConfigBuilder("spark.speculation.task.duration.threshold")
       .doc("Task duration after which scheduler would try to speculative run the task. If " +


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
 Improve the speculation for the inefficient tasks by the task metrics.


### Why are the changes needed?

1) Tasks will be speculated when meet certain conditions no matter they are inefficient or not，this would be a huge waste of cluster resources.
2) In production, the speculation task comes  from an efficient one  will be killed finally, which is unnecessary and wastes the cluster resources. Sometimes, it interferes with other task scheduling.
3) So, we should  evaluate whether the task is inefficient by success tasks metrics firstly,  and then decide to speculate it or not. The  inefficient task should be speculated and the efficient one should not, it is better for the cluster resources.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

Add UT.

