### PR TITLE
[SPARK-29358][SQL] Make unionByName optionally fill missing columns with nulls

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2656,6 +2656,14 @@ object SQLConf {
       .checkValue(_ > 0, "The difference must be positive.")
       .createWithDefault(4)
 
+  val ALLOW_MISSING_COLUMNS_IN_UNION_BY_NAME =
+    buildConf("spark.sql.allowMissingColumnsInUnionByName")
+    .doc("If this config is enabled, `Dataset.unionByName` allows different set of column names " +
+      "between two Datasets. Missing columns at each side, will be filled with null values.")
+    .version("3.1.0")
+    .booleanConf
+    .createWithDefault(false)
+
   /**
    * Holds information about keys that have been deprecated.
    *
@@ -3250,6 +3258,9 @@ class SQLConf extends Serializable with Logging {
 
   def legacyAllowCastNumericToTimestamp: Boolean =
     getConf(SQLConf.LEGACY_ALLOW_CAST_NUMERIC_TO_TIMESTAMP)
+
+  def allowMissingColumnsInUnionByName: Boolean =
+    getConf(SQLConf.ALLOW_MISSING_COLUMNS_IN_UNION_BY_NAME)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2656,14 +2656,6 @@ object SQLConf {
       .checkValue(_ > 0, "The difference must be positive.")
       .createWithDefault(4)
 
-  val ALLOW_MISSING_COLUMNS_IN_UNION_BY_NAME =
-    buildConf("spark.sql.allowMissingColumnsInUnionByName")
-    .doc("If this config is enabled, `Dataset.unionByName` allows different set of column names " +
-      "between two Datasets. Missing columns at each side, will be filled with null values.")
-    .version("3.1.0")
-    .booleanConf
-    .createWithDefault(false)
-
   /**
    * Holds information about keys that have been deprecated.
    *
@@ -3258,9 +3250,6 @@ class SQLConf extends Serializable with Logging {
 
   def legacyAllowCastNumericToTimestamp: Boolean =
     getConf(SQLConf.LEGACY_ALLOW_CAST_NUMERIC_TO_TIMESTAMP)
-
-  def allowMissingColumnsInUnionByName: Boolean =
-    getConf(SQLConf.ALLOW_MISSING_COLUMNS_IN_UNION_BY_NAME)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2035,9 +2035,6 @@ class Dataset[T] private[sql](
   /**
    * Returns a new Dataset containing union of rows in this Dataset and another Dataset.
    *
-   * This is different from both `UNION ALL` and `UNION DISTINCT` in SQL. To do a SQL-style set
-   * union (that does deduplication of elements), use this function followed by a [[distinct]].
-   *
    * The difference between this function and [[union]] is that this function
    * resolves columns by name (not by position).
    *

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2048,7 +2048,7 @@ class Dataset[T] private[sql](
    *   val df2 = Seq((4, 5, 6)).toDF("col1", "col0", "col3")
    *   df1.unionByName(df2, true).show
    *
-   *   // output:
+   *   // output: "col3" is missing at left df1 and added at the end of schema.
    *   // +----+----+----+----+
    *   // |col0|col1|col2|col3|
    *   // +----+----+----+----+
@@ -2058,7 +2058,7 @@ class Dataset[T] private[sql](
    *
    *   df2.unionByName(df1, true).show
    *
-   *   // output:
+   *   // output: "col2" is missing at left df2 and added at the end of schema.
    *   // +----+----+----+----+
    *   // |col1|col0|col3|col2|
    *   // +----+----+----+----+

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2040,7 +2040,32 @@ class Dataset[T] private[sql](
    *
    * When the parameter `allowMissingColumns` is true, this function allows different set
    * of column names between two Datasets. Missing columns at each side, will be filled with
-   * null values.
+   * null values. The missing columns at left Dataset will be added at the end in the schema
+   * of the union result:
+   *
+   * {{{
+   *   val df1 = Seq((1, 2, 3)).toDF("col0", "col1", "col2")
+   *   val df2 = Seq((4, 5, 6)).toDF("col1", "col0", "col3")
+   *   df1.unionByName(df2, true).show
+   *
+   *   // output:
+   *   // +----+----+----+----+
+   *   // |col0|col1|col2|col3|
+   *   // +----+----+----+----+
+   *   // |   1|   2|   3|null|
+   *   // |   5|   4|null|   6|
+   *   // +----+----+----+----+
+   *
+   *   df2.unionByName(df1, true).show
+   *
+   *   // output:
+   *   // +----+----+----+----+
+   *   // |col1|col0|col3|col2|
+   *   // +----+----+----+----+
+   *   // |   4|   5|   6|null|
+   *   // |   2|   1|null|   3|
+   *   // +----+----+----+----+
+   * }}}
    *
    * @group typedrel
    * @since 3.1.0

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
@@ -524,5 +524,17 @@ class DataFrameSetOperationsSuite extends QueryTest with SharedSparkSession {
       Row(1, 2, null) :: Row(3, 5, 4) :: Nil)
     checkAnswer(df2.unionByName(df1, true),
       Row(3, 4, 5) :: Row(1, null, 2) :: Nil)
+
+    withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
+      df2 = Seq((3, 4, 5)).toDF("a", "B", "C")
+      val union1 = df1.unionByName(df2, true)
+      val union2 = df2.unionByName(df1, true)
+
+      checkAnswer(union1, Row(1, 2, null, null) :: Row(3, null, 4, 5) :: Nil)
+      checkAnswer(union2, Row(3, 4, 5, null) :: Row(1, null, null, 2) :: Nil)
+
+      assert(union1.schema.fieldNames === Array("a", "c", "B", "C"))
+      assert(union2.schema.fieldNames === Array("a", "B", "C", "c"))
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
@@ -523,6 +523,8 @@ class DataFrameSetOperationsSuite extends QueryTest with SharedSparkSession {
       df2 = Seq((3, 4, 5)).toDF("a", "b", "c")
       checkAnswer(df1.unionByName(df2),
         Row(1, 2, null) :: Row(3, 5, 4) :: Nil)
+      checkAnswer(df2.unionByName(df1),
+        Row(3, 4, 5) :: Row(1, null, 2) :: Nil)
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
@@ -508,23 +508,21 @@ class DataFrameSetOperationsSuite extends QueryTest with SharedSparkSession {
   }
 
   test("SPARK-29358: Make unionByName optionally fill missing columns with nulls") {
-    withSQLConf(SQLConf.ALLOW_MISSING_COLUMNS_IN_UNION_BY_NAME.key -> "true") {
-      var df1 = Seq(1, 2, 3).toDF("a")
-      var df2 = Seq(3, 1, 2).toDF("b")
-      val df3 = Seq(2, 3, 1).toDF("c")
-      val unionDf = df1.unionByName(df2.unionByName(df3))
-      checkAnswer(unionDf,
-        Row(1, null, null) :: Row(2, null, null) :: Row(3, null, null) :: // df1
-          Row(null, 3, null) :: Row(null, 1, null) :: Row(null, 2, null) :: // df2
-          Row(null, null, 2) :: Row(null, null, 3) :: Row(null, null, 1) :: Nil // df3
-      )
+    var df1 = Seq(1, 2, 3).toDF("a")
+    var df2 = Seq(3, 1, 2).toDF("b")
+    val df3 = Seq(2, 3, 1).toDF("c")
+    val unionDf = df1.unionByName(df2.unionByName(df3, true), true)
+    checkAnswer(unionDf,
+      Row(1, null, null) :: Row(2, null, null) :: Row(3, null, null) :: // df1
+        Row(null, 3, null) :: Row(null, 1, null) :: Row(null, 2, null) :: // df2
+        Row(null, null, 2) :: Row(null, null, 3) :: Row(null, null, 1) :: Nil // df3
+    )
 
-      df1 = Seq((1, 2)).toDF("a", "c")
-      df2 = Seq((3, 4, 5)).toDF("a", "b", "c")
-      checkAnswer(df1.unionByName(df2),
-        Row(1, 2, null) :: Row(3, 5, 4) :: Nil)
-      checkAnswer(df2.unionByName(df1),
-        Row(3, 4, 5) :: Row(1, null, 2) :: Nil)
-    }
+    df1 = Seq((1, 2)).toDF("a", "c")
+    df2 = Seq((3, 4, 5)).toDF("a", "b", "c")
+    checkAnswer(df1.unionByName(df2, true),
+      Row(1, 2, null) :: Row(3, 5, 4) :: Nil)
+    checkAnswer(df2.unionByName(df1, true),
+      Row(3, 4, 5) :: Row(1, null, 2) :: Nil)
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This patch proposes to make `unionByName` optionally fill missing columns with nulls.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Currently, `unionByName` throws exception if detecting different column names between two Datasets. It is strict requirement and sometimes users require more flexible usage that two Datasets with different subset of columns can be union by name resolution.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes. Adding overloading `Dataset.unionByName` with a boolean parameter that allows different set of column names between two Datasets. Missing columns at each side, will be filled with null values.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Unit test.