### PR TITLE
[SPARK-32173][SQL] Deduplicate code in FromUTCTimestamp and ToUTCTimestamp

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -1193,25 +1193,26 @@ trait UTCTimestamp extends BinaryExpression with ImplicitCastInputTypes with Nul
       val tz = right.eval().asInstanceOf[UTF8String]
       if (tz == null) {
         ev.copy(code = code"""
-          |boolean ${ev.isNull} = true;
-          |long ${ev.value} = 0;
-          |""".stripMargin)
+           |boolean ${ev.isNull} = true;
+           |long ${ev.value} = 0;
+         """.stripMargin)
       } else {
         val tzClass = classOf[ZoneId].getName
         val dtu = DateTimeUtils.getClass.getName.stripSuffix("$")
         val escapedTz = StringEscapeUtils.escapeJava(tz.toString)
-        val utcTerm = "java.time.ZoneOffset.UTC"
         val tzTerm = ctx.addMutableState(tzClass, "tz",
           v => s"""$v = $dtu.getZoneId("$escapedTz");""")
+        val utcTerm = "java.time.ZoneOffset.UTC"
         val (fromTz, toTz) = if (funcName == "fromUTCTime") (utcTerm, tzTerm) else (tzTerm, utcTerm)
         val eval = left.genCode(ctx)
         ev.copy(code = code"""
-          |${eval.code}
-          |boolean ${ev.isNull} = ${eval.isNull};
-          |long ${ev.value} = 0;
-          |if (!${ev.isNull}) {
-          |  ${ev.value} = $dtu.convertTz(${eval.value}, $fromTz, $toTz);
-          |}""".stripMargin)
+           |${eval.code}
+           |boolean ${ev.isNull} = ${eval.isNull};
+           |long ${ev.value} = 0;
+           |if (!${ev.isNull}) {
+           |  ${ev.value} = $dtu.convertTz(${eval.value}, $fromTz, $toTz);
+           |}
+         """.stripMargin)
       }
     } else {
       defineCodeGen(ctx, ev, (timestamp, format) => {


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Extract common code from the `FromUTCTimestamp` and `ToUTCTimestamp` expressions to new trait `UTCTimestamp`.
- Move `ToUTCTimestamp` closer to `FromUTCTimestamp`

### Why are the changes needed?
Code deduplication improves maintainability.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
By running date-time test suites such as `DateFunctionsSuite`