### PR TITLE
[SPARK-32196][SQL] Extract In convertible part if it is not convertible

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -230,8 +230,9 @@ object ReorderAssociativeOperator extends Rule[LogicalPlan] {
  * Optimize IN predicates:
  * 1. Converts the predicate to false when the list is empty and
  *    the value is not nullable.
- * 2. Removes literal repetitions.
- * 3. Replaces [[In (value, seq[Literal])]] with optimized version
+ * 2. Extract convertible part from list.
+ * 3. Removes literal repetitions.
+ * 4. Replaces [[In (value, seq[Literal])]] with optimized version
  *    [[InSet (value, HashSet[Literal])]] which is much faster.
  */
 object OptimizeIn extends Rule[LogicalPlan] {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -265,7 +265,8 @@ object OptimizeIn extends Rule[LogicalPlan] {
         val (convertible, nonConvertible) = list.partition(_.isInstanceOf[Literal])
         if (convertible.nonEmpty && nonConvertible.isEmpty) {
           optimizeIn(expr, v, list)
-        } else if (convertible.nonEmpty && nonConvertible.nonEmpty) {
+        } else if (convertible.nonEmpty && nonConvertible.nonEmpty &&
+          SQLConf.get.optimizerInExtractLiteralPart) {
           val optimizedIn = optimizeIn(In(v, convertible), v, convertible)
           Or(optimizedIn, In(v, nonConvertible))
         } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -267,7 +267,7 @@ object OptimizeIn extends Rule[LogicalPlan] {
           optimizeIn(expr, v, list)
         } else if (convertible.nonEmpty && nonConvertible.nonEmpty) {
           val optimizedIn = optimizeIn(In(v, convertible), v, convertible)
-          And(optimizedIn, In(v, nonConvertible))
+          Or(optimizedIn, In(v, nonConvertible))
         } else {
           expr
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -261,7 +261,7 @@ object OptimizeIn extends Rule[LogicalPlan] {
         // to FalseLiteral which is tested in OptimizeInSuite.scala
         If(IsNotNull(v), FalseLiteral, Literal(null, BooleanType))
       case expr @ In(v, list) =>
-        // split list to 2 parts so that we can push down convertible part
+        // split list to 2 parts so that we can optimize convertible part
         val (convertible, nonConvertible) = list.partition(_.isInstanceOf[Literal])
         if (convertible.nonEmpty && nonConvertible.isEmpty) {
           optimizeIn(expr, v, list)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -197,6 +197,14 @@ object SQLConf {
     .intConf
     .createWithDefault(100)
 
+  val OPTIMIZER_IN_EXTRACT_LITERAL_PART =
+    buildConf("spark.sql.optimizer.inExtractLiteralPart")
+      .internal()
+      .doc("When true, we will extract and optimize the literal part of in if not all are literal.")
+      .version("3.1.0")
+      .booleanConf
+      .createWithDefault(true)
+
   val OPTIMIZER_INSET_CONVERSION_THRESHOLD =
     buildConf("spark.sql.optimizer.inSetConversionThreshold")
       .internal()
@@ -2760,6 +2768,8 @@ class SQLConf extends Serializable with Logging {
   def optimizerExcludedRules: Option[String] = getConf(OPTIMIZER_EXCLUDED_RULES)
 
   def optimizerMaxIterations: Int = getConf(OPTIMIZER_MAX_ITERATIONS)
+
+  def optimizerInExtractLiteralPart: Boolean = getConf(OPTIMIZER_IN_EXTRACT_LITERAL_PART)
 
   def optimizerInSetConversionThreshold: Int = getConf(OPTIMIZER_INSET_CONVERSION_THRESHOLD)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeInSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeInSuite.scala
@@ -91,21 +91,6 @@ class OptimizeInSuite extends PlanTest {
     comparePlans(optimized, correctAnswer)
   }
 
-  test("OptimizedIn test: In clause not optimized in case filter has attributes") {
-    val originalQuery =
-      testRelation
-        .where(In(UnresolvedAttribute("a"), Seq(Literal(1), Literal(2), UnresolvedAttribute("b"))))
-        .analyze
-
-    val optimized = Optimize.execute(originalQuery.analyze)
-    val correctAnswer =
-      testRelation
-        .where(In(UnresolvedAttribute("a"), Seq(Literal(1), Literal(2), UnresolvedAttribute("b"))))
-        .analyze
-
-    comparePlans(optimized, correctAnswer)
-  }
-
   test("OptimizedIn test: NULL IN (expr1, ..., exprN) gets transformed to Filter(null)") {
     val originalQuery =
       testRelation

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeInSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeInSuite.scala
@@ -233,7 +233,7 @@ class OptimizeInSuite extends PlanTest {
     val correctAnswer1 =
       testRelation
         .where(
-          And(EqualTo(UnresolvedAttribute("a"), Literal(1)),
+          Or(EqualTo(UnresolvedAttribute("a"), Literal(1)),
             In(UnresolvedAttribute("a"), Seq(UnresolvedAttribute("b"))))
         )
         .analyze

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeInSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeInSuite.scala
@@ -239,7 +239,7 @@ class OptimizeInSuite extends PlanTest {
     comparePlans(optimized, correctAnswer)
   }
 
-  test("SPARK-32196: Extract convertible part if In is not convertible") {
+  test("SPARK-32196: Extract In convertible part if it is not convertible") {
     val originalQuery1 =
       testRelation
         .where(In(UnresolvedAttribute("a"), Seq(Literal(1), UnresolvedAttribute("b"))))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Modify `OptimizeIn`, extract In convertible part if it is not convertible.
And a new config `spark.sql.optimizer.inExtractLiteralPart` to control if we should extract the literal part of `In`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Try to optimize more predicate.
First split `In` to 2 parts, one is convertible the other is not convertible. Then we can optimize the convertible part.

A table `create table t1 (c1 int, c2 int) using parquet`
```
select * from t1 where c1 in (1, 2, c2)
=>
select * from t1 where c1 in (1, 2) or c1 in (c2)

select * from t1 where c1 in(1, c2)
=>
select * from t1 where c1 = 1 or c1 in(c2)

select * from t1 where c1 in(1, 2, ..., c2)
=> 
select * from t1 where c1 inset(1, 2, ...) or c1 in (c2)
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Add ut.