### PR TITLE
[SPARK-32216][SQL] Remove redundant ProjectExec

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2989,8 +2989,6 @@ class SQLConf extends Serializable with Logging {
 
   def subqueryReuseEnabled: Boolean = getConf(SUBQUERY_REUSE_ENABLED)
 
-  def removeRedundantProjectsEnabled: Boolean = getConf(REMOVE_REDUNDANT_PROJECTS_ENABLED)
-
   def caseSensitiveAnalysis: Boolean = getConf(SQLConf.CASE_SENSITIVE)
 
   def constraintPropagationEnabled: Boolean = getConf(CONSTRAINT_PROPAGATION_ENABLED)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1211,6 +1211,15 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
+  val REMOVE_REDUNDANT_PROJECTS_ENABLED =
+    buildConf("spark.sql.execution.removeRedundantProjects")
+    .internal()
+    .doc("Whether to remove redundant project exec node based on children's output and " +
+      "ordering requirement.")
+    .version("3.0.0")
+    .booleanConf
+    .createWithDefault(true)
+
   val STATE_STORE_PROVIDER_CLASS =
     buildConf("spark.sql.streaming.stateStore.providerClass")
       .internal()
@@ -2979,6 +2988,8 @@ class SQLConf extends Serializable with Logging {
   def exchangeReuseEnabled: Boolean = getConf(EXCHANGE_REUSE_ENABLED)
 
   def subqueryReuseEnabled: Boolean = getConf(SUBQUERY_REUSE_ENABLED)
+
+  def removeRedundantProjectsEnabled: Boolean = getConf(REMOVE_REDUNDANT_PROJECTS_ENABLED)
 
   def caseSensitiveAnalysis: Boolean = getConf(SQLConf.CASE_SENSITIVE)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1211,8 +1211,7 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
-  val REMOVE_REDUNDANT_PROJECTS_ENABLED =
-    buildConf("spark.sql.execution.removeRedundantProjects")
+  val REMOVE_REDUNDANT_PROJECTS_ENABLED = buildConf("spark.sql.execution.removeRedundantProjects")
     .internal()
     .doc("Whether to remove redundant project exec node based on children's output and " +
       "ordering requirement.")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1216,7 +1216,7 @@ object SQLConf {
     .internal()
     .doc("Whether to remove redundant project exec node based on children's output and " +
       "ordering requirement.")
-    .version("3.0.0")
+    .version("3.1.0")
     .booleanConf
     .createWithDefault(true)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -342,6 +342,7 @@ object QueryExecution {
       CoalesceBucketsInJoin(sparkSession.sessionState.conf),
       PlanDynamicPruningFilters(sparkSession),
       PlanSubqueries(sparkSession),
+      RemoveRedundantProjects(sparkSession.sessionState.conf),
       EnsureRequirements(sparkSession.sessionState.conf),
       ApplyColumnarRulesAndInsertTransitions(sparkSession.sessionState.conf,
         sparkSession.sessionState.columnarRules),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/RemoveRedundantProjects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/RemoveRedundantProjects.scala
@@ -61,7 +61,6 @@ case class RemoveRedundantProjects(conf: SQLConf) extends Rule[SparkPlan] {
         val keepOrdering = a.aggregateExpressions
           .exists(ae => ae.mode.equals(Final) || ae.mode.equals(PartialMerge))
         a.mapChildren(removeProject(_, keepOrdering))
-      case w: WindowExec => w.mapChildren(removeProject(_, false))
       case g: GenerateExec => g.mapChildren(removeProject(_, false))
       // JoinExec ordering requirement will inherit from its parent. If there is no ProjectExec in
       // its ancestors, JoinExec should require output columns to be ordered.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/RemoveRedundantProjects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/RemoveRedundantProjects.scala
@@ -89,8 +89,10 @@ case class RemoveRedundantProjects(conf: SQLConf) extends Rule[SparkPlan] {
           project.output.map(_.exprId.id) == child.output.map(_.exprId.id) &&
             checkNullability(project.output, child.output)
         } else {
-          project.output.map(_.exprId.id).sorted == child.output.map(_.exprId.id).sorted &&
-            checkNullability(project.output, child.output)
+          val orderedProjectOutput = project.output.sortBy(_.exprId.id)
+          val orderedChildOutput = child.output.sortBy(_.exprId.id)
+          orderedProjectOutput.map(_.exprId.id) == orderedChildOutput.map(_.exprId.id) &&
+            checkNullability(orderedProjectOutput, orderedChildOutput)
         }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -83,12 +83,14 @@ case class AdaptiveSparkPlanExec(
     )
   }
 
+  @transient private val removeRedundantProjects = RemoveRedundantProjects(conf)
   @transient private val ensureRequirements = EnsureRequirements(conf)
 
   // A list of physical plan rules to be applied before creation of query stages. The physical
   // plan should reach a final status of query stages (i.e., no more addition or removal of
   // Exchange nodes) after running these rules.
   private def queryStagePreparationRules: Seq[Rule[SparkPlan]] = Seq(
+    removeRedundantProjects,
     ensureRequirements
   ) ++ context.session.sessionState.queryStagePrepRules
 

--- a/sql/core/src/test/resources/sql-tests/results/explain-aqe.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain-aqe.sql.out
@@ -53,6 +53,7 @@ EXPLAIN FORMATTED
 struct<plan:string>
 -- !query output
 == Physical Plan ==
+<<<<<<< HEAD
 AdaptiveSparkPlan (9)
 +- == Current Plan ==
    Sort (8)
@@ -72,6 +73,16 @@ AdaptiveSparkPlan (9)
                +- Project (3)
                   +- Filter (2)
                      +- Scan parquet default.explain_temp1 (1)
+=======
+AdaptiveSparkPlan (8)
++- Sort (7)
+   +- Exchange (6)
+      +- HashAggregate (5)
+         +- Exchange (4)
+            +- HashAggregate (3)
+               +- Filter (2)
+                  +- Scan parquet default.explain_temp1 (1)
+>>>>>>> 1632028d2a... fix tests
 
 
 (1) Scan parquet default.explain_temp1
@@ -85,37 +96,33 @@ ReadSchema: struct<key:int,val:int>
 Input [2]: [key#x, val#x]
 Condition : (isnotnull(key#x) AND (key#x > 0))
 
-(3) Project
-Output [2]: [key#x, val#x]
-Input [2]: [key#x, val#x]
-
-(4) HashAggregate
+(3) HashAggregate
 Input [2]: [key#x, val#x]
 Keys [1]: [key#x]
 Functions [1]: [partial_max(val#x)]
 Aggregate Attributes [1]: [max#x]
 Results [2]: [key#x, max#x]
 
-(5) Exchange
+(4) Exchange
 Input [2]: [key#x, max#x]
 Arguments: hashpartitioning(key#x, 4), true, [id=#x]
 
-(6) HashAggregate
+(5) HashAggregate
 Input [2]: [key#x, max#x]
 Keys [1]: [key#x]
 Functions [1]: [max(val#x)]
 Aggregate Attributes [1]: [max(val#x)#x]
 Results [2]: [key#x, max(val#x)#x AS max(val)#x]
 
-(7) Exchange
+(6) Exchange
 Input [2]: [key#x, max(val)#x]
 Arguments: rangepartitioning(key#x ASC NULLS FIRST, 4), true, [id=#x]
 
-(8) Sort
+(7) Sort
 Input [2]: [key#x, max(val)#x]
 Arguments: [key#x ASC NULLS FIRST], true, 0
 
-(9) AdaptiveSparkPlan
+(8) AdaptiveSparkPlan
 Output [2]: [key#x, max(val)#x]
 Arguments: isFinalPlan=false
 
@@ -131,6 +138,7 @@ EXPLAIN FORMATTED
 struct<plan:string>
 -- !query output
 == Physical Plan ==
+<<<<<<< HEAD
 AdaptiveSparkPlan (9)
 +- == Current Plan ==
    Project (8)
@@ -150,6 +158,16 @@ AdaptiveSparkPlan (9)
                +- Project (3)
                   +- Filter (2)
                      +- Scan parquet default.explain_temp1 (1)
+=======
+AdaptiveSparkPlan (8)
++- Project (7)
+   +- Filter (6)
+      +- HashAggregate (5)
+         +- Exchange (4)
+            +- HashAggregate (3)
+               +- Filter (2)
+                  +- Scan parquet default.explain_temp1 (1)
+>>>>>>> 1632028d2a... fix tests
 
 
 (1) Scan parquet default.explain_temp1
@@ -163,37 +181,33 @@ ReadSchema: struct<key:int,val:int>
 Input [2]: [key#x, val#x]
 Condition : (isnotnull(key#x) AND (key#x > 0))
 
-(3) Project
-Output [2]: [key#x, val#x]
-Input [2]: [key#x, val#x]
-
-(4) HashAggregate
+(3) HashAggregate
 Input [2]: [key#x, val#x]
 Keys [1]: [key#x]
 Functions [1]: [partial_max(val#x)]
 Aggregate Attributes [1]: [max#x]
 Results [2]: [key#x, max#x]
 
-(5) Exchange
+(4) Exchange
 Input [2]: [key#x, max#x]
 Arguments: hashpartitioning(key#x, 4), true, [id=#x]
 
-(6) HashAggregate
+(5) HashAggregate
 Input [2]: [key#x, max#x]
 Keys [1]: [key#x]
 Functions [1]: [max(val#x)]
 Aggregate Attributes [1]: [max(val#x)#x]
 Results [3]: [key#x, max(val#x)#x AS max(val)#x, max(val#x)#x AS max(val#x)#x]
 
-(7) Filter
+(6) Filter
 Input [3]: [key#x, max(val)#x, max(val#x)#x]
 Condition : (isnotnull(max(val#x)#x) AND (max(val#x)#x > 0))
 
-(8) Project
+(7) Project
 Output [2]: [key#x, max(val)#x]
 Input [3]: [key#x, max(val)#x, max(val#x)#x]
 
-(9) AdaptiveSparkPlan
+(8) AdaptiveSparkPlan
 Output [2]: [key#x, max(val)#x]
 Arguments: isFinalPlan=false
 
@@ -207,6 +221,7 @@ EXPLAIN FORMATTED
 struct<plan:string>
 -- !query output
 == Physical Plan ==
+<<<<<<< HEAD
 AdaptiveSparkPlan (11)
 +- == Current Plan ==
    HashAggregate (10)
@@ -230,6 +245,17 @@ AdaptiveSparkPlan (11)
             +- Project (6)
                +- Filter (5)
                   +- Scan parquet default.explain_temp1 (4)
+=======
+AdaptiveSparkPlan (9)
++- HashAggregate (8)
+   +- Exchange (7)
+      +- HashAggregate (6)
+         +- Union (5)
+            :- Filter (2)
+            :  +- Scan parquet default.explain_temp1 (1)
+            +- Filter (4)
+               +- Scan parquet default.explain_temp1 (3)
+>>>>>>> 1632028d2a... fix tests
 
 
 (1) Scan parquet default.explain_temp1
@@ -243,26 +269,29 @@ ReadSchema: struct<key:int,val:int>
 Input [2]: [key#x, val#x]
 Condition : (isnotnull(key#x) AND (key#x > 0))
 
-(3) Project
-Output [2]: [key#x, val#x]
-Input [2]: [key#x, val#x]
-
-(4) Scan parquet default.explain_temp1
+(3) Scan parquet default.explain_temp1
 Output [2]: [key#x, val#x]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/explain_temp1]
 PushedFilters: [IsNotNull(key), GreaterThan(key,0)]
 ReadSchema: struct<key:int,val:int>
 
-(5) Filter
+(4) Filter
 Input [2]: [key#x, val#x]
 Condition : (isnotnull(key#x) AND (key#x > 0))
 
-(6) Project
-Output [2]: [key#x, val#x]
-Input [2]: [key#x, val#x]
+(5) Union
 
-(7) Union
+(6) HashAggregate
+Input [2]: [key#x, val#x]
+Keys [2]: [key#x, val#x]
+Functions: []
+Aggregate Attributes: []
+Results [2]: [key#x, val#x]
+
+(7) Exchange
+Input [2]: [key#x, val#x]
+Arguments: hashpartitioning(key#x, val#x, 4), true, [id=#x]
 
 (8) HashAggregate
 Input [2]: [key#x, val#x]
@@ -271,18 +300,7 @@ Functions: []
 Aggregate Attributes: []
 Results [2]: [key#x, val#x]
 
-(9) Exchange
-Input [2]: [key#x, val#x]
-Arguments: hashpartitioning(key#x, val#x, 4), true, [id=#x]
-
-(10) HashAggregate
-Input [2]: [key#x, val#x]
-Keys [2]: [key#x, val#x]
-Functions: []
-Aggregate Attributes: []
-Results [2]: [key#x, val#x]
-
-(11) AdaptiveSparkPlan
+(9) AdaptiveSparkPlan
 Output [2]: [key#x, val#x]
 Arguments: isFinalPlan=false
 
@@ -297,6 +315,7 @@ EXPLAIN FORMATTED
 struct<plan:string>
 -- !query output
 == Physical Plan ==
+<<<<<<< HEAD
 AdaptiveSparkPlan (9)
 +- == Current Plan ==
    BroadcastHashJoin Inner BuildRight (8)
@@ -316,6 +335,15 @@ AdaptiveSparkPlan (9)
       +- Project (6)
          +- Filter (5)
             +- Scan parquet default.explain_temp2 (4)
+=======
+AdaptiveSparkPlan (7)
++- BroadcastHashJoin Inner BuildRight (6)
+   :- Filter (2)
+   :  +- Scan parquet default.explain_temp1 (1)
+   +- BroadcastExchange (5)
+      +- Filter (4)
+         +- Scan parquet default.explain_temp2 (3)
+>>>>>>> 1632028d2a... fix tests
 
 
 (1) Scan parquet default.explain_temp1
@@ -329,35 +357,27 @@ ReadSchema: struct<key:int,val:int>
 Input [2]: [key#x, val#x]
 Condition : isnotnull(key#x)
 
-(3) Project
-Output [2]: [key#x, val#x]
-Input [2]: [key#x, val#x]
-
-(4) Scan parquet default.explain_temp2
+(3) Scan parquet default.explain_temp2
 Output [2]: [key#x, val#x]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/explain_temp2]
 PushedFilters: [IsNotNull(key)]
 ReadSchema: struct<key:int,val:int>
 
-(5) Filter
+(4) Filter
 Input [2]: [key#x, val#x]
 Condition : isnotnull(key#x)
 
-(6) Project
-Output [2]: [key#x, val#x]
+(5) BroadcastExchange
 Input [2]: [key#x, val#x]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint))), [id=#x]
 
-(7) BroadcastExchange
-Input [2]: [key#x, val#x]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#x]
-
-(8) BroadcastHashJoin
+(6) BroadcastHashJoin
 Left keys [1]: [key#x]
 Right keys [1]: [key#x]
 Join condition: None
 
-(9) AdaptiveSparkPlan
+(7) AdaptiveSparkPlan
 Output [4]: [key#x, val#x, key#x, val#x]
 Arguments: isFinalPlan=false
 
@@ -372,6 +392,7 @@ EXPLAIN FORMATTED
 struct<plan:string>
 -- !query output
 == Physical Plan ==
+<<<<<<< HEAD
 AdaptiveSparkPlan (7)
 +- == Current Plan ==
    BroadcastHashJoin LeftOuter BuildRight (6)
@@ -382,11 +403,14 @@ AdaptiveSparkPlan (7)
             +- Scan parquet default.explain_temp2 (2)
 +- == Initial Plan ==
    BroadcastHashJoin LeftOuter BuildRight (6)
+=======
+AdaptiveSparkPlan (6)
++- BroadcastHashJoin LeftOuter BuildRight (5)
+>>>>>>> 1632028d2a... fix tests
    :- Scan parquet default.explain_temp1 (1)
-   +- BroadcastExchange (5)
-      +- Project (4)
-         +- Filter (3)
-            +- Scan parquet default.explain_temp2 (2)
+   +- BroadcastExchange (4)
+      +- Filter (3)
+         +- Scan parquet default.explain_temp2 (2)
 
 
 (1) Scan parquet default.explain_temp1
@@ -406,20 +430,16 @@ ReadSchema: struct<key:int,val:int>
 Input [2]: [key#x, val#x]
 Condition : isnotnull(key#x)
 
-(4) Project
-Output [2]: [key#x, val#x]
+(4) BroadcastExchange
 Input [2]: [key#x, val#x]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint))), [id=#x]
 
-(5) BroadcastExchange
-Input [2]: [key#x, val#x]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#x]
-
-(6) BroadcastHashJoin
+(5) BroadcastHashJoin
 Left keys [1]: [key#x]
 Right keys [1]: [key#x]
 Join condition: None
 
-(7) AdaptiveSparkPlan
+(6) AdaptiveSparkPlan
 Output [4]: [key#x, val#x, key#x, val#x]
 Arguments: isFinalPlan=false
 
@@ -439,6 +459,7 @@ EXPLAIN FORMATTED
 struct<plan:string>
 -- !query output
 == Physical Plan ==
+<<<<<<< HEAD
 AdaptiveSparkPlan (4)
 +- == Current Plan ==
    Project (3)
@@ -448,6 +469,11 @@ AdaptiveSparkPlan (4)
    Project (3)
    +- Filter (2)
       +- Scan parquet default.explain_temp1 (1)
+=======
+AdaptiveSparkPlan (3)
++- Filter (2)
+   +- Scan parquet default.explain_temp1 (1)
+>>>>>>> 1632028d2a... fix tests
 
 
 (1) Scan parquet default.explain_temp1
@@ -461,11 +487,7 @@ ReadSchema: struct<key:int,val:int>
 Input [2]: [key#x, val#x]
 Condition : (((isnotnull(key#x) AND isnotnull(val#x)) AND (key#x = Subquery subquery#x, [id=#x])) AND (val#x > 3))
 
-(3) Project
-Output [2]: [key#x, val#x]
-Input [2]: [key#x, val#x]
-
-(4) AdaptiveSparkPlan
+(3) AdaptiveSparkPlan
 Output [2]: [key#x, val#x]
 Arguments: isFinalPlan=false
 
@@ -553,6 +575,7 @@ EXPLAIN FORMATTED
 struct<plan:string>
 -- !query output
 == Physical Plan ==
+<<<<<<< HEAD
 AdaptiveSparkPlan (9)
 +- == Current Plan ==
    BroadcastHashJoin Inner BuildRight (8)
@@ -572,6 +595,15 @@ AdaptiveSparkPlan (9)
       +- Project (6)
          +- Filter (5)
             +- Scan parquet default.explain_temp1 (4)
+=======
+AdaptiveSparkPlan (7)
++- BroadcastHashJoin Inner BuildRight (6)
+   :- Filter (2)
+   :  +- Scan parquet default.explain_temp1 (1)
+   +- BroadcastExchange (5)
+      +- Filter (4)
+         +- Scan parquet default.explain_temp1 (3)
+>>>>>>> 1632028d2a... fix tests
 
 
 (1) Scan parquet default.explain_temp1
@@ -585,35 +617,27 @@ ReadSchema: struct<key:int,val:int>
 Input [2]: [key#x, val#x]
 Condition : (isnotnull(key#x) AND (key#x > 10))
 
-(3) Project
-Output [2]: [key#x, val#x]
-Input [2]: [key#x, val#x]
-
-(4) Scan parquet default.explain_temp1
+(3) Scan parquet default.explain_temp1
 Output [2]: [key#x, val#x]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/explain_temp1]
 PushedFilters: [IsNotNull(key), GreaterThan(key,10)]
 ReadSchema: struct<key:int,val:int>
 
-(5) Filter
+(4) Filter
 Input [2]: [key#x, val#x]
 Condition : (isnotnull(key#x) AND (key#x > 10))
 
-(6) Project
-Output [2]: [key#x, val#x]
+(5) BroadcastExchange
 Input [2]: [key#x, val#x]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint))), [id=#x]
 
-(7) BroadcastExchange
-Input [2]: [key#x, val#x]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#x]
-
-(8) BroadcastHashJoin
+(6) BroadcastHashJoin
 Left keys [1]: [key#x]
 Right keys [1]: [key#x]
 Join condition: None
 
-(9) AdaptiveSparkPlan
+(7) AdaptiveSparkPlan
 Output [4]: [key#x, val#x, key#x, val#x]
 Arguments: isFinalPlan=false
 
@@ -631,6 +655,7 @@ EXPLAIN FORMATTED
 struct<plan:string>
 -- !query output
 == Physical Plan ==
+<<<<<<< HEAD
 AdaptiveSparkPlan (15)
 +- == Current Plan ==
    BroadcastHashJoin Inner BuildRight (14)
@@ -662,6 +687,21 @@ AdaptiveSparkPlan (15)
                +- Project (9)
                   +- Filter (8)
                      +- Scan parquet default.explain_temp1 (7)
+=======
+AdaptiveSparkPlan (13)
++- BroadcastHashJoin Inner BuildRight (12)
+   :- HashAggregate (5)
+   :  +- Exchange (4)
+   :     +- HashAggregate (3)
+   :        +- Filter (2)
+   :           +- Scan parquet default.explain_temp1 (1)
+   +- BroadcastExchange (11)
+      +- HashAggregate (10)
+         +- Exchange (9)
+            +- HashAggregate (8)
+               +- Filter (7)
+                  +- Scan parquet default.explain_temp1 (6)
+>>>>>>> 1632028d2a... fix tests
 
 
 (1) Scan parquet default.explain_temp1
@@ -675,71 +715,63 @@ ReadSchema: struct<key:int,val:int>
 Input [2]: [key#x, val#x]
 Condition : (isnotnull(key#x) AND (key#x > 10))
 
-(3) Project
-Output [2]: [key#x, val#x]
-Input [2]: [key#x, val#x]
-
-(4) HashAggregate
+(3) HashAggregate
 Input [2]: [key#x, val#x]
 Keys [1]: [key#x]
 Functions [1]: [partial_max(val#x)]
 Aggregate Attributes [1]: [max#x]
 Results [2]: [key#x, max#x]
 
-(5) Exchange
+(4) Exchange
 Input [2]: [key#x, max#x]
 Arguments: hashpartitioning(key#x, 4), true, [id=#x]
 
-(6) HashAggregate
+(5) HashAggregate
 Input [2]: [key#x, max#x]
 Keys [1]: [key#x]
 Functions [1]: [max(val#x)]
 Aggregate Attributes [1]: [max(val#x)#x]
 Results [2]: [key#x, max(val#x)#x AS max(val)#x]
 
-(7) Scan parquet default.explain_temp1
+(6) Scan parquet default.explain_temp1
 Output [2]: [key#x, val#x]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/explain_temp1]
 PushedFilters: [IsNotNull(key), GreaterThan(key,10)]
 ReadSchema: struct<key:int,val:int>
 
-(8) Filter
+(7) Filter
 Input [2]: [key#x, val#x]
 Condition : (isnotnull(key#x) AND (key#x > 10))
 
-(9) Project
-Output [2]: [key#x, val#x]
-Input [2]: [key#x, val#x]
-
-(10) HashAggregate
+(8) HashAggregate
 Input [2]: [key#x, val#x]
 Keys [1]: [key#x]
 Functions [1]: [partial_max(val#x)]
 Aggregate Attributes [1]: [max#x]
 Results [2]: [key#x, max#x]
 
-(11) Exchange
+(9) Exchange
 Input [2]: [key#x, max#x]
 Arguments: hashpartitioning(key#x, 4), true, [id=#x]
 
-(12) HashAggregate
+(10) HashAggregate
 Input [2]: [key#x, max#x]
 Keys [1]: [key#x]
 Functions [1]: [max(val#x)]
 Aggregate Attributes [1]: [max(val#x)#x]
 Results [2]: [key#x, max(val#x)#x AS max(val)#x]
 
-(13) BroadcastExchange
+(11) BroadcastExchange
 Input [2]: [key#x, max(val)#x]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#x]
 
-(14) BroadcastHashJoin
+(12) BroadcastHashJoin
 Left keys [1]: [key#x]
 Right keys [1]: [key#x]
 Join condition: None
 
-(15) AdaptiveSparkPlan
+(13) AdaptiveSparkPlan
 Output [4]: [key#x, max(val)#x, key#x, max(val)#x]
 Arguments: isFinalPlan=false
 

--- a/sql/core/src/test/resources/sql-tests/results/explain-aqe.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain-aqe.sql.out
@@ -53,36 +53,23 @@ EXPLAIN FORMATTED
 struct<plan:string>
 -- !query output
 == Physical Plan ==
-<<<<<<< HEAD
-AdaptiveSparkPlan (9)
-+- == Current Plan ==
-   Sort (8)
-   +- Exchange (7)
-      +- HashAggregate (6)
-         +- Exchange (5)
-            +- HashAggregate (4)
-               +- Project (3)
-                  +- Filter (2)
-                     +- Scan parquet default.explain_temp1 (1)
-+- == Initial Plan ==
-   Sort (8)
-   +- Exchange (7)
-      +- HashAggregate (6)
-         +- Exchange (5)
-            +- HashAggregate (4)
-               +- Project (3)
-                  +- Filter (2)
-                     +- Scan parquet default.explain_temp1 (1)
-=======
 AdaptiveSparkPlan (8)
-+- Sort (7)
++- == Current Plan ==
+   Sort (7)
    +- Exchange (6)
       +- HashAggregate (5)
          +- Exchange (4)
             +- HashAggregate (3)
                +- Filter (2)
                   +- Scan parquet default.explain_temp1 (1)
->>>>>>> 1632028d2a... fix tests
++- == Initial Plan ==
+   Sort (7)
+   +- Exchange (6)
+      +- HashAggregate (5)
+         +- Exchange (4)
+            +- HashAggregate (3)
+               +- Filter (2)
+                  +- Scan parquet default.explain_temp1 (1)
 
 
 (1) Scan parquet default.explain_temp1
@@ -138,36 +125,23 @@ EXPLAIN FORMATTED
 struct<plan:string>
 -- !query output
 == Physical Plan ==
-<<<<<<< HEAD
-AdaptiveSparkPlan (9)
-+- == Current Plan ==
-   Project (8)
-   +- Filter (7)
-      +- HashAggregate (6)
-         +- Exchange (5)
-            +- HashAggregate (4)
-               +- Project (3)
-                  +- Filter (2)
-                     +- Scan parquet default.explain_temp1 (1)
-+- == Initial Plan ==
-   Project (8)
-   +- Filter (7)
-      +- HashAggregate (6)
-         +- Exchange (5)
-            +- HashAggregate (4)
-               +- Project (3)
-                  +- Filter (2)
-                     +- Scan parquet default.explain_temp1 (1)
-=======
 AdaptiveSparkPlan (8)
-+- Project (7)
++- == Current Plan ==
+   Project (7)
    +- Filter (6)
       +- HashAggregate (5)
          +- Exchange (4)
             +- HashAggregate (3)
                +- Filter (2)
                   +- Scan parquet default.explain_temp1 (1)
->>>>>>> 1632028d2a... fix tests
++- == Initial Plan ==
+   Project (7)
+   +- Filter (6)
+      +- HashAggregate (5)
+         +- Exchange (4)
+            +- HashAggregate (3)
+               +- Filter (2)
+                  +- Scan parquet default.explain_temp1 (1)
 
 
 (1) Scan parquet default.explain_temp1
@@ -221,33 +195,9 @@ EXPLAIN FORMATTED
 struct<plan:string>
 -- !query output
 == Physical Plan ==
-<<<<<<< HEAD
-AdaptiveSparkPlan (11)
-+- == Current Plan ==
-   HashAggregate (10)
-   +- Exchange (9)
-      +- HashAggregate (8)
-         +- Union (7)
-            :- Project (3)
-            :  +- Filter (2)
-            :     +- Scan parquet default.explain_temp1 (1)
-            +- Project (6)
-               +- Filter (5)
-                  +- Scan parquet default.explain_temp1 (4)
-+- == Initial Plan ==
-   HashAggregate (10)
-   +- Exchange (9)
-      +- HashAggregate (8)
-         +- Union (7)
-            :- Project (3)
-            :  +- Filter (2)
-            :     +- Scan parquet default.explain_temp1 (1)
-            +- Project (6)
-               +- Filter (5)
-                  +- Scan parquet default.explain_temp1 (4)
-=======
 AdaptiveSparkPlan (9)
-+- HashAggregate (8)
++- == Current Plan ==
+   HashAggregate (8)
    +- Exchange (7)
       +- HashAggregate (6)
          +- Union (5)
@@ -255,7 +205,15 @@ AdaptiveSparkPlan (9)
             :  +- Scan parquet default.explain_temp1 (1)
             +- Filter (4)
                +- Scan parquet default.explain_temp1 (3)
->>>>>>> 1632028d2a... fix tests
++- == Initial Plan ==
+   HashAggregate (8)
+   +- Exchange (7)
+      +- HashAggregate (6)
+         +- Union (5)
+            :- Filter (2)
+            :  +- Scan parquet default.explain_temp1 (1)
+            +- Filter (4)
+               +- Scan parquet default.explain_temp1 (3)
 
 
 (1) Scan parquet default.explain_temp1
@@ -315,35 +273,21 @@ EXPLAIN FORMATTED
 struct<plan:string>
 -- !query output
 == Physical Plan ==
-<<<<<<< HEAD
-AdaptiveSparkPlan (9)
-+- == Current Plan ==
-   BroadcastHashJoin Inner BuildRight (8)
-   :- Project (3)
-   :  +- Filter (2)
-   :     +- Scan parquet default.explain_temp1 (1)
-   +- BroadcastExchange (7)
-      +- Project (6)
-         +- Filter (5)
-            +- Scan parquet default.explain_temp2 (4)
-+- == Initial Plan ==
-   BroadcastHashJoin Inner BuildRight (8)
-   :- Project (3)
-   :  +- Filter (2)
-   :     +- Scan parquet default.explain_temp1 (1)
-   +- BroadcastExchange (7)
-      +- Project (6)
-         +- Filter (5)
-            +- Scan parquet default.explain_temp2 (4)
-=======
 AdaptiveSparkPlan (7)
-+- BroadcastHashJoin Inner BuildRight (6)
++- == Current Plan ==
+   BroadcastHashJoin Inner BuildRight (6)
    :- Filter (2)
    :  +- Scan parquet default.explain_temp1 (1)
    +- BroadcastExchange (5)
       +- Filter (4)
          +- Scan parquet default.explain_temp2 (3)
->>>>>>> 1632028d2a... fix tests
++- == Initial Plan ==
+   BroadcastHashJoin Inner BuildRight (6)
+   :- Filter (2)
+   :  +- Scan parquet default.explain_temp1 (1)
+   +- BroadcastExchange (5)
+      +- Filter (4)
+         +- Scan parquet default.explain_temp2 (3)
 
 
 (1) Scan parquet default.explain_temp1
@@ -392,21 +336,15 @@ EXPLAIN FORMATTED
 struct<plan:string>
 -- !query output
 == Physical Plan ==
-<<<<<<< HEAD
-AdaptiveSparkPlan (7)
-+- == Current Plan ==
-   BroadcastHashJoin LeftOuter BuildRight (6)
-   :- Scan parquet default.explain_temp1 (1)
-   +- BroadcastExchange (5)
-      +- Project (4)
-         +- Filter (3)
-            +- Scan parquet default.explain_temp2 (2)
-+- == Initial Plan ==
-   BroadcastHashJoin LeftOuter BuildRight (6)
-=======
 AdaptiveSparkPlan (6)
-+- BroadcastHashJoin LeftOuter BuildRight (5)
->>>>>>> 1632028d2a... fix tests
++- == Current Plan ==
+   BroadcastHashJoin LeftOuter BuildRight (5)
+   :- Scan parquet default.explain_temp1 (1)
+   +- BroadcastExchange (4)
+      +- Filter (3)
+         +- Scan parquet default.explain_temp2 (2)
++- == Initial Plan ==
+   BroadcastHashJoin LeftOuter BuildRight (5)
    :- Scan parquet default.explain_temp1 (1)
    +- BroadcastExchange (4)
       +- Filter (3)
@@ -459,21 +397,13 @@ EXPLAIN FORMATTED
 struct<plan:string>
 -- !query output
 == Physical Plan ==
-<<<<<<< HEAD
-AdaptiveSparkPlan (4)
-+- == Current Plan ==
-   Project (3)
-   +- Filter (2)
-      +- Scan parquet default.explain_temp1 (1)
-+- == Initial Plan ==
-   Project (3)
-   +- Filter (2)
-      +- Scan parquet default.explain_temp1 (1)
-=======
 AdaptiveSparkPlan (3)
-+- Filter (2)
++- == Current Plan ==
+   Filter (2)
    +- Scan parquet default.explain_temp1 (1)
->>>>>>> 1632028d2a... fix tests
++- == Initial Plan ==
+   Filter (2)
+   +- Scan parquet default.explain_temp1 (1)
 
 
 (1) Scan parquet default.explain_temp1
@@ -575,35 +505,21 @@ EXPLAIN FORMATTED
 struct<plan:string>
 -- !query output
 == Physical Plan ==
-<<<<<<< HEAD
-AdaptiveSparkPlan (9)
-+- == Current Plan ==
-   BroadcastHashJoin Inner BuildRight (8)
-   :- Project (3)
-   :  +- Filter (2)
-   :     +- Scan parquet default.explain_temp1 (1)
-   +- BroadcastExchange (7)
-      +- Project (6)
-         +- Filter (5)
-            +- Scan parquet default.explain_temp1 (4)
-+- == Initial Plan ==
-   BroadcastHashJoin Inner BuildRight (8)
-   :- Project (3)
-   :  +- Filter (2)
-   :     +- Scan parquet default.explain_temp1 (1)
-   +- BroadcastExchange (7)
-      +- Project (6)
-         +- Filter (5)
-            +- Scan parquet default.explain_temp1 (4)
-=======
 AdaptiveSparkPlan (7)
-+- BroadcastHashJoin Inner BuildRight (6)
++- == Current Plan ==
+   BroadcastHashJoin Inner BuildRight (6)
    :- Filter (2)
    :  +- Scan parquet default.explain_temp1 (1)
    +- BroadcastExchange (5)
       +- Filter (4)
          +- Scan parquet default.explain_temp1 (3)
->>>>>>> 1632028d2a... fix tests
++- == Initial Plan ==
+   BroadcastHashJoin Inner BuildRight (6)
+   :- Filter (2)
+   :  +- Scan parquet default.explain_temp1 (1)
+   +- BroadcastExchange (5)
+      +- Filter (4)
+         +- Scan parquet default.explain_temp1 (3)
 
 
 (1) Scan parquet default.explain_temp1
@@ -655,41 +571,9 @@ EXPLAIN FORMATTED
 struct<plan:string>
 -- !query output
 == Physical Plan ==
-<<<<<<< HEAD
-AdaptiveSparkPlan (15)
-+- == Current Plan ==
-   BroadcastHashJoin Inner BuildRight (14)
-   :- HashAggregate (6)
-   :  +- Exchange (5)
-   :     +- HashAggregate (4)
-   :        +- Project (3)
-   :           +- Filter (2)
-   :              +- Scan parquet default.explain_temp1 (1)
-   +- BroadcastExchange (13)
-      +- HashAggregate (12)
-         +- Exchange (11)
-            +- HashAggregate (10)
-               +- Project (9)
-                  +- Filter (8)
-                     +- Scan parquet default.explain_temp1 (7)
-+- == Initial Plan ==
-   BroadcastHashJoin Inner BuildRight (14)
-   :- HashAggregate (6)
-   :  +- Exchange (5)
-   :     +- HashAggregate (4)
-   :        +- Project (3)
-   :           +- Filter (2)
-   :              +- Scan parquet default.explain_temp1 (1)
-   +- BroadcastExchange (13)
-      +- HashAggregate (12)
-         +- Exchange (11)
-            +- HashAggregate (10)
-               +- Project (9)
-                  +- Filter (8)
-                     +- Scan parquet default.explain_temp1 (7)
-=======
 AdaptiveSparkPlan (13)
-+- BroadcastHashJoin Inner BuildRight (12)
++- == Current Plan ==
+   BroadcastHashJoin Inner BuildRight (12)
    :- HashAggregate (5)
    :  +- Exchange (4)
    :     +- HashAggregate (3)
@@ -701,7 +585,19 @@ AdaptiveSparkPlan (13)
             +- HashAggregate (8)
                +- Filter (7)
                   +- Scan parquet default.explain_temp1 (6)
->>>>>>> 1632028d2a... fix tests
++- == Initial Plan ==
+   BroadcastHashJoin Inner BuildRight (12)
+   :- HashAggregate (5)
+   :  +- Exchange (4)
+   :     +- HashAggregate (3)
+   :        +- Filter (2)
+   :           +- Scan parquet default.explain_temp1 (1)
+   +- BroadcastExchange (11)
+      +- HashAggregate (10)
+         +- Exchange (9)
+            +- HashAggregate (8)
+               +- Filter (7)
+                  +- Scan parquet default.explain_temp1 (6)
 
 
 (1) Scan parquet default.explain_temp1

--- a/sql/core/src/test/resources/sql-tests/results/explain-aqe.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain-aqe.sql.out
@@ -370,7 +370,7 @@ Condition : isnotnull(key#x)
 
 (5) BroadcastExchange
 Input [2]: [key#x, val#x]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint))), [id=#x]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#x]
 
 (6) BroadcastHashJoin
 Left keys [1]: [key#x]
@@ -432,7 +432,7 @@ Condition : isnotnull(key#x)
 
 (4) BroadcastExchange
 Input [2]: [key#x, val#x]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint))), [id=#x]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#x]
 
 (5) BroadcastHashJoin
 Left keys [1]: [key#x]
@@ -630,7 +630,7 @@ Condition : (isnotnull(key#x) AND (key#x > 10))
 
 (5) BroadcastExchange
 Input [2]: [key#x, val#x]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint))), [id=#x]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#x]
 
 (6) BroadcastHashJoin
 Left keys [1]: [key#x]

--- a/sql/core/src/test/resources/sql-tests/results/explain.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain.sql.out
@@ -53,15 +53,14 @@ EXPLAIN FORMATTED
 struct<plan:string>
 -- !query output
 == Physical Plan ==
-* Sort (9)
-+- Exchange (8)
-   +- * HashAggregate (7)
-      +- Exchange (6)
-         +- * HashAggregate (5)
-            +- * Project (4)
-               +- * Filter (3)
-                  +- * ColumnarToRow (2)
-                     +- Scan parquet default.explain_temp1 (1)
+* Sort (8)
++- Exchange (7)
+   +- * HashAggregate (6)
+      +- Exchange (5)
+         +- * HashAggregate (4)
+            +- * Filter (3)
+               +- * ColumnarToRow (2)
+                  +- Scan parquet default.explain_temp1 (1)
 
 
 (1) Scan parquet default.explain_temp1
@@ -78,33 +77,29 @@ Input [2]: [key#x, val#x]
 Input [2]: [key#x, val#x]
 Condition : (isnotnull(key#x) AND (key#x > 0))
 
-(4) Project [codegen id : 1]
-Output [2]: [key#x, val#x]
-Input [2]: [key#x, val#x]
-
-(5) HashAggregate [codegen id : 1]
+(4) HashAggregate [codegen id : 1]
 Input [2]: [key#x, val#x]
 Keys [1]: [key#x]
 Functions [1]: [partial_max(val#x)]
 Aggregate Attributes [1]: [max#x]
 Results [2]: [key#x, max#x]
 
-(6) Exchange
+(5) Exchange
 Input [2]: [key#x, max#x]
 Arguments: hashpartitioning(key#x, 4), true, [id=#x]
 
-(7) HashAggregate [codegen id : 2]
+(6) HashAggregate [codegen id : 2]
 Input [2]: [key#x, max#x]
 Keys [1]: [key#x]
 Functions [1]: [max(val#x)]
 Aggregate Attributes [1]: [max(val#x)#x]
 Results [2]: [key#x, max(val#x)#x AS max(val)#x]
 
-(8) Exchange
+(7) Exchange
 Input [2]: [key#x, max(val)#x]
 Arguments: rangepartitioning(key#x ASC NULLS FIRST, 4), true, [id=#x]
 
-(9) Sort [codegen id : 3]
+(8) Sort [codegen id : 3]
 Input [2]: [key#x, max(val)#x]
 Arguments: [key#x ASC NULLS FIRST], true, 0
 
@@ -120,15 +115,14 @@ EXPLAIN FORMATTED
 struct<plan:string>
 -- !query output
 == Physical Plan ==
-* Project (9)
-+- * Filter (8)
-   +- * HashAggregate (7)
-      +- Exchange (6)
-         +- * HashAggregate (5)
-            +- * Project (4)
-               +- * Filter (3)
-                  +- * ColumnarToRow (2)
-                     +- Scan parquet default.explain_temp1 (1)
+* Project (8)
++- * Filter (7)
+   +- * HashAggregate (6)
+      +- Exchange (5)
+         +- * HashAggregate (4)
+            +- * Filter (3)
+               +- * ColumnarToRow (2)
+                  +- Scan parquet default.explain_temp1 (1)
 
 
 (1) Scan parquet default.explain_temp1
@@ -145,33 +139,29 @@ Input [2]: [key#x, val#x]
 Input [2]: [key#x, val#x]
 Condition : (isnotnull(key#x) AND (key#x > 0))
 
-(4) Project [codegen id : 1]
-Output [2]: [key#x, val#x]
-Input [2]: [key#x, val#x]
-
-(5) HashAggregate [codegen id : 1]
+(4) HashAggregate [codegen id : 1]
 Input [2]: [key#x, val#x]
 Keys [1]: [key#x]
 Functions [1]: [partial_max(val#x)]
 Aggregate Attributes [1]: [max#x]
 Results [2]: [key#x, max#x]
 
-(6) Exchange
+(5) Exchange
 Input [2]: [key#x, max#x]
 Arguments: hashpartitioning(key#x, 4), true, [id=#x]
 
-(7) HashAggregate [codegen id : 2]
+(6) HashAggregate [codegen id : 2]
 Input [2]: [key#x, max#x]
 Keys [1]: [key#x]
 Functions [1]: [max(val#x)]
 Aggregate Attributes [1]: [max(val#x)#x]
 Results [3]: [key#x, max(val#x)#x AS max(val)#x, max(val#x)#x AS max(val#x)#x]
 
-(8) Filter [codegen id : 2]
+(7) Filter [codegen id : 2]
 Input [3]: [key#x, max(val)#x, max(val#x)#x]
 Condition : (isnotnull(max(val#x)#x) AND (max(val#x)#x > 0))
 
-(9) Project [codegen id : 2]
+(8) Project [codegen id : 2]
 Output [2]: [key#x, max(val)#x]
 Input [3]: [key#x, max(val)#x, max(val#x)#x]
 
@@ -185,18 +175,16 @@ EXPLAIN FORMATTED
 struct<plan:string>
 -- !query output
 == Physical Plan ==
-* HashAggregate (12)
-+- Exchange (11)
-   +- * HashAggregate (10)
-      +- Union (9)
-         :- * Project (4)
-         :  +- * Filter (3)
-         :     +- * ColumnarToRow (2)
-         :        +- Scan parquet default.explain_temp1 (1)
-         +- * Project (8)
-            +- * Filter (7)
-               +- * ColumnarToRow (6)
-                  +- Scan parquet default.explain_temp1 (5)
+* HashAggregate (10)
++- Exchange (9)
+   +- * HashAggregate (8)
+      +- Union (7)
+         :- * Filter (3)
+         :  +- * ColumnarToRow (2)
+         :     +- Scan parquet default.explain_temp1 (1)
+         +- * Filter (6)
+            +- * ColumnarToRow (5)
+               +- Scan parquet default.explain_temp1 (4)
 
 
 (1) Scan parquet default.explain_temp1
@@ -213,42 +201,34 @@ Input [2]: [key#x, val#x]
 Input [2]: [key#x, val#x]
 Condition : (isnotnull(key#x) AND (key#x > 0))
 
-(4) Project [codegen id : 1]
-Output [2]: [key#x, val#x]
-Input [2]: [key#x, val#x]
-
-(5) Scan parquet default.explain_temp1
+(4) Scan parquet default.explain_temp1
 Output [2]: [key#x, val#x]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/explain_temp1]
 PushedFilters: [IsNotNull(key), GreaterThan(key,0)]
 ReadSchema: struct<key:int,val:int>
 
-(6) ColumnarToRow [codegen id : 2]
+(5) ColumnarToRow [codegen id : 2]
 Input [2]: [key#x, val#x]
 
-(7) Filter [codegen id : 2]
+(6) Filter [codegen id : 2]
 Input [2]: [key#x, val#x]
 Condition : (isnotnull(key#x) AND (key#x > 0))
 
-(8) Project [codegen id : 2]
-Output [2]: [key#x, val#x]
-Input [2]: [key#x, val#x]
+(7) Union
 
-(9) Union
-
-(10) HashAggregate [codegen id : 3]
+(8) HashAggregate [codegen id : 3]
 Input [2]: [key#x, val#x]
 Keys [2]: [key#x, val#x]
 Functions: []
 Aggregate Attributes: []
 Results [2]: [key#x, val#x]
 
-(11) Exchange
+(9) Exchange
 Input [2]: [key#x, val#x]
 Arguments: hashpartitioning(key#x, val#x, 4), true, [id=#x]
 
-(12) HashAggregate [codegen id : 4]
+(10) HashAggregate [codegen id : 4]
 Input [2]: [key#x, val#x]
 Keys [2]: [key#x, val#x]
 Functions: []
@@ -266,16 +246,14 @@ EXPLAIN FORMATTED
 struct<plan:string>
 -- !query output
 == Physical Plan ==
-* BroadcastHashJoin Inner BuildRight (10)
-:- * Project (4)
-:  +- * Filter (3)
-:     +- * ColumnarToRow (2)
-:        +- Scan parquet default.explain_temp1 (1)
-+- BroadcastExchange (9)
-   +- * Project (8)
-      +- * Filter (7)
-         +- * ColumnarToRow (6)
-            +- Scan parquet default.explain_temp2 (5)
+* BroadcastHashJoin Inner BuildRight (8)
+:- * Filter (3)
+:  +- * ColumnarToRow (2)
+:     +- Scan parquet default.explain_temp1 (1)
++- BroadcastExchange (7)
+   +- * Filter (6)
+      +- * ColumnarToRow (5)
+         +- Scan parquet default.explain_temp2 (4)
 
 
 (1) Scan parquet default.explain_temp1
@@ -292,33 +270,25 @@ Input [2]: [key#x, val#x]
 Input [2]: [key#x, val#x]
 Condition : isnotnull(key#x)
 
-(4) Project [codegen id : 2]
-Output [2]: [key#x, val#x]
-Input [2]: [key#x, val#x]
-
-(5) Scan parquet default.explain_temp2
+(4) Scan parquet default.explain_temp2
 Output [2]: [key#x, val#x]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/explain_temp2]
 PushedFilters: [IsNotNull(key)]
 ReadSchema: struct<key:int,val:int>
 
-(6) ColumnarToRow [codegen id : 1]
+(5) ColumnarToRow [codegen id : 1]
 Input [2]: [key#x, val#x]
 
-(7) Filter [codegen id : 1]
+(6) Filter [codegen id : 1]
 Input [2]: [key#x, val#x]
 Condition : isnotnull(key#x)
 
-(8) Project [codegen id : 1]
-Output [2]: [key#x, val#x]
+(7) BroadcastExchange
 Input [2]: [key#x, val#x]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint))), [id=#x]
 
-(9) BroadcastExchange
-Input [2]: [key#x, val#x]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#x]
-
-(10) BroadcastHashJoin [codegen id : 2]
+(8) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [key#x]
 Right keys [1]: [key#x]
 Join condition: None
@@ -334,14 +304,13 @@ EXPLAIN FORMATTED
 struct<plan:string>
 -- !query output
 == Physical Plan ==
-* BroadcastHashJoin LeftOuter BuildRight (8)
+* BroadcastHashJoin LeftOuter BuildRight (7)
 :- * ColumnarToRow (2)
 :  +- Scan parquet default.explain_temp1 (1)
-+- BroadcastExchange (7)
-   +- * Project (6)
-      +- * Filter (5)
-         +- * ColumnarToRow (4)
-            +- Scan parquet default.explain_temp2 (3)
++- BroadcastExchange (6)
+   +- * Filter (5)
+      +- * ColumnarToRow (4)
+         +- Scan parquet default.explain_temp2 (3)
 
 
 (1) Scan parquet default.explain_temp1
@@ -367,15 +336,11 @@ Input [2]: [key#x, val#x]
 Input [2]: [key#x, val#x]
 Condition : isnotnull(key#x)
 
-(6) Project [codegen id : 1]
-Output [2]: [key#x, val#x]
+(6) BroadcastExchange
 Input [2]: [key#x, val#x]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint))), [id=#x]
 
-(7) BroadcastExchange
-Input [2]: [key#x, val#x]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#x]
-
-(8) BroadcastHashJoin [codegen id : 2]
+(7) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [key#x]
 Right keys [1]: [key#x]
 Join condition: None
@@ -396,10 +361,9 @@ EXPLAIN FORMATTED
 struct<plan:string>
 -- !query output
 == Physical Plan ==
-* Project (4)
-+- * Filter (3)
-   +- * ColumnarToRow (2)
-      +- Scan parquet default.explain_temp1 (1)
+* Filter (3)
++- * ColumnarToRow (2)
+   +- Scan parquet default.explain_temp1 (1)
 
 
 (1) Scan parquet default.explain_temp1
@@ -416,98 +380,94 @@ Input [2]: [key#x, val#x]
 Input [2]: [key#x, val#x]
 Condition : (((isnotnull(key#x) AND isnotnull(val#x)) AND (key#x = Subquery scalar-subquery#x, [id=#x])) AND (val#x > 3))
 
-(4) Project [codegen id : 1]
-Output [2]: [key#x, val#x]
-Input [2]: [key#x, val#x]
-
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#x, [id=#x]
-* HashAggregate (11)
-+- Exchange (10)
-   +- * HashAggregate (9)
-      +- * Project (8)
-         +- * Filter (7)
-            +- * ColumnarToRow (6)
-               +- Scan parquet default.explain_temp2 (5)
+* HashAggregate (10)
++- Exchange (9)
+   +- * HashAggregate (8)
+      +- * Project (7)
+         +- * Filter (6)
+            +- * ColumnarToRow (5)
+               +- Scan parquet default.explain_temp2 (4)
 
 
-(5) Scan parquet default.explain_temp2
+(4) Scan parquet default.explain_temp2
 Output [2]: [key#x, val#x]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/explain_temp2]
 PushedFilters: [IsNotNull(key), IsNotNull(val), EqualTo(val,2)]
 ReadSchema: struct<key:int,val:int>
 
-(6) ColumnarToRow [codegen id : 1]
+(5) ColumnarToRow [codegen id : 1]
 Input [2]: [key#x, val#x]
 
-(7) Filter [codegen id : 1]
+(6) Filter [codegen id : 1]
 Input [2]: [key#x, val#x]
 Condition : (((isnotnull(key#x) AND isnotnull(val#x)) AND (key#x = Subquery scalar-subquery#x, [id=#x])) AND (val#x = 2))
 
-(8) Project [codegen id : 1]
+(7) Project [codegen id : 1]
 Output [1]: [key#x]
 Input [2]: [key#x, val#x]
 
-(9) HashAggregate [codegen id : 1]
+(8) HashAggregate [codegen id : 1]
 Input [1]: [key#x]
 Keys: []
 Functions [1]: [partial_max(key#x)]
 Aggregate Attributes [1]: [max#x]
 Results [1]: [max#x]
 
-(10) Exchange
+(9) Exchange
 Input [1]: [max#x]
 Arguments: SinglePartition, true, [id=#x]
 
-(11) HashAggregate [codegen id : 2]
+(10) HashAggregate [codegen id : 2]
 Input [1]: [max#x]
 Keys: []
 Functions [1]: [max(key#x)]
 Aggregate Attributes [1]: [max(key#x)#x]
 Results [1]: [max(key#x)#x AS max(key)#x]
 
-Subquery:2 Hosting operator id = 7 Hosting Expression = Subquery scalar-subquery#x, [id=#x]
-* HashAggregate (18)
-+- Exchange (17)
-   +- * HashAggregate (16)
-      +- * Project (15)
-         +- * Filter (14)
-            +- * ColumnarToRow (13)
-               +- Scan parquet default.explain_temp3 (12)
+Subquery:2 Hosting operator id = 6 Hosting Expression = Subquery scalar-subquery#x, [id=#x]
+* HashAggregate (17)
++- Exchange (16)
+   +- * HashAggregate (15)
+      +- * Project (14)
+         +- * Filter (13)
+            +- * ColumnarToRow (12)
+               +- Scan parquet default.explain_temp3 (11)
 
 
-(12) Scan parquet default.explain_temp3
+(11) Scan parquet default.explain_temp3
 Output [2]: [key#x, val#x]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/explain_temp3]
 PushedFilters: [IsNotNull(val), GreaterThan(val,0)]
 ReadSchema: struct<key:int,val:int>
 
-(13) ColumnarToRow [codegen id : 1]
+(12) ColumnarToRow [codegen id : 1]
 Input [2]: [key#x, val#x]
 
-(14) Filter [codegen id : 1]
+(13) Filter [codegen id : 1]
 Input [2]: [key#x, val#x]
 Condition : (isnotnull(val#x) AND (val#x > 0))
 
-(15) Project [codegen id : 1]
+(14) Project [codegen id : 1]
 Output [1]: [key#x]
 Input [2]: [key#x, val#x]
 
-(16) HashAggregate [codegen id : 1]
+(15) HashAggregate [codegen id : 1]
 Input [1]: [key#x]
 Keys: []
 Functions [1]: [partial_max(key#x)]
 Aggregate Attributes [1]: [max#x]
 Results [1]: [max#x]
 
-(17) Exchange
+(16) Exchange
 Input [1]: [max#x]
 Arguments: SinglePartition, true, [id=#x]
 
-(18) HashAggregate [codegen id : 2]
+(17) HashAggregate [codegen id : 2]
 Input [1]: [max#x]
 Keys: []
 Functions [1]: [max(key#x)]
@@ -721,16 +681,14 @@ EXPLAIN FORMATTED
 struct<plan:string>
 -- !query output
 == Physical Plan ==
-* BroadcastHashJoin Inner BuildRight (10)
-:- * Project (4)
-:  +- * Filter (3)
-:     +- * ColumnarToRow (2)
-:        +- Scan parquet default.explain_temp1 (1)
-+- BroadcastExchange (9)
-   +- * Project (8)
-      +- * Filter (7)
-         +- * ColumnarToRow (6)
-            +- Scan parquet default.explain_temp1 (5)
+* BroadcastHashJoin Inner BuildRight (8)
+:- * Filter (3)
+:  +- * ColumnarToRow (2)
+:     +- Scan parquet default.explain_temp1 (1)
++- BroadcastExchange (7)
+   +- * Filter (6)
+      +- * ColumnarToRow (5)
+         +- Scan parquet default.explain_temp1 (4)
 
 
 (1) Scan parquet default.explain_temp1
@@ -747,33 +705,25 @@ Input [2]: [key#x, val#x]
 Input [2]: [key#x, val#x]
 Condition : (isnotnull(key#x) AND (key#x > 10))
 
-(4) Project [codegen id : 2]
-Output [2]: [key#x, val#x]
-Input [2]: [key#x, val#x]
-
-(5) Scan parquet default.explain_temp1
+(4) Scan parquet default.explain_temp1
 Output [2]: [key#x, val#x]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/explain_temp1]
 PushedFilters: [IsNotNull(key), GreaterThan(key,10)]
 ReadSchema: struct<key:int,val:int>
 
-(6) ColumnarToRow [codegen id : 1]
+(5) ColumnarToRow [codegen id : 1]
 Input [2]: [key#x, val#x]
 
-(7) Filter [codegen id : 1]
+(6) Filter [codegen id : 1]
 Input [2]: [key#x, val#x]
 Condition : (isnotnull(key#x) AND (key#x > 10))
 
-(8) Project [codegen id : 1]
-Output [2]: [key#x, val#x]
+(7) BroadcastExchange
 Input [2]: [key#x, val#x]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint))), [id=#x]
 
-(9) BroadcastExchange
-Input [2]: [key#x, val#x]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#x]
-
-(10) BroadcastHashJoin [codegen id : 2]
+(8) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [key#x]
 Right keys [1]: [key#x]
 Join condition: None
@@ -792,17 +742,16 @@ EXPLAIN FORMATTED
 struct<plan:string>
 -- !query output
 == Physical Plan ==
-* BroadcastHashJoin Inner BuildRight (11)
-:- * HashAggregate (7)
-:  +- Exchange (6)
-:     +- * HashAggregate (5)
-:        +- * Project (4)
-:           +- * Filter (3)
-:              +- * ColumnarToRow (2)
-:                 +- Scan parquet default.explain_temp1 (1)
-+- BroadcastExchange (10)
-   +- * HashAggregate (9)
-      +- ReusedExchange (8)
+* BroadcastHashJoin Inner BuildRight (10)
+:- * HashAggregate (6)
+:  +- Exchange (5)
+:     +- * HashAggregate (4)
+:        +- * Filter (3)
+:           +- * ColumnarToRow (2)
+:              +- Scan parquet default.explain_temp1 (1)
++- BroadcastExchange (9)
+   +- * HashAggregate (8)
+      +- ReusedExchange (7)
 
 
 (1) Scan parquet default.explain_temp1
@@ -819,43 +768,39 @@ Input [2]: [key#x, val#x]
 Input [2]: [key#x, val#x]
 Condition : (isnotnull(key#x) AND (key#x > 10))
 
-(4) Project [codegen id : 1]
-Output [2]: [key#x, val#x]
-Input [2]: [key#x, val#x]
-
-(5) HashAggregate [codegen id : 1]
+(4) HashAggregate [codegen id : 1]
 Input [2]: [key#x, val#x]
 Keys [1]: [key#x]
 Functions [1]: [partial_max(val#x)]
 Aggregate Attributes [1]: [max#x]
 Results [2]: [key#x, max#x]
 
-(6) Exchange
+(5) Exchange
 Input [2]: [key#x, max#x]
 Arguments: hashpartitioning(key#x, 4), true, [id=#x]
 
-(7) HashAggregate [codegen id : 4]
+(6) HashAggregate [codegen id : 4]
 Input [2]: [key#x, max#x]
 Keys [1]: [key#x]
 Functions [1]: [max(val#x)]
 Aggregate Attributes [1]: [max(val#x)#x]
 Results [2]: [key#x, max(val#x)#x AS max(val)#x]
 
-(8) ReusedExchange [Reuses operator id: 6]
+(7) ReusedExchange [Reuses operator id: 5]
 Output [2]: [key#x, max#x]
 
-(9) HashAggregate [codegen id : 3]
+(8) HashAggregate [codegen id : 3]
 Input [2]: [key#x, max#x]
 Keys [1]: [key#x]
 Functions [1]: [max(val#x)]
 Aggregate Attributes [1]: [max(val#x)#x]
 Results [2]: [key#x, max(val#x)#x AS max(val)#x]
 
-(10) BroadcastExchange
+(9) BroadcastExchange
 Input [2]: [key#x, max(val)#x]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#x]
 
-(11) BroadcastHashJoin [codegen id : 4]
+(10) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [key#x]
 Right keys [1]: [key#x]
 Join condition: None

--- a/sql/core/src/test/resources/sql-tests/results/explain.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain.sql.out
@@ -286,7 +286,7 @@ Condition : isnotnull(key#x)
 
 (7) BroadcastExchange
 Input [2]: [key#x, val#x]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint))), [id=#x]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#x]
 
 (8) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [key#x]
@@ -338,7 +338,7 @@ Condition : isnotnull(key#x)
 
 (6) BroadcastExchange
 Input [2]: [key#x, val#x]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint))), [id=#x]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#x]
 
 (7) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [key#x]
@@ -721,7 +721,7 @@ Condition : (isnotnull(key#x) AND (key#x > 10))
 
 (7) BroadcastExchange
 Input [2]: [key#x, val#x]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint))), [id=#x]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#x]
 
 (8) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [key#x]

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantProjectsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantProjectsSuite.scala
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import org.apache.spark.sql.{DataFrame, QueryTest}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+class RemoveRedundantProjectsSuite extends QueryTest with SharedSparkSession {
+
+  private def assertProjectExecCount(df: DataFrame, expected: Integer): Unit = {
+    withClue(df.queryExecution) {
+      val plan = df.queryExecution.executedPlan
+      val actual = plan.collectWithSubqueries { case p: ProjectExec => p }.size
+      assert(actual == expected)
+    }
+  }
+
+  private def assertProjectExec(query: String, enabled: Integer, disabled: Integer): Unit = {
+    val df = sql(query)
+    assertProjectExecCount(df, enabled)
+    val result1 = df.collect()
+    withSQLConf(SQLConf.REMOVE_REDUNDANT_PROJECTS_ENABLED.key -> "false") {
+      val df2 = sql(query)
+      assertProjectExecCount(df2, disabled)
+      QueryTest.sameRows(result1.toSeq, df2.collect().toSeq)
+    }
+  }
+
+  private def withTestView(f: => Unit): Unit = {
+    withTempPath { p =>
+      val path = p.getAbsolutePath
+      spark.range(100).selectExpr("id % 10 as key", "id * 2 as a",
+        "id * 3 as b", "cast(id as string) as c").write.partitionBy("key").parquet(path)
+      spark.read.parquet(path).createOrReplaceTempView("testView")
+      f
+    }
+  }
+
+  test("project") {
+    withTestView {
+      val query = "select * from testView"
+      assertProjectExec(query, 0, 0)
+    }
+  }
+
+  test("project with filter") {
+    withTestView {
+      val query = "select * from testView where a > 5"
+      assertProjectExec(query, 0, 1)
+    }
+  }
+
+  test("project with specific column ordering") {
+    withTestView {
+      val query = "select key, a, b, c from testView"
+      assertProjectExec(query, 1, 1)
+    }
+  }
+
+  test("project with extra columns") {
+    withTestView {
+      val query = "select a, b, c, key, a from testView"
+      assertProjectExec(query, 1, 1)
+    }
+  }
+
+  test("project with fewer columns") {
+    withTestView {
+      val query = "select a from testView where a > 3"
+      assertProjectExec(query, 1, 1)
+    }
+  }
+
+  test("aggregate without ordering requirement") {
+    withTestView {
+      val query = "select sum(a) as sum_a, key, last(b) as last_b " +
+        "from (select key, a, b from testView where a > 100) group by key"
+      assertProjectExec(query, 0, 1)
+    }
+  }
+
+  test("aggregate with ordering requirement") {
+    withTestView {
+      val query = "select a, sum(b) as sum_b from testView group by a"
+      assertProjectExec(query, 1, 1)
+    }
+  }
+
+  test("join without ordering requirement") {
+    withTestView {
+      val query = "select t1.key, t2.key, t1.a, t2.b from (select key, a, b, c from testView)" +
+        " as t1 join (select key, a, b, c from testView) as t2 on t1.c > t2.c and t1.key > 10"
+      assertProjectExec(query, 1, 3)
+    }
+  }
+
+  test("join with ordering requirement") {
+    withTestView {
+      val query = "select * from (select key, a, c, b from testView) as t1 join " +
+        "(select key, a, b, c from testView) as t2 on t1.key = t2.key where t2.a > 50"
+      assertProjectExec(query, 2, 2)
+    }
+  }
+
+  test("window function") {
+    withTestView {
+      val query = "select key, avg(a) over (partition by key order by a " +
+        "rows between 1 preceding and 1 following) as avg, b from testView"
+      assertProjectExec(query, 1, 2)
+    }
+  }
+
+  test("subquery") {
+    withTestView {
+      val query = "select * from testView where a in (select b from testView where key > 5)"
+      assertProjectExec(query, 1, 1)
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantProjectsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantProjectsSuite.scala
@@ -24,7 +24,6 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.Utils
 
 class RemoveRedundantProjectsSuite extends QueryTest with SharedSparkSession with SQLTestUtils {
-  import testImplicits._
 
   private def assertProjectExecCount(df: DataFrame, expected: Int): Unit = {
     withClue(df.queryExecution) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR added a physical rule to remove redundant project nodes. A `ProjectExec` is redundant when
1. It has the same output attributes and order as its child's output when ordering of these attributes is required.
2. It has the same output attributes as its child's output when attribute output ordering is not required.

For example:
After Filter: 
```
== Physical Plan ==
*(1) Project [a#14L, b#15L, c#16, key#17] 
+- *(1) Filter (isnotnull(a#14L) AND (a#14L > 5))
   +- *(1) ColumnarToRow
      +- FileScan parquet [a#14L,b#15L,c#16,key#17] 
```
The `Project a#14L, b#15L, c#16, key#17` is redundant because its output is exactly the same as filter's output.

Before Aggregate:
```
== Physical Plan ==
*(2) HashAggregate(keys=[key#17], functions=[sum(a#14L), last(b#15L, false)], output=[sum_a#39L, key#17, last_b#41L])
+- Exchange hashpartitioning(key#17, 5), true, [id=#77]
   +- *(1) HashAggregate(keys=[key#17], functions=[partial_sum(a#14L), partial_last(b#15L, false)], output=[key#17, sum#49L, last#50L, valueSet#51])
      +- *(1) Project [key#17, a#14L, b#15L]
         +- *(1) Filter (isnotnull(a#14L) AND (a#14L > 100))
            +- *(1) ColumnarToRow
               +- FileScan parquet [a#14L,b#15L,key#17] 
```
The `Project key#17, a#14L, b#15L` is redundant because hash aggregate doesn't require child plan's output to be in a specific order.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
It removes unnecessary query nodes and makes query plan cleaner.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit tests