### PR TITLE
[SPARK-32224][CORE] Add a simpler way to pass 'spark.yarn.priority' through the SparkSubmit

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -586,6 +586,7 @@ private[spark] class SparkSubmit extends Logging {
 
       // Yarn only
       OptionAssigner(args.queue, YARN, ALL_DEPLOY_MODES, confKey = "spark.yarn.queue"),
+      OptionAssigner(args.priority, YARN, ALL_DEPLOY_MODES, confKey = "spark.yarn.priority"),
       OptionAssigner(args.pyFiles, YARN, ALL_DEPLOY_MODES, confKey = "spark.yarn.dist.pyFiles",
         mergeFn = Some(mergeFileLists(_, _))),
       OptionAssigner(args.jars, YARN, ALL_DEPLOY_MODES, confKey = "spark.yarn.dist.jars",

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -52,6 +52,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
   var driverExtraLibraryPath: String = null
   var driverExtraJavaOptions: String = null
   var queue: String = null
+  var priority: String = null
   var numExecutors: String = null
   var files: String = null
   var archives: String = null
@@ -269,6 +270,9 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
         error(s"When running with master '$master' " +
           "either HADOOP_CONF_DIR or YARN_CONF_DIR must be set in the environment.")
       }
+      if (priority != null && Try(priority.toInt).getOrElse(-1) < 0) {
+        error("Value of yarn app priority must be more than 0")
+      }
     }
 
     if (proxyUser != null && principal != null) {
@@ -307,6 +311,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
     |  driverExtraJavaOptions  $driverExtraJavaOptions
     |  supervise               $supervise
     |  queue                   $queue
+    |  priority                $priority
     |  numExecutors            $numExecutors
     |  files                   $files
     |  pyFiles                 $pyFiles
@@ -394,6 +399,9 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
 
       case QUEUE =>
         queue = value
+
+      case PRIORITY =>
+        priority = value
 
       case FILES =>
         files = Utils.resolveURIs(value)
@@ -562,6 +570,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
         |
         | Spark on YARN only:
         |  --queue QUEUE_NAME          The YARN queue to submit to (Default: "default").
+        |  --priority PRIORITY         The priority of your YARN application.
         |  --archives ARCHIVES         Comma separated list of archives to be extracted into the
         |                              working directory of each executor.
       """.stripMargin

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -261,6 +261,7 @@ class SparkSubmitSuite
       "--jars", "one.jar,two.jar,three.jar",
       "--driver-memory", "4g",
       "--queue", "thequeue",
+      "--priority", "25",
       "--files", "file1.txt,file2.txt",
       "--archives", "archive1.txt,archive2.txt",
       "--num-executors", "6",
@@ -286,6 +287,7 @@ class SparkSubmitSuite
     conf.get("spark.driver.memory") should be ("4g")
     conf.get("spark.executor.cores") should be ("5")
     conf.get("spark.yarn.queue") should be ("thequeue")
+    conf.get("spark.yarn.priority") should be ("25")
     conf.get("spark.yarn.dist.jars") should include regex (".*one.jar,.*two.jar,.*three.jar")
     conf.get("spark.yarn.dist.files") should include regex (".*file1.txt,.*file2.txt")
     conf.get("spark.yarn.dist.archives") should include regex (".*archive1.txt,.*archive2.txt")
@@ -304,6 +306,7 @@ class SparkSubmitSuite
       "--jars", "one.jar,two.jar,three.jar",
       "--driver-memory", "4g",
       "--queue", "thequeue",
+      "--priority", "25",
       "--files", "file1.txt,file2.txt",
       "--archives", "archive1.txt,archive2.txt",
       "--num-executors", "6",
@@ -324,6 +327,7 @@ class SparkSubmitSuite
     conf.get("spark.executor.memory") should be ("5g")
     conf.get("spark.executor.cores") should be ("5")
     conf.get("spark.yarn.queue") should be ("thequeue")
+    conf.get("spark.yarn.priority") should be ("25")
     conf.get("spark.executor.instances") should be ("6")
     conf.get("spark.yarn.dist.files") should include regex (".*file1.txt,.*file2.txt")
     conf.get("spark.yarn.dist.archives") should include regex (".*archive1.txt,.*archive2.txt")

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -57,6 +57,7 @@ For example:
         --executor-memory 2g \
         --executor-cores 1 \
         --queue thequeue \
+        --priority 10 \
         examples/jars/spark-examples*.jar \
         10
 

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitOptionParser.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitOptionParser.java
@@ -75,6 +75,7 @@ class SparkSubmitOptionParser {
   protected final String NUM_EXECUTORS = "--num-executors";
   protected final String PRINCIPAL = "--principal";
   protected final String QUEUE = "--queue";
+  protected final String PRIORITY = "--priority";
 
   /**
    * This is the canonical list of spark-submit options. Each entry in the array contains the
@@ -112,6 +113,7 @@ class SparkSubmitOptionParser {
     { PROXY_USER },
     { PY_FILES },
     { QUEUE },
+    { PRIORITY },
     { REPOSITORIES },
     { STATUS },
     { TOTAL_EXECUTOR_CORES },


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a simpler way  to pass 'spark.yarn.priority' through the SparkSubmit, it only works in the yarn mode.

### Why are the changes needed?
We can use `--conf spark.yarn.priority` to achieve the same goal ,  but `--priority` is more simple and easy to remember by users.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Enhance `handles YARN cluster mode` and `handles YARN client mode` in `SparkSubmitSuite`
