### PR TITLE
[SPARK-31831][SQL][TESTS] HiveSessionImplSuite flakiness fix via mocking instances earlier than initializing HiveSessionImpl

### DIFF
--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -363,7 +363,8 @@ def build_spark_assembly_sbt(extra_profiles, checkstyle=False):
     if checkstyle:
         run_java_style_checks(build_profiles)
 
-    build_spark_unidoc_sbt(extra_profiles)
+    if not os.environ.get("AMPLAB_JENKINS"):
+        build_spark_unidoc_sbt(extra_profiles)
 
 
 def build_apache_spark(build_tool, extra_profiles):

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -363,8 +363,7 @@ def build_spark_assembly_sbt(extra_profiles, checkstyle=False):
     if checkstyle:
         run_java_style_checks(build_profiles)
 
-    if not os.environ.get("AMPLAB_JENKINS"):
-        build_spark_unidoc_sbt(extra_profiles)
+    build_spark_unidoc_sbt(extra_profiles)
 
 
 def build_apache_spark(build_tool, extra_profiles):

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveSessionImplSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveSessionImplSuite.scala
@@ -74,14 +74,3 @@ class HiveSessionImplSuite extends SparkFunSuite {
     verify(operationManager).closeOperation(operationHandle2)
   }
 }
-
-// FIXME: DEBUGGING HiveSessionImplSuite - to run the suite multiple times simply
-class HiveSessionImplSuiteTrial2 extends HiveSessionImplSuite
-class HiveSessionImplSuiteTrial3 extends HiveSessionImplSuite
-class HiveSessionImplSuiteTrial4 extends HiveSessionImplSuite
-class HiveSessionImplSuiteTrial5 extends HiveSessionImplSuite
-class HiveSessionImplSuiteTrial6 extends HiveSessionImplSuite
-class HiveSessionImplSuiteTrial7 extends HiveSessionImplSuite
-class HiveSessionImplSuiteTrial8 extends HiveSessionImplSuite
-class HiveSessionImplSuiteTrial9 extends HiveSessionImplSuite
-class HiveSessionImplSuiteTrial10 extends HiveSessionImplSuite

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveSessionImplSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveSessionImplSuite.scala
@@ -34,6 +34,11 @@ class HiveSessionImplSuite extends SparkFunSuite {
   override def beforeAll() {
     super.beforeAll()
 
+    // mock the instance first - we observed weird classloader issue on creating mock, so
+    // would like to avoid any cases classloader gets switched
+    val sessionManager = mock(classOf[SessionManager])
+    operationManager = mock(classOf[OperationManager])
+
     session = new HiveSessionImpl(
       ThriftserverShimUtils.testedProtocolVersions.head,
       "",
@@ -41,9 +46,7 @@ class HiveSessionImplSuite extends SparkFunSuite {
       new HiveConf(),
       ""
     )
-    val sessionManager = mock(classOf[SessionManager])
     session.setSessionManager(sessionManager)
-    operationManager = mock(classOf[OperationManager])
     session.setOperationManager(operationManager)
     when(operationManager.newGetCatalogsOperation(session)).thenAnswer(
       (_: InvocationOnMock) => {
@@ -71,3 +74,14 @@ class HiveSessionImplSuite extends SparkFunSuite {
     verify(operationManager).closeOperation(operationHandle2)
   }
 }
+
+// FIXME: DEBUGGING HiveSessionImplSuite - to run the suite multiple times simply
+class HiveSessionImplSuiteTrial2 extends HiveSessionImplSuite
+class HiveSessionImplSuiteTrial3 extends HiveSessionImplSuite
+class HiveSessionImplSuiteTrial4 extends HiveSessionImplSuite
+class HiveSessionImplSuiteTrial5 extends HiveSessionImplSuite
+class HiveSessionImplSuiteTrial6 extends HiveSessionImplSuite
+class HiveSessionImplSuiteTrial7 extends HiveSessionImplSuite
+class HiveSessionImplSuiteTrial8 extends HiveSessionImplSuite
+class HiveSessionImplSuiteTrial9 extends HiveSessionImplSuite
+class HiveSessionImplSuiteTrial10 extends HiveSessionImplSuite


### PR DESCRIPTION
### What changes were proposed in this pull request?

This patch changes the HiveSessionImplSuite to mock instances "before" initializing HiveSessionImpl, to avoid possible classloader issue. 

### Why are the changes needed?

The failures of HiveSessionImplSuite always come from classloader issue. While I don't have clear idea what is happening, there's no part possibly dealing with classloader, except initializing HiveSessionImpl. We can move the mock initializations earlier than initialing HiveSessionImpl so that it can avoid possible classloader issue.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Verified with multiple triggers of Jenkins builds