### PR TITLE
[SPARK-32230][R][INFRA] Use Hadoop 2.7 profile in AppVeyor SparkR build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,7 +49,7 @@ build_script:
   # '-Djna.nosys=true' is required to avoid kernel32.dll load failure.
   # See SPARK-28759.
   # Ideally we should check the tests related to Hive in SparkR as well (SPARK-31745).
-  - cmd: mvn -DskipTests -Psparkr -Djna.nosys=true package
+  - cmd: mvn -DskipTests -Phadoop-2.7 -Psparkr -Djna.nosys=true package
 
 environment:
   NOT_CRAN: true


### PR DESCRIPTION
### What changes were proposed in this pull request?

https://ci.appveyor.com/project/ApacheSoftwareFoundation/spark/builds/33976604

AppVeyor build seems broken after we change the default Hadoop version from 2 to 3.
This PR moves back to Hadoop 2 for now.

### Why are the changes needed?

To recover the build in AppVeyor.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

AppVeyor build will test it out.
