### PR TITLE
[SPARK-32205][SQL] Writing timestamp to mysql should be datetime type

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.jdbc
 import java.sql.Types
 import java.util.Locale
 
-import org.apache.spark.sql.types.{BooleanType, DataType, LongType, MetadataBuilder}
+import org.apache.spark.sql.types.{BooleanType, ByteType, DataType, DoubleType, FloatType, IntegerType, LongType, MetadataBuilder, ShortType, StringType, TimestampType}
 
 private case object MySQLDialect extends JdbcDialect {
 
@@ -48,4 +48,11 @@ private case object MySQLDialect extends JdbcDialect {
   }
 
   override def isCascadingTruncateTable(): Option[Boolean] = Some(false)
+
+  override def getJDBCType(dt: DataType): Option[JdbcType] = dt match {
+    // For more details, please see
+    // https://dev.mysql.com/doc/refman/5.7/en/datetime.html
+    case TimestampType => Some(JdbcType("DATETIME", java.sql.Types.TIMESTAMP))
+    case _ => None
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.jdbc
 import java.sql.Types
 import java.util.Locale
 
-import org.apache.spark.sql.types.{BooleanType, ByteType, DataType, DoubleType, FloatType, IntegerType, LongType, MetadataBuilder, ShortType, StringType, TimestampType}
+import org.apache.spark.sql.types.{BooleanType, DataType, LongType, MetadataBuilder, TimestampType}
 
 private case object MySQLDialect extends JdbcDialect {
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -1715,4 +1715,9 @@ class JDBCSuite extends QueryTest
     jdbcDF = sqlContext.jdbc(urlWithUserAndPass, "TEST.PEOPLE", parts)
     checkAnswer(jdbcDF, Row("mary", 2) :: Nil)
   }
+
+  test("SPARK-32205: Timestamp write to mysql is datetime") {
+    val mysqlDialect = JdbcDialects.get("jdbc:mysql://127.0.0.1/db")
+    assert(mysqlDialect.getJDBCType(TimestampType).map(_.databaseTypeDefinition).get == "DATETIME")
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Change date type from TIMESTAMP to DATETIME in mysql at `org.apache.spark.sql.jdbc.MySQLDialect#getJDBCType`
2. Add UT in `org.apache.spark.sql.test.SQLTestUtils#test` .

### Why are the changes needed?
Because write spark timestamp to mysql should has a '1000-01-01 00:00:00' to '9999-12-31 23:59:59' range.
see https://dev.mysql.com/doc/refman/5.7/en/datetime.html
While the date type in mysql should be datetime rather than timestamp.
**Before this patch**, when we use timestamp data type in mysql by auto created table：
`sql("select cast('1111-01-01 00:00:01' as timestamp)").toDF("ts").write.mode("append").jdbc("jdbc:mysql://localhost:3306/test", "ts_test3",prop)`
we will get an exception：
`com.mysql.jdbc.MysqlDataTruncation: Data truncation: Incorrect datetime value: '1111-01-01 00:00:01' for column 'ts' at row`

### Does this PR introduce _any_ user-facing change?
Yes, **after this patch**, people could insert '1000-01-01 00:00:00' to '9999-12-31 23:59:59' range timestamp to mysql DATETIME column rather than TIMESTAMP column because TIMESTAMP in mysql not have the same range in spark by table auto created.

### How was this patch tested?
Unit test.
