### PR TITLE
[SPARK-32234][SQL] Spark sql commands are failing on selecting the orc tables

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -20,8 +20,6 @@ package org.apache.spark.sql.execution.datasources.orc
 import java.io._
 import java.net.URI
 
-import scala.collection.JavaConverters._
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.hadoop.mapred.JobConf

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -160,11 +160,13 @@ class OrcFileFormat
     }
 
     val resultSchema = StructType(requiredSchema.fields ++ partitionSchema.fields)
+    val actualSchema = StructType(dataSchema.fields ++ partitionSchema.fields)
     val sqlConf = sparkSession.sessionState.conf
     val enableVectorizedReader = supportBatch(sparkSession, resultSchema)
     val capacity = sqlConf.orcVectorizedReaderBatchSize
 
     val resultSchemaString = OrcUtils.orcTypeDescriptionString(resultSchema)
+    val actualSchemaString = OrcUtils.orcTypeDescriptionString(actualSchema)
     OrcConf.MAPRED_INPUT_SCHEMA.setString(hadoopConf, resultSchemaString)
     OrcConf.IS_SCHEMA_EVOLUTION_CASE_SENSITIVE.setBoolean(hadoopConf, sqlConf.caseSensitiveAnalysis)
 
@@ -209,7 +211,7 @@ class OrcFileFormat
             Array.fill(requiredSchema.length)(-1) ++ Range(0, partitionSchema.length)
           batchReader.initialize(fileSplit, taskAttemptContext)
           batchReader.initBatch(
-            TypeDescription.fromString(resultSchemaString),
+            TypeDescription.fromString(actualSchemaString),
             resultSchema.fields,
             requestedDataColIds,
             requestedPartitionColIds,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -179,13 +179,13 @@ class OrcFileFormat
 
       val fs = filePath.getFileSystem(conf)
       val readerOptions = OrcFile.readerOptions(conf).filesystem(fs)
-      val (requestedColIdsOrEmptyFile, sendActualSchema) =
+      val (requestedColIdsOrEmptyFile, canPruneCols) =
         Utils.tryWithResource(OrcFile.createReader(filePath, readerOptions)) { reader =>
           OrcUtils.requestedColumnIds(
             isCaseSensitive, dataSchema, requiredSchema, reader, conf)
         }
 
-      if (sendActualSchema) {
+      if (canPruneCols) {
         resultSchemaString = OrcUtils.orcTypeDescriptionString(actualSchema)
       }
       OrcConf.MAPRED_INPUT_SCHEMA.setString(conf, resultSchemaString)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -185,7 +185,7 @@ class OrcFileFormat
             isCaseSensitive, dataSchema, requiredSchema, reader, conf)
         }
 
-      if (canPruneCols) {
+      if (!canPruneCols) {
         resultSchemaString = OrcUtils.orcTypeDescriptionString(actualSchema)
       }
       OrcConf.MAPRED_INPUT_SCHEMA.setString(conf, resultSchemaString)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -187,12 +187,8 @@ class OrcFileFormat
         Iterator.empty
       } else {
         val (requestedColIds, canPruneCols) = resultedColPruneInfo.get
-        val resultSchemaString = if (canPruneCols) {
-          OrcUtils.orcTypeDescriptionString(resultSchema)
-        } else {
-          OrcUtils.orcTypeDescriptionString(StructType(dataSchema.fields ++ partitionSchema.fields))
-        }
-        OrcConf.MAPRED_INPUT_SCHEMA.setString(conf, resultSchemaString)
+        val resultSchemaString = OrcUtils.orcResultSchemaString(canPruneCols,
+          dataSchema, resultSchema, partitionSchema, conf)
         assert(requestedColIds.length == requiredSchema.length,
           "[BUG] requested column IDs do not match required schema")
         val taskConf = new Configuration(conf)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
@@ -116,7 +116,7 @@ object OrcUtils extends Logging {
   }
 
   /**
-   * Returns the requested column ids from the given ORC file and Boolean flag to use actual
+   * @return Returns the requested column ids from the given ORC file and Boolean flag to use actual
    * schema or result schema. Column id can be -1, which means the requested column doesn't
    * exist in the ORC file. Returns None if the given ORC file is empty.
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
@@ -117,7 +117,7 @@ object OrcUtils extends Logging {
 
   /**
    * Returns the requested column ids from the given ORC file and Boolean flag to use actual
-   * schema or result scehma. Column id can be -1, which means the requested column doesn't
+   * schema or result schema. Column id can be -1, which means the requested column doesn't
    * exist in the ORC file. Returns None if the given ORC file is empty.
    */
   def requestedColumnIds(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
@@ -80,10 +80,10 @@ case class OrcPartitionReaderFactory(
           isCaseSensitive, dataSchema, readDataSchema, reader, conf)
       }
 
-    if (requestedColIdsOrEmptyFile.isEmpty) {
+    if (requestedColIdsOrEmptyFile._1.isEmpty) {
       new EmptyPartitionReader[InternalRow]
     } else {
-      val requestedColIds = requestedColIdsOrEmptyFile.get
+      val requestedColIds = requestedColIdsOrEmptyFile._1.get
       assert(requestedColIds.length == readDataSchema.length,
         "[BUG] requested column IDs do not match required schema")
 
@@ -126,10 +126,11 @@ case class OrcPartitionReaderFactory(
           isCaseSensitive, dataSchema, readDataSchema, reader, conf)
       }
 
-    if (requestedColIdsOrEmptyFile.isEmpty) {
+    if (requestedColIdsOrEmptyFile._1.isEmpty) {
       new EmptyPartitionReader
     } else {
-      val requestedColIds = requestedColIdsOrEmptyFile.get ++ Array.fill(partitionSchema.length)(-1)
+      val requestedColIds =
+        requestedColIdsOrEmptyFile._1.get ++ Array.fill(partitionSchema.length)(-1)
       assert(requestedColIds.length == resultSchema.length,
         "[BUG] requested column IDs do not match required schema")
       val taskConf = new Configuration(conf)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
@@ -74,16 +74,16 @@ case class OrcPartitionReaderFactory(
 
     val fs = filePath.getFileSystem(conf)
     val readerOptions = OrcFile.readerOptions(conf).filesystem(fs)
-    val requestedColIdsOrEmptyFile =
+    val (requestedColIdsOrEmptyFile, sendActualSchema) =
       Utils.tryWithResource(OrcFile.createReader(filePath, readerOptions)) { reader =>
         OrcUtils.requestedColumnIds(
           isCaseSensitive, dataSchema, readDataSchema, reader, conf)
       }
 
-    if (requestedColIdsOrEmptyFile._1.isEmpty) {
+    if (requestedColIdsOrEmptyFile.isEmpty) {
       new EmptyPartitionReader[InternalRow]
     } else {
-      val requestedColIds = requestedColIdsOrEmptyFile._1.get
+      val requestedColIds = requestedColIdsOrEmptyFile.get
       assert(requestedColIds.length == readDataSchema.length,
         "[BUG] requested column IDs do not match required schema")
 
@@ -120,17 +120,17 @@ case class OrcPartitionReaderFactory(
 
     val fs = filePath.getFileSystem(conf)
     val readerOptions = OrcFile.readerOptions(conf).filesystem(fs)
-    val requestedColIdsOrEmptyFile =
+    val (requestedColIdsOrEmptyFile, sendActualSchema) =
       Utils.tryWithResource(OrcFile.createReader(filePath, readerOptions)) { reader =>
         OrcUtils.requestedColumnIds(
           isCaseSensitive, dataSchema, readDataSchema, reader, conf)
       }
 
-    if (requestedColIdsOrEmptyFile._1.isEmpty) {
+    if (requestedColIdsOrEmptyFile.isEmpty) {
       new EmptyPartitionReader
     } else {
       val requestedColIds =
-        requestedColIdsOrEmptyFile._1.get ++ Array.fill(partitionSchema.length)(-1)
+        requestedColIdsOrEmptyFile.get ++ Array.fill(partitionSchema.length)(-1)
       assert(requestedColIds.length == resultSchema.length,
         "[BUG] requested column IDs do not match required schema")
       val taskConf = new Configuration(conf)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
@@ -74,7 +74,7 @@ case class OrcPartitionReaderFactory(
 
     val fs = filePath.getFileSystem(conf)
     val readerOptions = OrcFile.readerOptions(conf).filesystem(fs)
-    val (requestedColIdsOrEmptyFile, sendActualSchema) =
+    val (requestedColIdsOrEmptyFile, _) =
       Utils.tryWithResource(OrcFile.createReader(filePath, readerOptions)) { reader =>
         OrcUtils.requestedColumnIds(
           isCaseSensitive, dataSchema, readDataSchema, reader, conf)
@@ -120,7 +120,7 @@ case class OrcPartitionReaderFactory(
 
     val fs = filePath.getFileSystem(conf)
     val readerOptions = OrcFile.readerOptions(conf).filesystem(fs)
-    val (requestedColIdsOrEmptyFile, sendActualSchema) =
+    val (requestedColIdsOrEmptyFile, _) =
       Utils.tryWithResource(OrcFile.createReader(filePath, readerOptions)) { reader =>
         OrcUtils.requestedColumnIds(
           isCaseSensitive, dataSchema, readDataSchema, reader, conf)
@@ -129,8 +129,7 @@ case class OrcPartitionReaderFactory(
     if (requestedColIdsOrEmptyFile.isEmpty) {
       new EmptyPartitionReader
     } else {
-      val requestedColIds =
-        requestedColIdsOrEmptyFile.get ++ Array.fill(partitionSchema.length)(-1)
+      val requestedColIds = requestedColIdsOrEmptyFile.get ++ Array.fill(partitionSchema.length)(-1)
       assert(requestedColIds.length == resultSchema.length,
         "[BUG] requested column IDs do not match required schema")
       val taskConf = new Configuration(conf)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
@@ -127,11 +127,11 @@ case class OrcPartitionReaderFactory(
     if (resultedColPruneInfo.isEmpty) {
       new EmptyPartitionReader
     } else {
-      val (requestedColIds, canPruneCols) = resultedColPruneInfo.get
+      val (requestedDataColIds, canPruneCols) = resultedColPruneInfo.get
       val resultSchemaString = OrcUtils.orcResultSchemaString(canPruneCols,
         dataSchema, resultSchema, partitionSchema, conf)
-      val requestedDataColIds = requestedColIds ++ Array.fill(partitionSchema.length)(-1)
-      assert(requestedDataColIds.length == resultSchema.length,
+      val requestedColIds = requestedDataColIds ++ Array.fill(partitionSchema.length)(-1)
+      assert(requestedColIds.length == resultSchema.length,
         "[BUG] requested column IDs do not match required schema")
       val taskConf = new Configuration(conf)
 
@@ -147,7 +147,7 @@ case class OrcPartitionReaderFactory(
       batchReader.initBatch(
         TypeDescription.fromString(resultSchemaString),
         resultSchema.fields,
-        requestedDataColIds,
+        requestedColIds,
         requestedPartitionColIds,
         file.partitionValues)
       new PartitionRecordReader(batchReader)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
@@ -54,7 +54,6 @@ case class OrcPartitionReaderFactory(
     readDataSchema: StructType,
     partitionSchema: StructType) extends FilePartitionReaderFactory {
   private val resultSchema = StructType(readDataSchema.fields ++ partitionSchema.fields)
-  private val actualSchema = StructType(dataSchema.fields ++ partitionSchema.fields)
   private val isCaseSensitive = sqlConf.caseSensitiveAnalysis
   private val capacity = sqlConf.orcVectorizedReaderBatchSize
 
@@ -67,28 +66,28 @@ case class OrcPartitionReaderFactory(
   override def buildReader(file: PartitionedFile): PartitionReader[InternalRow] = {
     val conf = broadcastedConf.value.value
 
-    var resultSchemaString = OrcUtils.orcTypeDescriptionString(resultSchema)
     OrcConf.IS_SCHEMA_EVOLUTION_CASE_SENSITIVE.setBoolean(conf, isCaseSensitive)
 
     val filePath = new Path(new URI(file.filePath))
 
     val fs = filePath.getFileSystem(conf)
     val readerOptions = OrcFile.readerOptions(conf).filesystem(fs)
-    val (requestedColIdsOrEmptyFile, canPruneCols) =
+    val resultedColPruneInfo =
       Utils.tryWithResource(OrcFile.createReader(filePath, readerOptions)) { reader =>
         OrcUtils.requestedColumnIds(
           isCaseSensitive, dataSchema, readDataSchema, reader, conf)
       }
 
-    if (!canPruneCols) {
-      resultSchemaString = OrcUtils.orcTypeDescriptionString(actualSchema)
-    }
-    OrcConf.MAPRED_INPUT_SCHEMA.setString(conf, resultSchemaString)
-
-    if (requestedColIdsOrEmptyFile.isEmpty) {
+    if (resultedColPruneInfo.isEmpty) {
       new EmptyPartitionReader[InternalRow]
     } else {
-      val requestedColIds = requestedColIdsOrEmptyFile.get
+      val (requestedColIds, canPruneCols) = resultedColPruneInfo.get
+      val resultSchemaString = if (canPruneCols) {
+        OrcUtils.orcTypeDescriptionString(resultSchema)
+      } else {
+        OrcUtils.orcTypeDescriptionString(StructType(dataSchema.fields ++ partitionSchema.fields))
+      }
+      OrcConf.MAPRED_INPUT_SCHEMA.setString(conf, resultSchemaString)
       assert(requestedColIds.length == readDataSchema.length,
         "[BUG] requested column IDs do not match required schema")
 
@@ -117,29 +116,30 @@ case class OrcPartitionReaderFactory(
   override def buildColumnarReader(file: PartitionedFile): PartitionReader[ColumnarBatch] = {
     val conf = broadcastedConf.value.value
 
-    var resultSchemaString = OrcUtils.orcTypeDescriptionString(resultSchema)
     OrcConf.IS_SCHEMA_EVOLUTION_CASE_SENSITIVE.setBoolean(conf, isCaseSensitive)
 
     val filePath = new Path(new URI(file.filePath))
 
     val fs = filePath.getFileSystem(conf)
     val readerOptions = OrcFile.readerOptions(conf).filesystem(fs)
-    val (requestedColIdsOrEmptyFile, canPruneCols) =
+    val resultedColPruneInfo =
       Utils.tryWithResource(OrcFile.createReader(filePath, readerOptions)) { reader =>
         OrcUtils.requestedColumnIds(
           isCaseSensitive, dataSchema, readDataSchema, reader, conf)
       }
 
-    if (!canPruneCols) {
-      resultSchemaString = OrcUtils.orcTypeDescriptionString(actualSchema)
-    }
-    OrcConf.MAPRED_INPUT_SCHEMA.setString(conf, resultSchemaString)
-
-    if (requestedColIdsOrEmptyFile.isEmpty) {
+    if (resultedColPruneInfo.isEmpty) {
       new EmptyPartitionReader
     } else {
-      val requestedColIds = requestedColIdsOrEmptyFile.get ++ Array.fill(partitionSchema.length)(-1)
-      assert(requestedColIds.length == resultSchema.length,
+      val (requestedColIds, canPruneCols) = resultedColPruneInfo.get
+      val resultSchemaString = if (canPruneCols) {
+        OrcUtils.orcTypeDescriptionString(resultSchema)
+      } else {
+        OrcUtils.orcTypeDescriptionString(StructType(dataSchema.fields ++ partitionSchema.fields))
+      }
+      OrcConf.MAPRED_INPUT_SCHEMA.setString(conf, resultSchemaString)
+      val requestedDataColIds = requestedColIds ++ Array.fill(partitionSchema.length)(-1)
+      assert(requestedDataColIds.length == resultSchema.length,
         "[BUG] requested column IDs do not match required schema")
       val taskConf = new Configuration(conf)
 
@@ -155,7 +155,7 @@ case class OrcPartitionReaderFactory(
       batchReader.initBatch(
         TypeDescription.fromString(resultSchemaString),
         resultSchema.fields,
-        requestedColIds,
+        requestedDataColIds,
         requestedPartitionColIds,
         file.partitionValues)
       new PartitionRecordReader(batchReader)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
@@ -82,12 +82,8 @@ case class OrcPartitionReaderFactory(
       new EmptyPartitionReader[InternalRow]
     } else {
       val (requestedColIds, canPruneCols) = resultedColPruneInfo.get
-      val resultSchemaString = if (canPruneCols) {
-        OrcUtils.orcTypeDescriptionString(resultSchema)
-      } else {
-        OrcUtils.orcTypeDescriptionString(StructType(dataSchema.fields ++ partitionSchema.fields))
-      }
-      OrcConf.MAPRED_INPUT_SCHEMA.setString(conf, resultSchemaString)
+      val resultSchemaString = OrcUtils.orcResultSchemaString(canPruneCols,
+        dataSchema, resultSchema, partitionSchema, conf)
       assert(requestedColIds.length == readDataSchema.length,
         "[BUG] requested column IDs do not match required schema")
 
@@ -132,12 +128,8 @@ case class OrcPartitionReaderFactory(
       new EmptyPartitionReader
     } else {
       val (requestedColIds, canPruneCols) = resultedColPruneInfo.get
-      val resultSchemaString = if (canPruneCols) {
-        OrcUtils.orcTypeDescriptionString(resultSchema)
-      } else {
-        OrcUtils.orcTypeDescriptionString(StructType(dataSchema.fields ++ partitionSchema.fields))
-      }
-      OrcConf.MAPRED_INPUT_SCHEMA.setString(conf, resultSchemaString)
+      val resultSchemaString = OrcUtils.orcResultSchemaString(canPruneCols,
+        dataSchema, resultSchema, partitionSchema, conf)
       val requestedDataColIds = requestedColIds ++ Array.fill(partitionSchema.length)(-1)
       assert(requestedDataColIds.length == resultSchema.length,
         "[BUG] requested column IDs do not match required schema")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
@@ -80,7 +80,7 @@ case class OrcPartitionReaderFactory(
           isCaseSensitive, dataSchema, readDataSchema, reader, conf)
       }
 
-    if (canPruneCols) {
+    if (!canPruneCols) {
       resultSchemaString = OrcUtils.orcTypeDescriptionString(actualSchema)
     }
     OrcConf.MAPRED_INPUT_SCHEMA.setString(conf, resultSchemaString)
@@ -130,11 +130,10 @@ case class OrcPartitionReaderFactory(
           isCaseSensitive, dataSchema, readDataSchema, reader, conf)
       }
 
-    if (canPruneCols) {
+    if (!canPruneCols) {
       resultSchemaString = OrcUtils.orcTypeDescriptionString(actualSchema)
     }
     OrcConf.MAPRED_INPUT_SCHEMA.setString(conf, resultSchemaString)
-
 
     if (requestedColIdsOrEmptyFile.isEmpty) {
       new EmptyPartitionReader

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcColumnarBatchReaderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcColumnarBatchReaderSuite.scala
@@ -92,24 +92,13 @@ class OrcColumnarBatchReaderSuite extends QueryTest with SharedSparkSession {
           | test_date_hive_orc
           |  values(9, '12', 2020)
         """.stripMargin)
-      try {
-        val df = spark.sql("select _col2 from test_date_hive_orc")
-        checkAnswer(df, Row("12"))
-      } catch {
-        case e: Throwable =>
-          error = e
-      }
-      assert(error == null)
-      spark.sql(
-        s"""
-           |DROP TABLE IF
-           | EXISTS test_date_hive_orc
-         """.stripMargin)
+
+      val df = spark.sql("select _col2 from test_date_hive_orc")
+      checkAnswer(df, Row("12"))
     }
   }
 
   test("SPARK-32234: orc data created by the spark having proper fields name") {
-    var error: Throwable = null
     withTable("test_date_spark_orc") {
       spark.sql(
         """
@@ -122,19 +111,9 @@ class OrcColumnarBatchReaderSuite extends QueryTest with SharedSparkSession {
           | test_date_spark_orc
           |  values(9, '12', 2020)
         """.stripMargin)
-      try {
-        val df = spark.sql("select d_date_id from test_date_spark_orc")
-        checkAnswer(df, Row("12"))
-      } catch {
-        case e: Throwable =>
-          error = e
-      }
-      assert(error == null)
-      spark.sql(
-        s"""
-           |DROP TABLE IF
-           | EXISTS test_date_spark_orc
-         """.stripMargin)
+
+      val df = spark.sql("select d_date_id from test_date_spark_orc")
+      checkAnswer(df, Row("12"))
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcColumnarBatchReaderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcColumnarBatchReaderSuite.scala
@@ -19,10 +19,9 @@ package org.apache.spark.sql.execution.datasources.orc
 
 import org.apache.orc.TypeDescription
 
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.vectorized.{OnHeapColumnVector, WritableColumnVector}
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{StructField, StructType}
 import org.apache.spark.unsafe.types.UTF8String.fromString
@@ -76,31 +75,6 @@ class OrcColumnarBatchReaderSuite extends QueryTest with SharedSparkSession {
       val p1 = batch.column(1).asInstanceOf[OnHeapColumnVector]
       assert(isConstant.get(p1).asInstanceOf[Boolean]) // Partition column is constant.
       assert(p1.getUTF8String(0) === partitionValues.getUTF8String(0))
-    }
-  }
-
-  test("SPARK-32234: orc data created by the hive tables having _col fields" +
-    " name for vectorized reader") {
-    Seq(false, true).foreach { vectorized =>
-      withSQLConf(SQLConf.ORC_VECTORIZED_READER_ENABLED.key -> vectorized.toString) {
-        withTable("test_hive_orc_vect_read") {
-          spark.sql(
-            """
-              | CREATE TABLE test_hive_orc_vect_read
-              | (_col1 INT, _col2 STRING, _col3 INT)
-              | USING orc
-            """.stripMargin)
-          spark.sql(
-            """
-              | INSERT INTO
-              | test_hive_orc_vect_read
-              | VALUES(9, '12', 2020)
-            """.stripMargin)
-
-          val df = spark.sql("SELECT _col2 FROM test_hive_orc_vect_read")
-          checkAnswer(df, Row("12"))
-        }
-      }
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcColumnarBatchReaderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcColumnarBatchReaderSuite.scala
@@ -79,21 +79,21 @@ class OrcColumnarBatchReaderSuite extends QueryTest with SharedSparkSession {
   }
 
   test("SPARK-32234: orc data created by the hive tables having _col fields name") {
-    var error: Throwable = null
     withTable("test_date_hive_orc") {
       spark.sql(
         """
-          |CREATE TABLE `test_date_hive_orc`
-          | (`_col1` INT,`_col2` STRING,`_col3` INT)
+          | CREATE TABLE test_date_hive_orc
+          | (_col1 INT, _col2 STRING, _col3 INT)
           |  USING orc
         """.stripMargin)
       spark.sql(
-        """insert into
+        """
+          | INSERT INTO
           | test_date_hive_orc
-          |  values(9, '12', 2020)
+          | VALUES(9, '12', 2020)
         """.stripMargin)
 
-      val df = spark.sql("select _col2 from test_date_hive_orc")
+      val df = spark.sql("SELECT _col2 from test_date_hive_orc")
       checkAnswer(df, Row("12"))
     }
   }
@@ -102,17 +102,18 @@ class OrcColumnarBatchReaderSuite extends QueryTest with SharedSparkSession {
     withTable("test_date_spark_orc") {
       spark.sql(
         """
-          |CREATE TABLE `test_date_spark_orc`
-          | (`d_date_sk` INT,`d_date_id` STRING,`d_year` INT)
-          |  USING orc
+          | CREATE TABLE test_date_spark_orc
+          | (d_date_sk INT, d_date_id STRING, d_year INT)
+          | USING orc
         """.stripMargin)
       spark.sql(
-        """insert into
+        """
+          | INSERT INTO
           | test_date_spark_orc
-          |  values(9, '12', 2020)
+          | VALUES(9, '12', 2020)
         """.stripMargin)
 
-      val df = spark.sql("select d_date_id from test_date_spark_orc")
+      val df = spark.sql("SELECT d_date_id FROM test_date_spark_orc")
       checkAnswer(df, Row("12"))
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcQuerySuite.scala
@@ -289,52 +289,31 @@ class HiveOrcQuerySuite extends OrcQueryTest with TestHiveSingleton {
     }
   }
 
-  test("SPARK-32234: orc data created by the hive tables having _col fields" +
-    " name for vectorized reader") {
-    Seq(false, true).foreach { vectorized =>
-      withSQLConf(SQLConf.ORC_VECTORIZED_READER_ENABLED.key -> vectorized.toString) {
-        withTable("test_hive_orc_vect_read") {
-          spark.sql(
-            """
-              | CREATE TABLE test_hive_orc_vect_read
-              | (_col1 INT, _col2 STRING, _col3 INT)
-              | USING orc
-            """.stripMargin)
-          spark.sql(
-            """
-              | INSERT INTO
-              | test_hive_orc_vect_read
-              | VALUES(9, '12', 2020)
-            """.stripMargin)
-
-          val df = spark.sql("SELECT _col2 FROM test_hive_orc_vect_read")
-          checkAnswer(df, Row("12"))
-        }
-      }
-    }
-  }
-
   test("SPARK-32234: orc data created by the hive tables having _col fields name" +
     " for ORC_IMPLEMENTATION") {
     Seq("native", "hive").foreach { orcImpl =>
-      withSQLConf(SQLConf.ORC_IMPLEMENTATION.key -> orcImpl) {
-        withTempPath { dir =>
-          withTable("test_hive_orc_impl") {
-            spark.sql(
-              s"""
-                 | CREATE TABLE test_hive_orc_impl
-                 | (_col1 INT, _col2 STRING, _col3 INT)
-                 | STORED AS ORC LOCATION '$dir'
+      Seq("false", "true").foreach { vectorized =>
+        withSQLConf(
+          SQLConf.ORC_IMPLEMENTATION.key -> orcImpl,
+          SQLConf.ORC_VECTORIZED_READER_ENABLED.key -> vectorized) {
+          withTempPath { dir =>
+            withTable("test_hive_orc_impl") {
+              spark.sql(
+                s"""
+                   | CREATE TABLE test_hive_orc_impl
+                   | (_col1 INT, _col2 STRING, _col3 INT)
+                   | STORED AS ORC LOCATION '$dir'
               """.stripMargin)
-            spark.sql(
-              """
-                | INSERT INTO
-                | test_hive_orc_impl
-                | VALUES(9, '12', 2020)
-              """.stripMargin)
+              spark.sql(
+                """
+                  | INSERT INTO
+                  | test_hive_orc_impl
+                  | VALUES(9, '12', 2020)
+                """.stripMargin)
 
-            val df = spark.sql("SELECT _col2 FROM test_hive_orc_impl")
-            checkAnswer(df, Row("12"))
+              val df = spark.sql("SELECT _col2 FROM test_hive_orc_impl")
+              checkAnswer(df, Row("12"))
+            }
           }
         }
       }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcQuerySuite.scala
@@ -289,8 +289,7 @@ class HiveOrcQuerySuite extends OrcQueryTest with TestHiveSingleton {
     }
   }
 
-  test("SPARK-32234: orc data created by the hive tables having _col fields name" +
-    " for ORC_IMPLEMENTATION") {
+  test("SPARK-32234: read ORC table with column names all starting with '_col'") {
     Seq("native", "hive").foreach { orcImpl =>
       Seq("false", "true").foreach { vectorized =>
         withSQLConf(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcQuerySuite.scala
@@ -289,7 +289,7 @@ class HiveOrcQuerySuite extends OrcQueryTest with TestHiveSingleton {
     }
   }
 
-  test("SPARK-32234: read ORC table with column names all starting with '_col'") {
+  test("SPARK-32234 read ORC table with column names all starting with '_col'") {
     Seq("native", "hive").foreach { orcImpl =>
       Seq("false", "true").foreach { vectorized =>
         withSQLConf(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcQuerySuite.scala
@@ -298,17 +298,17 @@ class HiveOrcQuerySuite extends OrcQueryTest with TestHiveSingleton {
           SQLConf.ORC_VECTORIZED_READER_ENABLED.key -> vectorized) {
           withTable("test_hive_orc_impl") {
             spark.sql(
-              """
+              s"""
                  | CREATE TABLE test_hive_orc_impl
                  | (_col1 INT, _col2 STRING, _col3 INT)
                  | STORED AS ORC
-              """.stripMargin)
+               """.stripMargin)
             spark.sql(
-              """
-                | INSERT INTO
-                | test_hive_orc_impl
-                | VALUES(9, '12', 2020)
-              """.stripMargin)
+              s"""
+                 | INSERT INTO
+                 | test_hive_orc_impl
+                 | VALUES(9, '12', 2020)
+               """.stripMargin)
 
             val df = spark.sql("SELECT _col2 FROM test_hive_orc_impl")
             checkAnswer(df, Row("12"))

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcQuerySuite.scala
@@ -296,24 +296,22 @@ class HiveOrcQuerySuite extends OrcQueryTest with TestHiveSingleton {
         withSQLConf(
           SQLConf.ORC_IMPLEMENTATION.key -> orcImpl,
           SQLConf.ORC_VECTORIZED_READER_ENABLED.key -> vectorized) {
-          withTempPath { dir =>
-            withTable("test_hive_orc_impl") {
-              spark.sql(
-                s"""
-                   | CREATE TABLE test_hive_orc_impl
-                   | (_col1 INT, _col2 STRING, _col3 INT)
-                   | STORED AS ORC LOCATION '$dir'
+          withTable("test_hive_orc_impl") {
+            spark.sql(
+              """
+                 | CREATE TABLE test_hive_orc_impl
+                 | (_col1 INT, _col2 STRING, _col3 INT)
+                 | STORED AS ORC
               """.stripMargin)
-              spark.sql(
-                """
-                  | INSERT INTO
-                  | test_hive_orc_impl
-                  | VALUES(9, '12', 2020)
-                """.stripMargin)
+            spark.sql(
+              """
+                | INSERT INTO
+                | test_hive_orc_impl
+                | VALUES(9, '12', 2020)
+              """.stripMargin)
 
-              val df = spark.sql("SELECT _col2 FROM test_hive_orc_impl")
-              checkAnswer(df, Row("12"))
-            }
+            val df = spark.sql("SELECT _col2 FROM test_hive_orc_impl")
+            checkAnswer(df, Row("12"))
           }
         }
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Spark sql commands are failing on selecting the orc tables 
Steps to reproduce 
Example 1 - 
Prerequisite -  This is the location(/Users/test/tpcds_scale5data/date_dim) for orc data which is generated by the hive.
```
val table = """CREATE TABLE `date_dim` (
  `d_date_sk` INT,
  `d_date_id` STRING,
  `d_date` TIMESTAMP,
  `d_month_seq` INT,
  `d_week_seq` INT,
  `d_quarter_seq` INT,
  `d_year` INT,
  `d_dow` INT,
  `d_moy` INT,
  `d_dom` INT,
  `d_qoy` INT,
  `d_fy_year` INT,
  `d_fy_quarter_seq` INT,
  `d_fy_week_seq` INT,
  `d_day_name` STRING,
  `d_quarter_name` STRING,
  `d_holiday` STRING,
  `d_weekend` STRING,
  `d_following_holiday` STRING,
  `d_first_dom` INT,
  `d_last_dom` INT,
  `d_same_day_ly` INT,
  `d_same_day_lq` INT,
  `d_current_day` STRING,
  `d_current_week` STRING,
  `d_current_month` STRING,
  `d_current_quarter` STRING,
  `d_current_year` STRING)
USING orc
LOCATION '/Users/test/tpcds_scale5data/date_dim'"""

spark.sql(table).collect

val u = """select date_dim.d_date_id from date_dim limit 5"""

spark.sql(u).collect
```
Example 2

```
  val table = """CREATE TABLE `test_orc_data` (
  `_col1` INT,
  `_col2` STRING,
  `_col3` INT)
  USING orc"""

spark.sql(table).collect

spark.sql("insert into test_orc_data values(13, '155', 2020)").collect

val df = """select _col2 from test_orc_data limit 5"""
spark.sql(df).collect

```



Its Failing with below error 
```
org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 2.0 failed 1 times, most recent failure: Lost task 0.0 in stage 2.0 (TID 2, 192.168.0.103, executor driver): java.lang.ArrayIndexOutOfBoundsException: 1
    at org.apache.spark.sql.execution.datasources.orc.OrcColumnarBatchReader.initBatch(OrcColumnarBatchReader.java:156)
    at org.apache.spark.sql.execution.datasources.orc.OrcFileFormat.$anonfun$buildReaderWithPartitionValues$7(OrcFileFormat.scala:258)
    at org.apache.spark.sql.execution.datasources.FileScanRDD$$anon$1.org$apache$spark$sql$execution$datasources$FileScanRDD$$anon$$readCurrentFile(FileScanRDD.scala:141)
    at org.apache.spark.sql.execution.datasources.FileScanRDD$$anon$1.nextIterator(FileScanRDD.scala:203)
    at org.apache.spark.sql.execution.datasources.FileScanRDD$$anon$1.hasNext(FileScanRDD.scala:116)
    at org.apache.spark.sql.execution.FileSourceScanExec$$anon$1.hasNext(DataSourceScanExec.scala:620)
    at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.columnartorow_nextBatch_0$(Unknown Source)
    at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.processNext(Unknown Source)
    at org.apache.spark.sql.execution.BufferedRowIterator.hasNext(BufferedRowIterator.java:43)
    at org.apache.spark.sql.execution.WholeStageCodegenExec$$anon$1.hasNext(WholeStageCodegenExec.scala:729)
    at org.apache.spark.sql.execution.SparkPlan.$anonfun$getByteArrayRdd$1(SparkPlan.scala:343)
    at org.apache.spark.rdd.RDD.$anonfun$mapPartitionsInternal$2(RDD.scala:895)
    at org.apache.spark.rdd.RDD.$anonfun$mapPartitionsInternal$2$adapted(RDD.scala:895)
    at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
    at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:372)
    at org.apache.spark.rdd.RDD.iterator(RDD.scala:336)
    at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
    at org.apache.spark.scheduler.Task.run(Task.scala:133)
    at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:445)
    at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1489)
    at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:448)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    at java.lang.Thread.run(Thread.java:748)`
```

The reason behind this initBatch is not getting the schema that is needed to find out the column value in OrcFileFormat.scala
```
batchReader.initBatch(
 TypeDescription.fromString(resultSchemaString)
```

### Why are the changes needed?
Spark sql queries for orc tables are failing


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Unit test is added for this .Also Tested through spark shell and spark submit the failing queries
