### PR TITLE
[SPARK-32243][SQL]HiveSessionCatalog call super.makeFunctionExpression should throw earlier when got Spark UDAF Invalid arguments number error

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/AnalysisException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/AnalysisException.scala
@@ -64,3 +64,12 @@ class AnalysisException protected[sql] (
 class InvalidFunctionArgumentException protected[sql](message: String)
   extends AnalysisException(message, None, None, None, None) {
 }
+
+/**
+ * Thrown when a query failed for invalid function class, usually because a SQL
+ * function's class does not follow the rules of the UDF/UDAF class definition.
+ * @param message
+ */
+class InvalidUDFClassException protected[sql](message: String)
+  extends AnalysisException(message, None, None, None, None) {
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/AnalysisException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/AnalysisException.scala
@@ -54,22 +54,3 @@ class AnalysisException protected[sql] (
     s"$message;$lineAnnotation$positionAnnotation"
   }
 }
-
-/**
- * Thrown when a query failed for invalid function argument size, usually because
- * a SQL function is called with the wrong number of arguments.
- *
- * @Since 3.1.0
- */
-class InvalidFunctionArgumentException protected[sql](message: String)
-  extends AnalysisException(message, None, None, None, None) {
-}
-
-/**
- * Thrown when a query failed for invalid function class, usually because a SQL
- * function's class does not follow the rules of the UDF/UDAF class definition.
- * @param message
- */
-class InvalidUDFClassException protected[sql](message: String)
-  extends AnalysisException(message, None, None, None, None) {
-}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/AnalysisException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/AnalysisException.scala
@@ -56,8 +56,8 @@ class AnalysisException protected[sql] (
 }
 
 /**
- * Thrown when a query failed for invalid function argument size, usually because query pass
- * throw argument number to function.
+ * Thrown when a query failed for invalid function argument size, usually because
+ * a SQL function is called with the wrong number of arguments.
  *
  * @Since 3.1.0
  */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/AnalysisException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/AnalysisException.scala
@@ -54,3 +54,13 @@ class AnalysisException protected[sql] (
     s"$message;$lineAnnotation$positionAnnotation"
   }
 }
+
+/**
+ * Thrown when a query failed for invalid function argument size, usually because query pass
+ * throw argument number to function.
+ *
+ * @Since 3.1.0
+ */
+class InvalidFunctionArgumentException protected[sql](message: String)
+  extends AnalysisException(message, None, None, None, None) {
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InvalidUDFClassException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InvalidUDFClassException.scala
@@ -22,8 +22,6 @@ import org.apache.spark.sql.AnalysisException
 /**
  * Thrown when a query failed for invalid function class, usually because a SQL
  * function's class does not follow the rules of the UDF/UDAF/UDTF class definition.
- *
- * @Since 3.1.0
  */
 class InvalidUDFClassException private[sql](message: String)
   extends AnalysisException(message, None, None, None, None) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InvalidUDFClassException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InvalidUDFClassException.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.catalog
+
+import org.apache.spark.sql.AnalysisException
+
+/**
+ * Thrown when a query failed for invalid function class, usually because a SQL
+ * function's class does not follow the rules of the UDF/UDAF/UDTF class definition.
+ *
+ * @Since 3.1.0
+ */
+class InvalidUDFClassException private[sql](message: String)
+  extends AnalysisException(message, None, None, None, None) {
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -1299,7 +1299,7 @@ class SessionCatalog(
 
       // Check input argument size
       if (e.inputTypes.size != input.size) {
-        throw new AnalysisException(s"Invalid number of arguments for function $name. " +
+        throw new IllegalArgumentException(s"Invalid number of arguments for function $name. " +
           s"Expected: ${e.inputTypes.size}; Found: ${input.size}")
       }
       e

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -1299,8 +1299,8 @@ class SessionCatalog(
 
       // Check input argument size
       if (e.inputTypes.size != input.size) {
-        throw new AnalysisException(s"Invalid number of arguments for " +
-          s"function $name. Expected: ${e.inputTypes.size}; Found: ${input.size}")
+        throw new AnalysisException(s"Invalid number of arguments for function $name. " +
+          s"Expected: ${e.inputTypes.size}; Found: ${input.size}")
       }
       e
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -30,7 +30,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.{AnalysisException, InvalidFunctionArgumentException}
+import org.apache.spark.sql.{AnalysisException, InvalidFunctionArgumentException, InvalidUDFClassException}
 import org.apache.spark.sql.catalyst._
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FunctionBuilder
@@ -1304,7 +1304,7 @@ class SessionCatalog(
       }
       e
     } else {
-      throw new AnalysisException(s"No handler for UDAF '${clazz.getCanonicalName}'. " +
+      throw new InvalidUDFClassException(s"No handler for UDAF '${clazz.getCanonicalName}'. " +
         s"Use sparkSession.udf.register(...) instead.")
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -30,7 +30,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.{AnalysisException, InvalidFunctionArgumentException}
 import org.apache.spark.sql.catalyst._
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FunctionBuilder
@@ -1299,8 +1299,8 @@ class SessionCatalog(
 
       // Check input argument size
       if (e.inputTypes.size != input.size) {
-        throw new IllegalArgumentException(s"Invalid number of arguments for function $name. " +
-          s"Expected: ${e.inputTypes.size}; Found: ${input.size}")
+        throw new InvalidFunctionArgumentException(s"Invalid number of arguments for " +
+          s"function $name. Expected: ${e.inputTypes.size}; Found: ${input.size};")
       }
       e
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -30,7 +30,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.{AnalysisException, InvalidFunctionArgumentException, InvalidUDFClassException}
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst._
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FunctionBuilder
@@ -1299,7 +1299,7 @@ class SessionCatalog(
 
       // Check input argument size
       if (e.inputTypes.size != input.size) {
-        throw new InvalidFunctionArgumentException(s"Invalid number of arguments for " +
+        throw new AnalysisException(s"Invalid number of arguments for " +
           s"function $name. Expected: ${e.inputTypes.size}; Found: ${input.size}")
       }
       e

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -1300,7 +1300,7 @@ class SessionCatalog(
       // Check input argument size
       if (e.inputTypes.size != input.size) {
         throw new InvalidFunctionArgumentException(s"Invalid number of arguments for " +
-          s"function $name. Expected: ${e.inputTypes.size}; Found: ${input.size};")
+          s"function $name. Expected: ${e.inputTypes.size}; Found: ${input.size}")
       }
       e
     } else {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
@@ -69,49 +69,56 @@ private[sql] class HiveSessionCatalog(
     // Current thread context classloader may not be the one loaded the class. Need to switch
     // context classloader to initialize instance properly.
     Utils.withContextClassLoader(clazz.getClassLoader) {
-      Try(super.makeFunctionExpression(name, clazz, input)).getOrElse {
-        var udfExpr: Option[Expression] = None
-        try {
-          // When we instantiate hive UDF wrapper class, we may throw exception if the input
-          // expressions don't satisfy the hive UDF, such as type mismatch, input number
-          // mismatch, etc. Here we catch the exception and throw AnalysisException instead.
-          if (classOf[UDF].isAssignableFrom(clazz)) {
-            udfExpr = Some(HiveSimpleUDF(name, new HiveFunctionWrapper(clazz.getName), input))
-            udfExpr.get.dataType // Force it to check input data types.
-          } else if (classOf[GenericUDF].isAssignableFrom(clazz)) {
-            udfExpr = Some(HiveGenericUDF(name, new HiveFunctionWrapper(clazz.getName), input))
-            udfExpr.get.dataType // Force it to check input data types.
-          } else if (classOf[AbstractGenericUDAFResolver].isAssignableFrom(clazz)) {
-            udfExpr = Some(HiveUDAFFunction(name, new HiveFunctionWrapper(clazz.getName), input))
-            udfExpr.get.dataType // Force it to check input data types.
-          } else if (classOf[UDAF].isAssignableFrom(clazz)) {
-            udfExpr = Some(HiveUDAFFunction(
-              name,
-              new HiveFunctionWrapper(clazz.getName),
-              input,
-              isUDAFBridgeRequired = true))
-            udfExpr.get.dataType // Force it to check input data types.
-          } else if (classOf[GenericUDTF].isAssignableFrom(clazz)) {
-            udfExpr = Some(HiveGenericUDTF(name, new HiveFunctionWrapper(clazz.getName), input))
-            udfExpr.get.asInstanceOf[HiveGenericUDTF].elementSchema // Force it to check data types.
+      Try(super.makeFunctionExpression(name, clazz, input)) match {
+        case Success(value) => value
+        case Failure(exception) =>
+          val superError =
+            s"Make Expression failed in SessionCatalog for function name = ${name}:" +
+              s" ${exception.getMessage}"
+          var udfExpr: Option[Expression] = None
+          try {
+            // When we instantiate hive UDF wrapper class, we may throw exception if the input
+            // expressions don't satisfy the hive UDF, such as type mismatch, input number
+            // mismatch, etc. Here we catch the exception and throw AnalysisException instead.
+            if (classOf[UDF].isAssignableFrom(clazz)) {
+              udfExpr = Some(HiveSimpleUDF(name, new HiveFunctionWrapper(clazz.getName), input))
+              udfExpr.get.dataType // Force it to check input data types.
+            } else if (classOf[GenericUDF].isAssignableFrom(clazz)) {
+              udfExpr = Some(HiveGenericUDF(name, new HiveFunctionWrapper(clazz.getName), input))
+              udfExpr.get.dataType // Force it to check input data types.
+            } else if (classOf[AbstractGenericUDAFResolver].isAssignableFrom(clazz)) {
+              udfExpr = Some(HiveUDAFFunction(name, new HiveFunctionWrapper(clazz.getName), input))
+              udfExpr.get.dataType // Force it to check input data types.
+            } else if (classOf[UDAF].isAssignableFrom(clazz)) {
+              udfExpr = Some(HiveUDAFFunction(
+                name,
+                new HiveFunctionWrapper(clazz.getName),
+                input,
+                isUDAFBridgeRequired = true))
+              udfExpr.get.dataType // Force it to check input data types.
+            } else if (classOf[GenericUDTF].isAssignableFrom(clazz)) {
+              udfExpr = Some(HiveGenericUDTF(name, new HiveFunctionWrapper(clazz.getName), input))
+              // Force it to check data types.
+              udfExpr.get.asInstanceOf[HiveGenericUDTF].elementSchema
+            }
+          } catch {
+            case NonFatal(e) =>
+              val noHandlerMsg = s"No handler for UDF/UDAF/UDTF '${clazz.getCanonicalName}': $e"
+              val errorMsg =
+                if (classOf[GenericUDTF].isAssignableFrom(clazz)) {
+                  s"$noHandlerMsg\nPlease make sure your function overrides " +
+                    "`public StructObjectInspector initialize(ObjectInspector[] args)`."
+                } else {
+                  noHandlerMsg
+                }
+              val analysisException = new AnalysisException(s"1. $superError\n2. $errorMsg")
+              analysisException.setStackTrace(e.getStackTrace)
+              throw analysisException
           }
-        } catch {
-          case NonFatal(e) =>
-            val noHandlerMsg = s"No handler for UDF/UDAF/UDTF '${clazz.getCanonicalName}': $e"
-            val errorMsg =
-              if (classOf[GenericUDTF].isAssignableFrom(clazz)) {
-                s"$noHandlerMsg\nPlease make sure your function overrides " +
-                  "`public StructObjectInspector initialize(ObjectInspector[] args)`."
-              } else {
-                noHandlerMsg
-              }
-            val analysisException = new AnalysisException(errorMsg)
-            analysisException.setStackTrace(e.getStackTrace)
-            throw analysisException
-        }
-        udfExpr.getOrElse {
-          throw new AnalysisException(s"No handler for UDF/UDAF/UDTF '${clazz.getCanonicalName}'")
-        }
+          udfExpr.getOrElse {
+            throw new AnalysisException(
+              s"1. $superError\n2. No handler for UDF/UDAF/UDTF '${clazz.getCanonicalName}'")
+          }
       }
     }
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
@@ -27,7 +27,7 @@ import org.apache.hadoop.hive.ql.exec.{UDAF, UDF}
 import org.apache.hadoop.hive.ql.exec.{FunctionRegistry => HiveFunctionRegistry}
 import org.apache.hadoop.hive.ql.udf.generic.{AbstractGenericUDAFResolver, GenericUDF, GenericUDTF}
 
-import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.{AnalysisException, InvalidFunctionArgumentException}
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
 import org.apache.spark.sql.catalyst.catalog.{CatalogFunction, ExternalCatalog, FunctionResourceLoader, GlobalTempViewManager, SessionCatalog}
@@ -74,7 +74,7 @@ private[sql] class HiveSessionCatalog(
         t.asInstanceOf[Success[Expression]].get
       } else {
         val exception = t.asInstanceOf[Failure[Expression]].exception
-        if (exception.isInstanceOf[IllegalArgumentException]) {
+        if (exception.isInstanceOf[InvalidFunctionArgumentException]) {
           throw exception
         }
         var udfExpr: Option[Expression] = None

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
@@ -27,7 +27,7 @@ import org.apache.hadoop.hive.ql.exec.{UDAF, UDF}
 import org.apache.hadoop.hive.ql.exec.{FunctionRegistry => HiveFunctionRegistry}
 import org.apache.hadoop.hive.ql.udf.generic.{AbstractGenericUDAFResolver, GenericUDF, GenericUDTF}
 
-import org.apache.spark.sql.{AnalysisException, InvalidFunctionArgumentException}
+import org.apache.spark.sql.{AnalysisException, InvalidFunctionArgumentException, InvalidUDFClassException}
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
 import org.apache.spark.sql.catalyst.catalog.{CatalogFunction, ExternalCatalog, FunctionResourceLoader, GlobalTempViewManager, SessionCatalog}
@@ -116,7 +116,8 @@ private[sql] class HiveSessionCatalog(
               throw analysisException
           }
           udfExpr.getOrElse {
-            throw new AnalysisException(s"No handler for UDF/UDAF/UDTF '${clazz.getCanonicalName}'")
+            throw new InvalidUDFClassException(
+              s"No handler for UDF/UDAF/UDTF '${clazz.getCanonicalName}'")
           }
       }
     }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
@@ -27,10 +27,10 @@ import org.apache.hadoop.hive.ql.exec.{UDAF, UDF}
 import org.apache.hadoop.hive.ql.exec.{FunctionRegistry => HiveFunctionRegistry}
 import org.apache.hadoop.hive.ql.udf.generic.{AbstractGenericUDAFResolver, GenericUDF, GenericUDTF}
 
-import org.apache.spark.sql.{AnalysisException, InvalidFunctionArgumentException, InvalidUDFClassException}
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
-import org.apache.spark.sql.catalyst.catalog.{CatalogFunction, ExternalCatalog, FunctionResourceLoader, GlobalTempViewManager, SessionCatalog}
+import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.expressions.{Cast, Expression}
 import org.apache.spark.sql.catalyst.parser.ParserInterface
 import org.apache.spark.sql.hive.HiveShim.HiveFunctionWrapper
@@ -57,6 +57,56 @@ private[sql] class HiveSessionCatalog(
       parser,
       functionResourceLoader) {
 
+  def makeHiveFunctionExpression(
+      name: String,
+      clazz: Class[_],
+      input: Seq[Expression]): Expression = {
+    var udfExpr: Option[Expression] = None
+    try {
+      // When we instantiate hive UDF wrapper class, we may throw exception if the input
+      // expressions don't satisfy the hive UDF, such as type mismatch, input number
+      // mismatch, etc. Here we catch the exception and throw AnalysisException instead.
+      if (classOf[UDF].isAssignableFrom(clazz)) {
+        udfExpr = Some(HiveSimpleUDF(name, new HiveFunctionWrapper(clazz.getName), input))
+        udfExpr.get.dataType // Force it to check input data types.
+      } else if (classOf[GenericUDF].isAssignableFrom(clazz)) {
+        udfExpr = Some(HiveGenericUDF(name, new HiveFunctionWrapper(clazz.getName), input))
+        udfExpr.get.dataType // Force it to check input data types.
+      } else if (classOf[AbstractGenericUDAFResolver].isAssignableFrom(clazz)) {
+        udfExpr = Some(HiveUDAFFunction(name, new HiveFunctionWrapper(clazz.getName), input))
+        udfExpr.get.dataType // Force it to check input data types.
+      } else if (classOf[UDAF].isAssignableFrom(clazz)) {
+        udfExpr = Some(HiveUDAFFunction(
+          name,
+          new HiveFunctionWrapper(clazz.getName),
+          input,
+          isUDAFBridgeRequired = true))
+        udfExpr.get.dataType // Force it to check input data types.
+      } else if (classOf[GenericUDTF].isAssignableFrom(clazz)) {
+        udfExpr = Some(HiveGenericUDTF(name, new HiveFunctionWrapper(clazz.getName), input))
+        // Force it to check data types.
+        udfExpr.get.asInstanceOf[HiveGenericUDTF].elementSchema
+      }
+    } catch {
+      case NonFatal(e) =>
+        val noHandlerMsg = s"No handler for UDF/UDAF/UDTF '${clazz.getCanonicalName}': $e"
+        val errorMsg =
+          if (classOf[GenericUDTF].isAssignableFrom(clazz)) {
+            s"$noHandlerMsg\nPlease make sure your function overrides " +
+              "`public StructObjectInspector initialize(ObjectInspector[] args)`."
+          } else {
+            noHandlerMsg
+          }
+        val analysisException = new AnalysisException(errorMsg)
+        analysisException.setStackTrace(e.getStackTrace)
+        throw analysisException
+    }
+    udfExpr.getOrElse {
+      throw new InvalidUDFClassException(
+        s"No handler for UDF/UDAF/UDTF '${clazz.getCanonicalName}'")
+    }
+  }
+
   /**
    * Constructs a [[Expression]] based on the provided class that represents a function.
    *
@@ -72,53 +122,15 @@ private[sql] class HiveSessionCatalog(
       try {
         super.makeFunctionExpression(name, clazz, input)
       } catch {
-        case e: InvalidFunctionArgumentException =>
+        case _: InvalidUDFClassException =>
+          // If `super.makeFunctionExpression` throw `InvalidUDFClassException`, we construct
+          // Hive UDF/UDAF/UDTF with function definition.
+          makeHiveFunctionExpression(name, clazz, input)
+        case e: AnalysisException =>
+          // If `super.makeFunctionExpression` not throw `InvalidUDFClassException`, it means
+          // function definition satisfy Spark mode UDAF but construct failed or arguments invalid.
+          // we should throw this earlier.
           throw e
-        case _: Throwable =>
-          var udfExpr: Option[Expression] = None
-          try {
-            // When we instantiate hive UDF wrapper class, we may throw exception if the input
-            // expressions don't satisfy the hive UDF, such as type mismatch, input number
-            // mismatch, etc. Here we catch the exception and throw AnalysisException instead.
-            if (classOf[UDF].isAssignableFrom(clazz)) {
-              udfExpr = Some(HiveSimpleUDF(name, new HiveFunctionWrapper(clazz.getName), input))
-              udfExpr.get.dataType // Force it to check input data types.
-            } else if (classOf[GenericUDF].isAssignableFrom(clazz)) {
-              udfExpr = Some(HiveGenericUDF(name, new HiveFunctionWrapper(clazz.getName), input))
-              udfExpr.get.dataType // Force it to check input data types.
-            } else if (classOf[AbstractGenericUDAFResolver].isAssignableFrom(clazz)) {
-              udfExpr = Some(HiveUDAFFunction(name, new HiveFunctionWrapper(clazz.getName), input))
-              udfExpr.get.dataType // Force it to check input data types.
-            } else if (classOf[UDAF].isAssignableFrom(clazz)) {
-              udfExpr = Some(HiveUDAFFunction(
-                name,
-                new HiveFunctionWrapper(clazz.getName),
-                input,
-                isUDAFBridgeRequired = true))
-              udfExpr.get.dataType // Force it to check input data types.
-            } else if (classOf[GenericUDTF].isAssignableFrom(clazz)) {
-              udfExpr = Some(HiveGenericUDTF(name, new HiveFunctionWrapper(clazz.getName), input))
-              // Force it to check data types.
-              udfExpr.get.asInstanceOf[HiveGenericUDTF].elementSchema
-            }
-          } catch {
-            case NonFatal(e) =>
-              val noHandlerMsg = s"No handler for UDF/UDAF/UDTF '${clazz.getCanonicalName}': $e"
-              val errorMsg =
-                if (classOf[GenericUDTF].isAssignableFrom(clazz)) {
-                  s"$noHandlerMsg\nPlease make sure your function overrides " +
-                    "`public StructObjectInspector initialize(ObjectInspector[] args)`."
-                } else {
-                  noHandlerMsg
-                }
-              val analysisException = new AnalysisException(errorMsg)
-              analysisException.setStackTrace(e.getStackTrace)
-              throw analysisException
-          }
-          udfExpr.getOrElse {
-            throw new InvalidUDFClassException(
-              s"No handler for UDF/UDAF/UDTF '${clazz.getCanonicalName}'")
-          }
       }
     }
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
@@ -74,7 +74,7 @@ private[sql] class HiveSessionCatalog(
         t.asInstanceOf[Success[Expression]].get
       } else {
         val exception = t.asInstanceOf[Failure[Expression]].exception
-        if (exception.getMessage.contains("Invalid number of arguments for function")) {
+        if (exception.isInstanceOf[IllegalArgumentException]) {
           throw exception
         }
         var udfExpr: Option[Expression] = None

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
@@ -73,7 +73,7 @@ private[sql] class HiveSessionCatalog(
       if (t.isSuccess) {
         t.asInstanceOf[Success[Expression]].get
       } else {
-        val exception = t.asInstanceOf[Failure].exception
+        val exception = t.asInstanceOf[Failure[Expression]].exception
         var udfExpr: Option[Expression] = None
         try {
           // When we instantiate hive UDF wrapper class, we may throw exception if the input

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
@@ -97,8 +97,7 @@ private[sql] class HiveSessionCatalog(
             udfExpr.get.dataType // Force it to check input data types.
           } else if (classOf[GenericUDTF].isAssignableFrom(clazz)) {
             udfExpr = Some(HiveGenericUDTF(name, new HiveFunctionWrapper(clazz.getName), input))
-            // Force it to check data types.
-            udfExpr.get.asInstanceOf[HiveGenericUDTF].elementSchema
+            udfExpr.get.asInstanceOf[HiveGenericUDTF].elementSchema // Force it to check data types.
           }
         } catch {
           case NonFatal(e) =>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
@@ -69,59 +69,60 @@ private[sql] class HiveSessionCatalog(
     // Current thread context classloader may not be the one loaded the class. Need to switch
     // context classloader to initialize instance properly.
     Utils.withContextClassLoader(clazz.getClassLoader) {
-      try {
-        super.makeFunctionExpression(name, clazz, input)
-      } catch {
-        case NonFatal(exception) =>
-          var udfExpr: Option[Expression] = None
-          try {
-            // When we instantiate hive UDF wrapper class, we may throw exception if the input
-            // expressions don't satisfy the hive UDF, such as type mismatch, input number
-            // mismatch, etc. Here we catch the exception and throw AnalysisException instead.
-            if (classOf[UDF].isAssignableFrom(clazz)) {
-              udfExpr = Some(HiveSimpleUDF(name, new HiveFunctionWrapper(clazz.getName), input))
-              udfExpr.get.dataType // Force it to check input data types.
-            } else if (classOf[GenericUDF].isAssignableFrom(clazz)) {
-              udfExpr = Some(HiveGenericUDF(name, new HiveFunctionWrapper(clazz.getName), input))
-              udfExpr.get.dataType // Force it to check input data types.
-            } else if (classOf[AbstractGenericUDAFResolver].isAssignableFrom(clazz)) {
-              udfExpr = Some(HiveUDAFFunction(name, new HiveFunctionWrapper(clazz.getName), input))
-              udfExpr.get.dataType // Force it to check input data types.
-            } else if (classOf[UDAF].isAssignableFrom(clazz)) {
-              udfExpr = Some(HiveUDAFFunction(
-                name,
-                new HiveFunctionWrapper(clazz.getName),
-                input,
-                isUDAFBridgeRequired = true))
-              udfExpr.get.dataType // Force it to check input data types.
-            } else if (classOf[GenericUDTF].isAssignableFrom(clazz)) {
-              udfExpr = Some(HiveGenericUDTF(name, new HiveFunctionWrapper(clazz.getName), input))
-              // Force it to check data types.
-              udfExpr.get.asInstanceOf[HiveGenericUDTF].elementSchema
-            }
-          } catch {
-            case NonFatal(e) =>
-              val noHandlerMsg = s"No handler for UDF/UDAF/UDTF '${clazz.getCanonicalName}': $e"
-              val errorMsg =
-                if (classOf[GenericUDTF].isAssignableFrom(clazz)) {
-                  s"$noHandlerMsg\nPlease make sure your function overrides " +
-                    "`public StructObjectInspector initialize(ObjectInspector[] args)`."
-                } else {
-                  noHandlerMsg
-                }
-              val analysisException = new AnalysisException(
-                s"Spark UDAF Error: ${exception.getMessage}\n" +
-                  s"Hive UDF/UDAF/UDTF Error: $errorMsg"
-              )
-              analysisException.setStackTrace(e.getStackTrace)
-              throw analysisException
+      val t = Try(super.makeFunctionExpression(name, clazz, input))
+      if (t.isSuccess) {
+        t.asInstanceOf[Success[Expression]].get
+      } else {
+        val exception = t.asInstanceOf[Failure].exception
+        var udfExpr: Option[Expression] = None
+        try {
+          // When we instantiate hive UDF wrapper class, we may throw exception if the input
+          // expressions don't satisfy the hive UDF, such as type mismatch, input number
+          // mismatch, etc. Here we catch the exception and throw AnalysisException instead.
+          if (classOf[UDF].isAssignableFrom(clazz)) {
+            udfExpr = Some(HiveSimpleUDF(name, new HiveFunctionWrapper(clazz.getName), input))
+            udfExpr.get.dataType // Force it to check input data types.
+          } else if (classOf[GenericUDF].isAssignableFrom(clazz)) {
+            udfExpr = Some(HiveGenericUDF(name, new HiveFunctionWrapper(clazz.getName), input))
+            udfExpr.get.dataType // Force it to check input data types.
+          } else if (classOf[AbstractGenericUDAFResolver].isAssignableFrom(clazz)) {
+            udfExpr = Some(HiveUDAFFunction(name, new HiveFunctionWrapper(clazz.getName), input))
+            udfExpr.get.dataType // Force it to check input data types.
+          } else if (classOf[UDAF].isAssignableFrom(clazz)) {
+            udfExpr = Some(HiveUDAFFunction(
+              name,
+              new HiveFunctionWrapper(clazz.getName),
+              input,
+              isUDAFBridgeRequired = true))
+            udfExpr.get.dataType // Force it to check input data types.
+          } else if (classOf[GenericUDTF].isAssignableFrom(clazz)) {
+            udfExpr = Some(HiveGenericUDTF(name, new HiveFunctionWrapper(clazz.getName), input))
+            // Force it to check data types.
+            udfExpr.get.asInstanceOf[HiveGenericUDTF].elementSchema
           }
-          udfExpr.getOrElse {
-            throw new AnalysisException(
+        } catch {
+          case NonFatal(e) =>
+            val noHandlerMsg = s"No handler for UDF/UDAF/UDTF '${clazz.getCanonicalName}': $e"
+            val errorMsg =
+              if (classOf[GenericUDTF].isAssignableFrom(clazz)) {
+                s"$noHandlerMsg\nPlease make sure your function overrides " +
+                  "`public StructObjectInspector initialize(ObjectInspector[] args)`."
+              } else {
+                noHandlerMsg
+              }
+            val analysisException = new AnalysisException(
               s"Spark UDAF Error: ${exception.getMessage}\n" +
-                s"Hive UDF/UDAF/UDTF Error: " +
-                s"No handler for UDF/UDAF/UDTF '${clazz.getCanonicalName}'")
-          }
+                s"Hive UDF/UDAF/UDTF Error: $errorMsg"
+            )
+            analysisException.setStackTrace(e.getStackTrace)
+            throw analysisException
+        }
+        udfExpr.getOrElse {
+          throw new AnalysisException(
+            s"Spark UDAF Error: ${exception.getMessage}\n" +
+              s"Hive UDF/UDAF/UDTF Error: " +
+              s"No handler for UDF/UDAF/UDTF '${clazz.getCanonicalName}'")
+        }
       }
     }
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
@@ -69,9 +69,10 @@ private[sql] class HiveSessionCatalog(
     // Current thread context classloader may not be the one loaded the class. Need to switch
     // context classloader to initialize instance properly.
     Utils.withContextClassLoader(clazz.getClassLoader) {
-      Try(super.makeFunctionExpression(name, clazz, input)) match {
-        case Success(value) => value
-        case Failure(exception) =>
+      try {
+        super.makeFunctionExpression(name, clazz, input)
+      } catch {
+        case NonFatal(exception) =>
           val superError =
             s"Make Expression failed in SessionCatalog for function name = ${name}:" +
               s" ${exception.getMessage}"

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDAFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDAFSuite.scala
@@ -162,7 +162,8 @@ class HiveUDAFSuite extends QueryTest
     }
   }
 
-  test("SPARK-32243: Hive mode use spark udaf should show error") {
+  test("SPARK-32243: Spark UDAF Invalid arguments number error should throw earlier") {
+    // func need two arguments
     val functionName = "longProductSum"
     val functionClass = "org.apache.spark.sql.hive.execution.LongProductSum"
     withUserDefinedFunction(functionName -> true) {
@@ -170,10 +171,8 @@ class HiveUDAFSuite extends QueryTest
       val e = intercept[AnalysisException] {
         sql(s"SELECT $functionName(100)")
       }.getMessage
-      assert(
-        Seq(s"Invalid number of arguments for function $functionName. Expected: 2; Found: 1;",
-          "No handler for UDF/UDAF/UDTF 'org.apache.spark.sql.hive.execution.LongProductSum';")
-          .forall(e.contains))
+      assert(e.contains(
+        s"Invalid number of arguments for function $functionName. Expected: 2; Found: 1;"))
     }
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDAFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDAFSuite.scala
@@ -28,7 +28,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectIn
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo
 import test.org.apache.spark.sql.MyDoubleAvg
 
-import org.apache.spark.sql.{AnalysisException, InvalidFunctionArgumentException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.aggregate.ObjectHashAggregateExec
 import org.apache.spark.sql.hive.test.TestHiveSingleton

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDAFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDAFSuite.scala
@@ -168,11 +168,11 @@ class HiveUDAFSuite extends QueryTest
     val functionClass = "org.apache.spark.sql.hive.execution.LongProductSum"
     withUserDefinedFunction(functionName -> true) {
       sql(s"CREATE TEMPORARY FUNCTION $functionName AS '$functionClass'")
-      val e = intercept[AnalysisException] {
+      val e = intercept[IllegalArgumentException] {
         sql(s"SELECT $functionName(100)")
       }.getMessage
       assert(e.contains(
-        s"Invalid number of arguments for function $functionName. Expected: 2; Found: 1;"))
+        s"Invalid number of arguments for function $functionName. Expected: 2; Found: 1"))
     }
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDAFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDAFSuite.scala
@@ -28,7 +28,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectIn
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo
 import test.org.apache.spark.sql.MyDoubleAvg
 
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, InvalidFunctionArgumentException, QueryTest, Row}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.aggregate.ObjectHashAggregateExec
 import org.apache.spark.sql.hive.test.TestHiveSingleton
@@ -168,11 +168,11 @@ class HiveUDAFSuite extends QueryTest
     val functionClass = "org.apache.spark.sql.hive.execution.LongProductSum"
     withUserDefinedFunction(functionName -> true) {
       sql(s"CREATE TEMPORARY FUNCTION $functionName AS '$functionClass'")
-      val e = intercept[IllegalArgumentException] {
+      val e = intercept[AnalysisException] {
         sql(s"SELECT $functionName(100)")
       }.getMessage
       assert(e.contains(
-        s"Invalid number of arguments for function $functionName. Expected: 2; Found: 1"))
+        s"Invalid number of arguments for function $functionName. Expected: 2; Found: 1;"))
     }
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDAFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDAFSuite.scala
@@ -162,7 +162,7 @@ class HiveUDAFSuite extends QueryTest
     }
   }
 
-  test("Hive mode use spark udaf should show error") {
+  test("SPARK-32243: Hive mode use spark udaf should show error") {
     val functionName = "longProductSum"
     val functionClass = "org.apache.spark.sql.hive.execution.LongProductSum"
     withUserDefinedFunction(functionName -> true) {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDAFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDAFSuite.scala
@@ -167,13 +167,13 @@ class HiveUDAFSuite extends QueryTest
     val functionClass = "org.apache.spark.sql.hive.execution.LongProductSum"
     withUserDefinedFunction(functionName -> true) {
       sql(s"CREATE TEMPORARY FUNCTION $functionName AS '$functionClass'")
-      val e1 = intercept[AnalysisException] {
+      val e = intercept[AnalysisException] {
         sql(s"SELECT $functionName(100)")
       }.getMessage
       assert(
         Seq(s"Invalid number of arguments for function $functionName. Expected: 2; Found: 1;",
           "No handler for UDF/UDAF/UDTF 'org.apache.spark.sql.hive.execution.LongProductSum';")
-          .forall(e1.contains))
+          .forall(e.contains))
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
When we create a UDAF function use class extended `UserDefinedAggregeteFunction`,  when we call the function,  in support hive mode, in HiveSessionCatalog, it will call super.makeFunctionExpression, 

but it will catch error  such as the function need 2 parameter and we only give 1, throw exception only show 
```
No handler for UDF/UDAF/UDTF xxxxxxxx
```
This is confused for develop , we should show error thrown by super method too, 

For this pr's UT :
Before change, throw Exception like 
```
No handler for UDF/UDAF/UDTF 'org.apache.spark.sql.hive.execution.LongProductSum'; line 1 pos 7
```
After this pr, throw exception
```
Spark UDAF Error: Invalid number of arguments for function longProductSum. Expected: 2; Found: 1;
Hive UDF/UDAF/UDTF Error: No handler for UDF/UDAF/UDTF 'org.apache.spark.sql.hive.execution.LongProductSum'; line 1 pos 7
```

### Why are the changes needed?
Show more detail error message when define UDAF


### Does this PR introduce _any_ user-facing change?
People will see more detail error message when use spark sql's UDAF  in hive support Mode


### How was this patch tested?
Added UT
