### PR TITLE
[WIP][SPARK-32268][SQL] Bloom Filter Join

### DIFF
--- a/common/sketch/src/main/java/org/apache/spark/util/sketch/BloomFilterImpl.java
+++ b/common/sketch/src/main/java/org/apache/spark/util/sketch/BloomFilterImpl.java
@@ -19,7 +19,7 @@ package org.apache.spark.util.sketch;
 
 import java.io.*;
 
-class BloomFilterImpl extends BloomFilter implements Serializable {
+public class BloomFilterImpl extends BloomFilter implements Serializable {
 
   private int numHashFunctions;
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/BloomFilterUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/BloomFilterUtils.scala
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.util
+
+import java.lang.{Boolean => JBoolean, Double => JDouble, Float => JFloat}
+
+import org.apache.spark.sql.types.Decimal
+import org.apache.spark.unsafe.types.UTF8String
+import org.apache.spark.util.sketch.BloomFilter
+
+object BloomFilterUtils {
+
+  private def toBytes(decimal: Decimal): Array[Byte] = {
+    decimal.toJavaBigDecimal.unscaledValue().toByteArray
+  }
+
+  private def toBytes(str: UTF8String): Array[Byte] = {
+    str.getBytes
+  }
+
+  private def toLong(boolean: Boolean): Long = {
+    JBoolean.compare(boolean, false).toLong
+  }
+
+  private def toLong(float: Float): Long = {
+    JFloat.floatToIntBits(float.asInstanceOf[Float]).toLong
+  }
+
+  private def toLong(double: Double): Long = {
+    JDouble.doubleToLongBits(double)
+  }
+
+  private def toLong(number: Number): Long = {
+    number.asInstanceOf[Number].longValue()
+  }
+
+  def putValue(bloomFilter: BloomFilter, value: Any): Unit = value match {
+    case float: Float => bloomFilter.putLong(toLong(float))
+    case double: Double => bloomFilter.putLong(toLong(double))
+    case number: Number => bloomFilter.putLong(toLong(number))
+    case str: UTF8String => bloomFilter.putBinary(toBytes(str))
+    case bytes: Array[Byte] => bloomFilter.putBinary(bytes)
+    case decimal: Decimal => bloomFilter.putBinary(toBytes(decimal))
+    case boolean: Boolean => bloomFilter.putLong(toLong(boolean))
+    case other =>
+      throw new IllegalArgumentException(
+        s"Bloom filter only supports atomic types, but got ${other.getClass.getCanonicalName}.")
+  }
+
+  def mightContain(bloomFilter: BloomFilter, value: Any): Boolean = value match {
+    case float: Float => bloomFilter.mightContainLong(toLong(float))
+    case double: Double => bloomFilter.mightContainLong(toLong(double))
+    case number: Number => bloomFilter.mightContainLong(toLong(number))
+    case str: UTF8String => bloomFilter.mightContainBinary(toBytes(str))
+    case bytes: Array[Byte] => bloomFilter.mightContainBinary(bytes)
+    case decimal: Decimal => bloomFilter.mightContainBinary(toBytes(decimal))
+    case boolean: Boolean => bloomFilter.mightContainLong(toLong(boolean))
+    case other =>
+      throw new IllegalArgumentException(
+        s"Bloom filter only supports atomic types, but got ${other.getClass.getCanonicalName}.")
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -288,7 +288,7 @@ object SQLConf {
       .doc("The threshold to use bloom filter to pruning data.")
       .version("3.1.0")
       .longConf
-      .createWithDefault(2000000L)
+      .createWithDefault(100000L)
 
   val DYNAMIC_SHUFFLE_PRUNING_ENABLED =
     buildConf("spark.sql.optimizer.dynamicShufflePruning.enabled")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -282,13 +282,13 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
-  val DYNAMIC_PARTITION_PRUNING_PREFER_BLOOM_FILTER =
-    buildConf("spark.sql.optimizer.dynamicPartitionPruning.preferBloomFilter")
+  val DYNAMIC_PARTITION_PRUNING_BLOOM_FILTER_THRESHOLD =
+    buildConf("spark.sql.optimizer.dynamicPartitionPruning.bloomFilterThreshold")
       .internal()
-      .doc("When true, dynamic partition pruning will prefer use bloom filter to do pruning.")
+      .doc("The threshold to use bloom filter to pruning data.")
       .version("3.1.0")
-      .booleanConf
-      .createWithDefault(true)
+      .longConf
+      .createWithDefault(2000000L)
 
   val DYNAMIC_SHUFFLE_PRUNING_ENABLED =
     buildConf("spark.sql.optimizer.dynamicShufflePruning.enabled")
@@ -2900,8 +2900,8 @@ class SQLConf extends Serializable with Logging {
   def dynamicPartitionPruningReuseBroadcastOnly: Boolean =
     getConf(DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY)
 
-  def dynamicPartitionPruningPreferBloomFilter: Boolean =
-    getConf(DYNAMIC_PARTITION_PRUNING_PREFER_BLOOM_FILTER)
+  def dynamicPartitionPruningBloomFilterThreshold: Long =
+    getConf(DYNAMIC_PARTITION_PRUNING_BLOOM_FILTER_THRESHOLD)
 
   def dynamicShufflePruningEnabled: Boolean = getConf(DYNAMIC_SHUFFLE_PRUNING_ENABLED)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -282,6 +282,31 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val DYNAMIC_PARTITION_PRUNING_PREFER_BLOOM_FILTER =
+    buildConf("spark.sql.optimizer.dynamicPartitionPruning.preferBloomFilter")
+      .internal()
+      .doc("When true, dynamic partition pruning will prefer use bloom filter to do pruning.")
+      .version("3.1.0")
+      .booleanConf
+      .createWithDefault(true)
+
+  val DYNAMIC_SHUFFLE_PRUNING_ENABLED =
+    buildConf("spark.sql.optimizer.dynamicShufflePruning.enabled")
+      .doc("When true, we will generate predicate for column when it's used as join key " +
+        "and has shuffle.")
+      .version("3.1.0")
+      .booleanConf
+      .createWithDefault(true)
+
+  val DYNAMIC_SHUFFLE_PRUNING_SIDE_THRESHOLD =
+    buildConf("spark.sql.optimizer.dynamicShufflePruning.pruningSideThreshold")
+      .internal()
+      .doc("Specifies the lower limit of the threshold for a " +
+        "dynamic shuffle pruning to be considered.")
+      .version("3.1.0")
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefaultString("10GB")
+
   val COMPRESS_CACHED = buildConf("spark.sql.inMemoryColumnarStorage.compressed")
     .doc("When set to true Spark SQL will automatically select a compression codec for each " +
       "column based on statistics of the data.")
@@ -2874,6 +2899,13 @@ class SQLConf extends Serializable with Logging {
 
   def dynamicPartitionPruningReuseBroadcastOnly: Boolean =
     getConf(DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY)
+
+  def dynamicPartitionPruningPreferBloomFilter: Boolean =
+    getConf(DYNAMIC_PARTITION_PRUNING_PREFER_BLOOM_FILTER)
+
+  def dynamicShufflePruningEnabled: Boolean = getConf(DYNAMIC_SHUFFLE_PRUNING_ENABLED)
+
+  def dynamicShufflePruningSideThreshold: Long = getConf(DYNAMIC_SHUFFLE_PRUNING_SIDE_THRESHOLD)
 
   def stateStoreProviderClass: String = getConf(STATE_STORE_PROVIDER_CLASS)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -179,6 +179,9 @@ object FileSourceStrategy extends Strategy with PredicateHelper with Logging {
       val dataColumns =
         l.resolve(fsRelation.dataSchema, fsRelation.sparkSession.sessionState.analyzer.resolver)
 
+      val shufflePruningFilters =
+        normalizedFilters.filter(_.isInstanceOf[DynamicShufflePruningSubquery])
+
       // Partition keys are not available in the statistics of the files.
       // `dataColumns` might have partition columns, we need to filter them out.
       val dataColumnsWithoutPartitionCols = dataColumns.filterNot(partitionColumns.contains)
@@ -188,7 +191,7 @@ object FileSourceStrategy extends Strategy with PredicateHelper with Logging {
         } else {
           Some(f)
         }
-      }
+      } ++ shufflePruningFilters
       val supportNestedPredicatePushdown =
         DataSourceUtils.supportNestedPredicatePushdown(fsRelation)
       val pushedFilters = dataFilters

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -191,7 +191,7 @@ object FileSourceStrategy extends Strategy with PredicateHelper with Logging {
         } else {
           Some(f)
         }
-      } ++ shufflePruningFilters
+      }
       val supportNestedPredicatePushdown =
         DataSourceUtils.supportNestedPredicatePushdown(fsRelation)
       val pushedFilters = dataFilters
@@ -223,7 +223,7 @@ object FileSourceStrategy extends Strategy with PredicateHelper with Logging {
           partitionKeyFilters.toSeq,
           bucketSet,
           None,
-          dataFilters,
+          dataFilters ++ shufflePruningFilters,
           table.map(_.identifier))
 
       val afterScanFilter = afterScanFilters.toSeq.reduceOption(expressions.And)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilters.scala
@@ -597,9 +597,9 @@ class ParquetFilters(
         createFilterHelper(pred, canPartialPushDownConjuncts = false)
           .map(FilterApi.not)
 
-      case sources.In(name, values) if canMakeFilterOn(name, values.head)
-        && values.distinct.length <= pushDownInFilterThreshold =>
-        values.distinct.flatMap { v =>
+      case sources.In(name, values) if values.nonEmpty && canMakeFilterOn(name, values.head) &&
+        values.length <= pushDownInFilterThreshold =>
+        values.flatMap { v =>
           makeEq.lift(nameToParquetField(name).fieldType)
             .map(_(nameToParquetField(name).fieldNames, v))
         }.reduceLeftOption(FilterApi.or)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
@@ -135,6 +135,11 @@ case class ReuseExchange(conf: SQLConf) extends Rule[SparkPlan] {
           case exchange: Exchange => reuse(exchange)
         }
         in.copy(plan = newIn.asInstanceOf[BaseSubqueryExec])
+      case bf: BloomFilterSubqueryExec =>
+        val newBf = bf.plan.transformUp {
+          case exchange: Exchange => reuse(exchange)
+        }
+        bf.copy(plan = newBf.asInstanceOf[BaseSubqueryExec])
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/ShufflePruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ShufflePruningSuite.scala
@@ -1,0 +1,567 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import java.sql.{Date, Timestamp}
+
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.expressions.{CodegenObjectFactoryMode, DynamicPruningExpression, Expression, Literal}
+import org.apache.spark.sql.execution._
+import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, AdaptiveSparkPlanHelper}
+import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, ReusedExchangeExec}
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{Decimal, StringType}
+
+abstract class ShufflePruningSuiteBase
+  extends QueryTest
+    with SharedSparkSession
+    with AdaptiveSparkPlanHelper {
+
+  val tableFormat: String = "parquet"
+
+  val adaptiveExecutionOn: Boolean
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    spark.sessionState.conf.setConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED, adaptiveExecutionOn)
+    spark.sessionState.conf.setConf(SQLConf.ADAPTIVE_EXECUTION_FORCE_APPLY, true)
+    spark.sessionState.conf.setConf(SQLConf.AUTO_SIZE_UPDATE_ENABLED, true)
+    spark.sessionState.conf.setConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD, 5000L)
+    spark.sessionState.conf.setConf(SQLConf.PARQUET_COMPRESSION, "uncompressed")
+
+    spark.range(2000)
+      .select(col("id").as("a"), col("id").as("b"))
+      .write
+      .format(tableFormat)
+      .mode(SaveMode.Overwrite)
+      .saveAsTable("t1")
+
+    spark.range(2000)
+      .select(col("id").as("a"), col("id").as("b"))
+      .write
+      .format(tableFormat)
+      .mode(SaveMode.Overwrite)
+      .saveAsTable("t2")
+
+    spark.range(100)
+      .select(col("id").as("a"), col("id").as("b"))
+      .write
+      .format(tableFormat)
+      .mode(SaveMode.Overwrite)
+      .saveAsTable("t3")
+
+    spark.range(2000)
+      .select(col("id").%(10).as("a"), col("id").as("b"))
+      .write
+      .partitionBy("a")
+      .format(tableFormat)
+      .mode(SaveMode.Overwrite)
+      .saveAsTable("t_part1")
+
+    spark.range(2000)
+      .select(col("id").as("a"), col("id").as("b"))
+      .write
+      .bucketBy(5, "a")
+      .format(tableFormat)
+      .mode(SaveMode.Overwrite)
+      .saveAsTable("t_bucket1")
+  }
+
+  override def afterAll(): Unit = {
+    try {
+      sql("DROP TABLE IF EXISTS t1")
+      sql("DROP TABLE IF EXISTS t2")
+      sql("DROP TABLE IF EXISTS t3")
+      sql("DROP TABLE IF EXISTS t_part1")
+      sql("DROP TABLE IF EXISTS t_bucket1")
+    } finally {
+      spark.sessionState.conf.unsetConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED)
+      spark.sessionState.conf.unsetConf(SQLConf.ADAPTIVE_EXECUTION_FORCE_APPLY)
+      spark.sessionState.conf.unsetConf(SQLConf.AUTO_SIZE_UPDATE_ENABLED)
+      spark.sessionState.conf.unsetConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD)
+      spark.sessionState.conf.unsetConf(SQLConf.PARQUET_COMPRESSION)
+      super.afterAll()
+    }
+  }
+
+  /**
+   * Check if the query plan has a shuffle pruning filter inserted as
+   * a subquery duplicate or as a custom broadcast exchange.
+   */
+  def checkPartitionPruningPredicate(
+      df: DataFrame,
+      withSubquery: Boolean,
+      withBroadcast: Boolean): Unit = {
+    val plan = df.queryExecution.executedPlan
+    val dpExprs = collectDynamicPruningExpressions(plan)
+    val hasSubquery = dpExprs.exists {
+      case BloomFilterSubqueryExec(_, _: SubqueryExec, _, _) => true
+      case _ => false
+    }
+    val subqueryBroadcast = dpExprs.collect {
+      case BloomFilterSubqueryExec(_, b: SubqueryBroadcastExec, _, _) => b
+    }
+
+    val name = "trigger shuffle pruning"
+    val hasFilter = if (withSubquery) "Should" else "Shouldn't"
+    assert(hasSubquery == withSubquery,
+      s"$hasFilter $name with a subquery duplicate:\n${df.queryExecution}")
+    val hasBroadcast = if (withBroadcast) "Should" else "Shouldn't"
+    assert(subqueryBroadcast.nonEmpty == withBroadcast,
+      s"$hasBroadcast $name with a reused broadcast exchange:\n${df.queryExecution}")
+
+    subqueryBroadcast.foreach { s =>
+      s.child match {
+        case _: ReusedExchangeExec => // reuse check ok.
+        case b: BroadcastExchangeExec =>
+          val hasReuse = plan.find {
+            case ReusedExchangeExec(_, e) => e eq b
+            case _ => false
+          }.isDefined
+          assert(hasReuse, s"$s\nshould have been reused in\n$plan")
+        case _ =>
+          fail(s"Invalid child node found in\n$s")
+      }
+    }
+
+    val isMainQueryAdaptive = plan.isInstanceOf[AdaptiveSparkPlanExec]
+    subqueriesAll(plan).filterNot(subqueryBroadcast.contains).foreach { s =>
+      assert(s.find(_.isInstanceOf[AdaptiveSparkPlanExec]).isDefined == isMainQueryAdaptive)
+    }
+  }
+
+  /**
+   * Check if the plan has the given number of distinct broadcast exchange subqueries.
+   */
+  def checkDistinctSubqueries(df: DataFrame, n: Int): Unit = {
+    val buf = collectDynamicPruningExpressions(df.queryExecution.executedPlan).collect {
+      case BloomFilterSubqueryExec(_, b: SubqueryBroadcastExec, _, _) =>
+        b.index
+    }
+    assert(buf.distinct.size == n)
+  }
+
+  /**
+   * Collect the children of all correctly pushed down dynamic pruning expressions in a spark plan.
+   */
+  private def collectDynamicPruningExpressions(plan: SparkPlan): Seq[Expression] = {
+    plan.flatMap {
+      case s: FilterExec => s.condition.collect {
+        case d: DynamicPruningExpression => d.child
+      }
+      case _ => Nil
+    }
+  }
+
+  test("check table stats") {
+    val catalog = spark.sessionState.catalog
+    assert(catalog.getTableMetadata(TableIdentifier("t1")).stats.get.sizeInBytes > 10000L)
+    assert(catalog.getTableMetadata(TableIdentifier("t2")).stats.get.sizeInBytes > 10000L)
+    assert(catalog.getTableMetadata(TableIdentifier("t3")).stats.get.sizeInBytes < 5000L)
+    assert(catalog.getTableMetadata(TableIdentifier("t_part1")).stats.get.sizeInBytes > 10000L)
+    assert(catalog.getTableMetadata(TableIdentifier("t_bucket1")).stats.get.sizeInBytes > 10000L)
+  }
+
+  test("simple aggregate triggers shuffle pruning") {
+    withSQLConf(SQLConf.DYNAMIC_SHUFFLE_PRUNING_ENABLED.key -> "true",
+      SQLConf.DYNAMIC_SHUFFLE_PRUNING_SIDE_THRESHOLD.key -> "10K") {
+      val df = sql(
+        """
+          |SELECT t11.a,
+          |       t11.cnt
+          |FROM   (SELECT a,
+          |               Count(b) AS cnt
+          |        FROM   t1
+          |        GROUP  BY a) t11
+          |       JOIN t3
+          |         ON t11.a = t3.a AND t3.b < 2
+          |""".stripMargin)
+
+      checkPartitionPruningPredicate(df, false, true)
+      checkAnswer(df, Row(0, 1) :: Row(1, 1) :: Nil)
+    }
+  }
+
+  test("union triggers shuffle pruning") {
+    withSQLConf(SQLConf.DYNAMIC_SHUFFLE_PRUNING_ENABLED.key -> "true",
+      SQLConf.DYNAMIC_SHUFFLE_PRUNING_SIDE_THRESHOLD.key -> "10K") {
+      val df = sql(
+        """
+          |SELECT t11.a,
+          |       t11.b
+          |FROM   (SELECT a,
+          |               b
+          |        FROM   t1
+          |        WHERE  b < 10
+          |        UNION
+          |        SELECT a,
+          |               b
+          |        FROM   t1
+          |        WHERE  b > 10) t11
+          |       JOIN t3
+          |         ON t11.a = t3.a AND t3.b < 2
+          |""".stripMargin)
+
+      checkPartitionPruningPredicate(df, false, true)
+
+      checkAnswer(df, Row(0, 0) :: Row(1, 1) :: Nil)
+    }
+  }
+
+  test("union all should not triggers shuffle pruning") {
+    withSQLConf(SQLConf.DYNAMIC_SHUFFLE_PRUNING_ENABLED.key -> "true",
+      SQLConf.DYNAMIC_SHUFFLE_PRUNING_SIDE_THRESHOLD.key -> "10K") {
+      val df = sql(
+        """
+          |SELECT t11.a,
+          |       t11.b
+          |FROM   (SELECT a,
+          |               b
+          |        FROM   t1
+          |        WHERE  b < 10
+          |        UNION ALL
+          |        SELECT a,
+          |               b
+          |        FROM   t3
+          |        WHERE  b > 10) t11
+          |       JOIN t3
+          |         ON t11.a = t3.a
+          |            AND t3.b < 2
+          |""".stripMargin)
+
+      checkPartitionPruningPredicate(df, false, false)
+
+      checkAnswer(df, Row(0, 0) :: Row(1, 1) :: Nil)
+    }
+  }
+
+  test("SMJ should triggers shuffle pruning") {
+    withSQLConf(SQLConf.DYNAMIC_SHUFFLE_PRUNING_ENABLED.key -> "true",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "3K",
+      SQLConf.DYNAMIC_SHUFFLE_PRUNING_SIDE_THRESHOLD.key -> "10K") {
+      val df = sql(
+        """
+          |SELECT t11.a,
+          |       t11.b
+          |FROM   (SELECT t1.a,
+          |               t2.b
+          |        FROM t1
+          |        JOIN t2
+          |            ON t1.a = t2.a) t11
+          |       JOIN t3
+          |         ON t11.a = t3.a AND t3.b < 2
+          |""".stripMargin)
+
+      checkPartitionPruningPredicate(df, false, true)
+      checkAnswer(df, Row(0, 0) :: Row(1, 1) :: Nil)
+    }
+  }
+
+  test("SMJ should not triggers shuffle pruning with exchange reuse enabled") {
+    withSQLConf(SQLConf.DYNAMIC_SHUFFLE_PRUNING_ENABLED.key -> "true",
+      SQLConf.EXCHANGE_REUSE_ENABLED.key -> "false",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "3K",
+      SQLConf.DYNAMIC_SHUFFLE_PRUNING_SIDE_THRESHOLD.key -> "10K") {
+      val df = sql(
+        """
+          |SELECT t11.a,
+          |       t11.b
+          |FROM   (SELECT t1.a,
+          |               t2.b
+          |        FROM t1
+          |        JOIN t2
+          |            ON t1.a = t2.a) t11
+          |       JOIN t3
+          |         ON t11.a = t3.a AND t3.b < 2
+          |""".stripMargin)
+
+      checkPartitionPruningPredicate(df, false, false)
+      checkAnswer(df, Row(0, 0) :: Row(1, 1) :: Nil)
+    }
+  }
+
+  test("SMJ should triggers shuffle pruning with implicit type cast") {
+    withSQLConf(SQLConf.DYNAMIC_SHUFFLE_PRUNING_ENABLED.key -> "true",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "3K",
+      SQLConf.DYNAMIC_SHUFFLE_PRUNING_SIDE_THRESHOLD.key -> "10K") {
+      withTable("t_string1") {
+        spark.range(100)
+          .select(col("id").cast(StringType).as("a"), col("id").as("b"))
+          .write
+          .format(tableFormat)
+          .mode(SaveMode.Overwrite)
+          .saveAsTable("t_string1")
+
+        val df = sql(
+          """
+            |SELECT t11.a,
+            |       t11.b
+            |FROM   (SELECT t1.a,
+            |               t2.b
+            |        FROM t1
+            |        JOIN t2
+            |            ON t1.a = t2.a) t11
+            |       JOIN t_string1
+            |         ON t11.a = t_string1.a AND t_string1.b < 2
+            |""".stripMargin)
+
+        checkPartitionPruningPredicate(df, false, true)
+        checkAnswer(df, Row(0, 0) :: Row(1, 1) :: Nil)
+      }
+    }
+  }
+
+  test("SMJ should triggers shuffle pruning with implicit type cast(empty result)") {
+    withSQLConf(SQLConf.DYNAMIC_SHUFFLE_PRUNING_ENABLED.key -> "true",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "3K",
+      SQLConf.DYNAMIC_SHUFFLE_PRUNING_SIDE_THRESHOLD.key -> "10K") {
+      withTable("t_string1") {
+        spark.range(100)
+          .select(concat(col("id"), lit("str")).as("a"), col("id").as("b"))
+          .write
+          .format(tableFormat)
+          .mode(SaveMode.Overwrite)
+          .saveAsTable("t_string1")
+
+        val df = sql(
+          """
+            |SELECT t11.a,
+            |       t11.b
+            |FROM   (SELECT t1.a,
+            |               t2.b
+            |        FROM t1
+            |        JOIN t2
+            |            ON t1.a = t2.a) t11
+            |       JOIN t_string1
+            |         ON t11.a = t_string1.a AND t_string1.b < 2
+            |""".stripMargin)
+
+        checkPartitionPruningPredicate(df, false, true)
+        checkAnswer(df, Nil)
+      }
+    }
+  }
+
+  private def checkSupportedDataTypes(value: Any): Unit = {
+    test(s"Check support data type: ${value.getClass.getCanonicalName}") {
+      withSQLConf(SQLConf.DYNAMIC_SHUFFLE_PRUNING_ENABLED.key -> "true",
+        SQLConf.DYNAMIC_SHUFFLE_PRUNING_SIDE_THRESHOLD.key -> "10K") {
+        withTable("t_dt1", "t_dt2") {
+          spark.range(2000)
+            .select(lit(Literal(value)).as("a"), col("id").as("b"))
+            .write
+            .format(tableFormat)
+            .mode(SaveMode.Overwrite)
+            .saveAsTable("t_dt1")
+
+          spark.range(100)
+            .select(lit(Literal(value)).as("a"), col("id").as("b"))
+            .write
+            .format(tableFormat)
+            .mode(SaveMode.Overwrite)
+            .saveAsTable("t_dt2")
+
+          CodegenObjectFactoryMode.values.foreach { mode =>
+            withSQLConf(SQLConf.CODEGEN_FACTORY_MODE.key -> mode.toString) {
+              val df = sql(
+                """
+                  |SELECT t1.a,
+                  |       t1.cnt
+                  |FROM   (SELECT a,
+                  |               Count(b) AS cnt
+                  |        FROM   t_dt1
+                  |        GROUP  BY a) t1
+                  |       JOIN t_dt2 t2
+                  |         ON t1.a = t2.a AND t2.b < 2
+                  |""".stripMargin)
+
+              checkPartitionPruningPredicate(df, false, true)
+              checkAnswer(df, Row(value, 2000) :: Row(value, 2000) :: Nil)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  checkSupportedDataTypes(false)
+  checkSupportedDataTypes(1.toByte)
+  checkSupportedDataTypes(2.toShort)
+  checkSupportedDataTypes(3)
+  checkSupportedDataTypes(4L)
+  checkSupportedDataTypes(5.6.toFloat)
+  checkSupportedDataTypes(7.8)
+  checkSupportedDataTypes(new Decimal().set(9.0123).toPrecision(38, 18).toBigDecimal)
+  checkSupportedDataTypes("str")
+  checkSupportedDataTypes(Array[Byte](1, 2, 3, 4))
+  checkSupportedDataTypes(Date.valueOf("2020-07-24"))
+  checkSupportedDataTypes(Timestamp.valueOf("2020-07-24 14:01:11"))
+
+  test("Support mutiple join keys") {
+    withSQLConf(SQLConf.DYNAMIC_SHUFFLE_PRUNING_ENABLED.key -> "true",
+      SQLConf.DYNAMIC_SHUFFLE_PRUNING_SIDE_THRESHOLD.key -> "10K") {
+      withTable("t_mj1", "t_mj2") {
+        spark.range(2000)
+          .select(col("id").as("a"), col("id").cast(StringType).as("b"), col("id").as("c"))
+          .write
+          .format(tableFormat)
+          .mode(SaveMode.Overwrite)
+          .saveAsTable("t_mj1")
+
+        spark.range(100)
+          .select(col("id").as("a"), col("id").cast(StringType).as("b"), col("id").as("c"))
+          .write
+          .format(tableFormat)
+          .mode(SaveMode.Overwrite)
+          .saveAsTable("t_mj2")
+
+        val df = sql(
+          """
+            |SELECT t1.a,
+            |       t1.cnt
+            |FROM   (SELECT a,
+            |               b,
+            |               Count(c) AS cnt
+            |        FROM   t_mj1
+            |        GROUP  BY a, b) t1
+            |       JOIN t_mj2 t2
+            |         ON t1.a = t2.a AND t1.b = t2.b AND t2.c < 2
+            |""".stripMargin)
+
+        checkPartitionPruningPredicate(df, false, true)
+        checkDistinctSubqueries(df, 2)
+        checkAnswer(df, Row(0, 1) :: Row(1, 1) :: Nil)
+      }
+    }
+  }
+
+  test("BHJ should not triggers shuffle pruning") {
+    withSQLConf(SQLConf.DYNAMIC_SHUFFLE_PRUNING_ENABLED.key -> "true",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10M",
+      SQLConf.DYNAMIC_SHUFFLE_PRUNING_SIDE_THRESHOLD.key -> "10K") {
+      val df = sql(
+        """
+          |SELECT t11.a,
+          |       t11.b
+          |FROM   (SELECT t1.a,
+          |               t2.b
+          |        FROM t1
+          |        JOIN t2
+          |            ON t1.a = t2.a) t11
+          |       JOIN t3
+          |         ON t11.a = t3.a AND t3.b < 2
+          |""".stripMargin)
+
+      checkPartitionPruningPredicate(df, false, false)
+      checkAnswer(df, Row(0, 0) :: Row(1, 1) :: Nil)
+    }
+  }
+
+  test("partition column should not triggers shuffle pruning") {
+    withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "false",
+      SQLConf.DYNAMIC_SHUFFLE_PRUNING_ENABLED.key -> "true",
+      SQLConf.DYNAMIC_SHUFFLE_PRUNING_SIDE_THRESHOLD.key -> "10K") {
+      val df = sql(
+        """
+          |SELECT t11.a,
+          |       t11.cnt
+          |FROM   (SELECT a,
+          |               Count(b) AS cnt
+          |        FROM   t_part1
+          |        GROUP  BY a) t11
+          |       JOIN t3
+          |         ON t11.a = t3.a AND t3.b < 2
+          |""".stripMargin)
+
+      checkPartitionPruningPredicate(df, false, false)
+
+      checkAnswer(df, Row(0, 200) :: Row(1, 200) :: Nil)
+    }
+  }
+
+  test("bucket column should not triggers shuffle pruning") {
+    withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "false",
+      SQLConf.DYNAMIC_SHUFFLE_PRUNING_ENABLED.key -> "true",
+      SQLConf.DYNAMIC_SHUFFLE_PRUNING_SIDE_THRESHOLD.key -> "10K") {
+      val df = sql(
+        """
+          |SELECT t11.a,
+          |       t11.cnt
+          |FROM   (SELECT a,
+          |               Count(b) AS cnt
+          |        FROM   t_bucket1
+          |        GROUP  BY a) t11
+          |       JOIN t3
+          |         ON t11.a = t3.a AND t3.b < 2
+          |""".stripMargin)
+
+      checkPartitionPruningPredicate(df, false, false)
+
+      checkAnswer(df, Row(0, 1) :: Row(1, 1) :: Nil)
+    }
+  }
+
+  test("Unsupported data type should not triggers shuffle pruning") {
+    withSQLConf(SQLConf.DYNAMIC_SHUFFLE_PRUNING_ENABLED.key -> "true",
+      SQLConf.DYNAMIC_SHUFFLE_PRUNING_SIDE_THRESHOLD.key -> "10K") {
+      withTable("t_array1", "t_array2") {
+        spark.range(1000)
+          .select(array(col("id")).as("a"), col("id").as("b"))
+          .write
+          .format(tableFormat)
+          .mode(SaveMode.Overwrite)
+          .saveAsTable("t_array1")
+
+        spark.range(100)
+          .select(array(col("id")).as("a"), col("id").as("b"))
+          .write
+          .format(tableFormat)
+          .mode(SaveMode.Overwrite)
+          .saveAsTable("t_array2")
+
+        val df = sql(
+          """
+            |SELECT t1.a,
+            |       t1.cnt
+            |FROM   (SELECT a,
+            |               Count(b) AS cnt
+            |        FROM   t_array1
+            |        GROUP  BY a) t1
+            |       JOIN t_array2 t2
+            |         ON t1.a = t2.a AND t2.b < 2
+            |""".stripMargin)
+
+        checkPartitionPruningPredicate(df, false, false)
+
+        checkAnswer(df, Row(Array(0), 1) :: Row(Array(1), 1) :: Nil)
+      }
+    }
+  }
+
+}
+
+class ShufflePruningSuiteAEOff extends ShufflePruningSuiteBase {
+  override val adaptiveExecutionOn: Boolean = false
+}
+
+class ShufflePruningSuiteAEOn extends ShufflePruningSuiteBase {
+  override val adaptiveExecutionOn: Boolean = true
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/dynamicpruning/DynamicPartitionPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/dynamicpruning/DynamicPartitionPruningSuite.scala
@@ -20,8 +20,8 @@ package org.apache.spark.sql.execution.dynamicpruning
 import org.scalatest.GivenWhenThen
 
 import org.apache.spark.sql.{DataFrame, QueryTest, Row}
-import org.apache.spark.sql.catalyst.expressions.DynamicPruningExpression
 import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode._
+import org.apache.spark.sql.catalyst.expressions.DynamicPruningExpression
 import org.apache.spark.sql.catalyst.plans.ExistenceJoin
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/dynamicpruning/DynamicPruningHelp.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/dynamicpruning/DynamicPruningHelp.scala
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.dynamicpruning
+
+import org.apache.spark.sql.{DataFrame, QueryTest}
+import org.apache.spark.sql.catalyst.expressions.{DynamicPruningExpression, Expression}
+import org.apache.spark.sql.execution.{BloomFilterSubqueryExec, FileSourceScanExec, FilterExec, InSubqueryExec, SparkPlan, SubqueryBroadcastExec, SubqueryExec}
+import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, AdaptiveSparkPlanHelper}
+import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, ReusedExchangeExec}
+
+trait DynamicPruningHelp extends QueryTest with AdaptiveSparkPlanHelper {
+
+  /**
+   * Check if the query plan has a in filter predicate inserted as
+   * a subquery duplicate or as a custom broadcast exchange.
+   */
+  protected def checkInSubqueryPredicate(
+      df: DataFrame,
+      withSubquery: Boolean,
+      withBroadcast: Boolean): Unit = {
+    val plan = df.queryExecution.executedPlan
+    val dpExprs = collectDynamicPruningExpressions(plan)
+    val hasSubquery = dpExprs.exists {
+      case InSubqueryExec(_, _: SubqueryExec, _, _) => true
+      case _ => false
+    }
+    val subqueryBroadcast = dpExprs.collect {
+      case InSubqueryExec(_, b: SubqueryBroadcastExec, _, _) => b
+    }
+
+    val name = "trigger shuffle pruning"
+    val hasFilter = if (withSubquery) "Should" else "Shouldn't"
+    assert(hasSubquery == withSubquery,
+      s"$hasFilter $name with a subquery duplicate:\n${df.queryExecution}")
+    val hasBroadcast = if (withBroadcast) "Should" else "Shouldn't"
+    assert(subqueryBroadcast.nonEmpty == withBroadcast,
+      s"$hasBroadcast $name with a reused broadcast exchange:\n${df.queryExecution}")
+
+    subqueryBroadcast.foreach { s =>
+      s.child match {
+        case _: ReusedExchangeExec => // reuse check ok.
+        case b: BroadcastExchangeExec =>
+          val hasReuse = plan.find {
+            case ReusedExchangeExec(_, e) => e eq b
+            case _ => false
+          }.isDefined
+          assert(hasReuse, s"$s\nshould have been reused in\n$plan")
+        case _ =>
+          fail(s"Invalid child node found in\n$s")
+      }
+    }
+
+    val isMainQueryAdaptive = plan.isInstanceOf[AdaptiveSparkPlanExec]
+    subqueriesAll(plan).filterNot(subqueryBroadcast.contains).foreach { s =>
+      assert(s.find(_.isInstanceOf[AdaptiveSparkPlanExec]).isDefined == isMainQueryAdaptive)
+    }
+  }
+
+  /**
+   * Check if the query plan has a bloom filter predicate inserted as
+   * a subquery duplicate or as a custom broadcast exchange.
+   */
+  protected def checkBloomFilterSubqueryPredicate(
+      df: DataFrame,
+      withSubquery: Boolean,
+      withBroadcast: Boolean): Unit = {
+    val plan = df.queryExecution.executedPlan
+    val dpExprs = collectDynamicPruningExpressions(plan)
+    val hasSubquery = dpExprs.exists {
+      case BloomFilterSubqueryExec(_, _: SubqueryExec, _, _) => true
+      case _ => false
+    }
+    val subqueryBroadcast = dpExprs.collect {
+      case BloomFilterSubqueryExec(_, b: SubqueryBroadcastExec, _, _) => b
+    }
+
+    val name = "trigger shuffle pruning"
+    val hasFilter = if (withSubquery) "Should" else "Shouldn't"
+    assert(hasSubquery == withSubquery,
+      s"$hasFilter $name with a subquery duplicate:\n${df.queryExecution}")
+    val hasBroadcast = if (withBroadcast) "Should" else "Shouldn't"
+    assert(subqueryBroadcast.nonEmpty == withBroadcast,
+      s"$hasBroadcast $name with a reused broadcast exchange:\n${df.queryExecution}")
+
+    subqueryBroadcast.foreach { s =>
+      s.child match {
+        case _: ReusedExchangeExec => // reuse check ok.
+        case b: BroadcastExchangeExec =>
+          val hasReuse = plan.find {
+            case ReusedExchangeExec(_, e) => e eq b
+            case _ => false
+          }.isDefined
+          assert(hasReuse, s"$s\nshould have been reused in\n$plan")
+        case _ =>
+          fail(s"Invalid child node found in\n$s")
+      }
+    }
+
+    val isMainQueryAdaptive = plan.isInstanceOf[AdaptiveSparkPlanExec]
+    subqueriesAll(plan).filterNot(subqueryBroadcast.contains).foreach { s =>
+      assert(s.find(_.isInstanceOf[AdaptiveSparkPlanExec]).isDefined == isMainQueryAdaptive)
+    }
+  }
+
+  /**
+   * Check if the plan has the given number of distinct broadcast exchange subqueries.
+   */
+  protected def checkDistinctSubqueries(df: DataFrame, n: Int): Unit = {
+    val buf = collectDynamicPruningExpressions(df.queryExecution.executedPlan).collect {
+      case InSubqueryExec(_, b: SubqueryBroadcastExec, _, _) =>
+        b.index
+      case BloomFilterSubqueryExec(_, b: SubqueryBroadcastExec, _, _) =>
+        b.index
+    }
+    assert(buf.distinct.size == n)
+  }
+
+  /**
+   * Collect the children of all correctly pushed down dynamic pruning expressions in a spark plan.
+   */
+  protected def collectDynamicPruningExpressions(plan: SparkPlan): Seq[Expression] = {
+    plan.flatMap {
+      case s: FileSourceScanExec => s.partitionFilters.collect {
+        case d: DynamicPruningExpression => d.child
+      }
+      case s: FilterExec => s.condition.collect {
+        case d: DynamicPruningExpression => d.child
+      }
+      case _ => Nil
+    }
+  }
+
+  protected def getTableScan(plan: SparkPlan, tableName: String): SparkPlan = {
+    val scanOption =
+      find(plan) {
+        case s: FileSourceScanExec =>
+          s.tableIdentifier.exists(_.table.equals(tableName))
+        case _ => false
+      }
+    assert(scanOption.isDefined)
+    scanOption.get
+  }
+
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Reduce the shuffle data can significantly improve the query performance and increase Spark cluster stability. There is a DPP-like way to filter out shuffle data. The  main difference is that the bloom filter is used to filter the data([A simple Bloom filter benchmark](https://issues.apache.org/jira/browse/SPARK-32268?focusedCommentId=17166127&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17166127)). This PR add support this feature. The design document could be found [here](https://docs.google.com/document/d/1ndwynp1RPxaQ0dxykCWD-KW4MYxFWv-ojJzOMAei1S8/edit?usp=sharing).




### Why are the changes needed?

Improve query performance.

### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?
 
Evaluate dynamic Bloom Filter runtime-filtering by TPCDS.


SQL | Shuffle stage origin data size | Pruning shuffle stage data size | Shuffle stage origin records | Pruning shuffle stage records | Disable shuffle pruning (second) | Enable shuffle pruning (second)
-- | -- | -- | -- | -- | -- | --
q13 | 3.2 GiB | 93.1 MiB | 86,409,332 | 1,480,662 | 13 | 14
q16 | 158.2 GiB | 270.7 MiB | 7,136,969,739 | 10,295,246 | 84 | 36
q24a | 355.6 GiB | 39.7 GiB | 13,428,037,922 | 1,504,810,137 | 660 | 432
q24b | 355.6 GiB | 39.7 GiB | 13,428,037,922 | 1,504,810,137 | 660 | 492
q65 | 37.2 GiB | 37.2 GiB | 2,627,543,089 | 2,627,543,089 | 45 | 45
q72 | 40.9 GiB | 1543.3 MiB | 1,418,327,817 | 47,248,271 | 276 | 38
q80 | 8.3 GiB | 8.2 GiB | 295,853,928 | 292,353,065 | 37 | 36
q85 | 12.8 GiB | 1508.2 MiB | 329,635,219 | 37,337,231 | 16 | 12
q93 | 26.7 GiB | 435.9 MiB | 1,389,592,792 | 20,744,184 | 270 | 258
q94 | 87.6 GiB | 1012.0 MiB | 3,598,433,079 | 34,538,210 | 58 | 27
q95 | 640.5 GiB | 344.6 GiB | 872,596,314 | 793,654,526 | 414 | 402



