### PR TITLE
[SPARK-23889][SQL] DataSourceV2: required sorting and clustering for writes

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/distributions/ClusteredDistribution.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/distributions/ClusteredDistribution.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.distributions;
+
+import org.apache.spark.annotation.Experimental;
+import org.apache.spark.sql.connector.expressions.Expression;
+
+/**
+ * A distribution where tuples that share the same values for clustering expressions are co-located
+ * in the same partition.
+ */
+@Experimental
+public interface ClusteredDistribution extends Distribution {
+  /**
+   * Returns clustering expressions.
+   */
+  Expression[] clustering();
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/distributions/Distribution.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/distributions/Distribution.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.distributions;
+
+import org.apache.spark.annotation.Experimental;
+
+/**
+ * An interface that defines how data is distributed across partitions.
+ */
+@Experimental
+public interface Distribution {}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/distributions/Distributions.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/distributions/Distributions.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.distributions;
+
+import org.apache.spark.annotation.Experimental;
+import org.apache.spark.sql.connector.expressions.Expression;
+import org.apache.spark.sql.connector.expressions.SortOrder;
+
+/**
+ * Helper methods to create distributions to pass into Spark.
+ */
+@Experimental
+public class Distributions {
+  private Distributions() {
+  }
+
+  /**
+   * Creates a distribution where no promises are made about co-location of data.
+   */
+  public static UnspecifiedDistribution unspecified() {
+    return LogicalDistributions.unspecified();
+  }
+
+  /**
+   * Creates a distribution where tuples that share the same values for clustering expressions are
+   * co-located in the same partition.
+   */
+  public static ClusteredDistribution clustered(Expression[] clustering) {
+    return LogicalDistributions.clustered(clustering);
+  }
+
+  /**
+   * Creates a distribution where tuples have been ordered across partitions according
+   * to ordering expressions, but not necessarily within a given partition.
+   */
+  public static OrderedDistribution ordered(SortOrder[] ordering) {
+    return LogicalDistributions.ordered(ordering);
+  }
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/distributions/OrderedDistribution.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/distributions/OrderedDistribution.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.distributions;
+
+import org.apache.spark.annotation.Experimental;
+import org.apache.spark.sql.connector.expressions.SortOrder;
+
+/**
+ * A distribution where tuples have been ordered across partitions according
+ * to ordering expressions, but not necessarily within a given partition.
+ */
+@Experimental
+public interface OrderedDistribution extends Distribution {
+  /**
+   * Returns ordering expressions.
+   */
+  SortOrder[] ordering();
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/distributions/UnspecifiedDistribution.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/distributions/UnspecifiedDistribution.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.distributions;
+
+import org.apache.spark.annotation.Experimental;
+
+/**
+ * A distribution where no promises are made about co-location of data.
+ */
+@Experimental
+public interface UnspecifiedDistribution extends Distribution {}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/Expressions.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/Expressions.java
@@ -164,4 +164,15 @@ public class Expressions {
     return LogicalExpressions.hours(Expressions.column(column));
   }
 
+  /**
+   * Create a sort expression.
+   *
+   * @param expr an expression to produce values to sort
+   * @param direction direction of the sort
+   * @param nullOrder null order of the sort
+   * @return a SortOrder
+   */
+  public static SortOrder sort(Expression expr, SortDirection direction, NullOrdering nullOrder) {
+    return LogicalExpressions.sort(expr, direction, nullOrder);
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/NullOrdering.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/NullOrdering.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.expressions;
+
+import org.apache.spark.annotation.Experimental;
+
+/**
+ * A null order used in sorting expressions.
+ */
+@Experimental
+public enum NullOrdering {
+  NULLS_FIRST, NULLS_LAST;
+
+  @Override
+  public String toString() {
+    switch (this) {
+      case NULLS_FIRST:
+        return "NULLS FIRST";
+      case NULLS_LAST:
+        return "NULLS LAST";
+      default:
+        throw new IllegalArgumentException("Unexpected null order: " + this);
+    }
+  }
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/SortDirection.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/SortDirection.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.expressions;
+
+import org.apache.spark.annotation.Experimental;
+
+/**
+ * A sort direction used in sorting expressions.
+ */
+@Experimental
+public enum SortDirection {
+  ASCENDING, DESCENDING;
+
+  @Override
+  public String toString() {
+    switch (this) {
+      case ASCENDING:
+        return "ASC";
+      case DESCENDING:
+        return "DESC";
+      default:
+        throw new IllegalArgumentException("Unexpected sort direction: " + this);
+    }
+  }
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/SortOrder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/SortOrder.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.expressions;
+
+import org.apache.spark.annotation.Experimental;
+
+/**
+ * Represents a sort order in the public expression API.
+ */
+@Experimental
+public interface SortOrder extends Expression {
+  /**
+   * Returns the sort expression.
+   */
+  Expression expression();
+
+  /**
+   * Returns the sort direction.
+   */
+  SortDirection direction();
+
+  /**
+   * Returns the null ordering.
+   */
+  NullOrdering nullOrdering();
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/RequiresDistributionAndOrdering.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/RequiresDistributionAndOrdering.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.write;
+
+import org.apache.spark.annotation.Experimental;
+import org.apache.spark.sql.connector.distributions.Distribution;
+import org.apache.spark.sql.connector.distributions.UnspecifiedDistribution;
+import org.apache.spark.sql.connector.expressions.SortOrder;
+
+/**
+ * A write that requires a specific distribution and ordering of data.
+ */
+@Experimental
+public interface RequiresDistributionAndOrdering extends Write {
+  /**
+   * Returns the distribution required by this write.
+   * <p>
+   * Spark will distribute incoming records to satisfy the required distribution before
+   * passing those records to the data source table on write.
+   * <p>
+   * Implementations may return {@link UnspecifiedDistribution} if they don't require any specific
+   * distribution of data on write.
+   *
+   * @return the required distribution
+   */
+  Distribution requiredDistribution();
+
+  /**
+   * Returns the ordering required by this write.
+   * <p>
+   * Spark will order incoming records within partitions to satisfy the required ordering
+   * before passing those records to the data source table on write.
+   * <p>
+   * Implementations may return an empty array if they don't require any specific ordering of data
+   * on write.
+   *
+   * @return the required ordering
+   */
+  SortOrder[] requiredOrdering();
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/Write.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/Write.java
@@ -17,38 +17,23 @@
 
 package org.apache.spark.sql.connector.write;
 
-import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableCapability;
 import org.apache.spark.sql.connector.write.streaming.StreamingWrite;
 
 /**
- * An interface for building the {@link Write}. Implementations can mix in some interfaces to
- * support different ways to write data to data sources.
- *
- * Unless modified by a mixin interface, the {@link Write} configured by this builder is to
- * append data without affecting existing data.
- *
- * @since 3.0.0
+ * A logical representation of a data source write.
+ * <p>
+ * This logical representation is shared between batch and streaming write. Data sources must
+ * implement the corresponding methods in this interface to match what the table promises
+ * to support. For example, {@link #toBatch()} must be implemented if the {@link Table} that
+ * creates this {@link Write} returns {@link TableCapability#BATCH_WRITE} support in its
+ * {@link Table#capabilities()}.
  */
-@Evolving
-public interface WriteBuilder {
+public interface Write {
 
-  /**
-   * Returns a logical {@link Write} shared between batch and streaming.
-   */
-  default Write build() {
-    return new Write() {
-      @Override
-      public BatchWrite toBatch() {
-        return buildForBatch();
-      }
-
-      @Override
-      public StreamingWrite toStreaming() {
-        return buildForStreaming();
-      }
-    };
+  default String description() {
+    return this.getClass().toString();
   }
 
   /**
@@ -57,9 +42,8 @@ public interface WriteBuilder {
    * {@link Table} that creates this write returns {@link TableCapability#BATCH_WRITE} support in
    * its {@link Table#capabilities()}.
    */
-  default BatchWrite buildForBatch() {
-    throw new UnsupportedOperationException(getClass().getName() +
-      " does not support batch write");
+  default BatchWrite toBatch() {
+    throw new UnsupportedOperationException(description() + ": Batch write is not supported");
   }
 
   /**
@@ -68,8 +52,7 @@ public interface WriteBuilder {
    * {@link Table} that creates this write returns {@link TableCapability#STREAMING_WRITE} support
    * in its {@link Table#capabilities()}.
    */
-  default StreamingWrite buildForStreaming() {
-    throw new UnsupportedOperationException(getClass().getName() +
-      " does not support streaming write");
+  default StreamingWrite toStreaming() {
+    throw new UnsupportedOperationException(description() + ": Streaming write is not supported");
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.connector.catalog.TableChange.{AddColumn, ColumnChange}
 import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.connector.write.Write
 import org.apache.spark.sql.types.{DataType, MetadataBuilder, StringType, StructType}
 
 /**
@@ -65,7 +66,8 @@ case class AppendData(
     table: NamedRelation,
     query: LogicalPlan,
     writeOptions: Map[String, String],
-    isByName: Boolean) extends V2WriteCommand {
+    isByName: Boolean,
+    write: Option[Write] = None) extends V2WriteCommand {
   override def withNewQuery(newQuery: LogicalPlan): AppendData = copy(query = newQuery)
   override def withNewTable(newTable: NamedRelation): AppendData = copy(table = newTable)
 }
@@ -94,7 +96,8 @@ case class OverwriteByExpression(
     deleteExpr: Expression,
     query: LogicalPlan,
     writeOptions: Map[String, String],
-    isByName: Boolean) extends V2WriteCommand {
+    isByName: Boolean,
+    write: Option[Write] = None) extends V2WriteCommand {
   override lazy val resolved: Boolean = {
     table.resolved && query.resolved && outputResolved && deleteExpr.resolved
   }
@@ -132,7 +135,8 @@ case class OverwritePartitionsDynamic(
     table: NamedRelation,
     query: LogicalPlan,
     writeOptions: Map[String, String],
-    isByName: Boolean) extends V2WriteCommand {
+    isByName: Boolean,
+    write: Option[Write] = None) extends V2WriteCommand {
   override def withNewQuery(newQuery: LogicalPlan): OverwritePartitionsDynamic = {
     copy(query = newQuery)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/distributions/distributions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/distributions/distributions.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.distributions
+
+import org.apache.spark.sql.connector.expressions.{Expression, SortOrder}
+
+private[sql] object LogicalDistributions {
+
+  def unspecified(): UnspecifiedDistribution = {
+    UnspecifiedDistributionImpl
+  }
+
+  def clustered(clustering: Array[Expression]): ClusteredDistribution = {
+    ClusteredDistributionImpl(clustering)
+  }
+
+  def ordered(ordering: Array[SortOrder]): OrderedDistribution = {
+    OrderedDistributionImpl(ordering)
+  }
+}
+
+private[sql] object UnspecifiedDistributionImpl extends UnspecifiedDistribution {
+  override def toString: String = "UnspecifiedDistribution"
+}
+
+private[sql] final case class ClusteredDistributionImpl(
+    clusteringExprs: Seq[Expression]) extends ClusteredDistribution {
+
+  override def clustering: Array[Expression] = clusteringExprs.toArray
+
+  override def toString: String = {
+    s"ClusteredDistribution(${clusteringExprs.map(_.describe).mkString(", ")})"
+  }
+}
+
+private[sql] final case class OrderedDistributionImpl(
+    orderingExprs: Seq[SortOrder]) extends OrderedDistribution {
+
+  override def ordering: Array[SortOrder] = orderingExprs.toArray
+
+  override def toString: String = {
+    s"OrderedDistribution(${orderingExprs.map(_.describe).mkString(", ")})"
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/expressions/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/expressions/expressions.scala
@@ -54,6 +54,13 @@ private[sql] object LogicalExpressions {
   def days(reference: NamedReference): DaysTransform = DaysTransform(reference)
 
   def hours(reference: NamedReference): HoursTransform = HoursTransform(reference)
+
+  def sort(
+      reference: Expression,
+      direction: SortDirection,
+      nullOrdering: NullOrdering): SortOrder = {
+    SortValue(reference, direction, nullOrdering)
+  }
 }
 
 /**
@@ -110,6 +117,18 @@ private[sql] final case class BucketTransform(
 }
 
 private[sql] object BucketTransform {
+  def unapply(expr: Expression): Option[(Int, FieldReference)] = expr match {
+    case transform: Transform =>
+      transform match {
+        case BucketTransform(n, FieldReference(parts)) =>
+          Some((n, FieldReference(parts)))
+        case _ =>
+          None
+      }
+    case _ =>
+      None
+  }
+
   def unapply(transform: Transform): Option[(Int, NamedReference)] = transform match {
     case NamedTransform("bucket", Seq(
         Lit(value: Int, IntegerType),
@@ -170,6 +189,18 @@ private[sql] final case class IdentityTransform(
 }
 
 private[sql] object IdentityTransform {
+  def unapply(expr: Expression): Option[FieldReference] = expr match {
+    case transform: Transform =>
+      transform match {
+        case IdentityTransform(ref) =>
+          Some(ref)
+        case _ =>
+          None
+      }
+    case _ =>
+      None
+  }
+
   def unapply(transform: Transform): Option[FieldReference] = transform match {
     case NamedTransform("identity", Seq(Ref(parts))) =>
       Some(FieldReference(parts))
@@ -185,6 +216,18 @@ private[sql] final case class YearsTransform(
 }
 
 private[sql] object YearsTransform {
+  def unapply(expr: Expression): Option[FieldReference] = expr match {
+    case transform: Transform =>
+      transform match {
+        case YearsTransform(ref) =>
+          Some(ref)
+        case _ =>
+          None
+      }
+    case _ =>
+      None
+  }
+
   def unapply(transform: Transform): Option[FieldReference] = transform match {
     case NamedTransform("years", Seq(Ref(parts))) =>
       Some(FieldReference(parts))
@@ -200,6 +243,18 @@ private[sql] final case class MonthsTransform(
 }
 
 private[sql] object MonthsTransform {
+  def unapply(expr: Expression): Option[FieldReference] = expr match {
+    case transform: Transform =>
+      transform match {
+        case MonthsTransform(ref) =>
+          Some(ref)
+        case _ =>
+          None
+      }
+    case _ =>
+      None
+  }
+
   def unapply(transform: Transform): Option[FieldReference] = transform match {
     case NamedTransform("months", Seq(Ref(parts))) =>
       Some(FieldReference(parts))
@@ -215,6 +270,18 @@ private[sql] final case class DaysTransform(
 }
 
 private[sql] object DaysTransform {
+  def unapply(expr: Expression): Option[FieldReference] = expr match {
+    case transform: Transform =>
+      transform match {
+        case DaysTransform(ref) =>
+          Some(ref)
+        case _ =>
+          None
+      }
+    case _ =>
+      None
+  }
+
   def unapply(transform: Transform): Option[FieldReference] = transform match {
     case NamedTransform("days", Seq(Ref(parts))) =>
       Some(FieldReference(parts))
@@ -230,6 +297,18 @@ private[sql] final case class HoursTransform(
 }
 
 private[sql] object HoursTransform {
+  def unapply(expr: Expression): Option[FieldReference] = expr match {
+    case transform: Transform =>
+      transform match {
+        case HoursTransform(ref) =>
+          Some(ref)
+        case _ =>
+          None
+      }
+    case _ =>
+      None
+  }
+
   def unapply(transform: Transform): Option[FieldReference] = transform match {
     case NamedTransform("hours", Seq(Ref(parts))) =>
       Some(FieldReference(parts))
@@ -259,5 +338,22 @@ private[sql] final case class FieldReference(parts: Seq[String]) extends NamedRe
 private[sql] object FieldReference {
   def apply(column: String): NamedReference = {
     LogicalExpressions.parseReference(column)
+  }
+}
+
+private[sql] final case class SortValue(
+    expression: Expression,
+    direction: SortDirection,
+    nullOrdering: NullOrdering) extends SortOrder {
+
+  override def describe(): String = s"$expression $direction $nullOrdering"
+}
+
+private[sql] object SortValue {
+  def unapply(expr: Expression): Option[(Expression, SortDirection, NullOrdering)] = expr match {
+    case sort: SortOrder =>
+      Some((sort.expression, sort.direction, sort.nullOrdering))
+    case _ =>
+      None
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryTable.scala
@@ -257,7 +257,7 @@ class InMemoryTable(
     }
   }
 
-  private abstract class TestBatchWrite extends BatchWrite {
+  protected abstract class TestBatchWrite extends BatchWrite {
     override def createBatchWriterFactory(info: PhysicalWriteInfo): DataWriterFactory = {
       BufferedRowsWriterFactory
     }
@@ -265,13 +265,13 @@ class InMemoryTable(
     override def abort(messages: Array[WriterCommitMessage]): Unit = {}
   }
 
-  private object Append extends TestBatchWrite {
+  protected object Append extends TestBatchWrite {
     override def commit(messages: Array[WriterCommitMessage]): Unit = dataMap.synchronized {
       withData(messages.map(_.asInstanceOf[BufferedRows]))
     }
   }
 
-  private object DynamicOverwrite extends TestBatchWrite {
+  protected object DynamicOverwrite extends TestBatchWrite {
     override def commit(messages: Array[WriterCommitMessage]): Unit = dataMap.synchronized {
       val newData = messages.map(_.asInstanceOf[BufferedRows])
       dataMap --= newData.flatMap(_.rows.map(getKey))
@@ -279,7 +279,7 @@ class InMemoryTable(
     }
   }
 
-  private class Overwrite(filters: Array[Filter]) extends TestBatchWrite {
+  protected class Overwrite(filters: Array[Filter]) extends TestBatchWrite {
     import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.MultipartIdentifierHelper
     override def commit(messages: Array[WriterCommitMessage]): Unit = dataMap.synchronized {
       val deleteKeys = InMemoryTable.filtersToKeys(
@@ -289,7 +289,7 @@ class InMemoryTable(
     }
   }
 
-  private object TruncateAndAppend extends TestBatchWrite {
+  protected object TruncateAndAppend extends TestBatchWrite {
     override def commit(messages: Array[WriterCommitMessage]): Unit = dataMap.synchronized {
       dataMap.clear
       withData(messages.map(_.asInstanceOf[BufferedRows]))

--- a/sql/core/src/main/java/org/apache/spark/sql/connector/write/V1Write.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/connector/write/V1Write.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.write;
+
+import org.apache.spark.annotation.Unstable;
+import org.apache.spark.sql.connector.catalog.TableCapability;
+import org.apache.spark.sql.sources.InsertableRelation;
+
+/**
+ * A logical write that should be executed using V1 InsertableRelation interface.
+ * <p>
+ * Tables that have {@link TableCapability#V1_BATCH_WRITE} in the list of their capabilities
+ * must create {@link V1WriteBuilder} and build {@link V1Write}.
+ */
+@Unstable
+public interface V1Write extends Write {
+  InsertableRelation toInsertableRelation();
+}

--- a/sql/core/src/main/java/org/apache/spark/sql/connector/write/V1WriteBuilder.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/connector/write/V1WriteBuilder.java
@@ -33,6 +33,11 @@ import org.apache.spark.sql.sources.InsertableRelation;
  */
 @Unstable
 public interface V1WriteBuilder extends WriteBuilder {
+
+  default Write build() {
+    return (V1Write) this::buildForV1Write;
+  }
+
   /**
    * Creates an InsertableRelation that allows appending a DataFrame to a
    * a destination (using data source-specific parameters). The insert method will only be

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, StagingTableCatalog, SupportsNamespaces, SupportsPartitionManagement, TableCapability, TableCatalog, TableChange}
 import org.apache.spark.sql.connector.read.streaming.{ContinuousStream, MicroBatchStream}
+import org.apache.spark.sql.connector.write.V1Write
 import org.apache.spark.sql.execution.{FilterExec, LeafExecNode, LocalTableScanExec, ProjectExec, RowDataSourceScanExec, SparkPlan}
 import org.apache.spark.sql.execution.datasources.DataSourceStrategy
 import org.apache.spark.sql.execution.streaming.continuous.{WriteToContinuousDataSource, WriteToContinuousDataSourceExec}
@@ -178,15 +179,20 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
             orCreate = orCreate) :: Nil
       }
 
-    case AppendData(r: DataSourceV2Relation, query, writeOptions, _) =>
+    case AppendData(r: DataSourceV2Relation, query, writeOptions, _, write) =>
       r.table.asWritable match {
         case v1 if v1.supports(TableCapability.V1_BATCH_WRITE) =>
-          AppendDataExecV1(v1, writeOptions.asOptions, query, refreshCache(r)) :: Nil
+          AppendDataExecV1(
+            v1, writeOptions.asOptions, query,
+            refreshCache(r), write.map(_.asInstanceOf[V1Write])) :: Nil
         case v2 =>
-          AppendDataExec(v2, writeOptions.asOptions, planLater(query), refreshCache(r)) :: Nil
+          AppendDataExec(
+            v2, writeOptions.asOptions, planLater(query),
+            refreshCache(r), write.map(_.toBatch)) :: Nil
       }
 
-    case OverwriteByExpression(r: DataSourceV2Relation, deleteExpr, query, writeOptions, _) =>
+    case OverwriteByExpression(
+        r: DataSourceV2Relation, deleteExpr, query, writeOptions, _, write) =>
       // fail if any filter cannot be converted. correctness depends on removing all matching data.
       val filters = splitConjunctivePredicates(deleteExpr).map {
         filter => DataSourceStrategy.translateFilter(deleteExpr,
@@ -195,16 +201,19 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       }.toArray
       r.table.asWritable match {
         case v1 if v1.supports(TableCapability.V1_BATCH_WRITE) =>
-          OverwriteByExpressionExecV1(v1, filters, writeOptions.asOptions,
-            query, refreshCache(r)) :: Nil
+          OverwriteByExpressionExecV1(
+            v1, filters, writeOptions.asOptions, query,
+            refreshCache(r), write.map(_.asInstanceOf[V1Write])) :: Nil
         case v2 =>
-          OverwriteByExpressionExec(v2, filters,
-            writeOptions.asOptions, planLater(query), refreshCache(r)) :: Nil
+          OverwriteByExpressionExec(
+            v2, filters, writeOptions.asOptions, planLater(query),
+            refreshCache(r), write.map(_.toBatch)) :: Nil
       }
 
-    case OverwritePartitionsDynamic(r: DataSourceV2Relation, query, writeOptions, _) =>
+    case OverwritePartitionsDynamic(r: DataSourceV2Relation, query, writeOptions, _, write) =>
       OverwritePartitionsDynamicExec(
-        r.table.asWritable, writeOptions.asOptions, planLater(query), refreshCache(r)) :: Nil
+        r.table.asWritable, writeOptions.asOptions, planLater(query),
+        refreshCache(r), write.map(_.toBatch)) :: Nil
 
     case DeleteFromTable(relation, condition) =>
       relation match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/TableCapabilityCheck.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/TableCapabilityCheck.scala
@@ -49,14 +49,14 @@ object TableCapabilityCheck extends (LogicalPlan => Unit) {
 
       // TODO: check STREAMING_WRITE capability. It's not doable now because we don't have a
       //       a logical plan for streaming write.
-      case AppendData(r: DataSourceV2Relation, _, _, _) if !supportsBatchWrite(r.table) =>
+      case AppendData(r: DataSourceV2Relation, _, _, _, _) if !supportsBatchWrite(r.table) =>
         failAnalysis(s"Table ${r.table.name()} does not support append in batch mode.")
 
-      case OverwritePartitionsDynamic(r: DataSourceV2Relation, _, _, _)
+      case OverwritePartitionsDynamic(r: DataSourceV2Relation, _, _, _, _)
         if !r.table.supports(BATCH_WRITE) || !r.table.supports(OVERWRITE_DYNAMIC) =>
         failAnalysis(s"Table ${r.table.name()} does not support dynamic overwrite in batch mode.")
 
-      case OverwriteByExpression(r: DataSourceV2Relation, expr, _, _, _) =>
+      case OverwriteByExpression(r: DataSourceV2Relation, expr, _, _, _, _) =>
         expr match {
           case Literal(true, BooleanType) =>
             if (!supportsBatchWrite(r.table) ||

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2Writes.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2Writes.scala
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import java.util.UUID
+
+import org.apache.spark.SparkException
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst
+import org.apache.spark.sql.catalyst.analysis.Resolver
+import org.apache.spark.sql.catalyst.expressions.{NamedExpression, PredicateHelper, SortOrder}
+import org.apache.spark.sql.catalyst.plans.logical.{AppendData, LogicalPlan, OverwriteByExpression, OverwritePartitionsDynamic, RepartitionByExpression, Sort}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.connector.catalog.Table
+import org.apache.spark.sql.connector.distributions.{ClusteredDistribution, OrderedDistribution, UnspecifiedDistribution}
+import org.apache.spark.sql.connector.expressions.{Expression, FieldReference, IdentityTransform, NullOrdering, SortDirection, SortValue}
+import org.apache.spark.sql.connector.write.{LogicalWriteInfoImpl, RequiresDistributionAndOrdering, SupportsDynamicOverwrite, SupportsOverwrite, SupportsTruncate, Write, WriteBuilder}
+import org.apache.spark.sql.execution.datasources.DataSourceStrategy
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.sources.{AlwaysTrue, Filter}
+
+/**
+ * A rule that constructs [[Write]]s.
+ *
+ * This rule does resolution in the optimizer because some nodes like [[OverwriteByExpression]]
+ * must undergo the expression optimization before we can construct a logical write.
+ */
+object V2Writes extends Rule[LogicalPlan] with PredicateHelper {
+
+  import DataSourceV2Implicits._
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan transformDown {
+    case a @ AppendData(r: DataSourceV2Relation, query, options, _, None) =>
+      val writeBuilder = newWriteBuilder(r.table, query, options)
+      val write = writeBuilder.build()
+      a.copy(write = Some(write), query = addDistributionAndOrdering(write, query))
+
+    case o @ OverwriteByExpression(r: DataSourceV2Relation, deleteExpr, query, options, _, None) =>
+      // fail if any filter cannot be converted. correctness depends on removing all matching data.
+      val filters = splitConjunctivePredicates(deleteExpr).flatMap { p =>
+        val filter = DataSourceStrategy.translateFilter(p, supportNestedPredicatePushdown = true)
+        if (filter.isEmpty) {
+          throw new AnalysisException(s"Cannot translate expression to source filter: $p")
+        }
+        filter
+      }.toArray
+
+      val table = r.table
+      val writeBuilder = newWriteBuilder(table, query, options)
+      val write = writeBuilder match {
+        case builder: SupportsTruncate if isTruncate(filters) =>
+          builder.truncate().build()
+        case builder: SupportsOverwrite =>
+          builder.overwrite(filters).build()
+        case _ =>
+          throw new SparkException(s"Table does not support overwrite by expression: $table")
+      }
+
+      o.copy(write = Some(write), query = addDistributionAndOrdering(write, query))
+
+    case o @ OverwritePartitionsDynamic(r: DataSourceV2Relation, query, options, _, None) =>
+      val table = r.table
+      val writeBuilder = newWriteBuilder(table, query, options)
+      val write = writeBuilder match {
+        case builder: SupportsDynamicOverwrite =>
+          builder.overwriteDynamicPartitions().build()
+        case _ =>
+          throw new SparkException(s"Table does not support dynamic partition overwrite: $table")
+      }
+      o.copy(write = Some(write), query = addDistributionAndOrdering(write, query))
+  }
+
+  private def newWriteBuilder(
+      table: Table,
+      query: LogicalPlan,
+      writeOptions: Map[String, String]): WriteBuilder = {
+
+    val info = LogicalWriteInfoImpl(
+      queryId = UUID.randomUUID().toString,
+      query.schema,
+      writeOptions.asOptions)
+    table.asWritable.newWriteBuilder(info)
+  }
+
+  private def isTruncate(filters: Array[Filter]): Boolean = {
+    filters.length == 1 && filters(0).isInstanceOf[AlwaysTrue]
+  }
+
+  private def addDistributionAndOrdering(
+      write: Write,
+      query: LogicalPlan): LogicalPlan = write match {
+
+    case write: RequiresDistributionAndOrdering =>
+      val sqlConf = SQLConf.get
+      val resolver = sqlConf.resolver
+
+      val distribution = write.requiredDistribution match {
+        case d: OrderedDistribution =>
+          d.ordering.map(e => toCatalyst(e, query, resolver))
+        case d: ClusteredDistribution =>
+          d.clustering.map(e => toCatalyst(e, query, resolver))
+        case _: UnspecifiedDistribution =>
+          Array.empty[catalyst.expressions.Expression]
+      }
+
+      val queryWithDistribution = if (distribution.nonEmpty) {
+        val numShufflePartitions = sqlConf.numShufflePartitions
+        // the conversion to catalyst expressions above produces SortOrder expressions
+        // for OrderedDistribution and generic expressions for ClusteredDistribution
+        // this allows RepartitionByExpression to pick either range or hash partitioning
+        RepartitionByExpression(distribution, query, numShufflePartitions)
+      } else {
+        query
+      }
+
+      val ordering = write.requiredOrdering.toSeq
+          .map(e => toCatalyst(e, query, resolver))
+          .asInstanceOf[Seq[catalyst.expressions.SortOrder]]
+
+      val queryWithDistributionAndOrdering = if (ordering.nonEmpty) {
+        Sort(ordering, global = false, queryWithDistribution)
+      } else {
+        queryWithDistribution
+      }
+
+      queryWithDistributionAndOrdering
+    case _ =>
+      query
+  }
+
+  private def toCatalyst(
+      expr: Expression,
+      query: LogicalPlan,
+      resolver: Resolver): catalyst.expressions.Expression = {
+    def resolve(ref: FieldReference): NamedExpression = {
+      // this part is controversial as we perform resolution in the optimizer
+      // we cannot perform this step in the analyzer since we need to optimize expressions
+      // in nodes like OverwriteByExpression before constructing a logical write
+      query.resolve(ref.parts, resolver) match {
+        case Some(attr) => attr
+        case None => throw new AnalysisException(s"Cannot resolve '$ref' using ${query.output}")
+      }
+    }
+    expr match {
+      case SortValue(child, direction, nullOrdering) =>
+        val catalystChild = toCatalyst(child, query, resolver)
+        SortOrder(catalystChild, toCatalyst(direction), toCatalyst(nullOrdering), Seq.empty)
+      case IdentityTransform(ref) =>
+        resolve(ref)
+      case ref: FieldReference =>
+        resolve(ref)
+      case _ =>
+        throw new RuntimeException(s"$expr is not currently supported")
+    }
+  }
+
+  private def toCatalyst(direction: SortDirection): catalyst.expressions.SortDirection = {
+    direction match {
+      case SortDirection.ASCENDING => catalyst.expressions.Ascending
+      case SortDirection.DESCENDING => catalyst.expressions.Descending
+    }
+  }
+
+  private def toCatalyst(nullOrdering: NullOrdering): catalyst.expressions.NullOrdering = {
+    nullOrdering match {
+      case NullOrdering.NULLS_FIRST => catalyst.expressions.NullsFirst
+      case NullOrdering.NULLS_LAST => catalyst.expressions.NullsLast
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/WriteDistributionAndOrderingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/WriteDistributionAndOrderingSuite.scala
@@ -1,0 +1,594 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector
+
+import java.util
+import java.util.Collections
+
+import org.scalatest.BeforeAndAfter
+
+import org.apache.spark.sql.{catalyst, DataFrame, QueryTest}
+import org.apache.spark.sql.catalyst.analysis.{TableAlreadyExistsException, UnresolvedAttribute}
+import org.apache.spark.sql.catalyst.plans.physical
+import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, RangePartitioning, UnknownPartitioning}
+import org.apache.spark.sql.connector.catalog.{Identifier, Table}
+import org.apache.spark.sql.connector.distributions.{Distribution, Distributions}
+import org.apache.spark.sql.connector.expressions.{Expression, FieldReference, NullOrdering, SortDirection, SortOrder, Transform}
+import org.apache.spark.sql.connector.expressions.LogicalExpressions._
+import org.apache.spark.sql.connector.write.{BatchWrite, LogicalWriteInfo, RequiresDistributionAndOrdering, SupportsDynamicOverwrite, SupportsOverwrite, SupportsTruncate, Write, WriteBuilder}
+import org.apache.spark.sql.execution.{QueryExecution, SortExec, SparkPlan}
+import org.apache.spark.sql.execution.datasources.v2.V2TableWriteExec
+import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
+import org.apache.spark.sql.functions.lit
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
+import org.apache.spark.sql.util.{CaseInsensitiveStringMap, QueryExecutionListener}
+
+class WriteDistributionAndOrderingSuite
+  extends QueryTest with SharedSparkSession with BeforeAndAfter {
+
+  import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+  before {
+    spark.conf.set("spark.sql.catalog.testcat", classOf[ExtendedInMemoryTableCatalog].getName)
+  }
+
+  after {
+    spark.sessionState.catalogManager.reset()
+    spark.sessionState.conf.clear()
+  }
+
+  private val writeOperations = Seq("append", "overwrite", "overwriteDynamic")
+
+  private val namespace = Array("ns1")
+  private val ident = Identifier.of(namespace, "test_table")
+  private val tableNameAsString = "testcat." + ident.toString
+  private val emptyProps = Collections.emptyMap[String, String]
+  private val schema = new StructType()
+    .add("id", IntegerType)
+    .add("data", StringType)
+
+  writeOperations.foreach { operation =>
+    test(s"ordered distribution and sort with same exprs ($operation)") {
+      val ordering = Array[SortOrder](
+        sort(FieldReference("data"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST)
+      )
+      val distribution = Distributions.ordered(ordering)
+
+      val writeOrdering = Seq(
+        catalyst.expressions.SortOrder(
+          UnresolvedAttribute("data"),
+          catalyst.expressions.Ascending,
+          catalyst.expressions.NullsFirst,
+          Seq.empty
+        )
+      )
+      val numShufflePartitions = SQLConf.get.numShufflePartitions
+      val writePartitioning = RangePartitioning(writeOrdering, numShufflePartitions)
+
+      checkWriteRequirements(
+        tableDistribution = distribution,
+        tableOrdering = ordering,
+        expectedWritePartitioning = writePartitioning,
+        expectedWriteOrdering = writeOrdering,
+        writeOperation = operation
+      )
+    }
+  }
+
+  writeOperations.foreach { operation =>
+    test(s"clustered distribution and sort with same exprs ($operation)") {
+      val ordering = Array[SortOrder](
+        sort(FieldReference("data"), SortDirection.DESCENDING, NullOrdering.NULLS_FIRST),
+        sort(FieldReference("id"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST)
+      )
+      val clustering = Array[Expression](FieldReference("data"), FieldReference("id"))
+      val distribution = Distributions.clustered(clustering)
+
+      val writeOrdering = Seq(
+        catalyst.expressions.SortOrder(
+          attr("data"),
+          catalyst.expressions.Descending,
+          catalyst.expressions.NullsFirst,
+          Seq.empty
+        ),
+        catalyst.expressions.SortOrder(
+          attr("id"),
+          catalyst.expressions.Ascending,
+          catalyst.expressions.NullsFirst,
+          Seq.empty
+        )
+      )
+      val writePartitioningExprs = Seq(attr("data"), attr("id"))
+      val numShufflePartitions = SQLConf.get.numShufflePartitions
+      val writePartitioning = HashPartitioning(writePartitioningExprs, numShufflePartitions)
+
+      checkWriteRequirements(
+        tableDistribution = distribution,
+        tableOrdering = ordering,
+        expectedWritePartitioning = writePartitioning,
+        expectedWriteOrdering = writeOrdering,
+        writeOperation = operation
+      )
+    }
+  }
+
+  writeOperations.foreach { operation =>
+    test(s"clustered distribution and sort with extended exprs ($operation)") {
+      val ordering = Array[SortOrder](
+        sort(FieldReference("data"), SortDirection.DESCENDING, NullOrdering.NULLS_FIRST),
+        sort(FieldReference("id"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST)
+      )
+      val clustering = Array[Expression](FieldReference("data"))
+      val distribution = Distributions.clustered(clustering)
+
+      val writeOrdering = Seq(
+        catalyst.expressions.SortOrder(
+          attr("data"),
+          catalyst.expressions.Descending,
+          catalyst.expressions.NullsFirst,
+          Seq.empty
+        ),
+        catalyst.expressions.SortOrder(
+          attr("id"),
+          catalyst.expressions.Ascending,
+          catalyst.expressions.NullsFirst,
+          Seq.empty
+        )
+      )
+      val writePartitioningExprs = Seq(attr("data"))
+      val numShufflePartitions = SQLConf.get.numShufflePartitions
+      val writePartitioning = HashPartitioning(writePartitioningExprs, numShufflePartitions)
+
+      checkWriteRequirements(
+        tableDistribution = distribution,
+        tableOrdering = ordering,
+        expectedWritePartitioning = writePartitioning,
+        expectedWriteOrdering = writeOrdering,
+        writeOperation = operation
+      )
+    }
+  }
+
+  writeOperations.foreach { operation =>
+    test(s"unspecified distribution and local sort ($operation)") {
+      val ordering = Array[SortOrder](
+        sort(FieldReference("data"), SortDirection.DESCENDING, NullOrdering.NULLS_FIRST)
+      )
+      val distribution = Distributions.unspecified()
+
+      val writeOrdering = Seq(
+        catalyst.expressions.SortOrder(
+          attr("data"),
+          catalyst.expressions.Descending,
+          catalyst.expressions.NullsFirst,
+          Seq.empty
+        )
+      )
+      val writePartitioning = UnknownPartitioning(0)
+
+      checkWriteRequirements(
+        tableDistribution = distribution,
+        tableOrdering = ordering,
+        expectedWritePartitioning = writePartitioning,
+        expectedWriteOrdering = writeOrdering,
+        writeOperation = operation
+      )
+    }
+  }
+
+  writeOperations.foreach { operation =>
+    test(s"unspecified distribution and no sort ($operation)") {
+      val ordering = Array.empty[SortOrder]
+      val distribution = Distributions.unspecified()
+
+      val writeOrdering = Seq.empty[catalyst.expressions.SortOrder]
+      val writePartitioning = UnknownPartitioning(0)
+
+      checkWriteRequirements(
+        tableDistribution = distribution,
+        tableOrdering = ordering,
+        expectedWritePartitioning = writePartitioning,
+        expectedWriteOrdering = writeOrdering,
+        writeOperation = operation
+      )
+    }
+  }
+
+  writeOperations.foreach { operation =>
+    test(s"ordered distribution and sort with manual global sort ($operation)") {
+      val ordering = Array[SortOrder](
+        sort(FieldReference("data"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST),
+        sort(FieldReference("id"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST)
+      )
+      val distribution = Distributions.ordered(ordering)
+
+      val writeOrdering = Seq(
+        catalyst.expressions.SortOrder(
+          UnresolvedAttribute("data"),
+          catalyst.expressions.Ascending,
+          catalyst.expressions.NullsFirst,
+          Seq.empty
+        ),
+        catalyst.expressions.SortOrder(
+          UnresolvedAttribute("id"),
+          catalyst.expressions.Ascending,
+          catalyst.expressions.NullsFirst,
+          Seq.empty
+        )
+      )
+      val numShufflePartitions = SQLConf.get.numShufflePartitions
+      val writePartitioning = RangePartitioning(writeOrdering, numShufflePartitions)
+
+      checkWriteRequirements(
+        tableDistribution = distribution,
+        tableOrdering = ordering,
+        expectedWritePartitioning = writePartitioning,
+        expectedWriteOrdering = writeOrdering,
+        writeTransform = df => df.orderBy("data", "id"),
+        writeOperation = operation
+      )
+    }
+  }
+
+  writeOperations.foreach { operation =>
+    test(s"ordered distribution and sort with incompatible global sort ($operation)") {
+      val ordering = Array[SortOrder](
+        sort(FieldReference("data"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST),
+        sort(FieldReference("id"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST)
+      )
+      val distribution = Distributions.ordered(ordering)
+
+      val writeOrdering = Seq(
+        catalyst.expressions.SortOrder(
+          UnresolvedAttribute("data"),
+          catalyst.expressions.Ascending,
+          catalyst.expressions.NullsFirst,
+          Seq.empty
+        ),
+        catalyst.expressions.SortOrder(
+          UnresolvedAttribute("id"),
+          catalyst.expressions.Ascending,
+          catalyst.expressions.NullsFirst,
+          Seq.empty
+        )
+      )
+      val numShufflePartitions = SQLConf.get.numShufflePartitions
+      val writePartitioning = RangePartitioning(writeOrdering, numShufflePartitions)
+
+      checkWriteRequirements(
+        tableDistribution = distribution,
+        tableOrdering = ordering,
+        expectedWritePartitioning = writePartitioning,
+        expectedWriteOrdering = writeOrdering,
+        writeTransform = df => df.orderBy(df("data").desc, df("id").asc),
+        writeOperation = operation
+      )
+    }
+  }
+
+  writeOperations.foreach { operation =>
+    test(s"ordered distribution and sort with manual local sort ($operation)") {
+      val ordering = Array[SortOrder](
+        sort(FieldReference("data"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST),
+        sort(FieldReference("id"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST)
+      )
+      val distribution = Distributions.ordered(ordering)
+
+      val writeOrdering = Seq(
+        catalyst.expressions.SortOrder(
+          UnresolvedAttribute("data"),
+          catalyst.expressions.Ascending,
+          catalyst.expressions.NullsFirst,
+          Seq.empty
+        ),
+        catalyst.expressions.SortOrder(
+          UnresolvedAttribute("id"),
+          catalyst.expressions.Ascending,
+          catalyst.expressions.NullsFirst,
+          Seq.empty
+        )
+      )
+      val numShufflePartitions = SQLConf.get.numShufflePartitions
+      val writePartitioning = RangePartitioning(writeOrdering, numShufflePartitions)
+
+      checkWriteRequirements(
+        tableDistribution = distribution,
+        tableOrdering = ordering,
+        expectedWritePartitioning = writePartitioning,
+        expectedWriteOrdering = writeOrdering,
+        writeTransform = df => df.sortWithinPartitions("data", "id"),
+        writeOperation = operation
+      )
+    }
+  }
+
+  // TODO: do we need to dedup repartitions too? RepartitionByExpr -> Projects -> RepartitionByExpr
+  writeOperations.foreach { operation =>
+    ignore(s"ordered distribution and sort with manual repartition ($operation)") {
+      val ordering = Array[SortOrder](
+        sort(FieldReference("data"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST),
+        sort(FieldReference("id"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST)
+      )
+      val distribution = Distributions.ordered(ordering)
+
+      val writeOrdering = Seq(
+        catalyst.expressions.SortOrder(
+          UnresolvedAttribute("data"),
+          catalyst.expressions.Ascending,
+          catalyst.expressions.NullsFirst,
+          Seq.empty
+        ),
+        catalyst.expressions.SortOrder(
+          UnresolvedAttribute("id"),
+          catalyst.expressions.Ascending,
+          catalyst.expressions.NullsFirst,
+          Seq.empty
+        )
+      )
+      val numShufflePartitions = SQLConf.get.numShufflePartitions
+      val writePartitioning = RangePartitioning(writeOrdering, numShufflePartitions)
+
+      checkWriteRequirements(
+        tableDistribution = distribution,
+        tableOrdering = ordering,
+        expectedWritePartitioning = writePartitioning,
+        expectedWriteOrdering = writeOrdering,
+        writeTransform = df => df.repartitionByRange(df("data"), df("id")),
+        writeOperation = operation
+      )
+    }
+  }
+
+  writeOperations.foreach { operation =>
+    test(s"clustered distribution and local sort with manual global sort ($operation)") {
+      val ordering = Array[SortOrder](
+        sort(FieldReference("data"), SortDirection.DESCENDING, NullOrdering.NULLS_FIRST),
+        sort(FieldReference("id"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST)
+      )
+      val distribution = Distributions.clustered(Array(FieldReference("data")))
+
+      val writeOrdering = Seq(
+        catalyst.expressions.SortOrder(
+          UnresolvedAttribute("data"),
+          catalyst.expressions.Descending,
+          catalyst.expressions.NullsFirst,
+          Seq.empty
+        ),
+        catalyst.expressions.SortOrder(
+          UnresolvedAttribute("id"),
+          catalyst.expressions.Ascending,
+          catalyst.expressions.NullsFirst,
+          Seq.empty
+        )
+      )
+      val writePartitioningExprs = Seq(attr("data"))
+      val numShufflePartitions = SQLConf.get.numShufflePartitions
+      val writePartitioning = HashPartitioning(writePartitioningExprs, numShufflePartitions)
+
+      checkWriteRequirements(
+        tableDistribution = distribution,
+        tableOrdering = ordering,
+        expectedWritePartitioning = writePartitioning,
+        expectedWriteOrdering = writeOrdering,
+        writeTransform = df => df.orderBy("data", "id"),
+        writeOperation = operation
+      )
+    }
+  }
+
+  writeOperations.foreach { operation =>
+    test(s"clustered distribution and local sort with manual local sort ($operation)") {
+      val ordering = Array[SortOrder](
+        sort(FieldReference("data"), SortDirection.DESCENDING, NullOrdering.NULLS_FIRST),
+        sort(FieldReference("id"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST)
+      )
+      val distribution = Distributions.clustered(Array(FieldReference("data")))
+
+      val writeOrdering = Seq(
+        catalyst.expressions.SortOrder(
+          UnresolvedAttribute("data"),
+          catalyst.expressions.Descending,
+          catalyst.expressions.NullsFirst,
+          Seq.empty
+        ),
+        catalyst.expressions.SortOrder(
+          UnresolvedAttribute("id"),
+          catalyst.expressions.Ascending,
+          catalyst.expressions.NullsFirst,
+          Seq.empty
+        )
+      )
+      val writePartitioningExprs = Seq(attr("data"))
+      val numShufflePartitions = SQLConf.get.numShufflePartitions
+      val writePartitioning = HashPartitioning(writePartitioningExprs, numShufflePartitions)
+
+      checkWriteRequirements(
+        tableDistribution = distribution,
+        tableOrdering = ordering,
+        expectedWritePartitioning = writePartitioning,
+        expectedWriteOrdering = writeOrdering,
+        writeTransform = df => df.orderBy("data", "id"),
+        writeOperation = operation
+      )
+    }
+  }
+
+  private def checkWriteRequirements(
+      tableDistribution: Distribution,
+      tableOrdering: Array[SortOrder],
+      expectedWritePartitioning: physical.Partitioning,
+      expectedWriteOrdering: Seq[catalyst.expressions.SortOrder],
+      writeTransform: DataFrame => DataFrame = df => df,
+      writeOperation: String = "append"): Unit = {
+
+    catalog.createTable(ident, schema, Array.empty, emptyProps, tableDistribution, tableOrdering)
+
+    val df = spark.createDataFrame(Seq((1L, "a"), (2L, "b"), (3L, "c"))).toDF("id", "data")
+    val writer = writeTransform(df).writeTo(tableNameAsString)
+    val executedPlan = writeOperation match {
+      case "append" => execute(writer.append())
+      case "overwrite" => execute(writer.overwrite(lit(true)))
+      case "overwriteDynamic" => execute(writer.overwritePartitions())
+    }
+
+    checkPartitioningAndOrdering(executedPlan, expectedWritePartitioning, expectedWriteOrdering)
+
+    checkAnswer(spark.table(tableNameAsString), df)
+  }
+
+  private def checkPartitioningAndOrdering(
+      plan: SparkPlan,
+      partitioning: physical.Partitioning,
+      ordering: Seq[catalyst.expressions.SortOrder]): Unit = {
+
+    val sorts = plan.collect { case s: SortExec => s }
+    assert(sorts.size <= 1, "must be at most one sort")
+    val shuffles = plan.collect { case s: ShuffleExchangeExec => s }
+    assert(shuffles.size <= 1, "must be at most one shuffle")
+
+    val actualPartitioning = plan.outputPartitioning
+    val expectedPartitioning = partitioning match {
+      case p: physical.RangePartitioning =>
+        val resolvedOrdering = p.ordering.map(resolveAttrs(_, plan))
+        p.copy(ordering = resolvedOrdering.asInstanceOf[Seq[catalyst.expressions.SortOrder]])
+      case p: physical.HashPartitioning =>
+        val resolvedExprs = p.expressions.map(resolveAttrs(_, plan))
+        p.copy(expressions = resolvedExprs)
+      case other => other
+    }
+    // TODO: can be compatible, does not have to match 100%
+    assert(actualPartitioning == expectedPartitioning, "partitioning must match")
+
+    val actualOrdering = plan.outputOrdering
+    val expectedOrdering = ordering.map(resolveAttrs(_, plan))
+    // TODO: can be compatible, does not have to match 100%
+    assert(actualOrdering == expectedOrdering, "ordering must match")
+  }
+
+  private def resolveAttrs(
+      expr: catalyst.expressions.Expression,
+      plan: SparkPlan): catalyst.expressions.Expression = {
+
+    expr.transform {
+      case UnresolvedAttribute(parts) =>
+        val attrName = parts.mkString(",")
+        plan.output.find(a => a.name == attrName).get
+    }
+  }
+
+  private def attr(name: String): UnresolvedAttribute = {
+    UnresolvedAttribute(name)
+  }
+
+  private def catalog: ExtendedInMemoryTableCatalog = {
+    val catalog = spark.sessionState.catalogManager.catalog("testcat")
+    catalog.asTableCatalog.asInstanceOf[ExtendedInMemoryTableCatalog]
+  }
+
+  // executes a write operation and keeps the executed physical plan
+  private def execute(writeFunc: => Unit): SparkPlan = {
+    var executedPlan: SparkPlan = null
+
+    val listener = new QueryExecutionListener {
+      override def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit = {
+        executedPlan = qe.executedPlan
+      }
+      override def onFailure(funcName: String, qe: QueryExecution, exception: Exception): Unit = {
+      }
+    }
+    spark.listenerManager.register(listener)
+
+    writeFunc
+
+    sparkContext.listenerBus.waitUntilEmpty()
+
+    executedPlan.asInstanceOf[V2TableWriteExec].query
+  }
+}
+
+class ExtendedInMemoryTableCatalog extends InMemoryTableCatalog {
+
+  import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+  def createTable(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String],
+      distribution: Distribution,
+      ordering: Array[SortOrder]): Table = {
+
+    if (tables.containsKey(ident)) {
+      throw new TableAlreadyExistsException(ident)
+    }
+
+    InMemoryTableCatalog.maybeSimulateFailedTableCreation(properties)
+
+    val table = new ExtendedInMemoryTable(
+      s"$name.${ident.quoted}", schema, partitions, properties, distribution, ordering)
+    tables.put(ident, table)
+    namespaces.putIfAbsent(ident.namespace.toList, Map())
+    table
+  }
+}
+
+class ExtendedInMemoryTable(
+    override val name: String,
+    override val schema: StructType,
+    override val partitioning: Array[Transform],
+    override val properties: util.Map[String, String],
+    distribution: Distribution,
+    ordering: Array[SortOrder])
+  extends InMemoryTable(name, schema, partitioning, properties) {
+
+  override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {
+    InMemoryTable.maybeSimulateFailedTableWrite(new CaseInsensitiveStringMap(properties))
+    InMemoryTable.maybeSimulateFailedTableWrite(info.options)
+
+    new WriteBuilder with SupportsTruncate with SupportsOverwrite with SupportsDynamicOverwrite {
+      private var writer: BatchWrite = Append
+
+      override def truncate(): WriteBuilder = {
+        assert(writer == Append)
+        writer = TruncateAndAppend
+        this
+      }
+
+      override def overwrite(filters: Array[Filter]): WriteBuilder = {
+        assert(writer == Append)
+        writer = new Overwrite(filters)
+        this
+      }
+
+      override def overwriteDynamicPartitions(): WriteBuilder = {
+        assert(writer == Append)
+        writer = DynamicOverwrite
+        this
+      }
+
+      override def build(): Write = new RequiresDistributionAndOrdering {
+        override def requiredDistribution(): Distribution = distribution
+        override def requiredOrdering(): Array[SortOrder] = ordering
+        override def toBatch: BatchWrite = writer
+      }
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -1176,7 +1176,7 @@ class PlanResolutionSuite extends AnalysisTest {
         case Project(_, AsDataSourceV2Relation(r)) =>
           assert(r.catalog.exists(_ == catlogIdent))
           assert(r.identifier.exists(_.name() == tableIdent))
-        case AppendData(r: DataSourceV2Relation, _, _, _) =>
+        case AppendData(r: DataSourceV2Relation, _, _, _, _) =>
           assert(r.catalog.exists(_ == catlogIdent))
           assert(r.identifier.exists(_.name() == tableIdent))
         case DescribeRelation(r: ResolvedTable, _, _) =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?

This PR implements the core part of the [design doc](https://docs.google.com/document/d/1X0NsQSryvNmXBY9kcvfINeYyKC-AahZarUqg3nS1GQs/edit#) for SPARK-23889.

**Note**: This PR contains all changes in one place to simplify the review. Once we agree on the approach, I am going to split it into smaller PRs.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Data sources should be able to request a specific distribution and ordering of data on write. In particular, these scenarios are considered useful:
- global sort
- cluster data and sort within partitions
- local sort within partitions
- no sort

Please see the design doc above for a more detailed explanation of requirements.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

This PR introduces public changes to the DS V2 by adding a logical write abstraction as we have on the read path as well as additional interfaces to represent distribution and ordering of data (please see the doc for more info).

Important pieces:
- `Write` - a logical representation of a data source write
- `RequiresDistributionAndOrdering` - a write that requires a specific distribution/ordering
- `V2Writes` - a rule that constructs a logical write and inserts repartition/sort nodes
- `WriteDistributionAndOrderingSuite` - a test case with samples

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

The patch comes with a new test case.