### PR TITLE
[MINOR][DOCS] Fix typo in PySpark example in ml-datasource.md

### DIFF
--- a/docs/ml-datasource.md
+++ b/docs/ml-datasource.md
@@ -86,7 +86,7 @@ Will output:
 In PySpark we provide Spark SQL data source API for loading image data as a DataFrame.
 
 {% highlight python %}
->>> df = spark.read.format("image").option("dropInvalid", true).load("data/mllib/images/origin/kittens")
+>>> df = spark.read.format("image").option("dropInvalid", True).load("data/mllib/images/origin/kittens")
 >>> df.select("image.origin", "image.width", "image.height").show(truncate=False)
 +-----------------------------------------------------------------------+-----+------+
 |origin                                                                 |width|height|


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR changes `true` to `True` in the python code.

### Why are the changes needed?

The previous example is a syntax error.

### Does this PR introduce _any_ user-facing change?

Yes, but this is doc-only typo fix.

### How was this patch tested?

Manually run the example.