### PR TITLE
[SPARK-32245][INFRA][FOLLOWUP] Reenable Github Actions on commit

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,6 +1,9 @@
 name: master
 
 on:
+  push:
+    branches:
+    - master
   pull_request:
     branches:
     - master


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR reenables GitHub Action on every commit as a next step.

### Why are the changes needed?

We carefully enabled GitHub Action on every PRs, and it looks good so far.

As we saw at https://github.com/apache/spark/pull/29072, GitHub Action is already triggered at every commits on every PRs. Enabling GitHub Action on `master` branch commit doesn't make a big difference. And, we need to start to test at every commit as a next step.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual.