### PR TITLE
[SPARK-32289][SQL] Some characters are garbled when opening csv files with Excel

### DIFF
--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -396,7 +396,7 @@ class DataFrameReader(OptionUtils):
             maxCharsPerColumn=None, maxMalformedLogPerPartition=None, mode=None,
             columnNameOfCorruptRecord=None, multiLine=None, charToEscapeQuoteEscaping=None,
             samplingRatio=None, enforceSchema=None, emptyValue=None, locale=None, lineSep=None,
-            pathGlobFilter=None, recursiveFileLookup=None):
+            pathGlobFilter=None, recursiveFileLookup=None, writeBOM=None):
         r"""Loads a CSV file and returns the result as a  :class:`DataFrame`.
 
         This function will go through the input once to determine the input schema if
@@ -508,6 +508,8 @@ class DataFrameReader(OptionUtils):
                                It does not change the behavior of `partition discovery`_.
         :param recursiveFileLookup: recursively scan a directory for files. Using this option
                                     disables `partition discovery`_.
+        :param writeBOM: writes BOM to file before writing data if encoded by UTF-8 charset.
+                         If None is set, it uses the default value, ``false``.
 
         >>> df = spark.read.csv('python/test_support/sql/ages.csv')
         >>> df.dtypes

--- a/python/pyspark/sql/streaming.py
+++ b/python/pyspark/sql/streaming.py
@@ -636,7 +636,7 @@ class DataStreamReader(OptionUtils):
             maxCharsPerColumn=None, maxMalformedLogPerPartition=None, mode=None,
             columnNameOfCorruptRecord=None, multiLine=None, charToEscapeQuoteEscaping=None,
             enforceSchema=None, emptyValue=None, locale=None, lineSep=None,
-            pathGlobFilter=None, recursiveFileLookup=None):
+            pathGlobFilter=None, recursiveFileLookup=None, writeBOM=None):
         r"""Loads a CSV file stream and returns the result as a :class:`DataFrame`.
 
         This function will go through the input once to determine the input schema if
@@ -743,6 +743,8 @@ class DataStreamReader(OptionUtils):
                                It does not change the behavior of `partition discovery`_.
         :param recursiveFileLookup: recursively scan a directory for files. Using this option
                                     disables `partition discovery`_.
+        :param writeBOM: writes BOM to file before writing data if encoded by UTF-8 charset.
+                         If None is set, it uses the default value, ``false``.
 
         >>> csv_sdf = spark.readStream.csv(tempfile.mkdtemp(), schema = sdf_schema)
         >>> csv_sdf.isStreaming

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -135,6 +135,8 @@ class CSVOptions(
   val positiveInf = parameters.getOrElse("positiveInf", "Inf")
   val negativeInf = parameters.getOrElse("negativeInf", "-Inf")
 
+  // Set bom to true to fix some characters are garbled when opening with Excel.
+  val bom = getBool("bom")
 
   val compressionCodec: Option[String] = {
     val name = parameters.get("compression").orElse(parameters.get("codec"))

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -926,6 +926,8 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
    * trailing whitespaces from values being written should be skipped.</li>
    * <li>`lineSep` (default `\n`): defines the line separator that should be used for writing.
    * Maximum length is 1 character.</li>
+   * <li>`writeBOM` (default `false`): writes BOM to file before writing data if encoded by
+   * UTF-8 charset.</li>
    * </ul>
    *
    * @since 2.0.0

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CsvOutputWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CsvOutputWriter.scala
@@ -39,6 +39,10 @@ class CsvOutputWriter(
 
   private val gen = new UnivocityGenerator(dataSchema, writer, params)
 
+  if (params.bom) {
+    writer.write(0xFEFF)
+  }
+
   if (params.headerFlag) {
     gen.writeHeaders()
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CsvOutputWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CsvOutputWriter.scala
@@ -39,7 +39,7 @@ class CsvOutputWriter(
 
   private val gen = new UnivocityGenerator(dataSchema, writer, params)
 
-  if (params.bom) {
+  if (params.writeBOM) {
     writer.write(0xFEFF)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -2382,10 +2382,18 @@ abstract class CSVSuite extends QueryTest with SharedSparkSession with TestCsvDa
         try {
           spark.read.csv(path).limit(1).collect()
           sparkContext.listenerBus.waitUntilEmpty(1000L)
-          if (bom) {
-            assert(bytesReads.sum === 202)
+          if (sparkConf.get(SQLConf.USE_V1_SOURCE_LIST).equals("")) {
+            if (bom) {
+              assert(bytesReads.sum === 101)
+            } else {
+              assert(bytesReads.sum === 98)
+            }
           } else {
-            assert(bytesReads.sum === 196)
+            if (bom) {
+              assert(bytesReads.sum === 202)
+            } else {
+              assert(bytesReads.sum === 196)
+            }
           }
         } finally {
           sparkContext.removeSparkListener(bytesReadListener)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pr add a new `bom` CSVOptions to support fix some characters are garbled when opening with Excel.

Before this pr:
![image](https://user-images.githubusercontent.com/5399861/87321221-8a882f80-c55e-11ea-85fd-0a26cacbdaf8.png)


After this pr and set `bom` to true:
![image](https://user-images.githubusercontent.com/5399861/87321310-abe91b80-c55e-11ea-8b12-3b510385a1c0.png)


### Why are the changes needed?

Fix garbled issue.


### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Unit test.
