### PR TITLE
[SPARK-32293] Fix inconsistency between Spark memory configs and JVM option

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -245,7 +245,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
       error("Must specify a primary resource (JAR or Python or R file)")
     }
     if (driverMemory != null
-        && Try(JavaUtils.byteStringAsBytes(driverMemory)).getOrElse(-1L) <= 0) {
+        && Try(JavaUtils.byteStringAsMb(driverMemory)).getOrElse(-1L) <= 0) {
       error("Driver memory must be a positive number")
     }
     if (executorMemory != null

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -249,7 +249,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
       error("Driver memory must be a positive number")
     }
     if (executorMemory != null
-        && Try(JavaUtils.byteStringAsBytes(executorMemory)).getOrElse(-1L) <= 0) {
+        && Try(JavaUtils.byteStringAsMb(executorMemory)).getOrElse(-1L) <= 0) {
       error("Executor memory must be a positive number")
     }
     if (executorCores != null && Try(executorCores.toInt).getOrElse(-1) <= 0) {

--- a/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
+++ b/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
@@ -222,7 +222,7 @@ object UnifiedMemoryManager {
     }
     // SPARK-12759 Check executor memory to fail fast if memory is insufficient
     if (conf.contains(config.EXECUTOR_MEMORY)) {
-      val executorMemory = conf.getSizeAsBytes(config.EXECUTOR_MEMORY.key)
+      val executorMemory = conf.getSizeAsMb(config.EXECUTOR_MEMORY.key)
       if (executorMemory < minSystemMemory) {
         throw new IllegalArgumentException(s"Executor memory $executorMemory must be at least " +
           s"$minSystemMemory. Please increase executor memory using the " +

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -172,7 +172,8 @@ of the most common options to set are:
   <td>
     Amount of memory to use for the driver process, i.e. where SparkContext is initialized, in the
     same format as JVM memory strings with a size unit suffix ("k", "m", "g" or "t")
-    (e.g. <code>512m</code>, <code>2g</code>).
+    (e.g. <code>512m</code>, <code>2g</code>) using "m" as default suffix unit.
+d
     <br />
     <em>Note:</em> In client mode, this config must not be set through the <code>SparkConf</code>
     directly in your application, because the driver JVM has already started at that point.
@@ -249,7 +250,8 @@ of the most common options to set are:
   <td>1g</td>
   <td>
     Amount of memory to use per executor process, in the same format as JVM memory strings with
-    a size unit suffix ("k", "m", "g" or "t") (e.g. <code>512m</code>, <code>2g</code>).
+    a size unit suffix ("k", "m", "g" or "t") (e.g. <code>512m</code>, <code>2g</code>) using
+    "m" as default suffix unit.
   </td>
   <td>0.7.0</td>
 </tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -172,8 +172,7 @@ of the most common options to set are:
   <td>
     Amount of memory to use for the driver process, i.e. where SparkContext is initialized, in the
     same format as JVM memory strings with a size unit suffix ("k", "m", "g" or "t")
-    (e.g. <code>512m</code>, <code>2g</code>) using "m" as default suffix unit.
-d
+    (e.g. <code>512m</code>, <code>2g</code>) using "m" as the default unit.
     <br />
     <em>Note:</em> In client mode, this config must not be set through the <code>SparkConf</code>
     directly in your application, because the driver JVM has already started at that point.
@@ -251,7 +250,7 @@ d
   <td>
     Amount of memory to use per executor process, in the same format as JVM memory strings with
     a size unit suffix ("k", "m", "g" or "t") (e.g. <code>512m</code>, <code>2g</code>) using
-    "m" as default suffix unit.
+    "m" as the default unit.
   </td>
   <td>0.7.0</td>
 </tr>

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -71,9 +71,9 @@ The history server can be configured as follows:
   <tr>
     <td><code>SPARK_DAEMON_MEMORY</code></td>
     <td>
-    Memory to allocate to the history server (default: 1g). This can be configured with the same
-    format as JVM memory strings using a size unit suffix ("k", "m", "g" or "t") using "m" as
-    default suffix unit.
+    Memory to allocate to the history server (default: 1g). This can be configured in the same
+    format as JVM memory strings with a size unit suffix ("k", "m", "g" or "t") using "m" as
+    the default unit.
     </td>
   </tr>
   <tr>

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -70,7 +70,11 @@ The history server can be configured as follows:
   <tr><th style="width:21%">Environment Variable</th><th>Meaning</th></tr>
   <tr>
     <td><code>SPARK_DAEMON_MEMORY</code></td>
-    <td>Memory to allocate to the history server (default: 1g).</td>
+    <td>
+    Memory to allocate to the history server (default: 1g). This can be configured with the same
+    format as JVM memory strings using a size unit suffix ("k", "m", "g" or "t") using "m" as
+    default suffix unit.
+    </td>
   </tr>
   <tr>
     <td><code>SPARK_DAEMON_JAVA_OPTS</code></td>

--- a/docs/spark-standalone.md
+++ b/docs/spark-standalone.md
@@ -144,7 +144,10 @@ You can optionally configure the cluster further by setting environment variable
   </tr>
   <tr>
     <td><code>SPARK_WORKER_MEMORY</code></td>
-    <td>Total amount of memory to allow Spark applications to use on the machine, e.g. <code>1000m</code>, <code>2g</code> (default: total memory minus 1 GiB); note that each application's <i>individual</i> memory is configured using its <code>spark.executor.memory</code> property.</td>
+    <td>
+    Total amount of memory to allow Spark applications to use on the machine, e.g. <code>1000m</code>, <code>2g</code> (default: total memory minus 1 GiB); note that each application's <i>individual</i> memory is configured using its <code>spark.executor.memory</code> property.
+    This can be configured in the same format as JVM memory strings with a size unit suffix ("k", "m", "g" or "t") using "m" as the default unit.
+    </td>
   </tr>
   <tr>
     <td><code>SPARK_WORKER_PORT</code></td>

--- a/docs/spark-standalone.md
+++ b/docs/spark-standalone.md
@@ -164,7 +164,10 @@ You can optionally configure the cluster further by setting environment variable
   </tr>
   <tr>
     <td><code>SPARK_DAEMON_MEMORY</code></td>
-    <td>Memory to allocate to the Spark master and worker daemons themselves (default: 1g).</td>
+    <td>
+    Memory to allocate to the Spark master and worker daemons themselves (default: 1g). This can be configured with the same
+    format as JVM memory strings using a size unit suffix ("k", "m", "g" or "t") using "m" as default suffix unit.
+    </td>
   </tr>
   <tr>
     <td><code>SPARK_DAEMON_JAVA_OPTS</code></td>

--- a/docs/spark-standalone.md
+++ b/docs/spark-standalone.md
@@ -165,8 +165,8 @@ You can optionally configure the cluster further by setting environment variable
   <tr>
     <td><code>SPARK_DAEMON_MEMORY</code></td>
     <td>
-    Memory to allocate to the Spark master and worker daemons themselves (default: 1g). This can be configured with the same
-    format as JVM memory strings using a size unit suffix ("k", "m", "g" or "t") using "m" as default suffix unit.
+    Memory to allocate to the Spark master and worker daemons themselves (default: 1g). This can be configured in the same
+    format as JVM memory strings with a size unit suffix ("k", "m", "g" or "t") using "m" as the default unit.
     </td>
   </tr>
   <tr>

--- a/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
@@ -333,6 +333,8 @@ class CommandBuilderUtils {
    */
   static String addDefaultMSuffixIfNeeded(String memoryString) {
     if (memoryString.chars().allMatch(Character::isDigit)) {
+      System.err.println("Memory setting without explicit unit (" +
+        memoryString + ") is taken to be in MB by default! For details check SPARK-32293.");
       return memoryString + "m";
     } else {
       return memoryString;

--- a/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
@@ -328,4 +328,15 @@ class CommandBuilderUtils {
     return libdir.getAbsolutePath();
   }
 
+  /**
+   * Add "m" as the default suffix unit when no explicit unit is given.
+   */
+  static String addDefaultMSuffixIfNeeded(String memoryString) {
+    if (memoryString.chars().allMatch(Character::isDigit)) {
+      return memoryString + "m";
+    } else {
+      return memoryString;
+    }
+  }
+
 }

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkClassCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkClassCommandBuilder.java
@@ -108,6 +108,9 @@ class SparkClassCommandBuilder extends AbstractCommandBuilder {
     }
 
     String mem = firstNonEmpty(memKey != null ? System.getenv(memKey) : null, DEFAULT_MEM);
+    if (mem.chars().allMatch(Character::isDigit)) {
+      mem = mem + "m";
+    }
     cmd.add("-Xmx" + mem);
     cmd.add(className);
     cmd.addAll(classArgs);

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkClassCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkClassCommandBuilder.java
@@ -108,10 +108,7 @@ class SparkClassCommandBuilder extends AbstractCommandBuilder {
     }
 
     String mem = firstNonEmpty(memKey != null ? System.getenv(memKey) : null, DEFAULT_MEM);
-    if (mem.chars().allMatch(Character::isDigit)) {
-      mem = mem + "m";
-    }
-    cmd.add("-Xmx" + mem);
+    cmd.add("-Xmx" + addDefaultMSuffixIfNeeded(mem));
     cmd.add(className);
     cmd.addAll(classArgs);
     return cmd;

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -285,10 +285,7 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
         isThriftServer(mainClass) ? System.getenv("SPARK_DAEMON_MEMORY") : null;
       String memory = firstNonEmpty(tsMemory, config.get(SparkLauncher.DRIVER_MEMORY),
         System.getenv("SPARK_DRIVER_MEMORY"), System.getenv("SPARK_MEM"), DEFAULT_MEM);
-      if (memory.chars().allMatch(Character::isDigit)) {
-        memory = memory + "m";
-      }
-      cmd.add("-Xmx" + memory);
+      cmd.add("-Xmx" + addDefaultMSuffixIfNeeded(memory));
       addOptionString(cmd, driverDefaultJavaOptions);
       addOptionString(cmd, driverExtraJavaOptions);
       mergeEnvPathList(env, getLibPathEnvName(),

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -285,6 +285,9 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
         isThriftServer(mainClass) ? System.getenv("SPARK_DAEMON_MEMORY") : null;
       String memory = firstNonEmpty(tsMemory, config.get(SparkLauncher.DRIVER_MEMORY),
         System.getenv("SPARK_DRIVER_MEMORY"), System.getenv("SPARK_MEM"), DEFAULT_MEM);
+      if (memory.chars().allMatch(Character::isDigit)) {
+        memory = memory + "m";
+      }
       cmd.add("-Xmx" + memory);
       addOptionString(cmd, driverDefaultJavaOptions);
       addOptionString(cmd, driverExtraJavaOptions);

--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
@@ -116,6 +116,22 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
   }
 
   @Test
+  public void testParserWithDefaultUnit() throws Exception {
+    List<String> sparkSubmitArgs = Arrays.asList(
+      parser.MASTER,
+      "local",
+      parser.DRIVER_MEMORY,
+      "4200",
+      parser.DRIVER_CLASS_PATH,
+      "/driverCp",
+      SparkLauncher.NO_RESOURCE);
+    Map<String, String> env = new HashMap<>();
+    List<String> cmd = buildCommand(sparkSubmitArgs, env);
+
+    assertTrue("Driver -Xmx should be configured.", cmd.contains("-Xmx4200m"));
+  }
+
+  @Test
   public void testShellCliParser() throws Exception {
     List<String> sparkSubmitArgs = Arrays.asList(
       parser.CLASS,

--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
@@ -128,7 +128,7 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
     Map<String, String> env = new HashMap<>();
     List<String> cmd = buildCommand(sparkSubmitArgs, env);
 
-    assertTrue("Driver -Xmx should be configured.", cmd.contains("-Xmx4200m"));
+    assertTrue("Driver -Xmx should be configured in MB by default.", cmd.contains("-Xmx4200m"));
   }
 
   @Test

--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
@@ -78,11 +78,16 @@ case "$1" in
     ;;
   executor)
     shift 1
+    MEMORY_WITH_UNIT=$SPARK_EXECUTOR_MEMORY
+    if [[ $MEMORY_WITH_UNIT =~ ^[0-9]+$ ]]
+    then
+        MEMORY_WITH_UNIT="${MEMORY_WITH_UNIT}m"
+    fi
     CMD=(
       ${JAVA_HOME}/bin/java
       "${SPARK_EXECUTOR_JAVA_OPTS[@]}"
-      -Xms$SPARK_EXECUTOR_MEMORY
-      -Xmx$SPARK_EXECUTOR_MEMORY
+      -Xms$MEMORY_WITH_UNIT
+      -Xmx$MEMORY_WITH_UNIT
       -cp "$SPARK_CLASSPATH:$SPARK_DIST_CLASSPATH"
       org.apache.spark.executor.CoarseGrainedExecutorBackend
       --driver-url $SPARK_DRIVER_URL


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixing inconsistency between Spark memory configs and JVM option by adding the "m" default unit before setting Xmx/Xms JVM options when no suffix is provided.  

### Why are the changes needed?

Spark's maximum memory can be configured in several ways:

- via Spark config
- command line argument
- environment variables

Both for executors and for the driver the memory can be configured separately. All of these are following the format of JVM memory configurations in a way they are using the very same size unit suffixes ("k", "m", "g" or "t") but there is an inconsistency regarding the default unit. When no suffix is given then the given amount is passed as it is to the JVM (to the -Xmx and -Xms options) where this memory options are using bytes as a default unit, for this please see the example [here](https://docs.oracle.com/javase/8/docs/technotes/tools/windows/java.html):

> 
> The following examples show how to set the maximum allowed size of allocated memory to 80 MB using various units:
> 
> -Xmx83886080 
> -Xmx81920k 
> -Xmx80m

Although the Spark memory config is in MiB.

### Does this PR introduce _any_ user-facing change?

Yes, before this PR when no suffix was given the `XmX` and `Xms` JVM options could have been configured to the 1/1024 of the valid amount because of the conversion difference between the units (bytes and megabytes). 

This could happen in only in client mode. So the followings are affected:
- all the use cases when some kind of REPL is started: `spark-shell`, `spark-sql`, `pyspark`, `sparkR` and `beeline` as the result of the changes done in `SparkClassCommandBuilder`
- application submits via the `spark-submit` (only in client mode) as the result of the changes done in `SparkSubmitCommandBuilder` 

The fact the limit to start an application is 471859200 bytes (and this number is already long enough and inconvenient to calculate with) is decreasing the number of affected cases. 

### How was this patch tested?

####  With unit test

See `SparkSubmitCommandBuilderSuite`. 

#### With a manual testing

By executing a Spark example. 

Without my change and without explicit suffix unit:

```
$ ./bin/spark-submit  --driver-memory 500 --class org.apache.spark.examples.SparkPi examples/target/original-spark-examples_2.12-3.1.0-SNAPSHOT.jar 1000
Error occurred during initialization of VM
Too small initial heap
```

You can see from the error above that it is not the Spark check for the memory is triggered as with the contra test (still without my change, but with suffix is given but a too low memory is set):
```
$  ./bin/spark-submit  --driver-memory 300m --class org.apache.spark.examples.SparkPi examples/target/original-spark-examples_2.12-3.1.0-SNAPSHOT.jar 1000
...
20/07/13 20:51:15 ERROR SparkContext: Error initializing SparkContext.
java.lang.IllegalArgumentException: System memory 301465600 must be at least 471859200. Please increase heap size using the --driver-memory option or spark.driver.memory in Spark configuration.
	at org.apache.spark.memory.UnifiedMemoryManager$.getMaxMemory(UnifiedMemoryManager.scala:221)
```

And after this PR running the first case (without explicit suffix unit):
```
$ ./bin/spark-submit  --driver-memory 500 --class org.apache.spark.examples.SparkPi examples/target/original-spark-examples_2.12-3.1.0-SNAPSHOT.jar 1000
...
20/07/13 20:57:12 INFO TaskSetManager: Finished task 995.0 in stage 0.0 (TID 995) in 419 ms on 192.168.1.210 (executor driver) (999/1000)
20/07/13 20:57:12 INFO Executor: Finished task 999.0 in stage 0.0 (TID 999). 914 bytes result sent to driver
20/07/13 20:57:12 INFO TaskSetManager: Finished task 999.0 in stage 0.0 (TID 999) in 242 ms on 192.168.1.210 (executor driver) (1000/1000)
20/07/13 20:57:12 INFO TaskSchedulerImpl: Removed TaskSet 0.0, whose tasks have all completed, from pool
20/07/13 20:57:12 INFO DAGScheduler: ResultStage 0 (reduce at SparkPi.scala:38) finished in 45.892 s
20/07/13 20:57:12 INFO DAGScheduler: Job 0 is finished. Cancelling potential speculative or zombie tasks for this job
20/07/13 20:57:12 INFO TaskSchedulerImpl: Killing all running tasks in stage 0: Stage finished
20/07/13 20:57:12 INFO DAGScheduler: Job 0 finished: reduce at SparkPi.scala:38, took 45.967945 s
Pi is roughly 3.1417498714174985
20/07/13 20:57:12 INFO SparkUI: Stopped Spark web UI at http://192.168.1.210:4040
20/07/13 20:57:12 INFO MapOutputTrackerMasterEndpoint: MapOutputTrackerMasterEndpoint stopped!
20/07/13 20:57:12 INFO MemoryStore: MemoryStore cleared
20/07/13 20:57:12 INFO BlockManager: BlockManager stopped
20/07/13 20:57:12 INFO BlockManagerMaster: BlockManagerMaster stopped
20/07/13 20:57:12 INFO OutputCommitCoordinator$OutputCommitCoordinatorEndpoint: OutputCommitCoordinator stopped!
20/07/13 20:57:12 INFO SparkContext: Successfully stopped SparkContext
20/07/13 20:57:12 INFO ShutdownHookManager: Shutdown hook called
20/07/13 20:57:12 INFO ShutdownHookManager: Deleting directory /private/var/folders/t_/fr_vqcyx23vftk81ftz1k5hw0000gn/T/spark-02c73ca4-ff94-422f-a8dc-39d88365d391
20/07/13 20:57:12 INFO ShutdownHookManager: Deleting directory /private/var/folders/t_/fr_vqcyx23vftk81ftz1k5hw0000gn/T/spark-fa723796-b3a8-4d5b-94c7-65752cd653bd
```

And even `jps` shows the correct value:
```
$ jps -lvV
25269 org.apache.spark.deploy.SparkSubmit -Xmx500m
...
```