### PR TITLE
[SPARK-24983][SQL] limit number of leaf expressions in a single project when collapse project to prevent driver oom

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -734,12 +734,6 @@ object CollapseProject extends Rule[LogicalPlan] {
     }
   }
 
-  private def numberOfLeafExpressions(projectList: Seq[Expression]): Long = {
-    projectList
-      .map(expr => if (expr.children.nonEmpty) numberOfLeafExpressions(expr.children) else 1)
-      .sum
-  }
-
   private def collectAliases(projectList: Seq[NamedExpression]): AttributeMap[Alias] = {
     AttributeMap(projectList.collect {
       case a: Alias => a.toAttribute -> a

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -245,6 +245,15 @@ object SQLConf {
     .stringConf
     .createOptional
 
+  val OPTIMIZER_COLLAPSE_PROJECT_EXPRESSION_THRESHOLD =
+    buildConf("spark.sql.optimizer.collapseProjectExpressionThreshold")
+      .internal()
+      .doc("Sets a threshold for the size of expressions when collpase project, if the current " +
+        "project has more expressions than the threshold then the project won't collapse. " +
+        "Set to -1 to disable.")
+      .intConf
+      .createWithDefault(1000)
+
   val DYNAMIC_PARTITION_PRUNING_ENABLED =
     buildConf("spark.sql.optimizer.dynamicPartitionPruning.enabled")
       .doc("When true, we will generate predicate for partition column when it's used as join key")
@@ -2779,6 +2788,9 @@ class SQLConf extends Serializable with Logging {
   def optimizerPlanChangeRules: Option[String] = getConf(OPTIMIZER_PLAN_CHANGE_LOG_RULES)
 
   def optimizerPlanChangeBatches: Option[String] = getConf(OPTIMIZER_PLAN_CHANGE_LOG_BATCHES)
+
+  def optimizerCollapseProjectExpressionThreshold: Int =
+    getConf(OPTIMIZER_COLLAPSE_PROJECT_EXPRESSION_THRESHOLD)
 
   def dynamicPartitionPruningEnabled: Boolean = getConf(DYNAMIC_PARTITION_PRUNING_ENABLED)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?

Spark sql catalyst optimizer has a rule CollapseProject, it will try to collapse multi projects to a single one if possible. But the collapsed project may have more leaf expressions than the origin project. In the worst case the number of leaf expressions will grow 
exponentially, and will lead to driver oom. We could limit the max number of leaf expression a single project can have to prevent this. The logical is that if the project has more than 1000 leaf expressions, there is a risk to continue collapse it. So we think this single project is very complex and we stop collapse it. But other simple project can still collapse.


### Why are the changes needed?
refer to https://issues.apache.org/jira/browse/SPARK-24983 or the unit test added, collapse project optimizer may cause driver oom if leaf expressions grow exponentially.
As we can see in JIRA there is a closed PR: https://github.com/apache/spark/pull/21993 intend to fix this. There is a comment that we should black list "case when" in collapse project, but any kind of sql may lead to the memory problem(like the ut case), and there is a workaround to exclude the collapse project optimizer, but I think this rule is necessary which could improve performance. And it is hard to decide whether we should exclude this rule ahead of time.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add a unit test to check whether the query collapse to two project. And all the existing UT passed in CollapseProjectSuite
