### PR TITLE
[WIP][TESTS] Enable test-dependencies.sh and Unidoc test in Jenkins jobs

### DIFF
--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -738,7 +738,7 @@ def main():
     # if "DOCS" in changed_modules and test_env == "amplab_jenkins":
     #    build_spark_documentation()
 
-    if any(m.should_run_build_tests for m in test_modules):
+    if any(m.should_run_build_tests for m in test_modules) and test_env != "amplab_jenkins":
         run_build_tests()
 
     # spark build

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -739,7 +739,7 @@ def main():
     # if "DOCS" in changed_modules and test_env == "amplab_jenkins":
     #    build_spark_documentation()
 
-    if any(m.should_run_build_tests for m in test_modules) and test_env != "amplab_jenkins":
+    if any(m.should_run_build_tests for m in test_modules):
         run_build_tests()
 
     # spark build

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -387,8 +387,7 @@ def build_spark_assembly_sbt(extra_profiles, checkstyle=False):
     if checkstyle:
         run_java_style_checks(build_profiles)
 
-    if not os.environ.get("AMPLAB_JENKINS"):
-        build_spark_unidoc_sbt(extra_profiles)
+    build_spark_unidoc_sbt(extra_profiles)
 
 
 def build_apache_spark(build_tool, extra_profiles):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Seems like Jenkins machines came back to normal. Maybe we should just re-enable dependency test and Javadoc/Scaladoc build in Jenkins for simplicity. 

Now, without corner case exceptions, we can merge if Jenkins or GitHub Actions build pass without depending on each other for dependency testing or Unidoc.

### Why are the changes needed?

For simplicity.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Jenkins will test it here.