### PR TITLE
[SPARK-32309][PYSPARK] Import missing sys import

### DIFF
--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -5736,6 +5736,7 @@ class VarianceThresholdSelectorModel(JavaModel, _VarianceThresholdSelectorParams
 
 if __name__ == "__main__":
     import doctest
+    import sys
     import tempfile
 
     import pyspark.ml.feature


### PR DESCRIPTION
# What changes were proposed in this pull request?

While seeing if we can use mypy for checking the Python types, I've stumbled across this missing import:
https://github.com/apache/spark/blob/34fa913311bc1730015f1af111ff4a03c2bad9f6/python/pyspark/ml/feature.py#L5773-L5774

### Why are the changes needed?

The `import` is required because it's used.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual.