### PR TITLE
[SPARK-32311][PYSPARK][TESTS] Remove duplicate import

### DIFF
--- a/python/pyspark/sql/tests/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/test_pandas_udf_scalar.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import datetime
 import os
 import random
 import shutil


### PR DESCRIPTION
### What changes were proposed in this pull request?

`datetime` is already imported a few lines below :)

https://github.com/apache/spark/blob/ce27cc54c1b2e533cd91e31f2414f3e0a172c328/python/pyspark/sql/tests/test_pandas_udf_scalar.py#L24

### Why are the changes needed?

This is the last instance of the duplicate import.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual.