### PR TITLE
[SPARK-32363][PYTHON][BUILD] Fix flakiness in pip package testing in Jenkins

### DIFF
--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -75,19 +75,13 @@ for python in "${PYTHON_EXECS[@]}"; do
     echo "Using $VIRTUALENV_BASE for virtualenv"
     VIRTUALENV_PATH="$VIRTUALENV_BASE"/$python
     rm -rf "$VIRTUALENV_PATH"
-    USE_CONDA_CMD=0
     if [ -n "$USE_CONDA" ]; then
       if [ -f "$CONDA_PREFIX/etc/profile.d/conda.sh" ]; then
         # See also https://github.com/conda/conda/issues/7980
-        USE_CONDA_CMD=1
         source "$CONDA_PREFIX/etc/profile.d/conda.sh"
       fi
       conda create -y -p "$VIRTUALENV_PATH" python=$python numpy pandas pip setuptools
-      if [ $USE_CONDA_CMD = 1 ]; then
-        conda activate "$VIRTUALENV_PATH"
-      else
-        source activate "$VIRTUALENV_PATH"
-      fi
+      source activate "$VIRTUALENV_PATH" || (echo "Falling back to 'conda activate'" && conda activate "$VIRTUALENV_PATH")
     else
       mkdir -p "$VIRTUALENV_PATH"
       virtualenv --python=$python "$VIRTUALENV_PATH"
@@ -130,11 +124,7 @@ for python in "${PYTHON_EXECS[@]}"; do
 
     # conda / virtualenv environments need to be deactivated differently
     if [ -n "$USE_CONDA" ]; then
-      if [ $USE_CONDA_CMD = 1 ]; then
-        conda deactivate
-      else
-        source deactivate
-      fi
+      source deactivate || (echo "Falling back to 'conda deactivate'" && conda deactivate)
     else
       deactivate
     fi

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -103,6 +103,7 @@ for python in "${PYTHON_EXECS[@]}"; do
     # Delete the egg info file if it exists, this can cache the setup file.
     rm -rf pyspark.egg-info || echo "No existing egg info file, skipping deletion"
     # Also delete .local in case it was already installed via --user.
+    pip show pyspark
     rm -rf "$(python3 -m site --user-site)/pyspark*" || echo "No existing PySpark installation at user site-packages."
     python3 setup.py sdist
 

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -118,6 +118,8 @@ for python in "${PYTHON_EXECS[@]}"; do
     python3 "$FWDIR"/dev/pip-sanity-check.py
     echo "Run the tests for context.py"
     python3 -c "import pyspark; print(pyspark.__version__); print(pyspark.__file__)"
+    echo $CONDA_DEFAULT_ENV
+    conda env list
     python3 "$FWDIR"/python/pyspark/context.py
 
     cd "$FWDIR"

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -108,6 +108,8 @@ for python in "${PYTHON_EXECS[@]}"; do
     fi
     # Do the actual installation
     cd "$FWDIR"
+    echo `python3 -m site --user-site`
+    ls -al `python3 -m site --user-site`
     $install_command
 
     cd /

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -63,7 +63,7 @@ fi
 PYSPARK_VERSION=$(python3 -c "exec(open('python/pyspark/version.py').read());print(__version__)")
 PYSPARK_DIST="$FWDIR/python/dist/pyspark-$PYSPARK_VERSION.tar.gz"
 # The pip install options we use for all the pip commands
-PIP_OPTIONS="--user --upgrade --no-cache-dir --force-reinstall "
+PIP_OPTIONS="--upgrade --no-cache-dir --force-reinstall"
 # Test both regular user and edit/dev install modes.
 PIP_COMMANDS=("pip install $PIP_OPTIONS $PYSPARK_DIST"
 	      "pip install $PIP_OPTIONS -e python/")
@@ -75,13 +75,19 @@ for python in "${PYTHON_EXECS[@]}"; do
     echo "Using $VIRTUALENV_BASE for virtualenv"
     VIRTUALENV_PATH="$VIRTUALENV_BASE"/$python
     rm -rf "$VIRTUALENV_PATH"
+    USE_CONDA_CMD=0
     if [ -n "$USE_CONDA" ]; then
       if [ -f "$CONDA_PREFIX/etc/profile.d/conda.sh" ]; then
         # See also https://github.com/conda/conda/issues/7980
+        USE_CONDA_CMD=1
         source "$CONDA_PREFIX/etc/profile.d/conda.sh"
       fi
       conda create -y -p "$VIRTUALENV_PATH" python=$python numpy pandas pip setuptools
-      conda activate "$VIRTUALENV_PATH" || (echo "Falling back to 'source activate'" && source activate "$VIRTUALENV_PATH")
+      if [ $USE_CONDA_CMD = 1 ]; then
+        conda activate "$VIRTUALENV_PATH"
+      else
+        source activate "$VIRTUALENV_PATH"
+      fi
     else
       mkdir -p "$VIRTUALENV_PATH"
       virtualenv --python=$python "$VIRTUALENV_PATH"
@@ -96,8 +102,8 @@ for python in "${PYTHON_EXECS[@]}"; do
     cd "$FWDIR"/python
     # Delete the egg info file if it exists, this can cache the setup file.
     rm -rf pyspark.egg-info || echo "No existing egg info file, skipping deletion"
-    # Also, delete the symbolic link if exists. It can be left over from the previous editable mode installation.
-    python3 -c "from distutils.sysconfig import get_python_lib; import os; f = os.path.join(get_python_lib(), 'pyspark.egg-link'); os.unlink(f) if os.path.isfile(f) else 0"
+    # Also delete .local in case it was already installed via --user.
+    rm -rf "$(python3 -m site --user-site)/pyspark*" || echo "No existing PySpark installation at user site-packages."
     python3 setup.py sdist
 
 
@@ -116,7 +122,6 @@ for python in "${PYTHON_EXECS[@]}"; do
     cd /
 
     echo "Run basic sanity check on pip installed version with spark-submit"
-    export PATH="$(python3 -m site --user-base)/bin:$PATH"
     spark-submit "$FWDIR"/dev/pip-sanity-check.py
     echo "Run basic sanity check with import based"
     python3 "$FWDIR"/dev/pip-sanity-check.py
@@ -127,7 +132,11 @@ for python in "${PYTHON_EXECS[@]}"; do
 
     # conda / virtualenv environments need to be deactivated differently
     if [ -n "$USE_CONDA" ]; then
-      conda deactivate || (echo "Falling back to 'source deactivate'" && source deactivate)
+      if [ $USE_CONDA_CMD = 1 ]; then
+        conda deactivate
+      else
+        source deactivate
+      fi
     else
       deactivate
     fi

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -63,7 +63,7 @@ fi
 PYSPARK_VERSION=$(python3 -c "exec(open('python/pyspark/version.py').read());print(__version__)")
 PYSPARK_DIST="$FWDIR/python/dist/pyspark-$PYSPARK_VERSION.tar.gz"
 # The pip install options we use for all the pip commands
-PIP_OPTIONS="--upgrade --no-cache-dir --force-reinstall"
+PIP_OPTIONS="--upgrade --no-cache-dir --force-reinstall --ignore-installed"
 # Test both regular user and edit/dev install modes.
 PIP_COMMANDS=("pip install $PIP_OPTIONS $PYSPARK_DIST")
 
@@ -117,6 +117,7 @@ for python in "${PYTHON_EXECS[@]}"; do
     echo "Run basic sanity check with import based"
     python3 "$FWDIR"/dev/pip-sanity-check.py
     echo "Run the tests for context.py"
+    python3 -c "import pyspark; print(pyspark.__version__); print(pyspark.__file__)"
     python3 "$FWDIR"/python/pyspark/context.py
 
     cd "$FWDIR"

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -80,6 +80,7 @@ for python in "${PYTHON_EXECS[@]}"; do
         source "$CONDA_PREFIX/etc/profile.d/conda.sh"
       fi
       conda create -y -p "$VIRTUALENV_PATH" python=$python numpy pandas pip setuptools
+      conda env list
       source activate "$VIRTUALENV_PATH" || (echo "Falling back to 'conda activate'" && conda activate "$VIRTUALENV_PATH")
     else
       mkdir -p "$VIRTUALENV_PATH"
@@ -91,6 +92,7 @@ for python in "${PYTHON_EXECS[@]}"; do
       pip install --upgrade pip wheel numpy
     fi
 
+    conda env list
     echo "Creating pip installable source dist"
     cd "$FWDIR"/python
     # Delete the egg info file if it exists, this can cache the setup file.
@@ -121,7 +123,6 @@ for python in "${PYTHON_EXECS[@]}"; do
     echo "Run the tests for context.py"
     python3 -c "import pyspark; print(pyspark.__version__); print(pyspark.__file__)"
     echo $CONDA_DEFAULT_ENV
-    conda env list
     python3 "$FWDIR"/python/pyspark/context.py
 
     cd "$FWDIR"

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -65,8 +65,7 @@ PYSPARK_DIST="$FWDIR/python/dist/pyspark-$PYSPARK_VERSION.tar.gz"
 # The pip install options we use for all the pip commands
 PIP_OPTIONS="--upgrade --no-cache-dir --force-reinstall --ignore-installed"
 # Test both regular user and edit/dev install modes.
-PIP_COMMANDS=("pip install $PIP_OPTIONS $PYSPARK_DIST"
-	      "pip install $PIP_OPTIONS -e python/")
+PIP_COMMANDS=("pip install $PIP_OPTIONS $PYSPARK_DIST")
 
 for python in "${PYTHON_EXECS[@]}"; do
   for install_command in "${PIP_COMMANDS[@]}"; do

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -63,7 +63,7 @@ fi
 PYSPARK_VERSION=$(python3 -c "exec(open('python/pyspark/version.py').read());print(__version__)")
 PYSPARK_DIST="$FWDIR/python/dist/pyspark-$PYSPARK_VERSION.tar.gz"
 # The pip install options we use for all the pip commands
-PIP_OPTIONS="--upgrade --no-cache-dir --force-reinstall"
+PIP_OPTIONS="--upgrade --no-cache-dir --force-reinstall --ignore-installed"
 # Test both regular user and edit/dev install modes.
 PIP_COMMANDS=("pip install $PIP_OPTIONS $PYSPARK_DIST"
 	      "pip install $PIP_OPTIONS -e python/")
@@ -102,9 +102,6 @@ for python in "${PYTHON_EXECS[@]}"; do
     cd "$FWDIR"/python
     # Delete the egg info file if it exists, this can cache the setup file.
     rm -rf pyspark.egg-info || echo "No existing egg info file, skipping deletion"
-    # Also delete .local in case it was already installed via --user.
-    pip show pyspark
-    rm -rf "$(python3 -m site --user-site)/pyspark*" || echo "No existing PySpark installation at user site-packages."
     python3 setup.py sdist
 
 

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -63,7 +63,7 @@ fi
 PYSPARK_VERSION=$(python3 -c "exec(open('python/pyspark/version.py').read());print(__version__)")
 PYSPARK_DIST="$FWDIR/python/dist/pyspark-$PYSPARK_VERSION.tar.gz"
 # The pip install options we use for all the pip commands
-PIP_OPTIONS="--upgrade --no-cache-dir --force-reinstall --ignore-installed"
+PIP_OPTIONS="--upgrade --no-cache-dir --force-reinstall"
 # Test both regular user and edit/dev install modes.
 PIP_COMMANDS=("pip install $PIP_OPTIONS $PYSPARK_DIST")
 

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -68,6 +68,8 @@ PIP_OPTIONS="--upgrade --no-cache-dir --force-reinstall"
 PIP_COMMANDS=("pip install $PIP_OPTIONS $PYSPARK_DIST"
 	      "pip install $PIP_OPTIONS -e python/")
 
+# Jenkins has PySpark installed under user sitepackages shared for some reasons.
+# In this test, explicitly exclude user sitepackages to prevent side effects
 export PYTHONNOUSERSITE=1
 
 for python in "${PYTHON_EXECS[@]}"; do

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -63,9 +63,12 @@ fi
 PYSPARK_VERSION=$(python3 -c "exec(open('python/pyspark/version.py').read());print(__version__)")
 PYSPARK_DIST="$FWDIR/python/dist/pyspark-$PYSPARK_VERSION.tar.gz"
 # The pip install options we use for all the pip commands
-PIP_OPTIONS="--upgrade --no-cache-dir --force-reinstall --ignore-installed"
+PIP_OPTIONS="--upgrade --no-cache-dir --force-reinstall"
 # Test both regular user and edit/dev install modes.
-PIP_COMMANDS=("pip install $PIP_OPTIONS $PYSPARK_DIST")
+PIP_COMMANDS=("pip install $PIP_OPTIONS $PYSPARK_DIST"
+	      "pip install $PIP_OPTIONS -e python/")
+
+export PYTHONNOUSERSITE=1
 
 for python in "${PYTHON_EXECS[@]}"; do
   for install_command in "${PIP_COMMANDS[@]}"; do
@@ -80,7 +83,6 @@ for python in "${PYTHON_EXECS[@]}"; do
         source "$CONDA_PREFIX/etc/profile.d/conda.sh"
       fi
       conda create -y -p "$VIRTUALENV_PATH" python=$python numpy pandas pip setuptools
-      conda env list
       source activate "$VIRTUALENV_PATH" || (echo "Falling back to 'conda activate'" && conda activate "$VIRTUALENV_PATH")
     else
       mkdir -p "$VIRTUALENV_PATH"
@@ -92,7 +94,6 @@ for python in "${PYTHON_EXECS[@]}"; do
       pip install --upgrade pip wheel numpy
     fi
 
-    conda env list
     echo "Creating pip installable source dist"
     cd "$FWDIR"/python
     # Delete the egg info file if it exists, this can cache the setup file.
@@ -110,8 +111,6 @@ for python in "${PYTHON_EXECS[@]}"; do
     fi
     # Do the actual installation
     cd "$FWDIR"
-    echo `python3 -m site --user-site`
-    ls -al `python3 -m site --user-site`
     $install_command
 
     cd /
@@ -121,8 +120,6 @@ for python in "${PYTHON_EXECS[@]}"; do
     echo "Run basic sanity check with import based"
     python3 "$FWDIR"/dev/pip-sanity-check.py
     echo "Run the tests for context.py"
-    python3 -c "import pyspark; print(pyspark.__version__); print(pyspark.__file__)"
-    echo $CONDA_DEFAULT_ENV
     python3 "$FWDIR"/python/pyspark/context.py
 
     cd "$FWDIR"

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -711,61 +711,61 @@ def main():
     setup_test_environ(test_environ)
 
     should_run_java_style_checks = False
-    if not should_only_test_modules:
-        # license checks
-        run_apache_rat_checks()
-
-        # style checks
-        if not changed_files or any(f.endswith(".scala")
-                                    or f.endswith("scalastyle-config.xml")
-                                    for f in changed_files):
-            run_scala_style_checks(extra_profiles)
-        if not changed_files or any(f.endswith(".java")
-                                    or f.endswith("checkstyle.xml")
-                                    or f.endswith("checkstyle-suppressions.xml")
-                                    for f in changed_files):
-            # Run SBT Checkstyle after the build to prevent a side-effect to the build.
-            should_run_java_style_checks = True
-        if not changed_files or any(f.endswith("lint-python")
-                                    or f.endswith("tox.ini")
-                                    or f.endswith(".py")
-                                    for f in changed_files):
-            run_python_style_checks()
-        if not changed_files or any(f.endswith(".R")
-                                    or f.endswith("lint-r")
-                                    or f.endswith(".lintr")
-                                    for f in changed_files):
-            run_sparkr_style_checks()
-
-    # determine if docs were changed and if we're inside the amplab environment
-    # note - the below commented out until *all* Jenkins workers can get `jekyll` installed
-    # if "DOCS" in changed_modules and test_env == "amplab_jenkins":
-    #    build_spark_documentation()
-
-    if any(m.should_run_build_tests for m in test_modules) and test_env != "amplab_jenkins":
-        run_build_tests()
+    # if not should_only_test_modules:
+    #     # license checks
+    #     run_apache_rat_checks()
+    #
+    #     # style checks
+    #     if not changed_files or any(f.endswith(".scala")
+    #                                 or f.endswith("scalastyle-config.xml")
+    #                                 for f in changed_files):
+    #         run_scala_style_checks(extra_profiles)
+    #     if not changed_files or any(f.endswith(".java")
+    #                                 or f.endswith("checkstyle.xml")
+    #                                 or f.endswith("checkstyle-suppressions.xml")
+    #                                 for f in changed_files):
+    #         # Run SBT Checkstyle after the build to prevent a side-effect to the build.
+    #         should_run_java_style_checks = True
+    #     if not changed_files or any(f.endswith("lint-python")
+    #                                 or f.endswith("tox.ini")
+    #                                 or f.endswith(".py")
+    #                                 for f in changed_files):
+    #         run_python_style_checks()
+    #     if not changed_files or any(f.endswith(".R")
+    #                                 or f.endswith("lint-r")
+    #                                 or f.endswith(".lintr")
+    #                                 for f in changed_files):
+    #         run_sparkr_style_checks()
+    #
+    # # determine if docs were changed and if we're inside the amplab environment
+    # # note - the below commented out until *all* Jenkins workers can get `jekyll` installed
+    # # if "DOCS" in changed_modules and test_env == "amplab_jenkins":
+    # #    build_spark_documentation()
+    #
+    # if any(m.should_run_build_tests for m in test_modules) and test_env != "amplab_jenkins":
+    #     run_build_tests()
 
     # spark build
     build_apache_spark(build_tool, extra_profiles)
 
-    # backwards compatibility checks
-    if build_tool == "sbt":
-        # Note: compatibility tests only supported in sbt for now
-        detect_binary_inop_with_mima(extra_profiles)
-        # Since we did not build assembly/package before running dev/mima, we need to
-        # do it here because the tests still rely on it; see SPARK-13294 for details.
-        build_spark_assembly_sbt(extra_profiles, should_run_java_style_checks)
+    # # backwards compatibility checks
+    # if build_tool == "sbt":
+    #     # Note: compatibility tests only supported in sbt for now
+    #     detect_binary_inop_with_mima(extra_profiles)
+    #     # Since we did not build assembly/package before running dev/mima, we need to
+    #     # do it here because the tests still rely on it; see SPARK-13294 for details.
+    #     build_spark_assembly_sbt(extra_profiles, should_run_java_style_checks)
 
     # run the test suites
-    run_scala_tests(build_tool, extra_profiles, test_modules, excluded_tags, included_tags)
+    # run_scala_tests(build_tool, extra_profiles, test_modules, excluded_tags, included_tags)
 
     modules_with_python_tests = [m for m in test_modules if m.python_test_goals]
     if modules_with_python_tests:
         # We only run PySpark tests with coverage report in one specific job with
         # Spark master with SBT in Jenkins.
         is_sbt_master_job = "SPARK_MASTER_SBT_HADOOP_2_7" in os.environ
-        run_python_tests(
-            modules_with_python_tests, opts.parallelism, with_coverage=is_sbt_master_job)
+        # run_python_tests(
+        #     modules_with_python_tests, opts.parallelism, with_coverage=is_sbt_master_job)
         run_python_packaging_tests()
     if any(m.should_run_r_tests for m in test_modules):
         run_sparkr_tests()

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -711,64 +711,64 @@ def main():
     setup_test_environ(test_environ)
 
     should_run_java_style_checks = False
-    # if not should_only_test_modules:
-    #     # license checks
-    #     run_apache_rat_checks()
-    #
-    #     # style checks
-    #     if not changed_files or any(f.endswith(".scala")
-    #                                 or f.endswith("scalastyle-config.xml")
-    #                                 for f in changed_files):
-    #         run_scala_style_checks(extra_profiles)
-    #     if not changed_files or any(f.endswith(".java")
-    #                                 or f.endswith("checkstyle.xml")
-    #                                 or f.endswith("checkstyle-suppressions.xml")
-    #                                 for f in changed_files):
-    #         # Run SBT Checkstyle after the build to prevent a side-effect to the build.
-    #         should_run_java_style_checks = True
-    #     if not changed_files or any(f.endswith("lint-python")
-    #                                 or f.endswith("tox.ini")
-    #                                 or f.endswith(".py")
-    #                                 for f in changed_files):
-    #         run_python_style_checks()
-    #     if not changed_files or any(f.endswith(".R")
-    #                                 or f.endswith("lint-r")
-    #                                 or f.endswith(".lintr")
-    #                                 for f in changed_files):
-    #         run_sparkr_style_checks()
-    #
-    # # determine if docs were changed and if we're inside the amplab environment
-    # # note - the below commented out until *all* Jenkins workers can get `jekyll` installed
-    # # if "DOCS" in changed_modules and test_env == "amplab_jenkins":
-    # #    build_spark_documentation()
-    #
-    # if any(m.should_run_build_tests for m in test_modules) and test_env != "amplab_jenkins":
-    #     run_build_tests()
+    if not should_only_test_modules:
+        # license checks
+        run_apache_rat_checks()
+
+        # style checks
+        if not changed_files or any(f.endswith(".scala")
+                                    or f.endswith("scalastyle-config.xml")
+                                    for f in changed_files):
+            run_scala_style_checks(extra_profiles)
+        if not changed_files or any(f.endswith(".java")
+                                    or f.endswith("checkstyle.xml")
+                                    or f.endswith("checkstyle-suppressions.xml")
+                                    for f in changed_files):
+            # Run SBT Checkstyle after the build to prevent a side-effect to the build.
+            should_run_java_style_checks = True
+        if not changed_files or any(f.endswith("lint-python")
+                                    or f.endswith("tox.ini")
+                                    or f.endswith(".py")
+                                    for f in changed_files):
+            run_python_style_checks()
+        if not changed_files or any(f.endswith(".R")
+                                    or f.endswith("lint-r")
+                                    or f.endswith(".lintr")
+                                    for f in changed_files):
+            run_sparkr_style_checks()
+
+    # determine if docs were changed and if we're inside the amplab environment
+    # note - the below commented out until *all* Jenkins workers can get `jekyll` installed
+    # if "DOCS" in changed_modules and test_env == "amplab_jenkins":
+    #    build_spark_documentation()
+
+    if any(m.should_run_build_tests for m in test_modules) and test_env != "amplab_jenkins":
+        run_build_tests()
 
     # spark build
     build_apache_spark(build_tool, extra_profiles)
 
-    # # backwards compatibility checks
-    # if build_tool == "sbt":
-    #     # Note: compatibility tests only supported in sbt for now
-    #     detect_binary_inop_with_mima(extra_profiles)
-    #     # Since we did not build assembly/package before running dev/mima, we need to
-    #     # do it here because the tests still rely on it; see SPARK-13294 for details.
-    #     build_spark_assembly_sbt(extra_profiles, should_run_java_style_checks)
+    # backwards compatibility checks
+    if build_tool == "sbt":
+        # Note: compatibility tests only supported in sbt for now
+        detect_binary_inop_with_mima(extra_profiles)
+        # Since we did not build assembly/package before running dev/mima, we need to
+        # do it here because the tests still rely on it; see SPARK-13294 for details.
+        build_spark_assembly_sbt(extra_profiles, should_run_java_style_checks)
 
     # run the test suites
-    # run_scala_tests(build_tool, extra_profiles, test_modules, excluded_tags, included_tags)
+    run_scala_tests(build_tool, extra_profiles, test_modules, excluded_tags, included_tags)
 
     modules_with_python_tests = [m for m in test_modules if m.python_test_goals]
     if modules_with_python_tests:
         # We only run PySpark tests with coverage report in one specific job with
         # Spark master with SBT in Jenkins.
         is_sbt_master_job = "SPARK_MASTER_SBT_HADOOP_2_7" in os.environ
-        # run_python_tests(
-        #     modules_with_python_tests, opts.parallelism, with_coverage=is_sbt_master_job)
+        run_python_tests(
+            modules_with_python_tests, opts.parallelism, with_coverage=is_sbt_master_job)
         run_python_packaging_tests()
-    # if any(m.should_run_r_tests for m in test_modules):
-        # run_sparkr_tests()
+    if any(m.should_run_r_tests for m in test_modules):
+        run_sparkr_tests()
 
 
 def _test():

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -711,61 +711,61 @@ def main():
     setup_test_environ(test_environ)
 
     should_run_java_style_checks = False
-    # if not should_only_test_modules:
-    #     # license checks
-    #     run_apache_rat_checks()
-    #
-    #     # style checks
-    #     if not changed_files or any(f.endswith(".scala")
-    #                                 or f.endswith("scalastyle-config.xml")
-    #                                 for f in changed_files):
-    #         run_scala_style_checks(extra_profiles)
-    #     if not changed_files or any(f.endswith(".java")
-    #                                 or f.endswith("checkstyle.xml")
-    #                                 or f.endswith("checkstyle-suppressions.xml")
-    #                                 for f in changed_files):
-    #         # Run SBT Checkstyle after the build to prevent a side-effect to the build.
-    #         should_run_java_style_checks = True
-    #     if not changed_files or any(f.endswith("lint-python")
-    #                                 or f.endswith("tox.ini")
-    #                                 or f.endswith(".py")
-    #                                 for f in changed_files):
-    #         run_python_style_checks()
-    #     if not changed_files or any(f.endswith(".R")
-    #                                 or f.endswith("lint-r")
-    #                                 or f.endswith(".lintr")
-    #                                 for f in changed_files):
-    #         run_sparkr_style_checks()
-    #
-    # # determine if docs were changed and if we're inside the amplab environment
-    # # note - the below commented out until *all* Jenkins workers can get `jekyll` installed
-    # # if "DOCS" in changed_modules and test_env == "amplab_jenkins":
-    # #    build_spark_documentation()
-    #
-    # if any(m.should_run_build_tests for m in test_modules) and test_env != "amplab_jenkins":
-    #     run_build_tests()
+    if not should_only_test_modules:
+        # license checks
+        run_apache_rat_checks()
+
+        # style checks
+        if not changed_files or any(f.endswith(".scala")
+                                    or f.endswith("scalastyle-config.xml")
+                                    for f in changed_files):
+            run_scala_style_checks(extra_profiles)
+        if not changed_files or any(f.endswith(".java")
+                                    or f.endswith("checkstyle.xml")
+                                    or f.endswith("checkstyle-suppressions.xml")
+                                    for f in changed_files):
+            # Run SBT Checkstyle after the build to prevent a side-effect to the build.
+            should_run_java_style_checks = True
+        if not changed_files or any(f.endswith("lint-python")
+                                    or f.endswith("tox.ini")
+                                    or f.endswith(".py")
+                                    for f in changed_files):
+            run_python_style_checks()
+        if not changed_files or any(f.endswith(".R")
+                                    or f.endswith("lint-r")
+                                    or f.endswith(".lintr")
+                                    for f in changed_files):
+            run_sparkr_style_checks()
+
+    # determine if docs were changed and if we're inside the amplab environment
+    # note - the below commented out until *all* Jenkins workers can get `jekyll` installed
+    # if "DOCS" in changed_modules and test_env == "amplab_jenkins":
+    #    build_spark_documentation()
+
+    if any(m.should_run_build_tests for m in test_modules) and test_env != "amplab_jenkins":
+        run_build_tests()
 
     # spark build
     build_apache_spark(build_tool, extra_profiles)
 
-    # # backwards compatibility checks
-    # if build_tool == "sbt":
-    #     # Note: compatibility tests only supported in sbt for now
-    #     detect_binary_inop_with_mima(extra_profiles)
-    #     # Since we did not build assembly/package before running dev/mima, we need to
-    #     # do it here because the tests still rely on it; see SPARK-13294 for details.
-    #     build_spark_assembly_sbt(extra_profiles, should_run_java_style_checks)
+    # backwards compatibility checks
+    if build_tool == "sbt":
+        # Note: compatibility tests only supported in sbt for now
+        detect_binary_inop_with_mima(extra_profiles)
+        # Since we did not build assembly/package before running dev/mima, we need to
+        # do it here because the tests still rely on it; see SPARK-13294 for details.
+        build_spark_assembly_sbt(extra_profiles, should_run_java_style_checks)
 
     # run the test suites
-    # run_scala_tests(build_tool, extra_profiles, test_modules, excluded_tags, included_tags)
+    run_scala_tests(build_tool, extra_profiles, test_modules, excluded_tags, included_tags)
 
     modules_with_python_tests = [m for m in test_modules if m.python_test_goals]
     if modules_with_python_tests:
         # We only run PySpark tests with coverage report in one specific job with
         # Spark master with SBT in Jenkins.
         is_sbt_master_job = "SPARK_MASTER_SBT_HADOOP_2_7" in os.environ
-        # run_python_tests(
-        #     modules_with_python_tests, opts.parallelism, with_coverage=is_sbt_master_job)
+        run_python_tests(
+            modules_with_python_tests, opts.parallelism, with_coverage=is_sbt_master_job)
         run_python_packaging_tests()
     if any(m.should_run_r_tests for m in test_modules):
         run_sparkr_tests()

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -711,64 +711,64 @@ def main():
     setup_test_environ(test_environ)
 
     should_run_java_style_checks = False
-    if not should_only_test_modules:
-        # license checks
-        run_apache_rat_checks()
-
-        # style checks
-        if not changed_files or any(f.endswith(".scala")
-                                    or f.endswith("scalastyle-config.xml")
-                                    for f in changed_files):
-            run_scala_style_checks(extra_profiles)
-        if not changed_files or any(f.endswith(".java")
-                                    or f.endswith("checkstyle.xml")
-                                    or f.endswith("checkstyle-suppressions.xml")
-                                    for f in changed_files):
-            # Run SBT Checkstyle after the build to prevent a side-effect to the build.
-            should_run_java_style_checks = True
-        if not changed_files or any(f.endswith("lint-python")
-                                    or f.endswith("tox.ini")
-                                    or f.endswith(".py")
-                                    for f in changed_files):
-            run_python_style_checks()
-        if not changed_files or any(f.endswith(".R")
-                                    or f.endswith("lint-r")
-                                    or f.endswith(".lintr")
-                                    for f in changed_files):
-            run_sparkr_style_checks()
-
-    # determine if docs were changed and if we're inside the amplab environment
-    # note - the below commented out until *all* Jenkins workers can get `jekyll` installed
-    # if "DOCS" in changed_modules and test_env == "amplab_jenkins":
-    #    build_spark_documentation()
-
-    if any(m.should_run_build_tests for m in test_modules) and test_env != "amplab_jenkins":
-        run_build_tests()
+    # if not should_only_test_modules:
+    #     # license checks
+    #     run_apache_rat_checks()
+    #
+    #     # style checks
+    #     if not changed_files or any(f.endswith(".scala")
+    #                                 or f.endswith("scalastyle-config.xml")
+    #                                 for f in changed_files):
+    #         run_scala_style_checks(extra_profiles)
+    #     if not changed_files or any(f.endswith(".java")
+    #                                 or f.endswith("checkstyle.xml")
+    #                                 or f.endswith("checkstyle-suppressions.xml")
+    #                                 for f in changed_files):
+    #         # Run SBT Checkstyle after the build to prevent a side-effect to the build.
+    #         should_run_java_style_checks = True
+    #     if not changed_files or any(f.endswith("lint-python")
+    #                                 or f.endswith("tox.ini")
+    #                                 or f.endswith(".py")
+    #                                 for f in changed_files):
+    #         run_python_style_checks()
+    #     if not changed_files or any(f.endswith(".R")
+    #                                 or f.endswith("lint-r")
+    #                                 or f.endswith(".lintr")
+    #                                 for f in changed_files):
+    #         run_sparkr_style_checks()
+    #
+    # # determine if docs were changed and if we're inside the amplab environment
+    # # note - the below commented out until *all* Jenkins workers can get `jekyll` installed
+    # # if "DOCS" in changed_modules and test_env == "amplab_jenkins":
+    # #    build_spark_documentation()
+    #
+    # if any(m.should_run_build_tests for m in test_modules) and test_env != "amplab_jenkins":
+    #     run_build_tests()
 
     # spark build
     build_apache_spark(build_tool, extra_profiles)
 
-    # backwards compatibility checks
-    if build_tool == "sbt":
-        # Note: compatibility tests only supported in sbt for now
-        detect_binary_inop_with_mima(extra_profiles)
-        # Since we did not build assembly/package before running dev/mima, we need to
-        # do it here because the tests still rely on it; see SPARK-13294 for details.
-        build_spark_assembly_sbt(extra_profiles, should_run_java_style_checks)
+    # # backwards compatibility checks
+    # if build_tool == "sbt":
+    #     # Note: compatibility tests only supported in sbt for now
+    #     detect_binary_inop_with_mima(extra_profiles)
+    #     # Since we did not build assembly/package before running dev/mima, we need to
+    #     # do it here because the tests still rely on it; see SPARK-13294 for details.
+    #     build_spark_assembly_sbt(extra_profiles, should_run_java_style_checks)
 
     # run the test suites
-    run_scala_tests(build_tool, extra_profiles, test_modules, excluded_tags, included_tags)
+    # run_scala_tests(build_tool, extra_profiles, test_modules, excluded_tags, included_tags)
 
     modules_with_python_tests = [m for m in test_modules if m.python_test_goals]
     if modules_with_python_tests:
         # We only run PySpark tests with coverage report in one specific job with
         # Spark master with SBT in Jenkins.
         is_sbt_master_job = "SPARK_MASTER_SBT_HADOOP_2_7" in os.environ
-        run_python_tests(
-            modules_with_python_tests, opts.parallelism, with_coverage=is_sbt_master_job)
+        # run_python_tests(
+        #     modules_with_python_tests, opts.parallelism, with_coverage=is_sbt_master_job)
         run_python_packaging_tests()
-    if any(m.should_run_r_tests for m in test_modules):
-        run_sparkr_tests()
+    # if any(m.should_run_r_tests for m in test_modules):
+        # run_sparkr_tests()
 
 
 def _test():


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes:

- Don't use `--user` in pip packaging test
- Pull `source` out of the subshell, and place it first.
- Exclude user sitepackages in Python path during pip installation test

to address the flakiness of the pip packaging test in Jenkins.

(I think) #29116 caused this flakiness given my observation in the Jenkins log. I had to work around by specifying `--user` but it turned out that it does not properly work in old Conda on Jenkins for some reasons. Therefore, reverting this change back.

(I think) the installation at user site-packages affects other environments created by Conda in the old Conda version that Jenkins has. Seems it fails to isolate the environments for some reasons. So, it excludes user sitepackages in the Python path during the test.

In addition, #29116 also added some fallback logics of `conda (de)activate` and `source (de)activate` because Conda prefers to use `conda (de)activate` now per the official documentation and `source (de)activate` doesn't work for some reasons in certain environments (see also https://github.com/conda/conda/issues/7980). The problem was that `source` loads things to the current shell so does not affect the current shell. Therefore, this PR pulls `source` out of the subshell.

Disclaimer: I made the analysis purely based on Jenkins machine's log in this PR. It may have a different reason I missed during my observation.

### Why are the changes needed?

To make the build and tests pass in Jenkins.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Jenkins tests should test it out.