### PR TITLE
[SPARK-32291][SQL] COALESCE should not reduce the child parallelism if it contains a Join

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -79,8 +79,9 @@ abstract class Optimizer(catalogManager: CatalogManager)
         LimitPushDown,
         ColumnPruning,
         InferFiltersFromConstraints,
-        // Operator combine
+        // Add repartition
         RepartitionForCoalesceWithJoin,
+        // Operator combine
         CollapseRepartition,
         CollapseProject,
         CollapseWindow,
@@ -1810,7 +1811,7 @@ object OptimizeLimitZero extends Rule[LogicalPlan] {
 object RepartitionForCoalesceWithJoin extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan transform {
     case r @ Repartition(numPartitions, shuffle, child)
-      if !shuffle && child.find(_.isInstanceOf[Join]).isDefined =>
-      r.copy(child = Repartition(numPartitions, true, child))
+        if !shuffle && child.find(_.isInstanceOf[Join]).isDefined =>
+      r.copy(child = Repartition(numPartitions, shuffle = true, child))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Coalesce should not reduce the child parallelism if it contains a Join.
Add a new optimizer rule `RepartitionForCoalesceWithJoin` to add a Repartition if the child of Coalesce contains a Join.


### Why are the changes needed?
How to reproduce this issue:
```
spark.range(100).createTempView("t1")
spark.range(200).createTempView("t2")
spark.sql("set spark.sql.autoBroadcastJoinThreshold=0")
spark.sql("select /*+ COALESCE(1) */ t1.* from t1 join t2 on (t1.id = t2.id)").show
```
Before
![Screenshot_2020-07-15 test-sql-context - Details for Query 26(2)](https://user-images.githubusercontent.com/1853780/87517872-1363b000-c6b2-11ea-8611-94d64b60e1ec.png)
The number of partitions of SortMergeJoin is 1

After
![Screenshot_2020-07-15 test-sql-context - Details for Query 26(4)](https://user-images.githubusercontent.com/1853780/87517972-39895000-c6b2-11ea-941c-bfaa7b31938d.png)
The number of partitions of SortMergeJoin is 5.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Add a unit test.
