### PR TITLE
[SPARK-32331][SQL] Keep advanced statistics when pruning partitions

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
@@ -99,8 +99,9 @@ private[sql] object PruneFileSourcePartitions
         val prunedFsRelation =
           fsRelation.copy(location = prunedFileIndex)(fsRelation.sparkSession)
         // Change table stats based on the sizeInBytes of pruned files
-        val withStats = logicalRelation.catalogTable.map(_.copy(
-          stats = Some(CatalogStatistics(sizeInBytes = BigInt(prunedFileIndex.sizeInBytes)))))
+        val withStats = logicalRelation.catalogTable.map(ct => ct.copy(stats =
+          ct.stats.map(_.copy(sizeInBytes = BigInt(prunedFileIndex.sizeInBytes)))
+            .orElse(Some(CatalogStatistics(sizeInBytes = BigInt(prunedFileIndex.sizeInBytes))))))
         val prunedLogicalRelation = logicalRelation.copy(
           relation = prunedFsRelation, catalogTable = withStats)
         // Keep partition-pruning predicates so that they are visible in physical planning


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently the rule `PruneFileSourcePartitions` removes the advanced statistics (cardinality, column stats) of the underlying `LogicalRelation` and keeps only `sizeInBytes` as that is the only value we can be sure that is accurate when a partition pruning happens.
This PR changes that and keeps all statistics as they are a good upper limit estimates and by keeping them other rules that depend on the presence of these statistics (like `CostBasedJoinReorder`) can run.

### Why are the changes needed?
Performance improvement.

I measured nice improvement using a bit amended (spark.sql.cbo.enabled=true, spark.sql.cbo.joinReorder.enabled=true, analized source tables) TPCDSQueryBenchmark on scaleFactor=5 data with TPCDS queries:
Q10: 18%, Q17: 10%, Q18: 19%, Q25: 29%, Q29: 49%, Q30: 35%, Q37: 22%, Q50: 59%, Q65: 19%, Q69: 34%, Q73: 45%, Q76: 21%, Q81: 29%, Q82: 51%, Q91: 12%

Only 2 of the queries suffered performance degradation:
Q16: -19%, Q49: -18%

Please note that the % here are showing the difference due to this PR as the baseline was set with (spark.sql.cbo.enabled=true, spark.sql.cbo.joinReorder.enabled=true, analized source tables).

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing UTs and benchmarks.
