### PR TITLE
[SPARK-32337][SQL] Show initial plan in AQE plan tree string

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -588,7 +588,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
       addSuffix: Boolean,
       maxFields: Int,
       printOperatorId: Boolean): Unit = {
-    generateTreeString(0, Nil, append, verbose, "", addSuffix, maxFields, printOperatorId)
+    generateTreeString(0, Nil, append, verbose, "", addSuffix, maxFields, printOperatorId, 0)
   }
 
   /**
@@ -656,8 +656,9 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
       prefix: String = "",
       addSuffix: Boolean = false,
       maxFields: Int,
-      printNodeId: Boolean): Unit = {
-
+      printNodeId: Boolean,
+      indent: Int = 0): Unit = {
+    append("   " * indent)
     if (depth > 0) {
       lastChildren.init.foreach { isLast =>
         append(if (isLast) "   " else ":  ")
@@ -681,20 +682,20 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
     if (innerChildren.nonEmpty) {
       innerChildren.init.foreach(_.generateTreeString(
         depth + 2, lastChildren :+ children.isEmpty :+ false, append, verbose,
-        addSuffix = addSuffix, maxFields = maxFields, printNodeId = printNodeId))
+        addSuffix = addSuffix, maxFields = maxFields, printNodeId = printNodeId, indent = indent))
       innerChildren.last.generateTreeString(
         depth + 2, lastChildren :+ children.isEmpty :+ true, append, verbose,
-        addSuffix = addSuffix, maxFields = maxFields, printNodeId = printNodeId)
+        addSuffix = addSuffix, maxFields = maxFields, printNodeId = printNodeId, indent = indent)
     }
 
     if (children.nonEmpty) {
       children.init.foreach(_.generateTreeString(
         depth + 1, lastChildren :+ false, append, verbose, prefix, addSuffix,
-        maxFields, printNodeId = printNodeId)
+        maxFields, printNodeId = printNodeId, indent = indent)
       )
       children.last.generateTreeString(
         depth + 1, lastChildren :+ true, append, verbose, prefix,
-        addSuffix, maxFields, printNodeId = printNodeId)
+        addSuffix, maxFields, printNodeId = printNodeId, indent = indent)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
@@ -538,7 +538,8 @@ case class InputAdapter(child: SparkPlan) extends UnaryExecNode with InputRDDCod
       prefix: String = "",
       addSuffix: Boolean = false,
       maxFields: Int,
-      printNodeId: Boolean): Unit = {
+      printNodeId: Boolean,
+      indent: Int = 0): Unit = {
     child.generateTreeString(
       depth,
       lastChildren,
@@ -547,7 +548,8 @@ case class InputAdapter(child: SparkPlan) extends UnaryExecNode with InputRDDCod
       prefix = "",
       addSuffix = false,
       maxFields,
-      printNodeId)
+      printNodeId,
+      indent)
   }
 
   override def needCopyResult: Boolean = false
@@ -807,7 +809,8 @@ case class WholeStageCodegenExec(child: SparkPlan)(val codegenStageId: Int)
       prefix: String = "",
       addSuffix: Boolean = false,
       maxFields: Int,
-      printNodeId: Boolean): Unit = {
+      printNodeId: Boolean,
+      indent: Int = 0): Unit = {
     child.generateTreeString(
       depth,
       lastChildren,
@@ -816,7 +819,8 @@ case class WholeStageCodegenExec(child: SparkPlan)(val codegenStageId: Int)
       if (printNodeId) "* " else s"*($codegenStageId) ",
       false,
       maxFields,
-      printNodeId)
+      printNodeId,
+      indent)
   }
 
   override def needStopCheck: Boolean = true

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageExec.scala
@@ -123,7 +123,8 @@ abstract class QueryStageExec extends LeafExecNode {
       prefix: String = "",
       addSuffix: Boolean = false,
       maxFields: Int,
-      printNodeId: Boolean): Unit = {
+      printNodeId: Boolean,
+      indent: Int = 0): Unit = {
     super.generateTreeString(depth,
       lastChildren,
       append,
@@ -131,9 +132,10 @@ abstract class QueryStageExec extends LeafExecNode {
       prefix,
       addSuffix,
       maxFields,
-      printNodeId)
+      printNodeId,
+      indent)
     plan.generateTreeString(
-      depth + 1, lastChildren :+ true, append, verbose, "", false, maxFields, printNodeId)
+      depth + 1, lastChildren :+ true, append, verbose, "", false, maxFields, printNodeId, indent)
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -718,7 +718,8 @@ abstract class BaseSubqueryExec extends SparkPlan {
       prefix: String = "",
       addSuffix: Boolean = false,
       maxFields: Int,
-      printNodeId: Boolean): Unit = {
+      printNodeId: Boolean,
+      indent: Int = 0): Unit = {
     /**
      * In the new explain mode `EXPLAIN FORMATTED`, the subqueries are not shown in the
      * main plan and are printed separately along with correlation information with
@@ -734,7 +735,8 @@ abstract class BaseSubqueryExec extends SparkPlan {
         "",
         false,
         maxFields,
-        printNodeId)
+        printNodeId,
+        indent)
     }
   }
 }

--- a/sql/core/src/test/resources/sql-tests/results/explain-aqe.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain-aqe.sql.out
@@ -54,7 +54,8 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (9)
-+- CurrentPlan +- Sort (8)
++- == Current Plan ==
+   Sort (8)
    +- Exchange (7)
       +- HashAggregate (6)
          +- Exchange (5)
@@ -62,7 +63,8 @@ AdaptiveSparkPlan (9)
                +- Project (3)
                   +- Filter (2)
                      +- Scan parquet default.explain_temp1 (1)
-+- InitialPlan +- Sort (8)
++- == Initial Plan ==
+   Sort (8)
    +- Exchange (7)
       +- HashAggregate (6)
          +- Exchange (5)
@@ -130,7 +132,8 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (9)
-+- CurrentPlan +- Project (8)
++- == Current Plan ==
+   Project (8)
    +- Filter (7)
       +- HashAggregate (6)
          +- Exchange (5)
@@ -138,7 +141,8 @@ AdaptiveSparkPlan (9)
                +- Project (3)
                   +- Filter (2)
                      +- Scan parquet default.explain_temp1 (1)
-+- InitialPlan +- Project (8)
++- == Initial Plan ==
+   Project (8)
    +- Filter (7)
       +- HashAggregate (6)
          +- Exchange (5)
@@ -204,7 +208,8 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (11)
-+- CurrentPlan +- HashAggregate (10)
++- == Current Plan ==
+   HashAggregate (10)
    +- Exchange (9)
       +- HashAggregate (8)
          +- Union (7)
@@ -214,7 +219,8 @@ AdaptiveSparkPlan (11)
             +- Project (6)
                +- Filter (5)
                   +- Scan parquet default.explain_temp1 (4)
-+- InitialPlan +- HashAggregate (10)
++- == Initial Plan ==
+   HashAggregate (10)
    +- Exchange (9)
       +- HashAggregate (8)
          +- Union (7)
@@ -292,7 +298,8 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (9)
-+- CurrentPlan +- BroadcastHashJoin Inner BuildRight (8)
++- == Current Plan ==
+   BroadcastHashJoin Inner BuildRight (8)
    :- Project (3)
    :  +- Filter (2)
    :     +- Scan parquet default.explain_temp1 (1)
@@ -300,7 +307,8 @@ AdaptiveSparkPlan (9)
       +- Project (6)
          +- Filter (5)
             +- Scan parquet default.explain_temp2 (4)
-+- InitialPlan +- BroadcastHashJoin Inner BuildRight (8)
++- == Initial Plan ==
+   BroadcastHashJoin Inner BuildRight (8)
    :- Project (3)
    :  +- Filter (2)
    :     +- Scan parquet default.explain_temp1 (1)
@@ -365,13 +373,15 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (7)
-+- CurrentPlan +- BroadcastHashJoin LeftOuter BuildRight (6)
++- == Current Plan ==
+   BroadcastHashJoin LeftOuter BuildRight (6)
    :- Scan parquet default.explain_temp1 (1)
    +- BroadcastExchange (5)
       +- Project (4)
          +- Filter (3)
             +- Scan parquet default.explain_temp2 (2)
-+- InitialPlan +- BroadcastHashJoin LeftOuter BuildRight (6)
++- == Initial Plan ==
+   BroadcastHashJoin LeftOuter BuildRight (6)
    :- Scan parquet default.explain_temp1 (1)
    +- BroadcastExchange (5)
       +- Project (4)
@@ -430,10 +440,12 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (4)
-+- CurrentPlan +- Project (3)
++- == Current Plan ==
+   Project (3)
    +- Filter (2)
       +- Scan parquet default.explain_temp1 (1)
-+- InitialPlan +- Project (3)
++- == Initial Plan ==
+   Project (3)
    +- Filter (2)
       +- Scan parquet default.explain_temp1 (1)
 
@@ -474,9 +486,11 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (3)
-+- CurrentPlan +- Filter (2)
++- == Current Plan ==
+   Filter (2)
    +- Scan parquet default.explain_temp1 (1)
-+- InitialPlan +- Filter (2)
++- == Initial Plan ==
+   Filter (2)
    +- Scan parquet default.explain_temp1 (1)
 
 
@@ -504,9 +518,11 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (3)
-+- CurrentPlan +- Project (2)
++- == Current Plan ==
+   Project (2)
    +- Scan parquet default.explain_temp1 (1)
-+- InitialPlan +- Project (2)
++- == Initial Plan ==
+   Project (2)
    +- Scan parquet default.explain_temp1 (1)
 
 
@@ -538,7 +554,8 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (9)
-+- CurrentPlan +- BroadcastHashJoin Inner BuildRight (8)
++- == Current Plan ==
+   BroadcastHashJoin Inner BuildRight (8)
    :- Project (3)
    :  +- Filter (2)
    :     +- Scan parquet default.explain_temp1 (1)
@@ -546,7 +563,8 @@ AdaptiveSparkPlan (9)
       +- Project (6)
          +- Filter (5)
             +- Scan parquet default.explain_temp1 (4)
-+- InitialPlan +- BroadcastHashJoin Inner BuildRight (8)
++- == Initial Plan ==
+   BroadcastHashJoin Inner BuildRight (8)
    :- Project (3)
    :  +- Filter (2)
    :     +- Scan parquet default.explain_temp1 (1)
@@ -614,7 +632,8 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (15)
-+- CurrentPlan +- BroadcastHashJoin Inner BuildRight (14)
++- == Current Plan ==
+   BroadcastHashJoin Inner BuildRight (14)
    :- HashAggregate (6)
    :  +- Exchange (5)
    :     +- HashAggregate (4)
@@ -628,7 +647,8 @@ AdaptiveSparkPlan (15)
                +- Project (9)
                   +- Filter (8)
                      +- Scan parquet default.explain_temp1 (7)
-+- InitialPlan +- BroadcastHashJoin Inner BuildRight (14)
++- == Initial Plan ==
+   BroadcastHashJoin Inner BuildRight (14)
    :- HashAggregate (6)
    :  +- Exchange (5)
    :     +- HashAggregate (4)
@@ -762,11 +782,13 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (5)
-+- CurrentPlan +- HashAggregate (4)
++- == Current Plan ==
+   HashAggregate (4)
    +- Exchange (3)
       +- HashAggregate (2)
          +- Scan parquet default.explain_temp1 (1)
-+- InitialPlan +- HashAggregate (4)
++- == Initial Plan ==
+   HashAggregate (4)
    +- Exchange (3)
       +- HashAggregate (2)
          +- Scan parquet default.explain_temp1 (1)
@@ -811,11 +833,13 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (5)
-+- CurrentPlan +- ObjectHashAggregate (4)
++- == Current Plan ==
+   ObjectHashAggregate (4)
    +- Exchange (3)
       +- ObjectHashAggregate (2)
          +- Scan parquet default.explain_temp4 (1)
-+- InitialPlan +- ObjectHashAggregate (4)
++- == Initial Plan ==
+   ObjectHashAggregate (4)
    +- Exchange (3)
       +- ObjectHashAggregate (2)
          +- Scan parquet default.explain_temp4 (1)
@@ -860,13 +884,15 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (7)
-+- CurrentPlan +- SortAggregate (6)
++- == Current Plan ==
+   SortAggregate (6)
    +- Sort (5)
       +- Exchange (4)
          +- SortAggregate (3)
             +- Sort (2)
                +- Scan parquet default.explain_temp4 (1)
-+- InitialPlan +- SortAggregate (6)
++- == Initial Plan ==
+   SortAggregate (6)
    +- Sort (5)
       +- Exchange (4)
          +- SortAggregate (3)

--- a/sql/core/src/test/resources/sql-tests/results/explain-aqe.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain-aqe.sql.out
@@ -54,24 +54,22 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (9)
-:- CurrentPlan
-:  +- Sort (8)
-:     +- Exchange (7)
-:        +- HashAggregate (6)
-:           +- Exchange (5)
-:              +- HashAggregate (4)
-:                 +- Project (3)
-:                    +- Filter (2)
-:                       +- Scan parquet default.explain_temp1 (1)
-+- InitialPlan
-   +- Sort (8)
-      +- Exchange (7)
-         +- HashAggregate (6)
-            +- Exchange (5)
-               +- HashAggregate (4)
-                  +- Project (3)
-                     +- Filter (2)
-                        +- Scan parquet default.explain_temp1 (1)
++- CurrentPlan +- Sort (8)
+   +- Exchange (7)
+      +- HashAggregate (6)
+         +- Exchange (5)
+            +- HashAggregate (4)
+               +- Project (3)
+                  +- Filter (2)
+                     +- Scan parquet default.explain_temp1 (1)
++- InitialPlan +- Sort (8)
+   +- Exchange (7)
+      +- HashAggregate (6)
+         +- Exchange (5)
+            +- HashAggregate (4)
+               +- Project (3)
+                  +- Filter (2)
+                     +- Scan parquet default.explain_temp1 (1)
 
 
 (1) Scan parquet default.explain_temp1
@@ -132,24 +130,22 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (9)
-:- CurrentPlan
-:  +- Project (8)
-:     +- Filter (7)
-:        +- HashAggregate (6)
-:           +- Exchange (5)
-:              +- HashAggregate (4)
-:                 +- Project (3)
-:                    +- Filter (2)
-:                       +- Scan parquet default.explain_temp1 (1)
-+- InitialPlan
-   +- Project (8)
-      +- Filter (7)
-         +- HashAggregate (6)
-            +- Exchange (5)
-               +- HashAggregate (4)
-                  +- Project (3)
-                     +- Filter (2)
-                        +- Scan parquet default.explain_temp1 (1)
++- CurrentPlan +- Project (8)
+   +- Filter (7)
+      +- HashAggregate (6)
+         +- Exchange (5)
+            +- HashAggregate (4)
+               +- Project (3)
+                  +- Filter (2)
+                     +- Scan parquet default.explain_temp1 (1)
++- InitialPlan +- Project (8)
+   +- Filter (7)
+      +- HashAggregate (6)
+         +- Exchange (5)
+            +- HashAggregate (4)
+               +- Project (3)
+                  +- Filter (2)
+                     +- Scan parquet default.explain_temp1 (1)
 
 
 (1) Scan parquet default.explain_temp1
@@ -208,28 +204,26 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (11)
-:- CurrentPlan
-:  +- HashAggregate (10)
-:     +- Exchange (9)
-:        +- HashAggregate (8)
-:           +- Union (7)
-:              :- Project (3)
-:              :  +- Filter (2)
-:              :     +- Scan parquet default.explain_temp1 (1)
-:              +- Project (6)
-:                 +- Filter (5)
-:                    +- Scan parquet default.explain_temp1 (4)
-+- InitialPlan
-   +- HashAggregate (10)
-      +- Exchange (9)
-         +- HashAggregate (8)
-            +- Union (7)
-               :- Project (3)
-               :  +- Filter (2)
-               :     +- Scan parquet default.explain_temp1 (1)
-               +- Project (6)
-                  +- Filter (5)
-                     +- Scan parquet default.explain_temp1 (4)
++- CurrentPlan +- HashAggregate (10)
+   +- Exchange (9)
+      +- HashAggregate (8)
+         +- Union (7)
+            :- Project (3)
+            :  +- Filter (2)
+            :     +- Scan parquet default.explain_temp1 (1)
+            +- Project (6)
+               +- Filter (5)
+                  +- Scan parquet default.explain_temp1 (4)
++- InitialPlan +- HashAggregate (10)
+   +- Exchange (9)
+      +- HashAggregate (8)
+         +- Union (7)
+            :- Project (3)
+            :  +- Filter (2)
+            :     +- Scan parquet default.explain_temp1 (1)
+            +- Project (6)
+               +- Filter (5)
+                  +- Scan parquet default.explain_temp1 (4)
 
 
 (1) Scan parquet default.explain_temp1
@@ -298,24 +292,22 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (9)
-:- CurrentPlan
-:  +- BroadcastHashJoin Inner BuildRight (8)
-:     :- Project (3)
-:     :  +- Filter (2)
-:     :     +- Scan parquet default.explain_temp1 (1)
-:     +- BroadcastExchange (7)
-:        +- Project (6)
-:           +- Filter (5)
-:              +- Scan parquet default.explain_temp2 (4)
-+- InitialPlan
-   +- BroadcastHashJoin Inner BuildRight (8)
-      :- Project (3)
-      :  +- Filter (2)
-      :     +- Scan parquet default.explain_temp1 (1)
-      +- BroadcastExchange (7)
-         +- Project (6)
-            +- Filter (5)
-               +- Scan parquet default.explain_temp2 (4)
++- CurrentPlan +- BroadcastHashJoin Inner BuildRight (8)
+   :- Project (3)
+   :  +- Filter (2)
+   :     +- Scan parquet default.explain_temp1 (1)
+   +- BroadcastExchange (7)
+      +- Project (6)
+         +- Filter (5)
+            +- Scan parquet default.explain_temp2 (4)
++- InitialPlan +- BroadcastHashJoin Inner BuildRight (8)
+   :- Project (3)
+   :  +- Filter (2)
+   :     +- Scan parquet default.explain_temp1 (1)
+   +- BroadcastExchange (7)
+      +- Project (6)
+         +- Filter (5)
+            +- Scan parquet default.explain_temp2 (4)
 
 
 (1) Scan parquet default.explain_temp1
@@ -373,20 +365,18 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (7)
-:- CurrentPlan
-:  +- BroadcastHashJoin LeftOuter BuildRight (6)
-:     :- Scan parquet default.explain_temp1 (1)
-:     +- BroadcastExchange (5)
-:        +- Project (4)
-:           +- Filter (3)
-:              +- Scan parquet default.explain_temp2 (2)
-+- InitialPlan
-   +- BroadcastHashJoin LeftOuter BuildRight (6)
-      :- Scan parquet default.explain_temp1 (1)
-      +- BroadcastExchange (5)
-         +- Project (4)
-            +- Filter (3)
-               +- Scan parquet default.explain_temp2 (2)
++- CurrentPlan +- BroadcastHashJoin LeftOuter BuildRight (6)
+   :- Scan parquet default.explain_temp1 (1)
+   +- BroadcastExchange (5)
+      +- Project (4)
+         +- Filter (3)
+            +- Scan parquet default.explain_temp2 (2)
++- InitialPlan +- BroadcastHashJoin LeftOuter BuildRight (6)
+   :- Scan parquet default.explain_temp1 (1)
+   +- BroadcastExchange (5)
+      +- Project (4)
+         +- Filter (3)
+            +- Scan parquet default.explain_temp2 (2)
 
 
 (1) Scan parquet default.explain_temp1
@@ -440,14 +430,12 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (4)
-:- CurrentPlan
-:  +- Project (3)
-:     +- Filter (2)
-:        +- Scan parquet default.explain_temp1 (1)
-+- InitialPlan
-   +- Project (3)
-      +- Filter (2)
-         +- Scan parquet default.explain_temp1 (1)
++- CurrentPlan +- Project (3)
+   +- Filter (2)
+      +- Scan parquet default.explain_temp1 (1)
++- InitialPlan +- Project (3)
+   +- Filter (2)
+      +- Scan parquet default.explain_temp1 (1)
 
 
 (1) Scan parquet default.explain_temp1
@@ -486,12 +474,10 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (3)
-:- CurrentPlan
-:  +- Filter (2)
-:     +- Scan parquet default.explain_temp1 (1)
-+- InitialPlan
-   +- Filter (2)
-      +- Scan parquet default.explain_temp1 (1)
++- CurrentPlan +- Filter (2)
+   +- Scan parquet default.explain_temp1 (1)
++- InitialPlan +- Filter (2)
+   +- Scan parquet default.explain_temp1 (1)
 
 
 (1) Scan parquet default.explain_temp1
@@ -518,12 +504,10 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (3)
-:- CurrentPlan
-:  +- Project (2)
-:     +- Scan parquet default.explain_temp1 (1)
-+- InitialPlan
-   +- Project (2)
-      +- Scan parquet default.explain_temp1 (1)
++- CurrentPlan +- Project (2)
+   +- Scan parquet default.explain_temp1 (1)
++- InitialPlan +- Project (2)
+   +- Scan parquet default.explain_temp1 (1)
 
 
 (1) Scan parquet default.explain_temp1
@@ -554,24 +538,22 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (9)
-:- CurrentPlan
-:  +- BroadcastHashJoin Inner BuildRight (8)
-:     :- Project (3)
-:     :  +- Filter (2)
-:     :     +- Scan parquet default.explain_temp1 (1)
-:     +- BroadcastExchange (7)
-:        +- Project (6)
-:           +- Filter (5)
-:              +- Scan parquet default.explain_temp1 (4)
-+- InitialPlan
-   +- BroadcastHashJoin Inner BuildRight (8)
-      :- Project (3)
-      :  +- Filter (2)
-      :     +- Scan parquet default.explain_temp1 (1)
-      +- BroadcastExchange (7)
-         +- Project (6)
-            +- Filter (5)
-               +- Scan parquet default.explain_temp1 (4)
++- CurrentPlan +- BroadcastHashJoin Inner BuildRight (8)
+   :- Project (3)
+   :  +- Filter (2)
+   :     +- Scan parquet default.explain_temp1 (1)
+   +- BroadcastExchange (7)
+      +- Project (6)
+         +- Filter (5)
+            +- Scan parquet default.explain_temp1 (4)
++- InitialPlan +- BroadcastHashJoin Inner BuildRight (8)
+   :- Project (3)
+   :  +- Filter (2)
+   :     +- Scan parquet default.explain_temp1 (1)
+   +- BroadcastExchange (7)
+      +- Project (6)
+         +- Filter (5)
+            +- Scan parquet default.explain_temp1 (4)
 
 
 (1) Scan parquet default.explain_temp1
@@ -632,36 +614,34 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (15)
-:- CurrentPlan
-:  +- BroadcastHashJoin Inner BuildRight (14)
-:     :- HashAggregate (6)
-:     :  +- Exchange (5)
-:     :     +- HashAggregate (4)
-:     :        +- Project (3)
-:     :           +- Filter (2)
-:     :              +- Scan parquet default.explain_temp1 (1)
-:     +- BroadcastExchange (13)
-:        +- HashAggregate (12)
-:           +- Exchange (11)
-:              +- HashAggregate (10)
-:                 +- Project (9)
-:                    +- Filter (8)
-:                       +- Scan parquet default.explain_temp1 (7)
-+- InitialPlan
-   +- BroadcastHashJoin Inner BuildRight (14)
-      :- HashAggregate (6)
-      :  +- Exchange (5)
-      :     +- HashAggregate (4)
-      :        +- Project (3)
-      :           +- Filter (2)
-      :              +- Scan parquet default.explain_temp1 (1)
-      +- BroadcastExchange (13)
-         +- HashAggregate (12)
-            +- Exchange (11)
-               +- HashAggregate (10)
-                  +- Project (9)
-                     +- Filter (8)
-                        +- Scan parquet default.explain_temp1 (7)
++- CurrentPlan +- BroadcastHashJoin Inner BuildRight (14)
+   :- HashAggregate (6)
+   :  +- Exchange (5)
+   :     +- HashAggregate (4)
+   :        +- Project (3)
+   :           +- Filter (2)
+   :              +- Scan parquet default.explain_temp1 (1)
+   +- BroadcastExchange (13)
+      +- HashAggregate (12)
+         +- Exchange (11)
+            +- HashAggregate (10)
+               +- Project (9)
+                  +- Filter (8)
+                     +- Scan parquet default.explain_temp1 (7)
++- InitialPlan +- BroadcastHashJoin Inner BuildRight (14)
+   :- HashAggregate (6)
+   :  +- Exchange (5)
+   :     +- HashAggregate (4)
+   :        +- Project (3)
+   :           +- Filter (2)
+   :              +- Scan parquet default.explain_temp1 (1)
+   +- BroadcastExchange (13)
+      +- HashAggregate (12)
+         +- Exchange (11)
+            +- HashAggregate (10)
+               +- Project (9)
+                  +- Filter (8)
+                     +- Scan parquet default.explain_temp1 (7)
 
 
 (1) Scan parquet default.explain_temp1
@@ -782,16 +762,14 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (5)
-:- CurrentPlan
-:  +- HashAggregate (4)
-:     +- Exchange (3)
-:        +- HashAggregate (2)
-:           +- Scan parquet default.explain_temp1 (1)
-+- InitialPlan
-   +- HashAggregate (4)
-      +- Exchange (3)
-         +- HashAggregate (2)
-            +- Scan parquet default.explain_temp1 (1)
++- CurrentPlan +- HashAggregate (4)
+   +- Exchange (3)
+      +- HashAggregate (2)
+         +- Scan parquet default.explain_temp1 (1)
++- InitialPlan +- HashAggregate (4)
+   +- Exchange (3)
+      +- HashAggregate (2)
+         +- Scan parquet default.explain_temp1 (1)
 
 
 (1) Scan parquet default.explain_temp1
@@ -833,16 +811,14 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (5)
-:- CurrentPlan
-:  +- ObjectHashAggregate (4)
-:     +- Exchange (3)
-:        +- ObjectHashAggregate (2)
-:           +- Scan parquet default.explain_temp4 (1)
-+- InitialPlan
-   +- ObjectHashAggregate (4)
-      +- Exchange (3)
-         +- ObjectHashAggregate (2)
-            +- Scan parquet default.explain_temp4 (1)
++- CurrentPlan +- ObjectHashAggregate (4)
+   +- Exchange (3)
+      +- ObjectHashAggregate (2)
+         +- Scan parquet default.explain_temp4 (1)
++- InitialPlan +- ObjectHashAggregate (4)
+   +- Exchange (3)
+      +- ObjectHashAggregate (2)
+         +- Scan parquet default.explain_temp4 (1)
 
 
 (1) Scan parquet default.explain_temp4
@@ -884,20 +860,18 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (7)
-:- CurrentPlan
-:  +- SortAggregate (6)
-:     +- Sort (5)
-:        +- Exchange (4)
-:           +- SortAggregate (3)
-:              +- Sort (2)
-:                 +- Scan parquet default.explain_temp4 (1)
-+- InitialPlan
-   +- SortAggregate (6)
-      +- Sort (5)
-         +- Exchange (4)
-            +- SortAggregate (3)
-               +- Sort (2)
-                  +- Scan parquet default.explain_temp4 (1)
++- CurrentPlan +- SortAggregate (6)
+   +- Sort (5)
+      +- Exchange (4)
+         +- SortAggregate (3)
+            +- Sort (2)
+               +- Scan parquet default.explain_temp4 (1)
++- InitialPlan +- SortAggregate (6)
+   +- Sort (5)
+      +- Exchange (4)
+         +- SortAggregate (3)
+            +- Sort (2)
+               +- Scan parquet default.explain_temp4 (1)
 
 
 (1) Scan parquet default.explain_temp4

--- a/sql/core/src/test/resources/sql-tests/results/explain-aqe.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain-aqe.sql.out
@@ -54,14 +54,24 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (9)
-+- Sort (8)
-   +- Exchange (7)
-      +- HashAggregate (6)
-         +- Exchange (5)
-            +- HashAggregate (4)
-               +- Project (3)
-                  +- Filter (2)
-                     +- Scan parquet default.explain_temp1 (1)
+:- CurrentPlan
+:  +- Sort (8)
+:     +- Exchange (7)
+:        +- HashAggregate (6)
+:           +- Exchange (5)
+:              +- HashAggregate (4)
+:                 +- Project (3)
+:                    +- Filter (2)
+:                       +- Scan parquet default.explain_temp1 (1)
++- InitialPlan
+   +- Sort (8)
+      +- Exchange (7)
+         +- HashAggregate (6)
+            +- Exchange (5)
+               +- HashAggregate (4)
+                  +- Project (3)
+                     +- Filter (2)
+                        +- Scan parquet default.explain_temp1 (1)
 
 
 (1) Scan parquet default.explain_temp1
@@ -122,14 +132,24 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (9)
-+- Project (8)
-   +- Filter (7)
-      +- HashAggregate (6)
-         +- Exchange (5)
-            +- HashAggregate (4)
-               +- Project (3)
-                  +- Filter (2)
-                     +- Scan parquet default.explain_temp1 (1)
+:- CurrentPlan
+:  +- Project (8)
+:     +- Filter (7)
+:        +- HashAggregate (6)
+:           +- Exchange (5)
+:              +- HashAggregate (4)
+:                 +- Project (3)
+:                    +- Filter (2)
+:                       +- Scan parquet default.explain_temp1 (1)
++- InitialPlan
+   +- Project (8)
+      +- Filter (7)
+         +- HashAggregate (6)
+            +- Exchange (5)
+               +- HashAggregate (4)
+                  +- Project (3)
+                     +- Filter (2)
+                        +- Scan parquet default.explain_temp1 (1)
 
 
 (1) Scan parquet default.explain_temp1
@@ -188,16 +208,28 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (11)
-+- HashAggregate (10)
-   +- Exchange (9)
-      +- HashAggregate (8)
-         +- Union (7)
-            :- Project (3)
-            :  +- Filter (2)
-            :     +- Scan parquet default.explain_temp1 (1)
-            +- Project (6)
-               +- Filter (5)
-                  +- Scan parquet default.explain_temp1 (4)
+:- CurrentPlan
+:  +- HashAggregate (10)
+:     +- Exchange (9)
+:        +- HashAggregate (8)
+:           +- Union (7)
+:              :- Project (3)
+:              :  +- Filter (2)
+:              :     +- Scan parquet default.explain_temp1 (1)
+:              +- Project (6)
+:                 +- Filter (5)
+:                    +- Scan parquet default.explain_temp1 (4)
++- InitialPlan
+   +- HashAggregate (10)
+      +- Exchange (9)
+         +- HashAggregate (8)
+            +- Union (7)
+               :- Project (3)
+               :  +- Filter (2)
+               :     +- Scan parquet default.explain_temp1 (1)
+               +- Project (6)
+                  +- Filter (5)
+                     +- Scan parquet default.explain_temp1 (4)
 
 
 (1) Scan parquet default.explain_temp1
@@ -266,14 +298,24 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (9)
-+- BroadcastHashJoin Inner BuildRight (8)
-   :- Project (3)
-   :  +- Filter (2)
-   :     +- Scan parquet default.explain_temp1 (1)
-   +- BroadcastExchange (7)
-      +- Project (6)
-         +- Filter (5)
-            +- Scan parquet default.explain_temp2 (4)
+:- CurrentPlan
+:  +- BroadcastHashJoin Inner BuildRight (8)
+:     :- Project (3)
+:     :  +- Filter (2)
+:     :     +- Scan parquet default.explain_temp1 (1)
+:     +- BroadcastExchange (7)
+:        +- Project (6)
+:           +- Filter (5)
+:              +- Scan parquet default.explain_temp2 (4)
++- InitialPlan
+   +- BroadcastHashJoin Inner BuildRight (8)
+      :- Project (3)
+      :  +- Filter (2)
+      :     +- Scan parquet default.explain_temp1 (1)
+      +- BroadcastExchange (7)
+         +- Project (6)
+            +- Filter (5)
+               +- Scan parquet default.explain_temp2 (4)
 
 
 (1) Scan parquet default.explain_temp1
@@ -331,12 +373,20 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (7)
-+- BroadcastHashJoin LeftOuter BuildRight (6)
-   :- Scan parquet default.explain_temp1 (1)
-   +- BroadcastExchange (5)
-      +- Project (4)
-         +- Filter (3)
-            +- Scan parquet default.explain_temp2 (2)
+:- CurrentPlan
+:  +- BroadcastHashJoin LeftOuter BuildRight (6)
+:     :- Scan parquet default.explain_temp1 (1)
+:     +- BroadcastExchange (5)
+:        +- Project (4)
+:           +- Filter (3)
+:              +- Scan parquet default.explain_temp2 (2)
++- InitialPlan
+   +- BroadcastHashJoin LeftOuter BuildRight (6)
+      :- Scan parquet default.explain_temp1 (1)
+      +- BroadcastExchange (5)
+         +- Project (4)
+            +- Filter (3)
+               +- Scan parquet default.explain_temp2 (2)
 
 
 (1) Scan parquet default.explain_temp1
@@ -390,9 +440,14 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (4)
-+- Project (3)
-   +- Filter (2)
-      +- Scan parquet default.explain_temp1 (1)
+:- CurrentPlan
+:  +- Project (3)
+:     +- Filter (2)
+:        +- Scan parquet default.explain_temp1 (1)
++- InitialPlan
+   +- Project (3)
+      +- Filter (2)
+         +- Scan parquet default.explain_temp1 (1)
 
 
 (1) Scan parquet default.explain_temp1
@@ -431,8 +486,12 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (3)
-+- Filter (2)
-   +- Scan parquet default.explain_temp1 (1)
+:- CurrentPlan
+:  +- Filter (2)
+:     +- Scan parquet default.explain_temp1 (1)
++- InitialPlan
+   +- Filter (2)
+      +- Scan parquet default.explain_temp1 (1)
 
 
 (1) Scan parquet default.explain_temp1
@@ -459,8 +518,12 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (3)
-+- Project (2)
-   +- Scan parquet default.explain_temp1 (1)
+:- CurrentPlan
+:  +- Project (2)
+:     +- Scan parquet default.explain_temp1 (1)
++- InitialPlan
+   +- Project (2)
+      +- Scan parquet default.explain_temp1 (1)
 
 
 (1) Scan parquet default.explain_temp1
@@ -491,14 +554,24 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (9)
-+- BroadcastHashJoin Inner BuildRight (8)
-   :- Project (3)
-   :  +- Filter (2)
-   :     +- Scan parquet default.explain_temp1 (1)
-   +- BroadcastExchange (7)
-      +- Project (6)
-         +- Filter (5)
-            +- Scan parquet default.explain_temp1 (4)
+:- CurrentPlan
+:  +- BroadcastHashJoin Inner BuildRight (8)
+:     :- Project (3)
+:     :  +- Filter (2)
+:     :     +- Scan parquet default.explain_temp1 (1)
+:     +- BroadcastExchange (7)
+:        +- Project (6)
+:           +- Filter (5)
+:              +- Scan parquet default.explain_temp1 (4)
++- InitialPlan
+   +- BroadcastHashJoin Inner BuildRight (8)
+      :- Project (3)
+      :  +- Filter (2)
+      :     +- Scan parquet default.explain_temp1 (1)
+      +- BroadcastExchange (7)
+         +- Project (6)
+            +- Filter (5)
+               +- Scan parquet default.explain_temp1 (4)
 
 
 (1) Scan parquet default.explain_temp1
@@ -559,20 +632,36 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (15)
-+- BroadcastHashJoin Inner BuildRight (14)
-   :- HashAggregate (6)
-   :  +- Exchange (5)
-   :     +- HashAggregate (4)
-   :        +- Project (3)
-   :           +- Filter (2)
-   :              +- Scan parquet default.explain_temp1 (1)
-   +- BroadcastExchange (13)
-      +- HashAggregate (12)
-         +- Exchange (11)
-            +- HashAggregate (10)
-               +- Project (9)
-                  +- Filter (8)
-                     +- Scan parquet default.explain_temp1 (7)
+:- CurrentPlan
+:  +- BroadcastHashJoin Inner BuildRight (14)
+:     :- HashAggregate (6)
+:     :  +- Exchange (5)
+:     :     +- HashAggregate (4)
+:     :        +- Project (3)
+:     :           +- Filter (2)
+:     :              +- Scan parquet default.explain_temp1 (1)
+:     +- BroadcastExchange (13)
+:        +- HashAggregate (12)
+:           +- Exchange (11)
+:              +- HashAggregate (10)
+:                 +- Project (9)
+:                    +- Filter (8)
+:                       +- Scan parquet default.explain_temp1 (7)
++- InitialPlan
+   +- BroadcastHashJoin Inner BuildRight (14)
+      :- HashAggregate (6)
+      :  +- Exchange (5)
+      :     +- HashAggregate (4)
+      :        +- Project (3)
+      :           +- Filter (2)
+      :              +- Scan parquet default.explain_temp1 (1)
+      +- BroadcastExchange (13)
+         +- HashAggregate (12)
+            +- Exchange (11)
+               +- HashAggregate (10)
+                  +- Project (9)
+                     +- Filter (8)
+                        +- Scan parquet default.explain_temp1 (7)
 
 
 (1) Scan parquet default.explain_temp1
@@ -693,10 +782,16 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (5)
-+- HashAggregate (4)
-   +- Exchange (3)
-      +- HashAggregate (2)
-         +- Scan parquet default.explain_temp1 (1)
+:- CurrentPlan
+:  +- HashAggregate (4)
+:     +- Exchange (3)
+:        +- HashAggregate (2)
+:           +- Scan parquet default.explain_temp1 (1)
++- InitialPlan
+   +- HashAggregate (4)
+      +- Exchange (3)
+         +- HashAggregate (2)
+            +- Scan parquet default.explain_temp1 (1)
 
 
 (1) Scan parquet default.explain_temp1
@@ -738,10 +833,16 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (5)
-+- ObjectHashAggregate (4)
-   +- Exchange (3)
-      +- ObjectHashAggregate (2)
-         +- Scan parquet default.explain_temp4 (1)
+:- CurrentPlan
+:  +- ObjectHashAggregate (4)
+:     +- Exchange (3)
+:        +- ObjectHashAggregate (2)
+:           +- Scan parquet default.explain_temp4 (1)
++- InitialPlan
+   +- ObjectHashAggregate (4)
+      +- Exchange (3)
+         +- ObjectHashAggregate (2)
+            +- Scan parquet default.explain_temp4 (1)
 
 
 (1) Scan parquet default.explain_temp4
@@ -783,12 +884,20 @@ struct<plan:string>
 -- !query output
 == Physical Plan ==
 AdaptiveSparkPlan (7)
-+- SortAggregate (6)
-   +- Sort (5)
-      +- Exchange (4)
-         +- SortAggregate (3)
-            +- Sort (2)
-               +- Scan parquet default.explain_temp4 (1)
+:- CurrentPlan
+:  +- SortAggregate (6)
+:     +- Sort (5)
+:        +- Exchange (4)
+:           +- SortAggregate (3)
+:              +- Sort (2)
+:                 +- Scan parquet default.explain_temp4 (1)
++- InitialPlan
+   +- SortAggregate (6)
+      +- Sort (5)
+         +- Exchange (4)
+            +- SortAggregate (3)
+               +- Sort (2)
+                  +- Scan parquet default.explain_temp4 (1)
 
 
 (1) Scan parquet default.explain_temp4

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -829,6 +829,19 @@ class AdaptiveQueryExecSuite
     }
   }
 
+  test("tree string output") {
+    withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true") {
+      val df = sql("SELECT * FROM testData join testData2 ON key = a where value = '1'")
+      val planBefore = df.queryExecution.executedPlan
+      assert(planBefore.toString.contains("== Current Plan =="))
+      assert(planBefore.toString.contains("== Initial Plan =="))
+      df.collect()
+      val planAfter = df.queryExecution.executedPlan
+      assert(planAfter.toString.contains("== Final Plan =="))
+      assert(planAfter.toString.contains("== Initial Plan =="))
+    }
+  }
+
   test("SPARK-31384: avoid NPE in OptimizeSkewedJoin when there's 0 partition plan") {
     withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds initial plan in `AdaptiveSparkPlanExec` and generates tree string for both current plan and initial plan. When the adaptive plan is not final, `Current Plan` will be used to indicate current physical plan, and `Final Plan` will be used when the adaptive plan is final. The difference between `Current Plan` and `Final Plan` here is that current plan indicates an intermediate state. The plan is subject to further transformations, while final plan represents an end state, which means the plan will no longer be changed. 

Examples:

Before this change:
```
AdaptiveSparkPlan isFinalPlan=true
+- *(3) BroadcastHashJoin
   :- BroadcastQueryStage 2
       ...
```
`EXPLAIN FORMATTED`
```
== Physical Plan ==
AdaptiveSparkPlan (9)
+- BroadcastHashJoin Inner BuildRight (8)
   :- Project (3)
   :  +- Filter (2)
```

After this change
```
AdaptiveSparkPlan isFinalPlan=true
+- == Final Plan ==
   *(3) BroadcastHashJoin
   :- BroadcastQueryStage 2
   :  +- BroadcastExchange
           ...
+- == Initial Plan ==
   SortMergeJoin
   :- Sort
   :  +- Exchange
           ...
```

`EXPLAIN FORMATTED` 
```
== Physical Plan ==
AdaptiveSparkPlan (9)
+- == Current Plan ==
   BroadcastHashJoin Inner BuildRight (8)
   :- Project (3)
   :  +- Filter (2)
+- == Initial Plan ==
   BroadcastHashJoin Inner BuildRight (8)
   :- Project (3)
   :  +- Filter (2)
```

### Why are the changes needed?
It provides better visibility into the plan change introduced by AQE. 

### Does this PR introduce _any_ user-facing change?
Yes. It changed the AQE plan output string.

### How was this patch tested?
Unit test
