### PR TITLE
[SPARK-15118][SQL] Spark SQLConf should support loading hive properties in hive-site.xml

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
@@ -111,7 +111,7 @@ abstract class BaseSessionStateBuilder(
     }.getOrElse {
       val conf = new SQLConf
       mergeSparkConf(conf, session.sparkContext.conf)
-      mergeHiveConf(conf, SharedState.loadHiveConf().get)
+      mergeHiveConf(conf, SharedState.loadHiveConf())
       conf
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
@@ -84,12 +84,14 @@ abstract class BaseSessionStateBuilder(
   }
 
   /**
-    * Extract entries from `HiveConf` and put them in the `SQLConf`
-    */
+   * Extract entries from `SparkConf` and put them in the `SQLConf`
+   */
   protected def mergeHiveConf(sqlConf: SQLConf, hiveConf: Configuration): Unit = {
     import scala.collection.JavaConverters._
     hiveConf.asScala.foreach { entry =>
-      sqlConf.setConfString(entry.getKey, entry.getValue)
+      if (!sqlConf.contains(entry.getKey)) {
+        sqlConf.setConfString(entry.getKey, entry.getValue)
+      }
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -230,7 +230,7 @@ object SharedState extends Logging {
       hadoopConf: Configuration): Unit = {
     val hiveWarehouseKey = "hive.metastore.warehouse.dir"
     val hiveConf = loadHiveConf()
-    hiveConf.get.asScala.foreach { entry =>
+    hiveConf.asScala.foreach { entry =>
       hadoopConf.setIfUnset(entry.getKey, entry.getValue)
     }
     // hive.metastore.warehouse.dir only stay in hadoopConf
@@ -258,15 +258,13 @@ object SharedState extends Logging {
     logInfo(s"Warehouse path is '$warehousePath'.")
   }
 
-  def loadHiveConf(): Option[Configuration] = {
+  def loadHiveConf(): Configuration = {
+    val hiveConf = new Configuration()
     val configFile = Utils.getContextOrSparkClassLoader.getResource("hive-site.xml")
     if (configFile != null) {
       logInfo(s"loading hive config file: $configFile")
-      val hiveConf = new Configuration()
       hiveConf.addResource(configFile)
-      Option(hiveConf)
-    } else {
-      None
     }
+    hiveConf
   }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -573,4 +573,8 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
     // the date formatter for `java.sql.LocalDate` must output negative years with sign.
     runCliWithin(1.minute)("SELECT MAKE_DATE(-44, 3, 15);" -> "-0044-03-15")
   }
+
+  test("SPARK-15118 Spark SQLConf should support loading hive properties in hive-site.xml") {
+    runCliWithin(1.minute)("SET hive.in.test;" -> "true")
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
When initializing sqlconf, we merged sparkconf, we should also merge hiveconf too.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Usually, we have many default settings, such as:
```
set hive.default.fileformat=orcfile;
```
In hive, the default setting can be in hive-site.xml. I think we should support the same behavior.

In this example, when created a table which is stored as Orc by default, you don't execute command like this:
 ```
set hive.default.fileformat=orcfile;
create table ... stored as orc;
```
but spark need.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
UT test