### PR TITLE
[SPARK-32349][UI] Reduce unnecessary allexecutors call when render stage page executor summary

### DIFF
--- a/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
@@ -667,6 +667,10 @@ private[spark] class AppStatusListener(
       if (metricsDelta != null) {
         esummary.metrics = LiveEntityHelpers.addMetrics(esummary.metrics, metricsDelta)
       }
+      liveExecutors.get(event.taskInfo.executorId).foreach(e => {
+        esummary.hostPort = e.hostPort
+        esummary.executorLogs = e.executorLogs
+      })
 
       val isLastTask = stage.activeTasksPerExecutor(event.taskInfo.executorId) == 0
 

--- a/core/src/main/scala/org/apache/spark/status/LiveEntity.scala
+++ b/core/src/main/scala/org/apache/spark/status/LiveEntity.scala
@@ -362,11 +362,14 @@ private class LiveExecutorStageSummary(
   var failedTasks = 0
   var killedTasks = 0
   var isBlacklisted = false
+  var hostPort = "Unknown"
+  var executorLogs: Map[String, String] = Map.empty
 
   var metrics = createMetrics(default = 0L)
 
   override protected def doUpdate(): Any = {
     val info = new v1.ExecutorStageSummary(
+      hostPort,
       taskTime,
       failedTasks,
       succeededTasks,
@@ -381,6 +384,7 @@ private class LiveExecutorStageSummary(
       metrics.shuffleWriteMetrics.recordsWritten,
       metrics.memoryBytesSpilled,
       metrics.diskBytesSpilled,
+      executorLogs,
       isBlacklisted)
     new ExecutorStageSummaryWrapper(stageId, attemptId, executorId, info)
   }

--- a/core/src/main/scala/org/apache/spark/status/api/v1/api.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/api.scala
@@ -68,6 +68,7 @@ class ResourceProfileInfo private[spark](
     val taskResources: Map[String, TaskResourceRequest])
 
 class ExecutorStageSummary private[spark](
+    val hostPort: String,
     val taskTime : Long,
     val failedTasks : Int,
     val succeededTasks : Int,
@@ -82,6 +83,7 @@ class ExecutorStageSummary private[spark](
     val shuffleWriteRecords : Long,
     val memoryBytesSpilled : Long,
     val diskBytesSpilled : Long,
+    val executorLogs: Map[String, String],
     val isBlacklistedForStage: Boolean)
 
 class ExecutorSummary private[spark](

--- a/core/src/test/resources/HistoryServerExpectations/blacklisting_for_stage_expectation.json
+++ b/core/src/test/resources/HistoryServerExpectations/blacklisting_for_stage_expectation.json
@@ -683,6 +683,7 @@
   },
   "executorSummary" : {
     "0" : {
+      "hostPort" : "172.30.65.138:64290",
       "taskTime" : 589,
       "failedTasks" : 2,
       "succeededTasks" : 0,
@@ -697,9 +698,14 @@
       "shuffleWriteRecords" : 0,
       "memoryBytesSpilled" : 0,
       "diskBytesSpilled" : 0,
+      "executorLogs" : {
+        "stdout" : "http://172.30.65.138:64279/logPage/?appId=app-20180109111548-0000&executorId=0&logType=stdout",
+        "stderr" : "http://172.30.65.138:64279/logPage/?appId=app-20180109111548-0000&executorId=0&logType=stderr"
+      },
       "isBlacklistedForStage" : true
     },
     "1" : {
+      "hostPort" : "172.30.65.138:64291",
       "taskTime" : 708,
       "failedTasks" : 0,
       "succeededTasks" : 10,
@@ -714,6 +720,10 @@
       "shuffleWriteRecords" : 10,
       "memoryBytesSpilled" : 0,
       "diskBytesSpilled" : 0,
+      "executorLogs" : {
+        "stdout" : "http://172.30.65.138:64278/logPage/?appId=app-20180109111548-0000&executorId=1&logType=stdout",
+        "stderr" : "http://172.30.65.138:64278/logPage/?appId=app-20180109111548-0000&executorId=1&logType=stderr"
+      },
       "isBlacklistedForStage" : false
     }
   },

--- a/core/src/test/resources/HistoryServerExpectations/blacklisting_node_for_stage_expectation.json
+++ b/core/src/test/resources/HistoryServerExpectations/blacklisting_node_for_stage_expectation.json
@@ -791,6 +791,7 @@
   },
   "executorSummary" : {
     "4" : {
+      "hostPort" : "apiros-2.gce.test.com:33229",
       "taskTime" : 1589,
       "failedTasks" : 2,
       "succeededTasks" : 0,
@@ -805,9 +806,14 @@
       "shuffleWriteRecords" : 0,
       "memoryBytesSpilled" : 0,
       "diskBytesSpilled" : 0,
+      "executorLogs" : {
+        "stdout" : "http://apiros-2.gce.test.com:8042/node/containerlogs/container_1516285256255_0012_01_000005/attilapiros/stdout?start=-4096",
+        "stderr" : "http://apiros-2.gce.test.com:8042/node/containerlogs/container_1516285256255_0012_01_000005/attilapiros/stderr?start=-4096"
+      },
       "isBlacklistedForStage" : true
     },
     "5" : {
+      "hostPort" : "apiros-2.gce.test.com:45147",
       "taskTime" : 1579,
       "failedTasks" : 2,
       "succeededTasks" : 0,
@@ -822,9 +828,14 @@
       "shuffleWriteRecords" : 0,
       "memoryBytesSpilled" : 0,
       "diskBytesSpilled" : 0,
+      "executorLogs" : {
+        "stdout" : "http://apiros-2.gce.test.com:8042/node/containerlogs/container_1516285256255_0012_01_000007/attilapiros/stdout?start=-4096",
+        "stderr" : "http://apiros-2.gce.test.com:8042/node/containerlogs/container_1516285256255_0012_01_000007/attilapiros/stderr?start=-4096"
+      },
       "isBlacklistedForStage" : true
     },
     "1" : {
+      "hostPort" : "apiros-3.gce.test.com:34970",
       "taskTime" : 2411,
       "failedTasks" : 0,
       "succeededTasks" : 4,
@@ -839,9 +850,14 @@
       "shuffleWriteRecords" : 12,
       "memoryBytesSpilled" : 0,
       "diskBytesSpilled" : 0,
+      "executorLogs" : {
+        "stdout" : "http://apiros-3.gce.test.com:8042/node/containerlogs/container_1516285256255_0012_01_000002/attilapiros/stdout?start=-4096",
+        "stderr" : "http://apiros-3.gce.test.com:8042/node/containerlogs/container_1516285256255_0012_01_000002/attilapiros/stderr?start=-4096"
+      },
       "isBlacklistedForStage" : false
     },
     "2" : {
+      "hostPort" : "apiros-3.gce.test.com:38670",
       "taskTime" : 2446,
       "failedTasks" : 0,
       "succeededTasks" : 5,
@@ -856,9 +872,14 @@
       "shuffleWriteRecords" : 15,
       "memoryBytesSpilled" : 0,
       "diskBytesSpilled" : 0,
+      "executorLogs" : {
+        "stdout" : "http://apiros-3.gce.test.com:8042/node/containerlogs/container_1516285256255_0012_01_000003/attilapiros/stdout?start=-4096",
+        "stderr" : "http://apiros-3.gce.test.com:8042/node/containerlogs/container_1516285256255_0012_01_000003/attilapiros/stderr?start=-4096"
+      },
       "isBlacklistedForStage" : false
     },
     "3" : {
+      "hostPort" : "apiros-2.gce.test.com:38641",
       "taskTime" : 1774,
       "failedTasks" : 0,
       "succeededTasks" : 1,
@@ -873,6 +894,10 @@
       "shuffleWriteRecords" : 3,
       "memoryBytesSpilled" : 0,
       "diskBytesSpilled" : 0,
+      "executorLogs" : {
+        "stdout" : "http://apiros-2.gce.test.com:8042/node/containerlogs/container_1516285256255_0012_01_000004/attilapiros/stdout?start=-4096",
+        "stderr" : "http://apiros-2.gce.test.com:8042/node/containerlogs/container_1516285256255_0012_01_000004/attilapiros/stderr?start=-4096"
+      },
       "isBlacklistedForStage" : true
     }
   },

--- a/core/src/test/resources/HistoryServerExpectations/one_stage_attempt_json_expectation.json
+++ b/core/src/test/resources/HistoryServerExpectations/one_stage_attempt_json_expectation.json
@@ -445,6 +445,7 @@
   },
   "executorSummary" : {
     "driver" : {
+      "hostPort" : "localhost:57971",
       "taskTime" : 3624,
       "failedTasks" : 0,
       "succeededTasks" : 8,
@@ -459,6 +460,7 @@
       "shuffleWriteRecords" : 0,
       "memoryBytesSpilled" : 0,
       "diskBytesSpilled" : 0,
+      "executorLogs" : { },
       "isBlacklistedForStage" : false
     }
   },

--- a/core/src/test/resources/HistoryServerExpectations/one_stage_json_expectation.json
+++ b/core/src/test/resources/HistoryServerExpectations/one_stage_json_expectation.json
@@ -445,6 +445,7 @@
   },
   "executorSummary" : {
     "driver" : {
+      "hostPort" : "localhost:57971",
       "taskTime" : 3624,
       "failedTasks" : 0,
       "succeededTasks" : 8,
@@ -459,6 +460,7 @@
       "shuffleWriteRecords" : 0,
       "memoryBytesSpilled" : 0,
       "diskBytesSpilled" : 0,
+      "executorLogs" : { },
       "isBlacklistedForStage" : false
     }
   },

--- a/core/src/test/resources/HistoryServerExpectations/stage_with_accumulable_json_expectation.json
+++ b/core/src/test/resources/HistoryServerExpectations/stage_with_accumulable_json_expectation.json
@@ -489,6 +489,7 @@
   },
   "executorSummary" : {
     "driver" : {
+      "hostPort" : "localhost:58610",
       "taskTime" : 418,
       "failedTasks" : 0,
       "succeededTasks" : 8,
@@ -503,6 +504,7 @@
       "shuffleWriteRecords" : 0,
       "memoryBytesSpilled" : 0,
       "diskBytesSpilled" : 0,
+      "executorLogs" : { },
       "isBlacklistedForStage" : false
     }
   },


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `hostPort` and `executorLogs` in `v1.ExecutorStageSummary`, then `/allexecutors` call is not needed


### Why are the changes needed?
Save one unnecessary call and make frontend logic simpler

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Updated HistoryServerSuite
