### PR TITLE
[SPARK-32347][SQL] Hint in CTE should be resolved in Hints batch rule

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.catalyst.analysis
 import java.util.Locale
 
 import scala.collection.mutable
+
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.expressions.{Ascending, Expression, IntegerLiteral, SortOrder, SubqueryExpression}
 import org.apache.spark.sql.catalyst.plans.logical._

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -2559,10 +2559,11 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
     }
   }
 
-  test("SPARK-32347: cte hint regression") {
+  test("SPARK-32347: cte hint should be resolved in Hints batch rule") {
     withTempView("t") {
       sql("create temporary view t as select 1 as id")
       sql("with cte as (select /*+ BROADCAST(id) */ id from t) select id from cte")
+      sql("with cte as (select /*+ COALESCE(3) */ id from t) select id from cte")
     }
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -2558,6 +2558,13 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
       }
     }
   }
+
+  test("SPARK-32347: cte hint regression") {
+    withTempView("t") {
+      sql("create temporary view t as select 1 as id")
+      sql("with cte as (select /*+ BROADCAST(id) */ id from t) select id from cte")
+    }
+  }
 }
 
 @SlowHiveTest


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add CTE hint resolve in `org.apache.spark.sql.catalyst.analysis.ResolveHints.ResolveJoinStrategyHints#apply`
Add a UT in `org.apache.spark.sql.test.SQLTestUtils#test`

### Why are the changes needed?
Branch 2.4, when resolve CTE in `org.apache.spark.sql.catalyst.analysis.Analyzer.CTESubstitution`, we have a chance `executeSameContext` to apply all rules to CTE include hint resolve.
Branch 3.0, because `CTESubstitution` is moved to a separated class, we miss the feature as follow:
`
scala> sql("create temporary view t as select 1 as id")
res0: org.apache.spark.sql.DataFrame = []

scala> sql("with cte as (select /*+ BROADCAST(id) */ id from t) select id from cte")
org.apache.spark.sql.AnalysisException: cannot resolve '`id`' given input columns: [cte.id]; line 1 pos 59;
'Project ['id]
+- SubqueryAlias cte
   +- Project [id#0]
      +- SubqueryAlias t
         +- Project [1 AS id#0]
            +- OneRowRelation
`

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit test.