### PR TITLE
[SPARK-32280][SPARK-32372][SQL]  ResolveReferences.dedupRight should only rewrite attributes for ancestor nodes of the conflict plan

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1264,7 +1264,7 @@ class Analyzer(
         attrMapping ++= plan.output.zip(newRelation.output)
         newRelation -> attrMapping
       } else {
-        var newPlan = plan.mapChildren { child =>
+        val newPlan = plan.mapChildren { child =>
           // If not, we'd rewrite child plan recursively until we find the
           // conflict node or reach the leaf node.
           val (newChild, childAttrMapping) = rewritePlan(child, conflictPlanMap)
@@ -1280,13 +1280,12 @@ class Analyzer(
             "Found duplicate rewrite attributes")
           val attributeRewrites = AttributeMap(attrMapping)
           // rewrite the attributes of parent node
-          newPlan = newPlan.transformExpressions {
+          newPlan.transformExpressions {
             case a: Attribute =>
               dedupAttr(a, attributeRewrites)
             case s: SubqueryExpression =>
               s.withNewPlan(dedupOuterReferencesInSubquery(s.plan, attributeRewrites))
-          }
-          newPlan -> attrMapping
+          } -> attrMapping
         }
       }
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1255,16 +1255,15 @@ class Analyzer(
     }
 
     private def rewritePlan(plan: LogicalPlan, conflictPlanMap: Map[LogicalPlan, LogicalPlan])
-      : (LogicalPlan, mutable.ArrayBuffer[(Attribute, Attribute)]) = {
-      val attrMapping = new mutable.ArrayBuffer[(Attribute, Attribute)]()
+      : (LogicalPlan, Seq[(Attribute, Attribute)]) = {
       if (conflictPlanMap.contains(plan)) {
         // If the plan is the one that conflict the with left one, we'd
         // just replace it with the new plan and collect the rewrite
         // attributes for the parent node.
         val newRelation = conflictPlanMap(plan)
-        attrMapping ++= plan.output.zip(newRelation.output)
-        newRelation -> attrMapping
+        newRelation -> plan.output.zip(newRelation.output)
       } else {
+        val attrMapping = new mutable.ArrayBuffer[(Attribute, Attribute)]()
         val newPlan = plan.mapChildren { child =>
           // If not, we'd rewrite child plan recursively until we find the
           // conflict node or reach the leaf node.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1205,6 +1205,7 @@ class Analyzer(
           Seq((oldVersion, oldVersion.copy(
             aggregateExpressions = newAliases(aggregateExpressions))))
 
+        // We don't search the child plan recursively for the same reason as the above Project.
         case _ @ Aggregate(_, aggregateExpressions, _)
           if findAliases(aggregateExpressions).size == aggregateExpressions.size =>
           Nil

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1279,7 +1279,8 @@ class Analyzer(
             .exists(_._2.map(_._2.exprId).distinct.length > 1),
             "Found duplicate rewrite attributes")
           val attributeRewrites = AttributeMap(attrMapping)
-          // rewrite the attributes of parent node
+          // Using attrMapping from the children plans to rewrite their parent node.
+          // Note that we shouldn't rewrite a node using attrMapping from its sibling nodes.
           newPlan.transformExpressions {
             case a: Attribute =>
               dedupAttr(a, attributeRewrites)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1268,7 +1268,43 @@ class Analyzer(
           // If not, we'd rewrite child plan recursively until we find the
           // conflict node or reach the leaf node.
           val (newChild, childAttrMapping) = rewritePlan(child, conflictPlanMap)
-          attrMapping ++= childAttrMapping
+          // Only return rewrite attributes which could be used by the parent node.
+          // Otherwise, it could introduce duplicate rewrite attributes. For example,
+          // for the following plan, if we don't do filter for the `childAttrMapping`,
+          // the node `SubqueryAlias b` will return rewrite attribute of [kind#220 -> kind#228]
+          // (which is from the conflict plan `Project [id#218, foo AS kind#228]`), and the node
+          // `SubqueryAlias c` will return rewrite attribute of [kind#220 -> kind#229] (which
+          // is from the conflict plan `Project [id#227, foo AS kind#229]`). As a result, the top
+          // Join will have duplicated rewrite attribute.
+          //
+          // The problem is, the plan `Join Inner, (kind#229 = kind#223)` shouldn't keep returning
+          // rewrite attribute of [kind#220 -> kind#229] to its parent node `Project [id#227]` as
+          // it doesn't really need it.
+          //
+          // Join Inner, (id#218 = id#227)
+          // :- SubqueryAlias b
+          // :  +- Project [id#218, foo AS kind#228]
+          // :     +- SubqueryAlias a
+          // :        +- Project [1 AS id#218]
+          // :           +- OneRowRelation
+          // +- SubqueryAlias c
+          //    +- Project [id#227]
+          //       +- Join Inner, (kind#229 = kind#223)
+          //          :- SubqueryAlias l
+          //          :  +- SubqueryAlias b
+          //          :     +- Project [id#227, foo AS kind#229]
+          //          :        +- SubqueryAlias a
+          //          :           +- Project [1 AS id#227]
+          //          :              +- OneRowRelation
+          //          +- SubqueryAlias r
+          //             +- SubqueryAlias b
+          //                +- Project [id#224, foo AS kind#223]
+          //                   +- SubqueryAlias a
+          //                      +- Project [1 AS id#224]
+          //                         +- OneRowRelation
+          attrMapping ++= childAttrMapping.filter { case (oldAttr, _) =>
+            (plan.references ++ plan.outputSet ++ plan.producedAttributes).contains(oldAttr)
+          }
           newChild
         }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1269,9 +1269,11 @@ class Analyzer(
           // conflict node or reach the leaf node.
           val (newChild, childAttrMapping) = rewritePlan(child, conflictPlanMap)
           attrMapping ++= childAttrMapping.filter { case (oldAttr, _) =>
-            // If an attribute from the child is not output or referenced by the parent plan,
-            // it's useless to propagate this attribute to the parent plan, as they are not
-            // going to use this attribute.
+            // `attrMapping` is not only used to replace the attributes of the current `plan`,
+            // but also to be propagated to the parent plans of the current `plan`. Therefore,
+            // the `oldAttr` must be part of either `plan.references` (so that it can be used to
+            // replace attributes of the current `plan`) or `plan.outputSet` (so that it can be
+            // used by those parent plans).
             (plan.outputSet ++ plan.references).contains(oldAttr)
           }
           newChild

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3565,12 +3565,14 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     withTable("t") {
       sql("CREATE TABLE t USING PARQUET AS SELECT 1 AS id")
       checkAnswer(
-        sql(s"""
-          |WITH cte AS (SELECT /*+ REPARTITION(3) */ * FROM t)
-          |SELECT * FROM cte
+        sql(
+          s"""
+             |WITH cte AS (SELECT /*+ REPARTITION(3) */ * FROM t)
+             |SELECT * FROM cte
         """.stripMargin),
         Row(1) :: Nil)
     }
+  }
 
   test("SPARK-32372: ResolveReferences.dedupRight should only rewrite attributes for ancestor " +
     "plans of the conflict plan") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3565,10 +3565,9 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     withTable("t") {
       sql("CREATE TABLE t USING PARQUET AS SELECT 1 AS id")
       checkAnswer(
-        sql(
-          s"""
-             |WITH cte AS (SELECT /*+ REPARTITION(3) */ * FROM t)
-             |SELECT * FROM cte
+        sql(s"""
+          |WITH cte AS (SELECT /*+ REPARTITION(3) */ * FROM t)
+          |SELECT * FROM cte
         """.stripMargin),
         Row(1) :: Nil)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3573,7 +3573,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     }
 
   test("SPARK-32372: ResolveReferences.dedupRight should only rewrite attributes for ancestor " +
-    "nodes") {
+    "plans of the conflict plan") {
     sql("SELECT name, avg(age) as avg_age FROM person GROUP BY name")
       .createOrReplaceTempView("person_a")
     sql("SELECT p1.name, p2.avg_age FROM person p1 JOIN person_a p2 ON p1.name = p2.name")

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3588,7 +3588,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
   test("SPARK-32280: Avoid duplicate rewrite attributes when there're multiple JOINs") {
     sql("SELECT 1 AS id").createOrReplaceTempView("A")
     sql("SELECT id, 'foo' AS kind FROM A").createOrReplaceTempView("B")
-    sql("SELECT l.id  FROM B AS l JOIN B AS r ON l.kind = r.kind")
+    sql("SELECT l.id as id FROM B AS l LEFT SEMI JOIN B AS r ON l.kind = r.kind")
       .createOrReplaceTempView("C")
     checkAnswer(sql("SELECT 0 FROM ( SELECT * FROM B JOIN C USING (id)) " +
       "JOIN ( SELECT * FROM B JOIN C USING (id)) USING (id)"), Row(0))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR refactors `ResolveReferences.dedupRight` to make sure it only rewrite attributes for ancestor nodes of the conflict plan.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This is a bug fix.

```scala
sql("SELECT name, avg(age) as avg_age FROM person GROUP BY name")
  .createOrReplaceTempView("person_a")
sql("SELECT p1.name, p2.avg_age FROM person p1 JOIN person_a p2 ON p1.name = p2.name") 
  .createOrReplaceTempView("person_b")
sql("SELECT * FROM person_a UNION SELECT * FROM person_b")
  .createOrReplaceTempView("person_c")
sql("SELECT p1.name, p2.avg_age FROM person_c p1 JOIN person_c p2 ON p1.name = p2.name").show()
```
When executing the above query, we'll hit the error:

```scala
[info]   Failed to analyze query: org.apache.spark.sql.AnalysisException: Resolved attribute(s) avg_age#231 missing from name#223,avg_age#218,id#232,age#234,name#233 in operator !Project [name#233, avg_age#231]. Attribute(s) with the same name appear in the operation: avg_age. Please check if the right attribute(s) are used.;;
...
```

The plan below is the problematic plan which is the right plan of a `Join` operator. And, it has conflict plans comparing to the left plan. In this problematic plan, the first `Aggregate` operator (the one under the first child of `Union`) becomes a conflict plan compares to the left one and has a rewrite attribute pair as  `avg_age#218` -> `avg_age#231`. With the current `dedupRight` logic, we'll first replace this `Aggregate` with a new one, and then rewrites the attribute `avg_age#218` from bottom to up. As you can see, projects with the attribute `avg_age#218` of the second child of the `Union` can also be replaced with `avg_age#231`(That means we also rewrite attributes for non-ancestor plans for the conflict plan). Ideally, the attribute `avg_age#218` in the second `Aggregate` operator (the one under the second child of `Union`) should also be replaced. But it didn't because it's an `Alias` while we only rewrite `Attribute` yet. Therefore, the project above the second `Aggregate` becomes unresolved.



```scala
:    
:
+- SubqueryAlias p2
   +- SubqueryAlias person_c
      +- Distinct
         +- Union
            :- Project [name#233, avg_age#231]
            :  +- SubqueryAlias person_a
            :     +- Aggregate [name#233], [name#233, avg(cast(age#234 as bigint)) AS avg_age#231]
            :        +- SubqueryAlias person
            :           +- SerializeFromObject [knownnotnull(assertnotnull(input[0, org.apache.spark.sql.test.SQLTestData$Person, true])).id AS id#232, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, org.apache.spark.sql.test.SQLTestData$Person, true])).name, true, false) AS name#233, knownnotnull(assertnotnull(input[0, org.apache.spark.sql.test.SQLTestData$Person, true])).age AS age#234]
            :              +- ExternalRDD [obj#165]
            +- Project [name#233 AS name#227, avg_age#231 AS avg_age#228]
               +- Project [name#233, avg_age#231]
                  +- SubqueryAlias person_b
                     +- !Project [name#233, avg_age#231]
                        +- Join Inner, (name#233 = name#223)
                           :- SubqueryAlias p1
                           :  +- SubqueryAlias person
                           :     +- SerializeFromObject [knownnotnull(assertnotnull(input[0, org.apache.spark.sql.test.SQLTestData$Person, true])).id AS id#232, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, org.apache.spark.sql.test.SQLTestData$Person, true])).name, true, false) AS name#233, knownnotnull(assertnotnull(input[0, org.apache.spark.sql.test.SQLTestData$Person, true])).age AS age#234]
                           :        +- ExternalRDD [obj#165]
                           +- SubqueryAlias p2
                              +- SubqueryAlias person_a
                                 +- Aggregate [name#223], [name#223, avg(cast(age#224 as bigint)) AS avg_age#218]
                                    +- SubqueryAlias person
                                       +- SerializeFromObject [knownnotnull(assertnotnull(input[0, org.apache.spark.sql.test.SQLTestData$Person, true])).id AS id#222, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, org.apache.spark.sql.test.SQLTestData$Person, true])).name, true, false) AS name#223, knownnotnull(assertnotnull(input[0, org.apache.spark.sql.test.SQLTestData$Person, true])).age AS age#224]
                                          +- ExternalRDD [obj#165]
```



### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, users would no longer hit the error after this fix.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Added test.