### PR TITLE
[SPARK-30876][SQL] Optimizer fails to infer constraints within join

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -116,7 +116,8 @@ abstract class Optimizer(catalogManager: CatalogManager)
         operatorOptimizationRuleSet.filterNot(_ == InferFiltersFromConstraints)
       Batch("Operator Optimization before Inferring Filters", fixedPoint,
         rulesWithoutInferFiltersFromConstraints: _*) ::
-      Batch("Infer Filters", Once,
+      Batch("Infer Filters", fixedPoint,
+        PushDownPredicates,
         InferFiltersFromConstraints) ::
       Batch("Operator Optimization after Inferring Filters", fixedPoint,
         rulesWithoutInferFiltersFromConstraints: _*) ::

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferFiltersPredicatePushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferFiltersPredicatePushdownSuite.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.analysis.{EmptyFunctionRegistry, FakeV2SessionCatalog}
+import org.apache.spark.sql.catalyst.catalog.{InMemoryCatalog, SessionCatalog}
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions.{IsNotNull, Literal}
+import org.apache.spark.sql.catalyst.expressions.aggregate.Count
+import org.apache.spark.sql.catalyst.plans.{Inner, PlanTest}
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+import org.apache.spark.sql.connector.catalog.CatalogManager
+import org.apache.spark.sql.internal.SQLConf
+
+class InferFiltersPredicatePushdownSuite extends PlanTest {
+
+  object OptimizeOriginal extends Optimizer(
+    new CatalogManager(
+      new SQLConf(),
+      FakeV2SessionCatalog,
+      new SessionCatalog(new InMemoryCatalog, EmptyFunctionRegistry, new SQLConf()))) {
+    override def defaultBatches: Seq[Batch] = super.defaultBatches
+  }
+
+  object Optimize extends RuleExecutor[LogicalPlan] {
+    val b = Batch("InferAndPushDownFilters", FixedPoint(100),
+      PushPredicateThroughJoin,
+      ColumnPruning
+    )
+    val batches =
+      b ::
+      Batch("infer filter from constraints", FixedPoint(100),
+        PushDownPredicates,
+        InferFiltersFromConstraints) ::
+        Nil
+  }
+  val  testRelation = LocalRelation('a.int, 'b.int, 'c.int)
+
+  test("SPARK-30876: optimize constraints in 3-way join") {
+    val x = testRelation.subquery('x)
+    val y = testRelation.subquery('y)
+    val z = testRelation.subquery('z)
+    val originalQuery = x.join(y).join(z)
+      .where(("x.a".attr === "y.b".attr) && ("y.b".attr === "z.c".attr) && ("z.c".attr === 1))
+      .groupBy()(Count(Literal("*"))).analyze
+    val optimized = Optimize.execute(originalQuery)
+    val correctAnswer = x.where('a === 1 && IsNotNull('a)).select('a)
+      .join(y.where('b === 1 && IsNotNull('b))
+        .select('b), Inner, Some("x.a".attr === "y.b".attr))
+      .select('b)
+      .join(z.where('c === 1 && IsNotNull('c))
+        .select('c), Inner, Some('b === "z.c".attr))
+      .select()
+      .groupBy()(Count(Literal("*"))).analyze
+    comparePlans(optimized, correctAnswer)
+  }
+
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferFiltersPredicatePushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferFiltersPredicatePushdownSuite.scala
@@ -17,28 +17,15 @@
 
 package org.apache.spark.sql.catalyst.optimizer
 
-import org.apache.spark.sql.Row
-import org.apache.spark.sql.catalyst.analysis.{EmptyFunctionRegistry, FakeV2SessionCatalog}
-import org.apache.spark.sql.catalyst.catalog.{InMemoryCatalog, SessionCatalog}
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
-import org.apache.spark.sql.catalyst.expressions.{IsNotNull, Literal}
 import org.apache.spark.sql.catalyst.expressions.aggregate.Count
-import org.apache.spark.sql.catalyst.plans.{Inner, PlanTest}
+import org.apache.spark.sql.catalyst.expressions.{IsNotNull, Literal}
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.{Inner, PlanTest}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
-import org.apache.spark.sql.connector.catalog.CatalogManager
-import org.apache.spark.sql.internal.SQLConf
 
 class InferFiltersPredicatePushdownSuite extends PlanTest {
-
-  object OptimizeOriginal extends Optimizer(
-    new CatalogManager(
-      new SQLConf(),
-      FakeV2SessionCatalog,
-      new SessionCatalog(new InMemoryCatalog, EmptyFunctionRegistry, new SQLConf()))) {
-    override def defaultBatches: Seq[Batch] = super.defaultBatches
-  }
 
   object Optimize extends RuleExecutor[LogicalPlan] {
     val b = Batch("InferAndPushDownFilters", FixedPoint(100),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferFiltersPredicatePushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferFiltersPredicatePushdownSuite.scala
@@ -19,10 +19,10 @@ package org.apache.spark.sql.catalyst.optimizer
 
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
-import org.apache.spark.sql.catalyst.expressions.aggregate.Count
 import org.apache.spark.sql.catalyst.expressions.{IsNotNull, Literal}
-import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.expressions.aggregate.Count
 import org.apache.spark.sql.catalyst.plans.{Inner, PlanTest}
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 
 class InferFiltersPredicatePushdownSuite extends PlanTest {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
For a 3-way join of the kind described below, the optimizer fails to infer the constraint a=1. This appears to be because of the interaction between the following rules: ColumnPruning, InferFiltersFromConstraints, and PredicatePushdown.

For the following SQL query:
```
create table t1(a int, b int, c int);
create table t2(a int, b int, c int);
create table t3(a int, b int, c int);
select count(*) from t1 join t2 join t3 on (t1.a = t2.b and t2.b = t3.c and t3.c = 1);
```

The optimized logical plan produced is:
```
== Optimized Logical Plan ==
Aggregate [count(1) AS count(1)#66L]
+- Project
   +- Join Inner, (b#61 = c#65)
      :- Project [b#61]
      :  +- Join Inner, (a#57 = b#61)
      :     :- Project [a#57]
      :     :  +- Filter isnotnull(a#57)
      :     :     +- HiveTableRelation `default`.`t1`, org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe, [a#57, b#58, c#59], Statistics(sizeInBytes=8.0 EiB)
      :     +- Project [b#61]
      :        +- Filter (isnotnull(b#61) AND (b#61 = 1))
      :           +- HiveTableRelation `default`.`t2`, org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe, [a#60, b#61, c#62], Statistics(sizeInBytes=8.0 EiB)
      +- Project [c#65]
         +- Filter (isnotnull(c#65) AND (c#65 = 1))
            +- HiveTableRelation `default`.`t3`, org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe, [a#63, b#64, c#65], Statistics(sizeInBytes=8.0 EiB)
```

The constraint `a=1` does not get inferred because after column pruning, the InferFiltersFromConstraints rule on the outer join operator only infers `b=1`, since the project operator around the join operator drops the constraint that refers to 'a'. Later, when PushdownPredicates runs again, the `b=1` constraint gets pushed down to relation 'y'.

In order to resolve this, this patch proposes replacing the InferFiltersFromConstraints once batch with a batch of InferFiltersFromConstraints and PredicatePushdown to fixed point. With this change, the constraint `b=1` will be inferred and pushed down first. The constraint `a=1` can then be inferred for the inner join operator because `b=1` is now available in order to infer it. Running PredicatePushdown again will push `a=1` to its correct position.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Improves performance of optimization. Also this worked correctly earlier in 2.3.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added a unit test. The test should fail if InferFiltersFromConstraints is run only once.
