### PR TITLE
[SPARK-32379][BUILD] docker based spark release script should use correct CRAN repo.

### DIFF
--- a/dev/create-release/spark-rm/Dockerfile
+++ b/dev/create-release/spark-rm/Dockerfile
@@ -39,7 +39,7 @@ ARG PIP_PKGS="pyopenssl pypandoc numpy pygments sphinx"
 # This is all in a single "RUN" command so that if anything changes, "apt update" is run to fetch
 # the most current package versions (instead of potentially using old versions cached by docker).
 RUN apt-get clean && apt-get update && $APT_INSTALL gnupg ca-certificates apt-transport-https && \
-  echo 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran40/' >> /etc/apt/sources.list && \
+  echo 'deb https://cloud.r-project.org/bin/linux/ubuntu xenial-cran40/' >> /etc/apt/sources.list && \
   gpg --keyserver keyserver.ubuntu.com --recv-key E298A3A825C0D65DFD57CBB651716619E084DAB9 && \
   gpg -a --export E084DAB9 | apt-key add - && \
   apt-get clean && \


### PR DESCRIPTION
…


### What changes were proposed in this pull request?
Change repo for CRAN as per the ubuntu version used in docker image of the release script.


### Why are the changes needed?
Without this change, r-base and r-dev dependency won't install.

```
[root@kyok-test-1 ~]# tail docker-build.log 
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 r-base : Depends: r-base-core (>= 4.0.2-1.1804.0) but it is not going to be installed
          Depends: r-recommended (= 4.0.2-1.1804.0) but it is not going to be installed
 r-base-dev : Depends: r-base-core (>= 4.0.2-1.1804.0) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
The command '/bin/sh -c apt-get clean && apt-get update && $APT_INSTALL gnupg ca-certificates apt-transport-https &&   echo 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran40/' >> /etc/apt/sources.list &&   gpg --keyserver keyserver.ubuntu.com --recv-key E298A3A825C0D65DFD57CBB651716619E084DAB9 &&   gpg -a --export E084DAB9 | apt-key add - &&   apt-get clean &&   rm -rf /var/lib/apt/lists/* &&   apt-get clean &&   apt-get update &&   $APT_INSTALL software-properties-common &&   apt-add-repository -y ppa:brightbox/ruby-ng &&   apt-get update &&   $APT_INSTALL openjdk-8-jdk &&   update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java &&   $APT_INSTALL curl wget git maven ivy subversion make gcc lsof libffi-dev     pandoc pandoc-citeproc libssl-dev libcurl4-openssl-dev libxml2-dev &&   ln -s -T /usr/share/java/ivy.jar /usr/share/ant/lib/ivy.jar &&   curl -sL https://deb.nodesource.com/setup_4.x | bash &&   $APT_INSTALL nodejs &&   $APT_INSTALL libpython2.7-dev libpython3-dev python-pip python3-pip &&   pip install --upgrade pip && hash -r pip &&   pip install setuptools &&   pip install $BASE_PIP_PKGS &&   pip install $PIP_PKGS &&   cd &&   virtualenv -p python3 /opt/p35 &&   . /opt/p35/bin/activate &&   pip install setuptools &&   pip install $BASE_PIP_PKGS &&   pip install $PIP_PKGS &&   $APT_INSTALL r-base r-base-dev &&   $APT_INSTALL texlive-latex-base texlive texlive-fonts-extra texinfo qpdf &&   Rscript -e "install.packages(c('curl', 'xml2', 'httr', 'devtools', 'testthat', 'knitr', 'rmarkdown', 'roxygen2', 'e1071', 'survival'), repos='https://cloud.r-project.org/')" &&   Rscript -e "devtools::install_github('jimhester/lintr')" &&   $APT_INSTALL ruby2.3 ruby2.3-dev mkdocs &&   gem install jekyll --no-rdoc --no-ri -v 3.8.6 &&   gem install jekyll-redirect-from -v 0.15.0 &&   gem install pygments.rb' returned a non-zero code: 100
```

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manually, by applying this patch, create release script pass without errors.
