### PR TITLE
[SPARK-32380][SQL] fixed spark3.0 access hive table while data in hbase problem

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -299,7 +299,9 @@ class HadoopTableReader(
    */
   private def createHadoopRDD(localTableDesc: TableDesc, inputPathStr: String): RDD[Writable] = {
     val inputFormatClazz = localTableDesc.getInputFileFormatClass
-    if (classOf[newInputClass[_, _]].isAssignableFrom(inputFormatClazz)) {
+    if (!inputFormatClazz.getName.
+      equalsIgnoreCase("org.apache.hadoop.hive.hbase.HiveHBaseTableInputFormat")
+      && classOf[newInputClass[_, _]].isAssignableFrom(inputFormatClazz)) {
       createNewHadoopRDD(localTableDesc, inputPathStr)
     } else {
       createOldHadoopRDD(localTableDesc, inputPathStr)


### PR DESCRIPTION

### What changes were proposed in this pull request?
The PR modify TableReader.scala to create OldHadoopRDD when inputformat is 'org.apache.hadoop.hive.hbase.HiveHBaseTableInputFormat', beacuse default NewHadoopRDD can not access hbase table.
Reference link： https://issues.apache.org/jira/browse/SPARK-32380



- environments：
hadoop 2.8.5 
hive 2.3.7 
spark 3.0.0 
hbase 1.4.9

### Why are the changes needed?
When sparksql cannot access hive table while data in hbase will encounter abnormality, want to fixed this bug.

### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?

- step1: create hbase table

```
 hbase(main):001:0>create 'hbase_test1', 'cf1'
 hbase(main):001:0> put 'hbase_test', 'r1', 'cf1:c1', '123'

```


- step2: create hive table related to hbase table

hive> 
```
CREATE EXTERNAL TABLE `hivetest.hbase_test`(
  `key` string COMMENT '', 
  `value` string COMMENT '')
ROW FORMAT SERDE 
  'org.apache.hadoop.hive.hbase.HBaseSerDe' 
STORED BY 
  'org.apache.hadoop.hive.hbase.HBaseStorageHandler' 
WITH SERDEPROPERTIES ( 
  'hbase.columns.mapping'=':key,cf1:v1', 
  'serialization.format'='1')
TBLPROPERTIES (
  'hbase.table.name'='hbase_test')
```
 

- step3: sparksql query hive table while data in hbase

`spark-sql --master yarn -e "select * from hivetest.hbase_test"`
