### PR TITLE
[SPARK-32384][CORE] repartitionAndSortWithinPartitions avoid shuffle with same partitioner

### DIFF
--- a/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
@@ -862,6 +862,32 @@ class RDDSuite extends SparkFunSuite with SharedSparkContext with Eventually {
     assert(partitions(1) === Seq((1, 3), (3, 8), (3, 8)))
   }
 
+  test("repartitionAndSortWithinPartitions without shuffle") {
+    val data = sc.parallelize(Seq((0, 5), (3, 8), (2, 6), (0, 8), (3, 8), (1, 3)), 2)
+
+    class ModePartitioner(val numPartitions: Int) extends Partitioner {
+      def getPartition(key: Any): Int = key.asInstanceOf[Int] % numPartitions
+
+      override def equals(other: Any): Boolean = other match {
+        case h: ModePartitioner => h.numPartitions == this.numPartitions
+        case _ => false
+      }
+
+      override def hashCode: Int = numPartitions
+    }
+
+    val partitioner = new ModePartitioner(2)
+    val agged = data.reduceByKey(partitioner, _ + _)
+    assert(agged.partitioner == Some(partitioner))
+
+    val sorted = agged.repartitionAndSortWithinPartitions(partitioner)
+    assert(sorted.partitioner == Some(partitioner))
+
+    val partitions = sorted.glom().collect()
+    assert(partitions(0) === Seq((0, 13), (2, 6)))
+    assert(partitions(1) === Seq((1, 3), (3, 16)))
+  }
+
   test("cartesian on empty RDD") {
     val a = sc.emptyRDD[Int]
     val b = sc.parallelize(1 to 3)


### PR DESCRIPTION
### What changes were proposed in this pull request?
avoid unnecessary shuffle if possible

### Why are the changes needed?
In `combineByKeyWithClassTag`, there is a check to avoid unnecessary shuffle if possible:

```scala
if (self.partitioner == Some(partitioner)) {
  self.mapPartitions(iter => {
    val context = TaskContext.get()
    new InterruptibleIterator(context, aggregator.combineValuesByKey(iter, context))
  }, preservesPartitioning = true)
} else {
  new ShuffledRDD[K, V, C](self, partitioner)
    .setSerializer(serializer)
    .setAggregator(aggregator)
    .setMapSideCombine(mapSideCombine)
}
```

`repartitionAndSortWithinPartitions` should also avoid unnecessary shuffle.




### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
added testsuites and existing testsuites
