### PR TITLE
[SPARK-32386][SS][TESTS] Fix temp view leaking in Structured Streaming tests

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/MemorySinkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/MemorySinkSuite.scala
@@ -329,6 +329,21 @@ class MemorySinkSuite extends StreamTest with BeforeAndAfter {
     assert(sink.allData.map(_.getInt(0)).sorted == Seq(1, 2, 3, 4, 6, 7, 11, 22, 33))
   }
 
+  test("drop temp view") {
+    val input = MemoryStream[Int]
+    val tableName = "memStream"
+    val query = input.toDF().writeStream
+      .format("memory")
+      .queryName(tableName)
+      .start()
+    input.addData(1, 2, 3)
+    query.processAllAvailable()
+
+    assert(spark.catalog.tableExists(tableName))
+    query.stop()
+    assert(!spark.catalog.tableExists(tableName))
+  }
+
   private def addBatchFunc(sink: MemorySink, needTruncate: Boolean)(
       batchId: Long,
       vals: Seq[Int]): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Delete the temp view created by memory source stream writer.

### Why are the changes needed?
The memory source of stream writer will create temp view here: https://github.com/apache/spark/blob/d2ff5c5bfb29a7b22df3cb49b6584c3e2bec397c/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala#L312

We will hit the "temp view already exists" error when trying to create the view with the same name.

### Does this PR introduce _any_ user-facing change?
Yes, after stopping the stream query, the temp view will be deleted.


### How was this patch tested?
New UT.
