### PR TITLE
[SPARK-32392][SQL] Reduce duplicate error log for executing sql statement operation in thrift server

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
@@ -218,9 +218,7 @@ private[hive] class SparkExecuteStatementOperation(
                   execute()
                 }
               } catch {
-                case e: HiveSQLException =>
-                  setOperationException(e)
-                  log.error("Error running hive query: ", e)
+                case e: HiveSQLException => setOperationException(e)
               }
             }
           }

--- a/sql/hive-thriftserver/src/test/resources/log4j.properties
+++ b/sql/hive-thriftserver/src/test/resources/log4j.properties
@@ -64,4 +64,4 @@ log4j.logger.org.apache.hadoop.hive.ql.io.RCFile=ERROR
 log4j.logger.org.apache.parquet.CorruptStatistics=ERROR
 log4j.logger.parquet.CorruptStatistics=ERROR
 
-# log4j.logger.org.apache.spark.sql.hive.thriftserver.SparkExecuteStatementOperation=OFF
+log4j.logger.org.apache.spark.sql.hive.thriftserver.SparkExecuteStatementOperation=OFF

--- a/sql/hive-thriftserver/src/test/resources/log4j.properties
+++ b/sql/hive-thriftserver/src/test/resources/log4j.properties
@@ -63,3 +63,5 @@ log4j.logger.org.apache.hadoop.hive.ql.io.RCFile=ERROR
 # Parquet related logging
 log4j.logger.org.apache.parquet.CorruptStatistics=ERROR
 log4j.logger.parquet.CorruptStatistics=ERROR
+
+# log4j.logger.org.apache.spark.sql.hive.thriftserver.SparkExecuteStatementOperation=OFF


### PR DESCRIPTION

### What changes were proposed in this pull request?

This PR removes the duplicated error log which has been logged in `org.apache.spark.sql.hive.thriftserver.SparkExecuteStatementOperation#execute` but logged again in `runInternal`.

Besides, the log4j configuration for SparkExecuteStatementOperation is turned off because it's not very friendly for Jenkins


### Why are the changes needed?

remove the duplicated error log for better  user experience

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, less log in thrift server's driver log

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
locally verified the result in target/unit-test.log