### PR TITLE
[SPARK-32408][BUILD] Disable crossPaths only in GitHub Actions to prevent side effects

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -181,9 +181,16 @@ abstract class AbstractCommandBuilder {
         }
       }
       if (isTesting) {
+        boolean isGitHubActionsBuild = System.getenv("GITHUB_ACTIONS") != null;
         for (String project : projects) {
-          addToClassPath(cp, String.format("%s/%s/target/scala-%s/test-classes", sparkHome,
-            project, scala));
+          if (isGitHubActionsBuild) {
+            // In GitHub Actions build, SBT option 'crossPaths' is disabled so the Scala version
+            // directory is not created, see SPARK-32408. This is a temporary workaround.
+            addToClassPath(cp, String.format("%s/%s/target/test-classes", sparkHome, project));
+          } else {
+            addToClassPath(cp, String.format("%s/%s/target/scala-%s/test-classes", sparkHome,
+              project, scala));
+          }
         }
       }
 

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1035,7 +1035,7 @@ object TestSettings {
         Seq("-eNCXEHLOPQMDF")
       }.getOrElse(Nil): _*),
     testOptions in Test += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),
-    // This is currently only disabled in GitHun Actions build as a temporary workaround. See SPARK-32408.
+    // This is currently only disabled in GitHub Actions build as a temporary workaround. See SPARK-32408.
     // It is required to detect Junit tests for each project, see also
     // https://github.com/sbt/junit-interface/issues/35
     crossPaths := sys.env.get("GITHUB_ACTIONS").isEmpty,

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1035,8 +1035,10 @@ object TestSettings {
         Seq("-eNCXEHLOPQMDF")
       }.getOrElse(Nil): _*),
     testOptions in Test += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),
-    // Required to detect Junit tests for each project, see also https://github.com/sbt/junit-interface/issues/35
-    crossPaths := false,
+    // This is currently only disabled in GitHun Actions build as a temporary workaround. See SPARK-32408.
+    // It is required to detect Junit tests for each project, see also
+    // https://github.com/sbt/junit-interface/issues/35
+    crossPaths := sys.env.get("GITHUB_ACTIONS").isEmpty,
     // Enable Junit testing.
     libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test",
     // `parallelExecutionInTest` controls whether test suites belonging to the same SBT project

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -850,9 +850,10 @@ class QueryExecutionListenerTests(unittest.TestCase, SQLTestUtils):
 
         SPARK_HOME = _find_spark_home()
         filename_pattern = (
-            "sql/core/target/scala-*/test-classes/org/apache/spark/sql/"
+            "sql/core/target/**/test-classes/org/apache/spark/sql/"
             "TestQueryExecutionListener.class")
-        cls.has_listener = bool(glob.glob(os.path.join(SPARK_HOME, filename_pattern)))
+        cls.has_listener = bool(glob.glob(
+            os.path.join(SPARK_HOME, filename_pattern), recursive=True))
 
         if cls.has_listener:
             # Note that 'spark.sql.queryExecutionListeners' is a static immutable configuration.

--- a/python/pyspark/sql/tests/test_session.py
+++ b/python/pyspark/sql/tests/test_session.py
@@ -326,9 +326,9 @@ class SparkExtensionsTest(unittest.TestCase):
 
         SPARK_HOME = _find_spark_home()
         filename_pattern = (
-            "sql/core/target/scala-*/test-classes/org/apache/spark/sql/"
+            "sql/core/target/**/test-classes/org/apache/spark/sql/"
             "SparkSessionExtensionSuite.class")
-        if not glob.glob(os.path.join(SPARK_HOME, filename_pattern)):
+        if not glob.glob(os.path.join(SPARK_HOME, filename_pattern), recursive=True):
             raise unittest.SkipTest(
                 "'org.apache.spark.sql.SparkSessionExtensionSuite' is not "
                 "available. Will skip the related tests.")

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -155,7 +155,7 @@ def search_jar(project_relative_path, sbt_jar_name_prefix, mvn_jar_name_prefix):
     # Search jar in the project dir using the jar name_prefix for both sbt build and maven
     # build because the artifact jars are in different directories.
     sbt_build = glob.glob(os.path.join(
-        project_full_path, "target/scala-*/%s*.jar" % sbt_jar_name_prefix))
+        project_full_path, "target/**/%s*.jar" % sbt_jar_name_prefix), recursive=True)
     maven_build = glob.glob(os.path.join(
         project_full_path, "target/%s*.jar" % mvn_jar_name_prefix))
     jar_paths = sbt_build + maven_build

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -158,7 +158,7 @@ def search_jar(project_relative_path, sbt_jar_name_prefix, mvn_jar_name_prefix):
         project_full_path, "target/**/%s*.jar" % sbt_jar_name_prefix), recursive=True)
     maven_build = glob.glob(os.path.join(
         project_full_path, "target/%s*.jar" % mvn_jar_name_prefix))
-    jar_paths = sbt_build + maven_build
+    jar_paths = set(sbt_build + maven_build)
     jars = [jar for jar in jar_paths if not jar.endswith(ignored_jar_suffixes)]
 
     if not jars:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a kind of a followup of https://github.com/apache/spark/pull/29057 which disabled `crossPaths` in order to run JUnit tests together properly when an SBT project is explicitly selected. For example, if you run the tests via `sbt kvstore/test`, it didn't run relevant JUnit tests before disabling `crossPaths`, see also https://github.com/sbt/junit-interface/issues/35.

Disabling `crossPaths` removes a Scala version directory to the build output, for example,

from:

```
target/scala-2.12/classes
target/scala-2.12/test-classes
```

to:

```
target/classes
target/test-classes
```

The previous PR disabled it only for the main SBT projects that relates to the main codes only, and did not disable for other SBT projects such as Unidoc, assembly and examples to minimise the side effects. For example, the jars from the assembly output are still placed under `target/scala-2.12` properly.

However, I realised that later there are some codes dependent on this `scala-2.12` paths in the tests and main codes, for example, `SPARK_PREPEND_CLASSES` or some PySpark tests that require some classes present in JVM (you can search the instances via `git grep -r "target/scala-"`). Although these are mostly for dev purposes, I would like to minimise such side effects by only disabling `crossPaths` in GitHub Actions as a temporary workaround for now.


</br>

In the long run, I think we should disable `crossPaths` for all projects including Unidoc, assembly and etc.

Roughly speaking, the only advantage of enabling `crossPaths` is to support SBT's cross building, for example,`sbt +package` to build multiple Scala versions at once (which Maven build doesn't as far as I know). Up to my knowledge, we're not supporting this at all, and will be very difficult to support considering that we're currently relying on the conversion from poms to SBT projects.  More importantly, we're using Maven to make the releases.

There was already a try at SPARK-14574 before which was resolved as a `Later`. Probably, we should revisit it soon to solve JUnit testing problem together.


### Why are the changes needed?

To minimise the side effects from `crossPaths` such as `SPARK_PREPEND_CLASSES` or tests that run conditionally if the test classes are present in PySpark.


### Does this PR introduce _any_ user-facing change?

No, dev-only.


### How was this patch tested?

Manually tested by:

```bash
build/sbt -Phadoop-2.7 -Phive -Phive-2.3 -Phive-thriftserver -DskipTests clean test:package
./python/run-tests --python-executable=python3 --testname="pyspark.sql.tests.test_dataframe QueryExecutionListenerTests"
```

```bash
GITHUB_ACTIONS=1 build/sbt -Phadoop-2.7 -Phive -Phive-2.3 -Phive-thriftserver -DskipTests clean test:package
GITHUB_ACTIONS=1 ./python/run-tests --python-executable=python3 --testname="pyspark.sql.tests.test_dataframe QueryExecutionListenerTests"
```

Before:

```
python3 version is: Python 3.7.7
Starting test(python3): pyspark.sql.tests.test_dataframe QueryExecutionListenerTests
Finished test(python3): pyspark.sql.tests.test_dataframe QueryExecutionListenerTests (0s) ... 2 tests were skipped
Tests passed in 0 seconds

Skipped tests in pyspark.sql.tests.test_dataframe QueryExecutionListenerTests with python3:
      test_query_execution_listener_on_collect (pyspark.sql.tests.test_dataframe.QueryExecutionListenerTests) ... SKIP (0.000s)
      test_query_execution_listener_on_collect_with_arrow (pyspark.sql.tests.test_dataframe.QueryExecutionListenerTests) ... SKIP (0.000s)
```

After:

```
python3 version is: Python 3.7.7
Starting test(python3): pyspark.sql.tests.test_dataframe QueryExecutionListenerTests
Finished test(python3): pyspark.sql.tests.test_dataframe QueryExecutionListenerTests (10s)
Tests passed in 10 seconds
```

but it should be tested on GitHub Actions in this PR.