### PR TITLE
[SPARK-32408][BUILD] Enable crossPaths back to prevent side effects

### DIFF
--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -653,9 +653,6 @@ def main():
         # If we're running the tests in Github Actions, attempt to detect and test
         # only the affected modules.
         if test_env == "github_actions":
-            # Set the log level of sbt as ERROR to make the output more readable.
-            if build_tool == "sbt":
-                extra_profiles.append("--error")
             if os.environ["GITHUB_BASE_REF"] != "":
                 # Pull requests
                 changed_files = identify_changed_files_from_git_commits(

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -653,6 +653,9 @@ def main():
         # If we're running the tests in Github Actions, attempt to detect and test
         # only the affected modules.
         if test_env == "github_actions":
+            # Set the log level of sbt as ERROR to make the output more readable.
+            if build_tool == "sbt":
+                extra_profiles.append("--error")
             if os.environ["GITHUB_BASE_REF"] != "":
                 # Pull requests
                 changed_files = identify_changed_files_from_git_commits(

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1039,8 +1039,6 @@ object TestSettings {
         Seq("-eNCXEHLOPQMDF")
       }.getOrElse(Nil): _*),
     testOptions in Test += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),
-    // Required to detect Junit tests for each project, see also https://github.com/sbt/junit-interface/issues/35
-    crossPaths := false,
     // Enable Junit testing.
     libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test",
     // `parallelExecutionInTest` controls whether test suites belonging to the same SBT project

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1031,6 +1031,13 @@ object TestSettings {
       }.getOrElse(Nil): _*),
     // Show full stack trace and duration in test cases.
     testOptions in Test += Tests.Argument("-oDF"),
+    // Show only the failed test cases with full stack traces in github action to make the log more
+    // readable.
+    // Check https://www.scalatest.org/user_guide/using_the_runner for the details of options .
+    testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest,
+      sys.env.get("GITHUB_ACTIONS").map { _ =>
+        Seq("-eNCXEHLOPQMDF")
+      }.getOrElse(Nil): _*),
     testOptions in Test += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),
     // Enable Junit testing.
     libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test",

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1031,13 +1031,6 @@ object TestSettings {
       }.getOrElse(Nil): _*),
     // Show full stack trace and duration in test cases.
     testOptions in Test += Tests.Argument("-oDF"),
-    // Show only the failed test cases with full stack traces in github action to make the log more
-    // readable.
-    // Check https://www.scalatest.org/user_guide/using_the_runner for the details of options .
-    testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest,
-      sys.env.get("GITHUB_ACTIONS").map { _ =>
-        Seq("-eNCXEHLOPQMDF")
-      }.getOrElse(Nil): _*),
     testOptions in Test += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),
     // Enable Junit testing.
     libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to enable `corssPaths` back for now to match with the build as it was.
It still indeterministically doesn't run JUnit tests given my observation, and this PR basically reverts the partial fix from https://github.com/apache/spark/pull/29057.

See also https://github.com/apache/spark/pull/29205 for the full context.

### Why are the changes needed?

To prevent the side effects from crossPaths such as SPARK_PREPEND_CLASSES or tests that run conditionally if the test classes are present in PySpark.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually tested:

```bash
build/sbt -Phadoop-2.7 -Phive -Phive-2.3 -Phive-thriftserver -DskipTests clean test:package
./python/run-tests --python-executable=python3 --testname="pyspark.sql.tests.test_dataframe QueryExecutionListenerTests"
```
