### PR TITLE
Revert "[SPARK-32253][INFRA] Show errors only for the sbt tests of github actions"

### DIFF
--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -653,9 +653,6 @@ def main():
         # If we're running the tests in Github Actions, attempt to detect and test
         # only the affected modules.
         if test_env == "github_actions":
-            # Set the log level of sbt as ERROR to make the output more readable.
-            if build_tool == "sbt":
-                extra_profiles.append("--error")
             if os.environ["GITHUB_BASE_REF"] != "":
                 # Pull requests
                 changed_files = identify_changed_files_from_git_commits(

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1031,13 +1031,6 @@ object TestSettings {
       }.getOrElse(Nil): _*),
     // Show full stack trace and duration in test cases.
     testOptions in Test += Tests.Argument("-oDF"),
-    // Show only the failed test cases with full stack traces in github action to make the log more
-    // readable.
-    // Check https://www.scalatest.org/user_guide/using_the_runner for the details of options .
-    testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest,
-      sys.env.get("GITHUB_ACTIONS").map { _ =>
-        Seq("-eNCXEHLOPQMDF")
-      }.getOrElse(Nil): _*),
     testOptions in Test += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),
     // Required to detect Junit tests for each project, see also https://github.com/sbt/junit-interface/issues/35
     crossPaths := false,


### PR DESCRIPTION

### What changes were proposed in this pull request?

This reverts commit 026b0b926dfd40038f2cee932f38b917eb25b77e.

### Why are the changes needed?

As @HyukjinKwon pointed out in https://github.com/apache/spark/pull/29133#issuecomment-663339240, there is no JUnit test report after https://github.com/apache/spark/pull/29133. Let's revert https://github.com/apache/spark/pull/29133 for now and find a better solution to improve the log output later.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

GitHub Actions build



