### PR TITLE
[SPARK-32436][CORE] Recover numNonEmptyBlocks in HighlyCompressedMapStatus.readExternal

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
@@ -219,6 +219,7 @@ private[spark] class HighlyCompressedMapStatus private (
     loc = BlockManagerId(in)
     emptyBlocks = new RoaringBitmap()
     emptyBlocks.readExternal(in)
+    numNonEmptyBlocks = emptyBlocks.getCardinality
     avgSize = in.readLong()
     val count = in.readInt()
     val hugeBlockSizesImpl = mutable.Map.empty[Int, Byte]


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to recover `numNonEmptyBlocks` during `HighlyCompressedMapStatus.readExternal`

### Why are the changes needed?

Currently, it's corrupted.

### Does this PR introduce _any_ user-facing change?

No.
### How was this patch tested?

Pass the Jenkins.