### PR TITLE
[SPARK-32439][SQL] Override datasource implementation during look up via configuration

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -627,7 +627,14 @@ object DataSource extends Logging {
 
   /** Given a provider name, look up the data source class definition. */
   def lookupDataSource(provider: String, conf: SQLConf): Class[_] = {
-    val provider1 = backwardCompatibilityMap.getOrElse(provider, provider) match {
+    val overriddenProvider = conf.getConfString(
+      s"spark.sql.datasource.override.$provider", provider)
+    if (overriddenProvider != provider) {
+      logInfo(s"Provider '$provider' is overridden to '$overriddenProvider'.")
+    }
+
+    val provider1 = backwardCompatibilityMap.getOrElse(
+      overriddenProvider, overriddenProvider) match {
       case name if name.equalsIgnoreCase("orc") &&
           conf.getConf(SQLConf.ORC_IMPLEMENTATION) == "native" =>
         classOf[OrcDataSourceV2].getCanonicalName

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceSuite.scala
@@ -22,6 +22,8 @@ import org.apache.hadoop.fs.{FileStatus, Path, RawLocalFileSystem}
 import org.scalatest.PrivateMethodTester
 
 import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.execution.datasources.v2.csv.CSVDataSourceV2
+import org.apache.spark.sql.sources.FakeSourceFour
 import org.apache.spark.sql.test.SharedSparkSession
 
 class DataSourceSuite extends SharedSparkSession with PrivateMethodTester {
@@ -144,6 +146,16 @@ class DataSourceSuite extends SharedSparkSession with PrivateMethodTester {
     }.getMessage
     val expectMessage = "No FileSystem for scheme nonexistsFs"
     assert(message.filterNot(Set(':', '"').contains) == expectMessage)
+  }
+
+  test("Override datasource by configuration") {
+    val cls = DataSource.lookupDataSource("csv", spark.sessionState.conf)
+    assert(cls.newInstance.isInstanceOf[CSVDataSourceV2])
+
+    withSQLConf("spark.sql.datasource.override.csv" -> "datasource") {
+      val cls = DataSource.lookupDataSource("csv", spark.sessionState.conf)
+      assert(cls.newInstance.isInstanceOf[FakeSourceFour])
+    }
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR proposes to introduce an ability to override the datasource implementation via configuration.

For example, suppose I have a custom CSV datasource implementation called "my_csv". One way to use it is:
```scala
val df = spark.read.format("my_csv").load(...)
```

Since the source data is the same format (CSV), you should be able to override the default implementation.

With this PR, now you can do the following:
```scala
spark.conf.set("spark.sql.datasource.override.csv", "my_csv")
val df = spark.read.csv(...)
```

This has a benefit that the user doesn't have to change the application code to try out a new datasource implementation for the same source format.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Introduces a new hook to override datasource implementation via configuration

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, you can now override datasource implementation via config as described above.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added a test