### PR TITLE
[SPARK-32441][BUILD][CORE] Update json4s to 3.7.0-M5 for Scala 2.13

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.7-hive-1.2
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-1.2
@@ -129,10 +129,10 @@ jline/2.14.6//jline-2.14.6.jar
 joda-time/2.10.5//joda-time-2.10.5.jar
 jodd-core/3.5.2//jodd-core-3.5.2.jar
 jpam/1.1//jpam-1.1.jar
-json4s-ast_2.12/3.6.6//json4s-ast_2.12-3.6.6.jar
-json4s-core_2.12/3.6.6//json4s-core_2.12-3.6.6.jar
-json4s-jackson_2.12/3.6.6//json4s-jackson_2.12-3.6.6.jar
-json4s-scalap_2.12/3.6.6//json4s-scalap_2.12-3.6.6.jar
+json4s-ast_2.12/3.7.0-M5//json4s-ast_2.12-3.7.0-M5.jar
+json4s-core_2.12/3.7.0-M5//json4s-core_2.12-3.7.0-M5.jar
+json4s-jackson_2.12/3.7.0-M5//json4s-jackson_2.12-3.7.0-M5.jar
+json4s-scalap_2.12/3.7.0-M5//json4s-scalap_2.12-3.7.0-M5.jar
 jsp-api/2.1//jsp-api-2.1.jar
 jsr305/3.0.0//jsr305-3.0.0.jar
 jta/1.1//jta-1.1.jar

--- a/dev/deps/spark-deps-hadoop-2.7-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-2.3
@@ -144,10 +144,10 @@ joda-time/2.10.5//joda-time-2.10.5.jar
 jodd-core/3.5.2//jodd-core-3.5.2.jar
 jpam/1.1//jpam-1.1.jar
 json/1.8//json-1.8.jar
-json4s-ast_2.12/3.6.6//json4s-ast_2.12-3.6.6.jar
-json4s-core_2.12/3.6.6//json4s-core_2.12-3.6.6.jar
-json4s-jackson_2.12/3.6.6//json4s-jackson_2.12-3.6.6.jar
-json4s-scalap_2.12/3.6.6//json4s-scalap_2.12-3.6.6.jar
+json4s-ast_2.12/3.7.0-M5//json4s-ast_2.12-3.7.0-M5.jar
+json4s-core_2.12/3.7.0-M5//json4s-core_2.12-3.7.0-M5.jar
+json4s-jackson_2.12/3.7.0-M5//json4s-jackson_2.12-3.7.0-M5.jar
+json4s-scalap_2.12/3.7.0-M5//json4s-scalap_2.12-3.7.0-M5.jar
 jsp-api/2.1//jsp-api-2.1.jar
 jsr305/3.0.0//jsr305-3.0.0.jar
 jta/1.1//jta-1.1.jar

--- a/dev/deps/spark-deps-hadoop-3.2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3.2-hive-2.3
@@ -142,10 +142,10 @@ jodd-core/3.5.2//jodd-core-3.5.2.jar
 jpam/1.1//jpam-1.1.jar
 json-smart/2.3//json-smart-2.3.jar
 json/1.8//json-1.8.jar
-json4s-ast_2.12/3.6.6//json4s-ast_2.12-3.6.6.jar
-json4s-core_2.12/3.6.6//json4s-core_2.12-3.6.6.jar
-json4s-jackson_2.12/3.6.6//json4s-jackson_2.12-3.6.6.jar
-json4s-scalap_2.12/3.6.6//json4s-scalap_2.12-3.6.6.jar
+json4s-ast_2.12/3.7.0-M5//json4s-ast_2.12-3.7.0-M5.jar
+json4s-core_2.12/3.7.0-M5//json4s-core_2.12-3.7.0-M5.jar
+json4s-jackson_2.12/3.7.0-M5//json4s-jackson_2.12-3.7.0-M5.jar
+json4s-scalap_2.12/3.7.0-M5//json4s-scalap_2.12-3.7.0-M5.jar
 jsp-api/2.1//jsp-api-2.1.jar
 jsr305/3.0.0//jsr305-3.0.0.jar
 jta/1.1//jta-1.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -861,7 +861,7 @@
       <dependency>
         <groupId>org.json4s</groupId>
         <artifactId>json4s-jackson_${scala.binary.version}</artifactId>
-        <version>3.6.6</version>
+        <version>3.7.0-M5</version>
         <exclusions>
           <exclusion>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `json4s` to from 3.6.6 to 3.7.0-M5 for Scala 2.13 support at Apache Spark 3.1.0 on December. We will upgrade to the latest `json4s` around November.

### Why are the changes needed?

`json4s` starts to support Scala 2.13 since v3.7.0-M4.
- https://github.com/json4s/json4s/issues/660
- https://github.com/json4s/json4s/commit/b013af8e757ee15c15a6a1f19c672f7e7044a868

Old `json4s` causes many UT failures with `NoSuchMethodException`.
```scala
 Cause: java.lang.NoSuchMethodException: scala.collection.immutable.Seq$.apply(scala.collection.Seq)
  at java.lang.Class.getMethod(Class.java:1786)
```

The following is one example.
```scala
$ dev/change-scala-version.sh 2.13
$ build/mvn test -pl core --am -Pscala-2.13 -Dtest=none -DwildcardSuites=org.apache.spark.executor.CoarseGrainedExecutorBackendSuite
...
Tests: succeeded 4, failed 9, canceled 0, ignored 0, pending 0
*** 9 TESTS FAILED ***
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

1. **Scala 2.12**: Pass the Jenkins or GitHub Action with the existing tests.
2. **Scala 2.13**: Do the following manually at least.
```scala
$ dev/change-scala-version.sh 2.13
$ build/mvn test -pl core --am -Pscala-2.13 -Dtest=none -DwildcardSuites=org.apache.spark.executor.CoarseGrainedExecutorBackendSuite
...
Tests: succeeded 13, failed 0, canceled 0, ignored 0, pending 0
All tests passed.
```