### PR TITLE
[SPARK-32451][R][TESTS] Pin Apache Arrow to 0.17.1 in GitHubAction/AppVeyor SparkR tests

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -163,7 +163,9 @@ jobs:
       if: contains(matrix.modules, 'sparkr')
       run: |
         sudo apt-get install -y libcurl4-openssl-dev
-        sudo Rscript -e "install.packages(c('knitr', 'rmarkdown', 'testthat', 'devtools', 'e1071', 'survival', 'arrow', 'roxygen2'), repos='https://cloud.r-project.org/')"
+        sudo Rscript -e "install.packages(c('knitr', 'rmarkdown', 'testthat', 'devtools', 'e1071', 'survival', 'roxygen2'), repos='https://cloud.r-project.org/')"
+        # SPARK-XXX: arrow 1.0.0 breaks arrow unit tests
+        sudo Rscript -e "install.packages('https://cran.r-project.org/src/contrib/Archive/arrow/arrow_0.17.1.tar.gz', repos=NULL, type='source')"
         # Show installed packages in R.
         sudo Rscript -e 'pkg_list <- as.data.frame(installed.packages()[, c(1,3:4)]); pkg_list[is.na(pkg_list$Priority), 1:2, drop = FALSE]'
     # Run the tests.

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -164,7 +164,7 @@ jobs:
       run: |
         sudo apt-get install -y libcurl4-openssl-dev
         sudo Rscript -e "install.packages(c('knitr', 'rmarkdown', 'testthat', 'devtools', 'e1071', 'survival', 'roxygen2'), repos='https://cloud.r-project.org/')"
-        # SPARK-XXX: arrow 1.0.0 breaks arrow unit tests
+        # SPARK-32451: arrow 1.0.0 breaks unit tests
         sudo Rscript -e "install.packages('https://cran.r-project.org/src/contrib/Archive/arrow/arrow_0.17.1.tar.gz', repos=NULL, type='source')"
         # Show installed packages in R.
         sudo Rscript -e 'pkg_list <- as.data.frame(installed.packages()[, c(1,3:4)]); pkg_list[is.na(pkg_list$Priority), 1:2, drop = FALSE]'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,7 +42,9 @@ install:
   # Install maven and dependencies
   - ps: .\dev\appveyor-install-dependencies.ps1
   # Required package for R unit tests
-  - cmd: Rscript -e "install.packages(c('knitr', 'rmarkdown', 'testthat', 'e1071', 'survival', 'arrow'), repos='https://cloud.r-project.org/')"
+  - cmd: Rscript -e "install.packages(c('knitr', 'rmarkdown', 'testthat', 'e1071', 'survival'), repos='https://cloud.r-project.org/')"
+  # SPARK-32451: arrow 1.0.0 breaks unit tests
+  - cmd: Rscript -e "install.packages('https://cran.r-project.org/src/contrib/Archive/arrow/arrow_0.17.1.tar.gz', repos=NULL, type='source')"
   - cmd: Rscript -e "pkg_list <- as.data.frame(installed.packages()[,c(1, 3:4)]); pkg_list[is.na(pkg_list$Priority), 1:2, drop = FALSE]"
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,6 +59,8 @@ environment:
   # "(converted from warning) unable to identify current timezone 'C':" for an unknown reason.
   # This environment variable works around to test SparkR against a higher version.
   R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+  # AppVeyor doesn't have python3 yet
+  PYSPARK_PYTHON: python
 
 test_script:
   - cmd: .\bin\spark-submit2.cmd --driver-java-options "-Dlog4j.configuration=file:///%CD:\=/%/R/log4j.properties" --conf spark.hadoop.fs.defaultFS="file:///" R\pkg\tests\run-all.R


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to recover `GitHub Action` SparkR tests by pinning Apache Arrow to 0.17.1.

### Why are the changes needed?

- Apache Spark 3.1 supports Apache Arrow 0.15.1+. 
- Apache Arrow released 1.0.0 a few days ago and this causes GitHub Action SparkR test failures due to warnings.
    - https://github.com/apache/spark/commits/master

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the GitHub Action.