### PR TITLE
[SPARK-32451][R] Support Apache Arrow 1.0.0

### DIFF
--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -1233,7 +1233,7 @@ setMethod("collect",
                   port = port, blocking = TRUE, open = "wb", timeout = connectionTimeout)
                 output <- tryCatch({
                   doServerAuth(conn, authSecret)
-                  arrowTable <- arrow::read_arrow(readRaw(conn))
+                  arrowTable <- arrow::read_ipc_stream(readRaw(conn))
                   # Arrow drops `as_tibble` since 0.14.0, see ARROW-5190.
                   if (exists("as_tibble", envir = asNamespace("arrow"))) {
                     as.data.frame(arrow::as_tibble(arrowTable), stringsAsFactors = stringsAsFactors)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,8 +57,6 @@ environment:
   # "(converted from warning) unable to identify current timezone 'C':" for an unknown reason.
   # This environment variable works around to test SparkR against a higher version.
   R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-  # AppVeyor doesn't have python3 yet
-  PYSPARK_PYTHON: python
 
 test_script:
   - cmd: .\bin\spark-submit2.cmd --driver-java-options "-Dlog4j.configuration=file:///%CD:\=/%/R/log4j.properties" --conf spark.hadoop.fs.defaultFS="file:///" R\pkg\tests\run-all.R

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,6 +57,8 @@ environment:
   # "(converted from warning) unable to identify current timezone 'C':" for an unknown reason.
   # This environment variable works around to test SparkR against a higher version.
   R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+  # AppVeyor doesn't have python3 yet
+  PYSPARK_PYTHON: python
 
 test_script:
   - cmd: .\bin\spark-submit2.cmd --driver-java-options "-Dlog4j.configuration=file:///%CD:\=/%/R/log4j.properties" --conf spark.hadoop.fs.defaultFS="file:///" R\pkg\tests\run-all.R


### PR DESCRIPTION
### What changes were proposed in this pull request?

Currently, `GitHub Action` is broken due to `SparkR UT failure` from new Apache Arrow 1.0.0.

![Screen Shot 2020-07-26 at 5 12 08 PM](https://user-images.githubusercontent.com/9700541/88492923-3409f080-cf63-11ea-8fea-6051298c2dd0.png)

This PR aims to update R code according to Apache Arrow 1.0.0 recommendation to pass R unit tests.

An alternative is pinning Apache Arrow version at 0.17.1 and I also created a PR to compare with this.
- https://github.com/apache/spark/pull/29251

### Why are the changes needed?

- Apache Spark 3.1 supports Apache Arrow 0.15.1+.
- Apache Arrow released 1.0.0 a few days ago and this causes GitHub Action SparkR test failures due to warnings.
    - https://github.com/apache/spark/commits/master

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- [x] Pass the Jenkins (https://github.com/apache/spark/pull/29252#issuecomment-664067492)
- [x] Pass the GitHub (https://github.com/apache/spark/runs/912656867)