### PR TITLE
[SPARK-32417][TEST][CORE] Fix test flakiness in BlockManagerDecommissionIntegrationSuite

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -1314,6 +1314,8 @@ private[spark] class BlockManager(
 
     require(blockId != null, "BlockId is null")
     require(level != null && level.isValid, "StorageLevel is null or invalid")
+    // The decommissioning check is at the start of the doPut so that if we are
+    // computing and attempting to put an iterator the put can succeed.
     if (isDecommissioning()) {
       throw new BlockSavedOnDecommissionedBlockManagerException(blockId)
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This changes the test to ensure the executors are all the way up and accepting tasks before attempting to move on to decommissioning. This also sets the number of partitions based on the number of executors.


### Why are the changes needed?

Currently if the tasks don't get scheduled on the executor which is chosen for decommissioning it can fail.


### Does this PR introduce _any_ user-facing change?

No test change only


### How was this patch tested?

Ran test in a loop on my local machine
