### PR TITLE
[SPARK-32462][WEBUI] Reset previous search text for datatable

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/utils.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/utils.js
@@ -169,7 +169,7 @@ function setDataTableDefaults() {
 function formatDate(date) {
   if (date <= 0) return "-";
   else {
-     var dt = new Date(date.replace("GMT", "Z"))
+     var dt = new Date(date.replace("GMT", "Z"));
      return formatDateString(dt);
   }
 }

--- a/core/src/main/resources/org/apache/spark/ui/static/utils.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/utils.js
@@ -158,6 +158,9 @@ function createTemplateURI(appId, templateName) {
 function setDataTableDefaults() {
   $.extend($.fn.dataTable.defaults, {
     stateSave: true,
+    stateSaveParams: function(_, data) {
+        data.search.search = "";
+    },
     lengthMenu: [[20, 40, 60, 100, -1], [20, 40, 60, 100, "All"]],
     pageLength: 20
   });

--- a/core/src/test/scala/org/apache/spark/ui/ChromeUISeleniumSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/ChromeUISeleniumSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.ui
 
-import org.openqa.selenium.WebDriver
+import org.openqa.selenium.{JavascriptExecutor, WebDriver}
 import org.openqa.selenium.chrome.{ChromeDriver, ChromeOptions}
 
 import org.apache.spark.tags.ChromeUITest
@@ -28,7 +28,7 @@ import org.apache.spark.tags.ChromeUITest
 @ChromeUITest
 class ChromeUISeleniumSuite extends RealBrowserUISeleniumSuite("webdriver.chrome.driver") {
 
-  override var webDriver: WebDriver = _
+  override var webDriver: WebDriver with JavascriptExecutor = _
 
   override def beforeAll(): Unit = {
     super.beforeAll()

--- a/core/src/test/scala/org/apache/spark/ui/RealBrowserUISeleniumSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/RealBrowserUISeleniumSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.ui
 
-import org.openqa.selenium.{By, WebDriver}
+import org.openqa.selenium.{By, JavascriptExecutor, WebDriver}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.matchers.must.Matchers
@@ -37,7 +37,7 @@ import org.apache.spark.util.CallSite
 abstract class RealBrowserUISeleniumSuite(val driverProp: String)
   extends SparkFunSuite with WebBrowser with Matchers with BeforeAndAfterAll {
 
-  implicit var webDriver: WebDriver
+  implicit var webDriver: WebDriver with JavascriptExecutor
   private val driverPropPrefix = "spark.test."
 
   override def beforeAll(): Unit = {
@@ -127,6 +127,58 @@ abstract class RealBrowserUISeleniumSuite(val driverProp: String)
           assert(foundInStage1.size === 0)
         }
       }
+    }
+  }
+
+  test("Search text for paged tables should not be saved") {
+    withSpark(newSparkContext()) { sc =>
+      sc.parallelize(1 to 10).collect
+
+      eventually(timeout(10.seconds), interval(1.seconds)) {
+        val taskSearchBox = "$(\"input[aria-controls='active-tasks-table']\")"
+        goToUi(sc, "/stages/stage/?id=0&attempt=0")
+        // Wait for ajax loading done.
+        Thread.sleep(20)
+        setValueToSearchBox(taskSearchBox, "task1")
+        val taskSearchText = getTextFromSearchBox(taskSearchBox)
+        assert(taskSearchText === "task1")
+
+        val executorSearchBox = "$(\"input[aria-controls='active-executors-table']\")"
+        goToUi(sc, "/executors")
+        Thread.sleep(20)
+        setValueToSearchBox(executorSearchBox, "executor1")
+        val executorSearchText = getTextFromSearchBox(executorSearchBox)
+        assert(executorSearchText === "executor1")
+
+        goToUi(sc, "/stages/stage/?id=0&attempt=0")
+        Thread.sleep(20)
+        val revisitTaskSearchText = getTextFromSearchBox(taskSearchBox)
+        assert(revisitTaskSearchText === "")
+
+        goToUi(sc, "/executors")
+        Thread.sleep(20)
+        val revisitExecutorSearchText = getTextFromSearchBox(executorSearchBox)
+        assert(revisitExecutorSearchText === "")
+      }
+    }
+
+    def setValueToSearchBox(searchBox: String, text: String): Unit = {
+      webDriver.executeScript(s"$searchBox.val('$text');")
+      fireDataTable(searchBox)
+    }
+
+    def getTextFromSearchBox(searchBox: String): String = {
+      webDriver.executeScript(s"return $searchBox.val();").toString
+    }
+
+    def fireDataTable(searchBox: String): Unit = {
+      webDriver.executeScript(
+        s"""
+           |var keyEvent = $$.Event('keyup');
+           |// 13 means enter key.
+           |keyEvent.keyCode = keyEvent.which = 13;
+           |$searchBox.trigger(keyEvent);
+         """.stripMargin)
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala
@@ -46,7 +46,6 @@ import org.apache.spark.internal.config.Status._
 import org.apache.spark.internal.config.UI._
 import org.apache.spark.shuffle.FetchFailedException
 import org.apache.spark.status.api.v1.{JacksonMessageWriter, RDDDataDistribution, StageStatus}
-import org.apache.spark.util.CallSite
 
 private[spark] class SparkUICssErrorHandler extends DefaultCssErrorHandler {
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR proposes to change the behavior of DataTable for stage-page and executors-page not to save the previous search text.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
DataTable is used in stage-page and executors-page for pagination and filter tasks/executors by search text.
In the current implementation, search text is saved so if we visit stage-page for a job, the previous search text is filled in the textbox and the task table is filtered.
I'm sometimes surprised by this behavior as the stage-page lists no tasks because tasks are filtered by the previous search text.
I think, it's not useful.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. Search text is no longer saved.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
New testcase with the following command.
```
$ build/sbt -Dguava.version=27.0-jre -Dtest.default.exclude.tags= -Dspark.test.webdriver.chrome.driver=/path/to/chromedriver "testOnly org.apache.spark.ui.ChromeUISeleniumSuite -- -z Search"
```