### PR TITLE
[SPARK-32464][SQL] Support skew handling on join that has one side wi…

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/PartitionRecombinationedRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PartitionRecombinationedRDD.scala
@@ -25,8 +25,9 @@ import org.apache.spark.{Dependency, NarrowDependency, Partition, TaskContext}
  * A RDD that just redistribute the dependency RDD's partitions.
  * It provides the capability to reorder, remove, duplicate... any RDD partition level operation.
  */
-class RecombinationedRDD[T: ClassTag](prev: RDD[T],
-                                      f: (Seq[Int] => Seq[Int])) extends RDD[T](prev) {
+class RecombinationedRDD[T: ClassTag](
+    prev: RDD[T],
+    f: (Seq[Int] => Seq[Int])) extends RDD[T](prev) {
   private val recombinationed = {
     val partitionIndexes = prev.partitions.indices
     f(partitionIndexes)

--- a/core/src/main/scala/org/apache/spark/rdd/PartitionRecombinationedRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PartitionRecombinationedRDD.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.rdd
+
+import scala.reflect.ClassTag
+
+import org.apache.spark.{Dependency, NarrowDependency, Partition, TaskContext}
+
+/**
+ * A RDD that just redistribute the dependency RDD's partitions.
+ * It provides the capability to reorder, remove, duplicate... any RDD partition level operation.
+ */
+class RecombinationedRDD[T: ClassTag](prev: RDD[T],
+                                      f: (Seq[Int] => Seq[Int])) extends RDD[T](prev) {
+  private val recombinationed = {
+    val partitionIndexes = prev.partitions.indices
+    f(partitionIndexes)
+  }
+
+  override def compute(split: Partition, context: TaskContext): Iterator[T] = {
+    prev.iterator(split.asInstanceOf[RecombinationedPartition].parentPartition, context)
+  }
+
+  override protected def getPartitions: Array[Partition] = {
+    recombinationed.zipWithIndex.map { case (parentIndex, index) =>
+      RecombinationedPartition(index, prev.partitions(parentIndex))
+    }.toArray
+  }
+
+  override def getDependencies: Seq[Dependency[_]] = List(
+    new NarrowDependency(prev) {
+      def getParents(id: Int): Seq[Int] = List(recombinationed(id))
+    }
+  )
+}
+
+case class RecombinationedPartition(index: Int, parentPartition: Partition) extends Partition

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/PartitionRecombinationExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/PartitionRecombinationExec.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution
+
+import org.apache.spark.rdd.{RDD, RecombinationedRDD}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.physical.{Partitioning, UnknownPartitioning}
+
+/**
+ * A operator to redistribute the child operator's RDD partitions.
+ * Kinda like ShuffleExchangeExec, but ShuffleExchangeExec make the redistribution
+ * on each row of child's output, and PartitionDistributionExec just make the redistribution
+ * on child's RDD partition. It provides the capability to reorder, remove, duplicate...
+ * any RDD partition level's operation.
+ *
+ * @param f the function to apply on child RDD partitions. It takes a sequence of partition indexes
+ *          as input, and output a new sequence to represent the new partitions combination.
+ * @param child Child plan
+ */
+
+case class PartitionRecombinationExec(f: (Seq[Int] => Seq[Int]), targetPartitionNum: Int,
+  child: SparkPlan) extends SparkPlan {
+
+  override protected def doExecute(): RDD[InternalRow] = {
+    new RecombinationedRDD[InternalRow](child.execute(), f)
+  }
+
+  override def output: Seq[Attribute] = child.output
+
+  override def children: Seq[SparkPlan] = child :: Nil
+
+  override def outputPartitioning: Partitioning = UnknownPartitioning(targetPartitionNum)
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/PartitionRecombinationExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/PartitionRecombinationExec.scala
@@ -33,8 +33,10 @@ import org.apache.spark.sql.catalyst.plans.physical.{Partitioning, UnknownPartit
  * @param child Child plan
  */
 
-case class PartitionRecombinationExec(f: (Seq[Int] => Seq[Int]), targetPartitionNum: Int,
-  child: SparkPlan) extends SparkPlan {
+case class PartitionRecombinationExec(
+    f: (Seq[Int] => Seq[Int]),
+    targetPartitionNum: Int,
+    child: SparkPlan) extends SparkPlan {
 
   override protected def doExecute(): RDD[InternalRow] = {
     new RecombinationedRDD[InternalRow](child.execute(), f)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
@@ -253,7 +253,7 @@ case class OptimizeSkewedJoin(conf: SQLConf) extends Rule[SparkPlan] {
 
   def optimizeSingleStageSkewJoin(plan: SparkPlan): SparkPlan = plan.transformUp {
     case smj @ SortMergeJoinExec(_, _, joinType, _,
-    sort @ SortExec(_, _, ShuffleStage(qs: ShuffleStageInfo), _), right, _) =>
+        sort @ SortExec(_, _, ShuffleStage(qs: ShuffleStageInfo), _), right, _) =>
       if (qs.shuffleStage.shuffle.canChangeNumPartitions && canSplitLeftSide(joinType)) {
         val (numSkewed, splitPartitions, partitionIndexes) = handleSkewed(qs)
         if (numSkewed > 0) {
@@ -269,7 +269,7 @@ case class OptimizeSkewedJoin(conf: SQLConf) extends Rule[SparkPlan] {
       }
 
     case smj @ SortMergeJoinExec(_, _, _, _, left,
-    sort @ SortExec(_, _, ShuffleStage(qs: ShuffleStageInfo), _), _) =>
+        sort @ SortExec(_, _, ShuffleStage(qs: ShuffleStageInfo), _), _) =>
       val (numSkewed, splitPartitions, partitionIndexes) = handleSkewed(qs)
       if (numSkewed > 0) {
         logInfo(s"number of skewed partitions $numSkewed")
@@ -281,8 +281,8 @@ case class OptimizeSkewedJoin(conf: SQLConf) extends Rule[SparkPlan] {
       } else smj
   }
 
-  private def handleSkewed(queryStage: ShuffleStageInfo):
-  (Int, Seq[ShufflePartitionSpec], Seq[Int]) = {
+  private def handleSkewed(
+      queryStage: ShuffleStageInfo): (Int, Seq[ShufflePartitionSpec], Seq[Int]) = {
     val numPartitions = queryStage.partitionsWithSizes.length
     val medSize = medianSize(queryStage.mapStats)
     val actualSizes = queryStage.partitionsWithSizes.map(_._2)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
@@ -286,7 +286,7 @@ case class OptimizeSkewedJoin(conf: SQLConf) extends Rule[SparkPlan] {
     val numPartitions = queryStage.partitionsWithSizes.length
     val medSize = medianSize(queryStage.mapStats)
     val actualSizes = queryStage.partitionsWithSizes.map(_._2)
-    val targetSize = targetSize(actualSizes, medSize, conf)
+    val tgtSize = targetSize(actualSizes, medSize)
     val sizeInfo =
       getSizeInfo(medSize, queryStage.mapStats.bytesByPartitionId)
     logInfo(
@@ -310,7 +310,7 @@ case class OptimizeSkewedJoin(conf: SQLConf) extends Rule[SparkPlan] {
         val reducerId = partSpec.startReducerIndex
         val skewSpecs = createSkewPartitionSpecs(
           queryStage.shuffleStage.shuffle.shuffleDependency.shuffleId,
-          reducerId, targetSize)
+          reducerId, tgtSize)
         if (skewSpecs.isDefined) {
           logInfo(s"Skew side partition $partitionIndex " +
             s"(${FileUtils.byteCountToDisplaySize(actualSize)}) is skewed, " +

--- a/sql/core/src/test/scala/org/apache/spark/sql/PartitionRecombinationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/PartitionRecombinationSuite.scala
@@ -21,7 +21,6 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
 class PartitionRecombinationSuite extends QueryTest with SharedSparkSession {
-  import testImplicits._
   test("test operator PartitionDistributionExec") {
     withTable("tbl1") {
       withSQLConf(

--- a/sql/core/src/test/scala/org/apache/spark/sql/PartitionRecombinationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/PartitionRecombinationSuite.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql
+
+import org.apache.spark.sql.execution.PartitionRecombinationExec
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+class PartitionRecombinationSuite extends QueryTest with SharedSparkSession {
+  import testImplicits._
+  test("test operator PartitionDistributionExec") {
+    withTable("tbl1") {
+      withSQLConf(
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
+        SQLConf.SKEW_JOIN_ENABLED.key -> "true",
+        SQLConf.SKEW_JOIN_SKEWED_PARTITION_THRESHOLD.key -> "600",
+        SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES.key -> "600") {
+
+        spark
+          .range(0, 10, 1, 2)
+          .selectExpr("id % 1 as key1", "id as value1")
+          .write.bucketBy(5, "key1")
+          .format("parquet").saveAsTable("tbl1")
+        val p = spark.table("tbl1").queryExecution.executedPlan
+        assert(PartitionRecombinationExec(_ => Seq(3, 3, 3, 3), 4, p).executeCollect().length == 0)
+        assert(PartitionRecombinationExec(_ => Seq(0, 0, 0), 3, p).executeCollect().length == 30)
+        assert(PartitionRecombinationExec(_ => Seq(0, 0, 0, 0, 0, 0), 6, p).
+          executeCollect().length == 60)
+      }
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -1189,7 +1189,7 @@ class AdaptiveQueryExecSuite
 
       // During execution, the SMJ is changed to Union of SMJ + 10 SMJ of the skewed partition.
       val planAfter = join.queryExecution.executedPlan
-      assert(planAfter.toString.startsWith("AdaptiveSparkPlan(isFinalPlan=true)"))
+      assert(planAfter.toString.startsWith("AdaptiveSparkPlan isFinalPlan=true"))
       val adaptivePlan = planAfter.asInstanceOf[AdaptiveSparkPlanExec].executedPlan
       val smjAfterExecution = adaptivePlan.collect {
         case smj: SortMergeJoinExec => smj

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -1156,16 +1156,14 @@ class AdaptiveQueryExecSuite
       SQLConf.SKEW_JOIN_ENABLED.key -> "true",
       SQLConf.SKEW_JOIN_SKEWED_PARTITION_THRESHOLD.key -> "600",
       SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES.key -> "600") {
-      spark
-        .range(0, 10, 1, 2)
+      spark.range(0, 10, 1, 2)
         .selectExpr("id % 5 as key1", "id as value1")
         .write.bucketBy(5, "key1")
-        .format("parquet").saveAsTable("tbl1")
+        .format("parquet")
+        .saveAsTable("tbl1")
 
-      val df2 =
-        spark
-          .range(0, 1000, 1, 10)
-          .selectExpr("id % 1 as key2", "id as value2")
+      val df2 = spark.range(0, 1000, 1, 10)
+        .selectExpr("id % 1 as key2", "id as value2")
 
       val join = spark.table("tbl1")
         .join(df2, col("key1") === col("key2"))
@@ -1179,8 +1177,7 @@ class AdaptiveQueryExecSuite
 
       // Check the answer.
       val expectedAnswer =
-        spark
-          .range(0, 1000)
+        spark.range(0, 1000)
           .selectExpr("0 as key", "id as value")
           .union(spark.range(0, 1000).selectExpr("0 as key", "id as value"))
       checkAnswer(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support skew handling on join that has one side with no query stage.
The join side with no query stage must be a side with bucket table scan, and we cannot split the bucket table. But we can duplicate the bucket side, just leverage the RDD mechanism, try to duplicate some parent partitions in the child RDD.

For instance, we have a RDD A with partitions (0, 1, 2, 3), and now we need duplicate the second partition (partition 1). We can just create a new RDD, B for example, with partition (0, 1, 2, 3, 4), and build the dependency relationship:
- RDD B partition 0 <- RDD A partition 0
- RDD B partition 1 <- RDD A partition 1
- RDD B partition 2 <- RDD A partition 1
- RDD B partition 3 <- RDD A partition 2
- RDD B partition 4 <- RDD A partition 3

### Why are the changes needed?
In our production environment, there are many bucket tables, which are used to join with other tables. And there are some skewed joins now and then. While, in current implementation, the skew join handling can only applied when both sides of a SMJ are QueryStages. So skew join handling is not able to deal with such cases.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Ut.
