### PR TITLE
[SPARK-29544] Collect the row count info and optimize the skewed conditions with row count info in the OptimizeSkewedJoin rule

### DIFF
--- a/core/src/main/java/org/apache/spark/shuffle/sort/RowCountInfo.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/RowCountInfo.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.sort;
+
+import java.io.Serializable;
+
+public class RowCountInfo implements Serializable {
+  long mapId;
+  long[] rowCountInfo;
+
+  RowCountInfo(long mapId, long[] rowCountInfo) {
+    this.mapId = mapId;
+    this.rowCountInfo = rowCountInfo;
+  }
+
+  public  long getMapId() {
+    return mapId;
+  }
+
+  public long[] getRowCountInfo() {
+    return rowCountInfo;
+  }
+}

--- a/core/src/main/scala/org/apache/spark/InternalAccumulator.scala
+++ b/core/src/main/scala/org/apache/spark/InternalAccumulator.scala
@@ -61,6 +61,7 @@ private[spark] object InternalAccumulator {
     val BYTES_WRITTEN = SHUFFLE_WRITE_METRICS_PREFIX + "bytesWritten"
     val RECORDS_WRITTEN = SHUFFLE_WRITE_METRICS_PREFIX + "recordsWritten"
     val WRITE_TIME = SHUFFLE_WRITE_METRICS_PREFIX + "writeTime"
+    val ROW_COUNT_INFO = SHUFFLE_WRITE_METRICS_PREFIX + "rowCountInfo"
   }
 
   // Names of output metrics

--- a/core/src/main/scala/org/apache/spark/executor/ShuffleWriteMetrics.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ShuffleWriteMetrics.scala
@@ -18,8 +18,8 @@
 package org.apache.spark.executor
 
 import org.apache.spark.annotation.DeveloperApi
-import org.apache.spark.shuffle.sort.RowCountInfo
 import org.apache.spark.shuffle.ShuffleWriteMetricsReporter
+import org.apache.spark.shuffle.sort.RowCountInfo
 import org.apache.spark.util.{CollectionAccumulator, LongAccumulator}
 
 

--- a/core/src/main/scala/org/apache/spark/executor/ShuffleWriteMetrics.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ShuffleWriteMetrics.scala
@@ -18,8 +18,9 @@
 package org.apache.spark.executor
 
 import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.shuffle.sort.RowCountInfo
 import org.apache.spark.shuffle.ShuffleWriteMetricsReporter
-import org.apache.spark.util.LongAccumulator
+import org.apache.spark.util.{CollectionAccumulator, LongAccumulator}
 
 
 /**
@@ -32,6 +33,7 @@ class ShuffleWriteMetrics private[spark] () extends ShuffleWriteMetricsReporter 
   private[executor] val _bytesWritten = new LongAccumulator
   private[executor] val _recordsWritten = new LongAccumulator
   private[executor] val _writeTime = new LongAccumulator
+  private[executor] val _rowCountInfo = new CollectionAccumulator[RowCountInfo]
 
   /**
    * Number of bytes written for the shuffle by this task.
@@ -48,6 +50,8 @@ class ShuffleWriteMetrics private[spark] () extends ShuffleWriteMetricsReporter 
    */
   def writeTime: Long = _writeTime.sum
 
+  def mapRowCountInfo: java.util.List[RowCountInfo] = _rowCountInfo.value
+
   private[spark] override def incBytesWritten(v: Long): Unit = _bytesWritten.add(v)
   private[spark] override def incRecordsWritten(v: Long): Unit = _recordsWritten.add(v)
   private[spark] override def incWriteTime(v: Long): Unit = _writeTime.add(v)
@@ -57,4 +61,5 @@ class ShuffleWriteMetrics private[spark] () extends ShuffleWriteMetricsReporter 
   private[spark] override def decRecordsWritten(v: Long): Unit = {
     _recordsWritten.setValue(recordsWritten - v)
   }
+  private[spark] override def addMapRowCountInfo(v: RowCountInfo): Unit = _rowCountInfo.add(v)
 }

--- a/core/src/main/scala/org/apache/spark/executor/TaskMetrics.scala
+++ b/core/src/main/scala/org/apache/spark/executor/TaskMetrics.scala
@@ -229,6 +229,7 @@ class TaskMetrics private[spark] () extends Serializable {
     shuffleRead.RECORDS_READ -> shuffleReadMetrics._recordsRead,
     shuffleWrite.BYTES_WRITTEN -> shuffleWriteMetrics._bytesWritten,
     shuffleWrite.RECORDS_WRITTEN -> shuffleWriteMetrics._recordsWritten,
+    shuffleWrite.ROW_COUNT_INFO -> shuffleWriteMetrics._rowCountInfo,
     shuffleWrite.WRITE_TIME -> shuffleWriteMetrics._writeTime,
     input.BYTES_READ -> inputMetrics._bytesRead,
     input.RECORDS_READ -> inputMetrics._recordsRead,

--- a/core/src/main/scala/org/apache/spark/shuffle/metrics.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/metrics.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.shuffle
 
+import org.apache.spark.shuffle.sort.RowCountInfo
+
 /**
  * An interface for reporting shuffle read metrics, for each shuffle. This interface assumes
  * all the methods are called on a single-threaded, i.e. concrete implementations would not need
@@ -49,4 +51,5 @@ private[spark] trait ShuffleWriteMetricsReporter {
   private[spark] def incWriteTime(v: Long): Unit
   private[spark] def decBytesWritten(v: Long): Unit
   private[spark] def decRecordsWritten(v: Long): Unit
+  private[spark] def addMapRowCountInfo(v: RowCountInfo): Unit
 }

--- a/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleWriter.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleWriter.scala
@@ -59,7 +59,10 @@ private[spark] class SortShuffleWriter[K, V, C](
       new ExternalSorter[K, V, V](
         context, aggregator = None, Some(dep.partitioner), ordering = None, dep.serializer)
     }
-    sorter.insertAll(records)
+
+    val numPartitions = dep.partitioner.numPartitions
+    val rowCountInfo = sorter.insertAll(records, numPartitions)
+    writeMetrics.addMapRowCountInfo(new RowCountInfo(mapId, rowCountInfo))
 
     // Don't bother including the time to open the merged output file in the shuffle write time,
     // because it just opens a single file, so is typically too fast to measure accurately

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -510,6 +510,15 @@ object SQLConf {
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("256MB")
 
+  val SKEW_JOIN_SKEWED_PARTITION_ROW_COUNT_THRESHOLD =
+    buildConf("spark.sql.adaptive.skewJoin.skewedPartitionThresholdRowCount")
+      .doc("A partition is considered as skewed if its row count is larger than this " +
+        s"threshold and also larger than '${SKEW_JOIN_SKEWED_PARTITION_FACTOR.key}' " +
+        "multiplying the median partition row count")
+      .version("3.0.0")
+      .longConf
+      .createWithDefault(10L * 1000 * 1000)
+
   val NON_EMPTY_PARTITION_RATIO_FOR_BROADCAST_JOIN =
     buildConf("spark.sql.adaptive.nonEmptyPartitionRatioForBroadcastJoin")
       .internal()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageExec.scala
@@ -179,6 +179,22 @@ case class ShuffleQueryStageExec(
     }
   }
 
+  def computeRowCount: Array[Long] = {
+    val rowCountList = shuffle.rowCountMetric.value
+    val numPartitions = shuffle.shuffleDependency.partitioner.numPartitions
+    val result: Array[Long] = new Array[Long](numPartitions)
+
+    val length = rowCountList.size()
+    for(i <- 0 until length) {
+      val rowCounts = rowCountList.get(i).getRowCountInfo
+      rowCounts.zipWithIndex.foreach {
+        case (count, index) =>
+          result(index) += count
+      }
+    }
+    result
+  }
+
   /**
    * Returns the Option[MapOutputStatistics]. If the shuffle map stage has no partition,
    * this method returns None, as there is no map statistics.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
@@ -27,7 +27,7 @@ import org.apache.spark.internal.config
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.{ShuffleWriteMetricsReporter, ShuffleWriteProcessor}
-import org.apache.spark.shuffle.sort.SortShuffleManager
+import org.apache.spark.shuffle.sort.{RowCountInfo, SortShuffleManager}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.errors._
 import org.apache.spark.sql.catalyst.expressions.{Attribute, BoundReference, UnsafeProjection, UnsafeRow}
@@ -38,7 +38,7 @@ import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics, SQLShuffleReadMetricsReporter, SQLShuffleWriteMetricsReporter}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.util.MutablePair
+import org.apache.spark.util.{CollectionAccumulator, MutablePair}
 import org.apache.spark.util.collection.unsafe.sort.{PrefixComparators, RecordComparator}
 
 /**
@@ -94,6 +94,12 @@ case class ShuffleExchangeExec(
     SQLShuffleWriteMetricsReporter.createShuffleWriteMetrics(sparkContext)
   private[sql] lazy val readMetrics =
     SQLShuffleReadMetricsReporter.createShuffleReadMetrics(sparkContext)
+
+  lazy val rowCountMetric = {
+    val acc = new CollectionAccumulator[RowCountInfo]
+    acc.register(sparkContext, name = Some("row count per partition"), countFailedValues = false)
+    acc
+  }
   override lazy val metrics = Map(
     "dataSize" -> SQLMetrics.createSizeMetric(sparkContext, "data size")
   ) ++ readMetrics ++ writeMetrics
@@ -113,7 +119,7 @@ case class ShuffleExchangeExec(
       sparkContext.submitMapStage(shuffleDependency)
     }
   }
-
+  
   override def numMappers: Int = shuffleDependency.rdd.getNumPartitions
 
   override def numPartitions: Int = shuffleDependency.partitioner.numPartitions
@@ -140,7 +146,8 @@ case class ShuffleExchangeExec(
       child.output,
       outputPartitioning,
       serializer,
-      writeMetrics)
+      writeMetrics,
+      rowCountMetric)
   }
 
   /**
@@ -225,7 +232,8 @@ object ShuffleExchangeExec {
       outputAttributes: Seq[Attribute],
       newPartitioning: Partitioning,
       serializer: Serializer,
-      writeMetrics: Map[String, SQLMetric])
+      writeMetrics: Map[String, SQLMetric],
+      rowCountMetric: CollectionAccumulator[RowCountInfo] = new CollectionAccumulator[RowCountInfo])
     : ShuffleDependency[Int, InternalRow, InternalRow] = {
     val part: Partitioner = newPartitioning match {
       case RoundRobinPartitioning(numPartitions) => new HashPartitioner(numPartitions)
@@ -358,7 +366,7 @@ object ShuffleExchangeExec {
         rddWithPartitionIds,
         new PartitionIdPassthrough(part.numPartitions),
         serializer,
-        shuffleWriterProcessor = createShuffleWriteProcessor(writeMetrics))
+        shuffleWriterProcessor = createShuffleWriteProcessor(writeMetrics, rowCountMetric))
 
     dependency
   }
@@ -367,11 +375,14 @@ object ShuffleExchangeExec {
    * Create a customized [[ShuffleWriteProcessor]] for SQL which wrap the default metrics reporter
    * with [[SQLShuffleWriteMetricsReporter]] as new reporter for [[ShuffleWriteProcessor]].
    */
-  def createShuffleWriteProcessor(metrics: Map[String, SQLMetric]): ShuffleWriteProcessor = {
+  def createShuffleWriteProcessor(metrics: Map[String, SQLMetric],
+      rowCountMetric: CollectionAccumulator[RowCountInfo]): ShuffleWriteProcessor = {
     new ShuffleWriteProcessor {
       override protected def createMetricsReporter(
           context: TaskContext): ShuffleWriteMetricsReporter = {
-        new SQLShuffleWriteMetricsReporter(context.taskMetrics().shuffleWriteMetrics, metrics)
+        new SQLShuffleWriteMetricsReporter(context.taskMetrics().shuffleWriteMetrics,
+          metrics, rowCountMetric)
+
       }
     }
   }


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
Currently the `OptimizeSkewedJoin` rule check the skewed partition only based on the compressed data size, which is not accurate when the compression ratio is very high. This PR collect the row count info by using the `CollectionAccumulator` and then add the row count info to check the skew partition in the `OptimizeSkewedJoin` rule. 
### Why are the changes needed?
Optimize the `OptimizeSkewedJoin` rule by using the row count info.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
existing ut