### PR TITLE
[SPARK-32469][SQL] ApplyColumnarRulesAndInsertTransitions should be idempotent

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ColumnarRulesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ColumnarRulesSuite.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.test.SharedSparkSession
+
+class ColumnarRulesSuite extends PlanTest with SharedSparkSession {
+
+  test("Idempotency of columnar rules - RowToColumnar/ColumnarToRow") {
+    val rules = ApplyColumnarRulesAndInsertTransitions(
+      spark.sessionState.conf, spark.sessionState.columnarRules)
+
+    val plan = UnaryOp(UnaryOp(LeafOp(false), true), false)
+    val expected =
+      UnaryOp(ColumnarToRowExec(UnaryOp(RowToColumnarExec(LeafOp(false)), true)), false)
+    val appliedOnce = rules.apply(plan)
+    assert(appliedOnce == expected)
+    val appliedTwice = rules.apply(appliedOnce)
+    assert(appliedTwice == expected)
+  }
+
+  test("Idempotency of columnar rules - ColumnarToRow/RowToColumnar") {
+    val rules = ApplyColumnarRulesAndInsertTransitions(
+      spark.sessionState.conf, spark.sessionState.columnarRules)
+
+    val plan = UnaryOp(UnaryOp(LeafOp(true), false), true)
+    val expected = ColumnarToRowExec(
+      UnaryOp(RowToColumnarExec(UnaryOp(ColumnarToRowExec(LeafOp(true)), false)), true))
+    val appliedOnce = rules.apply(plan)
+    assert(appliedOnce == expected)
+    val appliedTwice = rules.apply(appliedOnce)
+    assert(appliedTwice == expected)
+  }
+}
+
+case class LeafOp(override val supportsColumnar: Boolean) extends LeafExecNode {
+  override protected def doExecute(): RDD[InternalRow] = throw new UnsupportedOperationException()
+  override def output: Seq[Attribute] = Seq.empty
+}
+
+case class UnaryOp(child: SparkPlan, override val supportsColumnar: Boolean) extends UnaryExecNode {
+  override protected def doExecute(): RDD[InternalRow] = throw new UnsupportedOperationException()
+  override def output: Seq[Attribute] = child.output
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR makes `ApplyColumnarRulesAndInsertTransitions` idempotent (assuming the custom columnar rules are also idempotent).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
It's good hygiene to keep rules idempotent

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
new suite