### PR TITLE
[SPARK-32471][SQL][DOCS][TESTS][PYTHON][SS] Describe JSON option `allowNonNumericNumbers` and support it by PySpark `json()`

### DIFF
--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -184,7 +184,7 @@ class DataFrameReader(OptionUtils):
              mode=None, columnNameOfCorruptRecord=None, dateFormat=None, timestampFormat=None,
              multiLine=None, allowUnquotedControlChars=None, lineSep=None, samplingRatio=None,
              dropFieldIfAllNull=None, encoding=None, locale=None, pathGlobFilter=None,
-             recursiveFileLookup=None):
+             recursiveFileLookup=None, allowNonNumericNumbers=None):
         """
         Loads JSON files and returns the results as a :class:`DataFrame`.
 
@@ -264,6 +264,14 @@ class DataFrameReader(OptionUtils):
                                It does not change the behavior of `partition discovery`_.
         :param recursiveFileLookup: recursively scan a directory for files. Using this option
                                     disables `partition discovery`_.
+        :param allowNonNumericNumbers: allows JSON parser to recognize set of "Not-a-Number" (NaN)
+                                       tokens as legal floating number values. If None is set,
+                                       it uses the default value, ``true``.
+
+                * ``+INF``: for positive infinity, as well as alias of
+                            ``+Infinity`` and ``Infinity``.
+                *  ``-INF``: for negative infinity, alias ``-Infinity``.
+                *  ``NaN``: for other not-a-numbers, like result of division by zero.
 
         .. _partition discovery:
           https://spark.apache.org/docs/latest/sql-data-sources-parquet.html#partition-discovery
@@ -287,7 +295,8 @@ class DataFrameReader(OptionUtils):
             timestampFormat=timestampFormat, multiLine=multiLine,
             allowUnquotedControlChars=allowUnquotedControlChars, lineSep=lineSep,
             samplingRatio=samplingRatio, dropFieldIfAllNull=dropFieldIfAllNull, encoding=encoding,
-            locale=locale, pathGlobFilter=pathGlobFilter, recursiveFileLookup=recursiveFileLookup)
+            locale=locale, pathGlobFilter=pathGlobFilter, recursiveFileLookup=recursiveFileLookup,
+            allowNonNumericNumbers=allowNonNumericNumbers)
         if isinstance(path, str):
             path = [path]
         if type(path) == list:

--- a/python/pyspark/sql/streaming.py
+++ b/python/pyspark/sql/streaming.py
@@ -420,7 +420,7 @@ class DataStreamReader(OptionUtils):
              mode=None, columnNameOfCorruptRecord=None, dateFormat=None, timestampFormat=None,
              multiLine=None,  allowUnquotedControlChars=None, lineSep=None, locale=None,
              dropFieldIfAllNull=None, encoding=None, pathGlobFilter=None,
-             recursiveFileLookup=None):
+             recursiveFileLookup=None, allowNonNumericNumbers=None):
         """
         Loads a JSON file stream and returns the results as a :class:`DataFrame`.
 
@@ -500,6 +500,14 @@ class DataStreamReader(OptionUtils):
                                It does not change the behavior of `partition discovery`_.
         :param recursiveFileLookup: recursively scan a directory for files. Using this option
                                     disables `partition discovery`_.
+        :param allowNonNumericNumbers: allows JSON parser to recognize set of "Not-a-Number" (NaN)
+                                       tokens as legal floating number values. If None is set,
+                                       it uses the default value, ``true``.
+
+                * ``+INF``: for positive infinity, as well as alias of
+                            ``+Infinity`` and ``Infinity``.
+                *  ``-INF``: for negative infinity, alias ``-Infinity``.
+                *  ``NaN``: for other not-a-numbers, like result of division by zero.
 
         .. _partition discovery:
           https://spark.apache.org/docs/latest/sql-data-sources-parquet.html#partition-discovery
@@ -520,7 +528,8 @@ class DataStreamReader(OptionUtils):
             timestampFormat=timestampFormat, multiLine=multiLine,
             allowUnquotedControlChars=allowUnquotedControlChars, lineSep=lineSep, locale=locale,
             dropFieldIfAllNull=dropFieldIfAllNull, encoding=encoding,
-            pathGlobFilter=pathGlobFilter, recursiveFileLookup=recursiveFileLookup)
+            pathGlobFilter=pathGlobFilter, recursiveFileLookup=recursiveFileLookup,
+            allowNonNumericNumbers=allowNonNumericNumbers)
         if isinstance(path, str):
             return self._df(self._jreader.json(path))
         else:

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -472,9 +472,9 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
    * <li>`allowNonNumericNumbers` (default `true`): allows JSON parser to recognize set of
    * "Not-a-Number" (NaN) tokens as legal floating number values:
    *   <ul>
-   *     <li>`+INF` (for positive infinity), as well as alias of `+Infinity` and `Infinity`
-   *     <li>`-INF` (for negative infinity), alias `-Infinity`
-   *     <li>`NaN` (for other not-a-numbers, like result of division by zero)
+   *     <li>`+INF` for positive infinity, as well as alias of `+Infinity` and `Infinity`.
+   *     <li>`-INF` for negative infinity), alias `-Infinity`.
+   *     <li>`NaN` for other not-a-numbers, like result of division by zero.
    *   </ul>
    * </li>
    * </ul>

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -425,14 +425,6 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
    * <li>`allowUnquotedControlChars` (default `false`): allows JSON Strings to contain unquoted
    * control characters (ASCII characters with value less than 32, including tab and line feed
    * characters) or not.</li>
-   * <li>`allowNonNumericNumbers` (default `true`): allows parser to recognize set of
-   * "Not-a-Number" (NaN) tokens as legal floating number values:
-   *   <ul>
-   *     <li>`+INF` (for positive infinity), as well as alias of `+Infinity` and `Infinity`
-   *     <li>`-INF` (for negative infinity), alias `-Infinity`
-   *     <li>`NaN` (for other not-a-numbers, like result of division by zero)
-   *   </ul>
-   * </li>
    * <li>`mode` (default `PERMISSIVE`): allows a mode for dealing with corrupt records
    * during parsing.
    *   <ul>
@@ -477,6 +469,14 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
    * It does not change the behavior of partition discovery.</li>
    * <li>`recursiveFileLookup`: recursively scan a directory for files. Using this option
    * disables partition discovery</li>
+   * <li>`allowNonNumericNumbers` (default `true`): allows JSON parser to recognize set of
+   * "Not-a-Number" (NaN) tokens as legal floating number values:
+   *   <ul>
+   *     <li>`+INF` (for positive infinity), as well as alias of `+Infinity` and `Infinity`
+   *     <li>`-INF` (for negative infinity), alias `-Infinity`
+   *     <li>`NaN` (for other not-a-numbers, like result of division by zero)
+   *   </ul>
+   * </li>
    * </ul>
    *
    * @since 2.0.0

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -425,6 +425,14 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
    * <li>`allowUnquotedControlChars` (default `false`): allows JSON Strings to contain unquoted
    * control characters (ASCII characters with value less than 32, including tab and line feed
    * characters) or not.</li>
+   * <li>`allowNonNumericNumbers` (default `true`): allows parser to recognize set of
+   * "Not-a-Number" (NaN) tokens as legal floating number values:
+   *   <ul>
+   *     <li>`+INF` (for positive infinity), as well as alias of `+Infinity` and `Infinity`
+   *     <li>`-INF` (for negative infinity), alias `-Infinity`
+   *     <li>`NaN` (for other not-a-numbers, like result of division by zero)
+   *   </ul>
+   * </li>
    * <li>`mode` (default `PERMISSIVE`): allows a mode for dealing with corrupt records
    * during parsing.
    *   <ul>

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
@@ -269,15 +269,7 @@ final class DataStreamReader private[sql](sparkSession: SparkSession) extends Lo
    * <li>`allowUnquotedControlChars` (default `false`): allows JSON Strings to contain unquoted
    * control characters (ASCII characters with value less than 32, including tab and line feed
    * characters) or not.</li>
-   * <li>`allowNonNumericNumbers` (default `true`): allows parser to recognize set of
-   * "Not-a-Number" (NaN) tokens as legal floating number values:
-   *   <ul>
-   *     <li>`+INF` (for positive infinity), as well as alias of `+Infinity` and `Infinity`
-   *     <li>`-INF` (for negative infinity), alias `-Infinity`
-   *     <li>`NaN` (for other not-a-numbers, like result of division by zero)
-   *   </ul>
-   * </li>
-   * <li>mode` (default `PERMISSIVE`): allows a mode for dealing with corrupt records
+   * <li>`mode` (default `PERMISSIVE`): allows a mode for dealing with corrupt records
    * during parsing.
    *   <ul>
    *     <li>`PERMISSIVE` : when it meets a corrupted record, puts the malformed string into a
@@ -316,6 +308,14 @@ final class DataStreamReader private[sql](sparkSession: SparkSession) extends Lo
    * It does not change the behavior of partition discovery.</li>
    * <li>`recursiveFileLookup`: recursively scan a directory for files. Using this option
    * disables partition discovery</li>
+   * <li>`allowNonNumericNumbers` (default `true`): allows JSON parser to recognize set of
+   * "Not-a-Number" (NaN) tokens as legal floating number values:
+   *   <ul>
+   *     <li>`+INF` (for positive infinity), as well as alias of `+Infinity` and `Infinity`
+   *     <li>`-INF` (for negative infinity), alias `-Infinity`
+   *     <li>`NaN` (for other not-a-numbers, like result of division by zero)
+   *   </ul>
+   * </li>
    * </ul>
    *
    * @since 2.0.0

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
@@ -269,7 +269,15 @@ final class DataStreamReader private[sql](sparkSession: SparkSession) extends Lo
    * <li>`allowUnquotedControlChars` (default `false`): allows JSON Strings to contain unquoted
    * control characters (ASCII characters with value less than 32, including tab and line feed
    * characters) or not.</li>
-   * <li>`mode` (default `PERMISSIVE`): allows a mode for dealing with corrupt records
+   * <li>`allowNonNumericNumbers` (default `true`): allows parser to recognize set of
+   * "Not-a-Number" (NaN) tokens as legal floating number values:
+   *   <ul>
+   *     <li>`+INF` (for positive infinity), as well as alias of `+Infinity` and `Infinity`
+   *     <li>`-INF` (for negative infinity), alias `-Infinity`
+   *     <li>`NaN` (for other not-a-numbers, like result of division by zero)
+   *   </ul>
+   * </li>
+   * <li>mode` (default `PERMISSIVE`): allows a mode for dealing with corrupt records
    * during parsing.
    *   <ul>
    *     <li>`PERMISSIVE` : when it meets a corrupted record, puts the malformed string into a

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
@@ -311,9 +311,9 @@ final class DataStreamReader private[sql](sparkSession: SparkSession) extends Lo
    * <li>`allowNonNumericNumbers` (default `true`): allows JSON parser to recognize set of
    * "Not-a-Number" (NaN) tokens as legal floating number values:
    *   <ul>
-   *     <li>`+INF` (for positive infinity), as well as alias of `+Infinity` and `Infinity`
-   *     <li>`-INF` (for negative infinity), alias `-Infinity`
-   *     <li>`NaN` (for other not-a-numbers, like result of division by zero)
+   *     <li>`+INF` for positive infinity, as well as alias of `+Infinity` and `Infinity`.
+   *     <li>`-INF` for negative infinity, alias `-Infinity`.
+   *     <li>`NaN` for other not-a-numbers, like result of division by zero.
    *   </ul>
    * </li>
    * </ul>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonParsingOptionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonParsingOptionsSuite.scala
@@ -112,12 +112,23 @@ class JsonParsingOptionsSuite extends QueryTest with SharedSparkSession {
   }
 
   test("allowNonNumericNumbers on") {
-    val str = """{"age": NaN}"""
+    val str = """{"c0":NaN, "c1":+INF, "c2":+Infinity, "c3":Infinity, "c4":-INF, "c5":-Infinity}"""
     val df = spark.read.option("allowNonNumericNumbers", true).json(Seq(str).toDS())
 
-    assert(df.schema.head.name == "age")
-    assert(df.schema.head.dataType == DoubleType)
-    assert(df.first().getDouble(0).isNaN)
+    assert(df.schema ===
+      new StructType()
+        .add("c0", "double")
+        .add("c1", "double")
+        .add("c2", "double")
+        .add("c3", "double")
+        .add("c4", "double")
+        .add("c5", "double"))
+    checkAnswer(
+      df,
+      Row(
+        Double.NaN,
+        Double.PositiveInfinity, Double.PositiveInfinity, Double.PositiveInfinity,
+        Double.NegativeInfinity, Double.NegativeInfinity))
   }
 
   test("allowBackslashEscapingAnyCharacter off") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Describe the JSON option `allowNonNumericNumbers` which is used in read
2. Add new test cases for allowed JSON field values: NaN, +INF, +Infinity, Infinity, -INF and -Infinity

### Why are the changes needed?
To improve UX with Spark SQL and to provide users full info about the supported option.

### Does this PR introduce _any_ user-facing change?
Yes, in PySpark.

### How was this patch tested?
Added new test to `JsonParsingOptionsSuite`