### PR TITLE
[SPARK-32479][PYSPARK] Fix the slicing logic in createDataFrame when converting pandas dataframe to arrow table

### DIFF
--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -404,8 +404,10 @@ class SparkConversionMixin(object):
                            for t in pdf.dtypes]
 
         # Slice the DataFrame to be batched
-        step = -(-len(pdf) // self.sparkContext.defaultParallelism)  # round int up
-        pdf_slices = (pdf.iloc[start:start + step] for start in range(0, len(pdf), step))
+        length = len(pdf)
+        num_slices = self.sparkContext.defaultParallelism
+        pdf_slices = (pdf.iloc[i * length // num_slices: (i + 1) * length // num_slices]
+                      for i in xrange(0, num_slices))
 
         # Create list of Arrow (columns, type) for serializer dump_stream
         arrow_data = [[(c, t) for (_, c), t in zip(pdf_slice.iteritems(), arrow_types)]

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -407,7 +407,7 @@ class SparkConversionMixin(object):
         length = len(pdf)
         num_slices = self.sparkContext.defaultParallelism
         pdf_slices = (pdf.iloc[i * length // num_slices: (i + 1) * length // num_slices]
-                      for i in xrange(0, num_slices))
+                      for i in range(0, num_slices))
 
         # Create list of Arrow (columns, type) for serializer dump_stream
         arrow_data = [[(c, t) for (_, c), t in zip(pdf_slice.iteritems(), arrow_types)]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

In `spark.createDataFrame(pdf: pd.DataFrame)`, the pdf will be sliced to `num_slices=defaultParallelism` slices before converting to arrow batches. However, the current logic may result in fewer partitions than specified. See the next section for details.

This PR replaced the slicing logic with the silimar logic as in [ParallelCollectionRDD.scala#L125](https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/rdd/ParallelCollectionRDD.scala#L125)
~~~python
# replace conversion.py#L417-418
# step = -(-len(pdf) // self.sparkContext.defaultParallelism)  # round int up
# pdf_slices = (pdf.iloc[start:start + step] for start in xrange(0, len(pdf), step))
pdf_slices = (pdf.iloc[i * length // num_slices: (i + 1) * length // num_slices] for i in xrange(0, num_slices))
~~~

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
#### Problem
Currently, in [conversion.py#L418](https://github.com/databricks/runtime/blob/84a952313ae73e3df32f065eb00cc0bcb024af14/python/pyspark/sql/pandas/conversion.py#L418|https://github.com/databricks/runtime/blob/84a952313ae73e3df32f065eb00cc0bcb024af14/python/pyspark/sql/pandas/conversion.py#L418), the slicing logic may result in fewer partitions than specified.
###### Example:

Assume:
```
length = 100 -> [0, 1, ..., 99]
num_slices = 99 = self.sparkContext.defaultParallelism
```
**Old method:**

step = math.ceil(length / num_slices) = 2
start = i * step, end = (i + 1) * step:
output: [0,1] [2,3] [4,5] ... [98,99] -> 50 slices != num_slices

**New method:**

start = i * length // num_slices, end = (i + 1) * length // num_slices:
output: [0] [1] [2] ... [98,99] -> 99 slices

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Use existing tests.