### PR TITLE
Modify log info in BroadcastExchangeExec.scala

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
@@ -108,7 +108,7 @@ case class BroadcastExchangeExec(
             longMetric("dataSize") += dataSize
             if (dataSize >= MAX_BROADCAST_TABLE_BYTES) {
               throw new SparkException(
-                s"Cannot broadcast the table that is larger than 8GB: ${dataSize >> 30} GB")
+                s"Cannot broadcast the table over $MAX_BROADCAST_TABLE_BYTES bytes: $dataSize bytes")
             }
 
             val beforeBroadcast = System.nanoTime()


### PR DESCRIPTION
“Cannot broadcast the table that is larger than 8GB: ${dataSize >> 30} GB  ” shoule be modified to be more accurate .


