### PR TITLE
[SPARK-32474][SQL][FOLLOWUP] NullAwareAntiJoin multi-column support

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
@@ -591,6 +591,15 @@ public final class UnsafeRow extends InternalRow implements Externalizable, Kryo
     return BitSetMethods.anySet(baseObject, baseOffset, bitSetWidthInBytes / 8);
   }
 
+  public boolean allNull() {
+    for (int i = 0; i < numFields; i++) {
+      if (!BitSetMethods.isSet(baseObject, baseOffset, i)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   /**
    * Writes the content of this row into a memory address, identified by an object and an offset.
    * The target memory address must already been allocated, and have enough space to hold all the

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2684,10 +2684,16 @@ object SQLConf {
       .doc("When true, NULL-aware anti join execution will be planed into " +
         "BroadcastHashJoinExec with flag isNullAwareAntiJoin enabled, " +
         "optimized from O(M*N) calculation into O(M) calculation " +
-        "using Hash lookup instead of Looping lookup." +
-        "Only support for singleColumn NAAJ for now.")
+        "using Hash lookup instead of Looping lookup.")
       .booleanConf
       .createWithDefault(true)
+
+  val OPTIMIZE_NULL_AWARE_ANTI_JOIN_MAX_NUM_KEYS =
+    buildConf("spark.sql.optimizeNullAwareAntiJoin.maxNumKeys")
+      .internal()
+      .doc("The maximum number of keys that will be supported to use NAAJ optimize.")
+      .intConf
+      .createWithDefault(3)
 
   /**
    * Holds information about keys that have been deprecated.
@@ -3298,6 +3304,9 @@ class SQLConf extends Serializable with Logging {
 
   def optimizeNullAwareAntiJoin: Boolean =
     getConf(SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN)
+
+  def optimizeNullAwareAntiJoinMaxNumKeys: Int =
+    getConf(SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN_MAX_NUM_KEYS)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -1648,7 +1648,13 @@ class SubquerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     checkAnswer(df, Nil)
   }
 
-  test("SPARK-32290: SingleColumn Null Aware Anti Join Optimize") {
+  private def findJoinExec(df: DataFrame): BaseJoinExec = {
+    df.queryExecution.sparkPlan.collectFirst {
+      case j: BaseJoinExec => j
+    }.get
+  }
+
+  test("SPARK-32474: NullAwareAntiJoin multi-column support") {
     Seq(true, false).foreach { enableNAAJ =>
       Seq(true, false).foreach { enableAQE =>
         Seq(true, false).foreach { enableCodegen =>
@@ -1657,11 +1663,81 @@ class SubquerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
             SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> enableAQE.toString,
             SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> enableCodegen.toString) {
 
-            def findJoinExec(df: DataFrame): BaseJoinExec = {
-              df.queryExecution.sparkPlan.collectFirst {
-                case j: BaseJoinExec => j
-              }.get
+            var df: DataFrame = null
+            var joinExec: BaseJoinExec = null
+
+            // multi column not in subquery -- empty sub-query
+            df = sql("select * from l where (a, b) not in (select * from r where c > 10)")
+            checkAnswer(df, spark.table("l"))
+            if (enableNAAJ) {
+              joinExec = findJoinExec(df)
+              assert(joinExec.isInstanceOf[BroadcastHashJoinExec])
+              assert(joinExec.asInstanceOf[BroadcastHashJoinExec].isNullAwareAntiJoin)
+            } else {
+              assert(findJoinExec(df).isInstanceOf[BroadcastNestedLoopJoinExec])
             }
+
+            // multi column not in subquery -- sub-query include all null column key
+            df = sql(
+              "select * from l where (a, b) not in (select * from r where c is null and d is null)")
+            checkAnswer(df, Seq.empty)
+            if (enableNAAJ) {
+              joinExec = findJoinExec(df)
+              assert(joinExec.isInstanceOf[BroadcastHashJoinExec])
+              assert(joinExec.asInstanceOf[BroadcastHashJoinExec].isNullAwareAntiJoin)
+            } else {
+              assert(findJoinExec(df).isInstanceOf[BroadcastNestedLoopJoinExec])
+            }
+
+            // multi column not in subquery -- streamedSide row is all null column key
+            df = sql("select * from l where a is null and b is null " +
+              "and (a, b) not in (select * from r where c is not null)")
+            checkAnswer(df, Seq.empty)
+            if (enableNAAJ) {
+              joinExec = findJoinExec(df)
+              assert(joinExec.isInstanceOf[BroadcastHashJoinExec])
+              assert(joinExec.asInstanceOf[BroadcastHashJoinExec].isNullAwareAntiJoin)
+            } else {
+              assert(findJoinExec(df).isInstanceOf[BroadcastNestedLoopJoinExec])
+            }
+
+            // multi column not in subquery -- streamedSide row is not all null, match found
+            df = sql("select * from l where a = 6 " +
+              "and (a, b) not in (select * from r where c is not null)")
+            checkAnswer(df, Seq.empty)
+            if (enableNAAJ) {
+              joinExec = findJoinExec(df)
+              assert(joinExec.isInstanceOf[BroadcastHashJoinExec])
+              assert(joinExec.asInstanceOf[BroadcastHashJoinExec].isNullAwareAntiJoin)
+            } else {
+              assert(findJoinExec(df).isInstanceOf[BroadcastNestedLoopJoinExec])
+            }
+
+            // multi column not in subquery -- streamedSide row is not all null, match not found
+            df = sql("select * from l where a = 1 " +
+              "and (a, b) not in (select * from r where c is not null)")
+            checkAnswer(df, Row(1, 2.0) :: Row(1, 2.0) :: Nil)
+            if (enableNAAJ) {
+              joinExec = findJoinExec(df)
+              assert(joinExec.isInstanceOf[BroadcastHashJoinExec])
+              assert(joinExec.asInstanceOf[BroadcastHashJoinExec].isNullAwareAntiJoin)
+            } else {
+              assert(findJoinExec(df).isInstanceOf[BroadcastNestedLoopJoinExec])
+            }
+          }
+        }
+      }
+    }
+  }
+
+  test("SPARK-32290: SingleColumn Null Aware Anti Join Optimize") {
+    Seq(true, false).foreach { enableNAAJ =>
+      Seq(true, false).foreach { enableAQE =>
+        Seq(true, false).foreach { enableCodegen =>
+          withSQLConf(
+            SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> enableNAAJ.toString,
+            SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> enableAQE.toString,
+            SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> enableCodegen.toString) {
 
             var df: DataFrame = null
             var joinExec: BaseJoinExec = null
@@ -1743,11 +1819,6 @@ class SubquerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
             } else {
               assert(findJoinExec(df).isInstanceOf[BroadcastNestedLoopJoinExec])
             }
-
-            // multi column not in subquery
-            df = sql("select * from l where (a, b) not in (select c, d from r where c > 10)")
-            checkAnswer(df, spark.table("l"))
-            assert(findJoinExec(df).isInstanceOf[BroadcastNestedLoopJoinExec])
           }
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -1654,82 +1654,6 @@ class SubquerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     }.get
   }
 
-  test("SPARK-32474: NullAwareAntiJoin multi-column support") {
-    Seq(true, false).foreach { enableNAAJ =>
-      Seq(true, false).foreach { enableAQE =>
-        Seq(true, false).foreach { enableCodegen =>
-          withSQLConf(
-            SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> enableNAAJ.toString,
-            SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> enableAQE.toString,
-            SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> enableCodegen.toString) {
-
-            var df: DataFrame = null
-            var joinExec: BaseJoinExec = null
-
-            // multi column not in subquery -- empty sub-query
-            df = sql("select * from l where (a, b) not in (select * from r where c > 10)")
-            checkAnswer(df, spark.table("l"))
-            if (enableNAAJ) {
-              joinExec = findJoinExec(df)
-              assert(joinExec.isInstanceOf[BroadcastHashJoinExec])
-              assert(joinExec.asInstanceOf[BroadcastHashJoinExec].isNullAwareAntiJoin)
-            } else {
-              assert(findJoinExec(df).isInstanceOf[BroadcastNestedLoopJoinExec])
-            }
-
-            // multi column not in subquery -- sub-query include all null column key
-            df = sql(
-              "select * from l where (a, b) not in (select * from r where c is null and d is null)")
-            checkAnswer(df, Seq.empty)
-            if (enableNAAJ) {
-              joinExec = findJoinExec(df)
-              assert(joinExec.isInstanceOf[BroadcastHashJoinExec])
-              assert(joinExec.asInstanceOf[BroadcastHashJoinExec].isNullAwareAntiJoin)
-            } else {
-              assert(findJoinExec(df).isInstanceOf[BroadcastNestedLoopJoinExec])
-            }
-
-            // multi column not in subquery -- streamedSide row is all null column key
-            df = sql("select * from l where a is null and b is null " +
-              "and (a, b) not in (select * from r where c is not null)")
-            checkAnswer(df, Seq.empty)
-            if (enableNAAJ) {
-              joinExec = findJoinExec(df)
-              assert(joinExec.isInstanceOf[BroadcastHashJoinExec])
-              assert(joinExec.asInstanceOf[BroadcastHashJoinExec].isNullAwareAntiJoin)
-            } else {
-              assert(findJoinExec(df).isInstanceOf[BroadcastNestedLoopJoinExec])
-            }
-
-            // multi column not in subquery -- streamedSide row is not all null, match found
-            df = sql("select * from l where a = 6 " +
-              "and (a, b) not in (select * from r where c is not null)")
-            checkAnswer(df, Seq.empty)
-            if (enableNAAJ) {
-              joinExec = findJoinExec(df)
-              assert(joinExec.isInstanceOf[BroadcastHashJoinExec])
-              assert(joinExec.asInstanceOf[BroadcastHashJoinExec].isNullAwareAntiJoin)
-            } else {
-              assert(findJoinExec(df).isInstanceOf[BroadcastNestedLoopJoinExec])
-            }
-
-            // multi column not in subquery -- streamedSide row is not all null, match not found
-            df = sql("select * from l where a = 1 " +
-              "and (a, b) not in (select * from r where c is not null)")
-            checkAnswer(df, Row(1, 2.0) :: Row(1, 2.0) :: Nil)
-            if (enableNAAJ) {
-              joinExec = findJoinExec(df)
-              assert(joinExec.isInstanceOf[BroadcastHashJoinExec])
-              assert(joinExec.asInstanceOf[BroadcastHashJoinExec].isNullAwareAntiJoin)
-            } else {
-              assert(findJoinExec(df).isInstanceOf[BroadcastNestedLoopJoinExec])
-            }
-          }
-        }
-      }
-    }
-  }
-
   test("SPARK-32290: SingleColumn Null Aware Anti Join Optimize") {
     Seq(true, false).foreach { enableNAAJ =>
       Seq(true, false).foreach { enableAQE =>
@@ -1812,6 +1736,82 @@ class SubquerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
             df =
               sql("select * from l where b = 5.0 and a not in (select c from r where d = b + 10)")
             checkAnswer(df, Row(null, 5.0) :: Nil)
+            if (enableNAAJ) {
+              joinExec = findJoinExec(df)
+              assert(joinExec.isInstanceOf[BroadcastHashJoinExec])
+              assert(joinExec.asInstanceOf[BroadcastHashJoinExec].isNullAwareAntiJoin)
+            } else {
+              assert(findJoinExec(df).isInstanceOf[BroadcastNestedLoopJoinExec])
+            }
+          }
+        }
+      }
+    }
+  }
+
+  test("SPARK-32474: NullAwareAntiJoin multi-column support") {
+    Seq(true, false).foreach { enableNAAJ =>
+      Seq(true, false).foreach { enableAQE =>
+        Seq(true, false).foreach { enableCodegen =>
+          withSQLConf(
+            SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> enableNAAJ.toString,
+            SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> enableAQE.toString,
+            SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> enableCodegen.toString) {
+
+            var df: DataFrame = null
+            var joinExec: BaseJoinExec = null
+
+            // multi column not in subquery -- empty sub-query
+            df = sql("select * from l where (a, b) not in (select * from r where c > 10)")
+            checkAnswer(df, spark.table("l"))
+            if (enableNAAJ) {
+              joinExec = findJoinExec(df)
+              assert(joinExec.isInstanceOf[BroadcastHashJoinExec])
+              assert(joinExec.asInstanceOf[BroadcastHashJoinExec].isNullAwareAntiJoin)
+            } else {
+              assert(findJoinExec(df).isInstanceOf[BroadcastNestedLoopJoinExec])
+            }
+
+            // multi column not in subquery -- sub-query include all null column key
+            df = sql(
+              "select * from l where (a, b) not in (select * from r where c is null and d is null)")
+            checkAnswer(df, Seq.empty)
+            if (enableNAAJ) {
+              joinExec = findJoinExec(df)
+              assert(joinExec.isInstanceOf[BroadcastHashJoinExec])
+              assert(joinExec.asInstanceOf[BroadcastHashJoinExec].isNullAwareAntiJoin)
+            } else {
+              assert(findJoinExec(df).isInstanceOf[BroadcastNestedLoopJoinExec])
+            }
+
+            // multi column not in subquery -- streamedSide row is all null column key
+            df = sql("select * from l where a is null and b is null " +
+              "and (a, b) not in (select * from r where c is not null)")
+            checkAnswer(df, Seq.empty)
+            if (enableNAAJ) {
+              joinExec = findJoinExec(df)
+              assert(joinExec.isInstanceOf[BroadcastHashJoinExec])
+              assert(joinExec.asInstanceOf[BroadcastHashJoinExec].isNullAwareAntiJoin)
+            } else {
+              assert(findJoinExec(df).isInstanceOf[BroadcastNestedLoopJoinExec])
+            }
+
+            // multi column not in subquery -- streamedSide row is not all null, match found
+            df = sql("select * from l where a = 6 " +
+              "and (a, b) not in (select * from r where c is not null)")
+            checkAnswer(df, Seq.empty)
+            if (enableNAAJ) {
+              joinExec = findJoinExec(df)
+              assert(joinExec.isInstanceOf[BroadcastHashJoinExec])
+              assert(joinExec.asInstanceOf[BroadcastHashJoinExec].isNullAwareAntiJoin)
+            } else {
+              assert(findJoinExec(df).isInstanceOf[BroadcastNestedLoopJoinExec])
+            }
+
+            // multi column not in subquery -- streamedSide row is not all null, match not found
+            df = sql("select * from l where a = 1 " +
+              "and (a, b) not in (select * from r where c is not null)")
+            checkAnswer(df, Row(1, 2.0) :: Row(1, 2.0) :: Nil)
             if (enableNAAJ) {
               joinExec = findJoinExec(df)
               assert(joinExec.isInstanceOf[BroadcastHashJoinExec])


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow up issue of [SPARK-32290](https://issues.apache.org/jira/browse/SPARK-32290).

In SPARK-32290, We only support Single Column NAAJ because of the complexity of Multi Column support, See. http://www.vldb.org/pvldb/vol2/vldb09-423.pdf Section 6. 

In this PR, proposed a trade-off that can also support multi column to perform hash lookup in buildSide, but required buildSide with extra duplicate data, the duplication would be 2^numKeys - 1, for example, if we are to support NAAJ with 3 column join key, the buildSide would be expanded into (2^3 - 1) times, 7X.

For example, if there is a UnsafeRow key (1,2,3)
In NullAware Mode, it should be expanded into 7 keys with extra C(3,1), C(3,2) combinations, within the combinations, we duplicated these record with null padding as following.

Original record

(1,2,3) 

Extra record to be appended into HashedRelation

(null, 2, 3) (1, null, 3) (1, 2, null)
(null, null, 3) (null, 2, null) (1, null, null))

with the expanded data we can extract a common pattern for both single and multi column. allNull refer to a unsafeRow which has all null columns.

* buildSide is empty input => return all rows
* allNullColumnKey Exists In buildSide input => reject all rows
* if streamedSideRow.allNull is true => drop the row
* if streamedSideRow.allNull is false & findMatch in NullAwareHashedRelation => drop the row
* if streamedSideRow.allNull is false & notFindMatch in NullAwareHashedRelation => return the row

### Why are the changes needed?
Considered that NAAJ in real production usage, the numKeys should not be that big, normally 1~3 keys, I think it's still worth to do such trade-off. 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

1. SQLQueryTestSuite with NOT IN keyword SQL, add CONFIG_DIM with spark.sql.optimizeNullAwareAntiJoin on and off
2. added case in org.apache.spark.sql.JoinSuite.
3. added case in org.apache.spark.sql.SubquerySuite.
4. added case in org.apache.spark.sql.execution.joins.HashedRelationSuite to make sure the data expand logical.
5. config combination against e2e test (both single and multi column cases) with following

```
Map(
  "spark.sql.optimizeNullAwareAntiJoin" -> "true",
  "spark.sql.adaptive.enabled" -> "false",
  "spark.sql.codegen.wholeStage" -> "false"
),
Map(
  "sspark.sql.optimizeNullAwareAntiJoin" -> "true",
  "spark.sql.adaptive.enabled" -> "false",
  "spark.sql.codegen.wholeStage" -> "true"
),
Map(
  "spark.sql.optimizeNullAwareAntiJoin" -> "true",
  "spark.sql.adaptive.enabled" -> "true",
  "spark.sql.codegen.wholeStage" -> "false"
),
Map(
  "spark.sql.optimizeNullAwareAntiJoin" -> "true",
  "spark.sql.adaptive.enabled" -> "true",
  "spark.sql.codegen.wholeStage" -> "true"
)
```