### PR TITLE
[SPARK-32494][SQL] Null Aware Anti Join Optimize Support Multi-Column

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
@@ -591,6 +591,15 @@ public final class UnsafeRow extends InternalRow implements Externalizable, Kryo
     return BitSetMethods.anySet(baseObject, baseOffset, bitSetWidthInBytes / 8);
   }
 
+  public boolean allNull() {
+    for (int i = 0; i < numFields; i++) {
+      if (!BitSetMethods.isSet(baseObject, baseOffset, i)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   /**
    * Writes the content of this row into a memory address, identified by an object and an offset.
    * The target memory address must already been allocated, and have enough space to hold all the

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
@@ -591,6 +591,9 @@ public final class UnsafeRow extends InternalRow implements Externalizable, Kryo
     return BitSetMethods.anySet(baseObject, baseOffset, bitSetWidthInBytes / 8);
   }
 
+  /**
+   * return whether an UnsafeRow is null on every column.
+   */
   public boolean allNull() {
     for (int i = 0; i < numFields; i++) {
       if (!BitSetMethods.isSet(baseObject, baseOffset, i)) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -395,6 +395,10 @@ object PhysicalWindow {
 
 object ExtractNullAwareAntiJoinKeys extends JoinSelectionHelper with PredicateHelper {
 
+  // FYI. Extra information about Null Aware Anti Join.
+  // https://dl.acm.org/doi/10.14778/1687553.1687563
+  // http://www.vldb.org/pvldb/vol2/vldb09-423.pdf
+
   // streamedSideKeys, buildSideKeys
   private type ReturnType = (Seq[Expression], Seq[Expression])
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2684,7 +2684,9 @@ object SQLConf {
       .doc("When true, NULL-aware anti join execution will be planed into " +
         "BroadcastHashJoinExec with flag isNullAwareAntiJoin enabled, " +
         "optimized from O(M*N) calculation into O(M) calculation " +
-        "using Hash lookup instead of Looping lookup.")
+        "using Hash lookup instead of Looping lookup. " +
+        "The number of keys supported for NAAJ is configured by " +
+        s"${OPTIMIZE_NULL_AWARE_ANTI_JOIN_MAX_NUM_KEYS.key}.")
       .version("3.1.0")
       .booleanConf
       .createWithDefault(true)
@@ -2692,7 +2694,11 @@ object SQLConf {
   val OPTIMIZE_NULL_AWARE_ANTI_JOIN_MAX_NUM_KEYS =
     buildConf("spark.sql.optimizeNullAwareAntiJoin.maxNumKeys")
       .internal()
-      .doc("The maximum number of keys that will be supported to use NAAJ optimize.")
+      .doc("The maximum number of keys that will be supported to use NAAJ optimize. " +
+        "While with NAAJ optimize, buildSide data would be expanded to (2^numKeys - 1) times, " +
+        "it might cause Driver OOM if NAAJ numKeys increased, since it is exponential growth. " +
+        "It's ok to increase this configuration if buildSide is small enough and safe enough " +
+        "to do such exponential expansion to gain performance improvement from O(M*N) to O(M).")
       .intConf
       .createWithDefault(3)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2678,6 +2678,17 @@ object SQLConf {
       .checkValue(_ >= 0, "The value must be non-negative.")
       .createWithDefault(8)
 
+  val OPTIMIZE_NULL_AWARE_ANTI_JOIN_MAX_NUM_KEYS =
+    buildConf("spark.sql.optimizeNullAwareAntiJoin.maxNumKeys")
+      .internal()
+      .doc("The maximum number of keys that will be supported to use NAAJ optimize. " +
+        "While with NAAJ optimize, buildSide data would be expanded to (2^numKeys - 1) times, " +
+        "it might cause Driver OOM if NAAJ numKeys increased, since it is exponential growth. " +
+        "It's ok to increase this configuration if buildSide is small enough and safe enough " +
+        "to do such exponential expansion to gain performance improvement from O(M*N) to O(M).")
+      .intConf
+      .createWithDefault(3)
+
   val OPTIMIZE_NULL_AWARE_ANTI_JOIN =
     buildConf("spark.sql.optimizeNullAwareAntiJoin")
       .internal()
@@ -2690,17 +2701,6 @@ object SQLConf {
       .version("3.1.0")
       .booleanConf
       .createWithDefault(true)
-
-  val OPTIMIZE_NULL_AWARE_ANTI_JOIN_MAX_NUM_KEYS =
-    buildConf("spark.sql.optimizeNullAwareAntiJoin.maxNumKeys")
-      .internal()
-      .doc("The maximum number of keys that will be supported to use NAAJ optimize. " +
-        "While with NAAJ optimize, buildSide data would be expanded to (2^numKeys - 1) times, " +
-        "it might cause Driver OOM if NAAJ numKeys increased, since it is exponential growth. " +
-        "It's ok to increase this configuration if buildSide is small enough and safe enough " +
-        "to do such exponential expansion to gain performance improvement from O(M*N) to O(M).")
-      .intConf
-      .createWithDefault(3)
 
   /**
    * Holds information about keys that have been deprecated.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2683,10 +2683,9 @@ object SQLConf {
       .internal()
       .doc("The maximum number of keys that will be supported to use NAAJ optimize. " +
         "While with NAAJ optimize, buildSide data would be expanded to (2^numKeys - 1) times, " +
-        "it might cause Driver OOM if NAAJ numKeys increased, since it is exponential growth. " +
-        "It's ok to increase this configuration if buildSide is small enough and safe enough " +
-        "to do such exponential expansion to gain performance improvement from O(M*N) to O(M).")
+        "it might cause Driver OOM if NAAJ numKeys increased, since it is exponential growth.")
       .intConf
+      .checkValue(_ > 0, "The value must be positive.")
       .createWithDefault(3)
 
   val OPTIMIZE_NULL_AWARE_ANTI_JOIN =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2684,6 +2684,7 @@ object SQLConf {
       .doc("The maximum number of keys that will be supported to use NAAJ optimize. " +
         "While with NAAJ optimize, buildSide data would be expanded to (2^numKeys - 1) times, " +
         "it might cause Driver OOM if NAAJ numKeys increased, since it is exponential growth.")
+      .version("3.1.0")
       .intConf
       .checkValue(_ > 0, "The value must be positive.")
       .createWithDefault(3)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2684,11 +2684,17 @@ object SQLConf {
       .doc("When true, NULL-aware anti join execution will be planed into " +
         "BroadcastHashJoinExec with flag isNullAwareAntiJoin enabled, " +
         "optimized from O(M*N) calculation into O(M) calculation " +
-        "using Hash lookup instead of Looping lookup." +
-        "Only support for singleColumn NAAJ for now.")
+        "using Hash lookup instead of Looping lookup.")
       .version("3.1.0")
       .booleanConf
       .createWithDefault(true)
+
+  val OPTIMIZE_NULL_AWARE_ANTI_JOIN_MAX_NUM_KEYS =
+    buildConf("spark.sql.optimizeNullAwareAntiJoin.maxNumKeys")
+      .internal()
+      .doc("The maximum number of keys that will be supported to use NAAJ optimize.")
+      .intConf
+      .createWithDefault(3)
 
   /**
    * Holds information about keys that have been deprecated.
@@ -3299,6 +3305,9 @@ class SQLConf extends Serializable with Logging {
 
   def optimizeNullAwareAntiJoin: Boolean =
     getConf(SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN)
+
+  def optimizeNullAwareAntiJoinMaxNumKeys: Int =
+    getConf(SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN_MAX_NUM_KEYS)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -232,7 +232,7 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
           .orElse { if (hintToShuffleReplicateNL(hint)) createCartesianProduct() else None }
           .getOrElse(createJoinWithoutHint())
 
-      case j @ ExtractSingleColumnNullAwareAntiJoin(leftKeys, rightKeys) =>
+      case j @ ExtractNullAwareAntiJoinKeys(leftKeys, rightKeys) =>
         Seq(joins.BroadcastHashJoinExec(leftKeys, rightKeys, LeftAnti, BuildRight,
           None, planLater(j.left), planLater(j.right), isNullAwareAntiJoin = true))
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/LogicalQueryStageStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/LogicalQueryStageStrategy.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.adaptive
 import org.apache.spark.sql.Strategy
 import org.apache.spark.sql.catalyst.expressions.PredicateHelper
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight}
-import org.apache.spark.sql.catalyst.planning.{ExtractEquiJoinKeys, ExtractSingleColumnNullAwareAntiJoin}
+import org.apache.spark.sql.catalyst.planning.{ExtractEquiJoinKeys, ExtractNullAwareAntiJoinKeys}
 import org.apache.spark.sql.catalyst.plans.LeftAnti
 import org.apache.spark.sql.catalyst.plans.logical.{Join, LogicalPlan}
 import org.apache.spark.sql.execution.{joins, SparkPlan}
@@ -49,7 +49,7 @@ object LogicalQueryStageStrategy extends Strategy with PredicateHelper {
       Seq(BroadcastHashJoinExec(
         leftKeys, rightKeys, joinType, buildSide, condition, planLater(left), planLater(right)))
 
-    case j @ ExtractSingleColumnNullAwareAntiJoin(leftKeys, rightKeys)
+    case j @ ExtractNullAwareAntiJoinKeys(leftKeys, rightKeys)
         if isBroadcastStage(j.right) =>
       Seq(joins.BroadcastHashJoinExec(leftKeys, rightKeys, LeftAnti, BuildRight,
         None, planLater(j.left), planLater(j.right), isNullAwareAntiJoin = true))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastHashJoinExec.scala
@@ -49,8 +49,6 @@ case class BroadcastHashJoinExec(
   extends HashJoin with CodegenSupport {
 
   if (isNullAwareAntiJoin) {
-    require(leftKeys.length == 1, "leftKeys length should be 1")
-    require(rightKeys.length == 1, "rightKeys length should be 1")
     require(joinType == LeftAnti, "joinType must be LeftAnti.")
     require(buildSide == BuildRight, "buildSide must be BuildRight.")
     require(condition.isEmpty, "null aware anti join optimize condition should be empty.")
@@ -156,7 +154,7 @@ case class BroadcastHashJoinExec(
           )
           streamedIter.filter(row => {
             val lookupKey: UnsafeRow = keyGenerator(row)
-            if (lookupKey.anyNull()) {
+            if (lookupKey.allNull()) {
               false
             } else {
               // Anti Join: Drop the row on the streamed side if it is a match on the build
@@ -228,6 +226,7 @@ case class BroadcastHashJoinExec(
       val (keyEv, anyNull) = genStreamSideJoinKey(ctx, input)
       val (matched, _, _) = getJoinCondition(ctx, input)
       val numOutput = metricTerm(ctx, "numOutputRows")
+      val isLongHashedRelation = broadcastRelation.value.isInstanceOf[LongHashedRelation]
 
       if (broadcastRelation.value == EmptyHashedRelation) {
         s"""
@@ -245,7 +244,7 @@ case class BroadcastHashJoinExec(
            |boolean $found = false;
            |// generate join key for stream side
            |${keyEv.code}
-           |if ($anyNull) {
+           |if (${ if (isLongHashedRelation) s"$anyNull" else s"${keyEv.value}.allNull()"}) {
            |  $found = true;
            |} else {
            |  UnsafeRow $matched = (UnsafeRow)$relationTerm.getValue(${keyEv.value});

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastHashJoinExec.scala
@@ -244,7 +244,7 @@ case class BroadcastHashJoinExec(
            |boolean $found = false;
            |// generate join key for stream side
            |${keyEv.code}
-           |if (${ if (isLongHashedRelation) s"$anyNull" else s"${keyEv.value}.allNull()"}) {
+           |if (${if (isLongHashedRelation) s"$anyNull" else s"${keyEv.value}.allNull()"}) {
            |  $found = true;
            |} else {
            |  UnsafeRow $matched = (UnsafeRow)$relationTerm.getValue(${keyEv.value});

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
@@ -342,9 +342,11 @@ trait HashJoin extends BaseJoinExec with CodegenSupport {
    */
   protected def genStreamSideJoinKey(
       ctx: CodegenContext,
-      input: Seq[ExprCode]): (ExprCode, String) = {
+      input: Seq[ExprCode],
+      forceUnsafe: Boolean = false): (ExprCode, String) = {
     ctx.currentVars = input
-    if (streamedBoundKeys.length == 1 && streamedBoundKeys.head.dataType == LongType) {
+    if (streamedBoundKeys.length == 1 && streamedBoundKeys.head.dataType == LongType &&
+      !forceUnsafe) {
       // generate the join key as Long
       val ev = streamedBoundKeys.head.genCode(ctx)
       (ev, ev.isNull)

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -1184,7 +1184,7 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
     }
   }
 
-  test("SPARK-32474: NullAwareAntiJoin multi-column support") {
+  test("SPARK-32494: Null Aware Anti Join Optimize Support Multi-Column") {
     withSQLConf(SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> Long.MaxValue.toString) {
       // positive not in subquery case

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -1154,7 +1154,7 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> Long.MaxValue.toString) {
       // positive not in subquery case
       var joinExec = assertJoin((
-        "select * from testData where key not in (select a from testData2)",
+        "SELECT * FROM testData WHERE key NOT IN (SELECT a FROM testData2)",
         classOf[BroadcastHashJoinExec]))
       assert(joinExec.asInstanceOf[BroadcastHashJoinExec].isNullAwareAntiJoin)
 
@@ -1162,7 +1162,7 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
       // testData.key nullable false
       // testData3.b nullable true
       joinExec = assertJoin((
-        "select * from testData left anti join testData3 ON key = b or isnull(key = b)",
+        "SELECT * FROM testData LEFT ANTI JOIN testData3 ON key = b OR ISNULL(key = b)",
         classOf[BroadcastHashJoinExec]))
       assert(joinExec.asInstanceOf[BroadcastHashJoinExec].isNullAwareAntiJoin)
 
@@ -1171,15 +1171,15 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
       // testData2.a nullable false
       // isnull(key = a) will be optimized to true literal and removed
       joinExec = assertJoin((
-        "select * from testData left anti join testData2 ON key = a or isnull(key = a)",
+        "SELECT * FROM testData LEFT ANTI JOIN testData2 ON key = a OR ISNULL(key = a)",
         classOf[BroadcastHashJoinExec]))
       assert(!joinExec.asInstanceOf[BroadcastHashJoinExec].isNullAwareAntiJoin)
 
       // negative hand-written left anti join
       // not match pattern Or(EqualTo(a=b), IsNull(EqualTo(a=b))
       assertJoin((
-        "select * from testData2 left anti join testData3 ON testData2.a = testData3.b or " +
-          "isnull(testData2.b = testData3.b)",
+        "SELECT * FROM testData2 LEFT ANTI JOIN testData3 ON testData2.a = testData3.b OR " +
+          "ISNULL(testData2.b = testData3.b)",
         classOf[BroadcastNestedLoopJoinExec]))
     }
   }
@@ -1189,7 +1189,7 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> Long.MaxValue.toString) {
       // positive not in subquery case
       var joinExec = assertJoin((
-        "select * from testData where (key, key + 1) not in (select * from testData2)",
+        "SELECT * FROM testData WHERE (key, key + 1) NOT IN (SELECT * FROM testData2)",
         classOf[BroadcastHashJoinExec]))
       assert(joinExec.asInstanceOf[BroadcastHashJoinExec].isNullAwareAntiJoin)
 
@@ -1197,8 +1197,8 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
       // testData.key nullable false
       // testData3.b nullable true
       joinExec = assertJoin((
-        "select * from testData left anti join testData3 ON (key = b or isnull(key = b)) " +
-          "and (key + 1 = b or isnull(key + 1 = b))",
+        "SELECT * FROM testData LEFT ANTI JOIN testData3 ON (key = b OR ISNULL(key = b)) " +
+          "AND (key + 1 = b OR ISNULL(key + 1 = b))",
         classOf[BroadcastHashJoinExec]))
       assert(joinExec.asInstanceOf[BroadcastHashJoinExec].isNullAwareAntiJoin)
 
@@ -1207,17 +1207,17 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
       // testData2.a nullable false
       // isnull(key = a) isnull(key+1=a) will be optimized to true literal and removed
       joinExec = assertJoin((
-        "select * from testData left anti join testData3 ON (key = a or isnull(key = a)) " +
-          "and (key + 1 = a or isnull(key + 1 = a))",
+        "SELECT * FROM testData LEFT ANTI JOIN testData3 ON (key = a OR ISNULL(key = a)) " +
+          "AND (key + 1 = a OR ISNULL(key + 1 = a))",
         classOf[BroadcastHashJoinExec]))
       assert(!joinExec.asInstanceOf[BroadcastHashJoinExec].isNullAwareAntiJoin)
 
       // negative exceed OPTIMIZE_NULL_AWARE_ANTI_JOIN_MAX_NUM_KEYS
       joinExec = assertJoin((
-        "select * from testData left anti join testData3 ON (key = b or isnull(key = b)) " +
-          "and (key + 2 = b or isnull(key + 2 = b)) " +
-          "and (key + 3 = b or isnull(key + 3 = b)) " +
-          "and (key + 4 = b or isnull(key + 4 = b))",
+        "SELECT * FROM testData LEFT ANTI JOIN testData3 ON (key = b OR ISNULL(key = b)) " +
+          "AND (key + 2 = b OR ISNULL(key + 2 = b)) " +
+          "AND (key + 3 = b OR ISNULL(key + 3 = b)) " +
+          "AND (key + 4 = b OR ISNULL(key + 4 = b))",
         classOf[BroadcastNestedLoopJoinExec]))
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -1749,7 +1749,7 @@ class SubquerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     }
   }
 
-  test("SPARK-32474: NullAwareAntiJoin multi-column support") {
+  test("SPARK-32494: Null Aware Anti Join Optimize Support Multi-Column") {
     Seq(true, false).foreach { enableNAAJ =>
       Seq(true, false).foreach { enableAQE =>
         Seq(true, false).foreach { enableCodegen =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -1667,7 +1667,7 @@ class SubquerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
             var joinExec: BaseJoinExec = null
 
             // single column not in subquery -- empty sub-query
-            df = sql("select * from l where a not in (select c from r where c > 10)")
+            df = sql("SELECT * FROM l WHERE a NOT IN (SELECT c FROM r WHERE c > 10)")
             checkAnswer(df, spark.table("l"))
             if (enableNAAJ) {
               joinExec = findJoinExec(df)
@@ -1678,7 +1678,7 @@ class SubquerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
             }
 
             // single column not in subquery -- sub-query include null
-            df = sql("select * from l where a not in (select c from r where d < 6.0)")
+            df = sql("SELECT * FROM l WHERE a NOT IN (SELECT c FROM r WHERE d < 6.0)")
             checkAnswer(df, Seq.empty)
             if (enableNAAJ) {
               joinExec = findJoinExec(df)
@@ -1689,8 +1689,8 @@ class SubquerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
             }
 
             // single column not in subquery -- streamedSide row is null
-            df =
-              sql("select * from l where b = 5.0 and a not in(select c from r where c is not null)")
+            df = sql("SELECT * FROM l WHERE b = 5.0 AND a NOT IN " +
+              "(SELECT c FROM r WHERE c IS NOT NULL)")
             checkAnswer(df, Seq.empty)
             if (enableNAAJ) {
               joinExec = findJoinExec(df)
@@ -1702,7 +1702,7 @@ class SubquerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
 
             // single column not in subquery -- streamedSide row is not null, match found
             df =
-              sql("select * from l where a = 6 and a not in (select c from r where c is not null)")
+              sql("SELECT * FROM l WHERE a = 6 AND a NOT IN (SELECT c FROM r WHERE c IS NOT NULL)")
             checkAnswer(df, Seq.empty)
             if (enableNAAJ) {
               joinExec = findJoinExec(df)
@@ -1714,7 +1714,7 @@ class SubquerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
 
             // single column not in subquery -- streamedSide row is not null, match not found
             df =
-              sql("select * from l where a = 1 and a not in (select c from r where c is not null)")
+              sql("SELECT * FROM l WHERE a = 1 AND a NOT IN (SELECT c FROM r WHERE c IS NOT NULL)")
             checkAnswer(df, Row(1, 2.0) :: Row(1, 2.0) :: Nil)
             if (enableNAAJ) {
               joinExec = findJoinExec(df)
@@ -1725,7 +1725,7 @@ class SubquerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
             }
 
             // single column not in subquery -- d = b + 10 joinKey found, match ExtractEquiJoinKeys
-            df = sql("select * from l where a not in (select c from r where d = b + 10)")
+            df = sql("SELECT * FROM l WHERE a NOT IN (SELECT c FROM r WHERE d = b + 10)")
             checkAnswer(df, spark.table("l"))
             joinExec = findJoinExec(df)
             assert(joinExec.isInstanceOf[BroadcastHashJoinExec])
@@ -1734,7 +1734,7 @@ class SubquerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
             // single column not in subquery -- d = b + 10 and b = 5.0 => d = 15, joinKey not found
             // match ExtractSingleColumnNullAwareAntiJoin
             df =
-              sql("select * from l where b = 5.0 and a not in (select c from r where d = b + 10)")
+              sql("SELECT * FROM l WHERE b = 5.0 AND a NOT IN (SELECT c FROM r WHERE d = b + 10)")
             checkAnswer(df, Row(null, 5.0) :: Nil)
             if (enableNAAJ) {
               joinExec = findJoinExec(df)
@@ -1762,7 +1762,7 @@ class SubquerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
             var joinExec: BaseJoinExec = null
 
             // multi column not in subquery -- empty sub-query
-            df = sql("select * from l where (a, b) not in (select * from r where c > 10)")
+            df = sql("SELECT * FROM l WHERE (a, b) NOT IN (SELECT * FROM r WHERE c > 10)")
             checkAnswer(df, spark.table("l"))
             if (enableNAAJ) {
               joinExec = findJoinExec(df)
@@ -1774,7 +1774,7 @@ class SubquerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
 
             // multi column not in subquery -- sub-query include all null column key
             df = sql(
-              "select * from l where (a, b) not in (select * from r where c is null and d is null)")
+              "SELECT * FROM l WHERE (a, b) NOT IN (SELECT * FROM r WHERE c IS NULL and d IS NULL)")
             checkAnswer(df, Seq.empty)
             if (enableNAAJ) {
               joinExec = findJoinExec(df)
@@ -1785,8 +1785,8 @@ class SubquerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
             }
 
             // multi column not in subquery -- streamedSide row is all null column key
-            df = sql("select * from l where a is null and b is null " +
-              "and (a, b) not in (select * from r where c is not null)")
+            df = sql("SELECT * FROM l WHERE a IS NULL and b IS NULL " +
+              "AND (a, b) NOT IN (SELECT * FROM r WHERE c IS NOT NULL)")
             checkAnswer(df, Seq.empty)
             if (enableNAAJ) {
               joinExec = findJoinExec(df)
@@ -1797,8 +1797,8 @@ class SubquerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
             }
 
             // multi column not in subquery -- streamedSide row is not all null, match found
-            df = sql("select * from l where a = 6 " +
-              "and (a, b) not in (select * from r where c is not null)")
+            df = sql("SELECT * FROM l WHERE a = 6 " +
+              "AND (a, b) NOT IN (SELECT * FROM r WHERE c IS NOT NULL)")
             checkAnswer(df, Seq.empty)
             if (enableNAAJ) {
               joinExec = findJoinExec(df)
@@ -1809,8 +1809,8 @@ class SubquerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
             }
 
             // multi column not in subquery -- streamedSide row is not all null, match not found
-            df = sql("select * from l where a = 1 " +
-              "and (a, b) not in (select * from r where c is not null)")
+            df = sql("SELECT * FROM l WHERE a = 1 " +
+              "AND (a, b) NOT IN (SELECT * FROM r WHERE c IS NOT NULL)")
             checkAnswer(df, Row(1, 2.0) :: Row(1, 2.0) :: Nil)
             if (enableNAAJ) {
               joinExec = findJoinExec(df)


### PR DESCRIPTION
### What changes were proposed in this pull request?

In this PR, proposed a trade-off that can also support multi column to perform hash lookup in buildSide, but required buildSide with extra duplicate data, the duplication would be 2^numKeys - 1, for example, if we are to support NAAJ with 3 column join key, the buildSide would be expanded into (2^3 - 1) times, 7X.

For example, if there is a UnsafeRow key (1,2,3)
In NullAware Mode, it should be expanded into 7 keys with extra C(3,1), C(3,2) combinations, within the combinations, we duplicated these record with null padding as following.

Original record

(1,2,3) 

Extra record to be appended into HashedRelation

(null, 2, 3) (1, null, 3) (1, 2, null)
(null, null, 3) (null, 2, null) (1, null, null))

with the expanded data we can extract a common pattern for both single and multi column. allNull refer to a unsafeRow which has all null columns.

* buildSide is empty input => return all rows
* allNullColumnKey Exists In buildSide input => reject all rows
* if streamedSideRow.allNull is true => drop the row
* if streamedSideRow.allNull is false & findMatch in NullAwareHashedRelation => drop the row
* if streamedSideRow.allNull is false & notFindMatch in NullAwareHashedRelation => return the row

### Why are the changes needed?
Considered that NAAJ in real production usage, the numKeys should not be that big, normally 1~3 keys, I think it's still worth to do such trade-off. 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

1. SQLQueryTestSuite with NOT IN keyword SQL, add CONFIG_DIM with spark.sql.optimizeNullAwareAntiJoin on and off
2. added case in org.apache.spark.sql.JoinSuite.
3. added case in org.apache.spark.sql.SubquerySuite.
4. added case in org.apache.spark.sql.execution.joins.HashedRelationSuite to make sure the data expand logical.
5. config combination against e2e test (both single and multi column cases) with following

```
Map(
  "spark.sql.optimizeNullAwareAntiJoin" -> "true",
  "spark.sql.adaptive.enabled" -> "false",
  "spark.sql.codegen.wholeStage" -> "false"
),
Map(
  "sspark.sql.optimizeNullAwareAntiJoin" -> "true",
  "spark.sql.adaptive.enabled" -> "false",
  "spark.sql.codegen.wholeStage" -> "true"
),
Map(
  "spark.sql.optimizeNullAwareAntiJoin" -> "true",
  "spark.sql.adaptive.enabled" -> "true",
  "spark.sql.codegen.wholeStage" -> "false"
),
Map(
  "spark.sql.optimizeNullAwareAntiJoin" -> "true",
  "spark.sql.adaptive.enabled" -> "true",
  "spark.sql.codegen.wholeStage" -> "true"
)
```