### PR TITLE
[SPARK-29886][SQL] Add support for satisfying HashClusteredDistribution by DataSourceV2 implementations

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/partitioning/HashClusteredDistribution.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/partitioning/HashClusteredDistribution.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.sql.connector.read.partitioning;
 
 import org.apache.spark.annotation.Evolving;

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/partitioning/HashClusteredDistribution.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/partitioning/HashClusteredDistribution.java
@@ -6,8 +6,7 @@ import java.util.OptionalInt;
 
 /**
  * A concrete implementation of {@link Distribution}.
- * Represents data where tuples have been clustered according to the hash of the given
- * `expressions`.
+ * Represents data where tuples have been clustered according to the hash of the given columns.
  *
  * This is a strictly stronger guarantee than [[ClusteredDistribution]]. Given a tuple and the
  * number of partitions, this distribution strictly requires which partition the tuple should be in.

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/partitioning/HashClusteredDistribution.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/partitioning/HashClusteredDistribution.java
@@ -1,0 +1,26 @@
+package org.apache.spark.sql.connector.read.partitioning;
+
+import org.apache.spark.annotation.Evolving;
+
+import java.util.OptionalInt;
+
+/**
+ * A concrete implementation of {@link Distribution}.
+ * Represents data where tuples have been clustered according to the hash of the given
+ * `expressions`.
+ *
+ * This is a strictly stronger guarantee than [[ClusteredDistribution]]. Given a tuple and the
+ * number of partitions, this distribution strictly requires which partition the tuple should be in.
+ *
+ * @since 3.x.x
+ */
+@Evolving
+public class HashClusteredDistribution implements Distribution {
+    public final String[] clusteredColumns;
+    public final OptionalInt numPartitions;
+
+    public HashClusteredDistribution(String[] clusteredColumns, OptionalInt numPartitions) {
+        this.clusteredColumns = clusteredColumns;
+        this.numPartitions = numPartitions;
+    }
+}

--- a/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaPartitionAwareDataSource.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaPartitionAwareDataSource.java
@@ -29,6 +29,7 @@ import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.read.*;
 import org.apache.spark.sql.connector.read.partitioning.ClusteredDistribution;
 import org.apache.spark.sql.connector.read.partitioning.Distribution;
+import org.apache.spark.sql.connector.read.partitioning.HashClusteredDistribution;
 import org.apache.spark.sql.connector.read.partitioning.Partitioning;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
@@ -81,6 +82,11 @@ public class JavaPartitionAwareDataSource implements TestingV2Source {
     public boolean satisfy(Distribution distribution) {
       if (distribution instanceof ClusteredDistribution) {
         String[] clusteredCols = ((ClusteredDistribution) distribution).clusteredColumns;
+        return Arrays.asList(clusteredCols).contains("i");
+      }
+
+      if (distribution instanceof HashClusteredDistribution) {
+        String[] clusteredCols = ((HashClusteredDistribution) distribution).clusteredColumns;
         return Arrays.asList(clusteredCols).contains("i");
       }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala
@@ -22,7 +22,9 @@ import java.util
 import java.util.OptionalLong
 
 import scala.collection.JavaConverters._
+
 import test.org.apache.spark.sql.connector._
+
 import org.apache.spark.SparkException
 import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
 import org.apache.spark.sql.catalyst.InternalRow


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
This PR adds support for satisfying HashClusteredDistribution by DataSourceV2 implementations.

### Why are the changes needed?
Currently, the DataSourcePartitioning class only allows satisfying ClusteredDistribution. However, we need to satisfy HashClusteredDistribution as well for operators like SortMergeJoinExec.

### Does this PR introduce _any_ user-facing change?
Yes, this lets DSV2 users implement their own Partitioning to satisfy HashClusteredDistribution. It is a change in the public facing API.

### How was this patch tested?
Unit tests.
