### PR TITLE
[SPARK-32503][CORE][TESTS] Add Scala 2.13 `core` and related module test in GitHub Action

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -271,3 +271,29 @@ jobs:
         mkdir -p ~/.m2
         ./build/mvn $MAVEN_CLI_OPTS -DskipTests -Pyarn -Pmesos -Pkubernetes -Phive -Phive-thriftserver -Phadoop-cloud -Djava.version=11 install
         rm -rf ~/.m2/repository/org/apache/spark
+
+  scala213:
+    name: Scala 2.13
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Spark repository
+      uses: actions/checkout@v2
+    - name: Cache Maven local repository
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: scala213-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          scala213-maven-
+    - name: Install Java 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Test with Maven
+      run: |
+        export MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=1g -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
+        export MAVEN_CLI_OPTS="--no-transfer-progress"
+        mkdir -p ~/.m2
+        dev/change-scala-version.sh 2.13
+        build/mvn test -pl core --am -Pscala-2.13
+        rm -rf ~/.m2/repository/org/apache/spark


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add Scala 2.13 build and test coverage for `core` and related modules.
```
$ dev/change-scala-version.sh 2.13
$ build/mvn test -pl core --am -Pscala-2.13
```

### Why are the changes needed?

To prevent any regression on Scala 2.13.


### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Pass GitHub Action with the new job.