### PR TITLE
[SPARK-32480] Support insert overwrite to move data to trash

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -270,7 +270,7 @@ private[spark] object Utils extends Logging {
   }
 
   /**
-   * Move data to trash if 'spark.sql.truncate.trash.enabled' is true, else
+   * Move data to trash if 'spark.sql.trash.enabled' is true, else
    * delete the data permanently. If move data to trash failed fallback to hard deletion.
    */
   def moveToTrashOrDelete(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2732,14 +2732,14 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
-  val TRUNCATE_TRASH_ENABLED =
-    buildConf("spark.sql.truncate.trash.enabled")
-      .doc("This configuration decides when truncating table, whether data files will be moved " +
-        "to trash directory or deleted permanently. The trash retention time is controlled by " +
-        "'fs.trash.interval', and in default, the server side configuration value takes " +
-        "precedence over the client-side one. Note that if 'fs.trash.interval' is non-positive, " +
-        "this will be a no-op and log a warning message. If the data fails to be moved to "  +
-        "trash, Spark will turn to delete it permanently.")
+  val TRASH_ENABLED =
+    buildConf("spark.sql.trash.enabled")
+      .doc("This configuration decides when truncating table and insert overwrite, whether data " +
+        "files will be moved to trash directory or deleted permanently. The trash retention " +
+        "time is controlled by 'fs.trash.interval', and in default, the server side " +
+        "configuration value takes precedence over the client-side one. Note that if " +
+        "'fs.trash.interval' is non-positive, this will be a no-op and log a warning message. " +
+        "If the data fails to be moved to trash, Spark will turn to delete it permanently.")
       .version("3.1.0")
       .booleanConf
       .createWithDefault(false)
@@ -3362,7 +3362,7 @@ class SQLConf extends Serializable with Logging {
 
   def legacyPathOptionBehavior: Boolean = getConf(SQLConf.LEGACY_PATH_OPTION_BEHAVIOR)
 
-  def truncateTrashEnabled: Boolean = getConf(SQLConf.TRUNCATE_TRASH_ENABLED)
+  def trashEnabled: Boolean = getConf(SQLConf.TRASH_ENABLED)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -490,7 +490,7 @@ case class TruncateTableCommand(
       }
     val hadoopConf = spark.sessionState.newHadoopConf()
     val ignorePermissionAcl = SQLConf.get.truncateTableIgnorePermissionAcl
-    val isTrashEnabled = SQLConf.get.truncateTrashEnabled
+    val isTrashEnabled = SQLConf.get.trashEnabled
     locations.foreach { location =>
       if (location.isDefined) {
         val path = new Path(location.get)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -3105,7 +3105,7 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
   test("SPARK-32481 Move data to trash on truncate table if enabled") {
     val trashIntervalKey = "fs.trash.interval"
     withTable("tab1") {
-      withSQLConf(SQLConf.TRUNCATE_TRASH_ENABLED.key -> "true") {
+      withSQLConf(SQLConf.TRASH_ENABLED.key -> "true") {
         sql("CREATE TABLE tab1 (col INT) USING parquet")
         sql("INSERT INTO tab1 SELECT 1")
         // scalastyle:off hadoopconfiguration
@@ -3134,7 +3134,7 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
   test("SPARK-32481 delete data permanently on truncate table if trash interval is non-positive") {
     val trashIntervalKey = "fs.trash.interval"
     withTable("tab1") {
-      withSQLConf(SQLConf.TRUNCATE_TRASH_ENABLED.key -> "true") {
+      withSQLConf(SQLConf.TRASH_ENABLED.key -> "true") {
         sql("CREATE TABLE tab1 (col INT) USING parquet")
         sql("INSERT INTO tab1 SELECT 1")
         // scalastyle:off hadoopconfiguration
@@ -3161,7 +3161,7 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
 
   test("SPARK-32481 Do not move data to trash on truncate table if disabled") {
     withTable("tab1") {
-      withSQLConf(SQLConf.TRUNCATE_TRASH_ENABLED.key -> "false") {
+      withSQLConf(SQLConf.TRASH_ENABLED.key -> "false") {
         sql("CREATE TABLE tab1 (col INT) USING parquet")
         sql("INSERT INTO tab1 SELECT 1")
         val hadoopConf = spark.sessionState.newHadoopConf()


### PR DESCRIPTION
### What changes were proposed in this pull request?
Instead of deleting the data, we can move the data to trash.
Based on the configuration provided by the user it will be deleted permanently from the trash.


### Why are the changes needed?
Instead of directly deleting the data, we can provide flexibility to move data to the trash and then delete it permanently.

### Does this PR introduce _any_ user-facing change?
Yes, After insert overwrite the data is not permanently deleted now.
It is first moved to the trash and then after the given time deleted permanently;

### How was this patch tested?
Manually