### PR TITLE
[SPARK-32402][SQL] Implement ALTER TABLE in JDBC Table Catalog

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -527,6 +527,13 @@ trait CheckAnalysis extends PredicateHelper {
                         s"${field.dataType.simpleString} cannot be cast to " +
                         s"${update.newDataType.simpleString}")
                 }
+              case update: UpdateColumnNullability =>
+                val field = findField("update", update.fieldNames)
+                val fieldName = update.fieldNames.quoted
+                if (!update.nullable && field.nullable) {
+                  alter.failAnalysis(
+                    s"Cannot change nullable column to non-nullable: $fieldName")
+                }
               case updatePos: UpdateColumnPosition =>
                 findField("update", updatePos.fieldNames)
                 val parent = findParentStruct("update", updatePos.fieldNames())

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -527,13 +527,6 @@ trait CheckAnalysis extends PredicateHelper {
                         s"${field.dataType.simpleString} cannot be cast to " +
                         s"${update.newDataType.simpleString}")
                 }
-              case update: UpdateColumnNullability =>
-                val field = findField("update", update.fieldNames)
-                val fieldName = update.fieldNames.quoted
-                if (!update.nullable && field.nullable) {
-                  alter.failAnalysis(
-                    s"Cannot change nullable column to non-nullable: $fieldName")
-                }
               case updatePos: UpdateColumnPosition =>
                 findField("update", updatePos.fieldNames)
                 val parent = findParentStruct("update", updatePos.fieldNames())

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -923,8 +923,9 @@ object JdbcUtils extends Logging {
     val statement = conn.createStatement
     try {
       statement.setQueryTimeout(options.queryTimeout)
-      for (stmt <- dialect.alterTable(tableName, changes))
-        statement.executeUpdate(stmt)
+      for (sql <- dialect.alterTable(tableName, changes)) {
+        statement.executeUpdate(sql)
+      }
     } finally {
       statement.close()
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -906,7 +906,7 @@ object JdbcUtils extends Logging {
     } else {
       val metadata = conn.getMetaData
       if (!metadata.supportsTransactions) {
-        throw new SQLFeatureNotSupportedException("The target JDBC server does not support" +
+        throw new SQLFeatureNotSupportedException("The target JDBC server does not support " +
           "transaction and can only support ALTER TABLE with a single action.")
       } else {
         conn.setAutoCommit(false)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -917,8 +917,7 @@ object JdbcUtils extends Logging {
       conn: Connection,
       tableName: String,
       changes: Seq[TableChange],
-      options: JDBCOptions
-      ): Unit = {
+      options: JDBCOptions): Unit = {
     val dialect = JdbcDialects.get(options.url)
     val statement = conn.createStatement
     try {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -179,7 +179,7 @@ object JdbcUtils extends Logging {
     }
   }
 
-  private[sql] def getJdbcType(dt: DataType, dialect: JdbcDialect): JdbcType = {
+  def getJdbcType(dt: DataType, dialect: JdbcDialect): JdbcType = {
     dialect.getJDBCType(dt).orElse(getCommonJDBCType(dt)).getOrElse(
       throw new IllegalArgumentException(s"Can't get JDBC type for ${dt.catalogString}"))
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -906,9 +906,8 @@ object JdbcUtils extends Logging {
     } else {
       val metadata = conn.getMetaData
       if (!metadata.supportsTransactions) {
-        throw new SQLFeatureNotSupportedException(s"${this.getClass.getName}.alterTable doesn't" +
-          s" support multiple alter table changes simultaneously for database server" +
-            s" that doesn't have transaction support.")
+        throw new SQLFeatureNotSupportedException("The target JDBC server does not support" +
+          "transaction and can only support ALTER TABLE with a single action.")
       } else {
         conn.setAutoCommit(false)
         val statement = conn.createStatement
@@ -919,7 +918,7 @@ object JdbcUtils extends Logging {
           }
           conn.commit()
         } catch {
-          case e: SQLException =>
+          case e: Exception =>
             if (conn != null) conn.rollback()
             throw e
         } finally {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
@@ -129,11 +129,12 @@ class JDBCTableCatalog extends TableCatalog with Logging {
     JDBCTable(ident, schema, writeOptions)
   }
 
-  // TODO (SPARK-32402): Implement ALTER TABLE in JDBC Table Catalog
   override def alterTable(ident: Identifier, changes: TableChange*): Table = {
-    // scalastyle:off throwerror
-    throw new NotImplementedError()
-    // scalastyle:on throwerror
+    checkNamespace(ident.namespace())
+    withConnection { conn =>
+      JdbcUtils.alterTable(conn, getTableName(ident), changes, options)
+      loadTable(ident)
+    }
   }
 
   private def checkNamespace(namespace: Array[String]): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -234,7 +234,7 @@ abstract class JdbcDialect extends Serializable {
                 s" ${delete.fieldNames}")
           }
         case _ => throw new IllegalArgumentException(s"JDBC alterTable has Unsupported" +
-          s" TableChange ${change}")
+          s" TableChange $change")
       }
     }
     updateClause.result()

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -234,11 +234,8 @@ abstract class JdbcDialect extends Serializable {
         case update: UpdateColumnNullability =>
           update.fieldNames match {
             case Array(name) =>
-              if (update.nullable()) {
-                updateClause += s"ALTER TABLE $tableName ALTER COLUMN $name SET NULL"
-              } else {
-                updateClause += s"ALTER TABLE $tableName ALTER COLUMN $name SET NOT NULL"
-              }
+              val nullable = if (update.nullable()) "NULL" else "NOT NULL"
+              updateClause += s"ALTER TABLE $tableName ALTER COLUMN $name SET " + nullable
           }
         // scalastyle:off throwerror
         case _ => throw new NotImplementedError(s"JDBC alterTable has Unsupported" +

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -236,11 +236,10 @@ abstract class JdbcDialect extends Serializable {
           update.fieldNames match {
             case Array(name) =>
               val nullable = if (update.nullable()) "NULL" else "NOT NULL"
-              updateClause += s"ALTER TABLE $tableName ALTER COLUMN $name SET " + nullable
+              updateClause += s"ALTER TABLE $tableName ALTER COLUMN $name SET $nullable"
           }
         case _ =>
-          throw new SQLFeatureNotSupportedException(s"${this.getClass.getName}.alterTable" +
-            s" has unsupported TableChange $change")
+          throw new SQLFeatureNotSupportedException(s"Unsupported TableChange $change")
       }
     }
     updateClause.result()

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.jdbc
 
-import java.sql.{Connection, Date, Timestamp}
+import java.sql.{Connection, Date, SQLFeatureNotSupportedException, Timestamp}
 
 import scala.collection.mutable.ArrayBuilder
 
@@ -199,6 +199,7 @@ abstract class JdbcDialect extends Serializable {
 
   /**
    * Alter an existing table.
+   * TODO (SPARK-32523): Override this method in the dialects that have different syntax.
    *
    * @param tableName The name of the table to be altered.
    * @param changes Changes to apply to the table.
@@ -237,10 +238,9 @@ abstract class JdbcDialect extends Serializable {
               val nullable = if (update.nullable()) "NULL" else "NOT NULL"
               updateClause += s"ALTER TABLE $tableName ALTER COLUMN $name SET " + nullable
           }
-        // scalastyle:off throwerror
-        case _ => throw new NotImplementedError(s"JDBC alterTable has Unsupported" +
-          s" TableChange $change")
-        // scalastyle:on throwerror
+        case _ =>
+          throw new SQLFeatureNotSupportedException(s"${this.getClass.getName}.alterTable" +
+            s" has unsupported TableChange $change")
       }
     }
     updateClause.result()

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -210,34 +210,24 @@ abstract class JdbcDialect extends Serializable {
     for (change <- changes) {
       change match {
         case add: AddColumn if add.fieldNames.length == 1 =>
-          add.fieldNames match {
-            case Array(name) =>
-              val dataType = JdbcUtils.getJdbcType(add.dataType(), this).databaseTypeDefinition
-              updateClause += s"ALTER TABLE $tableName ADD COLUMN $name $dataType"
-          }
+          val dataType = JdbcUtils.getJdbcType(add.dataType(), this).databaseTypeDefinition
+          val name = add.fieldNames
+          updateClause += s"ALTER TABLE $tableName ADD COLUMN ${name(0)} $dataType"
         case rename: RenameColumn if rename.fieldNames.length == 1 =>
-          rename.fieldNames match {
-            case Array(name) =>
-              updateClause += s"ALTER TABLE $tableName RENAME COLUMN $name TO ${rename.newName}"
-          }
+          val name = rename.fieldNames
+          updateClause += s"ALTER TABLE $tableName RENAME COLUMN ${name(0)} TO ${rename.newName}"
         case delete: DeleteColumn if delete.fieldNames.length == 1 =>
-          delete.fieldNames match {
-            case Array(name) =>
-              updateClause += s"ALTER TABLE $tableName DROP COLUMN $name"
-          }
-        case update: UpdateColumnType if update.fieldNames.length == 1 =>
-          update.fieldNames match {
-            case Array(name) =>
-              val dataType = JdbcUtils.getJdbcType(update.newDataType(), this)
-                .databaseTypeDefinition
-              updateClause += s"ALTER TABLE $tableName ALTER COLUMN $name $dataType"
-          }
-        case update: UpdateColumnNullability if update.fieldNames.length == 1 =>
-          update.fieldNames match {
-            case Array(name) =>
-              val nullable = if (update.nullable()) "NULL" else "NOT NULL"
-              updateClause += s"ALTER TABLE $tableName ALTER COLUMN $name SET $nullable"
-          }
+          val name = delete.fieldNames
+          updateClause += s"ALTER TABLE $tableName DROP COLUMN ${name(0)}"
+        case updateColumnType: UpdateColumnType if updateColumnType.fieldNames.length == 1 =>
+          val name = updateColumnType.fieldNames
+          val dataType = JdbcUtils.getJdbcType(updateColumnType.newDataType(), this)
+            .databaseTypeDefinition
+          updateClause += s"ALTER TABLE $tableName ALTER COLUMN ${name(0)} $dataType"
+        case updateNull: UpdateColumnNullability if updateNull.fieldNames.length == 1 =>
+          val name = updateNull.fieldNames
+          val nullable = if (updateNull.nullable()) "NULL" else "NOT NULL"
+          updateClause += s"ALTER TABLE $tableName ALTER COLUMN ${name(0)} SET $nullable"
         case _ =>
           throw new SQLFeatureNotSupportedException(s"Unsupported TableChange $change")
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -29,7 +29,6 @@ import org.apache.spark.sql.connector.catalog.TableChange.{AddColumn, DeleteColu
 import org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils
 import org.apache.spark.sql.types._
 
-
 /**
  * :: DeveloperApi ::
  * A database type definition coupled with the jdbc type needed to send null

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -209,30 +209,30 @@ abstract class JdbcDialect extends Serializable {
     val updateClause = ArrayBuilder.make[String]
     for (change <- changes) {
       change match {
-        case add: AddColumn =>
+        case add: AddColumn if add.fieldNames.length == 1 =>
           add.fieldNames match {
             case Array(name) =>
               val dataType = JdbcUtils.getJdbcType(add.dataType(), this).databaseTypeDefinition
               updateClause += s"ALTER TABLE $tableName ADD COLUMN $name $dataType"
           }
-        case rename: RenameColumn =>
+        case rename: RenameColumn if rename.fieldNames.length == 1 =>
           rename.fieldNames match {
             case Array(name) =>
               updateClause += s"ALTER TABLE $tableName RENAME COLUMN $name TO ${rename.newName}"
           }
-        case delete: DeleteColumn =>
+        case delete: DeleteColumn if delete.fieldNames.length == 1 =>
           delete.fieldNames match {
             case Array(name) =>
               updateClause += s"ALTER TABLE $tableName DROP COLUMN $name"
           }
-        case update: UpdateColumnType =>
+        case update: UpdateColumnType if update.fieldNames.length == 1 =>
           update.fieldNames match {
             case Array(name) =>
               val dataType = JdbcUtils.getJdbcType(update.newDataType(), this)
                 .databaseTypeDefinition
               updateClause += s"ALTER TABLE $tableName ALTER COLUMN $name $dataType"
           }
-        case update: UpdateColumnNullability =>
+        case update: UpdateColumnNullability if update.fieldNames.length == 1 =>
           update.fieldNames match {
             case Array(name) =>
               val nullable = if (update.nullable()) "NULL" else "NOT NULL"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
@@ -161,19 +161,10 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
   test("alter table ... update column nullability") {
     withTable("h2.test.alt_table") {
       sql("CREATE TABLE h2.test.alt_table (ID INTEGER NOT NULL) USING _")
-      var t = spark.table("h2.test.alt_table")
-      var expectedSchema = new StructType().add("ID", IntegerType, nullable = false)
-      // Todo: find out why the nullable for ID INTEGER NOT NULL is true
-      // assert(t.schema === expectedSchema)
       sql("ALTER TABLE h2.test.alt_table ALTER COLUMN ID DROP NOT NULL")
-      t = spark.table("h2.test.alt_table")
-      expectedSchema = new StructType().add("ID", IntegerType, nullable = true)
+      val t = spark.table("h2.test.alt_table")
+      val expectedSchema = new StructType().add("ID", IntegerType, nullable = true)
       assert(t.schema === expectedSchema)
-      sql("ALTER TABLE h2.test.alt_table ALTER COLUMN ID SET NOT NULL")
-      t = spark.table("h2.test.alt_table")
-      expectedSchema = new StructType().add("ID", IntegerType, nullable = false)
-      // Todo: find out why the nullable for ID INTEGER NOT NULL is true
-      // assert(t.schema === expectedSchema)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
@@ -140,9 +140,7 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
 
   test("alter table ... update column type") {
     withTable("h2.test.alt_table") {
-      withConnection { conn =>
-        sql("CREATE TABLE h2.test.alt_table (ID INTEGER) USING _")
-      }
+      sql("CREATE TABLE h2.test.alt_table (ID INTEGER) USING _")
       sql("ALTER TABLE h2.test.alt_table ALTER COLUMN id TYPE DOUBLE")
       assert(sql(s"DESCRIBE TABLE h2.test.alt_table").select("data_type").first()
         === Row("double"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
@@ -119,11 +119,7 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       assert(t.schema === expectedSchema)
       sql("ALTER TABLE h2.test.alt_table ADD COLUMNS (C3 DOUBLE)")
       t = spark.table("h2.test.alt_table")
-      expectedSchema = new StructType()
-        .add("ID", IntegerType)
-        .add("C1", IntegerType)
-        .add("C2", StringType)
-        .add("C3", DoubleType)
+      expectedSchema = expectedSchema.add("C3", DoubleType)
       assert(t.schema === expectedSchema)
     }
   }
@@ -174,7 +170,7 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       val thrown = intercept[java.sql.SQLFeatureNotSupportedException] {
         sql("ALTER TABLE h2.test.alt_table ALTER COLUMN ID COMMENT 'test'")
       }
-      assert(thrown.getMessage.contains("alterTable has unsupported TableChange"))
+      assert(thrown.getMessage.contains("Unsupported TableChange"))
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
@@ -131,9 +131,7 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
 
   test("alter table ... drop column") {
     withTable("h2.test.alt_table") {
-      withConnection { conn =>
-        sql("CREATE TABLE h2.test.alt_table (C1 INTEGER, C2 INTEGER) USING _")
-      }
+      sql("CREATE TABLE h2.test.alt_table (C1 INTEGER, C2 INTEGER) USING _")
       assert(checkColumnExistence("h2.test.alt_table", Array("C1", "C2")))
       sql("ALTER TABLE h2.test.alt_table DROP COLUMN C1")
       assert(checkColumnExistence("h2.test.alt_table", Array("C2")))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
@@ -149,9 +149,7 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
 
   test("alter table ... update column comment not supported") {
     withTable("h2.test.alt_table") {
-      withConnection { conn =>
-        sql("CREATE TABLE h2.test.alt_table (ID INTEGER) USING _")
-      }
+      sql("CREATE TABLE h2.test.alt_table (ID INTEGER) USING _")
       val thrown = intercept[scala.NotImplementedError] {
         sql("ALTER TABLE h2.test.alt_table ALTER COLUMN ID COMMENT 'test'")
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
@@ -122,9 +122,7 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
 
   test("alter table ... rename column") {
     withTable("h2.test.alt_table") {
-      withConnection { conn =>
-        sql("CREATE TABLE h2.test.alt_table (ID INTEGER) USING _")
-      }
+      sql("CREATE TABLE h2.test.alt_table (ID INTEGER) USING _")
       assert(checkColumnExistence("h2.test.alt_table", Array("ID")))
       sql("ALTER TABLE h2.test.alt_table RENAME COLUMN ID TO C")
       assert(checkColumnExistence("h2.test.alt_table", Array("C")))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
@@ -111,9 +111,7 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
 
   test("alter table ... add column") {
     withTable("h2.test.alt_table") {
-      withConnection { conn =>
-        sql("CREATE TABLE h2.test.alt_table (ID INTEGER) USING _")
-      }
+      sql("CREATE TABLE h2.test.alt_table (ID INTEGER) USING _")
       assert(checkColumnExistence("h2.test.alt_table", Array("ID")))
       sql("ALTER TABLE h2.test.alt_table ADD COLUMNS (C1 INTEGER, C2 STRING)")
       assert(checkColumnExistence("h2.test.alt_table", Array("ID", "C1", "C2")))


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implement ALTER TABLE in JDBC Table Catalog
The following ALTER TABLE are implemented:
```
ALTER TABLE table_name ADD COLUMNS ( column_name datatype [ , ... ] );
ALTER TABLE table_name RENAME COLUMN old_column_name TO new_column_name;
ALTER TABLE table_name DROP COLUMN column_name;
ALTER TABLE table_name ALTER COLUMN column_name TYPE new_type;
ALTER TABLE table_name ALTER COLUMN column_name SET NOT NULL;
```
I haven't checked ALTER TABLE syntax for all the databases yet. I will check. If there are different syntax, I will have a follow-up to override the dialect. 

Seems most of the databases don't support updating comments and column position, so I didn't implement UpdateColumnComment and UpdateColumnPosition.

 

### Why are the changes needed?
Complete the JDBCTableCatalog implementation


### Does this PR introduce _any_ user-facing change?
Yes
`JDBCTableCatalog.alterTable`


### How was this patch tested?
add new tests
