### PR TITLE
[WIP][SPARK-32502][BUILD] Upgrade Guava to 27.0-jre

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.7-hive-1.2
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-1.2
@@ -6,6 +6,7 @@ ST4/4.0.4//ST4-4.0.4.jar
 activation/1.1.1//activation-1.1.1.jar
 aircompressor/0.10//aircompressor-0.10.jar
 algebra_2.12/2.0.0-M2//algebra_2.12-2.0.0-M2.jar
+animal-sniffer-annotations/1.17//animal-sniffer-annotations-1.17.jar
 antlr-runtime/3.4//antlr-runtime-3.4.jar
 antlr/2.7.7//antlr-2.7.7.jar
 antlr4-runtime/4.7.1//antlr4-runtime-4.7.1.jar
@@ -29,6 +30,7 @@ bonecp/0.8.0.RELEASE//bonecp-0.8.0.RELEASE.jar
 breeze-macros_2.12/1.0//breeze-macros_2.12-1.0.jar
 breeze_2.12/1.0//breeze_2.12-1.0.jar
 cats-kernel_2.12/2.0.0-M4//cats-kernel_2.12-2.0.0-M4.jar
+checker-qual/2.5.2//checker-qual-2.5.2.jar
 chill-java/0.9.5//chill-java-0.9.5.jar
 chill_2.12/0.9.5//chill_2.12-0.9.5.jar
 commons-beanutils/1.9.4//commons-beanutils-1.9.4.jar
@@ -59,10 +61,12 @@ datanucleus-api-jdo/3.2.6//datanucleus-api-jdo-3.2.6.jar
 datanucleus-core/3.2.10//datanucleus-core-3.2.10.jar
 datanucleus-rdbms/3.2.9//datanucleus-rdbms-3.2.9.jar
 derby/10.12.1.1//derby-10.12.1.1.jar
+error_prone_annotations/2.2.0//error_prone_annotations-2.2.0.jar
+failureaccess/1.0//failureaccess-1.0.jar
 flatbuffers-java/1.9.0//flatbuffers-java-1.9.0.jar
 generex/1.0.2//generex-1.0.2.jar
 gson/2.2.4//gson-2.2.4.jar
-guava/14.0.1//guava-14.0.1.jar
+guava/27.0-jre//guava-27.0-jre.jar
 guice-servlet/3.0//guice-servlet-3.0.jar
 guice/3.0//guice-3.0.jar
 hadoop-annotations/2.7.4//hadoop-annotations-2.7.4.jar
@@ -88,6 +92,7 @@ httpclient/4.5.6//httpclient-4.5.6.jar
 httpcore/4.4.12//httpcore-4.4.12.jar
 istack-commons-runtime/3.0.8//istack-commons-runtime-3.0.8.jar
 ivy/2.4.0//ivy-2.4.0.jar
+j2objc-annotations/1.1//j2objc-annotations-1.1.jar
 jackson-annotations/2.10.0//jackson-annotations-2.10.0.jar
 jackson-core-asl/1.9.13//jackson-core-asl-1.9.13.jar
 jackson-core/2.10.0//jackson-core-2.10.0.jar
@@ -144,6 +149,7 @@ kubernetes-model/4.9.2//kubernetes-model-4.9.2.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 libfb303/0.9.3//libfb303-0.9.3.jar
 libthrift/0.12.0//libthrift-0.12.0.jar
+listenablefuture/9999.0-empty-to-avoid-conflict-with-guava//listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
 log4j/1.2.17//log4j-1.2.17.jar
 logging-interceptor/3.12.6//logging-interceptor-3.12.6.jar
 lz4-java/1.7.1//lz4-java-1.7.1.jar

--- a/dev/deps/spark-deps-hadoop-2.7-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-2.3
@@ -6,6 +6,7 @@ ST4/4.0.4//ST4-4.0.4.jar
 activation/1.1.1//activation-1.1.1.jar
 aircompressor/0.10//aircompressor-0.10.jar
 algebra_2.12/2.0.0-M2//algebra_2.12-2.0.0-M2.jar
+animal-sniffer-annotations/1.17//animal-sniffer-annotations-1.17.jar
 antlr-runtime/3.5.2//antlr-runtime-3.5.2.jar
 antlr4-runtime/4.7.1//antlr4-runtime-4.7.1.jar
 aopalliance-repackaged/2.6.1//aopalliance-repackaged-2.6.1.jar
@@ -27,6 +28,7 @@ bonecp/0.8.0.RELEASE//bonecp-0.8.0.RELEASE.jar
 breeze-macros_2.12/1.0//breeze-macros_2.12-1.0.jar
 breeze_2.12/1.0//breeze_2.12-1.0.jar
 cats-kernel_2.12/2.0.0-M4//cats-kernel_2.12-2.0.0-M4.jar
+checker-qual/2.5.2//checker-qual-2.5.2.jar
 chill-java/0.9.5//chill-java-0.9.5.jar
 chill_2.12/0.9.5//chill_2.12-0.9.5.jar
 commons-beanutils/1.9.4//commons-beanutils-1.9.4.jar
@@ -58,10 +60,12 @@ datanucleus-core/4.1.17//datanucleus-core-4.1.17.jar
 datanucleus-rdbms/4.1.19//datanucleus-rdbms-4.1.19.jar
 derby/10.12.1.1//derby-10.12.1.1.jar
 dropwizard-metrics-hadoop-metrics2-reporter/0.1.2//dropwizard-metrics-hadoop-metrics2-reporter-0.1.2.jar
+error_prone_annotations/2.2.0//error_prone_annotations-2.2.0.jar
+failureaccess/1.0//failureaccess-1.0.jar
 flatbuffers-java/1.9.0//flatbuffers-java-1.9.0.jar
 generex/1.0.2//generex-1.0.2.jar
 gson/2.2.4//gson-2.2.4.jar
-guava/14.0.1//guava-14.0.1.jar
+guava/27.0-jre//guava-27.0-jre.jar
 guice-servlet/3.0//guice-servlet-3.0.jar
 guice/3.0//guice-3.0.jar
 hadoop-annotations/2.7.4//hadoop-annotations-2.7.4.jar
@@ -101,6 +105,7 @@ httpclient/4.5.6//httpclient-4.5.6.jar
 httpcore/4.4.12//httpcore-4.4.12.jar
 istack-commons-runtime/3.0.8//istack-commons-runtime-3.0.8.jar
 ivy/2.4.0//ivy-2.4.0.jar
+j2objc-annotations/1.1//j2objc-annotations-1.1.jar
 jackson-annotations/2.10.0//jackson-annotations-2.10.0.jar
 jackson-core-asl/1.9.13//jackson-core-asl-1.9.13.jar
 jackson-core/2.10.0//jackson-core-2.10.0.jar
@@ -159,6 +164,7 @@ kubernetes-model/4.9.2//kubernetes-model-4.9.2.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 libfb303/0.9.3//libfb303-0.9.3.jar
 libthrift/0.12.0//libthrift-0.12.0.jar
+listenablefuture/9999.0-empty-to-avoid-conflict-with-guava//listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
 log4j/1.2.17//log4j-1.2.17.jar
 logging-interceptor/3.12.6//logging-interceptor-3.12.6.jar
 lz4-java/1.7.1//lz4-java-1.7.1.jar

--- a/dev/deps/spark-deps-hadoop-3.2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3.2-hive-2.3
@@ -7,6 +7,7 @@ accessors-smart/1.2//accessors-smart-1.2.jar
 activation/1.1.1//activation-1.1.1.jar
 aircompressor/0.10//aircompressor-0.10.jar
 algebra_2.12/2.0.0-M2//algebra_2.12-2.0.0-M2.jar
+animal-sniffer-annotations/1.17//animal-sniffer-annotations-1.17.jar
 antlr-runtime/3.5.2//antlr-runtime-3.5.2.jar
 antlr4-runtime/4.7.1//antlr4-runtime-4.7.1.jar
 aopalliance-repackaged/2.6.1//aopalliance-repackaged-2.6.1.jar
@@ -24,6 +25,7 @@ bonecp/0.8.0.RELEASE//bonecp-0.8.0.RELEASE.jar
 breeze-macros_2.12/1.0//breeze-macros_2.12-1.0.jar
 breeze_2.12/1.0//breeze_2.12-1.0.jar
 cats-kernel_2.12/2.0.0-M4//cats-kernel_2.12-2.0.0-M4.jar
+checker-qual/2.5.2//checker-qual-2.5.2.jar
 chill-java/0.9.5//chill-java-0.9.5.jar
 chill_2.12/0.9.5//chill_2.12-0.9.5.jar
 commons-beanutils/1.9.4//commons-beanutils-1.9.4.jar
@@ -57,11 +59,13 @@ derby/10.12.1.1//derby-10.12.1.1.jar
 dnsjava/2.1.7//dnsjava-2.1.7.jar
 dropwizard-metrics-hadoop-metrics2-reporter/0.1.2//dropwizard-metrics-hadoop-metrics2-reporter-0.1.2.jar
 ehcache/3.3.1//ehcache-3.3.1.jar
+error_prone_annotations/2.2.0//error_prone_annotations-2.2.0.jar
+failureaccess/1.0//failureaccess-1.0.jar
 flatbuffers-java/1.9.0//flatbuffers-java-1.9.0.jar
 generex/1.0.2//generex-1.0.2.jar
 geronimo-jcache_1.0_spec/1.0-alpha-1//geronimo-jcache_1.0_spec-1.0-alpha-1.jar
 gson/2.2.4//gson-2.2.4.jar
-guava/14.0.1//guava-14.0.1.jar
+guava/27.0-jre//guava-27.0-jre.jar
 guice-servlet/4.0//guice-servlet-4.0.jar
 guice/4.0//guice-4.0.jar
 hadoop-annotations/3.2.0//hadoop-annotations-3.2.0.jar
@@ -100,6 +104,7 @@ httpclient/4.5.6//httpclient-4.5.6.jar
 httpcore/4.4.12//httpcore-4.4.12.jar
 istack-commons-runtime/3.0.8//istack-commons-runtime-3.0.8.jar
 ivy/2.4.0//ivy-2.4.0.jar
+j2objc-annotations/1.1//j2objc-annotations-1.1.jar
 jackson-annotations/2.10.0//jackson-annotations-2.10.0.jar
 jackson-core-asl/1.9.13//jackson-core-asl-1.9.13.jar
 jackson-core/2.10.0//jackson-core-2.10.0.jar
@@ -171,6 +176,7 @@ kubernetes-model/4.9.2//kubernetes-model-4.9.2.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 libfb303/0.9.3//libfb303-0.9.3.jar
 libthrift/0.12.0//libthrift-0.12.0.jar
+listenablefuture/9999.0-empty-to-avoid-conflict-with-guava//listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
 log4j/1.2.17//log4j-1.2.17.jar
 logging-interceptor/3.12.6//logging-interceptor-3.12.6.jar
 lz4-java/1.7.1//lz4-java-1.7.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@
     <!-- org.apache.commons/commons-pool2/-->
     <commons-pool2.version>2.6.2</commons-pool2.version>
     <datanucleus-core.version>4.1.17</datanucleus-core.version>
-    <guava.version>14.0.1</guava.version>
+    <guava.version>27.0-jre</guava.version>
     <janino.version>3.1.2</janino.version>
     <jersey.version>2.30</jersey.version>
     <joda.version>2.10.5</joda.version>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -626,7 +626,7 @@ object KubernetesIntegrationTests {
  * Overrides to work around sbt's dependency resolution being different from Maven's.
  */
 object DependencyOverrides {
-  lazy val guavaVersion = sys.props.get("guava.version").getOrElse("14.0.1")
+  lazy val guavaVersion = sys.props.get("guava.version").getOrElse("27.0-jre")
   lazy val settings = Seq(
     dependencyOverrides += "com.google.guava" % "guava" % guavaVersion,
     dependencyOverrides += "xerces" % "xercesImpl" % "2.12.0",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR upgrades Guava to newer 27.0-jre.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Guava 14.0.1 is pretty old and is among the affected Guava versions of [CVE-2018-10237](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-10237).

All newer Hadoop releases are going to be built with a later guava version, e.g. 27.0-jre, including Hadoop [3.1.3](https://hadoop.apache.org/docs/r3.1.3/hadoop-project-dist/hadoop-common/dependency-analysis.html), [3.2.1](https://hadoop.apache.org/docs/r3.2.1/hadoop-project-dist/hadoop-common/dependency-analysis.html), [3.3.0](https://hadoop.apache.org/docs/r3.3.0/hadoop-project-dist/hadoop-common/dependency-analysis.html).

This PR leaves Hadoop version untouched.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Pass the Jenkins tests.