### PR TITLE
[SPARK-32399][SQL] Full outer shuffled hash join

### DIFF
--- a/core/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
+++ b/core/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
@@ -431,7 +431,8 @@ public final class BytesToBytesMap extends MemoryConsumer {
   /**
    * Iterator for the entries of this map. This is to first iterate over key index array
    * `longArray` then accessing values in `dataPages`. NOTE: this is different from `MapIterator`
-   * in the sense that key index is preserved here (See `UnsafeHashedRelation` for example of usage).
+   * in the sense that key index is preserved here
+   * (See `UnsafeHashedRelation` for example of usage).
    */
   public final class MapIteratorWithKeyIndex implements Iterator<Location> {
 
@@ -477,9 +478,9 @@ public final class BytesToBytesMap extends MemoryConsumer {
   }
 
   /**
-   * Number of allowed keys index.
+   * The maximum number of allowed keys index.
    */
-  public int numKeysIndex() {
+  public int maxNumKeysIndex() {
     return (int) (longArray.size() / 2);
   }
 

--- a/core/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
+++ b/core/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
@@ -429,6 +429,61 @@ public final class BytesToBytesMap extends MemoryConsumer {
   }
 
   /**
+   * Iterator for the entries of this map. This is to first iterate over key index array
+   * `longArray` then accessing values in `dataPages`. NOTE: this is different from `MapIterator`
+   * in the sense that key index is preserved here (See `UnsafeHashedRelation` for example of usage).
+   */
+  public final class MapIteratorWithKeyIndex implements Iterator<Location> {
+
+    private int keyIndex = 0;
+    private int numRecords;
+    private final Location loc;
+
+    private MapIteratorWithKeyIndex(int numRecords, Location loc) {
+      this.numRecords = numRecords;
+      this.loc = loc;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return numRecords > 0;
+    }
+
+    @Override
+    public Location next() {
+      if (!loc.isDefined() || !loc.nextValue()) {
+        while (longArray.get(keyIndex * 2) == 0) {
+          keyIndex++;
+        }
+        loc.with(keyIndex, (int) longArray.get(keyIndex * 2 + 1), true);
+        keyIndex++;
+      }
+      numRecords--;
+      return loc;
+    }
+  }
+
+  /**
+   * Returns an iterator for iterating over the entries of this map,
+   * by first iterating over the key index inside hash map's `longArray`.
+   *
+   * For efficiency, all calls to `next()` will return the same {@link Location} object.
+   *
+   * The returned iterator is NOT thread-safe. If the map is modified while iterating over it,
+   * the behavior of the returned iterator is undefined.
+   */
+  public MapIteratorWithKeyIndex iteratorWithKeyIndex() {
+    return new MapIteratorWithKeyIndex(numValues, new Location());
+  }
+
+  /**
+   * Number of allowed keys index.
+   */
+  public int numKeysIndex() {
+    return (int) (longArray.size() / 2);
+  }
+
+  /**
    * Looks up a key, and return a {@link Location} handle that can be used to test existence
    * and read/write values.
    *
@@ -599,6 +654,14 @@ public final class BytesToBytesMap extends MemoryConsumer {
      */
     public boolean isDefined() {
       return isDefined;
+    }
+
+    /**
+     * Returns index for key.
+     */
+    public int getKeyIndex() {
+      assert (isDefined);
+      return pos;
     }
 
     /**

--- a/core/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
+++ b/core/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
@@ -429,7 +429,7 @@ public final class BytesToBytesMap extends MemoryConsumer {
   }
 
   /**
-   * Iterator for the entries of this map. This is to first iterate over key index array
+   * Iterator for the entries of this map. This is to first iterate over key indices in
    * `longArray` then accessing values in `dataPages`. NOTE: this is different from `MapIterator`
    * in the sense that key index is preserved here
    * (See `UnsafeHashedRelation` for example of usage).

--- a/core/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
+++ b/core/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
@@ -436,13 +436,17 @@ public final class BytesToBytesMap extends MemoryConsumer {
    */
   public final class MapIteratorWithKeyIndex implements Iterator<Location> {
 
+    /**
+     * The index in `longArray` where the key is stored.
+     */
     private int keyIndex = 0;
+
     private int numRecords;
     private final Location loc;
 
-    private MapIteratorWithKeyIndex(int numRecords, Location loc) {
-      this.numRecords = numRecords;
-      this.loc = loc;
+    private MapIteratorWithKeyIndex() {
+      this.numRecords = numValues;
+      this.loc = new Location();
     }
 
     @Override
@@ -474,7 +478,7 @@ public final class BytesToBytesMap extends MemoryConsumer {
    * the behavior of the returned iterator is undefined.
    */
   public MapIteratorWithKeyIndex iteratorWithKeyIndex() {
-    return new MapIteratorWithKeyIndex(numValues, new Location());
+    return new MapIteratorWithKeyIndex();
   }
 
   /**

--- a/core/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
+++ b/core/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
@@ -456,7 +456,7 @@ public final class BytesToBytesMap extends MemoryConsumer {
         while (longArray.get(keyIndex * 2) == 0) {
           keyIndex++;
         }
-        loc.with(keyIndex, (int) longArray.get(keyIndex * 2 + 1), true);
+        loc.with(keyIndex, 0, true);
         keyIndex++;
       }
       numRecords--;
@@ -479,6 +479,8 @@ public final class BytesToBytesMap extends MemoryConsumer {
 
   /**
    * The maximum number of allowed keys index.
+   *
+   * The value of allowed keys index is in the range of [0, maxNumKeysIndex - 1].
    */
   public int maxNumKeysIndex() {
     return (int) (longArray.size() / 2);

--- a/core/src/test/java/org/apache/spark/unsafe/map/AbstractBytesToBytesMapSuite.java
+++ b/core/src/test/java/org/apache/spark/unsafe/map/AbstractBytesToBytesMapSuite.java
@@ -172,6 +172,7 @@ public abstract class AbstractBytesToBytesMapSuite {
       final byte[] key = getRandomByteArray(keyLengthInWords);
       Assert.assertFalse(map.lookup(key, Platform.BYTE_ARRAY_OFFSET, keyLengthInBytes).isDefined());
       Assert.assertFalse(map.iterator().hasNext());
+      Assert.assertFalse(map.iteratorWithKeyIndex().hasNext());
     } finally {
       map.free();
     }
@@ -233,9 +234,10 @@ public abstract class AbstractBytesToBytesMapSuite {
     }
   }
 
-  private void iteratorTestBase(boolean destructive) throws Exception {
+  private void iteratorTestBase(boolean destructive, boolean isWithKeyIndex) throws Exception {
     final int size = 4096;
     BytesToBytesMap map = new BytesToBytesMap(taskMemoryManager, size / 2, PAGE_SIZE_BYTES);
+    Assert.assertEquals(size / 2, map.maxNumKeysIndex());
     try {
       for (long i = 0; i < size; i++) {
         final long[] value = new long[] { i };
@@ -267,6 +269,8 @@ public abstract class AbstractBytesToBytesMapSuite {
       final Iterator<BytesToBytesMap.Location> iter;
       if (destructive) {
         iter = map.destructiveIterator();
+      } else if (isWithKeyIndex) {
+        iter = map.iteratorWithKeyIndex();
       } else {
         iter = map.iterator();
       }
@@ -291,6 +295,12 @@ public abstract class AbstractBytesToBytesMapSuite {
             countFreedPages++;
           }
         }
+        if (keyLength != 0 && isWithKeyIndex) {
+          final BytesToBytesMap.Location expectedLoc = map.lookup(
+            loc.getKeyBase(), loc.getKeyOffset(), loc.getKeyLength());
+          Assert.assertTrue(expectedLoc.isDefined() &&
+            expectedLoc.getKeyIndex() == loc.getKeyIndex());
+        }
       }
       if (destructive) {
         // Latest page is not freed by iterator but by map itself
@@ -304,12 +314,17 @@ public abstract class AbstractBytesToBytesMapSuite {
 
   @Test
   public void iteratorTest() throws Exception {
-    iteratorTestBase(false);
+    iteratorTestBase(false, false);
   }
 
   @Test
   public void destructiveIteratorTest() throws Exception {
-    iteratorTestBase(true);
+    iteratorTestBase(true, false);
+  }
+
+  @Test
+  public void iteratorWithKeyIndexTest() throws Exception {
+    iteratorTestBase(false, true);
   }
 
   @Test
@@ -602,6 +617,12 @@ public abstract class AbstractBytesToBytesMapSuite {
         assert iter.hasNext();
         final BytesToBytesMap.Location loc = iter.next();
         assert loc.isDefined();
+      }
+      BytesToBytesMap.MapIteratorWithKeyIndex iterWithKeyIndex = map.iteratorWithKeyIndex();
+      for (i = 0; i < 2048; i++) {
+        assert iterWithKeyIndex.hasNext();
+        final BytesToBytesMap.Location loc = iterWithKeyIndex.next();
+        assert loc.isDefined() && loc.getKeyIndex() >= 0;
       }
     } finally {
       map.free();

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -235,8 +235,8 @@ trait JoinSelectionHelper {
       canBroadcastBySize(right, conf) && !hintToNotBroadcastRight(hint)
     }
     getBuildSide(
-      canBuildLeft(joinType) && buildLeft,
-      canBuildRight(joinType) && buildRight,
+      canBuildBroadcastLeft(joinType) && buildLeft,
+      canBuildBroadcastRight(joinType) && buildRight,
       left,
       right
     )
@@ -260,8 +260,8 @@ trait JoinSelectionHelper {
       canBuildLocalHashMapBySize(right, conf) && muchSmaller(right, left)
     }
     getBuildSide(
-      canBuildLeft(joinType) && buildLeft,
-      canBuildRight(joinType) && buildRight,
+      canBuildShuffledHashJoinLeft(joinType) && buildLeft,
+      canBuildShuffledHashJoinRight(joinType) && buildRight,
       left,
       right
     )
@@ -278,16 +278,31 @@ trait JoinSelectionHelper {
     plan.stats.sizeInBytes >= 0 && plan.stats.sizeInBytes <= conf.autoBroadcastJoinThreshold
   }
 
-  def canBuildLeft(joinType: JoinType): Boolean = {
+  def canBuildBroadcastLeft(joinType: JoinType): Boolean = {
     joinType match {
       case _: InnerLike | RightOuter => true
       case _ => false
     }
   }
 
-  def canBuildRight(joinType: JoinType): Boolean = {
+  def canBuildBroadcastRight(joinType: JoinType): Boolean = {
     joinType match {
       case _: InnerLike | LeftOuter | LeftSemi | LeftAnti | _: ExistenceJoin => true
+      case _ => false
+    }
+  }
+
+  def canBuildShuffledHashJoinLeft(joinType: JoinType): Boolean = {
+    joinType match {
+      case _: InnerLike | RightOuter | FullOuter => true
+      case _ => false
+    }
+  }
+
+  def canBuildShuffledHashJoinRight(joinType: JoinType): Boolean = {
+    joinType match {
+      case _: InnerLike | LeftOuter | FullOuter |
+           LeftSemi | LeftAnti | _: ExistenceJoin => true
       case _ => false
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -330,8 +330,9 @@ object SQLConf {
   val PREFER_SORTMERGEJOIN = buildConf("spark.sql.join.preferSortMergeJoin")
     .internal()
     .doc("When true, prefer sort merge join over shuffled hash join. " +
-      "Note that shuffled hash join supports all join types (e.g. full outer) " +
-      "that sort merge join supports.")
+      "Sort merge join consumes less memory than shuffled hash join and it works efficiently " +
+      "when both join tables are large. On the other hand, shuffled hash join can improve " +
+      "performance (e.g., of full outer joins) when one of join tables is much smaller.")
     .version("2.0.0")
     .booleanConf
     .createWithDefault(true)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -329,7 +329,9 @@ object SQLConf {
 
   val PREFER_SORTMERGEJOIN = buildConf("spark.sql.join.preferSortMergeJoin")
     .internal()
-    .doc("When true, prefer sort merge join over shuffle hash join.")
+    .doc("When true, prefer sort merge join over shuffled hash join. " +
+      "Note that shuffled hash join supports all join types (e.g. full outer) " +
+      "that sort merge join supports.")
     .version("2.0.0")
     .booleanConf
     .createWithDefault(true)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -116,7 +116,9 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
    *
    * - Shuffle hash join:
    *     Only supported for equi-joins, while the join keys do not need to be sortable.
-   *     Supported for all join types except full outer joins.
+   *     Supported for all join types.
+   *     Building hash map from table is a memory-intensive operation and it could cause OOM
+   *     when the build side is big.
    *
    * - Shuffle sort merge join (SMJ):
    *     Only supported for equi-joins and the join keys have to be sortable.
@@ -260,7 +262,7 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
           // it's a right join, and broadcast right side if it's a left join.
           // TODO: revisit it. If left side is much smaller than the right side, it may be better
           // to broadcast the left side even if it's a left join.
-          if (canBuildLeft(joinType)) BuildLeft else BuildRight
+          if (canBuildBroadcastLeft(joinType)) BuildLeft else BuildRight
         }
 
         def createBroadcastNLJoin(buildLeft: Boolean, buildRight: Boolean) = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
@@ -114,7 +114,7 @@ trait HashJoin extends BaseJoinExec with CodegenSupport {
     }
   }
 
-  @transient private lazy val (buildOutput, streamedOutput) = {
+  @transient protected lazy val (buildOutput, streamedOutput) = {
     buildSide match {
       case BuildLeft => (left.output, right.output)
       case BuildRight => (right.output, left.output)
@@ -133,7 +133,7 @@ trait HashJoin extends BaseJoinExec with CodegenSupport {
   protected def streamSideKeyGenerator(): UnsafeProjection =
     UnsafeProjection.create(streamedBoundKeys)
 
-  @transient private[this] lazy val boundCondition = if (condition.isDefined) {
+  @transient protected[this] lazy val boundCondition = if (condition.isDefined) {
     Predicate.create(condition.get, streamedPlan.output ++ buildPlan.output).eval _
   } else {
     (r: InternalRow) => true

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
@@ -441,6 +441,8 @@ private[joins] object UnsafeHashedRelation {
       taskMemoryManager: TaskMemoryManager,
       isNullAware: Boolean = false,
       allowsNullKey: Boolean = false): HashedRelation = {
+    require(!(isNullAware && allowsNullKey),
+      "isNullAware and allowsNullKey cannot be enabled at same time")
 
     val pageSizeBytes = Option(SparkEnv.get).map(_.memoryManager.pageSizeBytes)
       .getOrElse(new SparkConf().get(BUFFER_PAGESIZE).getOrElse(16L * 1024 * 1024))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
@@ -137,7 +137,7 @@ private[execution] object HashedRelation {
         0)
     }
 
-    if (!input.hasNext) {
+    if (!input.hasNext && !allowsNullKey) {
       EmptyHashedRelation
     } else if (key.length == 1 && key.head.dataType == LongType && !allowsNullKey) {
       // NOTE: LongHashedRelation does not support NULL keys.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
@@ -75,6 +75,7 @@ private[execution] sealed trait HashedRelation extends KnownSizeEstimation {
 
   /**
    * Returns key index and matched single row.
+   * This is for unique key case.
    *
    * Returns null if there is no matched rows.
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
@@ -134,11 +134,8 @@ case class ShuffledHashJoinExec(
     val buildNullRow = new GenericInternalRow(buildOutput.length)
     val streamNullRow = new GenericInternalRow(streamedOutput.length)
 
-    def markRowLookedUp(row: UnsafeRow): Unit = {
-      if (!row.getBoolean(row.numFields() - 1)) {
-        row.setBoolean(row.numFields() - 1, true)
-      }
-    }
+    def markRowLookedUp(row: UnsafeRow): Unit =
+      row.setBoolean(row.numFields() - 1, true)
 
     // Process stream side with looking up hash relation
     val streamResultIter =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql.execution.joins
 
 import java.util.concurrent.TimeUnit._
 
+import scala.collection.mutable
+
 import org.apache.spark.TaskContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -29,6 +31,7 @@ import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.execution.{RowIterator, SparkPlan}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
+import org.apache.spark.util.collection.BitSet
 
 /**
  * Performs a hash join of two child relations by first shuffling the data using the join keys.
@@ -65,18 +68,12 @@ case class ShuffledHashJoinExec(
     val buildTime = longMetric("buildTime")
     val start = System.nanoTime()
     val context = TaskContext.get()
-
-    val (canMarkRowLookedUp, valueExprs) = if (joinType == FullOuter) {
-      (true, Some(BindReferences.bindReferences(buildOutput, buildOutput)))
-    } else {
-      (false, None)
-    }
     val relation = HashedRelation(
       iter,
       buildBoundKeys,
       taskMemoryManager = context.taskMemoryManager(),
-      canMarkRowLookedUp = canMarkRowLookedUp,
-      valueExprs = valueExprs)
+      // Full outer join needs support for NULL key in HashedRelation.
+      allowsNullKey = joinType == FullOuter)
     buildTime += NANOSECONDS.toMillis(System.nanoTime() - start)
     buildDataSize += relation.estimatedSize
     // This relation is usually used until the end of task.
@@ -95,20 +92,11 @@ case class ShuffledHashJoinExec(
     }
   }
 
-  /**
-   * Full outer shuffled hash join has three steps:
-   * 1. Construct hash relation from build side,
-   *    with extra boolean value at the end of row to track look up information
-   *    (done in `buildHashedRelation`).
-   * 2. Process rows from stream side by looking up hash relation,
-   *    and mark the matched rows from build side be looked up.
-   * 3. Process rows from build side by iterating hash relation,
-   *    and filter out rows from build side being matched already.
-   */
   private def fullOuterJoin(
       streamIter: Iterator[InternalRow],
       hashedRelation: HashedRelation,
       numOutputRows: SQLMetric): Iterator[InternalRow] = {
+    val joinKeys = streamSideKeyGenerator()
     val joinRow = new JoinedRow
     val (joinRowWithStream, joinRowWithBuild) = {
       buildSide match {
@@ -116,72 +104,8 @@ case class ShuffledHashJoinExec(
         case BuildRight => (joinRow.withLeft _, joinRow.withRight _)
       }
     }
-    val joinKeys = streamSideKeyGenerator()
-    val buildRowGenerator = UnsafeProjection.create(buildOutput, buildOutput)
     val buildNullRow = new GenericInternalRow(buildOutput.length)
     val streamNullRow = new GenericInternalRow(streamedOutput.length)
-
-    def markRowLookedUp(row: UnsafeRow): Unit =
-      row.setBoolean(row.numFields() - 1, true)
-
-    // Process stream side with looking up hash relation
-    val streamResultIter =
-      if (hashedRelation.keyIsUnique) {
-        streamIter.map { srow =>
-          joinRowWithStream(srow)
-          val keys = joinKeys(srow)
-          if (keys.anyNull) {
-            joinRowWithBuild(buildNullRow)
-          } else {
-            val matched = hashedRelation.getValue(keys)
-            if (matched != null) {
-              val buildRow = buildRowGenerator(matched)
-              if (boundCondition(joinRowWithBuild(buildRow))) {
-                markRowLookedUp(matched.asInstanceOf[UnsafeRow])
-                joinRow
-              } else {
-                joinRowWithBuild(buildNullRow)
-              }
-            } else {
-              joinRowWithBuild(buildNullRow)
-            }
-          }
-        }
-      } else {
-        streamIter.flatMap { srow =>
-          joinRowWithStream(srow)
-          val keys = joinKeys(srow)
-          if (keys.anyNull) {
-            Iterator.single(joinRowWithBuild(buildNullRow))
-          } else {
-            val buildIter = hashedRelation.get(keys)
-            new RowIterator {
-              private var found = false
-              override def advanceNext(): Boolean = {
-                while (buildIter != null && buildIter.hasNext) {
-                  val matched = buildIter.next()
-                  val buildRow = buildRowGenerator(matched)
-                  if (boundCondition(joinRowWithBuild(buildRow))) {
-                    markRowLookedUp(matched.asInstanceOf[UnsafeRow])
-                    found = true
-                    return true
-                  }
-                }
-                if (!found) {
-                  joinRowWithBuild(buildNullRow)
-                  found = true
-                  return true
-                }
-                false
-              }
-              override def getRow: InternalRow = joinRow
-            }.toScala
-          }
-        }
-      }
-
-    // Process build side with filtering out rows looked up and
-    // passed join condition already
     val streamNullJoinRow = new JoinedRow
     val streamNullJoinRowWithBuild = {
       buildSide match {
@@ -193,23 +117,176 @@ case class ShuffledHashJoinExec(
           streamNullJoinRow.withRight _
       }
     }
-    val buildResultIter = hashedRelation.values().flatMap { brow =>
-      val unsafebrow = brow.asInstanceOf[UnsafeRow]
-      val isLookup = unsafebrow.getBoolean(unsafebrow.numFields() - 1)
-      if (!isLookup) {
-        val buildRow = buildRowGenerator(unsafebrow)
-        streamNullJoinRowWithBuild(buildRow)
-        Some(streamNullJoinRow)
-      } else {
-        None
-      }
+
+    val iter = if (hashedRelation.keyIsUnique) {
+      fullOuterJoinWithUniqueKey(streamIter, hashedRelation, joinKeys, joinRow, streamNullJoinRow,
+        joinRowWithStream, joinRowWithBuild, streamNullJoinRowWithBuild, buildNullRow,
+        streamNullRow)
+    } else {
+      fullOuterJoinWithNonUniqueKey(streamIter, hashedRelation, joinKeys, joinRow,
+        streamNullJoinRow, joinRowWithStream, joinRowWithBuild, streamNullJoinRowWithBuild,
+        buildNullRow, streamNullRow)
     }
 
     val resultProj = UnsafeProjection.create(output, output)
-    (streamResultIter ++ buildResultIter).map { r =>
+    iter.map { r =>
       numOutputRows += 1
       resultProj(r)
     }
+  }
+
+  /**
+   * Full outer shuffled hash join with unique join keys:
+   * 1. Process rows from stream side by looking up hash relation.
+   *    Mark the matched rows from build side be looked up.
+   *    A `BitSet` is used to track matched rows with key index.
+   * 2. Process rows from build side by iterating hash relation.
+   *    Filter out rows from build side being matched already,
+   *    by checking key index from `BitSet`.
+   */
+  private def fullOuterJoinWithUniqueKey(
+      streamIter: Iterator[InternalRow],
+      hashedRelation: HashedRelation,
+      joinKeys: UnsafeProjection,
+      joinRow: JoinedRow,
+      streamNullJoinRow: JoinedRow,
+      joinRowWithStream: InternalRow => JoinedRow,
+      joinRowWithBuild: InternalRow => JoinedRow,
+      streamNullJoinRowWithBuild: InternalRow => JoinedRow,
+      buildNullRow: GenericInternalRow,
+      streamNullRow: GenericInternalRow): Iterator[InternalRow] = {
+    val matchedKeys = new BitSet(hashedRelation.numKeysIndex)
+
+    // Process stream side with looking up hash relation
+    val streamResultIter = streamIter.map { srow =>
+      joinRowWithStream(srow)
+      val keys = joinKeys(srow)
+      if (keys.anyNull) {
+        joinRowWithBuild(buildNullRow)
+      } else {
+        val matched = hashedRelation.getWithKeyIndex(keys)
+        if (matched != null) {
+          val (keyIndex, buildIter) = (matched._1, matched._2)
+          val buildRow = buildIter.next
+          if (boundCondition(joinRowWithBuild(buildRow))) {
+            matchedKeys.set(keyIndex)
+            joinRow
+          } else {
+            joinRowWithBuild(buildNullRow)
+          }
+        } else {
+          joinRowWithBuild(buildNullRow)
+        }
+      }
+    }
+
+    // Process build side with filtering out rows looked up and
+    // passed join condition already
+    val buildResultIter = hashedRelation.valuesWithKeyIndex().flatMap {
+      case (keyIndex, brow) =>
+        val isMatched = matchedKeys.get(keyIndex)
+        if (!isMatched) {
+          streamNullJoinRowWithBuild(brow)
+          Some(streamNullJoinRow)
+        } else {
+          None
+        }
+    }
+
+    streamResultIter ++ buildResultIter
+  }
+
+  /**
+   * Full outer shuffled hash join with unique join keys:
+   * 1. Process rows from stream side by looking up hash relation.
+   *    Mark the matched rows from build side be looked up.
+   *    A `HashSet[Long]` is used to track matched rows with
+   *    key index (Int) and value index (Int) together.
+   * 2. Process rows from build side by iterating hash relation.
+   *    Filter out rows from build side being matched already,
+   *    by checking key index and value index from `HashSet`.
+   */
+  private def fullOuterJoinWithNonUniqueKey(
+      streamIter: Iterator[InternalRow],
+      hashedRelation: HashedRelation,
+      joinKeys: UnsafeProjection,
+      joinRow: JoinedRow,
+      streamNullJoinRow: JoinedRow,
+      joinRowWithStream: InternalRow => JoinedRow,
+      joinRowWithBuild: InternalRow => JoinedRow,
+      streamNullJoinRowWithBuild: InternalRow => JoinedRow,
+      buildNullRow: GenericInternalRow,
+      streamNullRow: GenericInternalRow): Iterator[InternalRow] = {
+    val matchedRows = new mutable.HashSet[Long]
+
+    def markRowMatched(keyIndex: Int, valueIndex: Int): Unit = {
+      val rowIndex: Long = (keyIndex.toLong << 32) | valueIndex
+      matchedRows.add(rowIndex)
+    }
+
+    def isRowMatched(keyIndex: Int, valueIndex: Int): Boolean = {
+      val rowIndex: Long = (keyIndex.toLong << 32) | valueIndex
+      matchedRows.contains(rowIndex)
+    }
+
+    // Process stream side with looking up hash relation
+    val streamResultIter = streamIter.flatMap { srow =>
+      joinRowWithStream(srow)
+      val keys = joinKeys(srow)
+      if (keys.anyNull) {
+        Iterator.single(joinRowWithBuild(buildNullRow))
+      } else {
+        val matched = hashedRelation.getWithKeyIndex(keys)
+        if (matched != null) {
+          val (keyIndex, buildIter) = (matched._1, matched._2.zipWithIndex)
+
+          new RowIterator {
+            private var found = false
+            override def advanceNext(): Boolean = {
+              while (buildIter.hasNext) {
+                val (buildRow, valueIndex) = buildIter.next()
+                if (boundCondition(joinRowWithBuild(buildRow))) {
+                  markRowMatched(keyIndex, valueIndex)
+                  found = true
+                  return true
+                }
+              }
+              if (!found) {
+                joinRowWithBuild(buildNullRow)
+                found = true
+                return true
+              }
+              false
+            }
+            override def getRow: InternalRow = joinRow
+          }.toScala
+        } else {
+          Iterator.single(joinRowWithBuild(buildNullRow))
+        }
+      }
+    }
+
+    // Process build side with filtering out rows looked up and
+    // passed join condition already
+    var prevKeyIndex = -1
+    var valueIndex = -1
+    val buildResultIter = hashedRelation.valuesWithKeyIndex().flatMap {
+      case (keyIndex, brow) =>
+        if (prevKeyIndex == -1 || keyIndex != prevKeyIndex) {
+          prevKeyIndex = keyIndex
+          valueIndex = -1
+        }
+        valueIndex += 1
+        val isMatched = isRowMatched(keyIndex, valueIndex)
+        if (!isMatched) {
+          streamNullJoinRowWithBuild(brow)
+          Some(streamNullJoinRow)
+        } else {
+          None
+        }
+    }
+
+    streamResultIter ++ buildResultIter
   }
 
   // TODO(SPARK-32567): support full outer shuffled hash join code-gen

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
@@ -150,6 +150,8 @@ case class ShuffledHashJoinExec(
       streamNullJoinRowWithBuild: => InternalRow => JoinedRow,
       buildNullRow: GenericInternalRow,
       streamNullRow: GenericInternalRow): Iterator[InternalRow] = {
+    // TODO(SPARK-32629):record metrics of extra BitSet/HashSet
+    // in full outer shuffled hash join
     val matchedKeys = new BitSet(hashedRelation.maxNumKeysIndex)
 
     // Process stream side with looking up hash relation
@@ -216,6 +218,8 @@ case class ShuffledHashJoinExec(
       streamNullJoinRowWithBuild: => InternalRow => JoinedRow,
       buildNullRow: GenericInternalRow,
       streamNullRow: GenericInternalRow): Iterator[InternalRow] = {
+    // TODO(SPARK-32629):record metrics of extra BitSet/HashSet
+    // in full outer shuffled hash join
     val matchedRows = new mutable.HashSet[Long]
 
     def markRowMatched(keyIndex: Int, valueIndex: Int): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
@@ -201,6 +201,11 @@ case class ShuffledHashJoinExec(
    * 2. Process rows from build side by iterating hash relation.
    *    Filter out rows from build side being matched already,
    *    by checking key index and value index from `HashSet`.
+   *
+   * The "value index" is defined as the index of the tuple in the chain
+   * of tuples having the same key. For example, if certain key is found thrice,
+   * the value indices of its tuples will be 0, 1 and 2.
+   * Note that value indices of tuples with different keys are incomparable.
    */
   private def fullOuterJoinWithNonUniqueKey(
       streamIter: Iterator[InternalRow],

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
@@ -193,7 +193,7 @@ case class ShuffledHashJoinExec(
   }
 
   /**
-   * Full outer shuffled hash join with unique join keys:
+   * Full outer shuffled hash join with non-unique join keys:
    * 1. Process rows from stream side by looking up hash relation.
    *    Mark the matched rows from build side be looked up.
    *    A `HashSet[Long]` is used to track matched rows with
@@ -253,9 +253,11 @@ case class ShuffledHashJoinExec(
             }
             // When we reach here, it means no match is found for this key.
             // So we need to return one row with build side NULL row,
-            // to match the full outer join semantic.
+            // to satisfy the full outer join semantic.
             if (!found) {
               joinRowWithBuild(buildNullRow)
+              // Set `found` to be true as we only need to return one row
+              // but no more.
               found = true
               return true
             }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledJoin.scala
@@ -17,7 +17,8 @@
 
 package org.apache.spark.sql.execution.joins
 
-import org.apache.spark.sql.catalyst.plans.{FullOuter, InnerLike, LeftExistence, LeftOuter, RightOuter}
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.{ExistenceJoin, FullOuter, InnerLike, LeftExistence, LeftOuter, RightOuter}
 import org.apache.spark.sql.catalyst.plans.physical.{Distribution, HashClusteredDistribution, Partitioning, PartitioningCollection, UnknownPartitioning}
 
 /**
@@ -39,5 +40,25 @@ trait ShuffledJoin extends BaseJoinExec {
     case x =>
       throw new IllegalArgumentException(
         s"ShuffledJoin should not take $x as the JoinType")
+  }
+
+  override def output: Seq[Attribute] = {
+    joinType match {
+      case _: InnerLike =>
+        left.output ++ right.output
+      case LeftOuter =>
+        left.output ++ right.output.map(_.withNullability(true))
+      case RightOuter =>
+        left.output.map(_.withNullability(true)) ++ right.output
+      case FullOuter =>
+        (left.output ++ right.output).map(_.withNullability(true))
+      case j: ExistenceJoin =>
+        left.output :+ j.exists
+      case LeftExistence(_) =>
+        left.output
+      case x =>
+        throw new IllegalArgumentException(
+          s"ShuffledJoin not take $x as the JoinType")
+    }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledJoin.scala
@@ -58,7 +58,7 @@ trait ShuffledJoin extends BaseJoinExec {
         left.output
       case x =>
         throw new IllegalArgumentException(
-          s"ShuffledJoin not take $x as the JoinType")
+          s"${getClass.getSimpleName} not take $x as the JoinType")
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -52,26 +52,6 @@ case class SortMergeJoinExec(
 
   override def stringArgs: Iterator[Any] = super.stringArgs.toSeq.dropRight(1).iterator
 
-  override def output: Seq[Attribute] = {
-    joinType match {
-      case _: InnerLike =>
-        left.output ++ right.output
-      case LeftOuter =>
-        left.output ++ right.output.map(_.withNullability(true))
-      case RightOuter =>
-        left.output.map(_.withNullability(true)) ++ right.output
-      case FullOuter =>
-        (left.output ++ right.output).map(_.withNullability(true))
-      case j: ExistenceJoin =>
-        left.output :+ j.exists
-      case LeftExistence(_) =>
-        left.output
-      case x =>
-        throw new IllegalArgumentException(
-          s"${getClass.getSimpleName} should not take $x as the JoinType")
-    }
-  }
-
   override def requiredChildDistribution: Seq[Distribution] = {
     if (isSkewJoin) {
       // We re-arrange the shuffle partitions to deal with skew join, and the new children

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -1193,31 +1193,42 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
     val inputDFs = Seq(
       // Test unique join key
       (spark.range(10).selectExpr("id as k1"),
-        spark.range(30).selectExpr("id as k2")),
+        spark.range(30).selectExpr("id as k2"),
+        $"k1" === $"k2"),
       // Test non-unique join key
       (spark.range(10).selectExpr("id % 5 as k1"),
-        spark.range(30).selectExpr("id % 5 as k2")),
+        spark.range(30).selectExpr("id % 5 as k2"),
+        $"k1" === $"k2"),
       // Test string join key
       (spark.range(10).selectExpr("cast(id * 3 as string) as k1"),
-        spark.range(30).selectExpr("cast(id as string) as k2")),
+        spark.range(30).selectExpr("cast(id as string) as k2"),
+        $"k1" === $"k2"),
       // Test build side at right
       (spark.range(30).selectExpr("cast(id / 3 as string) as k1"),
-        spark.range(10).selectExpr("cast(id as string) as k2")),
+        spark.range(10).selectExpr("cast(id as string) as k2"),
+        $"k1" === $"k2"),
       // Test NULL join key
       (spark.range(10).map(i => if (i % 2 == 0) i else null).selectExpr("value as k1"),
-        spark.range(30).map(i => if (i % 4 == 0) i else null).selectExpr("value as k2"))
+        spark.range(30).map(i => if (i % 4 == 0) i else null).selectExpr("value as k2"),
+        $"k1" === $"k2"),
+      // Test multiple join keys
+      (spark.range(10).map(i => if (i % 2 == 0) i else null).selectExpr(
+        "value as k1", "cast(value % 5 as short) as k2", "cast(value * 3 as long) as k3"),
+        spark.range(30).map(i => if (i % 4 == 0) i else null).selectExpr(
+          "value as k4", "cast(value % 5 as short) as k5", "cast(value * 3 as long) as k6"),
+        $"k1" === $"k4" && $"k2" === $"k5" && $"k3" === $"k6")
     )
-    inputDFs.foreach { case (df1, df2) =>
+    inputDFs.foreach { case (df1, df2, joinExprs) =>
       withSQLConf(
         SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "80",
         SQLConf.SHUFFLE_PARTITIONS.key -> "2") {
-        val smjDF = df1.join(df2, $"k1" === $"k2", "full")
+        val smjDF = df1.join(df2, joinExprs, "full")
         assert(smjDF.queryExecution.executedPlan.collect {
           case _: SortMergeJoinExec => true }.size === 1)
         val smjResult = smjDF.collect()
 
         withSQLConf(SQLConf.PREFER_SORTMERGEJOIN.key -> "false") {
-          val shjDF = df1.join(df2, $"k1" === $"k2", "full")
+          val shjDF = df1.join(df2, joinExprs, "full")
           assert(shjDF.queryExecution.executedPlan.collect {
             case _: ShuffledHashJoinExec => true }.size === 1)
           // Same result between shuffled hash join and sort merge join

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -1214,12 +1214,14 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
       // Test multiple join keys
       (spark.range(10).map(i => if (i % 2 == 0) i else null).selectExpr(
         "value as k1", "cast(value % 5 as short) as k2", "cast(value * 3 as long) as k3"),
-        spark.range(30).map(i => if (i % 4 == 0) i else null).selectExpr(
+        spark.range(30).map(i => if (i % 3 == 0) i else null).selectExpr(
           "value as k4", "cast(value % 5 as short) as k5", "cast(value * 3 as long) as k6"),
         $"k1" === $"k4" && $"k2" === $"k5" && $"k3" === $"k6")
     )
     inputDFs.foreach { case (df1, df2, joinExprs) =>
       withSQLConf(
+        // Set broadcast join threshold and number of shuffle partitions,
+        // as shuffled hash join depends on these two configs.
         SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "80",
         SQLConf.SHUFFLE_PARTITIONS.key -> "2") {
         val smjDF = df1.join(df2, joinExprs, "full")

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -1199,6 +1199,18 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
       (spark.range(10).selectExpr("id % 5 as k1"),
         spark.range(30).selectExpr("id % 5 as k2"),
         $"k1" === $"k2"),
+      // Test empty build side
+      (spark.range(10).selectExpr("id as k1").filter("k1 < -1"),
+        spark.range(30).selectExpr("id as k2"),
+        $"k1" === $"k2"),
+      // Test empty stream side
+      (spark.range(10).selectExpr("id as k1"),
+        spark.range(30).selectExpr("id as k2").filter("k2 < -1"),
+        $"k1" === $"k2"),
+      // Test empty build and stream side
+      (spark.range(10).selectExpr("id as k1").filter("k1 < -1"),
+        spark.range(30).selectExpr("id as k2").filter("k2 < -1"),
+        $"k1" === $"k2"),
       // Test string join key
       (spark.range(10).selectExpr("cast(id * 3 as string) as k1"),
         spark.range(30).selectExpr("cast(id as string) as k2"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -1223,6 +1223,9 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
       (spark.range(10).map(i => if (i % 2 == 0) i else null).selectExpr("value as k1"),
         spark.range(30).map(i => if (i % 4 == 0) i else null).selectExpr("value as k2"),
         $"k1" === $"k2"),
+      (spark.range(10).map(i => if (i % 3 == 0) i else null).selectExpr("value as k1"),
+        spark.range(30).map(i => if (i % 5 == 0) i else null).selectExpr("value as k2"),
+        $"k1" === $"k2"),
       // Test multiple join keys
       (spark.range(10).map(i => if (i % 2 == 0) i else null).selectExpr(
         "value as k1", "cast(value % 5 as short) as k2", "cast(value * 3 as long) as k3"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -1189,7 +1189,7 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
     }
   }
 
-  test("Full outer shuffled hash join") {
+  test("SPARK-32399: Full outer shuffled hash join") {
     val inputDFs = Seq(
       // Test unique join key
       (spark.range(10).selectExpr("id as k1"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/HashedRelationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/HashedRelationSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution.joins
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
 
+import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
 
@@ -591,5 +592,82 @@ class HashedRelationSuite extends SharedSparkSession {
     assert(hashed.get(key) == null)
     assert(hashed.getValue(0L) == null)
     assert(hashed.getValue(key) == null)
+  }
+
+  test("SPARK-32399: test methods related to key index") {
+    val schema = StructType(StructField("a", IntegerType, true) :: Nil)
+    val toUnsafe = UnsafeProjection.create(schema)
+    val key = Seq(BoundReference(0, IntegerType, true))
+    val row = Seq(BoundReference(0, IntegerType, true), BoundReference(1, IntegerType, true))
+    val unsafeProj = UnsafeProjection.create(row)
+    var rows = (0 until 100).map(i => {
+      val k = if (i % 10 == 0) null else i % 10
+      unsafeProj(InternalRow(k, i)).copy()
+    })
+    rows = unsafeProj(InternalRow(-1, -1)).copy() +: rows
+    val unsafeRelation = UnsafeHashedRelation(rows.iterator, key, 10, mm, allowsNullKey = true)
+    val keyIndexToKeyMap = new mutable.HashMap[Int, String]
+    val keyIndexToValueMap = new mutable.HashMap[Int, Seq[Int]]
+
+    // test getWithKeyIndex()
+    (0 until 10).foreach(i => {
+      val key = if (i == 0) InternalRow(null) else InternalRow(i)
+      val valuesWithKeyIndex = unsafeRelation.getWithKeyIndex(toUnsafe(key))
+      val keyIndex = valuesWithKeyIndex._1
+      val actualValues = valuesWithKeyIndex._2.map(v => v.getInt(1)).toSeq
+      val expectedValues = (0 until 10).map(j => j * 10 + i)
+      if (i == 0) {
+        keyIndexToKeyMap(keyIndex) = "null"
+      } else {
+        keyIndexToKeyMap(keyIndex) = i.toString
+      }
+      keyIndexToValueMap(keyIndex) = actualValues
+      // key index is non-negative
+      assert(keyIndex >= 0)
+      // values are expected
+      assert(actualValues.sortWith(_ < _) === expectedValues)
+    })
+    // key index is unique per key
+    val numUniqueKeyIndex = (0 until 10).map(i => {
+      val key = if (i == 0) InternalRow(null) else InternalRow(i)
+      val keyIndex = unsafeRelation.getWithKeyIndex(toUnsafe(key))._1
+      keyIndex
+    }).distinct.size
+    assert(numUniqueKeyIndex == 10)
+    // NULL for non-existing key
+    assert(unsafeRelation.getWithKeyIndex(toUnsafe(InternalRow(100))) == null)
+
+    // test getValueWithKeyIndex()
+    val valuesWithKeyIndex = unsafeRelation.getValueWithKeyIndex(toUnsafe(InternalRow(-1)))
+    val keyIndex = valuesWithKeyIndex.getKeyIndex
+    keyIndexToKeyMap(keyIndex) = "-1"
+    keyIndexToValueMap(keyIndex) = Seq(-1)
+    // key index is non-negative
+    assert(valuesWithKeyIndex.getKeyIndex >= 0)
+    // value is expected
+    assert(valuesWithKeyIndex.getValue.getInt(1) == -1)
+    // NULL for non-existing key
+    assert(unsafeRelation.getValueWithKeyIndex(toUnsafe(InternalRow(100))) == null)
+
+    // test valuesWithKeyIndex()
+    val keyIndexToRowMap = unsafeRelation.valuesWithKeyIndex().map(
+      v => (v.getKeyIndex, v.getValue.copy())).toSeq.groupBy(_._1)
+    assert(keyIndexToRowMap.size == 11)
+    keyIndexToRowMap.foreach {
+      case (keyIndex, row) =>
+        val expectedKey = keyIndexToKeyMap(keyIndex)
+        val expectedValues = keyIndexToValueMap(keyIndex)
+        // key index returned from valuesWithKeyIndex()
+        // should be the same as returned from getWithKeyIndex()
+        if (expectedKey == "null") {
+          assert(row.head._2.isNullAt(0))
+        } else {
+          assert(row.head._2.getInt(0).toString == expectedKey)
+        }
+        // values returned from valuesWithKeyIndex()
+        // should have same value and order as returned from getWithKeyIndex()
+        val actualValues = row.map(_._2.getInt(1))
+        assert(actualValues === expectedValues)
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/HashedRelationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/HashedRelationSuite.scala
@@ -592,29 +592,4 @@ class HashedRelationSuite extends SharedSparkSession {
     assert(hashed.getValue(0L) == null)
     assert(hashed.getValue(key) == null)
   }
-
-  test("SPARK-32399: test values() method for HashedRelation") {
-    val key = Seq(BoundReference(0, LongType, false))
-    val value = Seq(BoundReference(0, IntegerType, true))
-    val unsafeProj = UnsafeProjection.create(value)
-    val rows = (0 until 100).map(i => unsafeProj(InternalRow(i + 1)).copy())
-    val expectedValues = (0 until 100).map(i => i + 1)
-
-    // test LongHashedRelation
-    val longRelation = LongHashedRelation(rows.iterator, key, 10, mm)
-    var values = longRelation.values()
-    assert(values.map(_.getInt(0)).toArray.sortWith(_ < _) === expectedValues)
-
-    // test UnsafeHashedRelation
-    val unsafeRelation = UnsafeHashedRelation(rows.iterator, key, 10, mm)
-    values = unsafeRelation.values()
-    assert(values.map(_.getInt(0)).toArray.sortWith(_ < _) === expectedValues)
-
-    // test UnsafeHashedRelation which can mark row looked up
-    val markRowUnsafeRelation = UnsafeHashedRelation(
-      rows.iterator, key, 10, mm, canMarkRowLookedUp = true, valueExprs = Some(value))
-    values = markRowUnsafeRelation.values()
-    assert(values.map(v => (v.getInt(0), v.getBoolean(1))).toArray.sortWith(_._1 < _._1)
-      === expectedValues.map(i => (i, false)))
-  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/HashedRelationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/HashedRelationSuite.scala
@@ -592,4 +592,28 @@ class HashedRelationSuite extends SharedSparkSession {
     assert(hashed.getValue(0L) == null)
     assert(hashed.getValue(key) == null)
   }
+
+  test("SPARK-32399: test values() method for HashedRelation") {
+    val key = Seq(BoundReference(0, LongType, false))
+    val value = Seq(BoundReference(0, IntegerType, true))
+    val unsafeProj = UnsafeProjection.create(value)
+    val rows = (0 until 100).map(i => unsafeProj(InternalRow(i + 1)).copy())
+
+    // test LongHashedRelation
+    val longRelation = LongHashedRelation(rows.iterator, key, 10, mm)
+    var values = longRelation.values()
+    assert(values.map(_.getInt(0)).toArray.sortWith(_ < _) === (0 until 100).map(i => i + 1))
+
+    // test UnsafeHashedRelation
+    val unsafeRelation = UnsafeHashedRelation(rows.iterator, key, 10, mm)
+    values = unsafeRelation.values()
+    assert(values.map(_.getInt(0)).toArray.sortWith(_ < _) === (0 until 100).map(i => i + 1))
+
+    // test lookup-aware UnsafeHashedRelation
+    val lookupAwareUnsafeRelation = UnsafeHashedRelation(
+      rows.iterator, key, 10, mm, isLookupAware = true, value = Some(value))
+    values = lookupAwareUnsafeRelation.values()
+    assert(values.map(v => (v.getInt(0), v.getBoolean(1))).toArray.sortWith(_._1 < _._1)
+      === (0 until 100).map(i => (i + 1, false)))
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Add support for full outer join inside shuffled hash join. Currently if the query is a full outer join, we only use sort merge join as the physical operator. However it can be CPU and IO intensive in case input table is large for sort merge join. Shuffled hash join on the other hand saves the sort CPU and IO compared to sort merge join, especially when table is large.

This PR implements the full outer join as followed:
* Process rows from stream side by looking up hash relation, and mark the matched rows from build side by:
  * for joining with unique key, a `BitSet` is used to record matched rows from build side (`key index` to represent each row)
  * for joining with non-unique key, a `HashSet[Long]` is  used to record matched rows from build side (`key index` + `value index` to represent each row).
`key index` is defined as the index into key addressing array `longArray` in `BytesToBytesMap`.
`value index` is defined as the iterator index of values for same key.

* Process rows from build side by iterating hash relation, and filter out rows from build side being looked up already (done in `ShuffledHashJoinExec.fullOuterJoin`)

For context, this PR was originally implemented as followed (up to commit https://github.com/apache/spark/pull/29342/commits/e3322766d4ea6d039f819a46e12dc8641ca59c63):
1. Construct hash relation from build side, with extra boolean value at the end of row to track look up information (done in `ShuffledHashJoinExec.buildHashedRelation` and `UnsafeHashedRelation.apply`).
2. Process rows from stream side by looking up hash relation, and mark the matched rows from build side be looked up (done in `ShuffledHashJoinExec.fullOuterJoin`).
3. Process rows from build side by iterating hash relation, and filter out rows from build side being looked up already (done in `ShuffledHashJoinExec.fullOuterJoin`). 


See discussion of pros and cons between these two approaches [here](https://github.com/apache/spark/pull/29342#issuecomment-672275450), [here](https://github.com/apache/spark/pull/29342#issuecomment-672288194) and [here](https://github.com/apache/spark/pull/29342#issuecomment-672640531).

TODO: codegen for full outer shuffled hash join can be implemented in another followup PR.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
As implementation in this PR, full outer shuffled hash join will have overhead to iterate build side twice (once for building hash map, and another for outputting non-matching rows), and iterate stream side once. However, full outer sort merge join needs to iterate both sides twice, and sort the large table can be more CPU and IO intensive. So full outer shuffled hash join can be more efficient than sort merge join when stream side is much more larger than build side.

For example query below, full outer SHJ saved 30% wall clock time compared to full outer SMJ.

```
def shuffleHashJoin(): Unit = {
    val N: Long = 4 << 22
    withSQLConf(
      SQLConf.SHUFFLE_PARTITIONS.key -> "2",
      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "20000000") {
      codegenBenchmark("shuffle hash join", N) {
        val df1 = spark.range(N).selectExpr(s"cast(id as string) as k1")
        val df2 = spark.range(N / 10).selectExpr(s"cast(id * 10 as string) as k2")
        val df = df1.join(df2, col("k1") === col("k2"), "full_outer")
        df.noop()
    }
  }
}
```

```
Running benchmark: shuffle hash join
  Running case: shuffle hash join off
  Stopped after 2 iterations, 16602 ms
  Running case: shuffle hash join on
  Stopped after 5 iterations, 31911 ms

Java HotSpot(TM) 64-Bit Server VM 1.8.0_181-b13 on Mac OS X 10.15.4
Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
shuffle hash join:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
shuffle hash join off                              7900           8301         567          2.1         470.9       1.0X
shuffle hash join on                               6250           6382          95          2.7         372.5       1.3X
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added unit test in `JoinSuite.scala`, `AbstractBytesToBytesMapSuite.java` and `HashedRelationSuite.scala`.