### PR TITLE
[SPARK-32526][SQL]Let sql/catalyst module compile for Scala 2.13

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1281,12 +1281,12 @@ class Analyzer(
         }
 
         if (attrMapping.isEmpty) {
-          newPlan -> attrMapping
+          newPlan -> attrMapping.toSeq
         } else {
           assert(!attrMapping.groupBy(_._1.exprId)
             .exists(_._2.map(_._2.exprId).distinct.length > 1),
             "Found duplicate rewrite attributes")
-          val attributeRewrites = AttributeMap(attrMapping)
+          val attributeRewrites = AttributeMap(attrMapping.toSeq)
           // Using attrMapping from the children plans to rewrite their parent node.
           // Note that we shouldn't rewrite a node using attrMapping from its sibling nodes.
           newPlan.transformExpressions {
@@ -1294,7 +1294,7 @@ class Analyzer(
               dedupAttr(a, attributeRewrites)
             case s: SubqueryExpression =>
               s.withNewPlan(dedupOuterReferencesInSubquery(s.plan, attributeRewrites))
-          } -> attrMapping
+          } -> attrMapping.toSeq
         }
       }
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -949,7 +949,7 @@ object CombineUnions extends Rule[LogicalPlan] {
           flattened += child
       }
     }
-    union.copy(children = flattened)
+    union.copy(children = flattened.toSeq)
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

The purpose of this PR is to resolve [SPARK-32526](https://issues.apache.org/jira/browse/SPARK-32526) which should allow Spark to compile `sql/catalyst` module with Scala 2.13 profile.

The main changes of this pr is adding `.toSeq` calls where mutable collections are returned as `Seq`, similar as #28791 .


### Why are the changes needed?
We need to support a Scala 2.13 build.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing tests. (2.13 was not tested, there are still about 100 failed test cases with 2.13 profile in sql/catalyst module.)