### PR TITLE
[SPARK-32532][SQL] Improve ORC read/write performance on nested structs and array of structs

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
@@ -21,7 +21,7 @@ import org.apache.hadoop.io._
 import org.apache.orc.mapred.{OrcList, OrcMap, OrcStruct, OrcTimestamp}
 
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{MutableAny, MutableBoolean, MutableByte, MutableDouble, MutableFloat, MutableInt, MutableLong, MutableShort, MutableValue, SpecificInternalRow, UnsafeArrayData}
+import org.apache.spark.sql.catalyst.expressions.{SpecificInternalRow, UnsafeArrayData}
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.catalyst.util.RebaseDateTime.rebaseJulianToGregorianDays
 import org.apache.spark.sql.types._
@@ -74,191 +74,159 @@ class OrcDeserializer(
   /**
    * Creates a writer to write ORC values to Catalyst data structure at the given ordinal.
    */
-  private def newWriter(dataType: DataType, reuseObj: Boolean):
-  (CatalystDataUpdater, Int, WritableComparable[_]) => Unit = dataType match {
-    case NullType => (updater, ordinal, _) =>
-      updater.setNullAt(ordinal)
+  private def newWriter(
+      dataType: DataType, reuseObj: Boolean)
+  : (CatalystDataUpdater, Int, WritableComparable[_]) => Unit =
+    dataType match {
+      case NullType => (updater, ordinal, _) =>
+        updater.setNullAt(ordinal)
 
-    case BooleanType => (updater, ordinal, value) =>
-      updater.setBoolean(ordinal, value.asInstanceOf[BooleanWritable].get)
+      case BooleanType => (updater, ordinal, value) =>
+        updater.setBoolean(ordinal, value.asInstanceOf[BooleanWritable].get)
 
-    case ByteType => (updater, ordinal, value) =>
-      updater.setByte(ordinal, value.asInstanceOf[ByteWritable].get)
+      case ByteType => (updater, ordinal, value) =>
+        updater.setByte(ordinal, value.asInstanceOf[ByteWritable].get)
 
-    case ShortType => (updater, ordinal, value) =>
-      updater.setShort(ordinal, value.asInstanceOf[ShortWritable].get)
+      case ShortType => (updater, ordinal, value) =>
+        updater.setShort(ordinal, value.asInstanceOf[ShortWritable].get)
 
-    case IntegerType => (updater, ordinal, value) =>
-      updater.setInt(ordinal, value.asInstanceOf[IntWritable].get)
+      case IntegerType => (updater, ordinal, value) =>
+        updater.setInt(ordinal, value.asInstanceOf[IntWritable].get)
 
-    case LongType => (updater, ordinal, value) =>
-      updater.setLong(ordinal, value.asInstanceOf[LongWritable].get)
+      case LongType => (updater, ordinal, value) =>
+        updater.setLong(ordinal, value.asInstanceOf[LongWritable].get)
 
-    case FloatType => (updater, ordinal, value) =>
-      updater.setFloat(ordinal, value.asInstanceOf[FloatWritable].get)
+      case FloatType => (updater, ordinal, value) =>
+        updater.setFloat(ordinal, value.asInstanceOf[FloatWritable].get)
 
-    case DoubleType => (updater, ordinal, value) =>
-      updater.setDouble(ordinal, value.asInstanceOf[DoubleWritable].get)
+      case DoubleType => (updater, ordinal, value) =>
+        updater.setDouble(ordinal, value.asInstanceOf[DoubleWritable].get)
 
-    case StringType => (updater, ordinal, value) =>
-      updater.set(ordinal, UTF8String.fromBytes(value.asInstanceOf[Text].copyBytes))
+      case StringType => (updater, ordinal, value) =>
+        updater.set(ordinal, UTF8String.fromBytes(value.asInstanceOf[Text].copyBytes))
 
-    case BinaryType => (updater, ordinal, value) =>
-      val binary = value.asInstanceOf[BytesWritable]
-      val bytes = new Array[Byte](binary.getLength)
-      System.arraycopy(binary.getBytes, 0, bytes, 0, binary.getLength)
-      updater.set(ordinal, bytes)
+      case BinaryType => (updater, ordinal, value) =>
+        val binary = value.asInstanceOf[BytesWritable]
+        val bytes = new Array[Byte](binary.getLength)
+        System.arraycopy(binary.getBytes, 0, bytes, 0, binary.getLength)
+        updater.set(ordinal, bytes)
 
-    case DateType => (updater, ordinal, value) =>
-      updater.setInt(ordinal, OrcShimUtils.getGregorianDays(value))
+      case DateType => (updater, ordinal, value) =>
+        updater.setInt(ordinal, OrcShimUtils.getGregorianDays(value))
 
-    case TimestampType => (updater, ordinal, value) =>
-      updater.setLong(ordinal, DateTimeUtils.fromJavaTimestamp(value.asInstanceOf[OrcTimestamp]))
+      case TimestampType => (updater, ordinal, value) =>
+        updater.setLong(ordinal, DateTimeUtils.fromJavaTimestamp(value.asInstanceOf[OrcTimestamp]))
 
-    case DecimalType.Fixed(precision, scale) => (updater, ordinal, value) =>
-      val v = OrcShimUtils.getDecimal(value)
-      v.changePrecision(precision, scale)
-      updater.set(ordinal, v)
+      case DecimalType.Fixed(precision, scale) => (updater, ordinal, value) =>
+        val v = OrcShimUtils.getDecimal(value)
+        v.changePrecision(precision, scale)
+        updater.set(ordinal, v)
 
-    case st: StructType =>
-      val createRow: () => InternalRow = getRowCreator(st)
-      val fieldConverters = st.map(_.dataType).map { dt => newWriter(dt, reuseObj)}.toArray
-      val baseConverter:
-          (InternalRow, RowUpdater, CatalystDataUpdater, Int, WritableComparable[_]) => Unit = {
-        (row, rowUpdater, updater, ordinal, value) => {
-          val orcStruct = value.asInstanceOf[OrcStruct]
+      case st: StructType =>
+        val fieldConverters = st.map(_.dataType).map { dt => newWriter(dt, reuseObj)}.toArray
+        val baseConverter:
+            (InternalRow, RowUpdater, CatalystDataUpdater, Int, WritableComparable[_]) => Unit = {
+          (row, rowUpdater, updater, ordinal, value) => {
+            val orcStruct = value.asInstanceOf[OrcStruct]
+
+            var i = 0
+            while (i < st.length) {
+              val value = orcStruct.getFieldValue(i)
+              if (value == null) {
+                row.setNullAt(i)
+              } else {
+                fieldConverters(i)(rowUpdater, i, value)
+              }
+              i += 1
+            }
+
+            updater.set(ordinal, row)
+          }
+        }
+
+        if (reuseObj) {
+          val row = new SpecificInternalRow(st)
+          val rowUpdater = new RowUpdater(row)
+          (updater, ordinal, value) => baseConverter.apply(row, rowUpdater, updater, ordinal, value)
+        } else {
+          (updater, ordinal, value) => {
+            val row = new SpecificInternalRow(st)
+            val rowUpdater = new RowUpdater(row)
+            baseConverter.apply(row, rowUpdater, updater, ordinal, value)
+          }
+        }
+
+      case ArrayType(elementType, _) =>
+        val elementConverter = newWriter(elementType, false)
+        (updater, ordinal, value) => {
+          val orcArray = value.asInstanceOf[OrcList[WritableComparable[_]]]
+          val length = orcArray.size()
+          val result = createArrayData(elementType, length)
+          val elementUpdater = new ArrayDataUpdater(result)
 
           var i = 0
-          while (i < st.length) {
-            val value = orcStruct.getFieldValue(i)
+          while (i < length) {
+            val value = orcArray.get(i)
             if (value == null) {
-              row.setNullAt(i)
+              result.setNullAt(i)
             } else {
-              fieldConverters(i)(rowUpdater, i, value)
+              elementConverter(elementUpdater, i, value)
             }
             i += 1
           }
 
-          updater.set(ordinal, row)
+          updater.set(ordinal, result)
         }
-      }
 
-      if (reuseObj) {
-        val row = createRow.apply()
-        val rowUpdater = new RowUpdater(row)
-        (updater, ordinal, value) => baseConverter.apply(row, rowUpdater, updater, ordinal, value)
-      } else {
+      case MapType(keyType, valueType, _) =>
+        val keyConverter = newWriter(keyType, false)
+        val valueConverter = newWriter(valueType, false)
         (updater, ordinal, value) => {
-          val row = createRow.apply()
-          val rowUpdater = new RowUpdater(row)
-          baseConverter.apply(row, rowUpdater, updater, ordinal, value)
-        }
-      }
+          val orcMap = value.asInstanceOf[OrcMap[WritableComparable[_], WritableComparable[_]]]
+          val length = orcMap.size()
+          val keyArray = createArrayData(keyType, length)
+          val keyUpdater = new ArrayDataUpdater(keyArray)
+          val valueArray = createArrayData(valueType, length)
+          val valueUpdater = new ArrayDataUpdater(valueArray)
 
-    case ArrayType(elementType, _) =>
-      val elementConverter = newWriter(elementType, false)
-      val createArray = getArrayDataCreator(elementType)
-      (updater, ordinal, value) => {
-        val orcArray = value.asInstanceOf[OrcList[WritableComparable[_]]]
-        val length = orcArray.size()
-        val result = createArray(length)
-        val elementUpdater = new ArrayDataUpdater(result)
-
-        var i = 0
-        while (i < length) {
-          val value = orcArray.get(i)
-          if (value == null) {
-            result.setNullAt(i)
-          } else {
-            elementConverter(elementUpdater, i, value)
+          var i = 0
+          val it = orcMap.entrySet().iterator()
+          while (it.hasNext) {
+            val entry = it.next()
+            keyConverter(keyUpdater, i, entry.getKey)
+            val value = entry.getValue
+            if (value == null) {
+              valueArray.setNullAt(i)
+            } else {
+              valueConverter(valueUpdater, i, value)
+            }
+            i += 1
           }
-          i += 1
+
+          // The ORC map will never have null or duplicated map keys, it's safe to create a
+          // ArrayBasedMapData directly here.
+          updater.set(ordinal, new ArrayBasedMapData(keyArray, valueArray))
         }
 
-        updater.set(ordinal, result)
-      }
-
-    case MapType(keyType, valueType, _) =>
-      val keyConverter = newWriter(keyType, false)
-      val createKeyArray = getArrayDataCreator(keyType)
-      val valueConverter = newWriter(valueType, false)
-      val createValueArray = getArrayDataCreator(valueType)
-      (updater, ordinal, value) => {
-        val orcMap = value.asInstanceOf[OrcMap[WritableComparable[_], WritableComparable[_]]]
-        val length = orcMap.size()
-        val keyArray = createKeyArray(length)
-        val keyUpdater = new ArrayDataUpdater(keyArray)
-        val valueArray = createValueArray(length)
-        val valueUpdater = new ArrayDataUpdater(valueArray)
-
-        var i = 0
-        val it = orcMap.entrySet().iterator()
-        while (it.hasNext) {
-          val entry = it.next()
-          keyConverter(keyUpdater, i, entry.getKey)
-          val value = entry.getValue
-          if (value == null) {
-            valueArray.setNullAt(i)
-          } else {
-            valueConverter(valueUpdater, i, value)
-          }
-          i += 1
+      case udt: UserDefinedType[_] =>
+        val converter = newWriter(udt.sqlType, reuseObj)
+        (updater, ordinal, value) => {
+          converter(updater, ordinal, value)
         }
 
-        // The ORC map will never have null or duplicated map keys, it's safe to create a
-        // ArrayBasedMapData directly here.
-        updater.set(ordinal, new ArrayBasedMapData(keyArray, valueArray))
-      }
-
-    case udt: UserDefinedType[_] =>
-      val converter = newWriter(udt.sqlType, reuseObj)
-      (updater, ordinal, value) => {
-        converter(updater, ordinal, value)
-      }
-
-    case _ =>
-      throw new UnsupportedOperationException(s"$dataType is not supported yet.")
-  }
-
-  private def getArrayDataCreator(elementType: DataType): Int => ArrayData = elementType match {
-    case BooleanType => length => UnsafeArrayData.createFreshArray(length, 1)
-    case ByteType => length => UnsafeArrayData.createFreshArray(length, 1)
-    case ShortType => length => UnsafeArrayData.createFreshArray(length, 2)
-    case IntegerType => length => UnsafeArrayData.createFreshArray(length, 4)
-    case LongType => length => UnsafeArrayData.createFreshArray(length, 8)
-    case FloatType => length => UnsafeArrayData.createFreshArray(length, 4)
-    case DoubleType => length => UnsafeArrayData.createFreshArray(length, 8)
-    case _ => length => new GenericArrayData(new Array[Any](length))
-  }
-
-  private def getRowCreator(st: StructType): () => InternalRow = {
-    val constructorsArray = new Array[() => MutableValue](st.fields.length)
-    var i = 0
-    while (i < st.fields.length) {
-      st.fields(i).dataType match {
-        case BooleanType => constructorsArray(i) = () => new MutableBoolean
-        case ByteType => constructorsArray(i) = () => new MutableByte
-        case ShortType => constructorsArray(i) = () => new MutableShort
-        // We use INT for DATE internally
-        case IntegerType | DateType => constructorsArray(i) = () => new MutableInt
-        // We use Long for Timestamp internally
-        case LongType | TimestampType => constructorsArray(i) = () => new MutableLong
-        case FloatType => constructorsArray(i) = () => new MutableFloat
-        case DoubleType => constructorsArray(i) = () => new MutableDouble
-        case _ => constructorsArray(i) = () => new MutableAny
-      }
-      i += 1
+      case _ =>
+        throw new UnsupportedOperationException(s"$dataType is not supported yet.")
     }
 
-    () => {
-      val array = new Array[MutableValue](constructorsArray.length)
-      var i = 0
-      while (i < constructorsArray.length) {
-        array(i) = constructorsArray(i).apply()
-        i += 1
-      }
-      new SpecificInternalRow(array)
-    }
+  private def createArrayData(elementType: DataType, length: Int): ArrayData = elementType match {
+    case BooleanType => UnsafeArrayData.createFreshArray(length, 1)
+    case ByteType => UnsafeArrayData.createFreshArray(length, 1)
+    case ShortType => UnsafeArrayData.createFreshArray(length, 2)
+    case IntegerType => UnsafeArrayData.createFreshArray(length, 4)
+    case LongType => UnsafeArrayData.createFreshArray(length, 8)
+    case FloatType => UnsafeArrayData.createFreshArray(length, 4)
+    case DoubleType => UnsafeArrayData.createFreshArray(length, 8)
+    case _ => new GenericArrayData(new Array[Any](length))
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcSerializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcSerializer.scala
@@ -32,8 +32,9 @@ import org.apache.spark.sql.types._
  */
 class OrcSerializer(dataSchema: StructType) {
 
-  // TODO: repeating steps here. Can pass as parameter to newConverter, but only done once at the
-  //  schema level.
+  // TODO(SPARK-32732)
+  //  Repeating steps here. Can convert at top level only once and pass as parameter to newConverter
+  //  However, steps are repeated only at the schema level.
   def schemaConverter(schema: DataType): TypeDescription = {
     TypeDescription.fromString(OrcFileFormat.getQuotedSchemaString(schema))
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcSerializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcSerializer.scala
@@ -27,7 +27,8 @@ import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.types._
 
 /**
- * A serializer to serialize Spark rows to ORC structs.
+ * A serializer to serialize Spark rows to ORC structs. Multiple calls return the same [[OrcStruct]]
+ * object. If needed, caller should copy before making a new call.
  */
 class OrcSerializer(dataSchema: StructType) {
 
@@ -175,14 +176,14 @@ class OrcSerializer(dataSchema: StructType) {
           result
         }
 
-//      if (reuseObj) {
-//        val result = new OrcStruct(orcSchema)
-//        (getter, ordinal) => baseConverter.apply(result, getter, ordinal)
-//      } else {
+      if (reuseObj) {
+        val result = new OrcStruct(orcSchema)
+        (getter, ordinal) => baseConverter.apply(result, getter, ordinal)
+      } else {
         (getter, ordinal) =>
           val result = new OrcStruct(orcSchema)
           baseConverter.apply(result, getter, ordinal)
-//      }
+      }
 
     case ArrayType(elementType, _) =>
       val orcSchema = schemaConverter(dataType)
@@ -203,20 +204,20 @@ class OrcSerializer(dataSchema: StructType) {
         }
       }
 
-//      if (reuseObj) {
-//        val result = new OrcList[WritableComparable[_]](orcSchema)
-//        (getter, ordinal) => {
-//          result.clear()
-//          baseArrayConverter.apply(result, getter, ordinal)
-//          result
-//        }
-//      } else {
+      if (reuseObj) {
+        val result = new OrcList[WritableComparable[_]](orcSchema)
+        (getter, ordinal) => {
+          result.clear()
+          baseArrayConverter.apply(result, getter, ordinal)
+          result
+        }
+      } else {
         (getter, ordinal) => {
           val result = new OrcList[WritableComparable[_]](orcSchema)
           baseArrayConverter.apply(result, getter, ordinal)
           result
         }
-//      }
+      }
 
     case MapType(keyType, valueType, _) =>
       val orcSchema = schemaConverter(dataType)
@@ -242,20 +243,20 @@ class OrcSerializer(dataSchema: StructType) {
         }
       }
 
-//      if (reuseObj) {
-//        val result = new OrcMap[WritableComparable[_], WritableComparable[_]](orcSchema)
-//        (getter, ordinal) => {
-//          result.clear()
-//          baseMapConverter.apply(result, getter, ordinal)
-//          result
-//        }
-//      } else {
+      if (reuseObj) {
+        val result = new OrcMap[WritableComparable[_], WritableComparable[_]](orcSchema)
+        (getter, ordinal) => {
+          result.clear()
+          baseMapConverter.apply(result, getter, ordinal)
+          result
+        }
+      } else {
         (getter, ordinal) => {
           val result = new OrcMap[WritableComparable[_], WritableComparable[_]](orcSchema)
           baseMapConverter.apply(result, getter, ordinal)
           result
         }
-//      }
+      }
 
     case udt: UserDefinedType[_] => newConverter(udt.sqlType, reuseObj)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
Changes to Serializing/Deserializing ORC file format. There are 3 commits. Attached PDF has info on improvements in each commit. Essentially pushing a lot of processing, which can be done solely based on the data schema, to the initialization stage so that it is not repeated for each row of data. Eg, before it would convert catalyst schema to orc schema and recursively create orc structs, for each row of data. Now, it only has to do the conversion once at the schema level.

I have left the PR as 3 commits to easily match with the benchmark pdf.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Spark performance is really slow for these cases. Attached pdf has info on improvements, but summarily the times (in seconds) go down as follows in each case:
Read:
Nested Structs: 184 -> 44
Array of Struct: 66 -> 15

Write
Nested Structs: 543 -> 39
Array of Struct: 330 -> 37
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Ran benchmarks (please see the PR: https://github.com/apache/spark/pull/29352 for [SPARK-32531](https://issues.apache.org/jira/browse/SPARK-32531) for additional details on added benchmarks) and tests, with branch-3.0 as base, on jdk-1.8
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
[OrcBenchmarks.pdf](https://github.com/apache/spark/files/5024525/OrcBenchmarks.pdf)
