### PR TITLE
[SPARK-32541][SQL]Add support msck repair table drop partitions

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -238,7 +238,8 @@ statement
     | LOAD DATA LOCAL? INPATH path=STRING OVERWRITE? INTO TABLE
         multipartIdentifier partitionSpec?                             #loadData
     | TRUNCATE TABLE multipartIdentifier partitionSpec?                #truncateTable
-    | MSCK REPAIR TABLE multipartIdentifier                            #repairTable
+    | MSCK REPAIR TABLE multipartIdentifier
+        (op=(ADD | DROP) PARTITIONS)?                                  #repairTable
     | op=(ADD | LIST) identifier (STRING | .*?)                        #manageResource
     | SET ROLE .*?                                                     #failNativeCommand
     | SET TIME ZONE interval                                           #setTimeZone

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statements.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statements.scala
@@ -378,9 +378,14 @@ case class AnalyzeColumnStatement(
 }
 
 /**
- * A REPAIR TABLE statement, as parsed from SQL
+ * A MSCK REPAIR TABLE ADD PARTITIONS statement, as parsed from SQL
  */
-case class RepairTableStatement(tableName: Seq[String]) extends ParsedStatement
+case class MsckRepairTableAddPartitionsStatement(tableName: Seq[String]) extends ParsedStatement
+
+/**
+ * A MSCK REPAIR TABLE DROP PARTITIONS statement, as parsed from SQL
+ */
+case class MsckRepairTableDropPartitionsStatement(tableName: Seq[String]) extends ParsedStatement
 
 /**
  * A LOAD DATA INTO TABLE statement, as parsed from SQL

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -1563,7 +1563,7 @@ class DDLParserSuite extends AnalysisTest {
   test("MSCK REPAIR TABLE") {
     comparePlans(
       parsePlan("MSCK REPAIR TABLE a.b.c"),
-      RepairTableStatement(Seq("a", "b", "c")))
+      MsckRepairTableAddPartitionsStatement(Seq("a", "b", "c")))
   }
 
   test("LOAD DATA INTO table") {

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -418,11 +418,15 @@ class ResolveSessionCatalog(
       val v1TableName = parseTempViewOrV1Table(tbl, "ANALYZE TABLE")
       AnalyzeColumnCommand(v1TableName.asTableIdentifier, columnNames, allColumns)
 
-    case RepairTableStatement(tbl) =>
+    case MsckRepairTableAddPartitionsStatement(tbl) =>
       val v1TableName = parseV1Table(tbl, "MSCK REPAIR TABLE")
       AlterTableRecoverPartitionsCommand(
         v1TableName.asTableIdentifier,
         "MSCK REPAIR TABLE")
+
+    case MsckRepairTableDropPartitionsStatement(tbl) =>
+      val v1TableName = parseV1Table(tbl, "MSCK REPAIR TABLE DROP PARTITIONS")
+      MsckRepairTableDropPartitionsCommand(v1TableName.asTableIdentifier)
 
     case LoadDataStatement(tbl, path, isLocal, isOverwrite, partition) =>
       val v1TableName = parseV1Table(tbl, "LOAD DATA")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
msck repair table <tablename> is often used in environments where the new partitions are loaded as directories on HDFS  and users want to create the missing partitions in bulk. However, currently it only supports addition of missing partitions. If there are any partitions which are present in metastore but not on the FileSystem, it should also delete them so that it truly repairs the table metadata.



### Why are the changes needed?
https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-RecoverPartitions(MSCKREPAIRTABLE)


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Unit Test.