### PR TITLE
[SPARK-32557][CORE] Logging and swallowing the exception per entry in History server

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -27,6 +27,7 @@ import java.util.zip.ZipOutputStream
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.io.Source
+import scala.util.control.NonFatal
 import scala.xml.Node
 
 import com.fasterxml.jackson.annotation.JsonIgnore
@@ -539,7 +540,8 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
                 case _: FileNotFoundException => false
               }
 
-            case _: FileNotFoundException =>
+            case NonFatal(e) =>
+              logWarning(s"Error while filtering log ${reader.rootPath}", e)
               false
           }
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds a try catch wrapping the History server scan logic to log and swallow the exception per entry.


### Why are the changes needed?
As discussed in #29350 , one entry failure shouldn't affect others.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manually tested.
