### PR TITLE
[SPARK-32481][CORE][SQL] Support truncate table to move data to trash

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -50,7 +50,7 @@ import com.google.common.net.InetAddresses
 import org.apache.commons.codec.binary.Hex
 import org.apache.commons.lang3.SystemUtils
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.{FileSystem, FileUtil, Path}
+import org.apache.hadoop.fs.{FileSystem, FileUtil, Path, Trash}
 import org.apache.hadoop.io.compress.{CompressionCodecFactory, SplittableCompressionCodec}
 import org.apache.hadoop.security.UserGroupInformation
 import org.apache.hadoop.yarn.conf.YarnConfiguration
@@ -267,6 +267,24 @@ private[spark] object Utils extends Logging {
     file.setWritable(true, true) &&
     file.setExecutable(false, false) &&
     file.setExecutable(true, true)
+  }
+
+  /**
+   * Move data to trash on truncate table given
+   * spark.sql.truncate.trash.interval is positive
+   */
+  def moveToTrashIfEnabled(
+      fs: FileSystem,
+      partitionPath: Path,
+      trashInterval: Int,
+      hadoopConf: Configuration): Unit = {
+    if (trashInterval < 0) {
+      fs.delete(partitionPath, true)
+    } else {
+      logDebug(s"will move data ${partitionPath.toString} to trash")
+      hadoopConf.setInt("fs.trash.interval", trashInterval)
+      Trash.moveToAppropriateTrash(fs, partitionPath, hadoopConf)
+    }
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -271,7 +271,7 @@ private[spark] object Utils extends Logging {
 
   /**
    * Move data to trash on truncate table given
-   * spark.sql.truncate.trash.enabled is true
+   * 'spark.sql.truncate.trash.enabled' is true
    */
   def moveToTrashIfEnabled(
       fs: FileSystem,

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -270,20 +270,21 @@ private[spark] object Utils extends Logging {
   }
 
   /**
-   * Move data to trash on truncate table given
-   * 'spark.sql.truncate.trash.enabled' is true
+   * Move data to trash if 'spark.sql.truncate.trash.enabled' is true
    */
   def moveToTrashIfEnabled(
       fs: FileSystem,
       partitionPath: Path,
       isTrashEnabled: Boolean,
-      hadoopConf: Configuration): Unit = {
+      hadoopConf: Configuration): Boolean = {
     if (isTrashEnabled) {
       logDebug(s"will move data ${partitionPath.toString} to trash")
       val isSuccess = Trash.moveToAppropriateTrash(fs, partitionPath, hadoopConf)
       if (!isSuccess) {
         logWarning(s"Failed to move data ${partitionPath.toString} to trash")
+        return fs.delete(partitionPath, true)
       }
+      isSuccess
     } else {
       fs.delete(partitionPath, true)
     }

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -271,19 +271,18 @@ private[spark] object Utils extends Logging {
 
   /**
    * Move data to trash on truncate table given
-   * spark.sql.truncate.trash.interval is positive
+   * spark.sql.truncate.trash.enabled is true
    */
   def moveToTrashIfEnabled(
       fs: FileSystem,
       partitionPath: Path,
-      trashInterval: Int,
+      isTrashEnabled: Boolean,
       hadoopConf: Configuration): Unit = {
-    if (trashInterval < 0) {
-      fs.delete(partitionPath, true)
-    } else {
+    if (isTrashEnabled && hadoopConf.getInt("fs.trash.interval", 0) > 0) {
       logDebug(s"will move data ${partitionPath.toString} to trash")
-      hadoopConf.setInt("fs.trash.interval", trashInterval)
       Trash.moveToAppropriateTrash(fs, partitionPath, hadoopConf)
+    } else {
+      fs.delete(partitionPath, true)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -280,7 +280,10 @@ private[spark] object Utils extends Logging {
       hadoopConf: Configuration): Unit = {
     if (isTrashEnabled && hadoopConf.getInt("fs.trash.interval", 0) > 0) {
       logDebug(s"will move data ${partitionPath.toString} to trash")
-      Trash.moveToAppropriateTrash(fs, partitionPath, hadoopConf)
+      val isSuccess = Trash.moveToAppropriateTrash(fs, partitionPath, hadoopConf)
+      if (!isSuccess) {
+        logWarning(s"Failed to move data ${partitionPath.toString} to trash")
+      }
     } else {
       fs.delete(partitionPath, true)
     }

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -278,7 +278,7 @@ private[spark] object Utils extends Logging {
       partitionPath: Path,
       isTrashEnabled: Boolean,
       hadoopConf: Configuration): Unit = {
-    if (isTrashEnabled && hadoopConf.getInt("fs.trash.interval", 0) > 0) {
+    if (isTrashEnabled) {
       logDebug(s"will move data ${partitionPath.toString} to trash")
       val isSuccess = Trash.moveToAppropriateTrash(fs, partitionPath, hadoopConf)
       if (!isSuccess) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2729,6 +2729,7 @@ object SQLConf {
         "fs.trash.interval, and in default, the server side configuration value takes " +
         "precedence over the client-side one. Note that if fs.trash.interval is non-positive, " +
         "this will be a no-op and log a warning message.")
+      .version("3.1.0")
       .booleanConf
       .createWithDefault(false)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2722,12 +2722,14 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
-  val TRUNCATE_TRASH_INTERVAL =
-    buildConf("spark.sql.truncate.trash.interval")
-      .doc("This Configuration will decide whether move files to trash on truncate table" +
-        "If -1 files will be deleted without moving to trash")
-      .intConf
-      .createWithDefault(-1)
+  val TRUNCATE_TRASH_ENABLED =
+    buildConf("spark.sql.truncate.trash.enabled")
+      .doc("This Configuration will decide whether move files to trash on truncate table given, " +
+        "'fs.trash.interval' is positive in Hadoop Configuration. " +
+        "Note that, in Hadoop conf if server side has this configured then the client side " +
+        "one will be ignored. ")
+      .booleanConf
+      .createWithDefault(false)
 
   /**
    * Holds information about keys that have been deprecated.
@@ -3341,7 +3343,7 @@ class SQLConf extends Serializable with Logging {
 
   def legacyPathOptionBehavior: Boolean = getConf(SQLConf.LEGACY_PATH_OPTION_BEHAVIOR)
 
-  def truncateTrashInterval: Int = getConf(SQLConf.TRUNCATE_TRASH_INTERVAL)
+  def truncateTrashEnabled: Boolean = getConf(SQLConf.TRUNCATE_TRASH_ENABLED)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2722,6 +2722,13 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val TRUNCATE_TRASH_INTERVAL =
+    buildConf("spark.sql.truncate.trash.interval")
+      .doc("This Configuration will decide whether move files to trash on truncate table" +
+        "If -1 files will be deleted without moving to trash")
+      .intConf
+      .createWithDefault(-1)
+
   /**
    * Holds information about keys that have been deprecated.
    *
@@ -3333,6 +3340,8 @@ class SQLConf extends Serializable with Logging {
     getConf(SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN)
 
   def legacyPathOptionBehavior: Boolean = getConf(SQLConf.LEGACY_PATH_OPTION_BEHAVIOR)
+
+  def truncateTrashInterval: Int = getConf(SQLConf.TRUNCATE_TRASH_INTERVAL)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2724,10 +2724,11 @@ object SQLConf {
 
   val TRUNCATE_TRASH_ENABLED =
     buildConf("spark.sql.truncate.trash.enabled")
-      .doc("This Configuration will decide whether move files to trash on truncate table given, " +
-        "'fs.trash.interval' is positive in Hadoop Configuration. " +
-        "Note that, in Hadoop conf if server side has this configured then the client side " +
-        "one will be ignored. ")
+      .doc("This configuration decides when truncating table, whether data files will be moved " +
+        "to trash directory or deleted permanently. The trash retention time is controlled by " +
+        "fs.trash.interval, and in default, the server side configuration value takes " +
+        "precedence over the client-side one. Note that if fs.trash.interval is non-positive, " +
+        "this will be a no-op and log a warning message.")
       .booleanConf
       .createWithDefault(false)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -490,7 +490,7 @@ case class TruncateTableCommand(
       }
     val hadoopConf = spark.sessionState.newHadoopConf()
     val ignorePermissionAcl = SQLConf.get.truncateTableIgnorePermissionAcl
-    val trashInterval = SQLConf.get.truncateTrashInterval
+    val isTrashEnabled = SQLConf.get.truncateTrashEnabled
     locations.foreach { location =>
       if (location.isDefined) {
         val path = new Path(location.get)
@@ -515,7 +515,7 @@ case class TruncateTableCommand(
             }
           }
 
-          Utils.moveToTrashIfEnabled(fs, path, trashInterval, hadoopConf)
+          Utils.moveToTrashIfEnabled(fs, path, isTrashEnabled, hadoopConf)
 
           // We should keep original permission/acl of the path.
           // For owner/group, only super-user can set it, for example on HDFS. Because

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -48,6 +48,7 @@ import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetDataSourceV2
 import org.apache.spark.sql.internal.{HiveSerDe, SQLConf}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.SchemaUtils
+import org.apache.spark.util.Utils
 
 /**
  * A command to create a table with the same definition of the given existing table.
@@ -489,6 +490,7 @@ case class TruncateTableCommand(
       }
     val hadoopConf = spark.sessionState.newHadoopConf()
     val ignorePermissionAcl = SQLConf.get.truncateTableIgnorePermissionAcl
+    val trashInterval = SQLConf.get.truncateTrashInterval
     locations.foreach { location =>
       if (location.isDefined) {
         val path = new Path(location.get)
@@ -513,7 +515,7 @@ case class TruncateTableCommand(
             }
           }
 
-          fs.delete(path, true)
+          Utils.moveToTrashIfEnabled(fs, path, trashInterval, hadoopConf)
 
           // We should keep original permission/acl of the path.
           // For owner/group, only super-user can set it, for example on HDFS. Because

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -3108,9 +3108,9 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
       withSQLConf(SQLConf.TRUNCATE_TRASH_ENABLED.key -> "true") {
         sql("CREATE TABLE tab1 (col INT) USING parquet")
         sql("INSERT INTO tab1 SELECT 1")
-        // scalastyle:off hadoopConfiguration
+        // scalastyle:off hadoopconfiguration
         val hadoopConf = spark.sparkContext.hadoopConfiguration
-        // scalastyle:on hadoopConfiguration
+        // scalastyle:on hadoopconfiguration
         val originalValue = hadoopConf.get(trashIntervalKey, "0")
         val tablePath = new Path(spark.sessionState.catalog
           .getTableMetadata(TableIdentifier("tab1")).storage.locationUri.get)
@@ -3136,9 +3136,9 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
       withSQLConf(SQLConf.TRUNCATE_TRASH_ENABLED.key -> "true") {
         sql("CREATE TABLE tab1 (col INT) USING parquet")
         sql("INSERT INTO tab1 SELECT 1")
-        // scalastyle:off hadoopConfiguration
+        // scalastyle:off hadoopconfiguration
         val hadoopConf = spark.sparkContext.hadoopConfiguration
-        // scalastyle:on hadoopConfiguration
+        // scalastyle:on hadoopconfiguration
         val originalValue = hadoopConf.get(trashIntervalKey, "0")
         val tablePath = new Path(spark.sessionState.catalog
           .getTableMetadata(TableIdentifier("tab1")).storage.locationUri.get)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -3157,7 +3157,7 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
     }
   }
 
-  test("SPARK-32481 Donot move data to trash on truncate table if disabled") {
+  test("SPARK-32481 Do not move data to trash on truncate table if disabled") {
     withTable("tab1") {
       withSQLConf(SQLConf.TRUNCATE_TRASH_ENABLED.key -> "false") {
         sql("CREATE TABLE tab1 (col INT) USING parquet")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Instead of deleting the data, we can move the data to trash.
Based on the configuration provided by the user it will be deleted permanently from the trash.


### Why are the changes needed?
Instead of directly deleting the data, we can provide flexibility to move data to the trash and then delete it permanently.

### Does this PR introduce _any_ user-facing change?
Yes, After truncate table the data is not permanently deleted now.
It is first moved to the trash and then after the given time deleted permanently;

### How was this patch tested?
new UTs added