### PR TITLE
[SPARK-32584][PYTHON][DOCS] Exclude _images and _sources that are generated by Sphinx in Jekyll build

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -14,6 +14,8 @@ plugins:
 include:
   - _static
   - _modules
+  - _images
+  - _sources
 
 # These allow the documentation to be updated with newer releases
 # of Spark, Scala, and Mesos.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to `include` `_images` and `_sources` directories, generated from Sphinx, in Jekyll build.

**For `_images` directory,**
After SPARK-31851, now we add some images to use within the pages built by Sphinx. It copies and images into `_images` directory. Later, when Jekyll builds, the underscore directories are ignored by default which ends up with missing image in the main doc.

Before:
![Screen Shot 2020-08-11 at 1 52 46 PM](https://user-images.githubusercontent.com/6477701/89859104-2e571080-dbdb-11ea-817c-c04bbcd4088e.png)

After:
![Screen Shot 2020-08-11 at 1 49 00 PM](https://user-images.githubusercontent.com/6477701/89859105-30b96a80-dbdb-11ea-85c6-8a135eddf613.png)


**For `_sources` directory,**
Please refer [here](https://github.com/sphinx-contrib/sphinx-pretty-searchresults#source-links) and [here](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_copy_source). They are generated by default and used by default in the documentations by Sphinx, and we should better include them.

### Why are the changes needed?

To show the images correctly in PySpark documentation.

### Does this PR introduce _any_ user-facing change?

No, only in unreleased branches.

### How was this patch tested?

Manually tested via:

```bash
SKIP_SCALADOC=1 SKIP_RDOC=1 SKIP_SQLDOC=1 jekyll serve --watch
```

