### PR TITLE
 [SPARK-32597][CORE] Tune Event Drop in Async Event Queue

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -293,12 +293,6 @@
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-graphite</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>com.rabbitmq</groupId>
-          <artifactId>amqp-client</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1915,4 +1915,22 @@ package object config {
       .version("3.0.1")
       .booleanConf
       .createWithDefault(false)
+
+  private[spark] val OPTMIZED_ASYNC_EVENT_QUEUE_SIZE_THRESHOLD =
+    ConfigBuilder("spark.set.optmized.event.queue.threshold")
+      .doc("Percentage threshold of async event Queue size that can be increased " +
+        "before dropping event from the queue")
+      .version("3.1.0")
+      .intConf
+      .checkValue(v => v > 0 && v < 100, "The percentage should be positive.")
+      .createWithDefault(10)
+
+  private[spark] val OPTMIZED_ASYNC_EVENT_QUEUE =
+    ConfigBuilder("spark.set.optmized.event.queue")
+      .doc("Comma seperated optimized variable size linked blocking queue " +
+        "for example --conf spark.set.optmized.event.queue=appStatus,executorManagement,eventLog " +
+        "In this case these 3 queues will have variable size linked blocking queue.")
+      .version("3.1.0")
+      .stringConf
+      .createWithDefault("")
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
@@ -69,7 +69,7 @@ private class AsyncEventQueue(
   private val queueSizeThreshold: Int = conf.get(OPTMIZED_ASYNC_EVENT_QUEUE_SIZE_THRESHOLD)
 
   private lazy val maxSizeQueue: Int = if (newQueueType) {
-    capacity + (capacity * queueSizeThreshold)/100
+    capacity + (capacity * queueSizeThreshold) / 100
   } else {
     capacity
   }

--- a/core/src/main/scala/org/apache/spark/scheduler/LiveListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/LiveListenerBus.scala
@@ -249,6 +249,11 @@ private[spark] class LiveListenerBus(conf: SparkConf) {
   private[scheduler] def getQueueCapacity(name: String): Option[Int] = {
     queues.asScala.find(_.name == name).map(_.capacity)
   }
+
+  // For testing only.
+  private[scheduler] def getOptimizedQueueCapacity(name: String): Option[Int] = {
+    queues.asScala.find(_.name == name).map(_.newQueueCapacity)
+  }
 }
 
 private[spark] object LiveListenerBus {

--- a/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
@@ -627,7 +627,7 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
     bus.post(SparkListenerJobEnd(0, jobCompletionTime, JobSucceeded))
     assert(sharedQueueSize(bus) === 1)
     assert(numDroppedEvents(bus) === 0)
-    
+
     bus.post(SparkListenerJobEnd(0, jobCompletionTime, JobSucceeded))
     assert(sharedQueueSize(bus) === 2)
     assert(bus.getOptimizedQueueCapacity(SHARED_QUEUE) == Some(2))

--- a/dev/deps/spark-deps-hadoop-2.7-hive-1.2
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-1.2
@@ -6,6 +6,7 @@ ST4/4.0.4//ST4-4.0.4.jar
 activation/1.1.1//activation-1.1.1.jar
 aircompressor/0.10//aircompressor-0.10.jar
 algebra_2.12/2.0.0-M2//algebra_2.12-2.0.0-M2.jar
+amqp-client/5.5.3//amqp-client-5.5.3.jar
 antlr-runtime/3.4//antlr-runtime-3.4.jar
 antlr/2.7.7//antlr-2.7.7.jar
 antlr4-runtime/4.7.1//antlr4-runtime-4.7.1.jar

--- a/dev/deps/spark-deps-hadoop-2.7-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-2.3
@@ -6,6 +6,7 @@ ST4/4.0.4//ST4-4.0.4.jar
 activation/1.1.1//activation-1.1.1.jar
 aircompressor/0.10//aircompressor-0.10.jar
 algebra_2.12/2.0.0-M2//algebra_2.12-2.0.0-M2.jar
+amqp-client/5.5.3//amqp-client-5.5.3.jar
 antlr-runtime/3.5.2//antlr-runtime-3.5.2.jar
 antlr4-runtime/4.7.1//antlr4-runtime-4.7.1.jar
 aopalliance-repackaged/2.6.1//aopalliance-repackaged-2.6.1.jar

--- a/dev/deps/spark-deps-hadoop-3.2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3.2-hive-2.3
@@ -7,6 +7,7 @@ accessors-smart/1.2//accessors-smart-1.2.jar
 activation/1.1.1//activation-1.1.1.jar
 aircompressor/0.10//aircompressor-0.10.jar
 algebra_2.12/2.0.0-M2//algebra_2.12-2.0.0-M2.jar
+amqp-client/5.5.3//amqp-client-5.5.3.jar
 antlr-runtime/3.5.2//antlr-runtime-3.5.2.jar
 antlr4-runtime/4.7.1//antlr4-runtime-4.7.1.jar
 aopalliance-repackaged/2.6.1//aopalliance-repackaged-2.6.1.jar


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
There are scenarios where we have seen the event drop in spark, resulting in the inconsistent state for the spark Application(some time application is hung state).

For example - This can be due to the large number of parallel task processing. Producer thread keeps on adding the events to the Queue and Consumer thread is consuming the events at the slower rate compare to the Producer adding in the queue. Resulting the Queue to reach max size and events get dropped from that.

There are times if Queue Size would be little bit higher like 10 percent (or 20 percent) extra of the existing Queue size, the events can be processed preventing the event drop at that point of time.

As per the current architecture size of event Queue can be configured at start of the application by setting spark.scheduler.listenerbus.eventqueue.capacity. Once this is set there is fixed size event Queue(LinkedBlockingQueue), which cannot be changed at run time to accommodate some extra events before dropping event from the Queue

This Jira for adding a support of VariableLinkedBlockingQueue to tune the dropping of the events.

VariableLinkedBlockingQueue -> https://www.rabbitmq.com/releases/rabbitmq-java-client/v3.5.4/rabbitmq-java-client-javadoc-3.5.4/com/rabbitmq/client/impl/VariableLinkedBlockingQueue.html

As the part of this PR, we can provide the support for VariableLinkedBlockingQueue. 
1) We need to add those Queue where we are seeing the event drop and add to spark.set.optmized.event.queue.
set --conf spark.set.optmized.event.queue=appStatus,executorManagement -> Now these two queues will be
VariableLinkedBlockingQueue and size of the queue can be increased at run time.
By default its empty string so all the Queues will use the old behavior LinkedBlockingQueue
2) We can set threshold of the size of the queue that we want to increase -> spark.set.optmized.event.queue.threshold
3) We can increase the capacity of the queue, if the driverMemoryUsed is less than 90 percent of max heap size.

Now if we use VariableLinkedBlockingQueue, at the time when the size of the queue reach the size initialized at start of the job , Queue will try to increase the size of the Queue to threshold (spark.set.optmized.event.queue.threshold) and prevent the Event drop at that point of time.



### Why are the changes needed?
Now if we use VariableLinkedBlockingQueue, at the time when the size of the queue reach the size initialised at start of the job , Queue will try to increase the size of the Queue to threshold (spark.set.optmized.event.queue.threshold) and prevent the Event drop at that point of time. Tune Event Drop in Async Event Queue 


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added the Unit test and tested the functionality using the spark-submit 
