### PR TITLE
[SPARK-32602][SQL] Fix issue where data with date type are saved into…

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DaysWritable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DaysWritable.scala
@@ -54,7 +54,9 @@ class DaysWritable(
   }
 
   override def getDays: Int = julianDays
-  override def get(): Date = new Date(DateWritable.daysToMillis(julianDays))
+
+  override def get(doesTimeMatter: Boolean): Date =
+    new Date(DateWritable.daysToMillis(julianDays, doesTimeMatter))
 
   override def set(d: Int): Unit = {
     gregorianDays = d

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertSuite.scala
@@ -847,4 +847,13 @@ class InsertSuite extends QueryTest with TestHiveSingleton with BeforeAndAfter
       }
     }
   }
+
+  test("SPARK-32602 Date type should be correctly stored into hive table.") {
+    withTable("t1") {
+      sql("create table t1 (d date)")
+      sql("insert overwrite table t1 values(cast('2020-08-09' as date))")
+      val r = spark.sql("select d from t1").collect.head.getDate(0).toString
+      assert(r == "2020-08-09")
+    }
+  }
 }


### PR DESCRIPTION
[SPARK-32602][SQL] Fix issue where data with date type are saved into hive table with wrong value '1970-01-01'

### What changes were proposed in this pull request?
Data with date type are saved into hive table with wrong value '1970-01-01'
scala> spark.sql("create table t1(d date)")
res2: org.apache.spark.sql.DataFrame = []
scala> spark.sql("insert into table t1 values(cast('2020-08-09' as date))")
res3: org.apache.spark.sql.DataFrame = []
scala> spark.sql("select d from t1").show
+----------+
|         d|
+----------+
|1970-01-01|
+----------+  
Spark 3.0 introduced DaysWritable which extends DateWrite from hive to handle date type. DaysWritable.toString() is called to write its value into hive table. DateWrite.toString() is defined as:
@Override
public String toString() {
 // For toString, the time does not matter
 return get(false).toString();
}

public Date get(boolean doesTimeMatter) {
  return new Date(daysToMillis(daysSinceEpoch, doesTimeMatter));
}

DaysWritable didn't override toString(), neither get(boolean doesTimeMatter)。It did override get():
override def get(): Date = new Date(DateWritable.daysToMillis(julianDays))
but this didn't help with toString(), so with daysSinceEpoch in DateWritable always as 0, calls to DaysWritable.toString() will always return '1970-01-01', and as a result date value stored into hive table will always have value '1970-01-01'。

This pull request overrides DaysWritable.get(boolean doesTimeMatter) so that it's toString() behaves properly.

### Why are the changes needed?
Fix the correctness issue describe above.


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
New test.