### PR TITLE
[SPARK-32350][FOLLOW-UP] Fix count update issue and partition the value list to a set of small batches for LevelDB writeAll

### DIFF
--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
@@ -191,12 +191,12 @@ public class LevelDB implements KVStore {
           final LevelDBTypeInfo.Index naturalIndex = ti.naturalIndex();
           final Collection<LevelDBTypeInfo.Index> indices = ti.indices();
 
-          try (WriteBatch batch = db().createWriteBatch()) {
-            while (valueIter.hasNext()) {
+          while (valueIter.hasNext()) {
+            try (WriteBatch batch = db().createWriteBatch()) {
               updateBatch(batch, valueIter.next(), serializedValueIter.next(), klass,
                 naturalIndex, indices);
+              db().write(batch);
             }
-            db().write(batch);
           }
         }
       }

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
@@ -211,9 +211,15 @@ public class LevelDBSuite {
       CustomType2 t2 = createCustomType2(i, i);
       values.add(t2);
     }
-    assertEquals(4, values.size());
+
+    CustomType1 t = createCustomType1(3);
+    t.id = "id1"; // test count of "id" index
+    values.add(t);
+
+    assertEquals(5, values.size());
     db.writeAll(values);
-    assertEquals(2, db.count(CustomType1.class));
+    assertEquals(3, db.count(CustomType1.class));
+    assertEquals(2, db.count(CustomType1.class, "id", t.id));
     assertEquals(2, db.count(CustomType2.class));
   }
 

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
@@ -18,6 +18,7 @@
 package org.apache.spark.util.kvstore;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -201,6 +202,22 @@ public class LevelDBSuite {
   }
 
   @Test
+  public void testWriteAll() throws Exception {
+    List<Object> values = new ArrayList<>();
+    for (int i = 0; i < 2; i++) {
+      CustomType1 t1 = createCustomType1(i);
+      values.add(t1);
+
+      CustomType2 t2 = createCustomType2(i, i);
+      values.add(t2);
+    }
+    assertEquals(4, values.size());
+    db.writeAll(values);
+    assertEquals(2, db.count(CustomType1.class));
+    assertEquals(2, db.count(CustomType2.class));
+  }
+
+  @Test
   public void testRemoveAll() throws Exception {
     for (int i = 0; i < 2; i++) {
       for (int j = 0; j < 2; j++) {
@@ -319,6 +336,14 @@ public class LevelDBSuite {
     t.name = "name" + i;
     t.num = i;
     t.child = "child" + i;
+    return t;
+  }
+
+  private CustomType2 createCustomType2(int i, int parentId) {
+    CustomType2 t = new CustomType2();
+    t.key = "key" + i;
+    t.id = "id" + i;
+    t.parentId = "parentId" + parentId;
     return t;
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This is a follow-up of https://github.com/apache/spark/pull/29149. The change is that when writing a large value list, we divide the value list to a set of 128-values smaller batches, and bulk write these smaller batches one by one. This improvement can reduce memory pressure caused by serialization and give fairness to other writing threads. The idea is proposed by @mridulm in https://github.com/apache/spark/pull/29149#issuecomment-671551444.

Update 9/1: After adding the unit test, I found the count of objects cannot be updated properly when using writeAll. This PR also fix the issue by using a hash map to temporarily store and update the delta of each countKey, and put the countKey with its delta to WriteBatch before calling db.write(batch).


### Why are the changes needed?
1. Fix the count update bug when calling writeAll().
2. Reduce the memory pressure and alleviate the fairness issue when batch writing a very long value list.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Unit test and manual test.

A test case testWriteAll() is added in LevelDBSuite.java.

I compared some write-related benchmark tests in LevelDBBenchmark.java between writeAll() and write(). The test was conducted in an HDD disk, and the disk is not busy.

| benchmark test (writing 10000 objects)           | with writeAll(), ms | with write(), ms |
| ------------------------ | ------------------- | ---------------- |
| randomUpdatesIndexed     | 593.202             | 791.28           |
| randomUpdatesNoIndex     | 253.803             | 388.076          |
| randomWritesIndexed      | 834.471             | 1290.984         |
| randomWritesNoIndex      | 248.064             | 475.399          |
| sequentialUpdatesIndexed | 351.207             | 454.227          |
| sequentialUpdatesNoIndex | 236.391             | 380.359          |
| sequentialWritesIndexed  | 433.044             | 782.449          |
| sequentialWritesNoIndex  | 229.85              | 523.149          |

