### PR TITLE
[SPARK-32626][CORE] Do not increase the input metrics when read rdd from cache

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -388,11 +388,9 @@ abstract class RDD[T: ClassTag](
       // Block hit.
       case Left(blockResult) =>
         if (readCachedBlock) {
-          val existingMetrics = context.taskMetrics().inputMetrics
-          existingMetrics.incBytesRead(blockResult.bytes)
+          // When we read rdd from cache, we should not increase the inputMetrics
           new InterruptibleIterator[T](context, blockResult.data.asInstanceOf[Iterator[T]]) {
             override def next(): T = {
-              existingMetrics.incRecordsRead(1)
               delegate.next()
             }
           }

--- a/core/src/test/scala/org/apache/spark/metrics/InputOutputMetricsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/metrics/InputOutputMetricsSuite.scala
@@ -82,7 +82,10 @@ class InputOutputMetricsSuite extends SparkFunSuite with SharedSparkContext
   test("input metrics with cache and coalesce") {
     // prime the cache manager
     val rdd = sc.textFile(tmpFilePath, 4).cache()
-    rdd.collect()
+    val bytesRead0 = runAndReturnBytesRead {
+      rdd.collect()
+    }
+    assert(bytesRead0 != 0)
 
     val bytesRead = runAndReturnBytesRead {
       rdd.count()
@@ -92,7 +95,7 @@ class InputOutputMetricsSuite extends SparkFunSuite with SharedSparkContext
     }
 
     // for count and coalesce, the same bytes should be read.
-    assert(bytesRead != 0)
+    assert(bytesRead == 0)
     assert(bytesRead2 == bytesRead)
   }
 
@@ -145,13 +148,16 @@ class InputOutputMetricsSuite extends SparkFunSuite with SharedSparkContext
   test("input metrics on records read with cache") {
     // prime the cache manager
     val rdd = sc.textFile(tmpFilePath, 4).cache()
-    rdd.collect()
+    val records0 = runAndReturnRecordsRead {
+      rdd.collect()
+    }
+    assert(records0 != 0)
 
     val records = runAndReturnRecordsRead {
       rdd.count()
     }
 
-    assert(records == numRecords)
+    assert(records == 0)
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
Do not increase the input metrics when reading rdd from the cache


### Why are the changes needed?
Input Metrics will be increased after the rdd is first computed, so it is not correct to increment the input metrics when we read rdd from the cache.


### Does this PR introduce _any_ user-facing change?
yes, the user will get the correct read metrics now.


### How was this patch tested?
Existing UTs
