### PR TITLE
[SPARK-32627][SQL][WEBUI] Add showSessionLink parameter to SqlStatsPagedTable class in ThriftServerPage

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerPage.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerPage.scala
@@ -87,7 +87,8 @@ private[ui] class ThriftServerPage(parent: ThriftServerTab) extends WebUIPage(""
           store.getExecutionList,
           "sqlserver",
           UIUtils.prependBaseUri(request, parent.basePath),
-          sqlTableTag).table(sqlTablePage))
+          sqlTableTag,
+          showSessionLink = true).table(sqlTablePage))
       } catch {
         case e@(_: IllegalArgumentException | _: IndexOutOfBoundsException) =>
           Some(<div class="alert alert-error">
@@ -170,7 +171,8 @@ private[ui] class SqlStatsPagedTable(
     data: Seq[ExecutionInfo],
     subPath: String,
     basePath: String,
-    sqlStatsTableTag: String) extends PagedTable[SqlStatsTableRow] {
+    sqlStatsTableTag: String,
+    showSessionLink: Boolean) extends PagedTable[SqlStatsTableRow] {
 
   private val (sortColumn, desc, pageSize) =
     getTableParameters(request, sqlStatsTableTag, "Start Time")
@@ -206,18 +208,34 @@ private[ui] class SqlStatsPagedTable(
 
   override def headers: Seq[Node] = {
     val sqlTableHeadersAndTooltips: Seq[(String, Boolean, Option[String])] =
-      Seq(
-        ("User", true, None),
-        ("JobID", true, None),
-        ("GroupID", true, None),
-        ("Start Time", true, None),
-        ("Finish Time", true, Some(THRIFT_SERVER_FINISH_TIME)),
-        ("Close Time", true, Some(THRIFT_SERVER_CLOSE_TIME)),
-        ("Execution Time", true, Some(THRIFT_SERVER_EXECUTION)),
-        ("Duration", true, Some(THRIFT_SERVER_DURATION)),
-        ("Statement", true, None),
-        ("State", true, None),
-        ("Detail", true, None))
+      if (showSessionLink) {
+        Seq(
+          ("User", true, None),
+          ("JobID", true, None),
+          ("GroupID", true, None),
+          ("Session ID", true, None),
+          ("Start Time", true, None),
+          ("Finish Time", true, Some(THRIFT_SERVER_FINISH_TIME)),
+          ("Close Time", true, Some(THRIFT_SERVER_CLOSE_TIME)),
+          ("Execution Time", true, Some(THRIFT_SERVER_EXECUTION)),
+          ("Duration", true, Some(THRIFT_SERVER_DURATION)),
+          ("Statement", true, None),
+          ("State", true, None),
+          ("Detail", true, None))
+      } else {
+        Seq(
+          ("User", true, None),
+          ("JobID", true, None),
+          ("GroupID", true, None),
+          ("Start Time", true, None),
+          ("Finish Time", true, Some(THRIFT_SERVER_FINISH_TIME)),
+          ("Close Time", true, Some(THRIFT_SERVER_CLOSE_TIME)),
+          ("Execution Time", true, Some(THRIFT_SERVER_EXECUTION)),
+          ("Duration", true, Some(THRIFT_SERVER_DURATION)),
+          ("Statement", true, None),
+          ("State", true, None),
+          ("Detail", true, None))
+      }
 
     isSortColumnValid(sqlTableHeadersAndTooltips, sortColumn)
 
@@ -247,6 +265,13 @@ private[ui] class SqlStatsPagedTable(
       <td>
         {info.groupId}
       </td>
+      {
+        if (showSessionLink) {
+          <td>
+            <a href={sessionLink}>{info.sessionId}</a>
+          </td>
+        }
+      }
       <td >
         {UIUtils.formatDate(startTime)}
       </td>

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerPage.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerPage.scala
@@ -255,6 +255,9 @@ private[ui] class SqlStatsPagedTable(
       }
     }
 
+    val sessionLink = "%s/%s/session/?id=%s".format(
+      UIUtils.prependBaseUri(request, parent.basePath), parent.prefix, info.sessionId)
+
     <tr>
       <td>
         {info.userName}

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerSessionPage.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerSessionPage.scala
@@ -86,7 +86,8 @@ private[ui] class ThriftServerSessionPage(parent: ThriftServerTab)
           executionList,
           "sqlserver/session",
           UIUtils.prependBaseUri(request, parent.basePath),
-          sqlTableTag
+          sqlTableTag,
+          showSessionLink = false
         ).table(sqlTablePage))
       } catch {
         case e@(_: IllegalArgumentException | _: IndexOutOfBoundsException) =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Introduced showSessionLink argument to SqlStatsPagedTable class in ThriftServerPage. When this argument is set to true, "Session ID" tooltip will be shown to the user.

### Why are the changes needed?
To show "Session ID" tooltip to users in ThriftServerPage.


### Does this PR introduce _any_ user-facing change?
Yes. Users would be able to see "Session ID"


### How was this patch tested?
Manual Test.
![49636319-3c837f80-fa3d-11e8-9e14-b87cb8e58746](https://user-images.githubusercontent.com/30429546/90323570-eb759f80-df30-11ea-8ba9-32a50a644f62.png)
