### PR TITLE
[WIP][SPARK-32628][SQL] Use bloom filter to improve dynamicPartitionPruning

### DIFF
--- a/common/sketch/src/main/java/org/apache/spark/util/sketch/BloomFilterImpl.java
+++ b/common/sketch/src/main/java/org/apache/spark/util/sketch/BloomFilterImpl.java
@@ -19,7 +19,7 @@ package org.apache.spark.util.sketch;
 
 import java.io.*;
 
-class BloomFilterImpl extends BloomFilter implements Serializable {
+public class BloomFilterImpl extends BloomFilter implements Serializable {
 
   private int numHashFunctions;
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/BuildBloomFilter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/BuildBloomFilter.scala
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions.aggregate
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import java.lang.{Double => JDouble, Float => JFloat}
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.types.{BinaryType, DoubleType, FloatType, StringType, _}
+import org.apache.spark.unsafe.types.UTF8String
+import org.apache.spark.util.Utils
+import org.apache.spark.util.sketch.BloomFilter
+
+case class BuildBloomFilter(
+    child: Expression,
+    expectedNumItems: Long,
+    override val mutableAggBufferOffset: Int = 0,
+    override val inputAggBufferOffset: Int = 0)
+  extends TypedImperativeAggregate[BloomFilter] with ExpectsInputTypes {
+
+  override def inputTypes: Seq[AbstractDataType] = {
+    Seq(TypeCollection(BuildBloomFilter.buildBloomFilterTypes: _*))
+  }
+
+  override def nullable: Boolean = child.nullable
+
+  override def dataType: DataType = BinaryType
+
+  override def createAggregationBuffer(): BloomFilter = {
+    BloomFilter.create(expectedNumItems)
+  }
+
+  override def update(buffer: BloomFilter, input: InternalRow): BloomFilter = {
+    val value = child.eval(input)
+    // Ignore empty rows
+    if (value != null) {
+      child.dataType match {
+        case _: IntegralType =>
+          buffer.putLong(value.asInstanceOf[Number].longValue())
+        case DateType | TimestampType =>
+          buffer.putLong(value.asInstanceOf[Number].longValue())
+        case FloatType =>
+          buffer.putLong(JFloat.floatToIntBits(value.asInstanceOf[Float]).toLong)
+        case DoubleType =>
+          buffer.putLong(JDouble.doubleToLongBits(value.asInstanceOf[Double]))
+        case StringType =>
+          buffer.putBinary(value.asInstanceOf[UTF8String].getBytes)
+        case BinaryType =>
+          buffer.putBinary(value.asInstanceOf[Array[Byte]])
+        case _: DecimalType =>
+          buffer.putBinary(value.asInstanceOf[Decimal].toJavaBigDecimal.unscaledValue().toByteArray)
+      }
+    }
+    buffer
+  }
+
+  override def merge(buffer: BloomFilter, input: BloomFilter): BloomFilter = {
+    buffer.mergeInPlace(input)
+    buffer
+  }
+
+  override def eval(buffer: BloomFilter): Any = serialize(buffer)
+
+  override def serialize(buffer: BloomFilter): Array[Byte] = {
+    Utils.tryWithResource(new ByteArrayOutputStream) { out =>
+      buffer.writeTo(out)
+      out.toByteArray
+    }
+  }
+
+  override def deserialize(storageFormat: Array[Byte]): BloomFilter = {
+    Utils.tryWithResource(new ByteArrayInputStream(storageFormat)) { in =>
+      BloomFilter.readFrom(in)
+    }
+  }
+
+  override def withNewMutableAggBufferOffset(newMutableAggBufferOffset: Int): BuildBloomFilter =
+    copy(mutableAggBufferOffset = newMutableAggBufferOffset)
+
+  override def withNewInputAggBufferOffset(newInputAggBufferOffset: Int): BuildBloomFilter =
+    copy(inputAggBufferOffset = newInputAggBufferOffset)
+
+  override def children: Seq[Expression] = Seq(child)
+
+  override def prettyName: String = "build_bloom_filter"
+}
+
+object BuildBloomFilter {
+  val buildBloomFilterTypes: Seq[AbstractDataType] =
+    Seq(IntegerType, LongType, FloatType, DoubleType, DecimalType, DateType, TimestampType,
+      StringType, BinaryType)
+
+  def isSupportBuildBloomFilterType(dataType: DataType): Boolean = {
+    dataType match {
+      case _: DecimalType => true
+      case other => buildBloomFilterTypes.contains(other)
+    }
+  }
+
+  def isSupportBuildBloomFilter(expression: Expression): Boolean = {
+    isSupportBuildBloomFilterType(expression.dataType)
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
+import java.lang.{Double => JDouble, Float => JFloat}
+
 import scala.collection.immutable.TreeSet
 import scala.collection.mutable
 
@@ -32,6 +34,8 @@ import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LeafNode, Logical
 import org.apache.spark.sql.catalyst.util.TypeUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.UTF8String
+import org.apache.spark.util.sketch.BloomFilter
 
 
 /**
@@ -977,6 +981,72 @@ case class GreaterThanOrEqual(left: Expression, right: Expression)
   override def symbol: String = ">="
 
   protected override def nullSafeEval(input1: Any, input2: Any): Any = ordering.gteq(input1, input2)
+}
+
+case class InBloomFilter(child: Expression, bloomFilter: BloomFilter)
+  extends UnaryExpression with Predicate {
+
+  require(bloomFilter != null, "bloomFilter could not be null")
+
+  override def toString: String = s"$child IN BLOOM FILTER"
+
+  override def nullable: Boolean = child.nullable
+
+  protected override def nullSafeEval(value: Any): Any = {
+    child.dataType match {
+      case _: IntegralType =>
+        bloomFilter.mightContainLong(value.asInstanceOf[Number].longValue())
+      case DateType | TimestampType =>
+        bloomFilter.mightContainLong(value.asInstanceOf[Number].longValue())
+      case FloatType =>
+        bloomFilter.mightContainLong(JFloat.floatToIntBits(value.asInstanceOf[Float]).toLong)
+      case DoubleType =>
+        bloomFilter.mightContainLong(JDouble.doubleToLongBits(value.asInstanceOf[Double]))
+      case StringType =>
+        bloomFilter.mightContainBinary(value.asInstanceOf[UTF8String].getBytes)
+      case BinaryType =>
+        bloomFilter.mightContainBinary(value.asInstanceOf[Array[Byte]])
+      case _: DecimalType =>
+        bloomFilter.mightContainBinary(value.asInstanceOf[Decimal]
+          .toJavaBigDecimal.unscaledValue().toByteArray)
+      case dataType =>
+        throw new IllegalArgumentException(
+          s"Bloom filter do not support ${dataType.catalogString} type.")
+    }
+  }
+
+  override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    val childCode = child.genCode(ctx)
+    val input = childCode.value
+    val bf = ctx.addReferenceObj("bloomFilter", bloomFilter)
+    val bloomFilterTestCode = child.dataType match {
+      case _: IntegralType => s"$bf.mightContainLong((long)$input)"
+      case DateType | TimestampType => s"$bf.mightContainLong((long)$input)"
+      case FloatType => s"$bf.mightContainLong((long)Float.floatToIntBits($input))"
+      case DoubleType => s"$bf.mightContainLong(Double.doubleToLongBits($input))"
+      case StringType => s"$bf.mightContainBinary($input.getBytes())"
+      case BinaryType => s"$bf.mightContainBinary($input)"
+      case _: DecimalType =>
+        s"$bf.mightContainBinary($input.toJavaBigDecimal().unscaledValue().toByteArray())"
+      case dataType =>
+        throw new IllegalArgumentException(
+          s"Bloom filter do not support ${dataType.catalogString} type.")
+    }
+
+    ev.copy(code = childCode.code +
+      code"""
+            |boolean ${ev.value} = true;
+            |boolean ${ev.isNull} = ${childCode.isNull};
+            |if (!${childCode.isNull}) {
+            |  ${ev.value} = $bloomFilterTestCode;
+            |}
+      """.stripMargin)
+  }
+
+  override def sql: String = {
+    val valueSQL = child.sql
+    s"($valueSQL IN BLOOM FILTER)"
+  }
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -282,6 +282,14 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val DYNAMIC_PARTITION_PRUNING_MAX_BLOOM_FILTER_ENTRIES =
+    buildConf("spark.sql.optimizer.dynamicPartitionPruning.maxBloomFilterEntries")
+      .internal()
+      .doc("The max number of entries to build the Bloom filter.")
+      .version("3.1.0")
+      .longConf
+      .createWithDefault(10000000L)
+
   val COMPRESS_CACHED = buildConf("spark.sql.inMemoryColumnarStorage.compressed")
     .doc("When set to true Spark SQL will automatically select a compression codec for each " +
       "column based on statistics of the data.")
@@ -2833,6 +2841,9 @@ class SQLConf extends Serializable with Logging {
 
   def dynamicPartitionPruningReuseBroadcastOnly: Boolean =
     getConf(DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY)
+
+  def dynamicPartitionPruningMaxBloomFilterEntries: Long =
+    getConf(DYNAMIC_PARTITION_PRUNING_MAX_BLOOM_FILTER_ENTRIES)
 
   def stateStoreProviderClass: String = getConf(STATE_STORE_PROVIDER_CLASS)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PlanDynamicPruningFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PlanDynamicPruningFilters.scala
@@ -20,11 +20,13 @@ package org.apache.spark.sql.execution.dynamicpruning
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeSeq, BindReferences, DynamicPruningExpression, DynamicPruningSubquery, Expression, ListQuery, Literal, PredicateHelper}
-import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight}
-import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LogicalPlan}
+import org.apache.spark.sql.catalyst.expressions.aggregate.{BuildBloomFilter, Max, Min}
+import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, JoinSelectionHelper}
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, RepartitionByExpression}
+import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.EstimationUtils
 import org.apache.spark.sql.catalyst.plans.physical.BroadcastMode
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.execution.{InSubqueryExec, QueryExecution, SparkPlan, SubqueryBroadcastExec}
+import org.apache.spark.sql.execution.{InSubqueryExec, MixedFilterSubqueryExec, QueryExecution, SparkPlan, SubqueryBroadcastExec, SubqueryExec}
 import org.apache.spark.sql.execution.exchange.BroadcastExchangeExec
 import org.apache.spark.sql.execution.joins._
 import org.apache.spark.sql.internal.SQLConf
@@ -35,7 +37,9 @@ import org.apache.spark.sql.internal.SQLConf
  * the fallback mechanism with subquery duplicate.
 */
 case class PlanDynamicPruningFilters(sparkSession: SparkSession)
-    extends Rule[SparkPlan] with PredicateHelper {
+    extends Rule[SparkPlan] with PredicateHelper with JoinSelectionHelper {
+
+  private val conf = SQLConf.get
 
   /**
    * Identify the shape in which keys of a given plan are broadcasted.
@@ -46,7 +50,7 @@ case class PlanDynamicPruningFilters(sparkSession: SparkSession)
   }
 
   override def apply(plan: SparkPlan): SparkPlan = {
-    if (!SQLConf.get.dynamicPartitionPruningEnabled) {
+    if (!conf.dynamicPartitionPruningEnabled) {
       return plan
     }
 
@@ -57,7 +61,7 @@ case class PlanDynamicPruningFilters(sparkSession: SparkSession)
           sparkSession, sparkSession.sessionState.planner, buildPlan)
         // Using `sparkPlan` is a little hacky as it is based on the assumption that this rule is
         // the first to be applied (apart from `InsertAdaptiveSparkPlan`).
-        val canReuseExchange = SQLConf.get.exchangeReuseEnabled && buildKeys.nonEmpty &&
+        val canReuseExchange = conf.exchangeReuseEnabled && buildKeys.nonEmpty &&
           plan.find {
             case BroadcastHashJoinExec(_, _, _, BuildLeft, _, left, _, _) =>
               left.sameResult(sparkPlan)
@@ -65,13 +69,13 @@ case class PlanDynamicPruningFilters(sparkSession: SparkSession)
               right.sameResult(sparkPlan)
             case _ => false
           }.isDefined
+        val name = s"dynamicpruning#${exprId.id}"
 
         if (canReuseExchange) {
           val executedPlan = QueryExecution.prepareExecutedPlan(sparkSession, sparkPlan)
           val mode = broadcastMode(buildKeys, executedPlan.output)
           // plan a broadcast exchange of the build side of the join
           val exchange = BroadcastExchangeExec(mode, executedPlan)
-          val name = s"dynamicpruning#${exprId.id}"
           // place the broadcast adaptor for reusing the broadcast results on the probe side
           val broadcastValues =
             SubqueryBroadcastExec(name, broadcastKeyIndex, buildKeys, exchange)
@@ -80,11 +84,42 @@ case class PlanDynamicPruningFilters(sparkSession: SparkSession)
           // it is not worthwhile to execute the query, so we fall-back to a true literal
           DynamicPruningExpression(Literal.TrueLiteral)
         } else {
-          // we need to apply an aggregate on the buildPlan in order to be column pruned
-          val alias = Alias(buildKeys(broadcastKeyIndex), buildKeys(broadcastKeyIndex).toString)()
-          val aggregate = Aggregate(Seq(alias), Seq(alias), buildPlan)
-          DynamicPruningExpression(expressions.InSubquery(
-            Seq(value), ListQuery(aggregate, childOutputs = aggregate.output)))
+          val buildKey = buildKeys(broadcastKeyIndex)
+          if (BuildBloomFilter.isSupportBuildBloomFilter(buildKey) &&
+            !canBroadcastBySize(buildPlan, conf)) {
+            val sizePerRow = EstimationUtils.getSizePerRow(buildKey.references.toSeq)
+            val sizeInBytes = buildPlan.stats.sizeInBytes
+            val rowCount = buildPlan.references.map {
+              attr => buildPlan.stats.attributeStats.get(attr).flatMap(_.distinctCount)
+            }.max.orElse(buildPlan.stats.rowCount).getOrElse(sizeInBytes / sizePerRow).toLong
+            val maxBloomFilterEntries = conf.dynamicPartitionPruningMaxBloomFilterEntries
+            val expectedNumItems = math.max(math.min(rowCount, maxBloomFilterEntries), 1L)
+            val aggregateExpressions = buildKey.flatMap { e =>
+              Seq(
+                Alias(Min(e).toAggregateExpression(), s"min_${e.toString}")(),
+                Alias(Max(e).toAggregateExpression(), s"max_${e.toString}")(),
+                Alias(BuildBloomFilter(e, expectedNumItems).toAggregateExpression(),
+                  s"bloom_filter${e.toString}")()
+              )
+            }
+            // Adding RepartitionByExpression may reuse exchange
+            val withRepartition = if (buildKeys.size == 1 && !canBroadcastBySize(buildPlan, conf)) {
+              RepartitionByExpression(Seq(buildKey), buildPlan, None)
+            } else {
+              buildPlan
+            }
+
+            val aggregate = Aggregate(Nil, aggregateExpressions, withRepartition)
+            val executedPlan = QueryExecution.prepareExecutedPlan(sparkSession, aggregate)
+            DynamicPruningExpression(
+              MixedFilterSubqueryExec(value, SubqueryExec(name, executedPlan), exprId))
+          } else {
+            // we need to apply an aggregate on the buildPlan in order to be column pruned
+            val alias = Alias(buildKey, buildKey.toString)()
+            val aggregate = Aggregate(Seq(alias), Seq(alias), buildPlan)
+            DynamicPruningExpression(expressions.InSubquery(
+              Seq(value), ListQuery(aggregate, childOutputs = aggregate.output)))
+          }
         }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
@@ -135,6 +135,12 @@ case class ReuseExchange(conf: SQLConf) extends Rule[SparkPlan] {
           case exchange: Exchange => reuse(exchange)
         }
         in.copy(plan = newIn.asInstanceOf[BaseSubqueryExec])
+
+      case mixedFilter: MixedFilterSubqueryExec =>
+        val newMixedFilter = mixedFilter.plan.transformUp {
+          case exchange: Exchange => reuse(exchange)
+        }
+        mixedFilter.copy(plan = newMixedFilter.asInstanceOf[BaseSubqueryExec])
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

It will make driver OOM if `spark.sql.optimizer.dynamicPartitionPruning.reuseBroadcastOnly` is disabled and build side have many results. We can use Bloom Filter to avoid this bottleneck and improve performance.

Please see the comparison chart below:
num Items(Long type) | Bloom Filter(ms) | hash set(ms) | sizeOf Bloom Filter(bytes) | sizeOf hash set(bytes)
-- | -- | -- | -- | --
10 | 6635 | 4147 | 80 | 720
100 | 7374 | 3908 | 160 | 6720
1000 | 7490 | 5095 | 984 | 64288
10000 | 7533 | 4196 | 9192 | 625632
100000 | 7838 | 5154 | 91296 | 6648672
1000000 | 8950 | 8425 | 912376 | 64388704
5000000 | 10465 | 25624 | 4561592 | 313554528
10000000 | 19287 | 104596 | 9123120 | 627108960

But the larger the expectedNumItems, the slower the Bloom Filter build, Please see the comparison chart below:

Number of Bloom Filter items | Build using UDAF time(ms) | Collect to driver build time(ms)
-- | -- | --
1000 | 842 | 640
10000 | 1086 | 810
10000000 | 6265 | 11457
30000000 | 16001 | 39385
50000000 | 27009 | 109192
70000000 | 26540 | 111459
100000000 | 27460 | N/A
200000000 | 46415 | N/A

So Bloom Filter is not enough. If there are many expectedNumItems, it will work better with minimum and maximum.


This pr enhances `PlanDynamicPruningFilters` to use minimum, maximum and Bloom Filter if build side larger than `spark.sql.autoBroadcastJoinThreshold`.  


### Why are the changes needed?

Enhance DPP.


### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Unit test and performance test:
```scala
spark.range(20000000000L)
  .select(col("id"), col("id").%(2000).as("k"))
  .write
  .partitionBy("k")
  .mode("overwrite")
  .saveAsTable("df1")

spark.range(2000000000L)
  .select(col("id"), col("id").as("k"))
  .write
  .mode("overwrite")
  .saveAsTable("df2")

spark.sql("CREATE TABLE t_result1 USING parquet as SELECT df1.id, df2.k FROM df1 JOIN df2 ON df1.k = df2.k AND df2.id > 1500 AND df2.id < 1000000000L")
```


Disable DPP(Seconds) | Enable DPP and disable reuseBroadcastOnly   before this patch | Enable DPP and disable reuseBroadcastOnly   after this patch(Seconds)
-- | -- | --
222 | SparkException | 108