### PR TITLE
[SPARK-32631][SQL] Handle Null error message in hive ThriftServer UI

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerPage.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerPage.scala
@@ -271,12 +271,13 @@ private[ui] class SqlStatsPagedTable(
       <td>
         {info.state}
       </td>
-      {errorMessageCell(sqlStatsTableRow.detail)}
+      {errorMessageCell(Option(sqlStatsTableRow.detail))}
     </tr>
   }
 
 
-  private def errorMessageCell(errorMessage: String): Seq[Node] = {
+  private def errorMessageCell(errorMessageOption: Option[String]): Seq[Node] = {
+    val errorMessage = errorMessageOption.getOrElse("")
     val isMultiline = errorMessage.indexOf('\n') >= 0
     val errorSummary = StringEscapeUtils.escapeHtml4(
       if (isMultiline) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This fix is trying to prevent NullPointerException caused by Null error message by wrapping the message with Option and using getOrElse to handle Null value.

The possible reason why the error message would be null is that java Throwable allows the detailMessage to be null. However, in the render code we assume that the error message would be be null and try to do indexOf() on the string. Therefore, if some exception doesn't set the error message, it would trigger NullPointerException in the hive ThriftServer UI.


### Why are the changes needed?
To prevent NullPointerException caused by Null error message.


### Does this PR introduce _any_ user-facing change?
User would see blank message instead of a NullPointerException.


### How was this patch tested?
Manual Testing.

For normal behavior, this change would not change anything.
![37435401-658510a8-27a0-11e8-8f8b-00271fd3ef58](https://user-images.githubusercontent.com/30429546/90350571-93f83200-e00b-11ea-9ff3-3b315d2114cc.png)

To test the null case, we manually set detail to be null in code. In this case,
![37435498-cebc8182-27a0-11e8-80e7-40df2a65612b](https://user-images.githubusercontent.com/30429546/90350601-ac684c80-e00b-11ea-8375-1911f5852bd5.png)
UI would show blank.
