### PR TITLE
[SPARK-32606][SPARK-32605][INFRA] Remove the forks of action-surefire-report and action-download-artifact in test_report.yml

### DIFF
--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -10,26 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Download test results to report
-      # TODO(SPARK-32605): It was forked to have a custom fix
-      # https://github.com/HyukjinKwon/action-surefire-report/commit/c96094cc35061fcf154a7cb46807f2f3e2339476
-      # in order to add the support of custom target commit SHA. It should be contributed back to the original
-      # plugin and avoid using the fork.
-      uses: HyukjinKwon/action-download-artifact@master
+      uses: dawidd6/action-download-artifact@v2
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         workflow: ${{ github.event.workflow_run.workflow_id }}
         commit: ${{ github.event.workflow_run.head_commit.id }}
     - name: Publish test report
-      # TODO(SPARK-32606): It was forked to have a custom fix
-      # https://github.com/HyukjinKwon/action-download-artifact/commit/750b71af351aba467757d7be6924199bb08db4ed
-      # in order to add the support to download all artifacts. It should be contributed back to the original
-      # plugin and avoid using the fork.
-      # Alternatively, we can use the official actions/download-artifact once they support to download artifacts
-      # between different workloads, see also https://github.com/actions/download-artifact/issues/3
-      uses: HyukjinKwon/action-surefire-report@master
+      uses: scacap/action-surefire-report@v1
       with:
-        check_name: Test report
+        check_name: Report test results
         github_token: ${{ secrets.GITHUB_TOKEN }}
         report_paths: "**/target/test-reports/*.xml"
         commit: ${{ github.event.workflow_run.head_commit.id }}
-


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to remove the usage of my own forks and use the original plugins in GitHub Actions testing report.

SPARK-32357 introduced the GitHub Actions test reporting by leveraging two plugins:
 - [ScaCap/action-surefire-report](https://github.com/ScaCap/action-surefire-report)
 - [dawidd6/action-download-artifact](https://github.com/dawidd6/action-download-artifact)

In order to make it working, it had to fork two repositories with custom fixes:
  - HyukjinKwon/action-surefire-report@c96094c
  - https://github.com/HyukjinKwon/action-download-artifact/commit/f86c565d52095e547b552eb46ba8e0696f6117f8

The two custom fixes are thankfully merged at https://github.com/ScaCap/action-surefire-report/pull/14 and https://github.com/dawidd6/action-download-artifact/pull/24, and they released new ones to use at [ScaCap/action-surefire-report/commits/v1](https://github.com/ScaCap/action-surefire-report/commits/v1) and [dawidd6/action-download-artifact/commits/v2](https://github.com/dawidd6/action-download-artifact/commits/v2)  - thanks @jmisur and @dawidd6 again.

### Why are the changes needed?

To avoid relying on forks and code duplications.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Logically there is no diff. I tested it at https://github.com/HyukjinKwon/spark/runs/992824229 for doubly sure.

NOTE that this PR cannot be tested here within the workflow triggered by this PR without merging the changes in `test_report.yml` into the master.