### PR TITLE
[SPARK-32643][CORE][K8s] Consolidate state decommissioning in the TaskSchedulerImpl realm

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
@@ -88,7 +88,7 @@ private[spark] trait ExecutorAllocationClient {
    * Default implementation delegates to kill, scheduler must override
    * if it supports graceful decommissioning.
    *
-   * @param executorsAndDecominfo identifiers of executors & decom info.
+   * @param executorsAndDecomInfo identifiers of executors & decom info.
    * @param adjustTargetNumExecutors whether the target number of executors will be adjusted down
    *                                 after these executors have been decommissioned.
    * @return the ids of the executors acknowledged by the cluster manager to be removed.

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1825,7 +1825,7 @@ private[spark] class DAGScheduler(
           if (bmAddress != null) {
             val externalShuffleServiceEnabled = env.blockManager.externalShuffleServiceEnabled
             val isHostDecommissioned = taskScheduler
-              .getExecutorDecommissionInfo(bmAddress.executorId)
+              .getExecutorDecommissionState(bmAddress.executorId)
               .exists(_.isHostDecommissioned)
 
             // Shuffle output of all executors on host `bmAddress.host` may be lost if:

--- a/core/src/main/scala/org/apache/spark/scheduler/ExecutorDecommissionInfo.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ExecutorDecommissionInfo.scala
@@ -33,7 +33,6 @@ case class ExecutorDecommissionInfo(message: String, isHostDecommissioned: Boole
  * from the message.
  */
 case class ExecutorDecommissionState(
-    message: String,
     // Timestamp the decommissioning commenced as per the Driver's clock,
     // to estimate when the executor might eventually be lost if EXECUTOR_DECOMMISSION_KILL_INTERVAL
     // is configured.

--- a/core/src/main/scala/org/apache/spark/scheduler/ExecutorDecommissionInfo.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ExecutorDecommissionInfo.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.scheduler
 
 /**
- * Provides more detail when an executor is being decommissioned.
+ * Message providing more detail when an executor is being decommissioned.
  * @param message Human readable reason for why the decommissioning is happening.
  * @param isHostDecommissioned Whether the host (aka the `node` or `worker` in other places) is
  *                             being decommissioned too. Used to infer if the shuffle data might
@@ -26,3 +26,14 @@ package org.apache.spark.scheduler
  */
 private[spark]
 case class ExecutorDecommissionInfo(message: String, isHostDecommissioned: Boolean)
+
+/**
+ * State related to decommissioning that is kept by the TaskSchedulerImpl. This state is derived
+ * from the info message above but it is kept distinct to allow the state to evolve independently
+ * from the message.
+ */
+case class ExecutorDecommissionState(
+    message: String,
+    // Timestamp in milliseconds when decommissioning was triggered
+    tsMillis: Long,
+    isHostDecommissioned: Boolean)

--- a/core/src/main/scala/org/apache/spark/scheduler/ExecutorDecommissionInfo.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ExecutorDecommissionInfo.scala
@@ -34,6 +34,8 @@ case class ExecutorDecommissionInfo(message: String, isHostDecommissioned: Boole
  */
 case class ExecutorDecommissionState(
     message: String,
-    // Timestamp the decommissioning commenced in millis since epoch of the driver's clock
+    // Timestamp the decommissioning commenced as per the Driver's clock,
+    // to estimate when the executor might eventually be lost if EXECUTOR_DECOMMISSION_KILL_INTERVAL
+    // is configured.
     startTime: Long,
     isHostDecommissioned: Boolean)

--- a/core/src/main/scala/org/apache/spark/scheduler/ExecutorDecommissionInfo.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ExecutorDecommissionInfo.scala
@@ -34,6 +34,6 @@ case class ExecutorDecommissionInfo(message: String, isHostDecommissioned: Boole
  */
 case class ExecutorDecommissionState(
     message: String,
-    // Timestamp in milliseconds when decommissioning was triggered
-    tsMillis: Long,
+    // Timestamp the decommissioning commenced in millis since epoch of the driver's clock
+    startTime: Long,
     isHostDecommissioned: Boolean)

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskScheduler.scala
@@ -106,7 +106,7 @@ private[spark] trait TaskScheduler {
   /**
    * If an executor is decommissioned, return its corresponding decommission info
    */
-  def getExecutorDecommissionInfo(executorId: String): Option[ExecutorDecommissionInfo]
+  def getExecutorDecommissionState(executorId: String): Option[ExecutorDecommissionState]
 
   /**
    * Process a lost executor

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -930,7 +930,7 @@ private[spark] class TaskSchedulerImpl(
         if (!oldDecomState.exists(_.isHostDecommissioned)) {
           executorsPendingDecommission(executorId) = ExecutorDecommissionState(
             decommissionInfo.message,
-            oldDecomState.map(_.tsMillis).getOrElse(clock.getTimeMillis()),
+            oldDecomState.map(_.startTime).getOrElse(clock.getTimeMillis()),
             decommissionInfo.isHostDecommissioned)
         }
       }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -927,7 +927,6 @@ private[spark] class TaskSchedulerImpl(
           // This is the first time we are hearing of decommissioning this executor,
           // so create a brand new state.
           ExecutorDecommissionState(
-            decommissionInfo.message,
             clock.getTimeMillis(),
             decommissionInfo.isHostDecommissioned)
         } else {
@@ -938,7 +937,6 @@ private[spark] class TaskSchedulerImpl(
             // manager and is thus authoritative. Flip isHostDecommissioned to true but keep the old
             // decommission start time.
             ExecutorDecommissionState(
-              oldDecomState.message,
               oldDecomState.startTime,
               isHostDecommissioned = true)
           } else {

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -1052,10 +1052,10 @@ private[spark] class TaskSetManager(
       logDebug("Task length threshold for speculation: " + threshold)
       for (tid <- runningTasksSet) {
         var speculated = checkAndSubmitSpeculatableTask(tid, time, threshold)
-        if (!speculated && executorDecommissionKillInterval.nonEmpty) {
+        if (!speculated && executorDecommissionKillInterval.isDefined) {
           val taskInfo = taskInfos(tid)
           val decomState = sched.getExecutorDecommissionState(taskInfo.executorId)
-          if (decomState.nonEmpty) {
+          if (decomState.isDefined) {
             // Check if this task might finish after this executor is decommissioned.
             // We estimate the task's finish time by using the median task duration.
             // Whereas the time when the executor might be decommissioned is estimated using the

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -1033,7 +1033,8 @@ private[spark] class TaskSetManager(
     // No need to speculate if the task set is zombie or is from a barrier stage. If there is only
     // one task we don't speculate since we don't have metrics to decide whether it's taking too
     // long or not, unless a task duration threshold is explicitly provided.
-    if (isZombie || isBarrier || (numTasks == 1 && !speculationTaskDurationThresOpt.isDefined)) {
+    if (!speculationEnabled || isZombie || isBarrier ||
+      (numTasks == 1 && !speculationTaskDurationThresOpt.isDefined)) {
       return false
     }
     var foundTasks = false

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -1033,8 +1033,7 @@ private[spark] class TaskSetManager(
     // No need to speculate if the task set is zombie or is from a barrier stage. If there is only
     // one task we don't speculate since we don't have metrics to decide whether it's taking too
     // long or not, unless a task duration threshold is explicitly provided.
-    if (!speculationEnabled || isZombie || isBarrier ||
-      (numTasks == 1 && !speculationTaskDurationThresOpt.isDefined)) {
+    if (isZombie || isBarrier || (numTasks == 1 && !speculationTaskDurationThresOpt.isDefined)) {
       return false
     }
     var foundTasks = false

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -178,8 +178,8 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     override def executorDecommission(
       executorId: String,
       decommissionInfo: ExecutorDecommissionInfo): Unit = {}
-    override def getExecutorDecommissionInfo(
-      executorId: String): Option[ExecutorDecommissionInfo] = None
+    override def getExecutorDecommissionState(
+      executorId: String): Option[ExecutorDecommissionState] = None
   }
 
   /**
@@ -787,8 +787,8 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
       override def executorDecommission(
         executorId: String,
         decommissionInfo: ExecutorDecommissionInfo): Unit = {}
-      override def getExecutorDecommissionInfo(
-        executorId: String): Option[ExecutorDecommissionInfo] = None
+      override def getExecutorDecommissionState(
+        executorId: String): Option[ExecutorDecommissionState] = None
     }
     val noKillScheduler = new DAGScheduler(
       sc,

--- a/core/src/test/scala/org/apache/spark/scheduler/ExternalClusterManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/ExternalClusterManagerSuite.scala
@@ -101,6 +101,6 @@ private class DummyTaskScheduler extends TaskScheduler {
   override def executorDecommission(
     executorId: String,
     decommissionInfo: ExecutorDecommissionInfo): Unit = {}
-  override def getExecutorDecommissionInfo(
-    executorId: String): Option[ExecutorDecommissionInfo] = None
+  override def getExecutorDecommissionState(
+    executorId: String): Option[ExecutorDecommissionState] = None
 }

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -1859,9 +1859,9 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     scheduler.executorDecommission("executor1", ExecutorDecommissionInfo("1 new", false))
 
     assert(scheduler.getExecutorDecommissionState("executor0")
-      === Some(ExecutorDecommissionState("0", oldTime, false)))
+      === Some(ExecutorDecommissionState(oldTime, false)))
     assert(scheduler.getExecutorDecommissionState("executor1")
-      === Some(ExecutorDecommissionState("1", oldTime, true)))
+      === Some(ExecutorDecommissionState(oldTime, true)))
     assert(scheduler.getExecutorDecommissionState("executor2").isEmpty)
   }
 

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -1859,7 +1859,7 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     scheduler.executorDecommission("executor1", ExecutorDecommissionInfo("1 new", false))
 
     assert(scheduler.getExecutorDecommissionState("executor0")
-      === Some(ExecutorDecommissionState("0 new", oldTime, false)))
+      === Some(ExecutorDecommissionState("0", oldTime, false)))
     assert(scheduler.getExecutorDecommissionState("executor1")
       === Some(ExecutorDecommissionState("1", oldTime, true)))
     assert(scheduler.getExecutorDecommissionState("executor2").isEmpty)

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -88,15 +88,10 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
   }
 
   def setupSchedulerWithMaster(master: String, confs: (String, String)*): TaskSchedulerImpl = {
-    setupSchedulerWithMasterAndClock(master, new SystemClock, confs: _*)
-  }
-
-  def setupSchedulerWithMasterAndClock(master: String, clock: Clock, confs: (String, String)*):
-  TaskSchedulerImpl = {
     val conf = new SparkConf().setMaster(master).setAppName("TaskSchedulerImplSuite")
     confs.foreach { case (k, v) => conf.set(k, v) }
     sc = new SparkContext(conf)
-    taskScheduler = new TaskSchedulerImpl(sc, sc.conf.get(config.TASK_MAX_FAILURES), clock = clock)
+    taskScheduler = new TaskSchedulerImpl(sc, sc.conf.get(config.TASK_MAX_FAILURES))
     setupHelper()
   }
 
@@ -1834,22 +1829,41 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     assert(2 == taskDescriptions.head.resources(GPU).addresses.size)
   }
 
-  private def setupSchedulerForDecommissionTests(clock: Clock): TaskSchedulerImpl = {
-    val taskScheduler = setupSchedulerWithMasterAndClock(
-      s"local[2]",
-      clock,
-      config.CPUS_PER_TASK.key -> 1.toString)
-    taskScheduler.submitTasks(FakeTask.createTaskSet(2))
-    val multiCoreWorkerOffers = IndexedSeq(WorkerOffer("executor0", "host0", 1),
-      WorkerOffer("executor1", "host1", 1))
-    val taskDescriptions = taskScheduler.resourceOffers(multiCoreWorkerOffers).flatten
-    assert(taskDescriptions.map(_.executorId).sorted === Seq("executor0", "executor1"))
+  private def setupSchedulerForDecommissionTests(clock: Clock, numTasks: Int): TaskSchedulerImpl = {
+    // one task per host
+    val numHosts = numTasks
+    val conf = new SparkConf()
+      .setMaster(s"local[$numHosts]")
+      .setAppName("TaskSchedulerImplSuite")
+      .set(config.CPUS_PER_TASK.key, "1")
+    sc = new SparkContext(conf)
+    val maxTaskFailures = sc.conf.get(config.TASK_MAX_FAILURES)
+    taskScheduler = new TaskSchedulerImpl(sc, maxTaskFailures, clock = clock) {
+      override def createTaskSetManager(taskSet: TaskSet, maxFailures: Int): TaskSetManager = {
+        val tsm = super.createTaskSetManager(taskSet, maxFailures)
+        // we need to create a spied tsm so that we can see the copies running
+        val tsmSpy = spy(tsm)
+        stageToMockTaskSetManager(taskSet.stageId) = tsmSpy
+        tsmSpy
+      }
+    }
+    setupHelper()
+    // Spawn the tasks on different executors/hosts
+    taskScheduler.submitTasks(FakeTask.createTaskSet(numTasks))
+    for (i <- 0 until numTasks) {
+      val executorId = s"executor$i"
+      val taskDescriptions = taskScheduler.resourceOffers(IndexedSeq(WorkerOffer(
+         executorId, s"host$i", 1))).flatten
+      assert(taskDescriptions.size === 1)
+      assert(taskDescriptions(0).executorId == executorId)
+      assert(taskDescriptions(0).index === i)
+    }
     taskScheduler
   }
 
   test("scheduler should keep the decommission state where host was decommissioned") {
     val clock = new ManualClock(10000L)
-    val scheduler = setupSchedulerForDecommissionTests(clock)
+    val scheduler = setupSchedulerForDecommissionTests(clock, 2)
     val oldTime = clock.getTimeMillis()
     scheduler.executorDecommission("executor0", ExecutorDecommissionInfo("0", false))
     scheduler.executorDecommission("executor1", ExecutorDecommissionInfo("1", true))
@@ -1865,9 +1879,12 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     assert(scheduler.getExecutorDecommissionState("executor2").isEmpty)
   }
 
-  test("scheduler should eventually purge removed and decommissioned executors") {
+  test("test full decommissioning flow") {
     val clock = new ManualClock(10000L)
-    val scheduler = setupSchedulerForDecommissionTests(clock)
+    val scheduler = setupSchedulerForDecommissionTests(clock, 2)
+    val manager = stageToMockTaskSetManager(0)
+    // The task started should be running.
+    assert(manager.copiesRunning.take(2) === Array(1, 1))
 
     // executor 0 is decommissioned after loosing
     assert(scheduler.getExecutorDecommissionState("executor0").isEmpty)
@@ -1876,28 +1893,47 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     scheduler.executorDecommission("executor0", ExecutorDecommissionInfo("", false))
     assert(scheduler.getExecutorDecommissionState("executor0").isEmpty)
 
+    // 0th task just died above
+    assert(manager.copiesRunning.take(2) === Array(0, 1))
+
     assert(scheduler.executorsPendingDecommission.isEmpty)
     clock.advance(5000)
 
-    // executor 1 is decommissioned before loosing
+    // executor1 hasn't been decommissioned yet
     assert(scheduler.getExecutorDecommissionState("executor1").isEmpty)
+
+    // executor 1 is decommissioned before loosing
     scheduler.executorDecommission("executor1", ExecutorDecommissionInfo("", false))
     assert(scheduler.getExecutorDecommissionState("executor1").isDefined)
     clock.advance(2000)
+
+    // executor1 is eventually lost
     scheduler.executorLost("executor1", ExecutorExited(0, false, "normal"))
     assert(scheduler.decommissionedExecutorsRemoved.size === 1)
     assert(scheduler.executorsPendingDecommission.isEmpty)
+    // So now both the tasks are no longer running
+    assert(manager.copiesRunning.take(2) === Array(0, 0))
     clock.advance(2000)
+
     // Decommission state should hang around a bit after removal ...
     assert(scheduler.getExecutorDecommissionState("executor1").isDefined)
     scheduler.executorDecommission("executor1", ExecutorDecommissionInfo("", false))
     clock.advance(2000)
     assert(scheduler.decommissionedExecutorsRemoved.size === 1)
     assert(scheduler.getExecutorDecommissionState("executor1").isDefined)
-    // The default timeout is 5 minutes which completes now.
-    clock.advance(301000)
+
+    // The default timeout for expiry is 300k milliseconds (5 minutes) which completes now,
+    // and the executor1's decommission state should finally be purged.
+    clock.advance(300000)
     assert(scheduler.getExecutorDecommissionState("executor1").isEmpty)
     assert(scheduler.decommissionedExecutorsRemoved.isEmpty)
+
+    // Now give it some resources and both tasks should be rerun
+    val taskDescriptions = taskScheduler.resourceOffers(IndexedSeq(
+      WorkerOffer("executor2", "host2", 1), WorkerOffer("executor3", "host3", 1))).flatten
+    assert(taskDescriptions.size === 2)
+    assert(taskDescriptions.map(_.index).sorted == Seq(0, 1))
+    assert(manager.copiesRunning.take(2) === Array(1, 1))
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -109,8 +109,10 @@ object FakeRackUtil {
  * a list of "live" executors and their hostnames for isExecutorAlive and hasExecutorsAliveOnHost
  * to work, and these are required for locality in TaskSetManager.
  */
-class FakeTaskScheduler(sc: SparkContext, clock: Clock,
-                        liveExecutors: (String, String)* /* execId, host */)
+class FakeTaskScheduler(
+    sc: SparkContext,
+    clock: Clock,
+    liveExecutors: (String, String)* /* execId, host */)
   extends TaskSchedulerImpl(sc, sc.conf.get(config.TASK_MAX_FAILURES), clock = clock)
 {
   val startedTasks = new ArrayBuffer[Long]
@@ -121,7 +123,7 @@ class FakeTaskScheduler(sc: SparkContext, clock: Clock,
 
   val executors = new mutable.HashMap[String, String]
 
-  def this(sc: SparkContext, liveExecutors: (String, String)*) {
+  def this(sc: SparkContext, liveExecutors: (String, String)*) = {
     this(sc, new SystemClock, liveExecutors: _*)
   }
 

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -41,7 +41,7 @@ import org.apache.spark.resource.TestResourceIDs._
 import org.apache.spark.scheduler.cluster.CoarseGrainedSchedulerBackend
 import org.apache.spark.serializer.SerializerInstance
 import org.apache.spark.storage.BlockManagerId
-import org.apache.spark.util.{AccumulatorV2, ManualClock}
+import org.apache.spark.util.{AccumulatorV2, Clock, ManualClock, SystemClock}
 
 class FakeDAGScheduler(sc: SparkContext, taskScheduler: FakeTaskScheduler)
   extends DAGScheduler(sc) {
@@ -109,8 +109,9 @@ object FakeRackUtil {
  * a list of "live" executors and their hostnames for isExecutorAlive and hasExecutorsAliveOnHost
  * to work, and these are required for locality in TaskSetManager.
  */
-class FakeTaskScheduler(sc: SparkContext, liveExecutors: (String, String)* /* execId, host */)
-  extends TaskSchedulerImpl(sc)
+class FakeTaskScheduler(sc: SparkContext, clock: Clock,
+                        liveExecutors: (String, String)* /* execId, host */)
+  extends TaskSchedulerImpl(sc, sc.conf.get(config.TASK_MAX_FAILURES), clock = clock)
 {
   val startedTasks = new ArrayBuffer[Long]
   val endedTasks = new mutable.HashMap[Long, TaskEndReason]
@@ -119,6 +120,10 @@ class FakeTaskScheduler(sc: SparkContext, liveExecutors: (String, String)* /* ex
   val speculativeTasks = new ArrayBuffer[Int]
 
   val executors = new mutable.HashMap[String, String]
+
+  def this(sc: SparkContext, liveExecutors: (String, String)*) {
+    this(sc, new SystemClock, liveExecutors: _*)
+  }
 
   // this must be initialized before addExecutor
   override val defaultRackValue: Option[String] = Some("default")
@@ -1974,14 +1979,16 @@ class TaskSetManagerSuite
   test("SPARK-21040: Check speculative tasks are launched when an executor is decommissioned" +
     " and the tasks running on it cannot finish within EXECUTOR_DECOMMISSION_KILL_INTERVAL") {
     sc = new SparkContext("local", "test")
-    sched = new FakeTaskScheduler(sc, ("exec1", "host1"), ("exec2", "host2"), ("exec3", "host3"))
+    val clock = new ManualClock()
+    sched = new FakeTaskScheduler(sc, clock,
+      ("exec1", "host1"), ("exec2", "host2"), ("exec3", "host3"))
+    sched.backend = mock(classOf[SchedulerBackend])
     val taskSet = FakeTask.createTaskSet(4)
     sc.conf.set(config.SPECULATION_ENABLED, true)
     sc.conf.set(config.SPECULATION_MULTIPLIER, 1.5)
     sc.conf.set(config.SPECULATION_QUANTILE, 0.5)
     sc.conf.set(config.EXECUTOR_DECOMMISSION_KILL_INTERVAL.key, "5s")
-    val clock = new ManualClock()
-    val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES, clock = clock)
+    val manager = sched.createTaskSetManager(taskSet, MAX_TASK_FAILURES)
     val accumUpdatesByTask: Array[Seq[AccumulatorV2[_, _]]] = taskSet.tasks.map { task =>
       task.metrics.internalAccums
     }
@@ -2020,10 +2027,10 @@ class TaskSetManagerSuite
     // decommission exec-2. All tasks running on exec-2 (i.e. TASK 2,3)  will be added to
     // executorDecommissionSpeculationTriggerTimeoutOpt
     // (TASK 2 -> 15, TASK 3 -> 15)
-    manager.executorDecommission("exec2")
-    assert(manager.tidToExecutorKillTimeMapping.keySet === Set(2, 3))
-    assert(manager.tidToExecutorKillTimeMapping(2) === 15*1000)
-    assert(manager.tidToExecutorKillTimeMapping(3) === 15*1000)
+    sched.executorDecommission("exec2", ExecutorDecommissionInfo("decom",
+      isHostDecommissioned = false))
+    assert(sched.getExecutorDecommissionState("exec2").map(_.tsMillis) ===
+      Some(clock.getTimeMillis()))
 
     assert(manager.checkSpeculatableTasks(0))
     // TASK 2 started at t=0s, so it can still finish before t=15s (Median task runtime = 10s)

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -2086,27 +2086,6 @@ class TaskSetManagerSuite
     assert(manager.resourceOffer("exec1", "host1", ANY)._1.isEmpty)
   }
 
-  test("Check that speculation does not happen when disabled") {
-    sc = new SparkContext("local", "test")
-    val clock = new ManualClock()
-    sched = new FakeTaskScheduler(sc, clock,
-      ("exec1", "host1"), ("exec2", "host2"), ("exec3", "host3"))
-    sched.backend = mock(classOf[SchedulerBackend])
-    val taskSet = FakeTask.createTaskSet(1)
-    sc.conf.set(config.SPECULATION_ENABLED, false)
-    val manager = sched.createTaskSetManager(taskSet, MAX_TASK_FAILURES)
-    val taskOption = manager.resourceOffer("exec1", "host1", NO_PREF)._1
-    assert(taskOption.isDefined)
-    assert(taskOption.get.executorId === "exec1")
-    assert(taskOption.get.index === 0)
-    assert(sched.startedTasks.toSet === Set(0))
-    assert(manager.copiesRunning(0) === 1)
-
-    // Speculation is disabled so nothing should be speculated.
-    assert(!manager.checkSpeculatableTasks(0))
-    assert(sched.speculativeTasks.toSet === Set())
-  }
-
   test("SPARK-29976 Regular speculation configs should still take effect even when a " +
       "threshold is provided") {
     val (manager, clock) = testSpeculationDurationSetup(

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -2029,7 +2029,7 @@ class TaskSetManagerSuite
     // (TASK 2 -> 15, TASK 3 -> 15)
     sched.executorDecommission("exec2", ExecutorDecommissionInfo("decom",
       isHostDecommissioned = false))
-    assert(sched.getExecutorDecommissionState("exec2").map(_.tsMillis) ===
+    assert(sched.getExecutorDecommissionState("exec2").map(_.startTime) ===
       Some(clock.getTimeMillis()))
 
     assert(manager.checkSpeculatableTasks(0))

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -2086,96 +2086,25 @@ class TaskSetManagerSuite
     assert(manager.resourceOffer("exec1", "host1", ANY)._1.isEmpty)
   }
 
-  test("SPARK-21040: Tasks are not speculated on decommissioning if speculation is disabled") {
+  test("Check that speculation does not happen when disabled") {
     sc = new SparkContext("local", "test")
     val clock = new ManualClock()
     sched = new FakeTaskScheduler(sc, clock,
       ("exec1", "host1"), ("exec2", "host2"), ("exec3", "host3"))
     sched.backend = mock(classOf[SchedulerBackend])
-    val taskSet = FakeTask.createTaskSet(4)
+    val taskSet = FakeTask.createTaskSet(1)
     sc.conf.set(config.SPECULATION_ENABLED, false)
-    sc.conf.set(config.EXECUTOR_DECOMMISSION_KILL_INTERVAL.key, "5s")
     val manager = sched.createTaskSetManager(taskSet, MAX_TASK_FAILURES)
-    val accumUpdatesByTask: Array[Seq[AccumulatorV2[_, _]]] = taskSet.tasks.map { task =>
-      task.metrics.internalAccums
-    }
-
-    // Start TASK 0,1 on exec1, TASK 2 on exec2
-    (0 until 2).foreach { _ =>
-      val taskOption = manager.resourceOffer("exec1", "host1", NO_PREF)._1
-      assert(taskOption.isDefined)
-      assert(taskOption.get.executorId === "exec1")
-    }
-    val taskOption2 = manager.resourceOffer("exec2", "host2", NO_PREF)._1
-    assert(taskOption2.isDefined)
-    assert(taskOption2.get.executorId === "exec2")
-
-    clock.advance(6*1000) // time = 6s
-    // Start TASK 3 on exec2 after some delay
-    val taskOption3 = manager.resourceOffer("exec2", "host2", NO_PREF)._1
-    assert(taskOption3.isDefined)
-    assert(taskOption3.get.executorId === "exec2")
-
-    assert(sched.startedTasks.toSet === Set(0, 1, 2, 3))
-
-    clock.advance(4*1000) // time = 10s
-    // Complete the first 2 tasks and leave the other 2 tasks in running
-    for (id <- Set(0, 1)) {
-      manager.handleSuccessfulTask(id, createTaskResult(id, accumUpdatesByTask(id)))
-      assert(sched.endedTasks(id) === Success)
-    }
+    val taskOption = manager.resourceOffer("exec1", "host1", NO_PREF)._1
+    assert(taskOption.isDefined)
+    assert(taskOption.get.executorId === "exec1")
+    assert(taskOption.get.index === 0)
+    assert(sched.startedTasks.toSet === Set(0))
+    assert(manager.copiesRunning(0) === 1)
 
     // Speculation is disabled so nothing should be speculated.
     assert(!manager.checkSpeculatableTasks(0))
     assert(sched.speculativeTasks.toSet === Set())
-
-    // decommission exec-2. All tasks running on exec-2 (i.e. TASK 2,3) will be now
-    // checked if they should be speculated.
-    // (TASK 2 -> 15, TASK 3 -> 15)
-    sched.executorDecommission("exec2", ExecutorDecommissionInfo("decom",
-      isHostDecommissioned = false))
-    assert(sched.getExecutorDecommissionState("exec2").map(_.startTime) ===
-      Some(clock.getTimeMillis()))
-
-    // Speculation is disabled so nothing should be speculated.
-    assert(!manager.checkSpeculatableTasks(0))
-    assert(sched.speculativeTasks.toSet === Set())
-    // Old copy should continue to be running.
-    assert(manager.copiesRunning(3) === 1)
-
-    // Offer resource to start the speculative attempt for the running task
-    assert(manager.resourceOffer("exec3", "host3", NO_PREF)._1.isEmpty)
-    assert(manager.resourceOffer("exec3", "host3", NO_PREF)._1.isEmpty)
-
-    clock.advance(1*1000) // time = 11s
-    // Running checkSpeculatableTasks again should return false
-    assert(!manager.checkSpeculatableTasks(0))
-    assert(manager.copiesRunning(2) === 1)
-    assert(manager.copiesRunning(3) === 1)
-
-    clock.advance(5*1000) // time = 16s
-    // The decommissioned executor will finally die and take down the running tasks 2 and 3 with it
-    manager.executorLost("exec2", "host2", ExecutorProcessLost("decommissioned"))
-    // Still no speculation
-    assert(!manager.checkSpeculatableTasks(0))
-    assert(sched.speculativeTasks.toSet === Set())
-    assert(manager.copiesRunning(2) === 0)
-    assert(manager.copiesRunning(3) === 0)
-    // Give it 2 new resources and it should spawn the tasks 2 and 3 lost on exec2
-    val indicesRerun = (1 to 2).map { _ =>
-      val taskRerunOpt = manager.resourceOffer("exec3", "host3", NO_PREF)._1
-      assert(taskRerunOpt.isDefined)
-      val taskRerun = taskRerunOpt.get
-      assert(taskRerun.executorId === "exec3")
-      assert(taskRerun.attemptNumber === 1)
-      taskRerun.index
-    }.toSet
-    assert(indicesRerun === Set(2, 3))
-    assert(manager.copiesRunning(2) === 1)
-    assert(manager.copiesRunning(3) === 1)
-
-    // Offering additional resources should not lead to any more tasks being respawned
-    assert(manager.resourceOffer("exec1", "host1", ANY)._1.isEmpty)
   }
 
   test("SPARK-29976 Regular speculation configs should still take effect even when a " +


### PR DESCRIPTION
### What changes were proposed in this pull request?
The decommissioning state is a bit fragment across two places in the TaskSchedulerImpl:

https://github.com/apache/spark/pull/29014/ stored the incoming decommission info messages in TaskSchedulerImpl.executorsPendingDecommission.
While https://github.com/apache/spark/pull/28619/ was storing just the executor end time in the map TaskSetManager.tidToExecutorKillTimeMapping (which in turn is contained in TaskSchedulerImpl).
While the two states are not really overlapping, it's a bit of a code hygiene concern to save this state in two places. 

With https://github.com/apache/spark/pull/29422, TaskSchedulerImpl is emerging as the place where all decommissioning book keeping is kept within the driver. So consolidate the information in _tidToExecutorKillTimeMapping_ into _executorsPendingDecommission_. 

However, in order to do so, we need to walk away from keeping the raw ExecutorDecommissionInfo messages and instead keep another class ExecutorDecommissionState. This decoupling will allow the RPC message class ExecutorDecommissionInfo to evolve independently from the book keeping ExecutorDecommissionState.


### Why are the changes needed?

This is just a code cleanup. These two features were added independently and its time to consolidate their state for good hygiene.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Existing tests.