### PR TITLE
[SPARK-32644][SQL] NAAJ support for ShuffleHashJoin when AQE is on

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2702,7 +2702,7 @@ object SQLConf {
     buildConf("spark.sql.optimizeNullAwareAntiJoin")
       .internal()
       .doc("When true, NULL-aware anti join execution will be planed into " +
-        "BroadcastHashJoinExec with flag isNullAwareAntiJoin enabled, " +
+        "BroadcastHashJoinExec or ShuffledHashJoinExec with flag isNullAwareAntiJoin enabled, " +
         "optimized from O(M*N) calculation into O(M) calculation " +
         "using Hash lookup instead of Looping lookup." +
         "Only support for singleColumn NAAJ for now.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -344,6 +344,7 @@ object QueryExecution {
       PlanSubqueries(sparkSession),
       RemoveRedundantProjects(sparkSession.sessionState.conf),
       EnsureRequirements(sparkSession.sessionState.conf),
+      RemoveShuffledNaaJIfBuildSideNotExchange(sparkSession, sparkSession.sessionState.conf),
       ApplyColumnarRulesAndInsertTransitions(sparkSession.sessionState.conf,
         sparkSession.sessionState.columnarRules),
       CollapseCodegenStages(sparkSession.sessionState.conf),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/RemoveShuffledNaaJIfBuildSideNotExchange.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/RemoveShuffledNaaJIfBuildSideNotExchange.scala
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.expressions.{IsNull, Literal}
+import org.apache.spark.sql.catalyst.expressions.aggregate.{Count, CountIf}
+import org.apache.spark.sql.catalyst.optimizer.BuildRight
+import org.apache.spark.sql.catalyst.planning.ExtractSingleColumnNullAwareAntiJoin
+import org.apache.spark.sql.catalyst.plans.LeftAnti
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LocalRelation}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
+import org.apache.spark.sql.execution.exchange.Exchange
+import org.apache.spark.sql.execution.joins.ShuffledHashJoinExec
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * This optimization rule detects and eliminate Shuffled NAAJ with following scenarios.
+ * 1. Join is single column shuffled NAAJ and buildSide is not [[Exchange]],
+ * when buildSide is Empty, the Join will be rewritten into its streamedSide logical plan.
+ * 2. Join is single column shuffled NAAJ and buildSide is not [[Exchange]],
+ * when buildSide contains record with all the partition keys to be null,
+ * the Join will be rewritten into an Empty LocalRelation.
+ */
+case class RemoveShuffledNaaJIfBuildSideNotExchange(
+    sparkSession: SparkSession,
+    conf: SQLConf) extends Rule[SparkPlan] {
+  def apply(plan: SparkPlan): SparkPlan = {
+    if (!conf.adaptiveExecutionEnabled || !plan.isInstanceOf[AdaptiveSparkPlanExec]) {
+      plan
+    } else {
+      val updatedInputPlan = plan.asInstanceOf[AdaptiveSparkPlanExec].inputPlan.transformDown {
+        case shj @ ShuffledHashJoinExec(_, _, LeftAnti, BuildRight, _, left, right, true)
+          if !right.isInstanceOf[Exchange] =>
+          // When BuildSide is not an Exchange, pre-compute information
+          // whether the buildSide is empty or contains record with all the partition.
+          shj.logicalLink.get match {
+            case j @ ExtractSingleColumnNullAwareAntiJoin(_, _) =>
+              val executedPlan = new QueryExecution(sparkSession,
+                Aggregate(Seq.empty, Seq(
+                  Count(Literal(1)).toAggregateExpression().as("outputNumRows"),
+                  CountIf(IsNull(j.right.output.head))
+                    .toAggregateExpression().as("nullPartitionKeyNumRows")), j.right))
+                .executedPlan
+
+              val statsRow = executedPlan.executeTake(1).head
+
+              val isEmpty = statsRow.getLong(0) == 0L
+              val containsNullPartitionKeys = statsRow.getLong(1) > 0L
+
+              if (isEmpty) {
+                left
+              } else if (containsNullPartitionKeys) {
+                val newPlan = LocalTableScanExec(shj.output, Seq.empty)
+                newPlan.setLogicalLink(
+                  LocalRelation(j.output, data = Seq.empty, isStreaming = j.isStreaming)
+                )
+                newPlan
+              } else {
+                shj
+              }
+          }
+      }
+      plan.asInstanceOf[AdaptiveSparkPlanExec].copy(inputPlan = updatedInputPlan)
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQEOptimizer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQEOptimizer.scala
@@ -29,7 +29,8 @@ class AQEOptimizer(conf: SQLConf) extends RuleExecutor[LogicalPlan] {
   private val defaultBatches = Seq(
     Batch("Demote BroadcastHashJoin", Once,
       DemoteBroadcastHashJoin(conf)),
-    Batch("Eliminate Join to Empty Relation", Once, EliminateJoinToEmptyRelation)
+    Batch("Eliminate Join to Empty Relation", Once, EliminateJoinToEmptyRelation),
+    Batch("Eliminate Shuffled Null Aware Anti Join", Once, EliminateShuffledNullAwareAntiJoin)
   )
 
   final override protected def batches: Seq[Batch] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/EliminateShuffledNullAwareAntiJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/EliminateShuffledNullAwareAntiJoin.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.adaptive
+
+import org.apache.spark.sql.catalyst.planning.ExtractSingleColumnNullAwareAntiJoin
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.exchange.ExchangeStatisticsCollector
+
+/**
+ * This optimization rule detects and eliminate Shuffled NAAJ with following scenarios.
+ * 1. Join is single column shuffled NAAJ and buildSide is [[LogicalQueryStage]],
+ * when buildSide is Empty, the Join will be rewritten into its streamedSide logical plan.
+ * 2. Join is single column shuffled NAAJ and buildSide is [[LogicalQueryStage]],
+ * when buildSide contains record with all the partition keys to be null,
+ * the Join will be rewritten into an Empty LocalRelation.
+ */
+case object EliminateShuffledNullAwareAntiJoin
+    extends Rule[LogicalPlan] with AdaptiveSparkPlanHelper {
+
+  private def isEmpty(plan: LogicalPlan): Boolean = plan match {
+    case LogicalQueryStage(_, stage: ShuffleQueryStageExec) if stage.resultOption.get().isDefined =>
+      stage.shuffle.asInstanceOf[ExchangeStatisticsCollector].getOutputNumRows.contains(0L)
+    case _ => false
+  }
+
+  private def containsNullPartitionKeys(plan: LogicalPlan): Boolean = plan match {
+    case LogicalQueryStage(_, stage: ShuffleQueryStageExec) if stage.resultOption.get().isDefined =>
+      stage.shuffle.asInstanceOf[ExchangeStatisticsCollector]
+        .getNullPartitionKeyNumRows.exists(_ > 0L)
+    case _ => false
+  }
+
+  def apply(plan: LogicalPlan): LogicalPlan = plan.transformDown {
+    case j @ ExtractSingleColumnNullAwareAntiJoin(_, _) if containsNullPartitionKeys(j.right) =>
+      LocalRelation(j.output, data = Seq.empty, isStreaming = j.isStreaming)
+
+    case j @ ExtractSingleColumnNullAwareAntiJoin(_, _) if isEmpty(j.right) =>
+      j.left
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ExchangeStatisticsCollector.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ExchangeStatisticsCollector.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.exchange
+
+sealed trait ExchangeStatisticsSpec
+
+case object NullPartitionKeyStatisticsSpec extends ExchangeStatisticsSpec
+
+trait ExchangeStatisticsCollector {
+
+  /**
+   * types of Spec to indicate which ExchangeStatistics need to be collected.
+   */
+  def statSpecs: Seq[ExchangeStatisticsSpec]
+
+  /**
+   * return whether an Exchange knows how many records with all the partition keys to be null.
+   */
+  def getNullPartitionKeyNumRows: Option[Long]
+
+  /**
+   * return shuffle output number of rows.
+   */
+  def getOutputNumRows: Option[Long]
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1431,7 +1431,7 @@ class DatasetSuite extends QueryTest
         val agg = cp.groupBy($"id" % 2).agg(count($"id"))
 
         agg.queryExecution.executedPlan.collectFirst {
-          case ShuffleExchangeExec(_, _: RDDScanExec, _) =>
+          case ShuffleExchangeExec(_, _: RDDScanExec, _, _) =>
           case BroadcastExchangeExec(_, _: RDDScanExec) =>
         }.foreach { _ =>
           fail(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -715,10 +715,10 @@ class PlannerSuite extends SharedSparkSession with AdaptiveSparkPlanHelper {
     outputPlan match {
       case SortMergeJoinExec(leftKeys, rightKeys, _, _,
              SortExec(_, _,
-               ShuffleExchangeExec(HashPartitioning(leftPartitioningExpressions, _), _, _), _),
+               ShuffleExchangeExec(HashPartitioning(leftPartitioningExpressions, _), _, _, _), _),
              SortExec(_, _,
                ShuffleExchangeExec(HashPartitioning(rightPartitioningExpressions, _),
-               _, _), _), _) =>
+               _, _, _), _), _) =>
         assert(leftKeys === smjExec.leftKeys)
         assert(rightKeys === smjExec.rightKeys)
         assert(leftKeys === leftPartitioningExpressions)


### PR DESCRIPTION
### What changes were proposed in this pull request?
In [SPARK-32290](https://issues.apache.org/jira/browse/SPARK-32290), we managed to optimize NAAJ scenario from BNLJ to BHJ, but skipped the checking the BuildSide plan with `spark.sql.autoBroadcastJoinThreshold` parameter, which means in very bad case, BuildSide Plan being too big might cause Driver OOM. So the NAAJ support for ShuffledHashJoin is important as well.

The support of SHJ for NAAJ has some difficulties in NullKey scenario, as for normal HashedRelation and EmtpyHashedRelation, the code logical should be the same when it comes to BHJ and SHJ, but if NullKey exists in global BuildSide data, and only one partition could be built into EmptyHashedRelationWithAllNullKeys, and this partition was not able to do `fast stop` for the entire RDD. So after offline talked with some committers and discussion, decided to support NAAJ for SHJ when AQE is on, because when AQE is on, Shuffle will be pre-executed, and we should be able to know that whether the BuildSide contains NullKey or not before the actual JOIN executed.

Basically, In NAAJ SHJ Implementation, we collected information whether BuildSide is Empty or contains NullKey, and keep these information in ShuffleExchangeExec Metrics, and during AQE, we rewritten these two case into LocalTableScan and StreamedSidePlan to Avoid NAAJ, as for the normal relation, we processed it in Distributed style.

### Why are the changes needed?
If BuildSide plan is too big in NAAJ scenario, it might cause Driver OOM, distributed implementation for NAAJ (ShuffledHashJoin) is neccesary. 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
* added case in AdaptiveQueryExecSuite.
* updated case in SubquerySuite.
* Make sure JoinSuite SQLQueryTestSuite passed.