### PR TITLE
[SPARK-32647][INFRA] Report SparkR test results with JUnit reporter

### DIFF
--- a/R/pkg/tests/fulltests/test_sparkSQL.R
+++ b/R/pkg/tests/fulltests/test_sparkSQL.R
@@ -120,9 +120,9 @@ test_that("calling sparkR.session returns existing SparkSession", {
 })
 
 test_that("infer types and check types", {
-  expect_equal(infer_type(1L), "integer")
-  expect_equal(infer_type(1.0), "double")
-  expect_equal(infer_type("abc"), "string")
+  expect_equal(infer_type(1L), "intger")
+  expect_equal(infer_type(1.0), "doble")
+  expect_equal(infer_type("abc"), "tring")
   expect_equal(infer_type(TRUE), "boolean")
   expect_equal(infer_type(as.Date("2015-03-11")), "date")
   expect_equal(infer_type(as.POSIXlt("2015-03-11 12:13:04.043")), "timestamp")
@@ -141,7 +141,7 @@ test_that("infer types and check types", {
 test_that("structType and structField", {
   testField <- structField("a", "string")
   expect_is(testField, "structField")
-  expect_equal(testField$name(), "a")
+  expect_equal(testField$name(), "")
   expect_true(testField$nullable())
 
   testSchema <- structType(testField, structField("b", "integer"))
@@ -152,7 +152,7 @@ test_that("structType and structField", {
   testSchema <- structType("a STRING, b INT")
   expect_is(testSchema, "structType")
   expect_is(testSchema$fields()[[2]], "structField")
-  expect_equal(testSchema$fields()[[1]]$dataType.toString(), "StringType")
+  expect_equal(testSchema$fields()[[1]]$dataType.toString(), "Stringype")
 
   expect_error(structType("A stri"), "DataType stri is not supported.")
 })

--- a/R/pkg/tests/fulltests/test_sparkSQL.R
+++ b/R/pkg/tests/fulltests/test_sparkSQL.R
@@ -120,9 +120,9 @@ test_that("calling sparkR.session returns existing SparkSession", {
 })
 
 test_that("infer types and check types", {
-  expect_equal(infer_type(1L), "intger")
-  expect_equal(infer_type(1.0), "doble")
-  expect_equal(infer_type("abc"), "tring")
+  expect_equal(infer_type(1L), "integer")
+  expect_equal(infer_type(1.0), "double")
+  expect_equal(infer_type("abc"), "string")
   expect_equal(infer_type(TRUE), "boolean")
   expect_equal(infer_type(as.Date("2015-03-11")), "date")
   expect_equal(infer_type(as.POSIXlt("2015-03-11 12:13:04.043")), "timestamp")
@@ -141,7 +141,7 @@ test_that("infer types and check types", {
 test_that("structType and structField", {
   testField <- structField("a", "string")
   expect_is(testField, "structField")
-  expect_equal(testField$name(), "")
+  expect_equal(testField$name(), "a")
   expect_true(testField$nullable())
 
   testSchema <- structType(testField, structField("b", "integer"))
@@ -152,7 +152,7 @@ test_that("structType and structField", {
   testSchema <- structType("a STRING, b INT")
   expect_is(testSchema, "structType")
   expect_is(testSchema$fields()[[2]], "structField")
-  expect_equal(testSchema$fields()[[1]]$dataType.toString(), "Stringype")
+  expect_equal(testSchema$fields()[[1]]$dataType.toString(), "StringType")
 
   expect_error(structType("A stri"), "DataType stri is not supported.")
 })

--- a/R/pkg/tests/run-all.R
+++ b/R/pkg/tests/run-all.R
@@ -61,15 +61,18 @@ if (identical(Sys.getenv("NOT_CRAN"), "true")) {
     set.seed(42)
 
     # TODO (SPARK-30663) To be removed once testthat 1.x is removed from all builds
-    if (grepl("^1\\..*", packageVersion("testthat"))) {
+    if (packageVersion("testthat")$major <= 1) {
       # testthat 1.x
       test_runner <- testthat:::run_tests
       reporter <- "summary"
-
     } else {
       # testthat >= 2.0.0
       test_runner <- testthat:::test_package_dir
-      reporter <- testthat::default_reporter()
+      dir.create("target/test-reports", showWarnings = FALSE)
+      reporter <- MultiReporter$new(list(
+        SummaryReporter$new(),
+        JunitReporter$new(file = "target/test-reports/test-results.xml")
+      ))
     }
 
     test_runner("SparkR",

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,8 +41,8 @@ cache:
 install:
   # Install maven and dependencies
   - ps: .\dev\appveyor-install-dependencies.ps1
-  # Required package for R unit tests
-  - cmd: Rscript -e "install.packages(c('knitr', 'rmarkdown', 'testthat', 'e1071', 'survival', 'arrow'), repos='https://cloud.r-project.org/')"
+  # Required package for R unit tests. xml2 is required to use jUnit reporter in testthat.
+  - cmd: Rscript -e "install.packages(c('knitr', 'rmarkdown', 'testthat', 'e1071', 'survival', 'arrow', 'xml2'), repos='https://cloud.r-project.org/')"
   - cmd: Rscript -e "pkg_list <- as.data.frame(installed.packages()[,c(1, 3:4)]); pkg_list[is.na(pkg_list$Priority), 1:2, drop = FALSE]"
 
 build_script:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to generate JUnit XML test report in SparkR tests that can be leveraged in both Jenkins and GitHub Actions.

**GitHub Actions**

![Screen Shot 2020-08-18 at 12 42 46 PM](https://user-images.githubusercontent.com/6477701/90467934-55b85b00-e150-11ea-863c-c8415e764ddb.png)

**Jenkins**

![Screen Shot 2020-08-18 at 2 03 42 PM](https://user-images.githubusercontent.com/6477701/90472509-a5505400-e15b-11ea-9165-777ec9b96eaa.png)


NOTE that while I am here, I am switching back the console reporter from "progress" to "summary". Currently non-ascii codes are broken in Jenkins console and switching it to "summary" can work around it.
"summary" is the default format used in testthat 1.x.

### Why are the changes needed?

To check the test failures more easily.

### Does this PR introduce _any_ user-facing change?

No, dev-only

### How was this patch tested?

It is tested in GitHub Actions at https://github.com/HyukjinKwon/spark/pull/23/checks?check_run_id=996586446
In case of Jenkins, https://amplab.cs.berkeley.edu/jenkins/job/SparkPullRequestBuilder/127525/testReport/
