### PR TITLE
[SPARK-32456][SS][FOLLOWUP] Update doc to note about using SQL statement with streaming Dataset

### DIFF
--- a/docs/structured-streaming-programming-guide.md
+++ b/docs/structured-streaming-programming-guide.md
@@ -861,9 +861,7 @@ isStreaming(df)
 </div>
 </div>
 
-You may want to check the logical plan of the query, as Spark converts the operation into another operation, which includes adding streaming aggregation. (e.g. count, distinct, union, etc.)
-
-If aggregation is injected, you may need to check your query for all the points you need to be aware of on streaming aggregation. (e.g. output mode, watermark, state store size maintenance, etc.)
+You may want to check the query plan of the query, as Spark could inject stateful operations during interpret of SQL statement against streaming dataset. Once stateful operations are injected in the query plan, you may need to check your query with considerations in stateful operations. (e.g. output mode, watermark, state store size maintenance, etc.)
 
 ### Window Operations on Event Time
 Aggregations over a sliding event-time window are straightforward with Structured Streaming and are very similar to grouped aggregations. In a grouped aggregation, aggregate values (e.g. counts) are maintained for each unique value in the user-specified grouping column. In case of window-based aggregations, aggregate values are maintained for each window the event-time of a row falls into. Let's understand this with an illustration. 

--- a/docs/structured-streaming-programming-guide.md
+++ b/docs/structured-streaming-programming-guide.md
@@ -861,6 +861,11 @@ isStreaming(df)
 </div>
 </div>
 
+You may want to check the logical plan of the query, as Spark converts the operation into another
+operation, which includes adding streaming aggregation. If aggregation is injected, you may need to
+check your query for all the points you need to be aware of on streaming aggregation.
+(e.g. output mode, watermark, state store size maintenance, etc.)
+
 ### Window Operations on Event Time
 Aggregations over a sliding event-time window are straightforward with Structured Streaming and are very similar to grouped aggregations. In a grouped aggregation, aggregate values (e.g. counts) are maintained for each unique value in the user-specified grouping column. In case of window-based aggregations, aggregate values are maintained for each window the event-time of a row falls into. Let's understand this with an illustration. 
 

--- a/docs/structured-streaming-programming-guide.md
+++ b/docs/structured-streaming-programming-guide.md
@@ -861,10 +861,9 @@ isStreaming(df)
 </div>
 </div>
 
-You may want to check the logical plan of the query, as Spark converts the operation into another
-operation, which includes adding streaming aggregation. If aggregation is injected, you may need to
-check your query for all the points you need to be aware of on streaming aggregation.
-(e.g. output mode, watermark, state store size maintenance, etc.)
+You may want to check the logical plan of the query, as Spark converts the operation into another operation, which includes adding streaming aggregation. (e.g. count, distinct, union, etc.)
+
+If aggregation is injected, you may need to check your query for all the points you need to be aware of on streaming aggregation. (e.g. output mode, watermark, state store size maintenance, etc.)
 
 ### Window Operations on Event Time
 Aggregations over a sliding event-time window are straightforward with Structured Streaming and are very similar to grouped aggregations. In a grouped aggregation, aggregate values (e.g. counts) are maintained for each unique value in the user-specified grouping column. In case of window-based aggregations, aggregate values are maintained for each window the event-time of a row falls into. Let's understand this with an illustration. 

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2534,9 +2534,9 @@ class Dataset[T] private[sql](
    * the state. In addition, too late data older than watermark will be dropped to avoid any
    * possibility of duplicates.
    *
-   * Note that for a streaming [[Dataset]], this method only returns distinct rows only once,
-   * regardless of the output mode. Spark may convert the `distinct` operation to aggregation`,
-   * and then the behavior will depend on the output mode, not exactly same as `dropDuplicates`.
+   * Note that for a streaming [[Dataset]], this method only returns distinct rows only once
+   * regardless of the output mode, which the behavior may not be same with using distinct in
+   * SQL statement against streaming [[Dataset]].
    *
    * @group typedrel
    * @since 2.0.0
@@ -2553,9 +2553,9 @@ class Dataset[T] private[sql](
    * the state. In addition, too late data older than watermark will be dropped to avoid any
    * possibility of duplicates.
    *
-   * Note that for a streaming [[Dataset]], this method only returns distinct rows only once,
-   * regardless of the output mode. Spark may convert the `distinct` operation to aggregation`,
-   * and then the behavior will depend on the output mode, not exactly same as `dropDuplicates`.
+   * Note that for a streaming [[Dataset]], this method only returns distinct rows only once
+   * regardless of the output mode, which the behavior may not be same with using distinct in
+   * SQL statement against streaming [[Dataset]].
    *
    * @group typedrel
    * @since 2.0.0
@@ -2588,9 +2588,9 @@ class Dataset[T] private[sql](
    * the state. In addition, too late data older than watermark will be dropped to avoid any
    * possibility of duplicates.
    *
-   * Note that for a streaming [[Dataset]], this method only returns distinct rows only once,
-   * regardless of the output mode. Spark may convert the `distinct` operation to aggregation`,
-   * and then the behavior will depend on the output mode, not exactly same as `dropDuplicates`.
+   * Note that for a streaming [[Dataset]], this method only returns distinct rows only once
+   * regardless of the output mode, which the behavior may not be same with using distinct in
+   * SQL statement against streaming [[Dataset]].
    *
    * @group typedrel
    * @since 2.0.0
@@ -2607,9 +2607,9 @@ class Dataset[T] private[sql](
    * the state. In addition, too late data older than watermark will be dropped to avoid any
    * possibility of duplicates.
    *
-   * Note that for a streaming [[Dataset]], this method only returns distinct rows only once,
-   * regardless of the output mode. Spark may convert the `distinct` operation to aggregation`,
-   * and then the behavior will depend on the output mode, not exactly same as `dropDuplicates`.
+   * Note that for a streaming [[Dataset]], this method only returns distinct rows only once
+   * regardless of the output mode, which the behavior may not be same with using distinct in
+   * SQL statement against streaming [[Dataset]].
    *
    * @group typedrel
    * @since 2.0.0

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2525,13 +2525,18 @@ class Dataset[T] private[sql](
 
   /**
    * Returns a new Dataset that contains only the unique rows from this Dataset.
-   * This is an alias for `distinct`.
+   * This is an alias for `distinct` on batch [[Dataset]]. For streaming [[Dataset]], it would show
+   * slightly different behavior. (see below)
    *
    * For a static batch [[Dataset]], it just drops duplicate rows. For a streaming [[Dataset]], it
    * will keep all data across triggers as intermediate state to drop duplicates rows. You can use
    * [[withWatermark]] to limit how late the duplicate data can be and system will accordingly limit
    * the state. In addition, too late data older than watermark will be dropped to avoid any
    * possibility of duplicates.
+   *
+   * Note that for a streaming [[Dataset]], this method only returns distinct rows only once,
+   * regardless of the output mode. Spark may convert the `distinct` operation to aggregation`,
+   * and then the behavior will depend on the output mode, not exactly same as `dropDuplicates`.
    *
    * @group typedrel
    * @since 2.0.0
@@ -2547,6 +2552,10 @@ class Dataset[T] private[sql](
    * [[withWatermark]] to limit how late the duplicate data can be and system will accordingly limit
    * the state. In addition, too late data older than watermark will be dropped to avoid any
    * possibility of duplicates.
+   *
+   * Note that for a streaming [[Dataset]], this method only returns distinct rows only once,
+   * regardless of the output mode. Spark may convert the `distinct` operation to aggregation`,
+   * and then the behavior will depend on the output mode, not exactly same as `dropDuplicates`.
    *
    * @group typedrel
    * @since 2.0.0
@@ -2579,6 +2588,10 @@ class Dataset[T] private[sql](
    * the state. In addition, too late data older than watermark will be dropped to avoid any
    * possibility of duplicates.
    *
+   * Note that for a streaming [[Dataset]], this method only returns distinct rows only once,
+   * regardless of the output mode. Spark may convert the `distinct` operation to aggregation`,
+   * and then the behavior will depend on the output mode, not exactly same as `dropDuplicates`.
+   *
    * @group typedrel
    * @since 2.0.0
    */
@@ -2593,6 +2606,10 @@ class Dataset[T] private[sql](
    * [[withWatermark]] to limit how late the duplicate data can be and system will accordingly limit
    * the state. In addition, too late data older than watermark will be dropped to avoid any
    * possibility of duplicates.
+   *
+   * Note that for a streaming [[Dataset]], this method only returns distinct rows only once,
+   * regardless of the output mode. Spark may convert the `distinct` operation to aggregation`,
+   * and then the behavior will depend on the output mode, not exactly same as `dropDuplicates`.
    *
    * @group typedrel
    * @since 2.0.0

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2525,18 +2525,13 @@ class Dataset[T] private[sql](
 
   /**
    * Returns a new Dataset that contains only the unique rows from this Dataset.
-   * This is an alias for `distinct` on batch [[Dataset]]. For streaming [[Dataset]], it would show
-   * slightly different behavior. (see below)
+   * This is an alias for `distinct`.
    *
    * For a static batch [[Dataset]], it just drops duplicate rows. For a streaming [[Dataset]], it
    * will keep all data across triggers as intermediate state to drop duplicates rows. You can use
    * [[withWatermark]] to limit how late the duplicate data can be and system will accordingly limit
    * the state. In addition, too late data older than watermark will be dropped to avoid any
    * possibility of duplicates.
-   *
-   * Note that for a streaming [[Dataset]], this method only returns distinct rows only once
-   * regardless of the output mode, which the behavior may not be same with using distinct in
-   * SQL statement against streaming [[Dataset]].
    *
    * @group typedrel
    * @since 2.0.0
@@ -2552,10 +2547,6 @@ class Dataset[T] private[sql](
    * [[withWatermark]] to limit how late the duplicate data can be and system will accordingly limit
    * the state. In addition, too late data older than watermark will be dropped to avoid any
    * possibility of duplicates.
-   *
-   * Note that for a streaming [[Dataset]], this method only returns distinct rows only once
-   * regardless of the output mode, which the behavior may not be same with using distinct in
-   * SQL statement against streaming [[Dataset]].
    *
    * @group typedrel
    * @since 2.0.0
@@ -2588,10 +2579,6 @@ class Dataset[T] private[sql](
    * the state. In addition, too late data older than watermark will be dropped to avoid any
    * possibility of duplicates.
    *
-   * Note that for a streaming [[Dataset]], this method only returns distinct rows only once
-   * regardless of the output mode, which the behavior may not be same with using distinct in
-   * SQL statement against streaming [[Dataset]].
-   *
    * @group typedrel
    * @since 2.0.0
    */
@@ -2606,10 +2593,6 @@ class Dataset[T] private[sql](
    * [[withWatermark]] to limit how late the duplicate data can be and system will accordingly limit
    * the state. In addition, too late data older than watermark will be dropped to avoid any
    * possibility of duplicates.
-   *
-   * Note that for a streaming [[Dataset]], this method only returns distinct rows only once
-   * regardless of the output mode, which the behavior may not be same with using distinct in
-   * SQL statement against streaming [[Dataset]].
    *
    * @group typedrel
    * @since 2.0.0
@@ -3148,8 +3131,12 @@ class Dataset[T] private[sql](
    * Returns a new Dataset that contains only the unique rows from this Dataset.
    * This is an alias for `dropDuplicates`.
    *
+   * Note that for a streaming [[Dataset]], this method only returns distinct rows only once
+   * regardless of the output mode, which the behavior may not be same with `DISTINCT` in SQL
+   * against streaming [[Dataset]].
+   *
    * @note Equality checking is performed directly on the encoded representation of the data
-   * and thus is not affected by a custom `equals` function defined on `T`.
+   * and thus is not affected by a custom equals function defined on `T`.
    *
    * @group typedrel
    * @since 2.0.0

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -3131,12 +3131,12 @@ class Dataset[T] private[sql](
    * Returns a new Dataset that contains only the unique rows from this Dataset.
    * This is an alias for `dropDuplicates`.
    *
-   * Note that for a streaming [[Dataset]], this method only returns distinct rows only once
+   * Note that for a streaming [[Dataset]], this method returns distinct rows only once
    * regardless of the output mode, which the behavior may not be same with `DISTINCT` in SQL
    * against streaming [[Dataset]].
    *
    * @note Equality checking is performed directly on the encoded representation of the data
-   * and thus is not affected by a custom equals function defined on `T`.
+   * and thus is not affected by a custom `equals` function defined on `T`.
    *
    * @group typedrel
    * @since 2.0.0


### PR DESCRIPTION
### What changes were proposed in this pull request?

This patch proposes to update the doc (both SS guide doc and Dataset dropDuplicates method doc) to leave a note to check on using SQL statements with streaming Dataset.

Once end users create a temp view based on streaming Dataset, they won't bother with thinking about "streaming" and do whatever they do with batch query. In many cases it works, but not just smoothly for the case when streaming aggregation is involved. They still need to concern about maintaining state store.

### Why are the changes needed?

Although SPARK-32456 fixed the weird error message, as a side effect some operations are enabled on streaming workload via SQL statement, which is error-prone if end users don't indicate what they're doing.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Only doc change.