### PR TITLE
[SPARK-32451][R][3.0] Support Apache Arrow 1.0.0

### DIFF
--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -1231,9 +1231,14 @@ setMethod("collect",
                 authSecret <- portAuth[[2]]
                 conn <- socketConnection(
                   port = port, blocking = TRUE, open = "wb", timeout = connectionTimeout)
+                version <- packageVersion("arrow")
                 output <- tryCatch({
                   doServerAuth(conn, authSecret)
-                  arrowTable <- arrow::read_arrow(readRaw(conn))
+                  if (version$minor >= 17 || version$major >= 1) {
+                    arrowTable <- arrow::read_ipc_stream(readRaw(conn))
+                  } else {
+                    arrowTable <- arrow::read_arrow(readRaw(conn))
+                  }
                   as.data.frame(arrowTable, stringsAsFactors = stringsAsFactors)
                 }, finally = {
                   close(conn)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR ports back https://github.com/apache/spark/pull/29252 to support Arrow 1.0.0.

Currently, SparkR with Arrow tests fails with the latest Arrow version in branch-3.0, see https://github.com/apache/spark/pull/29460/checks?check_run_id=996972267

### Why are the changes needed?

To support higher Arrow R version with SparkR.

### Does this PR introduce _any_ user-facing change?

Yes, users will be able to use SparkR with Arrow 1.0.0+.

### How was this patch tested?

Manually tested, GitHub Actions will test it.