### PR TITLE
[SPARK-32653][CORE] Decommissioned host/executor should be considered as inactive in TaskSchedulerImpl

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -1062,15 +1062,11 @@ private[spark] class TaskSchedulerImpl(
   }
 
   def getExecutorsAliveOnHost(host: String): Option[Set[String]] = synchronized {
-    if (isHostDecommissioned(host)) {
-      None
-    } else {
-      hostToExecutors.get(host).map(_.filterNot(isExecutorDecommissioned)).map(_.toSet)
-    }
+    hostToExecutors.get(host).map(_.filterNot(isExecutorDecommissioned)).map(_.toSet)
   }
 
   def hasExecutorsAliveOnHost(host: String): Boolean = synchronized {
-    !isHostDecommissioned(host) && hostToExecutors.get(host)
+    hostToExecutors.get(host)
       .exists(executors => executors.exists(e => !isExecutorDecommissioned(e)))
   }
 
@@ -1089,7 +1085,7 @@ private[spark] class TaskSchedulerImpl(
 
   // exposed for test
   protected def isExecutorDecommissioned(execId: String): Boolean =
-    isHostDecommissioned(executorIdToHost(execId)) || getExecutorDecommissionInfo(execId).nonEmpty
+    getExecutorDecommissionInfo(execId).nonEmpty || isHostDecommissioned(executorIdToHost(execId))
 
   // exposed for test
   protected def isHostDecommissioned(host: String): Boolean = {

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -1087,10 +1087,11 @@ private[spark] class TaskSchedulerImpl(
     executorIdToRunningTaskIds.get(execId).exists(_.nonEmpty)
   }
 
+  // exposed for test
   protected def isExecutorDecommissioned(execId: String): Boolean =
-    !isHostDecommissioned(executorIdToHost(execId)) &&
-      getExecutorDecommissionInfo(execId).nonEmpty
+    isHostDecommissioned(executorIdToHost(execId)) || getExecutorDecommissionInfo(execId).nonEmpty
 
+  // exposed for test
   protected def isHostDecommissioned(host: String): Boolean = {
     hostToExecutors.get(host).exists { executors =>
       executors.exists(e => getExecutorDecommissionInfo(e).exists(_.isHostDecommissioned))

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -1062,23 +1062,34 @@ private[spark] class TaskSchedulerImpl(
   }
 
   def getExecutorsAliveOnHost(host: String): Option[Set[String]] = synchronized {
-    hostToExecutors.get(host).map(_.toSet)
+    hostToExecutors.get(host).map(_.filterNot(isExecutorDecommissioned)).map(_.toSet)
   }
 
   def hasExecutorsAliveOnHost(host: String): Boolean = synchronized {
-    hostToExecutors.contains(host)
+      hostToExecutors.get(host)
+        .exists(executors => executors.exists(e => !isExecutorDecommissioned(e)))
   }
 
   def hasHostAliveOnRack(rack: String): Boolean = synchronized {
-    hostsByRack.contains(rack)
+    hostsByRack.get(rack)
+      .exists(hosts => hosts.exists(h => !isHostDecommissioned(h)))
   }
 
   def isExecutorAlive(execId: String): Boolean = synchronized {
-    executorIdToRunningTaskIds.contains(execId)
+    executorIdToRunningTaskIds.contains(execId) && !isExecutorDecommissioned(execId)
   }
 
   def isExecutorBusy(execId: String): Boolean = synchronized {
     executorIdToRunningTaskIds.get(execId).exists(_.nonEmpty)
+  }
+
+  private def isExecutorDecommissioned(execId: String): Boolean =
+    getExecutorDecommissionInfo(execId).nonEmpty
+
+  private def isHostDecommissioned(host: String): Boolean = {
+    hostToExecutors.get(host).exists { executors =>
+      executors.exists(e => getExecutorDecommissionInfo(e).exists(_.isHostDecommissioned))
+    }
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -1084,11 +1084,11 @@ private[spark] class TaskSchedulerImpl(
   }
 
   // exposed for test
-  protected def isExecutorDecommissioned(execId: String): Boolean =
-    getExecutorDecommissionInfo(execId).nonEmpty || isHostDecommissioned(executorIdToHost(execId))
+  protected final def isExecutorDecommissioned(execId: String): Boolean =
+    getExecutorDecommissionInfo(execId).nonEmpty
 
   // exposed for test
-  protected def isHostDecommissioned(host: String): Boolean = {
+  protected final def isHostDecommissioned(host: String): Boolean = {
     hostToExecutors.get(host).exists { executors =>
       executors.exists(e => getExecutorDecommissionInfo(e).exists(_.isHostDecommissioned))
     }

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -145,7 +145,7 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     taskScheduler
   }
 
-  test("SPARK-XXXX: Decommissioned host/executor should be considered as inactive") {
+  test("SPARK-32653: Decommissioned host/executor should be considered as inactive") {
     val scheduler = setupScheduler()
     val exec0 = "exec0"
     val exec1 = "exec1"

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -145,6 +145,33 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     taskScheduler
   }
 
+  test("SPARK-XXXX: Decommissioned host/executor should be considered as inactive") {
+    val scheduler = setupScheduler()
+    val exec0 = "exec0"
+    val exec1 = "exec1"
+    val exec2 = "exec2"
+    val host0 = "host0"
+    val host1 = "host1"
+    val workerOffers = IndexedSeq(
+      WorkerOffer(exec0, host0, 1),
+      WorkerOffer(exec1, host0, 1),
+      WorkerOffer(exec2, host1, 1))
+    scheduler.resourceOffers(workerOffers)
+    assert(Seq(exec0, exec1, exec2).forall(scheduler.isExecutorAlive))
+    assert(Seq(host0, host1).forall(scheduler.hasExecutorsAliveOnHost))
+    assert(scheduler.getExecutorsAliveOnHost(host0)
+      .exists(s => s.contains(exec0) && s.contains(exec1)))
+    assert(scheduler.getExecutorsAliveOnHost(host1).exists(_.contains(exec2)))
+
+    scheduler.executorDecommission(exec1, ExecutorDecommissionInfo("test", false))
+    scheduler.executorDecommission(exec2, ExecutorDecommissionInfo("test", true))
+
+    assert(scheduler.isExecutorAlive(exec0))
+    assert(!Seq(exec1, exec2).exists(scheduler.isExecutorAlive))
+    assert(scheduler.hasExecutorsAliveOnHost(host0))
+    assert(!scheduler.hasExecutorsAliveOnHost(host1))
+  }
+
   test("Scheduler does not always schedule tasks on the same workers") {
     val taskScheduler = setupScheduler()
     val numFreeCores = 1

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -149,13 +149,12 @@ class FakeTaskScheduler(sc: SparkContext, liveExecutors: (String, String)* /* ex
 
   override def taskSetFinished(manager: TaskSetManager): Unit = finishedManagers += manager
 
-  override def isExecutorAlive(execId: String): Boolean = executors.contains(execId)
+  override def isExecutorAlive(execId: String): Boolean =
+    executors.contains(execId) && !isExecutorDecommissioned(execId)
 
-  override def hasExecutorsAliveOnHost(host: String): Boolean = executors.values.exists(_ == host)
-
-  override def hasHostAliveOnRack(rack: String): Boolean = {
-    hostsByRack.get(rack) != None
-  }
+  override def hasExecutorsAliveOnHost(host: String): Boolean =
+    !isHostDecommissioned(host) && executors
+      .exists { case (e, h) => h == host && !isExecutorDecommissioned(e) }
 
   def addExecutor(execId: String, host: String): Unit = {
     executors.put(execId, host)
@@ -651,6 +650,33 @@ class TaskSetManagerSuite
     // And we'll shift to the new highest locality level, which is PROCESS_LOCAL in this case.
     assert(manager.resourceOffer("execC", "host3", ANY)._1.isEmpty)
     assert(manager.resourceOffer("execA", "host1", ANY)._1.isDefined)
+  }
+
+  test("SPARK-32653: Decommissioned host/executor should not be used to calculate locality " +
+    "levels") {
+    sc = new SparkContext("local", "test")
+    sched = new FakeTaskScheduler(sc)
+    val backend = mock(classOf[SchedulerBackend])
+    doNothing().when(backend).reviveOffers()
+    sched.initialize(backend)
+
+    val exec0 = "exec0"
+    val exec1 = "exec1"
+    val host0 = "host0"
+    sched.addExecutor(exec0, host0)
+    sched.addExecutor(exec1, host0)
+
+    val taskSet = FakeTask.createTaskSet(2,
+      Seq(TaskLocation(host0, exec0)),
+      Seq(TaskLocation(host0, exec1)))
+    sched.submitTasks(taskSet)
+    val manager = sched.taskSetManagerForAttempt(0, 0).get
+
+    assert(manager.myLocalityLevels === Array(PROCESS_LOCAL, NODE_LOCAL, ANY))
+
+    sched.executorDecommission(exec0, ExecutorDecommissionInfo("test", true))
+
+    assert(manager.myLocalityLevels === Array(ANY))
   }
 
   test("test RACK_LOCAL tasks") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Add decommissioning status checking for a host or executor while checking it's active or not. And a decommissioned host or executor should be considered as inactive.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

First of all, this PR is not a correctness bug fix but gives improvement indeed. And the main problem here we want to fix is that a decommissioned host or executor should be considered as inactive.

`TaskSetManager.computeValidLocalityLevels` depends on `TaskSchedulerImpl.isExecutorAlive/hasExecutorsAliveOnHost` to calculate the locality levels. Therefore, the `TaskSetManager` could also get corresponding locality levels of those decommissioned hosts or executors if they're not considered as inactive. However, on the other side,  `CoarseGrainedSchedulerBackend` won't construct the `WorkerOffer` for those decommissioned executors. That also means `TaskSetManager` might never have a chance to launch tasks at certain locality levels but only suffers the unnecessary delay because of delay scheduling. So, this PR helps to reduce this kind of unnecessary delay by making decommissioned host/executor inactive in `TaskSchedulerImpl`.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Added unit tests
