### PR TITLE
[SPARK-32661][K8S] Spark executors on K8S should request extra memory for off-heap allocations.

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
@@ -328,19 +328,9 @@ private[spark] object KubernetesUtils extends Logging {
   /**
    * Convert MEMORY_OFFHEAP_SIZE to MB Unit, return 0 if MEMORY_OFFHEAP_ENABLED is false.
    */
-  def executorOffHeapMemorySizeAsMb(kubernetesConf: KubernetesExecutorConf): Int = {
-    val sizeInMB = Utils.memoryStringToMb(kubernetesConf.get(MEMORY_OFFHEAP_SIZE).toString)
-    checkOffHeapEnabled(kubernetesConf, sizeInMB).toInt
-  }
-
-  /**
-   * return 0 if MEMORY_OFFHEAP_ENABLED is false.
-   */
-  def checkOffHeapEnabled(kubernetesConf: KubernetesExecutorConf, offHeapSize: Long): Long = {
+  def executorOffHeapMemorySizeAsMb(kubernetesConf: KubernetesConf): Int = {
     if (kubernetesConf.get(MEMORY_OFFHEAP_ENABLED)) {
-      require(offHeapSize > 0,
-        s"${MEMORY_OFFHEAP_SIZE.key} must be > 0 when ${MEMORY_OFFHEAP_ENABLED.key} == true")
-      offHeapSize
+      Utils.memoryStringToMb(kubernetesConf.get(MEMORY_OFFHEAP_SIZE).toString)
     } else {
       0
     }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
@@ -59,7 +59,8 @@ private[spark] class BasicExecutorFeatureStep(
     .getOrElse(math.max(
       (kubernetesConf.get(MEMORY_OVERHEAD_FACTOR) * executorMemoryMiB).toInt,
       MEMORY_OVERHEAD_MIN_MIB))
-  private val executorMemoryWithOverhead = executorMemoryMiB + memoryOverheadMiB
+  private val memoryOffHeapMiB = KubernetesUtils.executorOffHeapMemorySizeAsMb(kubernetesConf)
+  private val executorMemoryWithOverhead = executorMemoryMiB + memoryOverheadMiB + memoryOffHeapMiB
   private val executorMemoryTotal =
     if (kubernetesConf.get(APP_RESOURCE_TYPE) == Some(APP_RESOURCE_TYPE_PYTHON)) {
       executorMemoryWithOverhead +

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
@@ -205,6 +205,16 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
     assert(amountAndFormat(executor.container.getResources.getRequests.get("memory")) === "1450Mi")
   }
 
+  test("SPARK-32661 test executor offheap memory") {
+    baseConf.set(MEMORY_OFFHEAP_ENABLED, true)
+    baseConf.set("spark.memory.offHeap.size", "42m")
+
+    val step = new BasicExecutorFeatureStep(newExecutorConf(), new SecurityManager(baseConf))
+    val executor = step.configurePod(SparkPod.initialPod())
+    // This is checking that basic executor + executorMemory = 1408 + 42 = 1450
+    assert(amountAndFormat(executor.container.getResources.getRequests.get("memory")) === "1450Mi")
+  }
+
   test("auth secret propagation") {
     val conf = baseConf.clone()
       .set(config.NETWORK_AUTH_ENABLED, true)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Off-heap memory allocations are configured using `spark.memory.offHeap.enabled=true` and `conf spark.memory.offHeap.size=<size>`. Spark on YARN adds the off-heap memory size to the executor container resources. Spark on Kubernetes does not request the allocation of the off-heap memory. This PR proposes to make Spark on Kubernetes behave as Spark on YARN, that is by adding spark.memory.offHeap.size to the memory request for executor containers.

### Why are the changes needed?
Currently, this issue can be worked around by using `spark.executor.memoryOverhead` to reserve memory for off-heap allocations. This PR proposes to provide a more clean solution and align with Spark on YARN.

### Does this PR introduce _any_ user-facing change?
Yes: when running on K8S, the memory specifies in `spark.memory.offHeap.size` will be added to the executor container memory request.

### How was this patch tested?
Manually tested on a K8S cluster + a unit test is provided.