### PR TITLE
[K8s] Fix K8s integration test

### DIFF
--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DecommissionSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DecommissionSuite.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.deploy.k8s.integrationtest
 
 import org.apache.spark.internal.config
-import org.apache.spark.internal.config.Worker
 
 private[spark] trait DecommissionSuite { k8sSuite: KubernetesSuite =>
 
@@ -26,7 +25,7 @@ private[spark] trait DecommissionSuite { k8sSuite: KubernetesSuite =>
 
   test("Test basic decommissioning", k8sTestTag) {
     sparkAppConf
-      .set(Worker.WORKER_DECOMMISSION_ENABLED.key, "true")
+      .set(config.DECOMMISSION_ENABLED.key, "true")
       .set("spark.kubernetes.pyspark.pythonVersion", "3")
       .set("spark.kubernetes.container.image", pyImage)
       .set(config.STORAGE_DECOMMISSION_ENABLED.key, "true")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Apparently #29466 broke the K8s integration test:
```
[ERROR] [Error] /home/jenkins/workspace/SparkPullRequestBuilder-K8s/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DecommissionSuite.scala:29: value WORKER_DECOMMISSION_ENABLED is not a member of object org.apache.spark.internal.config.Worker
```
This PR fixes that.

### Why are the changes needed?

Enables running K8s integration tests again.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

K8s testing from Github