### PR TITLE
[SPARK-32662][ML] CountVectorizerModel: Remove requirement for minimum Vocab size

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
@@ -241,7 +241,10 @@ class CountVectorizer @Since("1.5.0") (@Since("1.5.0") override val uid: String)
     }
     wordCounts.unpersist()
 
-    require(vocab.length > 0, "The vocabulary size should be > 0. Lower minDF as necessary.")
+    if (vocab.isEmpty) {
+      this.logWarning("The vocabulary size is empty. " +
+        "If this was unexpected, you may wish to lower minDF (or) increase maxDF.")
+    }
     copyValues(new CountVectorizerModel(uid, vocab).setParent(this))
   }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/CountVectorizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/CountVectorizerSuite.scala
@@ -188,21 +188,6 @@ class CountVectorizerSuite extends MLTest with DefaultReadWriteTest {
     }
   }
 
-  test("CountVectorizer throws exception when vocab is empty") {
-    intercept[IllegalArgumentException] {
-      val df = Seq(
-        (0, split("a a b b c c")),
-        (1, split("aa bb cc"))
-      ).toDF("id", "words")
-      val cvModel = new CountVectorizer()
-        .setInputCol("words")
-        .setOutputCol("features")
-        .setVocabSize(3) // limit vocab size to 3
-        .setMinDF(3)
-        .fit(df)
-    }
-  }
-
   test("CountVectorizerModel with minTF count") {
     val df = Seq(
       (0, split("a a a b b c c c d "), Vectors.sparse(4, Seq((0, 3.0), (2, 3.0)))),
@@ -304,5 +289,64 @@ class CountVectorizerSuite extends MLTest with DefaultReadWriteTest {
     val interaction = new Interaction().setInputCols(Array("features1", "features2"))
       .setOutputCol("features")
     interaction.transform(df1)
+  }
+
+  test("SPARK-32662: Test on empty dataset") {
+    val df = Seq[(Int, Array[String])]().toDF("id", "words")
+    val cvModel = new CountVectorizer()
+      .setInputCol("words")
+      .setOutputCol("features")
+      .fit(df)
+    assert(cvModel.vocabulary.isEmpty === true)
+    val ans = cvModel.transform(df).select("features").collect()
+    assert(ans.length === 0)
+  }
+
+  test("SPARK-32662: Remove requirement for minimum vocabulary size") {
+    val df = Seq(
+      (0, Array[String]()),
+      (1, Array[String]())
+    ).toDF("id", "words")
+    val cvModel = new CountVectorizer()
+      .setInputCol("words")
+      .setOutputCol("features")
+      .fit(df)
+    assert(cvModel.vocabulary.isEmpty === true)
+    testTransformer[(Int, Seq[String])](df, cvModel, "features") {
+      case Row(features: Vector) =>
+        assert(features === Vectors.sparse(0, Seq()))
+    }
+
+    val df2 = Seq(
+      (0, Array("a", "b", "c")),
+      (1, Array("d", "e")),
+      (2, Array[String]())
+    ).toDF("id", "words")
+    val cvModel2 = new CountVectorizer()
+      .setInputCol("words")
+      .setOutputCol("features")
+      .setMinDF(2)
+      .fit(df2)
+    assert(cvModel2.vocabulary.isEmpty === true)
+    testTransformer[(Int, Seq[String])](df2, cvModel2, "features") {
+      case Row(features: Vector) =>
+        assert(features === Vectors.sparse(0, Seq()))
+    }
+
+    val df3 = Seq(
+      (0, Array("a")),
+      (1, Array("a")),
+      (2, Array("a"))
+    ).toDF("id", "words")
+    val cvModel3 = new CountVectorizer()
+      .setInputCol("words")
+      .setOutputCol("features")
+      .setMaxDF(2)
+      .fit(df3)
+    assert(cvModel3.vocabulary.isEmpty === true)
+    testTransformer[(Int, Seq[String])](df3, cvModel3, "features") {
+      case Row(features: Vector) =>
+        assert(features === Vectors.sparse(0, Seq()))
+    }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

The strict requirement for the vocabulary to remain non-empty has been removed in this pull request.

Link to the discussion: http://apache-spark-user-list.1001560.n3.nabble.com/Ability-to-have-CountVectorizerModel-vocab-as-empty-td38396.html

### Why are the changes needed?

This soothens running it across the corner cases. Without this, the user has to manupulate the data in genuine case, which may be a perfectly fine valid use-case.

Question: Should we a log when empty vocabulary is found instead?

### Does this PR introduce _any_ user-facing change?

May be a slight change. If someone has put a try-catch to detect an empty vocab. Then that behavior would no longer stand still.

### How was this patch tested?

1. Added testcase to `fit` generating an empty vocabulary
2. Added testcase to `transform` with empty vocabulary

Request to review: @srowen @hhbyyh 