### PR TITLE
[SPARK-32663][CORE] Avoid individual closing of pooled TransportClients (which must be closed through the pool)

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
@@ -175,8 +175,6 @@ public class ExternalBlockStoreClient extends BlockStoreClient {
           logger.warn("Error trying to remove RDD blocks " + Arrays.toString(blockIds) +
             " via external shuffle service from executor: " + execId, t);
           numRemovedBlocksFuture.complete(0);
-        } finally {
-          client.close();
         }
       }
 
@@ -185,7 +183,6 @@ public class ExternalBlockStoreClient extends BlockStoreClient {
         logger.warn("Error trying to remove RDD blocks " + Arrays.toString(blockIds) +
           " via external shuffle service from executor: " + execId, e);
         numRemovedBlocksFuture.complete(0);
-        client.close();
       }
     });
     return numRemovedBlocksFuture;
@@ -212,8 +209,6 @@ public class ExternalBlockStoreClient extends BlockStoreClient {
               Arrays.toString(getLocalDirsMessage.execIds) + " via external shuffle service",
               t.getCause());
             hostLocalDirsCompletable.completeExceptionally(t);
-          } finally {
-            client.close();
           }
         }
 
@@ -223,7 +218,6 @@ public class ExternalBlockStoreClient extends BlockStoreClient {
             Arrays.toString(getLocalDirsMessage.execIds) + " via external shuffle service",
             t.getCause());
           hostLocalDirsCompletable.completeExceptionally(t);
-          client.close();
         }
       });
     } catch (IOException | InterruptedException e) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Removing the individual `close` method calls on the pooled `TransportClient` instances. 
The pooled clients should be only closed via `TransportClientFactory#close()`.

### Why are the changes needed?

Reusing a closed `TransportClient` leads to the exception `java.nio.channels.ClosedChannelException`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

This is a trivial case which is not tested by specific test.