### PR TITLE
[SPARK-32678][SQL] Rename EmptyHashedRelationWithAllNullKeys and simplify NAAJ generated code

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/EliminateNullAwareAntiJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/EliminateNullAwareAntiJoin.scala
@@ -20,17 +20,17 @@ package org.apache.spark.sql.execution.adaptive
 import org.apache.spark.sql.catalyst.planning.ExtractSingleColumnNullAwareAntiJoin
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.execution.joins.EmptyHashedRelationWithAllNullKeys
+import org.apache.spark.sql.execution.joins.HashedRelationWithAllNullKeys
 
 /**
  * This optimization rule detects and convert a NAAJ to an Empty LocalRelation
- * when buildSide is EmptyHashedRelationWithAllNullKeys.
+ * when buildSide is HashedRelationWithAllNullKeys.
  */
 object EliminateNullAwareAntiJoin extends Rule[LogicalPlan] {
 
   private def canEliminate(plan: LogicalPlan): Boolean = plan match {
     case LogicalQueryStage(_, stage: BroadcastQueryStageExec) if stage.resultOption.get().isDefined
-      && stage.broadcast.relationFuture.get().value == EmptyHashedRelationWithAllNullKeys => true
+      && stage.broadcast.relationFuture.get().value == HashedRelationWithAllNullKeys => true
     case _ => false
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
@@ -472,7 +472,7 @@ private[joins] object UnsafeHashedRelation {
           // scalastyle:on throwerror
         }
       } else if (isNullAware) {
-        return EmptyHashedRelationWithAllNullKeys
+        return HashedRelationWithAllNullKeys
       }
     }
 
@@ -1056,7 +1056,7 @@ private[joins] object LongHashedRelation {
         val key = rowKey.getLong(0)
         map.append(key, unsafeRow)
       } else if (isNullAware) {
-        return EmptyHashedRelationWithAllNullKeys
+        return HashedRelationWithAllNullKeys
       }
     }
     map.optimize()
@@ -1067,7 +1067,7 @@ private[joins] object LongHashedRelation {
 /**
  * Common trait with dummy implementation for NAAJ special HashedRelation
  * EmptyHashedRelation
- * EmptyHashedRelationWithAllNullKeys
+ * HashedRelationWithAllNullKeys
  */
 trait NullAwareHashedRelation extends HashedRelation with Externalizable {
   override def get(key: InternalRow): Iterator[InternalRow] = {
@@ -1130,8 +1130,8 @@ object EmptyHashedRelation extends NullAwareHashedRelation {
  * A special HashedRelation indicates it built from a non-empty input:Iterator[InternalRow],
  * which contains all null columns key.
  */
-object EmptyHashedRelationWithAllNullKeys extends NullAwareHashedRelation {
-  override def asReadOnlyCopy(): EmptyHashedRelationWithAllNullKeys.type = this
+object HashedRelationWithAllNullKeys extends NullAwareHashedRelation {
+  override def asReadOnlyCopy(): HashedRelationWithAllNullKeys.type = this
 }
 
 /** The HashedRelationBroadcastMode requires that rows are broadcasted as a HashedRelation. */

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -1168,7 +1168,7 @@ class AdaptiveQueryExecSuite
     }
   }
 
-  test("SPARK-32573: Eliminate NAAJ when BuildSide is EmptyHashedRelationWithAllNullKeys") {
+  test("SPARK-32573: Eliminate NAAJ when BuildSide is HashedRelationWithAllNullKeys") {
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> Long.MaxValue.toString) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Some Code refine.

1. rename EmptyHashedRelationWithAllNullKeys to HashedRelationWithAllNullKeys.
2. simplify generated code for BHJ NAAJ.

### Why are the changes needed?
Refine code and naming to avoid confusing understanding.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing test.