### PR TITLE
[SPARK-32608][SQL][FOLLOW-UP][test-hadoop2.7][test-hive1.2] Script Transform ROW FORMAT DELIMIT value should format value 

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/BaseScriptTransformationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/BaseScriptTransformationSuite.scala
@@ -345,7 +345,7 @@ abstract class BaseScriptTransformationSuite extends SparkPlanTest with SQLTestU
           'a.cast("string"),
           'b.cast("string"),
           'c.cast("string"),
-          decimalToString('d),
+          'd.cast("string"),
           'e.cast("string")).collect())
 
       // input/output with different delimit and show result
@@ -368,7 +368,7 @@ abstract class BaseScriptTransformationSuite extends SparkPlanTest with SQLTestU
             'a.cast("string"),
             'b.cast("string"),
             'c.cast("string"),
-            decimalToString('d),
+            'd.cast("string"),
             'e.cast("string"))).collect())
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
As mentioned in https://github.com/apache/spark/pull/29428#issuecomment-678735163 by @viirya , 
fix bug in UT, since in script transformation no-serde mode, output of decimal is same in both hive-1.2/hive-2.3


### Why are the changes needed?
FIX UT


### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
EXISTED UT
