### PR TITLE
[SPARK-32608][SQL][3.0][FOLLOW-UP][test-hadoop2.7][test-hive1.2] Script Transform ROW FORMAT DELIMIT value should format value

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/ScriptTransformationSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/ScriptTransformationSuite.scala
@@ -299,7 +299,7 @@ class ScriptTransformationSuite extends SparkPlanTest with SQLTestUtils with Tes
           'a.cast("string"),
           'b.cast("string"),
           'c.cast("string"),
-          decimalToString('d),
+          'd.cast("string"),
           'e.cast("string")).collect())
 
       // input/output with different delimit and show result
@@ -322,7 +322,7 @@ class ScriptTransformationSuite extends SparkPlanTest with SQLTestUtils with Tes
             'a.cast("string"),
             'b.cast("string"),
             'c.cast("string"),
-            decimalToString('d),
+            'd.cast("string"),
             'e.cast("string"))).collect())
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
As mentioned in https://github.com/apache/spark/pull/29428#issuecomment-678735163 by @viirya , 
fix bug in UT, since in script transformation no-serde mode, output of decimal is same in both hive-1.2/hive-2.3


### Why are the changes needed?
FIX UT


### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
EXISTED UT
