### PR TITLE
[SPARK-32641][SQL] withField + getField should return null if original struct was null

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/ComplexTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/ComplexTypes.scala
@@ -47,7 +47,8 @@ object SimplifyExtractValueOps extends Rule[LogicalPlan] {
           // For example, if a user submits a query like this:
           // `$"struct_col".withField("b", lit(1)).withField("b", lit(2)).getField("b")`
           // we want to return `lit(2)` (and not `lit(1)`).
-          matches.last._2
+          val expr = matches.last._2
+          If(IsNull(struct), Literal(null, expr.dataType), expr)
         } else {
           GetStructField(struct, ordinal, maybeName)
         }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/complexTypesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/complexTypesSuite.scala
@@ -453,46 +453,78 @@ class ComplexTypesSuite extends PlanTest with ExpressionEvalHelper {
     checkEvaluation(GetMapValue(mb0, Literal(Array[Byte](3, 4))), null)
   }
 
-  private val structAttr = 'struct1.struct('a.int)
+  private val structAttr = AttributeReference("struct1",
+    StructType(Seq(StructField("a", IntegerType, nullable = false))), nullable = false)()
   private val testStructRelation = LocalRelation(structAttr)
 
+  private val nullableStructAttr = 'struct1.struct('a.int)
+  private val testNullableStructRelation = LocalRelation(nullableStructAttr)
+
   test("simplify GetStructField on WithFields that is not changing the attribute being extracted") {
-    val query = testStructRelation.select(
-      GetStructField(WithFields('struct1, Seq("b"), Seq(Literal(1))), 0, Some("a")) as "outerAtt")
-    val expected = testStructRelation.select(GetStructField('struct1, 0, Some("a")) as "outerAtt")
-    checkRule(query, expected)
+    def query(relation: LocalRelation): LogicalPlan = relation.select(
+      GetStructField(WithFields('struct1, Seq("b"), Seq(Literal(1))), 0, Some("a")) as "outerAttr")
+
+    checkRule(
+      query(testStructRelation),
+      testStructRelation.select(GetStructField('struct1, 0, Some("a")) as "outerAttr"))
+
+    checkRule(
+      query(testNullableStructRelation),
+      testNullableStructRelation.select(GetStructField('struct1, 0, Some("a")) as "outerAttr"))
   }
 
   test("simplify GetStructField on WithFields that is changing the attribute being extracted") {
-    val query = testStructRelation.select(
-      GetStructField(WithFields('struct1, Seq("b"), Seq(Literal(1))), 1, Some("b")) as "outerAtt")
-    val expected = testStructRelation.select(Literal(1) as "outerAtt")
-    checkRule(query, expected)
+    def query(relation: LocalRelation): LogicalPlan = relation.select(
+      GetStructField(WithFields('struct1, Seq("b"), Seq(Literal(1))), 1, Some("b")) as "res")
+
+    checkRule(
+      query(testStructRelation),
+      testStructRelation.select(Literal(1) as "res"))
+
+    checkRule(
+      query(testNullableStructRelation),
+      testNullableStructRelation.select(
+        If(IsNull('struct1), Literal(null, IntegerType), Literal(1)) as "res"))
   }
 
   test(
     "simplify GetStructField on WithFields that is changing the attribute being extracted twice") {
-    val query = testStructRelation
-      .select(GetStructField(WithFields('struct1, Seq("b", "b"), Seq(Literal(1), Literal(2))), 1,
-        Some("b")) as "outerAtt")
-    val expected = testStructRelation.select(Literal(2) as "outerAtt")
-    checkRule(query, expected)
+    def query(relation: LocalRelation): LogicalPlan = relation.select(
+      GetStructField(WithFields('struct1, Seq("b", "b"), Seq(Literal(1), Literal(2))), 1, Some("b"))
+        as "outerAtt")
+
+    checkRule(
+      query(testStructRelation),
+      testStructRelation.select(Literal(2) as "outerAtt"))
+
+    checkRule(
+      query(testNullableStructRelation),
+      testNullableStructRelation.select(
+        If(IsNull('struct1), Literal(null, IntegerType), Literal(2)) as "outerAtt"))
   }
 
   test("collapse multiple GetStructField on the same WithFields") {
-    val query = testStructRelation
+    def query(relation: LocalRelation): LogicalPlan = relation
       .select(WithFields('struct1, Seq("b"), Seq(Literal(2))) as "struct2")
       .select(
         GetStructField('struct2, 0, Some("a")) as "struct1A",
         GetStructField('struct2, 1, Some("b")) as "struct1B")
-    val expected = testStructRelation.select(
-      GetStructField('struct1, 0, Some("a")) as "struct1A",
-      Literal(2) as "struct1B")
-    checkRule(query, expected)
+
+    checkRule(
+      query(testStructRelation),
+      testStructRelation.select(
+        GetStructField('struct1, 0, Some("a")) as "struct1A",
+        Literal(2) as "struct1B"))
+
+    checkRule(
+      query(testNullableStructRelation),
+      testNullableStructRelation.select(
+        GetStructField('struct1, 0, Some("a")) as "struct1A",
+        If(IsNull('struct1), Literal(null, IntegerType), Literal(2)) as "struct1B"))
   }
 
   test("collapse multiple GetStructField on different WithFields") {
-    val query = testStructRelation
+    def query(relation: LocalRelation): LogicalPlan = relation
       .select(
         WithFields('struct1, Seq("b"), Seq(Literal(2))) as "struct2",
         WithFields('struct1, Seq("b"), Seq(Literal(3))) as "struct3")
@@ -501,12 +533,23 @@ class ComplexTypesSuite extends PlanTest with ExpressionEvalHelper {
         GetStructField('struct2, 1, Some("b")) as "struct2B",
         GetStructField('struct3, 0, Some("a")) as "struct3A",
         GetStructField('struct3, 1, Some("b")) as "struct3B")
-    val expected = testStructRelation
-      .select(
-        GetStructField('struct1, 0, Some("a")) as "struct2A",
-        Literal(2) as "struct2B",
-        GetStructField('struct1, 0, Some("a")) as "struct3A",
-        Literal(3) as "struct3B")
-    checkRule(query, expected)
+
+    checkRule(
+      query(testStructRelation),
+      testStructRelation
+        .select(
+          GetStructField('struct1, 0, Some("a")) as "struct2A",
+          Literal(2) as "struct2B",
+          GetStructField('struct1, 0, Some("a")) as "struct3A",
+          Literal(3) as "struct3B"))
+
+    checkRule(
+      query(testNullableStructRelation),
+      testNullableStructRelation
+        .select(
+          GetStructField('struct1, 0, Some("a")) as "struct2A",
+          If(IsNull('struct1), Literal(null, IntegerType), Literal(2)) as "struct2B",
+          GetStructField('struct1, 0, Some("a")) as "struct3A",
+          If(IsNull('struct1), Literal(null, IntegerType), Literal(3)) as "struct3B"))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/complexTypesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/complexTypesSuite.scala
@@ -453,8 +453,7 @@ class ComplexTypesSuite extends PlanTest with ExpressionEvalHelper {
     checkEvaluation(GetMapValue(mb0, Literal(Array[Byte](3, 4))), null)
   }
 
-  private val structAttr = AttributeReference("struct1",
-    StructType(Seq(StructField("a", IntegerType, nullable = false))), nullable = false)()
+  private val structAttr = 'struct1.struct('a.int).withNullability(false)
   private val testStructRelation = LocalRelation(structAttr)
 
   private val nullableStructAttr = 'struct1.struct('a.int)

--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -1509,7 +1509,9 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
 
   test("SPARK-32641: extracting field from nullable struct column which contains both null and " +
     "non-null values after withField should return null if the original struct was null") {
-    val df = structLevel1.union(nullStructLevel1).cache()
+    val df = spark.createDataFrame(
+      sparkContext.parallelize(Row(Row(1, null, 3)) :: Row(null) :: Nil),
+      StructType(Seq(StructField("a", structType, nullable = true))))
 
     // extract newly added field
     checkAnswerAndSchema(
@@ -1534,7 +1536,5 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
       df.withColumn("a", $"a".withField("a", lit(4)).getField("c")),
       Row(3) :: Row(null):: Nil,
       StructType(Seq(StructField("a", IntegerType, nullable = true))))
-
-    df.unpersist()
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -1452,4 +1452,89 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
         .select($"struct_col".withField("a.c", lit(3)))
     }.getMessage should include("Ambiguous reference to fields")
   }
+
+  test("SPARK-32641: extracting field from non-null struct column after withField should return " +
+    "field value") {
+    // extract newly added field
+    checkAnswerAndSchema(
+      structLevel1.withColumn("a", $"a".withField("d", lit(4)).getField("d")),
+      Row(4) :: Nil,
+      StructType(Seq(StructField("a", IntegerType, nullable = false))))
+
+    // extract newly replaced field
+    checkAnswerAndSchema(
+      structLevel1.withColumn("a", $"a".withField("a", lit(4)).getField("a")),
+      Row(4) :: Nil,
+      StructType(Seq(StructField("a", IntegerType, nullable = false))))
+
+    // add new field, extract another field from original struct
+    checkAnswerAndSchema(
+      structLevel1.withColumn("a", $"a".withField("d", lit(4)).getField("c")),
+      Row(3):: Nil,
+      StructType(Seq(StructField("a", IntegerType, nullable = false))))
+
+    // replace field, extract another field from original struct
+    checkAnswerAndSchema(
+      structLevel1.withColumn("a", $"a".withField("a", lit(4)).getField("c")),
+      Row(3):: Nil,
+      StructType(Seq(StructField("a", IntegerType, nullable = false))))
+  }
+
+  test("SPARK-32641: extracting field from null struct column after withField should return " +
+    "null if the original struct was null") {
+    // extract newly added field
+    checkAnswerAndSchema(
+      nullStructLevel1.withColumn("a", $"a".withField("d", lit(4)).getField("d")),
+      Row(null) :: Nil,
+      StructType(Seq(StructField("a", IntegerType, nullable = true))))
+
+    // extract newly replaced field
+    checkAnswerAndSchema(
+      nullStructLevel1.withColumn("a", $"a".withField("a", lit(4)).getField("a")),
+      Row(null):: Nil,
+      StructType(Seq(StructField("a", IntegerType, nullable = true))))
+
+    // add new field, extract another field from original struct
+    checkAnswerAndSchema(
+      nullStructLevel1.withColumn("a", $"a".withField("d", lit(4)).getField("c")),
+      Row(null):: Nil,
+      StructType(Seq(StructField("a", IntegerType, nullable = true))))
+
+    // replace field, extract another field from original struct
+    checkAnswerAndSchema(
+      nullStructLevel1.withColumn("a", $"a".withField("a", lit(4)).getField("c")),
+      Row(null):: Nil,
+      StructType(Seq(StructField("a", IntegerType, nullable = true))))
+  }
+
+  test("SPARK-32641: extracting field from nullable struct column which contains both null and " +
+    "non-null values after withField should return null if the original struct was null") {
+    val df = structLevel1.union(nullStructLevel1).cache()
+
+    // extract newly added field
+    checkAnswerAndSchema(
+      df.withColumn("a", $"a".withField("d", lit(4)).getField("d")),
+      Row(4) :: Row(null) :: Nil,
+      StructType(Seq(StructField("a", IntegerType, nullable = true))))
+
+    // extract newly replaced field
+    checkAnswerAndSchema(
+      df.withColumn("a", $"a".withField("a", lit(4)).getField("a")),
+      Row(4) :: Row(null):: Nil,
+      StructType(Seq(StructField("a", IntegerType, nullable = true))))
+
+    // add new field, extract another field from original struct
+    checkAnswerAndSchema(
+      df.withColumn("a", $"a".withField("d", lit(4)).getField("c")),
+      Row(3) :: Row(null):: Nil,
+      StructType(Seq(StructField("a", IntegerType, nullable = true))))
+
+    // replace field, extract another field from original struct
+    checkAnswerAndSchema(
+      df.withColumn("a", $"a".withField("a", lit(4)).getField("c")),
+      Row(3) :: Row(null):: Nil,
+      StructType(Seq(StructField("a", IntegerType, nullable = true))))
+
+    df.unpersist()
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
There is a bug in the way the optimizer rule in `SimplifyExtractValueOps` is currently written in master branch which yields incorrect results in scenarios like the following: 
```
sql("SELECT CAST(NULL AS struct<a:int,b:int>) struct_col")
.select($"struct_col".withField("d", lit(4)).getField("d").as("d"))

// currently returns this:
+---+
|d  |
+---+
|4  |
+---+

// when in fact it should return this: 
+----+
|d   |
+----+
|null|
+----+
```
The changes in this PR will fix this bug. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To fix the aforementioned bug. Optimizer rules should improve the performance of the  query but yield exactly the same results. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, this bug will no longer occur. 
That said, this isn't something to be concerned about as this bug was introduced in Spark 3.1 and Spark 3.1 has yet to be released. 

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit tests were added. Jenkins must pass them. 