### PR TITLE
[SPARK-32594][SQL][FOLLOWUP][test-hadoop2.7][test-hive1.2] Override `get()` and use Julian days in `DaysWritable`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DaysWritable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DaysWritable.scala
@@ -54,6 +54,9 @@ class DaysWritable(
   }
 
   override def getDays: Int = julianDays
+  override def get: Date = {
+    new Date(DateWritable.daysToMillis(julianDays))
+  }
   override def get(doesTimeMatter: Boolean): Date = {
     new Date(DateWritable.daysToMillis(julianDays, doesTimeMatter))
   }

--- a/sql/core/v1.2/src/main/scala/org/apache/spark/sql/execution/datasources/orc/DaysWritable.scala
+++ b/sql/core/v1.2/src/main/scala/org/apache/spark/sql/execution/datasources/orc/DaysWritable.scala
@@ -59,7 +59,9 @@ class DaysWritable(
   }
 
   override def getDays: Int = julianDays
-  override def get(): Date = new Date(DateWritable.daysToMillis(julianDays))
+  override def get(doesTimeMatter: Boolean): Date = {
+    new Date(DateWritable.daysToMillis(julianDays, doesTimeMatter))
+  }
 
   override def set(d: Int): Unit = {
     gregorianDays = d

--- a/sql/core/v1.2/src/main/scala/org/apache/spark/sql/execution/datasources/orc/DaysWritable.scala
+++ b/sql/core/v1.2/src/main/scala/org/apache/spark/sql/execution/datasources/orc/DaysWritable.scala
@@ -59,9 +59,7 @@ class DaysWritable(
   }
 
   override def getDays: Int = julianDays
-  override def get(doesTimeMatter: Boolean): Date = {
-    new Date(DateWritable.daysToMillis(julianDays, doesTimeMatter))
-  }
+  override def get(): Date = new Date(DateWritable.daysToMillis(julianDays))
 
   override def set(d: Int): Unit = {
     gregorianDays = d


### PR DESCRIPTION
### What changes were proposed in this pull request?
Override `def get: Date` in `DaysWritable` use the `daysToMillis(int d)` from the parent class `DateWritable` instead of `long daysToMillis(int d, boolean doesTimeMatter)`.


### Why are the changes needed?
It fixes failures of `HiveSerDeReadWriteSuite` with the profile `hive-1.2`. In that case, the parent class `DateWritable` has different implementation before the commit to Hive https://github.com/apache/hive/commit/da3ed68eda10533f3c50aae19731ac6d059cda87. In particular, `get()` calls `new Date(daysToMillis(daysSinceEpoch))` instead of overrided `def get(doesTimeMatter: Boolean): Date` in the child class. The `get()` method returns wrong result `1970-01-01` because it uses not updated `daysSinceEpoch`.

### Does this PR introduce _any_ user-facing change?
Yes.

### How was this patch tested?
By running the test suite `HiveSerDeReadWriteSuite`:
```
$ build/sbt -Phive-1.2 -Phadoop-2.7 "test:testOnly org.apache.spark.sql.hive.execution.HiveSerDeReadWriteSuite"
```
and 
```
$ build/sbt -Phive-2.3 -Phadoop-2.7 "test:testOnly org.apache.spark.sql.hive.execution.HiveSerDeReadWriteSuite"
```