### PR TITLE
[SPARK-32695][INFRA] Explicitly cache and hash 'build' directly in GitHub Actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -102,7 +102,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: build
-        key: build-${{ hashFiles('**/pom.xml') }}
+        key: build-${{ hashFiles('**/pom.xml') }}-${{ hashFiles('project/build.properties') }}-${{ hashFiles('build') }}
         restore-keys: |
           build-
     - name: Cache Maven local repository

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -106,13 +106,7 @@ jobs:
           build/zinc-*
           build/scala-*
           build/*.jar
-        key: >-
-          build-${{ hashFiles('**/pom.xml') }}
-          -${{ hashFiles('project/build.properties') }}
-          -${{ hashFiles('build/mvn') }}
-          -${{ hashFiles('build/sbt') }}
-          -${{ hashFiles('build/sbt-launch-lib.bash') }}
-          -${{ hashFiles('build/spark-build-info') }}
+        key: build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
         restore-keys: |
           build-
     - name: Cache Maven local repository
@@ -126,7 +120,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.ivy2/cache
-        key: ${{ matrix.java }}-${{ matrix.hadoop }}-ivy-${{ hashFiles('**/pom.xml') }}-${{ hashFiles('**/plugins.sbt') }}
+        key: ${{ matrix.java }}-${{ matrix.hadoop }}-ivy-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
         restore-keys: |
           ${{ matrix.java }}-${{ matrix.hadoop }}-ivy-
     - name: Install JDK ${{ matrix.java }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -99,10 +99,20 @@ jobs:
       run: git merge --progress --ff-only origin/${{ github.event.inputs.target }}
     # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
     - name: Cache Scala, SBT, Maven and Zinc
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
-        path: build
-        key: build-${{ hashFiles('**/pom.xml') }}-${{ hashFiles('project/build.properties') }}-${{ hashFiles('build') }}
+        path: |
+          build/apache-maven-*
+          build/zinc-*
+          build/scala-*
+          build/*.jar
+        key: >-
+          build-${{ hashFiles('**/pom.xml') }}
+          -${{ hashFiles('project/build.properties') }}
+          -${{ hashFiles('build/mvn') }}
+          -${{ hashFiles('build/sbt') }}
+          -${{ hashFiles('build/sbt-launch-lib.bash') }}
+          -${{ hashFiles('build/spark-build-info') }}
         restore-keys: |
           build-
     - name: Cache Maven local repository

--- a/build/mvn
+++ b/build/mvn
@@ -17,8 +17,6 @@
 # limitations under the License.
 #
 
-# Change in build
-
 # Determine the current working directory
 _DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Preserve the calling directory

--- a/build/mvn
+++ b/build/mvn
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+# Change in build
+
 # Determine the current working directory
 _DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Preserve the calling directory


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to explicitly cache and hash the files/directories under 'build' for SBT and Zinc at GitHub Actions. Otherwise, it can end up with overwriting `build` directory. See also https://github.com/apache/spark/pull/29286#issuecomment-679368436

Previously, other files like `build/mvn` and `build/sbt` are also cached and overwritten. So, when you have some changes there, they are ignored.

### Why are the changes needed?

To make GitHub Actions build stable.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

The builds in this PR test it out.
