### PR TITLE
[SPARK-32698][SQL] Do not fall back to default parallelism if the minimum number of coalesced partitions is not set in AQE

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
@@ -62,10 +62,7 @@ case class CoalesceShufflePartitions(session: SparkSession) extends Rule[SparkPl
       val distinctNumPreShufflePartitions =
         validMetrics.map(stats => stats.bytesByPartitionId.length).distinct
       if (validMetrics.nonEmpty && distinctNumPreShufflePartitions.length == 1) {
-        // We fall back to Spark default parallelism if the minimum number of coalesced partitions
-        // is not set, so to avoid perf regressions compared to no coalescing.
         val minPartitionNum = conf.getConf(SQLConf.COALESCE_PARTITIONS_MIN_PARTITION_NUM)
-          .getOrElse(session.sparkContext.defaultParallelism)
         val partitionSpecs = ShufflePartitionsUtil.coalescePartitions(
           validMetrics.toArray,
           advisoryTargetSize = conf.getConf(SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ShufflePartitionsUtil.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ShufflePartitionsUtil.scala
@@ -56,7 +56,7 @@ object ShufflePartitionsUtil extends Logging {
   def coalescePartitions(
       mapOutputStatistics: Array[MapOutputStatistics],
       advisoryTargetSize: Long,
-      minNumPartitions: Int): Seq[ShufflePartitionSpec] = {
+      minNumPartitions: Option[Int]): Seq[ShufflePartitionSpec] = {
     // If `minNumPartitions` is very large, it is possible that we need to use a value less than
     // `advisoryTargetSize` as the target size of a coalesced task.
     val totalPostShuffleInputSize = mapOutputStatistics.map(_.bytesByPartitionId.sum).sum
@@ -64,9 +64,11 @@ object ShufflePartitionsUtil extends Logging {
     // coalesced partition.
     // There is no particular reason that we pick 16. We just need a number to prevent
     // `maxTargetSize` from being set to 0.
-    val maxTargetSize = math.max(
-      math.ceil(totalPostShuffleInputSize / minNumPartitions.toDouble).toLong, 16)
-    val targetSize = math.min(maxTargetSize, advisoryTargetSize)
+    val targetSize = minNumPartitions.map { num =>
+      val maxTargetSize = math.max(
+        math.ceil(totalPostShuffleInputSize / num.toDouble).toLong, 16)
+      math.min(maxTargetSize, advisoryTargetSize)
+    }.getOrElse(advisoryTargetSize)
 
     val shuffleIds = mapOutputStatistics.map(_.shuffleId).mkString(", ")
     logInfo(s"For shuffle($shuffleIds), advisory target size: $advisoryTargetSize, " +

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ShufflePartitionsUtilSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ShufflePartitionsUtilSuite.scala
@@ -34,7 +34,7 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
     val estimatedPartitionStartIndices = ShufflePartitionsUtil.coalescePartitions(
       mapOutputStatistics,
       targetSize,
-      minNumPartitions)
+      Some(minNumPartitions))
     assert(estimatedPartitionStartIndices === expectedPartitionStartIndices)
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

When the minimum number of coalesced partitions is not set in AQE, we do not fall back to default parallelism but coalesce partitions towards the `advisoryTargetSize`.


### Why are the changes needed?

The default parallelism is usually the number of total executors cores which might be different across different runs of the same job when dynamic allocation is enabled. It results in uncertainty of the number of tasks after coalescing and leads to many small output files in some cases. The behavior is complex and hard to reason about.

Hence, I'm proposing not falling back to the default parallelism but coalescing towards the `advisoryTargetSize` when the minimum number of coalesced partitions is not set.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing Tests.
