### PR TITLE
[SPARK-32705][SQL] Fix serialization issue for EmptyHashedRelation

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
@@ -71,7 +71,9 @@ private[execution] sealed trait HashedRelation extends KnownSizeEstimation {
    *
    * Returns null if there is no matched rows.
    */
-  def getWithKeyIndex(key: InternalRow): Iterator[ValueRowWithKeyIndex]
+  def getWithKeyIndex(key: InternalRow): Iterator[ValueRowWithKeyIndex] = {
+    throw new UnsupportedOperationException
+  }
 
   /**
    * Returns key index and matched single row.
@@ -79,17 +81,23 @@ private[execution] sealed trait HashedRelation extends KnownSizeEstimation {
    *
    * Returns null if there is no matched rows.
    */
-  def getValueWithKeyIndex(key: InternalRow): ValueRowWithKeyIndex
+  def getValueWithKeyIndex(key: InternalRow): ValueRowWithKeyIndex = {
+    throw new UnsupportedOperationException
+  }
 
   /**
    * Returns an iterator for keys index and rows of InternalRow type.
    */
-  def valuesWithKeyIndex(): Iterator[ValueRowWithKeyIndex]
+  def valuesWithKeyIndex(): Iterator[ValueRowWithKeyIndex] = {
+    throw new UnsupportedOperationException
+  }
 
   /**
    * Returns the maximum number of allowed keys index.
    */
-  def maxNumKeysIndex: Int
+  def maxNumKeysIndex: Int = {
+    throw new UnsupportedOperationException
+  }
 
   /**
    * Returns true iff all the keys are unique.
@@ -1066,31 +1074,14 @@ private[joins] object LongHashedRelation {
 
 /**
  * Common trait with dummy implementation for NAAJ special HashedRelation
- * EmptyHashedRelation
  * HashedRelationWithAllNullKeys
  */
-trait NullAwareHashedRelation extends HashedRelation with Externalizable {
+trait NullAwareHashedRelation extends HashedRelation {
   override def get(key: InternalRow): Iterator[InternalRow] = {
     throw new UnsupportedOperationException
   }
 
   override def getValue(key: InternalRow): InternalRow = {
-    throw new UnsupportedOperationException
-  }
-
-  override def getWithKeyIndex(key: InternalRow): Iterator[ValueRowWithKeyIndex] = {
-    throw new UnsupportedOperationException
-  }
-
-  override def getValueWithKeyIndex(key: InternalRow): ValueRowWithKeyIndex = {
-    throw new UnsupportedOperationException
-  }
-
-  override def valuesWithKeyIndex(): Iterator[ValueRowWithKeyIndex] = {
-    throw new UnsupportedOperationException
-  }
-
-  override def maxNumKeysIndex: Int = {
     throw new UnsupportedOperationException
   }
 
@@ -1102,10 +1093,6 @@ trait NullAwareHashedRelation extends HashedRelation with Externalizable {
 
   override def close(): Unit = {}
 
-  override def writeExternal(out: ObjectOutput): Unit = {}
-
-  override def readExternal(in: ObjectInput): Unit = {}
-
   override def estimatedSize: Long = 0
 }
 
@@ -1114,7 +1101,7 @@ trait NullAwareHashedRelation extends HashedRelation with Externalizable {
  * get & getValue will return null just like
  * empty LongHashedRelation or empty UnsafeHashedRelation does.
  */
-object EmptyHashedRelation extends NullAwareHashedRelation {
+case object EmptyHashedRelation extends HashedRelation {
   override def get(key: Long): Iterator[InternalRow] = null
 
   override def get(key: InternalRow): Iterator[InternalRow] = null
@@ -1124,13 +1111,23 @@ object EmptyHashedRelation extends NullAwareHashedRelation {
   override def getValue(key: InternalRow): InternalRow = null
 
   override def asReadOnlyCopy(): EmptyHashedRelation.type = this
+
+  override def keyIsUnique: Boolean = true
+
+  override def keys(): Iterator[InternalRow] = {
+    throw new UnsupportedOperationException
+  }
+
+  override def close(): Unit = {}
+
+  override def estimatedSize: Long = 0
 }
 
 /**
  * A special HashedRelation indicates it built from a non-empty input:Iterator[InternalRow],
  * which contains all null columns key.
  */
-object HashedRelationWithAllNullKeys extends NullAwareHashedRelation {
+case object HashedRelationWithAllNullKeys extends NullAwareHashedRelation {
   override def asReadOnlyCopy(): HashedRelationWithAllNullKeys.type = this
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
@@ -1073,30 +1073,6 @@ private[joins] object LongHashedRelation {
 }
 
 /**
- * Common trait with dummy implementation for NAAJ special HashedRelation
- * HashedRelationWithAllNullKeys
- */
-trait NullAwareHashedRelation extends HashedRelation {
-  override def get(key: InternalRow): Iterator[InternalRow] = {
-    throw new UnsupportedOperationException
-  }
-
-  override def getValue(key: InternalRow): InternalRow = {
-    throw new UnsupportedOperationException
-  }
-
-  override def keyIsUnique: Boolean = true
-
-  override def keys(): Iterator[InternalRow] = {
-    throw new UnsupportedOperationException
-  }
-
-  override def close(): Unit = {}
-
-  override def estimatedSize: Long = 0
-}
-
-/**
  * A special HashedRelation indicates it built from a empty input:Iterator[InternalRow].
  * get & getValue will return null just like
  * empty LongHashedRelation or empty UnsafeHashedRelation does.
@@ -1127,8 +1103,26 @@ case object EmptyHashedRelation extends HashedRelation {
  * A special HashedRelation indicates it built from a non-empty input:Iterator[InternalRow],
  * which contains all null columns key.
  */
-case object HashedRelationWithAllNullKeys extends NullAwareHashedRelation {
+case object HashedRelationWithAllNullKeys extends HashedRelation {
+  override def get(key: InternalRow): Iterator[InternalRow] = {
+    throw new UnsupportedOperationException
+  }
+
+  override def getValue(key: InternalRow): InternalRow = {
+    throw new UnsupportedOperationException
+  }
+
   override def asReadOnlyCopy(): HashedRelationWithAllNullKeys.type = this
+
+  override def keyIsUnique: Boolean = true
+
+  override def keys(): Iterator[InternalRow] = {
+    throw new UnsupportedOperationException
+  }
+
+  override def close(): Unit = {}
+
+  override def estimatedSize: Long = 0
 }
 
 /** The HashedRelationBroadcastMode requires that rows are broadcasted as a HashedRelation. */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
@@ -1073,7 +1073,7 @@ private[joins] object LongHashedRelation {
 }
 
 /**
- * A special HashedRelation indicates it built from a empty input:Iterator[InternalRow].
+ * A special HashedRelation indicating that it's built from a empty input:Iterator[InternalRow].
  * get & getValue will return null just like
  * empty LongHashedRelation or empty UnsafeHashedRelation does.
  */
@@ -1100,8 +1100,8 @@ case object EmptyHashedRelation extends HashedRelation {
 }
 
 /**
- * A special HashedRelation indicates it built from a non-empty input:Iterator[InternalRow],
- * which contains all null columns key.
+ * A special HashedRelation indicating that it's built from a non-empty input:Iterator[InternalRow]
+ * with all the keys to be null.
  */
 case object HashedRelationWithAllNullKeys extends HashedRelation {
   override def get(key: InternalRow): Iterator[InternalRow] = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, EmptyHashedRelation and HashedRelationWithAllNullKeys is an object, and it will cause JavaDeserialization Exception as following

```
20/08/26 11:13:30 WARN [task-result-getter-2] TaskSetManager: Lost task 34.0 in stage 57.0 (TID 18076, emr-worker-5.cluster-183257, executor 18): java.io.InvalidClassException: org.apache.spark.sql.execution.joins.EmptyHashedRelation$; no valid constructor
        at java.io.ObjectStreamClass$ExceptionInfo.newInvalidClassException(ObjectStreamClass.java:169)
        at java.io.ObjectStreamClass.checkDeserialize(ObjectStreamClass.java:874)
        at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2042)
        at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1572)
        at java.io.ObjectInputStream.readObject(ObjectInputStream.java:430)
        at org.apache.spark.serializer.JavaDeserializationStream.readObject(JavaSerializer.scala:76)
        at org.apache.spark.broadcast.TorrentBroadcast$.$anonfun$unBlockifyObject$4(TorrentBroadcast.scala:328)
```

This PR includes

* Using case object instead to fix serialization issue. 
* Also change EmptyHashedRelation not to extend NullAwareHashedRelation since it's already being used in other non-NAAJ joins.

### Why are the changes needed?
It will cause BHJ failed when buildSide is Empty and BHJ(NAAJ) failed when buildSide with null partition keys.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
* Existing UT.
* Run entire TPCDS for E2E coverage.