### PR TITLE
[SPARK-32481][TESTS][FOLLOWUP] Use different directory name for MacOS

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -3116,16 +3116,17 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
           .getTableMetadata(TableIdentifier("tab1")).storage.locationUri.get)
 
         val fs = tablePath.getFileSystem(hadoopConf)
-        val trashRoot = fs.getTrashRoot(tablePath)
-        assert(!fs.exists(trashRoot))
+        val trashCurrent = new Path(fs.getTrashRoot(tablePath), "Current")
+        val trashPath = Path.mergePaths(trashCurrent, tablePath)
+        assert(!fs.exists(trashPath))
         try {
           hadoopConf.set(trashIntervalKey, "5")
           sql("TRUNCATE TABLE tab1")
         } finally {
           hadoopConf.set(trashIntervalKey, originalValue)
         }
-        assert(fs.exists(trashRoot))
-        fs.delete(trashRoot, true)
+        assert(fs.exists(trashPath))
+        fs.delete(trashPath, true)
       }
     }
   }
@@ -3144,15 +3145,16 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
           .getTableMetadata(TableIdentifier("tab1")).storage.locationUri.get)
 
         val fs = tablePath.getFileSystem(hadoopConf)
-        val trashRoot = fs.getTrashRoot(tablePath)
-        assert(!fs.exists(trashRoot))
+        val trashCurrent = new Path(fs.getTrashRoot(tablePath), "Current")
+        val trashPath = Path.mergePaths(trashCurrent, tablePath)
+        assert(!fs.exists(trashPath))
         try {
           hadoopConf.set(trashIntervalKey, "0")
           sql("TRUNCATE TABLE tab1")
         } finally {
           hadoopConf.set(trashIntervalKey, originalValue)
         }
-        assert(!fs.exists(trashRoot))
+        assert(!fs.exists(trashPath))
       }
     }
   }
@@ -3167,9 +3169,10 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
           .getTableMetadata(TableIdentifier("tab1")).storage.locationUri.get)
 
         val fs = tablePath.getFileSystem(hadoopConf)
-        val trashRoot = fs.getTrashRoot(tablePath)
+        val trashCurrent = new Path(fs.getTrashRoot(tablePath), "Current")
+        val trashPath = Path.mergePaths(trashCurrent, tablePath)
         sql("TRUNCATE TABLE tab1")
-        assert(!fs.exists(trashRoot))
+        assert(!fs.exists(trashPath))
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This is a followup of #29387 to correct the test-case.

### Why are the changes needed?
`trashRoot` is always present in macOS, so it's better to use exact `trashPath` to check if data is moved to trash.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Test modified