### PR TITLE
[SPARK-32731][SQL][TEST] Add tests for arrays/maps of nested structs to ReadSchemaSuite to test structs reuse

### DIFF
--- a/external/avro/src/test/scala/org/apache/spark/sql/execution/datasources/AvroReadSchemaSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/execution/datasources/AvroReadSchemaSuite.scala
@@ -23,7 +23,9 @@ class AvroReadSchemaSuite
   with HideColumnInTheMiddleTest
   with AddNestedColumnTest
   with HideNestedColumnTest
-  with ChangePositionTest {
+  with ChangePositionTest
+  with ArrayWithNestedStructTest
+  with MapWithNestedStructTest {
 
   override val format: String = "avro"
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ReadSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ReadSchemaSuite.scala
@@ -84,7 +84,9 @@ class JsonReadSchemaSuite
   with IntegralTypeTest
   with ToDoubleTypeTest
   with ToDecimalTypeTest
-  with ToStringTypeTest {
+  with ToStringTypeTest
+  with ArrayWithNestedStructTest
+  with MapWithNestedStructTest {
 
   override val format: String = "json"
 }
@@ -95,7 +97,9 @@ class OrcReadSchemaSuite
   with HideColumnInTheMiddleTest
   with AddNestedColumnTest
   with HideNestedColumnTest
-  with ChangePositionTest {
+  with ChangePositionTest
+  with ArrayWithNestedStructTest
+  with MapWithNestedStructTest {
 
   override val format: String = "orc"
 
@@ -145,7 +149,9 @@ class MergedOrcReadSchemaSuite
   with ChangePositionTest
   with BooleanTypeTest
   with IntegralTypeTest
-  with ToDoubleTypeTest {
+  with ToDoubleTypeTest
+  with ArrayWithNestedStructTest
+  with MapWithNestedStructTest {
 
   override val format: String = "orc"
 
@@ -161,7 +167,9 @@ class ParquetReadSchemaSuite
   with HideColumnInTheMiddleTest
   with AddNestedColumnTest
   with HideNestedColumnTest
-  with ChangePositionTest {
+  with ChangePositionTest
+  with ArrayWithNestedStructTest
+  with MapWithNestedStructTest {
 
   override val format: String = "parquet"
 
@@ -205,7 +213,9 @@ class MergedParquetReadSchemaSuite
   with HideColumnInTheMiddleTest
   with AddNestedColumnTest
   with HideNestedColumnTest
-  with ChangePositionTest {
+  with ChangePositionTest
+  with ArrayWithNestedStructTest
+  with MapWithNestedStructTest {
 
   override val format: String = "parquet"
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Splitting tests originally posted in [PR](https://github.com/apache/spark/pull/29352) for SPARK-32531.

### Why are the changes needed?
The added tests cover cases for maps and arrays of nested structs for different file formats. Eg, https://github.com/apache/spark/pull/29353 and https://github.com/apache/spark/pull/29354 add object reuse when reading ORC and Avro files. However, for dynamic data structures like arrays and maps, we do not know just by looking at the schema what the size of the data structure will be so it has to be allocated when reading the data points. The added tests provide coverage so that objects are not accidentally reused when encountering maps and arrays.

AFAIK this is not covered by existing tests.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
build/sbt "sql/test:testOnly **ReadSchemaSuite"
