### PR TITLE
[SPARK-32756][SQL] Fix CaseInsensitiveMap usage for Scala 2.13

### DIFF
--- a/sql/catalyst/src/main/scala-2.12/org/apache/spark/sql/catalyst/util/CaseInsensitiveMap.scala
+++ b/sql/catalyst/src/main/scala-2.12/org/apache/spark/sql/catalyst/util/CaseInsensitiveMap.scala
@@ -42,7 +42,7 @@ class CaseInsensitiveMap[T] private (val originalMap: Map[String, T]) extends Ma
   override def +[B1 >: T](kv: (String, B1)): CaseInsensitiveMap[B1] = {
     new CaseInsensitiveMap(originalMap.filter(!_._1.equalsIgnoreCase(kv._1)) + kv)
   }
-  
+
   def ++(xs: TraversableOnce[(String, T)]): CaseInsensitiveMap[T] = {
     xs.foldLeft(this)(_ + _)
   }

--- a/sql/catalyst/src/main/scala-2.12/org/apache/spark/sql/catalyst/util/CaseInsensitiveMap.scala
+++ b/sql/catalyst/src/main/scala-2.12/org/apache/spark/sql/catalyst/util/CaseInsensitiveMap.scala
@@ -43,9 +43,6 @@ class CaseInsensitiveMap[T] private (val originalMap: Map[String, T]) extends Ma
     new CaseInsensitiveMap(originalMap.filter(!_._1.equalsIgnoreCase(kv._1)) + kv)
   }
   
-  override def updated[B1 >: T](key: String, value: B1): CaseInsensitiveMap[B1] =
-    this + (key -> value)
-  
   def ++(xs: TraversableOnce[(String, T)]): CaseInsensitiveMap[T] = {
     xs.foldLeft(this)(_ + _)
   }

--- a/sql/catalyst/src/main/scala-2.12/org/apache/spark/sql/catalyst/util/CaseInsensitiveMap.scala
+++ b/sql/catalyst/src/main/scala-2.12/org/apache/spark/sql/catalyst/util/CaseInsensitiveMap.scala
@@ -42,7 +42,10 @@ class CaseInsensitiveMap[T] private (val originalMap: Map[String, T]) extends Ma
   override def +[B1 >: T](kv: (String, B1)): CaseInsensitiveMap[B1] = {
     new CaseInsensitiveMap(originalMap.filter(!_._1.equalsIgnoreCase(kv._1)) + kv)
   }
-
+  
+  override def updated[B1 >: T](key: String, value: B1): CaseInsensitiveMap[B1] =
+    this + (key -> value)
+  
   def ++(xs: TraversableOnce[(String, T)]): CaseInsensitiveMap[T] = {
     xs.foldLeft(this)(_ + _)
   }

--- a/sql/catalyst/src/main/scala-2.13/org/apache/spark/sql/catalyst/util/CaseInsensitiveMap.scala
+++ b/sql/catalyst/src/main/scala-2.13/org/apache/spark/sql/catalyst/util/CaseInsensitiveMap.scala
@@ -42,7 +42,7 @@ class CaseInsensitiveMap[T] private (val originalMap: Map[String, T]) extends Ma
   override def updated[B1 >: T](key: String, value: B1): CaseInsensitiveMap[B1] = {
     new CaseInsensitiveMap[B1](originalMap.filter(!_._1.equalsIgnoreCase(key)) + (key -> value))
   }
-  
+
   override def +[B1 >: T](kv: (String, B1)): CaseInsensitiveMap[B1] = this.updated(kv._1, kv._2)  
 
   def ++(xs: IterableOnce[(String, T)]): CaseInsensitiveMap[T] = {

--- a/sql/catalyst/src/main/scala-2.13/org/apache/spark/sql/catalyst/util/CaseInsensitiveMap.scala
+++ b/sql/catalyst/src/main/scala-2.13/org/apache/spark/sql/catalyst/util/CaseInsensitiveMap.scala
@@ -42,6 +42,8 @@ class CaseInsensitiveMap[T] private (val originalMap: Map[String, T]) extends Ma
   override def updated[B1 >: T](key: String, value: B1): CaseInsensitiveMap[B1] = {
     new CaseInsensitiveMap[B1](originalMap.filter(!_._1.equalsIgnoreCase(key)) + (key -> value))
   }
+  
+  override def +[B1 >: T](kv: (String, B1)): CaseInsensitiveMap[B1] = this.updated(kv._1, kv._2)  
 
   def ++(xs: IterableOnce[(String, T)]): CaseInsensitiveMap[T] = {
     xs.iterator.foldLeft(this) { (m, kv) => m.updated(kv._1, kv._2) }

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -118,7 +118,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
    * @since 1.4.0
    */
   def option(key: String, value: String): DataFrameReader = {
-    this.extraOptions = this.extraOptions.updated(key, value)
+    this.extraOptions = this.extraOptions + (key -> value)
     this
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -118,7 +118,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
    * @since 1.4.0
    */
   def option(key: String, value: String): DataFrameReader = {
-    this.extraOptions += (key -> value)
+    this.extraOptions = this.extraOptions.updated(key, value)
     this
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -129,7 +129,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
    * @since 1.4.0
    */
   def option(key: String, value: String): DataFrameWriter[T] = {
-    this.extraOptions += (key -> value)
+    this.extraOptions = this.extraOptions.updated(key, value)
     this
   }
 
@@ -291,7 +291,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
         "parameter. Either remove the path option, or call save() without the parameter. " +
         s"To ignore this check, set '${SQLConf.LEGACY_PATH_OPTION_BEHAVIOR.key}' to 'true'.")
     }
-    this.extraOptions += ("path" -> path)
+    this.extraOptions = this.extraOptions .updated("path", path)
     save()
   }
 
@@ -314,7 +314,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
       val sessionOptions = DataSourceV2Utils.extractSessionConfigs(
         provider, df.sparkSession.sessionState.conf)
       val options = sessionOptions.filterKeys(!extraOptions.contains(_)) ++ extraOptions.toMap
-      val dsOptions = new CaseInsensitiveStringMap(options.asJava)
+      val dsOptions = new CaseInsensitiveStringMap(options.toMap.asJava)
 
       def getTable: Table = {
         // For file source, it's expensive to infer schema/partition at each write. Here we pass
@@ -409,7 +409,8 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
 
   private def saveToV1Source(): Unit = {
     partitioningColumns.foreach { columns =>
-      extraOptions += (DataSourceUtils.PARTITIONING_COLUMNS_KEY ->
+      extraOptions = extraOptions.updated(
+        DataSourceUtils.PARTITIONING_COLUMNS_KEY,
         DataSourceUtils.encodePartitioningColumns(columns))
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -129,7 +129,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
    * @since 1.4.0
    */
   def option(key: String, value: String): DataFrameWriter[T] = {
-    this.extraOptions = this.extraOptions.updated(key, value)
+    this.extraOptions = this.extraOptions + (key -> value)
     this
   }
 
@@ -291,7 +291,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
         "parameter. Either remove the path option, or call save() without the parameter. " +
         s"To ignore this check, set '${SQLConf.LEGACY_PATH_OPTION_BEHAVIOR.key}' to 'true'.")
     }
-    this.extraOptions = this.extraOptions .updated("path", path)
+    this.extraOptions = this.extraOptions + ("path" -> path)
     save()
   }
 
@@ -409,8 +409,8 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
 
   private def saveToV1Source(): Unit = {
     partitioningColumns.foreach { columns =>
-      extraOptions = extraOptions.updated(
-        DataSourceUtils.PARTITIONING_COLUMNS_KEY,
+      extraOptions = extraOptions + (
+        DataSourceUtils.PARTITIONING_COLUMNS_KEY ->
         DataSourceUtils.encodePartitioningColumns(columns))
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFiltersBase.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFiltersBase.scala
@@ -82,7 +82,7 @@ trait OrcFiltersBase {
         .groupBy(_._1.toLowerCase(Locale.ROOT))
         .filter(_._2.size == 1)
         .mapValues(_.head._2)
-      CaseInsensitiveMap(dedupPrimitiveFields)
+      CaseInsensitiveMap(dedupPrimitiveFields.toMap)
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileDataSourceV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileDataSourceV2.scala
@@ -61,7 +61,7 @@ trait FileDataSourceV2 extends TableProvider with DataSourceRegister {
     val withoutPath = map.asCaseSensitiveMap().asScala.filterKeys { k =>
       !k.equalsIgnoreCase("path") && !k.equalsIgnoreCase("paths")
     }
-    new CaseInsensitiveStringMap(withoutPath.asJava)
+    new CaseInsensitiveStringMap(withoutPath.toMap.asJava)
   }
 
   protected def getTableName(map: CaseInsensitiveStringMap, paths: Seq[String]): String = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of #29160. This allows Spark SQL project to compile for Scala 2.13. 

### Why are the changes needed?

It's needed for #28545

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

I compiled with Scala 2.13. It fails in `Spark REPL` project, which will be fixed by #28545