### PR TITLE
[SPARK-32191][FOLLOW-UP][PYTHON][DOCS] Indent the table and reword the main page in migration guide

### DIFF
--- a/python/docs/source/migration_guide/index.rst
+++ b/python/docs/source/migration_guide/index.rst
@@ -21,7 +21,7 @@ Migration Guide
 ===============
 
 This page describes the migration guide specific to PySpark.
-Many items of other migration guides can be applied when migrating PySpark to higher versions because PySpark internally shares other components.
+Many items of other migration guides can also be applied when migrating PySpark to higher versions because PySpark internally shares other components.
 Please also refer other migration guides such as `Migration Guide: SQL, Datasets and DataFrame <http://spark.apache.org/docs/latest/sql-migration-guide.html>`_.
 
 .. toctree::

--- a/python/docs/source/migration_guide/index.rst
+++ b/python/docs/source/migration_guide/index.rst
@@ -20,11 +20,9 @@
 Migration Guide
 ===============
 
-Migration Guide: PySpark (Python on Spark)
-
-Note that this migration guide describes the items specific to PySpark.
-Many items of SQL migration can be applied when migrating PySpark to higher versions.
-Please refer `Migration Guide: SQL, Datasets and DataFrame <http://spark.apache.org/docs/latest/sql-migration-guide.html>`_.
+This page describes the migration guide specific to PySpark.
+Many items of other migration guides can be applied when migrating PySpark to higher versions because PySpark internally shares other components.
+Please also refer other migration guides such as `Migration Guide: SQL, Datasets and DataFrame <http://spark.apache.org/docs/latest/sql-migration-guide.html>`_.
 
 .. toctree::
    :maxdepth: 2

--- a/python/docs/source/migration_guide/pyspark_2.4_to_3.0.rst
+++ b/python/docs/source/migration_guide/pyspark_2.4_to_3.0.rst
@@ -28,13 +28,13 @@ Upgrading from PySpark 2.4 to 3.0
 
 * In PySpark, when Arrow optimization is enabled, if Arrow version is higher than 0.11.0, Arrow can perform safe type conversion when converting pandas.Series to an Arrow array during serialization. Arrow raises errors when detecting unsafe type conversions like overflow. You enable it by setting ``spark.sql.execution.pandas.convertToArrowArraySafely`` to true. The default setting is false. PySpark behavior for Arrow versions is illustrated in the following table:
 
-=======================================  ================  =========================
-PyArrow version                          Integer overflow  Floating point truncation
-=======================================  ================  =========================
-0.11.0 and below                         Raise error       Silently allows
-> 0.11.0, arrowSafeTypeConversion=false  Silent overflow   Silently allows
-> 0.11.0, arrowSafeTypeConversion=true   Raise error       Raise error
-=======================================  ================  =========================
+    =======================================  ================  =========================
+    PyArrow version                          Integer overflow  Floating point truncation
+    =======================================  ================  =========================
+    0.11.0 and below                         Raise error       Silently allows
+    > 0.11.0, arrowSafeTypeConversion=false  Silent overflow   Silently allows
+    > 0.11.0, arrowSafeTypeConversion=true   Raise error       Raise error
+    =======================================  ================  =========================
 
 * In Spark 3.0, ``createDataFrame(..., verifySchema=True)`` validates LongType as well in PySpark. Previously, LongType was not verified and resulted in None in case the value overflows. To restore this behavior, verifySchema can be set to False to disable the validation.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a minor followup to fix:

1. Slightly reword the wording in the main page.

2. The indentation in the table at the migration guide;

    from
  
    ![Screen Shot 2020-09-01 at 1 53 40 PM](https://user-images.githubusercontent.com/6477701/91796204-91781800-ec5a-11ea-9f57-d7a9f4207ba0.png)

    to

    ![Screen Shot 2020-09-01 at 1 53 26 PM](https://user-images.githubusercontent.com/6477701/91796202-9046eb00-ec5a-11ea-9db2-815139ddfdb9.png)


### Why are the changes needed?

In order to show the migration guide pretty.

### Does this PR introduce _any_ user-facing change?

Yes, this is a change to user-facing documentation.

### How was this patch tested?

Manually built the documentation.
