### PR TITLE
[SPARK-32768][docs] Add Parquet Timestamp output configuration to docs

### DIFF
--- a/docs/sql-data-sources-parquet.md
+++ b/docs/sql-data-sources-parquet.md
@@ -279,6 +279,19 @@ Configuration of Parquet can be done using the `setConf` method on `SparkSession
   <td>1.3.0</td>
 </tr>
 <tr>
+  <td><code>spark.sql.parquet.outputTimestampType</code></td>
+  <td>INT96</td>
+  <td>
+    Sets which Parquet timestamp type to use when Spark writes data to Parquet files.<br/>
+	<code>INT96</code> is a non-standard but commonly used timestamp type in Parquet.<br/>
+	<code>TIMESTAMP_MICROS</code> is a standard timestamp type in Parquet, which stores number of microseconds from the Unix epoch.<br/>
+	<code>TIMESTAMP_MILLIS</code> is also standard, but with millisecond precision, which means Spark has to truncate the microsecond portion of its timestamp value.<br/>
+	Note that Spark is able to read parquet timestamps written in any of the 3 types. This option should be used for compatibility with
+	external systems that need to read the output from Spark.
+  </td>
+  <td>2.3.0</td>
+</tr>
+<tr>
   <td><code>spark.sql.parquet.compression.codec</code></td>
   <td>snappy</td>
   <td>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Spark 2.3.0 added the spark.sql.parquet.outputTimestampType configuration option for controlling the underlying datatype used when writing Timestamp column types into parquet files.


### Why are the changes needed?
This was never exposed in the documentation. Fix should be applied to docs for both to the next 3.x release and 2.4.x release


### Does this PR introduce _any_ user-facing change?
Yes, updates the documentation on the parquet datasource page

### How was this patch tested?
Docs change only. Visual test
