### PR TITLE
[SPARK-32765][SQL] EliminateJoinToEmptyRelation should respect exchange behavior when canChangeNumPartitions == false

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -1252,10 +1252,10 @@ class AdaptiveQueryExecSuite
           "SELECT a FROM pm LEFT SEMI JOIN (SELECT * FROM s WHERE s.d > 100) ts ON pm.a = ts.c"
         ).foreach(query => {
           val (plan, adaptivePlan) = runAdaptiveAndVerifyResult(query)
-          val bhjInAQE = findTopLevelBroadcastHashJoin(plan)
-          assert(bhjInAQE.size == 1)
-          val join = findTopLevelBaseJoin(adaptivePlan)
-          assert(join.isEmpty)
+          val bhj = findTopLevelBroadcastHashJoin(plan)
+          assert(bhj.size == 1)
+          val joinInAQE = findTopLevelBaseJoin(adaptivePlan)
+          assert(joinInAQE.isEmpty)
         })
 
         Seq(
@@ -1265,10 +1265,10 @@ class AdaptiveQueryExecSuite
           "SELECT /*+ broadcast(m) */ a FROM m, ps WHERE m.a = ps.c and m.b > 100"
         ).foreach(query => {
           val (plan, adaptivePlan) = runAdaptiveAndVerifyResult(query)
-          val bhjInAQE = findTopLevelBroadcastHashJoin(plan)
-          assert(bhjInAQE.size == 1)
-          val join = findTopLevelBaseJoin(adaptivePlan)
-          assert(join.nonEmpty)
+          val bhj = findTopLevelBroadcastHashJoin(plan)
+          assert(bhj.size == 1)
+          val bhjInAQE = findTopLevelBroadcastHashJoin(adaptivePlan)
+          assert(bhjInAQE.nonEmpty)
         })
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -1245,9 +1245,9 @@ class AdaptiveQueryExecSuite
         // Join to EmptyRelation does not lost user specified number partition information.
         Seq(
           // NAAJ streamedSide canChangeNumPartitions == false
-          "SELECT a FROM pm WHERE pm.a not in (SELECT c FROM s)",
+          "SELECT a FROM pm WHERE pm.a NOT IN (SELECT c FROM s)",
           // NAAJ(hand-written left anti join) streamedSide canChangeNumPartitions == false
-          "SELECT a FROM pm LEFT ANTI JOIN s ON a = c or isnull(a = c)",
+          "SELECT a FROM pm LEFT ANTI JOIN s ON a = c OR ISNULL(a = c)",
           // LeftSemi streamedSide canChangeNumPartitions == false
           "SELECT a FROM pm LEFT SEMI JOIN (SELECT * FROM s WHERE s.d > 100) ts ON pm.a = ts.c"
         ).foreach(query => {
@@ -1260,15 +1260,15 @@ class AdaptiveQueryExecSuite
 
         Seq(
           // Inner streamedSide(Left) canChangeNumPartitions == false
-          "SELECT /*+ broadcast(s) */a FROM pm, s WHERE pm.a = s.c and s.d > 100",
+          "SELECT /*+ BROADCAST(s) */a FROM pm, s WHERE pm.a = s.c AND s.d > 100",
           // Inner streamedSide(Right) canChangeNumPartitions == false
-          "SELECT /*+ broadcast(m) */ a FROM m, ps WHERE m.a = ps.c and m.b > 100"
+          "SELECT /*+ BROADCAST(m) */ a FROM m, ps WHERE m.a = ps.c AND m.b > 100"
         ).foreach(query => {
           val (plan, adaptivePlan) = runAdaptiveAndVerifyResult(query)
           val bhj = findTopLevelBroadcastHashJoin(plan)
           assert(bhj.size == 1)
           val bhjInAQE = findTopLevelBroadcastHashJoin(adaptivePlan)
-          assert(bhjInAQE.nonEmpty)
+          assert(bhjInAQE.size == 1)
         })
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, EliminateJoinToEmptyRelation Rule will convert Join into EmptyRelation in some cases with AQE on. But if streamedSide of Join is a ShuffleQueryStage(canChangeNumPartitions == false), which means the Exchange produced by repartition Or singlePartition, in this case, if we were to convert it into an EmptyRelation, it will lost user specified number partition information for downstream operator, it's not right. 

### Why are the changes needed?
NumPartition info incorrect when streamedSide is a repartition plan or SinglePartition plan.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Added case in AdaptiveQueryExecSuite.