### PR TITLE
[SPARK-19320][MESOS] Allow guaranteed amount of GPU to be used when launching jobs

### DIFF
--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -738,10 +738,19 @@ See the [configuration page](configuration.html) for information on Spark config
   <td><code>spark.mesos.gpus.max</code></td>
   <td><code>0</code></td>
   <td>
-    Set the maximum number GPU resources to acquire for this job. Note that executors will still launch when no GPU resources are found
-    since this configuration is just an upper limit and not a guaranteed amount.
+    Set the maximum number GPU resources that can be acquired for this job.
+    If total number of gpus to request exceeds this setting, the new executors will not get launched.
+    The executors that have obtained gpus before exceeding this setting will still be launched.
   </td>
   <td>2.1.0</td>
+</tr>
+<tr>
+  <td><code>spark.mesos.executor.gpus</code></td>
+  <td><code>0</code></td>
+  <td>
+    Set the hard limit on the number of gpus to request for each executor.
+  </td>
+  <td>3.0.1</td>
 </tr>
 <tr>
   <td><code>spark.mesos.network.name</code></td>

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
@@ -360,8 +360,9 @@ package object config {
   private[spark] val MAX_GPUS =
     ConfigBuilder("spark.mesos.gpus.max")
       .doc("Set the maximum number GPU resources that can be acquired for this job. " +
-        "If total number of gpus to request exceeds this setting, the new executors will not get launched. " +
-        "The executors that have obtained gpus before exceeding this setting will still be launched.")
+        "If total number of gpus to request exceeds this setting, the new executors will " +
+        "not get launched. The executors that have obtained gpus before exceeding this " +
+        "setting will still be launched.")
       .version("2.1.0")
       .intConf
       .createWithDefault(0)

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/config.scala
@@ -350,11 +350,18 @@ package object config {
       .toSequence
       .createOptional
 
+  private[spark] val EXECUTOR_GPUS =
+    ConfigBuilder("spark.mesos.executor.gpus")
+      .doc("Set the hard limit on the number of gpus to request for each executor.")
+      .version("3.0.1")
+      .intConf
+      .createWithDefault(0)
+
   private[spark] val MAX_GPUS =
     ConfigBuilder("spark.mesos.gpus.max")
-      .doc("Set the maximum number GPU resources to acquire for this job. Note that executors " +
-        "will still launch when no GPU resources are found since this configuration is just an " +
-        "upper limit and not a guaranteed amount.")
+      .doc("Set the maximum number GPU resources that can be acquired for this job. " +
+        "If total number of gpus to request exceeds this setting, the new executors will not get launched. " +
+        "The executors that have obtained gpus before exceeding this setting will still be launched.")
       .version("2.1.0")
       .intConf
       .createWithDefault(0)

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -81,7 +81,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
 
   private val useFetcherCache = conf.get(ENABLE_FETCHER_CACHE)
 
-  private val executorGpusOption = conf.getOption(EXECUTOR_GPUS.key)
+  private val executorGpusOption = conf.getOption(EXECUTOR_GPUS.key).map(_.toInt)
 
   private val maxGpus = conf.get(MAX_GPUS)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, Spark only allows specifying overall GPU resources as an upper limit, this adds a new conf parameter to allow specifying a hard limit on the number of GPUs for each executor while still respecting the overall GPU resource constraint.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
* Added Unit Test
* Manually tested with Mesos Cluster having GPUs