### PR TITLE
[SPARK-32783][DOCS][PYTHON] Development - Testing PySpark

### DIFF
--- a/python/docs/source/development/index.rst
+++ b/python/docs/source/development/index.rst
@@ -23,4 +23,4 @@ Development
     :maxdepth: 2
 
     contributing
-
+    testing

--- a/python/docs/source/development/testing.rst
+++ b/python/docs/source/development/testing.rst
@@ -31,10 +31,7 @@ After that, the PySpark test cases can be run via using ``python/run-tests``. Fo
 
     python/run-tests --python-executable=python3
 
-Note that:
-
-* If you are running tests on Mac OS, you may set ``OBJC_DISABLE_INITIALIZE_FORK_SAFETY`` environment variable to ``YES``.
-* If you are using JDK 11, you should set ``-Dio.netty.tryReflectionSetAccessible=true`` for Arrow related features. See also `Downloading <https://spark.apache.org/docs/latest/#downloading>`_.
+Note that you may set ``OBJC_DISABLE_INITIALIZE_FORK_SAFETY`` environment variable to ``YES`` if you are running tests on Mac OS.
 
 Please see the guidance on how to `build Spark <https://github.com/apache/spark#building-spark>`_,
 `run tests for a module, or individual tests <https://spark.apache.org/developer-tools.html>`_.

--- a/python/docs/source/development/testing.rst
+++ b/python/docs/source/development/testing.rst
@@ -1,0 +1,61 @@
+..  Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+..    http://www.apache.org/licenses/LICENSE-2.0
+
+..  Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+===============
+Testing PySpark
+===============
+
+In order to run PySpark tests, you should build Spark itself first via Maven
+or SBT. For example,
+
+.. code-block:: bash
+
+    ./build/mvn -DskipTests clean package
+
+After that, the PySpark test cases can be run via using ``python/run-tests``. For example,
+
+.. code-block:: bash
+
+    $ python/run-tests --python-executable=python3
+
+Note that:
+
+* If you are running tests on Mac OS, you may set ``OBJC_DISABLE_INITIALIZE_FORK_SAFETY`` environment variable to ``YES``.
+* If you're using JDK 11, you should set ``-Dio.netty.tryReflectionSetAccessible=true`` for Arrow related features. See also `Downloading <https://spark.apache.org/docs/latest/#downloading>`_.
+
+Please see the guidance on how to `build Spark <https://github.com/apache/spark#building-spark>`_,
+`run tests for a module, or individual tests <https://spark.apache.org/developer-tools.html>`_.
+
+
+Running Individual PySpark Tests
+--------------------------------
+
+You can run a specific test via using ``python/run-tests``, for example, as below:
+
+.. code-block:: bash
+
+    $ python/run-tests --testnames pyspark.sql.tests.test_arrow
+
+Please refer `Testing PySpark <https://spark.apache.org/developer-tools.html>`_ for more details.
+
+
+Running tests using GitHub Actions
+----------------------------------
+
+You can run the full PySpark tests by using GitHub Actions in your own forked GitHub
+repositry by few clicks. Please refer
+`Running tests in your forked repository using GitHub Actions <https://spark.apache.org/developer-tools.html>`_ for more details.

--- a/python/docs/source/development/testing.rst
+++ b/python/docs/source/development/testing.rst
@@ -24,13 +24,13 @@ or SBT. For example,
 
 .. code-block:: bash
 
-    ./build/mvn -DskipTests clean package
+    build/mvn -DskipTests clean package
 
 After that, the PySpark test cases can be run via using ``python/run-tests``. For example,
 
 .. code-block:: bash
 
-    $ python/run-tests --python-executable=python3
+    python/run-tests --python-executable=python3
 
 Note that:
 
@@ -48,7 +48,7 @@ You can run a specific test via using ``python/run-tests``, for example, as belo
 
 .. code-block:: bash
 
-    $ python/run-tests --testnames pyspark.sql.tests.test_arrow
+    python/run-tests --testnames pyspark.sql.tests.test_arrow
 
 Please refer `Testing PySpark <https://spark.apache.org/developer-tools.html>`_ for more details.
 

--- a/python/docs/source/development/testing.rst
+++ b/python/docs/source/development/testing.rst
@@ -19,8 +19,7 @@
 Testing PySpark
 ===============
 
-In order to run PySpark tests, you should build Spark itself first via Maven
-or SBT. For example,
+In order to run PySpark tests, you should build Spark itself first via Maven or SBT. For example,
 
 .. code-block:: bash
 
@@ -50,12 +49,12 @@ You can run a specific test via using ``python/run-tests``, for example, as belo
 
     python/run-tests --testnames pyspark.sql.tests.test_arrow
 
-Please refer `Testing PySpark <https://spark.apache.org/developer-tools.html>`_ for more details.
+Please refer to `Testing PySpark <https://spark.apache.org/developer-tools.html>`_ for more details.
 
 
 Running tests using GitHub Actions
 ----------------------------------
 
 You can run the full PySpark tests by using GitHub Actions in your own forked GitHub
-repositry by few clicks. Please refer
+repositry with a few clicks. Please refer to
 `Running tests in your forked repository using GitHub Actions <https://spark.apache.org/developer-tools.html>`_ for more details.

--- a/python/docs/source/development/testing.rst
+++ b/python/docs/source/development/testing.rst
@@ -35,7 +35,7 @@ After that, the PySpark test cases can be run via using ``python/run-tests``. Fo
 Note that:
 
 * If you are running tests on Mac OS, you may set ``OBJC_DISABLE_INITIALIZE_FORK_SAFETY`` environment variable to ``YES``.
-* If you're using JDK 11, you should set ``-Dio.netty.tryReflectionSetAccessible=true`` for Arrow related features. See also `Downloading <https://spark.apache.org/docs/latest/#downloading>`_.
+* If you are using JDK 11, you should set ``-Dio.netty.tryReflectionSetAccessible=true`` for Arrow related features. See also `Downloading <https://spark.apache.org/docs/latest/#downloading>`_.
 
 Please see the guidance on how to `build Spark <https://github.com/apache/spark#building-spark>`_,
 `run tests for a module, or individual tests <https://spark.apache.org/developer-tools.html>`_.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add a page to describe how to test PySpark. Note that it avoids duplication of https://spark.apache.org/developer-tools.html and it more aims to add put the relevant links together.

I made a demo site to review more effectively: https://hyukjin-spark.readthedocs.io/en/stable/development/testing.html

### Why are the changes needed?

To guide PySpark developers easily test.

### Does this PR introduce _any_ user-facing change?

Yes, it will adds a new documentation page.

### How was this patch tested?

Manually tested.