### PR TITLE
[SPARK-XXXXX][SQL][TEST] Add tests to check if since fields are set correctly in ExpressionInfo

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/expressions/ExpressionInfoSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/expressions/ExpressionInfoSuite.scala
@@ -191,4 +191,85 @@ class ExpressionInfoSuite extends SparkFunSuite with SharedSparkSession {
       }
     }
   }
+
+  test("Check if since fields are set correctly in ExpressionInfo") {
+    // SPARK-32780: Fill since fields for all the expressions
+    val ignoreSet = Set(
+      "org.apache.spark.sql.catalyst.expressions.Abs",
+      "org.apache.spark.sql.catalyst.expressions.Add",
+      "org.apache.spark.sql.catalyst.expressions.And",
+      "org.apache.spark.sql.catalyst.expressions.ArrayContains",
+      "org.apache.spark.sql.catalyst.expressions.AssertTrue",
+      "org.apache.spark.sql.catalyst.expressions.BitwiseAnd",
+      "org.apache.spark.sql.catalyst.expressions.BitwiseNot",
+      "org.apache.spark.sql.catalyst.expressions.BitwiseOr",
+      "org.apache.spark.sql.catalyst.expressions.BitwiseXor",
+      "org.apache.spark.sql.catalyst.expressions.CallMethodViaReflection",
+      "org.apache.spark.sql.catalyst.expressions.CaseWhen",
+      "org.apache.spark.sql.catalyst.expressions.Cast",
+      "org.apache.spark.sql.catalyst.expressions.Concat",
+      "org.apache.spark.sql.catalyst.expressions.Crc32",
+      "org.apache.spark.sql.catalyst.expressions.CreateArray",
+      "org.apache.spark.sql.catalyst.expressions.CreateMap",
+      "org.apache.spark.sql.catalyst.expressions.CreateNamedStruct",
+      "org.apache.spark.sql.catalyst.expressions.CurrentDatabase",
+      "org.apache.spark.sql.catalyst.expressions.Divide",
+      "org.apache.spark.sql.catalyst.expressions.EqualNullSafe",
+      "org.apache.spark.sql.catalyst.expressions.EqualTo",
+      "org.apache.spark.sql.catalyst.expressions.Explode",
+      "org.apache.spark.sql.catalyst.expressions.GetJsonObject",
+      "org.apache.spark.sql.catalyst.expressions.GreaterThan",
+      "org.apache.spark.sql.catalyst.expressions.GreaterThanOrEqual",
+      "org.apache.spark.sql.catalyst.expressions.Greatest",
+      "org.apache.spark.sql.catalyst.expressions.If",
+      "org.apache.spark.sql.catalyst.expressions.In",
+      "org.apache.spark.sql.catalyst.expressions.Inline",
+      "org.apache.spark.sql.catalyst.expressions.InputFileBlockLength",
+      "org.apache.spark.sql.catalyst.expressions.InputFileBlockStart",
+      "org.apache.spark.sql.catalyst.expressions.InputFileName",
+      "org.apache.spark.sql.catalyst.expressions.JsonTuple",
+      "org.apache.spark.sql.catalyst.expressions.Least",
+      "org.apache.spark.sql.catalyst.expressions.LessThan",
+      "org.apache.spark.sql.catalyst.expressions.LessThanOrEqual",
+      "org.apache.spark.sql.catalyst.expressions.MapKeys",
+      "org.apache.spark.sql.catalyst.expressions.MapValues",
+      "org.apache.spark.sql.catalyst.expressions.Md5",
+      "org.apache.spark.sql.catalyst.expressions.MonotonicallyIncreasingID",
+      "org.apache.spark.sql.catalyst.expressions.Multiply",
+      "org.apache.spark.sql.catalyst.expressions.Murmur3Hash",
+      "org.apache.spark.sql.catalyst.expressions.Not",
+      "org.apache.spark.sql.catalyst.expressions.Or",
+      "org.apache.spark.sql.catalyst.expressions.Overlay",
+      "org.apache.spark.sql.catalyst.expressions.Pmod",
+      "org.apache.spark.sql.catalyst.expressions.PosExplode",
+      "org.apache.spark.sql.catalyst.expressions.Remainder",
+      "org.apache.spark.sql.catalyst.expressions.Sha1",
+      "org.apache.spark.sql.catalyst.expressions.Sha2",
+      "org.apache.spark.sql.catalyst.expressions.Size",
+      "org.apache.spark.sql.catalyst.expressions.SortArray",
+      "org.apache.spark.sql.catalyst.expressions.SparkPartitionID",
+      "org.apache.spark.sql.catalyst.expressions.Stack",
+      "org.apache.spark.sql.catalyst.expressions.Subtract",
+      "org.apache.spark.sql.catalyst.expressions.TimeWindow",
+      "org.apache.spark.sql.catalyst.expressions.UnaryMinus",
+      "org.apache.spark.sql.catalyst.expressions.UnaryPositive",
+      "org.apache.spark.sql.catalyst.expressions.Uuid",
+      "org.apache.spark.sql.catalyst.expressions.xml.XPathBoolean",
+      "org.apache.spark.sql.catalyst.expressions.xml.XPathDouble",
+      "org.apache.spark.sql.catalyst.expressions.xml.XPathFloat",
+      "org.apache.spark.sql.catalyst.expressions.xml.XPathInt",
+      "org.apache.spark.sql.catalyst.expressions.xml.XPathList",
+      "org.apache.spark.sql.catalyst.expressions.xml.XPathLong",
+      "org.apache.spark.sql.catalyst.expressions.xml.XPathShort",
+      "org.apache.spark.sql.catalyst.expressions.xml.XPathString"
+    )
+    val sinceMissingExprs = spark.sessionState.functionRegistry.listFunction()
+      .map(spark.sessionState.catalog.lookupFunctionInfo)
+      .filterNot(e => ignoreSet.contains(e.getClassName))
+      .filter(funcInfo => !funcInfo.getSince.matches("[0-9]+\\.[0-9]+\\.[0-9]+"))
+      .map(_.getClassName)
+      .distinct
+      .sorted
+    assert(sinceMissingExprs.isEmpty)
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR intends to add a test to check if `since` fields are set correctly in `ExpressionInfo`.
This comes from the discussion in https://github.com/apache/spark/pull/29577#discussion_r479794502.

The credit should be @tanelk.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To prevent one from forgetting setting a `since` field when adding a new expression.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added tests.