### PR TITLE
[SPARK-32807][SQL] ThriftServer open session use direct API to  init current DB

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLSessionManager.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLSessionManager.scala
@@ -69,7 +69,7 @@ private[hive] class SparkSQLSessionManager(hiveServer: HiveServer2, sqlContext: 
     setConfMap(ctx, hiveSessionState.getOverriddenConfigurations)
     setConfMap(ctx, hiveSessionState.getHiveVariables)
     if (sessionConf != null && sessionConf.containsKey("use:database")) {
-      ctx.sql(s"use ${sessionConf.get("use:database")}")
+      ctx.sparkSession.sessionState.catalog.setCurrentDatabase(sessionConf.get("use:database"))
     }
     sparkSqlOperationManager.sessionToContexts.put(sessionHandle, ctx)
     sessionHandle

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLSessionManager.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLSessionManager.scala
@@ -69,7 +69,7 @@ private[hive] class SparkSQLSessionManager(hiveServer: HiveServer2, sqlContext: 
     setConfMap(ctx, hiveSessionState.getOverriddenConfigurations)
     setConfMap(ctx, hiveSessionState.getHiveVariables)
     if (sessionConf != null && sessionConf.containsKey("use:database")) {
-      ctx.sparkSession.sessionState.catalog.setCurrentDatabase(sessionConf.get("use:database"))
+      ctx.sessionState.catalog.setCurrentDatabase(sessionConf.get("use:database"))
     }
     sparkSqlOperationManager.sessionToContexts.put(sessionHandle, ctx)
     sessionHandle


### PR DESCRIPTION
### What changes were proposed in this pull request?
When init current database, we can use direct API, don't need to call  SQL

### Why are the changes needed?
No


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Not need