### PR TITLE
[SPARK-32811][SQL] optimize IN predicate against continuous range

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -237,8 +237,9 @@ object ReorderAssociativeOperator extends Rule[LogicalPlan] {
  */
 object OptimizeIn extends Rule[LogicalPlan] {
   private def getIntegerBound(nums: Set[Expression]): Option[(Expression, Expression)] = {
+    val values = nums.map(e => e.eval(EmptyRow))
+
     def getBound(nums: Set[Expression]): (Expression, Expression) = {
-      val values = nums.map(e => e.eval(EmptyRow))
       val dt = nums.head.dataType
       val ordering = dt.asInstanceOf[AtomicType].ordering.asInstanceOf[Ordering[Any]]
       val min = values.min(ordering)
@@ -251,7 +252,7 @@ object OptimizeIn extends Rule[LogicalPlan] {
       case _ => false
     }
 
-    if (nums.nonEmpty && isInteger(nums.head) && nums.forall(_.eval(EmptyRow) != null)) {
+    if (nums.nonEmpty && isInteger(nums.head) && !values.contains(null)) {
       val (min, max) = getBound(nums)
       val minL = min.eval(EmptyRow).asInstanceOf[Number].longValue()
       val maxL = max.eval(EmptyRow).asInstanceOf[Number].longValue()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -197,6 +197,14 @@ object SQLConf {
     .intConf
     .createWithDefault(100)
 
+  val OPTIMIZER_INSET_RANGE_CHECK_THRESHOLD =
+    buildConf("spark.sql.optimizer.inSetRangeCheckThreshold")
+      .internal()
+      .doc("The threshold of set size for continuous range check conversion.")
+      .version("2.0.0")
+      .intConf
+      .createWithDefault(20)
+
   val OPTIMIZER_INSET_CONVERSION_THRESHOLD =
     buildConf("spark.sql.optimizer.inSetConversionThreshold")
       .internal()
@@ -2854,6 +2862,8 @@ class SQLConf extends Serializable with Logging {
   def optimizerExcludedRules: Option[String] = getConf(OPTIMIZER_EXCLUDED_RULES)
 
   def optimizerMaxIterations: Int = getConf(OPTIMIZER_MAX_ITERATIONS)
+
+  def optimizerInSetRangeCheckThreshold: Int = getConf(OPTIMIZER_INSET_RANGE_CHECK_THRESHOLD)
 
   def optimizerInSetConversionThreshold: Int = getConf(OPTIMIZER_INSET_CONVERSION_THRESHOLD)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceOperatorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceOperatorSuite.scala
@@ -229,12 +229,12 @@ class ReplaceOperatorSuite extends PlanTest {
 
   test("SPARK-26366: ReplaceExceptWithFilter should handle properly NULL") {
     val basePlan = LocalRelation(Seq('a.int, 'b.int))
-    val otherPlan = basePlan.where('a.in(1, 2) || 'b.in())
+    val otherPlan = basePlan.where('a.in(1, 3) || 'b.in())
     val except = Except(basePlan, otherPlan, false)
     val result = OptimizeIn(Optimize.execute(except.analyze))
     val correctAnswer = Aggregate(basePlan.output, basePlan.output,
       Filter(!Coalesce(Seq(
-        'a.in(1, 2) || If('b.isNotNull, Literal.FalseLiteral, Literal(null, BooleanType)),
+        'a.in(1, 3) || If('b.isNotNull, Literal.FalseLiteral, Literal(null, BooleanType)),
         Literal.FalseLiteral)),
         basePlan)).analyze
     comparePlans(result, correctAnswer)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceOperatorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceOperatorSuite.scala
@@ -229,12 +229,12 @@ class ReplaceOperatorSuite extends PlanTest {
 
   test("SPARK-26366: ReplaceExceptWithFilter should handle properly NULL") {
     val basePlan = LocalRelation(Seq('a.int, 'b.int))
-    val otherPlan = basePlan.where('a.in(1, 3) || 'b.in())
+    val otherPlan = basePlan.where('a.in(1, 2) || 'b.in())
     val except = Except(basePlan, otherPlan, false)
     val result = OptimizeIn(Optimize.execute(except.analyze))
     val correctAnswer = Aggregate(basePlan.output, basePlan.output,
       Filter(!Coalesce(Seq(
-        'a.in(1, 3) || If('b.isNotNull, Literal.FalseLiteral, Literal(null, BooleanType)),
+        'a.in(1, 2) || If('b.isNotNull, Literal.FalseLiteral, Literal(null, BooleanType)),
         Literal.FalseLiteral)),
         basePlan)).analyze
     comparePlans(result, correctAnswer)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/PartitionBatchPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/PartitionBatchPruningSuite.scala
@@ -44,6 +44,8 @@ class PartitionBatchPruningSuite extends SharedSparkSession {
     spark.conf.set(SQLConf.IN_MEMORY_PARTITION_PRUNING.key, true)
     // Enable in-memory table scan accumulators
     spark.conf.set(SQLConf.IN_MEMORY_TABLE_SCAN_STATISTICS_ENABLED.key, "true")
+    // Disable IN range check optimization
+    spark.conf.set(SQLConf.OPTIMIZER_INSET_RANGE_CHECK_THRESHOLD.key, 31)
   }
 
   override protected def afterAll(): Unit = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
This PR add extra optimization for OptimizeIN rule. i.e when checking against a continuous set of values e.g `x IN (1,3,2,4,2)`, the rule can be simplified to `x >= 1 AND x <= 4` 


### Why are the changes needed?
* make evaluating batch filtering faster e.g. parquet row group filter: and(gte(x, 1), lte(x, 4)) instead of evaluating or(or(or(eq(x, 1), eq(x, 2)), eq(x, 3)), eq(x, 4)) which is O(N)
* make query string more compact. As you seen previously, the filter tree can become deeply nested. 


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
add tests
