### PR TITLE
[SPARK-32818][SQL] Make `CONVERT_METASTORE_PARQUET` and  `CONVERT_METASTORE_ORC` session level  configurable

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
@@ -85,7 +85,7 @@ class HiveSessionStateBuilder(session: SparkSession, parentState: Option[Session
     override val postHocResolutionRules: Seq[Rule[LogicalPlan]] =
       new DetectAmbiguousSelfJoin(conf) +:
         new DetermineTableStats(session) +:
-        RelationConversions(conf, catalog) +:
+        RelationConversions(session, catalog) +:
         PreprocessTableCreation(session) +:
         PreprocessTableInsertion(conf) +:
         DataSourceAnalysis(conf) +:

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -191,7 +191,7 @@ object HiveAnalysis extends Rule[LogicalPlan] {
  * `PreprocessTableCreation`, `PreprocessTableInsertion`, `DataSourceAnalysis` and `HiveAnalysis`.
  */
 case class RelationConversions(
-    conf: SQLConf,
+    session: SparkSession,
     sessionCatalog: HiveSessionCatalog) extends Rule[LogicalPlan] {
   private def isConvertible(relation: HiveTableRelation): Boolean = {
     isConvertible(relation.tableMeta)
@@ -199,8 +199,8 @@ case class RelationConversions(
 
   private def isConvertible(tableMeta: CatalogTable): Boolean = {
     val serde = tableMeta.storage.serde.getOrElse("").toLowerCase(Locale.ROOT)
-    serde.contains("parquet") && SQLConf.get.getConf(HiveUtils.CONVERT_METASTORE_PARQUET) ||
-      serde.contains("orc") && SQLConf.get.getConf(HiveUtils.CONVERT_METASTORE_ORC)
+    serde.contains("parquet") && session.conf.get[Boolean](HiveUtils.CONVERT_METASTORE_PARQUET) ||
+      serde.contains("orc") && session.conf.get[Boolean](HiveUtils.CONVERT_METASTORE_ORC)
   }
 
   private val metastoreCatalog = sessionCatalog.metastoreCatalog


### PR DESCRIPTION
### What changes were proposed in this pull request?
There are some cases that we have history hive  table, in the past, it use `TEXTFILE` serde, later  it's change to `ORC` serde, since during metastore convert, we will use table level serde to scan all partition, if some old partition's file format is not same , will failed to convert , we need to close metastore convert and restart spark program then run.
But we know that enable hive metastore convert can speed up data r/w, and avoid many minor problem.
It's bad for ad-hoc engine such as long running spark thrift server. so I think it's necessary to make these two config can be changed by use in session level


### Why are the changes needed?
Make use range more flexiable


### Does this PR introduce _any_ user-facing change?
People can set` CONVERT_METASTORE_PARQUET` and `CONVERT_METASTORE_ORC` in session level


### How was this patch tested?
WIP
