### PR TITLE
[SPARK-32748][SQL] Revert "Support local property propagation in SubqueryBroadcastExec"

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/ExecutorSideSQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/ExecutorSideSQLConfSuite.scala
@@ -25,9 +25,9 @@ import org.apache.spark.{SparkException, SparkFunSuite, TaskContext}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Dataset, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Attribute, DynamicPruningExpression}
+import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
-import org.apache.spark.sql.execution.{FileSourceScanExec, InSubqueryExec, LeafExecNode, QueryExecution, SparkPlan, SubqueryBroadcastExec}
+import org.apache.spark.sql.execution.{LeafExecNode, QueryExecution, SparkPlan}
 import org.apache.spark.sql.execution.adaptive.DisableAdaptiveExecution
 import org.apache.spark.sql.execution.debug.codegenStringSeq
 import org.apache.spark.sql.functions.col
@@ -186,65 +186,6 @@ class ExecutorSideSQLConfSuite extends SparkFunSuite with SQLTestUtils {
       spark.sparkContext.setLocalProperty(confKey, confValue2)
       val checks2 = df1.join(df3).collect()
       assert(checks2.forall(_.toSeq == Seq(true, true)))
-    }
-  }
-
-  test("SPARK-32748: propagate local properties to dynamic pruning thread") {
-    val factTable = "fact_local_prop_dpp"
-    val dimTable = "dim_local_prop_dpp"
-
-    def checkPropertyValueByUdfResult(propKey: String, propValue: String): Unit = {
-      spark.sparkContext.setLocalProperty(propKey, propValue)
-      val df = sql(
-        s"""
-           |SELECT compare_property_value(f.id, '$propKey', '$propValue') as col
-           |FROM $factTable f
-           |INNER JOIN $dimTable s
-           |ON f.id = s.id AND s.value < 3
-          """.stripMargin)
-
-      val subqueryBroadcastSeq = df.queryExecution.executedPlan.flatMap {
-        case s: FileSourceScanExec => s.partitionFilters.collect {
-          case DynamicPruningExpression(InSubqueryExec(_, b: SubqueryBroadcastExec, _, _)) => b
-        }
-        case _ => Nil
-      }
-      assert(subqueryBroadcastSeq.nonEmpty,
-        s"Should trigger DPP with a reused broadcast exchange:\n${df.queryExecution}")
-
-      assert(df.collect().forall(_.toSeq == Seq(true)))
-    }
-
-    withTable(factTable, dimTable) {
-      spark.range(10).select($"id", $"id".as("value"))
-        .write.partitionBy("id").mode("overwrite").saveAsTable(factTable)
-      spark.range(5).select($"id", $"id".as("value"))
-        .write.mode("overwrite").saveAsTable(dimTable)
-
-      withSQLConf(
-        StaticSQLConf.BROADCAST_EXCHANGE_MAX_THREAD_THRESHOLD.key -> "1",
-        SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "true",
-        SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> "true") {
-
-        try {
-          spark.udf.register(
-            "compare_property_value",
-            (input: Int, propKey: String, propValue: String) =>
-              TaskContext.get().getLocalProperty(propKey) == propValue
-          )
-          val propKey = "spark.sql.subquery.broadcast.prop.key"
-
-          // set local property and assert
-          val propValue1 = UUID.randomUUID().toString()
-          checkPropertyValueByUdfResult(propKey, propValue1)
-
-          // change local property and re-assert
-          val propValue2 = UUID.randomUUID().toString()
-          checkPropertyValueByUdfResult(propKey, propValue2)
-        } finally {
-          spark.sessionState.catalog.dropTempFunction("compare_property_value", true)
-        }
-      }
     }
   }
 }


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This reverts commit 04f7f6dac0b9177e11482cca4e7ebf7b7564e45f due to the discussion in [comment](https://github.com/apache/spark/pull/29589#discussion_r484657207).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Based on  the discussion in [comment](https://github.com/apache/spark/pull/29589#discussion_r484657207), propagation for thread local properties in `SubqueryBroadcastExec` is not necessary, since they will be propagated by broadcast exchange threads anyway.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Also revert the added test.