### PR TITLE
[SPARK-32815][ML][2.4] Fix LibSVM data source loading error on file paths with glob metacharacters

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/source/libsvm/LibSVMRelation.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/source/libsvm/LibSVMRelation.scala
@@ -99,7 +99,7 @@ private[libsvm] class LibSVMFileFormat
         "though the input. If you know the number in advance, please specify it via " +
         "'numFeatures' option to avoid the extra scan.")
 
-      val paths = files.map(_.getPath.toUri.toString)
+      val paths = files.map(_.getPath.toString)
       val parsed = MLUtils.parseLibSVMFile(sparkSession, paths)
       MLUtils.computeNumFeatures(parsed)
     }

--- a/mllib/src/main/scala/org/apache/spark/mllib/util/MLUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/util/MLUtils.scala
@@ -110,7 +110,8 @@ object MLUtils extends Logging {
       DataSource.apply(
         sparkSession,
         paths = paths,
-        className = classOf[TextFileFormat].getName
+        className = classOf[TextFileFormat].getName,
+        options = Map(DataSource.GLOB_PATHS_KEY -> "false")
       ).resolveRelation(checkFilesExist = false))
       .select("value")
 

--- a/mllib/src/test/scala/org/apache/spark/ml/source/libsvm/LibSVMRelationSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/source/libsvm/LibSVMRelationSuite.scala
@@ -185,7 +185,7 @@ class LibSVMRelationSuite extends SparkFunSuite with MLlibTestSparkContext {
     }
   }
 
-  test("SPARK-XXXXX: Test LibSVM data source on file paths with glob metacharacters") {
+  test("SPARK-32815: Test LibSVM data source on file paths with glob metacharacters") {
     withTempDir { dir =>
       val basePath = dir.getCanonicalPath
 

--- a/mllib/src/test/scala/org/apache/spark/ml/source/libsvm/LibSVMRelationSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/source/libsvm/LibSVMRelationSuite.scala
@@ -193,10 +193,9 @@ class LibSVMRelationSuite extends SparkFunSuite with MLlibTestSparkContext {
       val escapedSvmFileName = "\\[abc\\]"
       val rawData = new java.util.ArrayList[Row]()
       rawData.add(Row(1.0, Vectors.sparse(2, Seq((0, 2.0), (1, 3.0)))))
-      val struct = StructType(
-        StructField("labelFoo", DoubleType, false) ::
-          StructField("featuresBar", VectorType, false) :: Nil
-      )
+      val struct = new StructType()
+        .add("labelFoo", DoubleType, false)
+        .add("featuresBar", VectorType, false)
       val df = spark.createDataFrame(rawData, struct)
       df.write.format("libsvm").save(s"$basePath/$svmFileName")
       val df2 = spark.read.format("libsvm").load(s"$basePath/$escapedSvmFileName")

--- a/mllib/src/test/scala/org/apache/spark/ml/source/libsvm/LibSVMRelationSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/source/libsvm/LibSVMRelationSuite.scala
@@ -184,4 +184,31 @@ class LibSVMRelationSuite extends SparkFunSuite with MLlibTestSparkContext {
       spark.sql("DROP TABLE IF EXISTS libsvmTable")
     }
   }
+
+  test("SPARK-XXXXX: Test LibSVM data source on file paths with glob metacharacters") {
+    withTempDir { dir =>
+      val basePath = dir.getCanonicalPath
+
+      // test libsvm writer / reader without specifying schema
+      val svmFileName = "[abc]"
+      val escapedSvmFileName = "\\[abc\\]"
+
+      val rawData = new java.util.ArrayList[Row]()
+      rawData.add(Row(1.0, Vectors.sparse(2, Seq((0, 2.0), (1, 3.0)))))
+
+      val struct = StructType(
+        StructField("labelFoo", DoubleType, false) ::
+          StructField("featuresBar", VectorType, false) :: Nil
+      )
+      val df = spark.sqlContext.createDataFrame(rawData, struct)
+      df.write.format("libsvm").save(s"$basePath/$svmFileName")
+
+      val df2 = spark.read.format("libsvm")
+        .load(s"$basePath/$escapedSvmFileName")
+
+      val row1 = df2.first()
+      val v = row1.getAs[SparseVector](1)
+      assert(v == Vectors.sparse(2, Seq((0, 2.0), (1, 3.0))))
+    }
+  }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/source/libsvm/LibSVMRelationSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/source/libsvm/LibSVMRelationSuite.scala
@@ -186,22 +186,20 @@ class LibSVMRelationSuite extends SparkFunSuite with MLlibTestSparkContext {
   }
 
   test("SPARK-32815: Test LibSVM data source on file paths with glob metacharacters") {
-    withTempDir { dir =>
-      val basePath = dir.getCanonicalPath
-      // test libsvm writer / reader without specifying schema
-      val svmFileName = "[abc]"
-      val escapedSvmFileName = "\\[abc\\]"
-      val rawData = new java.util.ArrayList[Row]()
-      rawData.add(Row(1.0, Vectors.sparse(2, Seq((0, 2.0), (1, 3.0)))))
-      val struct = new StructType()
-        .add("labelFoo", DoubleType, false)
-        .add("featuresBar", VectorType, false)
-      val df = spark.createDataFrame(rawData, struct)
-      df.write.format("libsvm").save(s"$basePath/$svmFileName")
-      val df2 = spark.read.format("libsvm").load(s"$basePath/$escapedSvmFileName")
-      val row1 = df2.first()
-      val v = row1.getAs[SparseVector](1)
-      assert(v == Vectors.sparse(2, Seq((0, 2.0), (1, 3.0))))
-    }
+    val basePath = Utils.createDirectory(tempDir.getCanonicalPath, "globbing")
+    // test libsvm writer / reader without specifying schema
+    val svmFileName = "[abc]"
+    val escapedSvmFileName = "\\[abc\\]"
+    val rawData = new java.util.ArrayList[Row]()
+    rawData.add(Row(1.0, Vectors.sparse(2, Seq((0, 2.0), (1, 3.0)))))
+    val struct = new StructType()
+      .add("labelFoo", DoubleType, false)
+      .add("featuresBar", VectorType, false)
+    val df = spark.createDataFrame(rawData, struct)
+    df.write.format("libsvm").save(s"$basePath/$svmFileName")
+    val df2 = spark.read.format("libsvm").load(s"$basePath/$escapedSvmFileName")
+    val row1 = df2.first()
+    val v = row1.getAs[SparseVector](1)
+    assert(v == Vectors.sparse(2, Seq((0, 2.0), (1, 3.0))))
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/source/libsvm/LibSVMRelationSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/source/libsvm/LibSVMRelationSuite.scala
@@ -188,24 +188,18 @@ class LibSVMRelationSuite extends SparkFunSuite with MLlibTestSparkContext {
   test("SPARK-32815: Test LibSVM data source on file paths with glob metacharacters") {
     withTempDir { dir =>
       val basePath = dir.getCanonicalPath
-
       // test libsvm writer / reader without specifying schema
       val svmFileName = "[abc]"
       val escapedSvmFileName = "\\[abc\\]"
-
       val rawData = new java.util.ArrayList[Row]()
       rawData.add(Row(1.0, Vectors.sparse(2, Seq((0, 2.0), (1, 3.0)))))
-
       val struct = StructType(
         StructField("labelFoo", DoubleType, false) ::
           StructField("featuresBar", VectorType, false) :: Nil
       )
-      val df = spark.sqlContext.createDataFrame(rawData, struct)
+      val df = spark.createDataFrame(rawData, struct)
       df.write.format("libsvm").save(s"$basePath/$svmFileName")
-
-      val df2 = spark.read.format("libsvm")
-        .load(s"$basePath/$escapedSvmFileName")
-
+      val df2 = spark.read.format("libsvm").load(s"$basePath/$escapedSvmFileName")
       val row1 = df2.first()
       val v = row1.getAs[SparseVector](1)
       assert(v == Vectors.sparse(2, Seq((0, 2.0), (1, 3.0))))


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to fix an issue with LibSVM datasource when both of the following are true:
* no user specified schema
* some file paths contain escaped glob metacharacters, such as `[``]`, `{``}`, `*` etc.

The fix is a backport of https://github.com/apache/spark/pull/29675, and it is based on another bug fix for CSV/JSON datasources https://github.com/apache/spark/pull/29663.

### Why are the changes needed?
To fix the issue when the follow two queries try to read from paths `[abc]`:
```scala
spark.read.format("libsvm").load("""/tmp/\[abc\].csv""").show
```
but would end up hitting an exception:
```
Path does not exist: file:/private/var/folders/p3/dfs6mf655d7fnjrsjvldh0tc0000gn/T/spark-6ef0ae5e-ff9f-4c4f-9ff4-0db3ee1f6a82/[abc]/part-00000-26406ab9-4e56-45fd-a25a-491c18a05e76-c000.libsvm;
org.apache.spark.sql.AnalysisException: Path does not exist: file:/private/var/folders/p3/dfs6mf655d7fnjrsjvldh0tc0000gn/T/spark-6ef0ae5e-ff9f-4c4f-9ff4-0db3ee1f6a82/[abc]/part-00000-26406ab9-4e56-45fd-a25a-491c18a05e76-c000.libsvm;
	at org.apache.spark.sql.execution.datasources.DataSource$.$anonfun$checkAndGlobPathIfNecessary$3(DataSource.scala:770)
	at org.apache.spark.util.ThreadUtils$.$anonfun$parmap$2(ThreadUtils.scala:373)
	at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:659)
	at scala.util.Success.$anonfun$map$1(Try.scala:255)
	at scala.util.Success.map(Try.scala:213)
```

### Does this PR introduce _any_ user-facing change?
Yes

### How was this patch tested?
Added UT to `LibSVMRelationSuite`.