### PR TITLE
[SPARK-32204][SPARK-32182][DOCS][FOLLOW-UP] Use IPython instead of ipython to check if installed in dev/lint-python

### DIFF
--- a/dev/lint-python
+++ b/dev/lint-python
@@ -205,7 +205,7 @@ function sphinx_test {
     fi
 
     # TODO(SPARK-32666): Install ipython in Jenkins machines
-    PYTHON_HAS_IPYTHON=$("$PYTHON_EXECUTABLE" -c 'import importlib.util; print(importlib.util.find_spec("ipython") is not None)')
+    PYTHON_HAS_IPYTHON=$("$PYTHON_EXECUTABLE" -c 'import importlib.util; print(importlib.util.find_spec("IPython") is not None)')
     if [[ "$PYTHON_HAS_IPYTHON" == "False" ]]; then
         echo "$PYTHON_EXECUTABLE does not have ipython installed. Skipping Sphinx build for now."
         echo


### PR DESCRIPTION
### What changes were proposed in this pull request?

It should check `IPython` as it's imported as a package. Currently, Sphinx build is being skipped in GitHub Actions as below:

https://github.com/apache/spark/runs/1084164546

```
starting python compilation test...
python compilation succeeded.

starting pycodestyle test...
pycodestyle checks passed.

starting flake8 test...
flake8 checks passed.

python3 does not have ipython installed. Skipping Sphinx build for now.


all lint-python tests passed!
```

### Why are the changes needed?

To run the documentation builds in Github Actions.

### Does this PR introduce _any_ user-facing change?

No, dev-only

### How was this patch tested?

Manually tested as `dev/lint-python`.
