### PR TITLE
[SPARK-32755][SQL][FOLLOWUP] Ensure `--` method of AttributeSet have same behavior under Scala 2.12 and 2.13

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AttributeSet.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AttributeSet.scala
@@ -105,10 +105,12 @@ class AttributeSet private (private val baseSet: mutable.LinkedHashSet[Attribute
    */
   def --(other: Iterable[NamedExpression]): AttributeSet = {
     other match {
+      // SPARK-32755: `--` method behave differently under scala 2.12 and 2.13,
+      // use a Scala 2.12 based compatibility solution
       case otherSet: AttributeSet =>
-        new AttributeSet(baseSet -- otherSet.baseSet)
+        new AttributeSet(baseSet.clone() --= otherSet.baseSet)
       case _ =>
-        new AttributeSet(baseSet -- other.map(a => new AttributeEquals(a.toAttribute)))
+        new AttributeSet(baseSet.clone() --= other.map(a => new AttributeEquals(a.toAttribute)))
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AttributeSet.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AttributeSet.scala
@@ -106,7 +106,7 @@ class AttributeSet private (private val baseSet: mutable.LinkedHashSet[Attribute
   def --(other: Iterable[NamedExpression]): AttributeSet = {
     other match {
       // SPARK-32755: `--` method behave differently under scala 2.12 and 2.13,
-      // use a Scala 2.12 based compatibility solution
+      // use a Scala 2.12 based code to maintains the insertion order in Scala 2.13
       case otherSet: AttributeSet =>
         new AttributeSet(baseSet.clone() --= otherSet.baseSet)
       case _ =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
 `--` method of `AttributeSet` behave differently under Scala 2.12 and 2.13 because `--` method of `LinkedHashSet` in Scala 2.13 can't maintains the insertion order.

This pr use a Scala 2.12 based code to ensure `--` method of AttributeSet have same behavior under Scala 2.12 and 2.13.


### Why are the changes needed?
The behavior of `AttributeSet`  needs to be compatible with Scala 2.12 and 2.13

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Scala 2.12: Pass the Jenkins or GitHub Action

Scala 2.13: Manual test sub-suites of `PlanStabilitySuite`

- **Before** ：293 TESTS FAILED

- **After**：13 TESTS FAILED(The remaining failures are not associated with the current issue)