### PR TITLE
[SPARK-32828][SQL] Cast from a derived user-defined type to a base type

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -884,8 +884,7 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
       castArrayCode(from.asInstanceOf[ArrayType].elementType, array.elementType, ctx)
     case map: MapType => castMapCode(from.asInstanceOf[MapType], map, ctx)
     case struct: StructType => castStructCode(from.asInstanceOf[StructType], struct, ctx)
-    case udt: UserDefinedType[_]
-      if udt.userClass == from.asInstanceOf[UserDefinedType[_]].userClass =>
+    case udt: UserDefinedType[_] if udt.acceptsType(from) =>
       (c, evPrim, evNull) => code"$evPrim = $c;"
     case _: UserDefinedType[_] =>
       throw new SparkException(s"Cannot cast $from to $to.")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -1346,8 +1346,8 @@ class CastSuite extends CastSuiteBase {
   }
 
   test("SPARK-32828: cast from a derived user-defined type to a base type") {
-    val v = Literal.create(Row(1), new TestUDT.ExampleSubTypeUDT())
-    checkEvaluation(cast(v, new TestUDT.ExampleBaseTypeUDT), Row(1))
+    val v = Literal.create(Row(1), new ExampleSubTypeUDT())
+    checkEvaluation(cast(v, new ExampleBaseTypeUDT), Row(1))
   }
 }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -1344,6 +1344,11 @@ class CastSuite extends CastSuiteBase {
       }
     }
   }
+
+  test("SPARK-32828: cast from a derived user-defined type to a base type") {
+    val v = Literal.create(Row(1), new TestUDT.ExampleSubTypeUDT())
+    checkEvaluation(cast(v, new TestUDT.ExampleBaseTypeUDT), Row(1))
+  }
 }
 
 /**

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/TestUDT.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/TestUDT.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.types
 
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.catalyst.util.{ArrayData, GenericArrayData}
 
 
@@ -57,5 +59,78 @@ object TestUDT {
     override def hashCode(): Int = getClass.hashCode()
 
     override def equals(other: Any): Boolean = other.isInstanceOf[MyDenseVectorUDT]
+  }
+
+  // object and classes to test SPARK-19311
+
+  // Trait/Interface for base type
+  sealed trait IExampleBaseType extends Serializable {
+    def field: Int
+  }
+
+  // Trait/Interface for derived type
+  sealed trait IExampleSubType extends IExampleBaseType
+
+  // a base class
+  @SQLUserDefinedType(udt = classOf[ExampleBaseTypeUDT])
+  class ExampleBaseClass(override val field: Int) extends IExampleBaseType
+
+  // a derived class
+  @SQLUserDefinedType(udt = classOf[ExampleSubTypeUDT])
+  class ExampleSubClass(override val field: Int)
+    extends ExampleBaseClass(field) with IExampleSubType
+
+  // UDT for base class
+  class ExampleBaseTypeUDT extends UserDefinedType[IExampleBaseType] {
+
+    override def sqlType: StructType = {
+      StructType(Seq(
+        StructField("intfield", IntegerType, nullable = false)))
+    }
+
+    override def serialize(obj: IExampleBaseType): InternalRow = {
+      val row = new GenericInternalRow(1)
+      row.setInt(0, obj.field)
+      row
+    }
+
+    override def deserialize(datum: Any): IExampleBaseType = {
+      datum match {
+        case row: InternalRow =>
+          require(row.numFields == 1,
+            "ExampleBaseTypeUDT requires row with length == 1")
+          val field = row.getInt(0)
+          new ExampleBaseClass(field)
+      }
+    }
+
+    override def userClass: Class[IExampleBaseType] = classOf[IExampleBaseType]
+  }
+
+  // UDT for derived class
+  private[spark] class ExampleSubTypeUDT extends UserDefinedType[IExampleSubType] {
+
+    override def sqlType: StructType = {
+      StructType(Seq(
+        StructField("intfield", IntegerType, nullable = false)))
+    }
+
+    override def serialize(obj: IExampleSubType): InternalRow = {
+      val row = new GenericInternalRow(1)
+      row.setInt(0, obj.field)
+      row
+    }
+
+    override def deserialize(datum: Any): IExampleSubType = {
+      datum match {
+        case row: InternalRow =>
+          require(row.numFields == 1,
+            "ExampleSubTypeUDT requires row with length == 1")
+          val field = row.getInt(0)
+          new ExampleSubClass(field)
+      }
+    }
+
+    override def userClass: Class[IExampleSubType] = classOf[IExampleSubType]
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/UserDefinedTypeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UserDefinedTypeSuite.scala
@@ -65,9 +65,9 @@ class UserDefinedTypeSuite extends QueryTest with SharedSparkSession with Parque
 
 
   test("SPARK-32090: equal") {
-    val udt1 = new TestUDT.ExampleBaseTypeUDT
-    val udt2 = new TestUDT.ExampleSubTypeUDT
-    val udt3 = new TestUDT.ExampleSubTypeUDT
+    val udt1 = new ExampleBaseTypeUDT
+    val udt2 = new ExampleSubTypeUDT
+    val udt3 = new ExampleSubTypeUDT
     assert(udt1 !== udt2)
     assert(udt2 !== udt1)
     assert(udt2 === udt3)
@@ -75,8 +75,8 @@ class UserDefinedTypeSuite extends QueryTest with SharedSparkSession with Parque
   }
 
   test("SPARK-32090: acceptsType") {
-    val udt1 = new TestUDT.ExampleBaseTypeUDT
-    val udt2 = new TestUDT.ExampleSubTypeUDT
+    val udt1 = new ExampleBaseTypeUDT
+    val udt2 = new ExampleSubTypeUDT
     assert(udt1.acceptsType(udt2))
     assert(!udt2.acceptsType(udt1))
   }
@@ -200,23 +200,23 @@ class UserDefinedTypeSuite extends QueryTest with SharedSparkSession with Parque
   }
 
   test("SPARK-19311: UDFs disregard UDT type hierarchy") {
-    UDTRegistration.register(classOf[TestUDT.IExampleBaseType].getName,
-      classOf[TestUDT.ExampleBaseTypeUDT].getName)
-    UDTRegistration.register(classOf[TestUDT.IExampleSubType].getName,
-      classOf[TestUDT.ExampleSubTypeUDT].getName)
+    UDTRegistration.register(classOf[IExampleBaseType].getName,
+      classOf[ExampleBaseTypeUDT].getName)
+    UDTRegistration.register(classOf[IExampleSubType].getName,
+      classOf[ExampleSubTypeUDT].getName)
 
     // UDF that returns a base class object
     sqlContext.udf.register("doUDF", (param: Int) => {
-      new TestUDT.ExampleBaseClass(param)
-    }: TestUDT.IExampleBaseType)
+      new ExampleBaseClass(param)
+    }: IExampleBaseType)
 
     // UDF that returns a derived class object
     sqlContext.udf.register("doSubTypeUDF", (param: Int) => {
-      new TestUDT.ExampleSubClass(param)
-    }: TestUDT.IExampleSubType)
+      new ExampleSubClass(param)
+    }: IExampleSubType)
 
     // UDF that takes a base class object as parameter
-    sqlContext.udf.register("doOtherUDF", (obj: TestUDT.IExampleBaseType) => {
+    sqlContext.udf.register("doOtherUDF", (obj: IExampleBaseType) => {
       obj.field
     }: Int)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR intends to fix an existing bug below in `UserDefinedTypeSuite`;
```
[info] - SPARK-19311: UDFs disregard UDT type hierarchy (931 milliseconds)
16:22:35.936 WARN org.apache.spark.sql.catalyst.expressions.SafeProjection: Expr codegen error and falling back to interpreter mode
org.apache.spark.SparkException: Cannot cast org.apache.spark.sql.ExampleSubTypeUDT@46b1771f to org.apache.spark.sql.ExampleBaseTypeUDT@31e8d979.
	at org.apache.spark.sql.catalyst.expressions.CastBase.nullSafeCastFunction(Cast.scala:891)
	at org.apache.spark.sql.catalyst.expressions.CastBase.doGenCode(Cast.scala:852)
	at org.apache.spark.sql.catalyst.expressions.Expression.$anonfun$genCode$3(Expression.scala:147)
    ...
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
bugfix

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added unit tests.