### PR TITLE
[DO-NOT-MERGE] Remove temporary fallbacks in HiveExternalCatalogVersionsSuite

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
@@ -243,7 +243,7 @@ object PROCESS_TABLES extends QueryTest with SQLTestUtils {
         .filter(_ < org.apache.spark.SPARK_VERSION)
     } catch {
       // do not throw exception during object initialization.
-      case NonFatal(_) => Seq("2.3.4", "2.4.5") // A temporary fallback to use a specific version
+      case NonFatal(_) => Nil
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

The fallback was added because Jenkins builders were unstable. This PR removes it.

### Why are the changes needed?

TBD

### Does this PR introduce _any_ user-facing change?

TBD

### How was this patch tested?

TBD
