### PR TITLE
[WIP][SPARK-32842] Support dynamic partition pruning hint

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/hints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/hints.scala
@@ -115,7 +115,8 @@ object JoinStrategyHint {
     BROADCAST,
     SHUFFLE_MERGE,
     SHUFFLE_HASH,
-    SHUFFLE_REPLICATE_NL)
+    SHUFFLE_REPLICATE_NL,
+    DYNAMIC_PRUNING)
 }
 
 /**
@@ -165,6 +166,12 @@ case object SHUFFLE_REPLICATE_NL extends JoinStrategyHint {
 case object NO_BROADCAST_HASH extends JoinStrategyHint {
   override def displayName: String = "no_broadcast_hash"
   override def hintAliases: Set[String] = Set.empty
+}
+
+case object DYNAMIC_PRUNING extends JoinStrategyHint {
+  override def displayName: String = "dynamic_pruning"
+  override def hintAliases: Set[String] = Set(
+    "DYNAMIC_PRUNING")
 }
 
 /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pr add support dynamic partition pruning hint.


### Why are the changes needed?

For some joins, one side is very small but can not broadcast, for example:
- left join but left side very small
- right join but the right side very small

Some real case from our cluster:
- Case 1:
![image](https://user-images.githubusercontent.com/5399861/92703898-24b0fc00-f385-11ea-8ed8-be4f9e43460a.png)
- Case 2:
![image](https://user-images.githubusercontent.com/5399861/92704038-3e524380-f385-11ea-9c3a-faba0815cb59.png)


At this time, `PlanDynamicPruningFilters` may not insert dynamic partition pruning. We can add a hint to support users to force insert a dynamic partition pruning for specific side.

### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Unit test.