### PR TITLE
[SPARK-32843][SQL] Add an optimization rule to combine range repartition and range operation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
@@ -344,6 +344,8 @@ package object dsl {
 
       def limit(limitExpr: Expression): LogicalPlan = Limit(limitExpr, logicalPlan)
 
+      def tail(tailExpr: Expression): LogicalPlan = Tail(tailExpr, logicalPlan)
+
       def join(
         otherPlan: LogicalPlan,
         joinType: JoinType = Inner,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombineRepartitionAndRangeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombineRepartitionAndRangeSuite.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Range}
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+
+class CombineRepartitionAndRangeSuite extends PlanTest {
+  object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches =
+      Batch("CombineRepartitionAndRange", FixedPoint(10),
+        CombineRepartitionAndRange) :: Nil
+  }
+
+  test("Combine range repartition and immediate child range operation") {
+    val query = Range(1, 100, 1, 10).distribute('id.asc)(20)
+    val optimized = Optimize.execute(query.analyze)
+    val correctAnswer = Range(1, 100, 1, 20)
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("Effect if all intermediate nodes are OrderPreservingUnaryNode") {
+    val query = Range(1, 100, 1, 10)
+      .where('id > 2)
+      .select('id, 'id * 2)
+      .limit(50)
+      .tail(10)
+      .distribute('id.asc)(20)
+    val optimized = Optimize.execute(query.analyze)
+    val correctAnswer = Range(1, 100, 1, 20)
+      .where('id > 2)
+      .select('id, 'id * 2)
+      .limit(50)
+      .tail(10)
+      .analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("Do not effect if not all intermediate nodes are OrderPreservingUnaryNode") {
+        val query = Range(1, 100, 1, 10)
+      .where('id > 2)
+      .select('id, 'id * 2)
+      .limit(50)
+      .orderBy('id.desc)
+      .tail(10)
+      .distribute('id.asc)(20)
+    val optimized = Optimize.execute(query.analyze)
+    val correctAnswer = query.analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombineRepartitionAndRangeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombineRepartitionAndRangeSuite.scala
@@ -44,9 +44,9 @@ class CombineRepartitionAndRangeSuite extends PlanTest {
       .select('id, 'id * 2)
       .limit(50)
       .tail(10)
-      .distribute('id.asc)(20)
+      .distribute('id.asc)(10)
     val optimized = Optimize.execute(query.analyze)
-    val correctAnswer = Range(1, 100, 1, 20)
+    val correctAnswer = Range(1, 100, 1, 10)
       .where('id > 2)
       .select('id, 'id * 2)
       .limit(50)
@@ -57,11 +57,24 @@ class CombineRepartitionAndRangeSuite extends PlanTest {
   }
 
   test("Do not effect if not all intermediate nodes are OrderPreservingUnaryNode") {
-        val query = Range(1, 100, 1, 10)
+    val query = Range(1, 100, 1, 10)
       .where('id > 2)
       .select('id, 'id * 2)
       .limit(50)
       .orderBy('id.desc)
+      .tail(10)
+      .distribute('id.asc)(20)
+    val optimized = Optimize.execute(query.analyze)
+    val correctAnswer = query.analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("Do not effect if num partitions is different between range partitioning and range") {
+    val query = Range(1, 100, 1, 10)
+      .where('id > 2)
+      .select('id, 'id * 2)
+      .limit(50)
       .tail(10)
       .distribute('id.asc)(20)
     val optimized = Optimize.execute(query.analyze)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent, SparkListe
 import org.apache.spark.sql.{Dataset, QueryTest, Row, SparkSession, Strategy}
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight}
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LogicalPlan}
-import org.apache.spark.sql.execution.{PartialReducerPartitionSpec, ReusedSubqueryExec, ShuffledRowRDD, SparkPlan}
+import org.apache.spark.sql.execution.{PartialReducerPartitionSpec, RangeExec, ReusedSubqueryExec, ShuffledRowRDD, SparkPlan, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.command.DataWritingCommandExec
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, Exchange, ReusedExchangeExec, ShuffleExchangeExec}
 import org.apache.spark.sql.execution.joins.{BaseJoinExec, BroadcastHashJoinExec, SortMergeJoinExec}
@@ -1105,10 +1105,11 @@ class AdaptiveQueryExecSuite
         val partitionsNum2 = df2.rdd.collectPartitions().length
 
         if (enableAQE) {
-          assert(partitionsNum1 < 10)
+          assert(partitionsNum1  === 10)
           assert(partitionsNum2 < 10)
 
-          checkInitialPartitionNum(df1, 10)
+          assert(df1.queryExecution.executedPlan.isInstanceOf[WholeStageCodegenExec])
+          assert(df1.queryExecution.executedPlan.children(0).isInstanceOf[RangeExec])
           checkInitialPartitionNum(df2, 10)
         } else {
           assert(partitionsNum1 === 10)


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR proposes to add a optimization rule to combine range repartition and range operation.
If all operations between range repartition and range operation are `OrderPreservingUnaryNode`, and ordering of the repartition and range operation are the same, they can be combined.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
For the better performance.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. After this change applied, range repartition can be combined with range operation.
One example here.

Before:
```
spark.range(1, 100, 1, 10).filter($"id" > 2).repartitionByRange(10, $"id").explain(true)

== Optimized Logical Plan ==
RepartitionByExpression [id#21L ASC NULLS FIRST], 10
+- Filter (id#21L > 2)
   +- Range (1, 100, step=1, splits=Some(10))
```

After:
```
spark.range(1, 100, 1, 10).filter($"id" > 2).repartitionByRange($"id").explain(true)
== Optimized Logical Plan ==
Filter (id#0L > 2)
+- Range (1, 100, step=1, splits=Some(10))
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
New test.