### PR TITLE
[SPARK-32849][PYSPARK] Add default values for non-required keys when creating StructType

### DIFF
--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -970,6 +970,66 @@ class DataTypeVerificationTests(unittest.TestCase):
         self.assertEqual(repr(r), "Row(b=1, a=2)")
 
 
+class DataTypeJsonTests(unittest.TestCase):
+
+    def test_data_type_json(self):
+        testname_sparktype_jsondata_expected_expectedjson = [
+            (
+                "ArrayType with default values",
+                ArrayType,
+                {"elementType": "string"},
+                ArrayType(StringType()),
+                {'type': 'array', 'elementType': 'string', 'containsNull': True}
+            ),
+            (
+                "ArrayType without default values",
+                ArrayType,
+                {"elementType": "string", "containsNull": False},
+                ArrayType(StringType(), False),
+                {'type': 'array', 'elementType': 'string', 'containsNull': False}
+            ),
+            (
+                "MapType with default values",
+                MapType,
+                {"keyType": "string", "valueType": "long"},
+                MapType(StringType(), LongType()),
+                {"keyType": "string", "valueType": "long", "valueContainsNull": True}
+            ),
+            (
+                "MapType without default values",
+                MapType,
+                {"keyType": "string", "valueType": "long", "valueContainsNull": False},
+                MapType(StringType(), LongType(), False),
+                {"keyType": "string", "valueType": "long", "valueContainsNull": False},
+            ),
+            (
+                "StructField with default values",
+                StructField,
+                {"name": "col1", "type": "string"},
+                StructField("col1", StringType()),
+                {"name": "col1", "type": "string", "nullable": True, "metadata": {}}
+            ),
+            (
+                "StructField without default values",
+                StructField,
+                {
+                    "name": "col1", "type": "string",
+                    "nullable": False, "metadata": {"thing1": "thing2"}
+                },
+                StructField("col1", StringType(), False, {"thing1": "thing2"}),
+                {"name": "col1", "type": "string", "nullable": False, "metadata": {"thing1": "thing2"}}
+            ),
+        ]
+        for testname, sparktype, jsondata, expected, expectedjson in testname_sparktype_jsondata_expected_expectedjson:
+            with self.subTest(testname):
+                # verify fromJson loads properly
+                self.assertEqual(expected, sparktype.fromJson(jsondata))
+                # verify expected can round trip properly
+                self.assertEqual(expected, sparktype.fromJson(expected.jsonValue()))
+                # verify jsonValue is as expected
+                self.assertEqual(expectedjson, expected.jsonValue())
+
+
 if __name__ == "__main__":
     from pyspark.sql.tests.test_types import *  # noqa: F401
 

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -305,7 +305,7 @@ class ArrayType(DataType):
     @classmethod
     def fromJson(cls, json):
         return ArrayType(_parse_datatype_json_value(json["elementType"]),
-                         json["containsNull"])
+                         json.get("containsNull", True))
 
     def needConversion(self):
         return self.elementType.needConversion()
@@ -365,7 +365,7 @@ class MapType(DataType):
     def fromJson(cls, json):
         return MapType(_parse_datatype_json_value(json["keyType"]),
                        _parse_datatype_json_value(json["valueType"]),
-                       json["valueContainsNull"])
+                       json.get("valueContainsNull", True))
 
     def needConversion(self):
         return self.keyType.needConversion() or self.valueType.needConversion()
@@ -426,8 +426,8 @@ class StructField(DataType):
     def fromJson(cls, json):
         return StructField(json["name"],
                            _parse_datatype_json_value(json["type"]),
-                           json["nullable"],
-                           json["metadata"])
+                           json.get("nullable", True),
+                           json.get("metadata", {}))
 
     def needConversion(self):
         return self.dataType.needConversion()


### PR DESCRIPTION
### What changes were proposed in this pull request?
When create a StructType from a Python dictionary you utilize the [StructType.fromJson](https://github.com/apache/spark/blob/master/python/pyspark/sql/types.py#L569-L571) function. This function then internally calls [StructField.fromJson](https://github.com/apache/spark/blob/328d81a2d1131742bcfba5117896c093db39e721/python/pyspark/sql/types.py#L425-L430) for each field in the list. This function requires that you must have all keys populated:
```
1. name
2. type
3. nullable
4. metadata
```
`name` & `type` most definitely need to be populated but `nullable` and `metadata` can be taken care of by default args.

The constructor for [StructField](https://github.com/apache/spark/blob/328d81a2d1131742bcfba5117896c093db39e721/python/pyspark/sql/types.py#L386-L395) has default arguments:
```python
class StructField(DataType):
    ...
    def __init__(self, name, dataType, nullable=True, metadata=None):
        ...
        self.name = name
        self.dataType = dataType
        self.nullable = nullable
        self.metadata = metadata or {}
 ```

It seems logical to mirror this when creating it from a Python dict. In addition, I added similar logic to `MapType` and `ArrayType` that follow the same pattern of **_not_** requiring keys in the JSON that have default arguments in the constructor.

### Why are the changes needed?
This change is needed to make it easier to define JSON schemas. The excess keys provide added functionality but they are not always required so developers should not have to worry about them unless they need to.


### Does this PR introduce _any_ user-facing change?
No. There are no user facing changes. 

### How was this patch tested?
Added unit tests to `spark/python/pyspark/sql/tests/test_types.py`