### PR TITLE
[SPARK-32850][CORE] Simplify the RPC message flow of decommission

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
@@ -120,7 +120,7 @@ private[spark] trait ExecutorAllocationClient {
       executorId: String,
       decommissionInfo: ExecutorDecommissionInfo,
       adjustTargetNumExecutors: Boolean,
-      triggeredByExecutor: Boolean = true): Boolean = {
+      triggeredByExecutor: Boolean = false): Boolean = {
     val decommissionedExecutors = decommissionExecutors(
       Array((executorId, decommissionInfo)),
       adjustTargetNumExecutors = adjustTargetNumExecutors,

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
@@ -88,7 +88,7 @@ private[spark] trait ExecutorAllocationClient {
    * Default implementation delegates to kill, scheduler must override
    * if it supports graceful decommissioning.
    *
-   * @param executorsAndDecomInfo    identifiers of executors & decom info.
+   * @param executorsAndDecomInfo identifiers of executors & decom info.
    * @param adjustTargetNumExecutors whether the target number of executors will be adjusted down
    *                                 after these executors have been decommissioned.
    * @param triggeredByExecutor whether the decommission is triggered at executor.

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
@@ -110,11 +110,10 @@ private[spark] trait ExecutorAllocationClient {
    * @param executorId identifiers of executor to decommission
    * @param decommissionInfo information about the decommission (reason, host loss)
    * @param adjustTargetNumExecutors if we should adjust the target number of executors.
-   * @param triggeredByExecutor   whether the decommission is triggered by sending the
-   *                                 `DecommissionExecutor` from driver to executor
-   *                                 (TODO: add a new type like `ExecutorDecommissionInfo` for the
-   *                                 case where executor is decommissioned at executor first, so we
-   *                                 don't need this extra parameter.)
+   * @param triggeredByExecutor   whether the decommission is triggered at executor.
+   *                              (TODO: add a new type like `ExecutorDecommissionInfo` for the
+   *                              case where executor is decommissioned at executor first, so we
+   *                              don't need this extra parameter.)
    * @return whether the request is acknowledged by the cluster manager.
    */
   final def decommissionExecutor(

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
@@ -96,7 +96,7 @@ private[spark] trait ExecutorAllocationClient {
   def decommissionExecutors(
       executorsAndDecomInfo: Array[(String, ExecutorDecommissionInfo)],
       adjustTargetNumExecutors: Boolean,
-      decommissionFromDriver: Boolean): Seq[String] = {
+      triggeredByExecutor: Boolean): Seq[String] = {
     killExecutors(executorsAndDecomInfo.map(_._1),
       adjustTargetNumExecutors,
       countFailures = false)
@@ -110,7 +110,7 @@ private[spark] trait ExecutorAllocationClient {
    * @param executorId identifiers of executor to decommission
    * @param decommissionInfo information about the decommission (reason, host loss)
    * @param adjustTargetNumExecutors if we should adjust the target number of executors.
-   * @param decommissionFromDriver   whether the decommission is triggered by sending the
+   * @param triggeredByExecutor   whether the decommission is triggered by sending the
    *                                 `DecommissionExecutor` from driver to executor
    *                                 (TODO: add a new type like `ExecutorDecommissionInfo` for the
    *                                 case where executor is decommissioned at executor first, so we
@@ -121,11 +121,11 @@ private[spark] trait ExecutorAllocationClient {
       executorId: String,
       decommissionInfo: ExecutorDecommissionInfo,
       adjustTargetNumExecutors: Boolean,
-      decommissionFromDriver: Boolean = true): Boolean = {
+      triggeredByExecutor: Boolean = true): Boolean = {
     val decommissionedExecutors = decommissionExecutors(
       Array((executorId, decommissionInfo)),
       adjustTargetNumExecutors = adjustTargetNumExecutors,
-      decommissionFromDriver = decommissionFromDriver)
+      triggeredByExecutor = triggeredByExecutor)
     decommissionedExecutors.nonEmpty && decommissionedExecutors(0).equals(executorId)
   }
 

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
@@ -88,9 +88,10 @@ private[spark] trait ExecutorAllocationClient {
    * Default implementation delegates to kill, scheduler must override
    * if it supports graceful decommissioning.
    *
-   * @param executorsAndDecomInfo identifiers of executors & decom info.
+   * @param executorsAndDecomInfo    identifiers of executors & decom info.
    * @param adjustTargetNumExecutors whether the target number of executors will be adjusted down
    *                                 after these executors have been decommissioned.
+   * @param triggeredByExecutor whether the decommission is triggered at executor.
    * @return the ids of the executors acknowledged by the cluster manager to be removed.
    */
   def decommissionExecutors(
@@ -110,10 +111,10 @@ private[spark] trait ExecutorAllocationClient {
    * @param executorId identifiers of executor to decommission
    * @param decommissionInfo information about the decommission (reason, host loss)
    * @param adjustTargetNumExecutors if we should adjust the target number of executors.
-   * @param triggeredByExecutor   whether the decommission is triggered at executor.
-   *                              (TODO: add a new type like `ExecutorDecommissionInfo` for the
-   *                              case where executor is decommissioned at executor first, so we
-   *                              don't need this extra parameter.)
+   * @param triggeredByExecutor whether the decommission is triggered at executor.
+   *                            (TODO: add a new type like `ExecutorDecommissionInfo` for the
+   *                            case where executor is decommissioned at executor first, so we
+   *                            don't need this extra parameter.)
    * @return whether the request is acknowledged by the cluster manager.
    */
   final def decommissionExecutor(

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
@@ -94,8 +94,9 @@ private[spark] trait ExecutorAllocationClient {
    * @return the ids of the executors acknowledged by the cluster manager to be removed.
    */
   def decommissionExecutors(
-    executorsAndDecomInfo: Array[(String, ExecutorDecommissionInfo)],
-    adjustTargetNumExecutors: Boolean): Seq[String] = {
+      executorsAndDecomInfo: Array[(String, ExecutorDecommissionInfo)],
+      adjustTargetNumExecutors: Boolean,
+      decommissionFromDriver: Boolean): Seq[String] = {
     killExecutors(executorsAndDecomInfo.map(_._1),
       adjustTargetNumExecutors,
       countFailures = false)
@@ -109,14 +110,19 @@ private[spark] trait ExecutorAllocationClient {
    * @param executorId identifiers of executor to decommission
    * @param decommissionInfo information about the decommission (reason, host loss)
    * @param adjustTargetNumExecutors if we should adjust the target number of executors.
+   * @param decommissionFromDriver whether the decommission is triggered by sending the
+   *                                `DecommissionExecutor` from driver to executor
    * @return whether the request is acknowledged by the cluster manager.
    */
-  final def decommissionExecutor(executorId: String,
+  final def decommissionExecutor(
+      executorId: String,
       decommissionInfo: ExecutorDecommissionInfo,
-      adjustTargetNumExecutors: Boolean): Boolean = {
+      adjustTargetNumExecutors: Boolean,
+      decommissionFromDriver: Boolean = true): Boolean = {
     val decommissionedExecutors = decommissionExecutors(
       Array((executorId, decommissionInfo)),
-      adjustTargetNumExecutors = adjustTargetNumExecutors)
+      adjustTargetNumExecutors = adjustTargetNumExecutors,
+      decommissionFromDriver = decommissionFromDriver)
     decommissionedExecutors.nonEmpty && decommissionedExecutors(0).equals(executorId)
   }
 

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
@@ -110,8 +110,11 @@ private[spark] trait ExecutorAllocationClient {
    * @param executorId identifiers of executor to decommission
    * @param decommissionInfo information about the decommission (reason, host loss)
    * @param adjustTargetNumExecutors if we should adjust the target number of executors.
-   * @param decommissionFromDriver whether the decommission is triggered by sending the
-   *                                `DecommissionExecutor` from driver to executor
+   * @param decommissionFromDriver   whether the decommission is triggered by sending the
+   *                                 `DecommissionExecutor` from driver to executor
+   *                                 (TODO: add a new type like `ExecutorDecommissionInfo` for the
+   *                                 case where executor is decommissioned at executor first, so we
+   *                                 don't need this extra parameter.)
    * @return whether the request is acknowledged by the cluster manager.
    */
   final def decommissionExecutor(

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -584,7 +584,7 @@ private[spark] class ExecutorAllocationManager(
         client.decommissionExecutors(
           executorIdsWithoutHostLoss,
           adjustTargetNumExecutors = false,
-          decommissionFromDriver = true)
+          triggeredByExecutor = true)
       } else {
         client.killExecutors(executorIdsToBeRemoved.toSeq, adjustTargetNumExecutors = false,
           countFailures = false, force = false)

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -581,7 +581,10 @@ private[spark] class ExecutorAllocationManager(
       if (decommissionEnabled) {
         val executorIdsWithoutHostLoss = executorIdsToBeRemoved.toSeq.map(
           id => (id, ExecutorDecommissionInfo("spark scale down"))).toArray
-        client.decommissionExecutors(executorIdsWithoutHostLoss, adjustTargetNumExecutors = false)
+        client.decommissionExecutors(
+          executorIdsWithoutHostLoss,
+          adjustTargetNumExecutors = false,
+          decommissionFromDriver = true)
       } else {
         client.killExecutors(executorIdsToBeRemoved.toSeq, adjustTargetNumExecutors = false,
           countFailures = false, force = false)

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -584,7 +584,7 @@ private[spark] class ExecutorAllocationManager(
         client.decommissionExecutors(
           executorIdsWithoutHostLoss,
           adjustTargetNumExecutors = false,
-          triggeredByExecutor = true)
+          triggeredByExecutor = false)
       } else {
         client.killExecutors(executorIdsToBeRemoved.toSeq, adjustTargetNumExecutors = false,
           countFailures = false, force = false)

--- a/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
@@ -77,12 +77,12 @@ private[deploy] object DeployMessages {
   object DecommissionWorker extends DeployMessage
 
   /**
-   * A message that sent from Worker to Master to tell Master that the Worker has been
-   * decommissioned. It's used for the case where decommission is triggered at Worker.
+   * A message sent from Worker to Master to tell Master that the Worker has started
+   * decommissioning. It's used for the case where decommission is triggered at Worker.
    *
    * @param id the worker id
    */
-  case class WorkerDecommissioned(id: String, workerRef: RpcEndpointRef) extends DeployMessage
+  case class WorkerDecommissioning(id: String, workerRef: RpcEndpointRef) extends DeployMessage
 
   case class ExecutorStateChanged(
       appId: String,

--- a/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
@@ -63,7 +63,7 @@ private[deploy] object DeployMessages {
   /**
    * An internal message that used by Master itself, in order to handle the
    * `DecommissionWorkersOnHosts` request from `MasterWebUI` asynchronously.
-   * @param ids A collection of Worker ids, which are pending to be decommissioned.
+   * @param ids A collection of Worker ids, which should be decommissioned.
    */
   case class DecommissionWorkers(ids: Seq[String])
 

--- a/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
@@ -68,8 +68,9 @@ private[deploy] object DeployMessages {
   case class DecommissionWorkers(ids: Seq[String])
 
   /**
-   * A message that sent from Master to Worker to decommission the Worker.
-   * It's used for the case where decommission is triggered at MasterWebUI.
+   * A message that sent to Worker to decommission the Worker. The message can be sent by the Master
+   * if decommission is triggered at MasterWebUI or the Worker itself if decommission is triggered
+   * at Worker.
    *
    * Note that decommission a Worker will cause all the executors on that Worker
    * to be decommissioned as well.

--- a/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
@@ -77,6 +77,12 @@ private[deploy] object DeployMessages {
   object DecommissionWorker extends DeployMessage
 
   /**
+   * A message that sent to the Worker itself when it receives PWR signal,
+   * indicating the Worker starts to decommission.
+   */
+  object WorkerSigPWRReceived extends DeployMessage
+
+  /**
    * A message sent from Worker to Master to tell Master that the Worker has started
    * decommissioning. It's used for the case where decommission is triggered at Worker.
    *

--- a/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
@@ -82,7 +82,7 @@ private[deploy] object DeployMessages {
    *
    * @param id the worker id
    */
-  case class WorkerDecommissioned(id: String) extends DeployMessage
+  case class WorkerDecommissioned(id: String, workerRef: RpcEndpointRef) extends DeployMessage
 
   case class ExecutorStateChanged(
       appId: String,

--- a/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
@@ -65,7 +65,7 @@ private[deploy] object DeployMessages {
    * `DecommissionWorkersOnHosts` request from `MasterWebUI` asynchronously.
    * @param ids A collection of Worker ids, which should be decommissioned.
    */
-  case class DecommissionWorkers(ids: Seq[String])
+  case class DecommissionWorkers(ids: Seq[String]) extends DeployMessage
 
   /**
    * A message that sent from Master to Worker to decommission the Worker.

--- a/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
@@ -68,9 +68,8 @@ private[deploy] object DeployMessages {
   case class DecommissionWorkers(ids: Seq[String])
 
   /**
-   * A message that sent to Worker to decommission the Worker. The message can be sent by the Master
-   * if decommission is triggered at MasterWebUI or the Worker itself if decommission is triggered
-   * at Worker.
+   * A message that sent from Master to Worker to decommission the Worker.
+   * It's used for the case where decommission is triggered at MasterWebUI.
    *
    * Note that decommission a Worker will cause all the executors on that Worker
    * to be decommissioned as well.

--- a/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
@@ -61,13 +61,28 @@ private[deploy] object DeployMessages {
   }
 
   /**
-   * @param id the worker id
-   * @param worker the worker endpoint ref
+   * An internal message that used by Master itself, in order to handle the
+   * `DecommissionWorkersOnHosts` request from `MasterWebUI` asynchronously.
+   * @param ids A collection of Worker ids, which are pending to be decommissioned.
    */
-  case class WorkerDecommission(
-      id: String,
-      worker: RpcEndpointRef)
-    extends DeployMessage
+  case class DecommissionWorkers(ids: Seq[String])
+
+  /**
+   * A message that sent from Master to Worker to decommission the Worker.
+   * It's used for the case where decommission is triggered at MasterWebUI.
+   *
+   * Note that decommission a Worker will cause all the executors on that Worker
+   * to be decommissioned as well.
+   */
+  object DecommissionWorker extends DeployMessage
+
+  /**
+   * A message that sent from Worker to Master to tell Master that the Worker has been
+   * decommissioned. It's used for the case where decommission is triggered at Worker.
+   *
+   * @param id the worker id
+   */
+  case class WorkerDecommissioned(id: String) extends DeployMessage
 
   case class ExecutorStateChanged(
       appId: String,

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -249,6 +249,7 @@ private[deploy] class Master(
       if (state == RecoveryState.STANDBY) {
         workerRef.send(MasterInStandby)
       } else {
+        // We use foreach since get gives us an option and we can skip the failures.
         idToWorker.get(id).foreach(w => decommissionWorker(w, triggeredByWorker = true))
       }
 

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -245,7 +245,7 @@ private[deploy] class Master(
       logError("Leadership has been revoked -- master shutting down.")
       System.exit(0)
 
-    case WorkerDecommissioned(id, workerRef) =>
+    case WorkerDecommissioning(id, workerRef) =>
       if (state == RecoveryState.STANDBY) {
         workerRef.send(MasterInStandby)
       } else {

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -245,8 +245,12 @@ private[deploy] class Master(
       logError("Leadership has been revoked -- master shutting down.")
       System.exit(0)
 
-    case WorkerDecommissioned(id) =>
-      idToWorker.get(id).foreach(w => decommissionWorker(w, sentFromWorker = true))
+    case WorkerDecommissioned(id, workerRef) =>
+      if (state == RecoveryState.STANDBY) {
+        workerRef.send(MasterInStandby)
+      } else {
+        idToWorker.get(id).foreach(w => decommissionWorker(w, sentFromWorker = true))
+      }
 
     case DecommissionWorkers(ids) =>
       ids.foreach ( id =>

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -254,6 +254,9 @@ private[deploy] class Master(
       }
 
     case DecommissionWorkers(ids) =>
+      // The caller has already checked the state when handling DecommissionWorkersOnHosts,
+      // so it should not be the STANDBY
+      assert(state != RecoveryState.STANDBY)
       ids.foreach ( id =>
         // We use foreach since get gives us an option and we can skip the failures.
         idToWorker.get(id).foreach { w =>

--- a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
@@ -773,7 +773,7 @@ private[deploy] class Worker(
       logDebug("Decommissioning self")
       decommissioned = true
       if (!fromMaster) {
-        sendToMaster(WorkerDecommissioned(workerId))
+        sendToMaster(WorkerDecommissioned(workerId, self))
       }
     } else {
       logWarning("Asked to decommission self, but decommissioning not enabled")

--- a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
@@ -549,7 +549,7 @@ private[deploy] class Worker(
     case LaunchExecutor(masterUrl, appId, execId, appDesc, cores_, memory_, resources_) =>
       if (masterUrl != activeMasterUrl) {
         logWarning("Invalid Master (" + masterUrl + ") attempted to launch executor.")
-      } else if (decommissioned.get()) {
+      } else if (decommissioned) {
         logWarning("Asked to launch an executor while decommissioned. Not launching executor.")
       } else {
         try {

--- a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
@@ -772,6 +772,7 @@ private[deploy] class Worker(
     if (conf.get(config.DECOMMISSION_ENABLED)) {
       logDebug("Decommissioning self")
       decommissioned = true
+      // No need to notify the Master if the decommission message already came from it
       if (!fromMaster) {
         sendToMaster(WorkerDecommissioned(workerId, self))
       }

--- a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
@@ -70,7 +70,7 @@ private[deploy] class Worker(
   if (conf.get(config.DECOMMISSION_ENABLED)) {
     logInfo("Registering SIGPWR handler to trigger decommissioning.")
     SignalUtils.register("PWR", "Failed to register SIGPWR handler - " +
-      "disabling worker decommission feature.")(decommissionSelf(triggeredByMaster = false))
+      "disabling worker decommission feature.")(decommissionSelf(triggeredByWorker = true))
   } else {
     logInfo("Worker decommissioning not enabled, SIGPWR will result in exiting.")
   }
@@ -669,7 +669,7 @@ private[deploy] class Worker(
       maybeCleanupApplication(id)
 
     case DecommissionWorker =>
-      decommissionSelf(triggeredByMaster = true)
+      decommissionSelf(triggeredByWorker = false)
   }
 
   override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {
@@ -768,12 +768,12 @@ private[deploy] class Worker(
     }
   }
 
-  private[deploy] def decommissionSelf(triggeredByMaster: Boolean): Boolean = {
+  private[deploy] def decommissionSelf(triggeredByWorker: Boolean): Boolean = {
     if (conf.get(config.DECOMMISSION_ENABLED)) {
       logDebug("Decommissioning self")
       decommissioned = true
       // No need to notify the Master if the decommission message already came from it
-      if (!triggeredByMaster) {
+      if (triggeredByWorker) {
         sendToMaster(WorkerDecommissioning(workerId, self))
       }
     } else {

--- a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
@@ -774,7 +774,7 @@ private[deploy] class Worker(
       decommissioned = true
       // No need to notify the Master if the decommission message already came from it
       if (!triggeredByMaster) {
-        sendToMaster(WorkerDecommissioned(workerId, self))
+        sendToMaster(WorkerDecommissioning(workerId, self))
       }
     } else {
       logWarning("Asked to decommission self, but decommissioning not enabled")

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -261,11 +261,13 @@ private[spark] class CoarseGrainedExecutorBackend(
       if (env.conf.get(STORAGE_DECOMMISSION_ENABLED)) {
         env.blockManager.decommissionBlockManager()
       }
-      // Tell master we are are decommissioned so it stops trying to schedule us
-      if (driver.nonEmpty && !fromDriver) {
-        driver.get.askSync[Boolean](ExecutorDecommissioned(executorId))
-      } else {
-        logError("No driver to message decommissioning.")
+      // Tell driver we are decommissioned so it stops trying to schedule us
+      if (!fromDriver) {
+        if (driver.nonEmpty) {
+          driver.get.askSync[Boolean](ExecutorDecommissioned(executorId))
+        } else {
+          logError("No driver to message decommissioning.")
+        }
       }
       if (executor != null) {
         executor.decommission()

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -40,7 +40,7 @@ import org.apache.spark.resource.ResourceProfile
 import org.apache.spark.resource.ResourceProfile._
 import org.apache.spark.resource.ResourceUtils._
 import org.apache.spark.rpc._
-import org.apache.spark.scheduler.{ExecutorDecommissionInfo, ExecutorLossReason, TaskDescription}
+import org.apache.spark.scheduler.{ExecutorLossReason, TaskDescription}
 import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages._
 import org.apache.spark.serializer.SerializerInstance
 import org.apache.spark.util.{ChildFirstURLClassLoader, MutableURLClassLoader, SignalUtils, ThreadUtils, Utils}
@@ -79,12 +79,23 @@ private[spark] class CoarseGrainedExecutorBackend(
    */
   private[executor] val taskResources = new mutable.HashMap[Long, Map[String, ResourceInformation]]
 
-  @volatile private var decommissioned = false
+  private var decommissioned = false
 
   override def onStart(): Unit = {
-    logInfo("Registering PWR handler.")
-    SignalUtils.register("PWR", "Failed to register SIGPWR handler - " +
-      "disabling decommission feature.")(decommissionSelf(triggeredByExecutor = true))
+    if (env.conf.get(DECOMMISSION_ENABLED)) {
+      logInfo("Registering PWR handler to trigger decommissioning.")
+      SignalUtils.register("PWR", "Failed to register SIGPWR handler - " +
+      "disabling executor decommission feature.") {
+        self.send(DecommissionExecutor)
+        if (driver.nonEmpty) {
+          // Tell driver we starts decommissioning so it stops trying to schedule us
+          driver.get.askSync[Boolean](ExecutorDecommissioning(executorId))
+        } else {
+          logError("No driver to message decommissioning.")
+        }
+        true
+      }
+    }
 
     logInfo("Connecting to driver: " + driverUrl)
     try {
@@ -203,8 +214,7 @@ private[spark] class CoarseGrainedExecutorBackend(
       SparkHadoopUtil.get.addDelegationTokens(tokenBytes, env.conf)
 
     case DecommissionExecutor =>
-      logInfo("Received decommission self")
-      decommissionSelf(triggeredByExecutor = false)
+      decommissionSelf()
   }
 
   override def onDisconnected(remoteAddress: RpcAddress): Unit = {
@@ -253,21 +263,20 @@ private[spark] class CoarseGrainedExecutorBackend(
     System.exit(code)
   }
 
-  private def decommissionSelf(triggeredByExecutor: Boolean): Boolean = {
-    val msg = "Decommissioning self w/sync"
+  private def decommissionSelf(): Unit = {
+    if (!env.conf.get(DECOMMISSION_ENABLED)) {
+      logWarning(s"Receive decommission request, but decommission feature is disabled.")
+      return
+    } else if (decommissioned) {
+      logWarning(s"Executor $executorId already started decommissioning.")
+      return
+    }
+    val msg = s"Decommission executor $executorId."
     logInfo(msg)
     try {
       decommissioned = true
       if (env.conf.get(STORAGE_DECOMMISSION_ENABLED)) {
         env.blockManager.decommissionBlockManager()
-      }
-      // Tell driver we starts decommissioning so it stops trying to schedule us
-      if (triggeredByExecutor) {
-        if (driver.nonEmpty) {
-          driver.get.askSync[Boolean](ExecutorDecommissioning(executorId))
-        } else {
-          logError("No driver to message decommissioning.")
-        }
       }
       if (executor != null) {
         executor.decommission()
@@ -326,13 +335,12 @@ private[spark] class CoarseGrainedExecutorBackend(
       shutdownThread.start()
 
       logInfo("Will exit when finished decommissioning")
-      // Return true since we are handling a signal
-      true
     } catch {
       case e: Exception =>
         logError("Unexpected error while decommissioning self", e)
-        false
+        return false
     }
+    decommissioned.get()
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -338,9 +338,7 @@ private[spark] class CoarseGrainedExecutorBackend(
     } catch {
       case e: Exception =>
         logError("Unexpected error while decommissioning self", e)
-        return false
     }
-    decommissioned.get()
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -264,7 +264,7 @@ private[spark] class CoarseGrainedExecutorBackend(
       // Tell driver we are decommissioned so it stops trying to schedule us
       if (!fromDriver) {
         if (driver.nonEmpty) {
-          driver.get.askSync[Boolean](ExecutorDecommissioned(executorId))
+          driver.get.askSync[Boolean](ExecutorDecommissioning(executorId))
         } else {
           logError("No driver to message decommissioning.")
         }

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
@@ -103,6 +103,10 @@ private[spark] object CoarseGrainedClusterMessages {
   // It's used for Standalone's cases, where decommission is triggered at MasterWebUI or Worker.
   object DecommissionExecutor extends CoarseGrainedClusterMessage
 
+  // A message that sent to the executor itself when it receives PWR signal,
+  // indicating the executor starts to decommission.
+  object ExecutorSigPWRReceived extends CoarseGrainedClusterMessage
+
   case class RemoveWorker(workerId: String, host: String, message: String)
     extends CoarseGrainedClusterMessage
 

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
@@ -97,7 +97,7 @@ private[spark] object CoarseGrainedClusterMessages {
 
   // A message that sent from executor to driver to tell driver that the executor has started
   // decommissioning. It's used for the case where decommission is triggered at executor (e.g., K8S)
-  case class ExecutorDecommissioning(executorId: String)
+  case class ExecutorDecommissioning(executorId: String) extends CoarseGrainedClusterMessage
 
   // A message that sent from driver to executor to decommission that executor.
   // It's used for Standalone's cases, where decommission is triggered at MasterWebUI or Worker.

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
@@ -99,8 +99,9 @@ private[spark] object CoarseGrainedClusterMessages {
   // decommissioning. It's used for the case where decommission is triggered at executor (e.g., K8S)
   case class ExecutorDecommissioning(executorId: String)
 
-  // A message that sent from driver to executor to decommission that executor.
-  // It's used for Standalone's cases, where decommission is triggered at MasterWebUI or Worker.
+  // A message that sent to executor backend to decommission that executor. The message can be
+  // sent by the driver if decommission is triggered at MasterWebUI or Worker in Standalone or
+  // the executor itself if decommission is triggered at executor in K8S.
   object DecommissionExecutor extends CoarseGrainedClusterMessage
 
   case class RemoveWorker(workerId: String, host: String, message: String)

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
@@ -95,8 +95,13 @@ private[spark] object CoarseGrainedClusterMessages {
   case class RemoveExecutor(executorId: String, reason: ExecutorLossReason)
     extends CoarseGrainedClusterMessage
 
-  case class DecommissionExecutor(executorId: String, decommissionInfo: ExecutorDecommissionInfo)
-    extends CoarseGrainedClusterMessage
+  // A message that sent from executor to driver to tell driver that the executor has been
+  // used. It's used for the case where decommission is triggered at executor (e.g., K8S)
+  case class ExecutorDecommissioned(executorId: String)
+
+  // A message that sent from driver to executor to decommission that executor.
+  // It's used for Standalone's case yet, where decommission is triggered at Worker.
+  object DecommissionExecutor extends CoarseGrainedClusterMessage
 
   case class RemoveWorker(workerId: String, host: String, message: String)
     extends CoarseGrainedClusterMessage
@@ -136,7 +141,4 @@ private[spark] object CoarseGrainedClusterMessages {
 
   // The message to check if `CoarseGrainedSchedulerBackend` thinks the executor is alive or not.
   case class IsExecutorAlive(executorId: String) extends CoarseGrainedClusterMessage
-
-  // Used to ask an executor to decommission itself. (Can be an internal message)
-  case object DecommissionSelf extends CoarseGrainedClusterMessage
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
@@ -99,9 +99,8 @@ private[spark] object CoarseGrainedClusterMessages {
   // decommissioning. It's used for the case where decommission is triggered at executor (e.g., K8S)
   case class ExecutorDecommissioning(executorId: String)
 
-  // A message that sent to executor backend to decommission that executor. The message can be
-  // sent by the driver if decommission is triggered at MasterWebUI or Worker in Standalone or
-  // the executor itself if decommission is triggered at executor in K8S.
+  // A message that sent from driver to executor to decommission that executor.
+  // It's used for Standalone's cases, where decommission is triggered at MasterWebUI or Worker.
   object DecommissionExecutor extends CoarseGrainedClusterMessage
 
   case class RemoveWorker(workerId: String, host: String, message: String)

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
@@ -100,7 +100,7 @@ private[spark] object CoarseGrainedClusterMessages {
   case class ExecutorDecommissioned(executorId: String)
 
   // A message that sent from driver to executor to decommission that executor.
-  // It's used for Standalone's case yet, where decommission is triggered at Worker.
+  // It's used for Standalone's cases, where decommission is triggered at MasterWebUI or Worker.
   object DecommissionExecutor extends CoarseGrainedClusterMessage
 
   case class RemoveWorker(workerId: String, host: String, message: String)

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
@@ -95,9 +95,9 @@ private[spark] object CoarseGrainedClusterMessages {
   case class RemoveExecutor(executorId: String, reason: ExecutorLossReason)
     extends CoarseGrainedClusterMessage
 
-  // A message that sent from executor to driver to tell driver that the executor has been
-  // used. It's used for the case where decommission is triggered at executor (e.g., K8S)
-  case class ExecutorDecommissioned(executorId: String)
+  // A message that sent from executor to driver to tell driver that the executor has started
+  // decommissioning. It's used for the case where decommission is triggered at executor (e.g., K8S)
+  case class ExecutorDecommissioning(executorId: String)
 
   // A message that sent from driver to executor to decommission that executor.
   // It's used for Standalone's cases, where decommission is triggered at MasterWebUI or Worker.

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -275,8 +275,6 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
             executorId,
             ExecutorDecommissionInfo(s"Executor $executorId is decommissioned."),
             adjustTargetNumExecutors = false,
-            // TODO: add a new type like `ExecutorDecommissionInfo` for the case where executor
-            // is decommissioned at executor first, so we don't need this extra parameter.
             decommissionFromDriver = false))
 
       case RetrieveSparkAppConfig(resourceProfileId) =>

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -493,7 +493,9 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
     // decommission notification to executors. So, it's less likely to lead to the race
     // condition where `getPeer` request from the decommissioned executor comes first
     // before the BlockManagers are marked as decommissioned.
-    scheduler.sc.env.blockManager.master.decommissionBlockManagers(executorsToDecommission)
+    if (conf.get(STORAGE_DECOMMISSION_ENABLED)) {
+      scheduler.sc.env.blockManager.master.decommissionBlockManagers(executorsToDecommission)
+    }
 
     if (decommissionFromDriver) {
       CoarseGrainedSchedulerBackend.this.synchronized {

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -494,7 +494,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
       scheduler.sc.env.blockManager.master.decommissionBlockManagers(executorsToDecommission)
     }
 
-    if (triggeredByExecutor) {
+    if (!triggeredByExecutor) {
       executorsToDecommission.foreach { executorId =>
         logInfo(s"Asking executor $executorId to decommissioning.")
         executorDataMap(executorId).executorEndpoint.send(DecommissionExecutor)

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -191,10 +191,6 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
         executorDataMap.get(executorId).foreach(_.executorEndpoint.send(StopExecutor))
         removeExecutor(executorId, reason)
 
-      case DecommissionExecutor(executorId, decommissionInfo) =>
-        logError(s"Received decommission executor message ${executorId}: $decommissionInfo")
-        decommissionExecutor(executorId, decommissionInfo, adjustTargetNumExecutors = false)
-
       case RemoveWorker(workerId, host, message) =>
         removeWorker(workerId, host, message)
 
@@ -272,10 +268,16 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
         removeWorker(workerId, host, message)
         context.reply(true)
 
-      case DecommissionExecutor(executorId, decommissionInfo) =>
-        logError(s"Received decommission executor message ${executorId}: ${decommissionInfo}.")
-        context.reply(decommissionExecutor(executorId, decommissionInfo,
-          adjustTargetNumExecutors = false))
+      case ExecutorDecommissioned(executorId) =>
+        logWarning(s"Received executor $executorId decommissioned message")
+        context.reply(
+          decommissionExecutor(
+            executorId,
+            ExecutorDecommissionInfo(s"Executor $executorId is decommissioned."),
+            adjustTargetNumExecutors = false,
+            // TODO: add a new type like `ExecutorDecommissionInfo` for the case where executor
+            // is decommissioned at executor first, so we don't need this extra parameter.
+            decommissionFromDriver = false))
 
       case RetrieveSparkAppConfig(resourceProfileId) =>
         val rp = scheduler.sc.resourceProfileManager.resourceProfileFromId(resourceProfileId)
@@ -467,66 +469,43 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
    */
   override def decommissionExecutors(
       executorsAndDecomInfo: Array[(String, ExecutorDecommissionInfo)],
-      adjustTargetNumExecutors: Boolean): Seq[String] = {
-
-    val executorsToDecommission = executorsAndDecomInfo.filter { case (executorId, decomInfo) =>
-      CoarseGrainedSchedulerBackend.this.synchronized {
+      adjustTargetNumExecutors: Boolean,
+      decommissionFromDriver: Boolean): Seq[String] = {
+    val executorsToDecommission = withLock {
+      executorsAndDecomInfo.flatMap { case (executorId, decomInfo) =>
         // Only bother decommissioning executors which are alive.
         if (isExecutorActive(executorId)) {
+          scheduler.executorDecommission(executorId, decomInfo)
           executorsPendingDecommission(executorId) = decomInfo.workerHost
-          true
+          Some(executorId)
         } else {
-          false
+          None
         }
       }
     }
 
     // If we don't want to replace the executors we are decommissioning
     if (adjustTargetNumExecutors) {
-      adjustExecutors(executorsToDecommission.map(_._1))
+      adjustExecutors(executorsToDecommission)
     }
 
-    executorsToDecommission.filter { case (executorId, decomInfo) =>
-      doDecommission(executorId, decomInfo)
-    }.map(_._1)
-  }
+    // Mark those corresponding BlockManagers as decommissioned first before we sending
+    // decommission notification to executors. So, it's less likely to lead to the race
+    // condition where `getPeer` request from the decommissioned executor comes first
+    // before the BlockManagers are marked as decommissioned.
+    scheduler.sc.env.blockManager.master.decommissionBlockManagers(executorsToDecommission)
 
-
-  private def doDecommission(executorId: String,
-      decomInfo: ExecutorDecommissionInfo): Boolean = {
-
-    logInfo(s"Asking executor $executorId to decommissioning.")
-    scheduler.executorDecommission(executorId, decomInfo)
-    // Send decommission message to the executor (it could have originated on the executor
-    // but not necessarily).
-    CoarseGrainedSchedulerBackend.this.synchronized {
-      executorDataMap.get(executorId) match {
-        case Some(executorInfo) =>
-          executorInfo.executorEndpoint.send(DecommissionSelf)
-        case None =>
-          // Ignoring the executor since it is not registered.
-          logWarning(s"Attempted to decommission unknown executor $executorId.")
-          return false
+    if (decommissionFromDriver) {
+      CoarseGrainedSchedulerBackend.this.synchronized {
+        executorsToDecommission.foreach { executorId =>
+          logInfo(s"Asking executor $executorId to decommissioning.")
+          executorDataMap(executorId).executorEndpoint.send(DecommissionExecutor)
+        }
       }
     }
-    logInfo(s"Asked executor $executorId to decommission.")
 
-    if (conf.get(STORAGE_DECOMMISSION_ENABLED)) {
-      try {
-        logInfo(s"Asking block manager corresponding to executor $executorId to decommission.")
-        scheduler.sc.env.blockManager.master.decommissionBlockManagers(Seq(executorId))
-      } catch {
-        case e: Exception =>
-          logError("Unexpected error during block manager " +
-            s"decommissioning for executor $executorId: ${e.toString}", e)
-          return false
-      }
-      logInfo(s"Acknowledged decommissioning block manager corresponding to $executorId.")
-    }
-
-    true
+    executorsToDecommission
   }
-
 
   override def start(): Unit = {
     if (UserGroupInformation.isSecurityEnabled()) {

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -268,7 +268,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
         removeWorker(workerId, host, message)
         context.reply(true)
 
-      case ExecutorDecommissioned(executorId) =>
+      case ExecutorDecommissioning(executorId) =>
         logWarning(s"Received executor $executorId decommissioned message")
         context.reply(
           decommissionExecutor(

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -463,6 +463,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
    * @param executorsAndDecomInfo Identifiers of executors & decommission info.
    * @param adjustTargetNumExecutors whether the target number of executors will be adjusted down
    *                                 after these executors have been decommissioned.
+   * @param triggeredByExecutor whether the decommission is triggered at executor.
    * @return the ids of the executors acknowledged by the cluster manager to be removed.
    */
   override def decommissionExecutors(

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/StandaloneSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/StandaloneSchedulerBackend.scala
@@ -183,7 +183,7 @@ private[spark] class StandaloneSchedulerBackend(
     decommissionExecutors(
       Array((execId, decommissionInfo)),
       adjustTargetNumExecutors = false,
-      decommissionFromDriver = true)
+      triggeredByExecutor = true)
     logInfo("Executor %s decommissioned: %s".format(fullId, decommissionInfo))
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/StandaloneSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/StandaloneSchedulerBackend.scala
@@ -178,9 +178,12 @@ private[spark] class StandaloneSchedulerBackend(
   }
 
   override def executorDecommissioned(fullId: String, decommissionInfo: ExecutorDecommissionInfo) {
-    logInfo("Asked to decommission executor")
+    logInfo(s"Asked to decommission executor $fullId")
     val execId = fullId.split("/")(1)
-    decommissionExecutors(Array((execId, decommissionInfo)), adjustTargetNumExecutors = false)
+    decommissionExecutors(
+      Array((execId, decommissionInfo)),
+      adjustTargetNumExecutors = false,
+      decommissionFromDriver = true)
     logInfo("Executor %s decommissioned: %s".format(fullId, decommissionInfo))
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/StandaloneSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/StandaloneSchedulerBackend.scala
@@ -183,7 +183,7 @@ private[spark] class StandaloneSchedulerBackend(
     decommissionExecutors(
       Array((execId, decommissionInfo)),
       adjustTargetNumExecutors = false,
-      triggeredByExecutor = true)
+      triggeredByExecutor = false)
     logInfo("Executor %s decommissioned: %s".format(fullId, decommissionInfo))
   }
 

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -264,8 +264,6 @@ private[spark] class BlockManager(
     shuffleManager.shuffleBlockResolver.asInstanceOf[MigratableResolver]
   }
 
-  def decommissionBlockManager(): Unit = storageEndpoint.ask(DecommissionBlockManager)
-
   override def getLocalDiskDirs: Array[String] = diskBlockManager.localDirsString
 
   /**
@@ -1810,6 +1808,8 @@ private[spark] class BlockManager(
     blocksToRemove.foreach { blockId => removeBlock(blockId, tellMaster = false) }
     blocksToRemove.size
   }
+
+  def decommissionBlockManager(): Unit = storageEndpoint.ask(DecommissionBlockManager)
 
   private[spark] def decommissionSelf(): Unit = synchronized {
     decommissioner match {

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -264,7 +264,7 @@ private[spark] class BlockManager(
     shuffleManager.shuffleBlockResolver.asInstanceOf[MigratableResolver]
   }
 
-  def decommissionBlockManager(): Unit = storageEndpoint.send(DecommissionBlockManager)
+  def decommissionBlockManager(): Unit = storageEndpoint.ask(DecommissionBlockManager)
 
   override def getLocalDiskDirs: Array[String] = diskBlockManager.localDirsString
 

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -56,7 +56,7 @@ import org.apache.spark.scheduler.ExecutorCacheTaskLocation
 import org.apache.spark.serializer.{SerializerInstance, SerializerManager}
 import org.apache.spark.shuffle.{MigratableResolver, ShuffleManager, ShuffleWriteMetricsReporter}
 import org.apache.spark.shuffle.{ShuffleManager, ShuffleWriteMetricsReporter}
-import org.apache.spark.storage.BlockManagerMessages.ReplicateBlock
+import org.apache.spark.storage.BlockManagerMessages.{DecommissionBlockManager, ReplicateBlock}
 import org.apache.spark.storage.memory._
 import org.apache.spark.unsafe.Platform
 import org.apache.spark.util._
@@ -263,6 +263,8 @@ private[spark] class BlockManager(
   private[storage] lazy val migratableResolver: MigratableResolver = {
     shuffleManager.shuffleBlockResolver.asInstanceOf[MigratableResolver]
   }
+
+  def decommissionBlockManager(): Unit = storageEndpoint.send(DecommissionBlockManager)
 
   override def getLocalDiskDirs: Array[String] = diskBlockManager.localDirsString
 
@@ -1809,7 +1811,7 @@ private[spark] class BlockManager(
     blocksToRemove.size
   }
 
-  def decommissionBlockManager(): Unit = synchronized {
+  private[spark] def decommissionSelf(): Unit = synchronized {
     decommissioner match {
       case None =>
         logInfo("Starting block manager decommissioning process...")

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
@@ -163,8 +163,7 @@ class BlockManagerMasterEndpoint(
       context.reply(true)
 
     case DecommissionBlockManagers(executorIds) =>
-      val bmIds = executorIds.flatMap(blockManagerIdByExecutor.get)
-      decommissionBlockManagers(bmIds)
+      decommissioningBlockManagerSet ++= executorIds.flatMap(blockManagerIdByExecutor.get)
       context.reply(true)
 
     case GetReplicateInfoForRDDBlocks(blockManagerId) =>
@@ -357,21 +356,6 @@ class BlockManagerMasterEndpoint(
   private def removeExecutor(execId: String): Unit = {
     logInfo("Trying to remove executor " + execId + " from BlockManagerMaster.")
     blockManagerIdByExecutor.get(execId).foreach(removeBlockManager)
-  }
-
-  /**
-   * Decommission the given Seq of blockmanagers
-   *    - Adds these block managers to decommissioningBlockManagerSet Set
-   *    - Sends the DecommissionBlockManager message to each of the [[BlockManagerReplicaEndpoint]]
-   */
-  def decommissionBlockManagers(blockManagerIds: Seq[BlockManagerId]): Future[Seq[Unit]] = {
-    val newBlockManagersToDecommission = blockManagerIds.toSet.diff(decommissioningBlockManagerSet)
-    val futures = newBlockManagersToDecommission.map { blockManagerId =>
-      decommissioningBlockManagerSet.add(blockManagerId)
-      val info = blockManagerInfo(blockManagerId)
-      info.storageEndpoint.ask[Unit](DecommissionBlockManager)
-    }
-    Future.sequence{ futures.toSeq }
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerStorageEndpoint.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerStorageEndpoint.scala
@@ -62,7 +62,7 @@ class BlockManagerStorageEndpoint(
       }
 
     case DecommissionBlockManager =>
-      context.reply(blockManager.decommissionBlockManager())
+      context.reply(blockManager.decommissionSelf())
 
     case RemoveBroadcast(broadcastId, _) =>
       doAsync[Int]("removing broadcast " + broadcastId, context) {

--- a/core/src/test/scala/org/apache/spark/deploy/DecommissionWorkerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/DecommissionWorkerSuite.scala
@@ -28,7 +28,7 @@ import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.Eventually._
 
 import org.apache.spark._
-import org.apache.spark.deploy.DeployMessages.{MasterStateResponse, RequestMasterState, WorkerDecommission}
+import org.apache.spark.deploy.DeployMessages.{DecommissionWorkers, MasterStateResponse, RequestMasterState}
 import org.apache.spark.deploy.master.{ApplicationInfo, Master, WorkerInfo}
 import org.apache.spark.deploy.worker.Worker
 import org.apache.spark.internal.{config, Logging}
@@ -414,7 +414,7 @@ class DecommissionWorkerSuite
 
   def decommissionWorkerOnMaster(workerInfo: WorkerInfo, reason: String): Unit = {
     logInfo(s"Trying to decommission worker ${workerInfo.id} for reason `$reason`")
-    master.self.send(WorkerDecommission(workerInfo.id, workerInfo.endpoint))
+    master.self.send(DecommissionWorkers(Seq(workerInfo.id)))
   }
 
   def killWorkerAfterTimeout(workerInfo: WorkerInfo, secondsToWait: Int): Unit = {

--- a/core/src/test/scala/org/apache/spark/deploy/client/AppClientSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/client/AppClientSuite.scala
@@ -122,7 +122,7 @@ class AppClientSuite
 
       // Send a decommission self to all the workers
       // Note: normally the worker would send this on their own.
-      workers.foreach(worker => worker.decommissionSelf(triggeredByWorker = true))
+      workers.foreach(worker => worker.decommissionSelf(triggeredByMaster = false))
 
       // Decommissioning is async.
       eventually(timeout(1.seconds), interval(10.millis)) {

--- a/core/src/test/scala/org/apache/spark/deploy/client/AppClientSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/client/AppClientSuite.scala
@@ -122,7 +122,7 @@ class AppClientSuite
 
       // Send a decommission self to all the workers
       // Note: normally the worker would send this on their own.
-      workers.foreach(worker => worker.decommissionSelf())
+      workers.foreach(worker => worker.decommissionSelf(fromMaster = false))
 
       // Decommissioning is async.
       eventually(timeout(1.seconds), interval(10.millis)) {

--- a/core/src/test/scala/org/apache/spark/deploy/client/AppClientSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/client/AppClientSuite.scala
@@ -122,7 +122,7 @@ class AppClientSuite
 
       // Send a decommission self to all the workers
       // Note: normally the worker would send this on their own.
-      workers.foreach(worker => worker.decommissionSelf(triggeredByMaster = false))
+      workers.foreach(worker => worker.decommissionSelf(triggeredByWorker = true))
 
       // Decommissioning is async.
       eventually(timeout(1.seconds), interval(10.millis)) {

--- a/core/src/test/scala/org/apache/spark/deploy/client/AppClientSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/client/AppClientSuite.scala
@@ -27,7 +27,7 @@ import org.scalatest.concurrent.{Eventually, ScalaFutures}
 
 import org.apache.spark._
 import org.apache.spark.deploy.{ApplicationDescription, Command}
-import org.apache.spark.deploy.DeployMessages.{MasterStateResponse, RequestMasterState}
+import org.apache.spark.deploy.DeployMessages.{MasterStateResponse, RequestMasterState, WorkerDecommissioning}
 import org.apache.spark.deploy.master.{ApplicationInfo, Master}
 import org.apache.spark.deploy.worker.Worker
 import org.apache.spark.internal.{config, Logging}
@@ -122,7 +122,10 @@ class AppClientSuite
 
       // Send a decommission self to all the workers
       // Note: normally the worker would send this on their own.
-      workers.foreach(worker => worker.decommissionSelf(triggeredByWorker = true))
+      workers.foreach { worker =>
+       worker.decommissionSelf()
+       master.self.send(WorkerDecommissioning(worker.workerId, worker.self))
+      }
 
       // Decommissioning is async.
       eventually(timeout(1.seconds), interval(10.millis)) {

--- a/core/src/test/scala/org/apache/spark/deploy/client/AppClientSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/client/AppClientSuite.scala
@@ -122,7 +122,7 @@ class AppClientSuite
 
       // Send a decommission self to all the workers
       // Note: normally the worker would send this on their own.
-      workers.foreach(worker => worker.decommissionSelf(fromMaster = false))
+      workers.foreach(worker => worker.decommissionSelf(triggeredByWorker = true))
 
       // Decommissioning is async.
       eventually(timeout(1.seconds), interval(10.millis)) {

--- a/core/src/test/scala/org/apache/spark/scheduler/WorkerDecommissionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/WorkerDecommissionSuite.scala
@@ -81,7 +81,7 @@ class WorkerDecommissionSuite extends SparkFunSuite with LocalSparkContext {
     sched.decommissionExecutors(
       execsAndDecomInfo,
       adjustTargetNumExecutors = true,
-      decommissionFromDriver = true)
+      triggeredByExecutor = true)
     val asyncCountResult = ThreadUtils.awaitResult(asyncCount, 20.seconds)
     assert(asyncCountResult === 10)
   }

--- a/core/src/test/scala/org/apache/spark/scheduler/WorkerDecommissionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/WorkerDecommissionSuite.scala
@@ -31,7 +31,7 @@ import org.apache.spark.util.{RpcUtils, SerializableBuffer, ThreadUtils}
 class WorkerDecommissionSuite extends SparkFunSuite with LocalSparkContext {
 
   override def beforeEach(): Unit = {
-    val conf = new SparkConf().setAppName("test").setMaster("local")
+    val conf = new SparkConf().setAppName("test")
       .set(config.DECOMMISSION_ENABLED, true)
 
     sc = new SparkContext("local-cluster[2, 1, 1024]", "test", conf)
@@ -78,7 +78,10 @@ class WorkerDecommissionSuite extends SparkFunSuite with LocalSparkContext {
     val execs = sched.getExecutorIds()
     // Make the executors decommission, finish, exit, and not be replaced.
     val execsAndDecomInfo = execs.map((_, ExecutorDecommissionInfo("", None))).toArray
-    sched.decommissionExecutors(execsAndDecomInfo, adjustTargetNumExecutors = true)
+    sched.decommissionExecutors(
+      execsAndDecomInfo,
+      adjustTargetNumExecutors = true,
+      decommissionFromDriver = true)
     val asyncCountResult = ThreadUtils.awaitResult(asyncCount, 20.seconds)
     assert(asyncCountResult === 10)
   }

--- a/core/src/test/scala/org/apache/spark/scheduler/WorkerDecommissionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/WorkerDecommissionSuite.scala
@@ -81,7 +81,7 @@ class WorkerDecommissionSuite extends SparkFunSuite with LocalSparkContext {
     sched.decommissionExecutors(
       execsAndDecomInfo,
       adjustTargetNumExecutors = true,
-      triggeredByExecutor = true)
+      triggeredByExecutor = false)
     val asyncCountResult = ThreadUtils.awaitResult(asyncCount, 20.seconds)
     assert(asyncCountResult === 10)
   }

--- a/streaming/src/test/scala/org/apache/spark/streaming/scheduler/ExecutorAllocationManagerSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/scheduler/ExecutorAllocationManagerSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.streaming.scheduler
 
-import org.mockito.ArgumentMatchers.{eq => meq}
+import org.mockito.ArgumentMatchers.{any, eq => meq}
 import org.mockito.Mockito.{never, reset, times, verify, when}
 import org.scalatest.{BeforeAndAfterEach, PrivateMethodTester}
 import org.scalatest.concurrent.Eventually.{eventually, timeout}
@@ -101,12 +101,12 @@ class ExecutorAllocationManagerSuite extends TestSuiteBase
           val decomInfo = ExecutorDecommissionInfo("spark scale down", None)
           if (decommissioning) {
             verify(allocationClient, times(1)).decommissionExecutor(
-              meq(expectedExec.get), meq(decomInfo), meq(true))
+              meq(expectedExec.get), meq(decomInfo), meq(true), any())
             verify(allocationClient, never).killExecutor(meq(expectedExec.get))
           } else {
             verify(allocationClient, times(1)).killExecutor(meq(expectedExec.get))
             verify(allocationClient, never).decommissionExecutor(
-              meq(expectedExec.get), meq(decomInfo), meq(true))
+              meq(expectedExec.get), meq(decomInfo), meq(true), any())
           }
         } else {
           if (decommissioning) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


This PR cleans up the RPC message flow among the multiple decommission use cases, it includes changes:

* Keep `Worker`'s decommission status be consistent between the case where decommission starts from `Worker` and the case where decommission starts from the `MasterWebUI`: sending `DecommissionWorker` from `Master` to `Worker` in the latter case.

* Change from two-way communication to one-way communication when notifying decommission between driver and executor: it's obviously unnecessary for the executor to acknowledge the decommission status to the driver since the decommission request is from the driver. And it's same in reverse.

* Only send one message instead of two(`DecommissionSelf`/`DecommissionBlockManager`) when decommission the executor: executor and `BlockManager` are in the same JVM.

* Clean up codes around here.



### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Before:

<img width="1948" alt="WeChat56c00cc34d9785a67a544dca036d49da" src="https://user-images.githubusercontent.com/16397174/92850308-dc461c80-f41e-11ea-8ac0-287825f4e0c4.png">

After:
<img width="1968" alt="WeChat05f7afb017e3f0132394c5e54245e49e" src="https://user-images.githubusercontent.com/16397174/93189571-de88dd80-f774-11ea-9300-1943920aa27d.png">




(Note the diagrams only counts those RPC calls that needed to go through the network. Local RPC calls are not counted here.)

After this change, We reduced 6 original RPC calls and added one more RPC call for keeping the consistent decommission status for the Worker. And the RPC flow becomes more clear.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Updated existing tests.