### PR TITLE
[SPARK-32856][SQL] Prohibit binary comparisons chain

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
@@ -317,7 +317,6 @@ class SparkSqlParserSuite extends AnalysisTest {
         EqualTo(UnresolvedAttribute("a"), UnresolvedAttribute("b")),
         Literal.TrueLiteral)) :: Nil, OneRowRelation()))
 
-    intercept("SELECT a <> b <> c", "Syntax error at or near")
     intercept("SELECT a = b = c", "Syntax error at or near")
     intercept("SELECT a <=> b <=> c", "Syntax error at or near")
     intercept("SELECT a <> b <> c", "Syntax error at or near")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pr prohibit binary comparisons chain.

### Why are the changes needed?

1. Returns incorrect query result: 
  ```scala
   spark.range(1).selectExpr("id as a", "id as b", "id as c").createTempView("t1")
   spark.sql("select * from t1 where a = b = c").show
  ```


2. There are potential issues in enabling the binary comparison chain. Wrong SQL written by users will affect the stability of the entire thrift server because of Spark sql will use `BroadcastNestedLoopJoin `. This is a real case:
    <img src="https://user-images.githubusercontent.com/5399861/92910722-e980fc80-f45a-11ea-9e17-5c4ff9eee54f.png" width="313">


3. Most SQL engine do not support:
PostgresSQL, Presto, SQL Server, Oracle and Teradata.



### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Unit test.
