### PR TITLE
[SPARK-32865][DOC] python section in quickstart page doesn't display SPARK_VERSION correctly

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -399,7 +399,7 @@ If you are building a packaged PySpark application or library you can add it to 
 
 {% highlight python %}
     install_requires=[
-        'pyspark=={site.SPARK_VERSION}'
+        'pyspark=={{site.SPARK_VERSION}}'
     ]
 {% endhighlight %}
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

In https://github.com/apache/spark/blame/master/docs/quick-start.md#L402,it should be `{{site.SPARK_VERSION}}` rather than `{site.SPARK_VERSION}`

### Why are the changes needed?

SPARK_VERSION isn't displayed correctly, as shown below

![image](https://user-images.githubusercontent.com/1892692/93006726-d03c8680-f514-11ea-85e3-1d7cfb682ef2.png)


### Does this PR introduce _any_ user-facing change?

no


### How was this patch tested?

tested locally, as shown below

![image](https://user-images.githubusercontent.com/1892692/93006712-a6835f80-f514-11ea-8d78-6831c9d65265.png)

