### PR TITLE
[SPARK-32882][K8S] Remove python2 installation in K8s python image

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/python/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/python/Dockerfile
@@ -24,15 +24,9 @@ WORKDIR /
 USER 0
 
 RUN mkdir ${SPARK_HOME}/python
-# TODO: Investigate running both pip and pip3 via virtualenvs
 RUN apt-get update && \
-    apt install -y python python-pip && \
     apt install -y python3 python3-pip && \
-    # We remove ensurepip since it adds no functionality since pip is
-    # installed on the image and it just takes up 1.6MB on the image
-    rm -r /usr/lib/python*/ensurepip && \
-    pip install --upgrade pip setuptools && \
-    # You may install with python3 packages by using pip3.6
+    pip3 install --upgrade pip setuptools && \
     # Removed the .cache to save space
     rm -r /root/.cache && rm -rf /var/cache/apt/*
 


### PR DESCRIPTION

### What changes were proposed in this pull request?
This PR aims to remove python2 installation in K8s python image because spark 3.1 does not support python2. 


### Why are the changes needed?

This will save disk space.

**BEFORE**
```
kubespark/spark-py ... 917MB
```

**AFTER**
```
kubespark/spark-py ... 823MB
```

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?

Pass the Jenkins with the K8s IT.