### PR TITLE
[SPARK-32481][SQL][TESTS][FOLLOW-UP] Skip the test if trash directory cannot be created

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -3118,7 +3118,9 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
         val fs = tablePath.getFileSystem(hadoopConf)
         val trashCurrent = new Path(fs.getHomeDirectory, ".Trash/Current")
         val trashPath = Path.mergePaths(trashCurrent, tablePath)
-        assume(fs.mkdirs(trashPath) && fs.delete(trashPath, false))
+        assume(
+          fs.mkdirs(trashPath) && fs.delete(trashPath, false),
+          "Trash directory could not be created, skipping.")
         assert(!fs.exists(trashPath))
         try {
           hadoopConf.set(trashIntervalKey, "5")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -3118,6 +3118,7 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
         val fs = tablePath.getFileSystem(hadoopConf)
         val trashCurrent = new Path(fs.getHomeDirectory, ".Trash/Current")
         val trashPath = Path.mergePaths(trashCurrent, tablePath)
+        assume(fs.mkdirs(trashPath) && fs.delete(trashPath, false))
         assert(!fs.exists(trashPath))
         try {
           hadoopConf.set(trashIntervalKey, "5")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR skips the test if trash directory cannot be created. It is possible that the trash directory cannot be created, for example, by permission. And the test fails below:

```
- SPARK-32481 Move data to trash on truncate table if enabled *** FAILED *** (154 milliseconds)
  fs.exists(trashPath) was false (DDLSuite.scala:3184)
  org.scalatest.exceptions.TestFailedException:
  at org.scalatest.Assertions.newAssertionFailedException(Assertions.scala:530)
  at org.scalatest.Assertions.newAssertionFailedException$(Assertions.scala:529)
  at org.scalatest.FunSuite.newAssertionFailedException(FunSuite.scala:1560)
  at org.scalatest.Assertions$AssertionsHelper.macroAssert(Assertions.scala:503)
```

### Why are the changes needed?

To make the tests pass independently.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually tested.