### PR TITLE
[SPARK-32892][CORE][SQL] Fix hash functions on big-endian platforms.

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/hash/Murmur3_x86_32.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/hash/Murmur3_x86_32.java
@@ -17,12 +17,16 @@
 
 package org.apache.spark.unsafe.hash;
 
+import java.nio.ByteOrder;
+
 import org.apache.spark.unsafe.Platform;
 
 /**
  * 32-bit Murmur3 hasher.  This is based on Guava's Murmur3_32HashFunction.
  */
 public final class Murmur3_x86_32 {
+  private static final boolean isBigEndian = ByteOrder.nativeOrder().equals(ByteOrder.BIG_ENDIAN);
+
   private static final int C1 = 0xcc9e2d51;
   private static final int C2 = 0x1b873593;
 
@@ -92,8 +96,10 @@ public final class Murmur3_x86_32 {
     int h1 = seed;
     for (int i = 0; i < lengthInBytes; i += 4) {
       int halfWord = Platform.getInt(base, offset + i);
-      int k1 = mixK1(halfWord);
-      h1 = mixH1(h1, k1);
+      if (isBigEndian) {
+        halfWord = Integer.reverseBytes(halfWord);
+      }
+      h1 = mixH1(h1, mixK1(halfWord));
     }
     return h1;
   }

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/XXH64Suite.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/XXH64Suite.java
@@ -91,6 +91,46 @@ public class XXH64Suite {
   }
 
   @Test
+  public void testKnownWordArrayInputs() {
+    Assert.assertEquals(0XEF46DB3751D8E999L,
+            hasher.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 0));
+    Assert.assertEquals(0XAC75FDA2929B17EFL,
+            XXH64.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 0, PRIME));
+    Assert.assertEquals(0XF74CB1451B32B8CFL,
+            hasher.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 8));
+    Assert.assertEquals(0X9C44B77FBCC302C5L,
+            XXH64.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 8, PRIME));
+    Assert.assertEquals(0X169173A697113B29L,
+            hasher.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 16));
+    Assert.assertEquals(0XA0B652822C1538F6L,
+            XXH64.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 16, PRIME));
+    Assert.assertEquals(0XCEF5D1497F99F246L,
+            hasher.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 24));
+    Assert.assertEquals(0X1FA29EA08AA60D77L,
+            XXH64.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 24, PRIME));
+    Assert.assertEquals(0XAF5753D39159EDEEL,
+            hasher.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 32));
+    Assert.assertEquals(0XDCAB9233B8CA7B0FL,
+            XXH64.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 32, PRIME));
+    Assert.assertEquals(0XBAB04D3F1769013L,
+            hasher.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 40));
+    Assert.assertEquals(0X21273A6B8D344CF0L,
+            XXH64.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 40, PRIME));
+    Assert.assertEquals(0XB3571A0E02A3F4E1L,
+            hasher.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 48));
+    Assert.assertEquals(0X867479AC0EF16154L,
+            XXH64.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 48, PRIME));
+    Assert.assertEquals(0XA3D5C82BD2EE104AL,
+            hasher.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 56));
+    Assert.assertEquals(0X55EF042CF82C04D7L,
+            XXH64.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 56, PRIME));
+    Assert.assertEquals(0X18F5388F1D2BA08CL,
+            hasher.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 64));
+    Assert.assertEquals(0X479E7103CF9AA020L,
+            XXH64.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 64, PRIME));
+  }
+
+  @Test
   public void randomizedStressTest() {
     int size = 65536;
     Random rand = new Random();

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/XXH64Suite.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/XXH64Suite.java
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.catalyst.expressions;
 
-import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Random;
@@ -73,42 +72,22 @@ public class XXH64Suite {
             hasher.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, 1));
     Assert.assertEquals(0x739840CB819FA723L,
             XXH64.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, 1, PRIME));
-
-    if (ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN) {
-      Assert.assertEquals(0x9256E58AA397AEF1L,
-              hasher.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, 4));
-      Assert.assertEquals(0x9D5FFDFB928AB4BL,
-              XXH64.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, 4, PRIME));
-      Assert.assertEquals(0xF74CB1451B32B8CFL,
-              hasher.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, 8));
-      Assert.assertEquals(0x9C44B77FBCC302C5L,
-              XXH64.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, 8, PRIME));
-      Assert.assertEquals(0xCFFA8DB881BC3A3DL,
-              hasher.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, 14));
-      Assert.assertEquals(0x5B9611585EFCC9CBL,
-              XXH64.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, 14, PRIME));
-      Assert.assertEquals(0x0EAB543384F878ADL,
-              hasher.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, SIZE));
-      Assert.assertEquals(0xCAA65939306F1E21L,
-              XXH64.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, SIZE, PRIME));
-    } else {
-      Assert.assertEquals(0x7F875412350ADDDCL,
-              hasher.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, 4));
-      Assert.assertEquals(0x564D279F524D8516L,
-              XXH64.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, 4, PRIME));
-      Assert.assertEquals(0x7D9F07E27E0EB006L,
-              hasher.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, 8));
-      Assert.assertEquals(0x893CEF564CB7858L,
-              XXH64.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, 8, PRIME));
-      Assert.assertEquals(0xC6198C4C9CC49E17L,
-              hasher.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, 14));
-      Assert.assertEquals(0x4E21BEF7164D4BBL,
-              XXH64.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, 14, PRIME));
-      Assert.assertEquals(0xBCF5FAEDEE1F2B5AL,
-              hasher.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, SIZE));
-      Assert.assertEquals(0x6F680C877A358FE5L,
-              XXH64.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, SIZE, PRIME));
-    }
+    Assert.assertEquals(0x9256E58AA397AEF1L,
+            hasher.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, 4));
+    Assert.assertEquals(0x9D5FFDFB928AB4BL,
+            XXH64.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, 4, PRIME));
+    Assert.assertEquals(0xF74CB1451B32B8CFL,
+            hasher.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, 8));
+    Assert.assertEquals(0x9C44B77FBCC302C5L,
+            XXH64.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, 8, PRIME));
+    Assert.assertEquals(0xCFFA8DB881BC3A3DL,
+            hasher.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, 14));
+    Assert.assertEquals(0x5B9611585EFCC9CBL,
+            XXH64.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, 14, PRIME));
+    Assert.assertEquals(0x0EAB543384F878ADL,
+            hasher.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, SIZE));
+    Assert.assertEquals(0xCAA65939306F1E21L,
+            XXH64.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, SIZE, PRIME));
   }
 
   @Test


### PR DESCRIPTION
MurmurHash3 and xxHash64 interpret sequences of bytes as integers
encoded in little-endian byte order. This requires a byte reversal
on big endian platforms.

I've left the hashInt and hashLong functions as-is for now. My
interpretation of these functions is that they perform the hash on
the integer value as if it were serialized in little-endian byte
order. Therefore no byte reversal is necessary.

### What changes were proposed in this pull request?
Modify hash functions to produce correct results on big-endian platforms.

### Why are the changes needed?
Hash functions produce incorrect results on big-endian platforms which, amongst other potential issues, causes test failures.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing tests run on the IBM Z (s390x) platform which uses a big-endian byte order.