### PR TITLE
[SPARK-32704][SQL][TESTS][FOLLOW-UP] Check any physical rule instead of a specific rule in the test

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
@@ -219,7 +219,7 @@ class QueryExecutionSuite extends SharedSparkSession {
         spark.range(1).groupBy("id").count().queryExecution.executedPlan
       }
     }
-    Seq("=== Applying Rule org.apache.spark.sql.execution.CollapseCodegenStages ===",
+    Seq("=== Applying Rule org.apache.spark.sql.execution",
         "=== Result of Batch Preparations ===").foreach { expectedMsg =>
       assert(testAppender.loggingEvents.exists(_.getRenderedMessage.contains(expectedMsg)))
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR only checks if there's any physical rule runs instead of a specific rule. This is rather just a trivial fix to make the tests more robust.

In fact, I faced a test failure from a in-house fork that applies a different physical rule that makes `CollapseCodegenStages` ineffective.

### Why are the changes needed?

To make the test more robust by unrelated changes.

### Does this PR introduce _any_ user-facing change?

No, test-only

### How was this patch tested?

Manually tested. Jenkins tests should pass.