### PR TITLE
[SPARK-32804][Launcher][FOLLOWUP] Fix SparkSubmitCommandBuilderSuite test failure without jars

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -404,12 +404,17 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
   }
 
   private String findExamplesAppJar() {
-    for (String exampleJar : findExamplesJars()) {
-      if (new File(exampleJar).getName().startsWith("spark-examples")) {
-        return exampleJar;
+    boolean isTesting = "1".equals(getenv("SPARK_TESTING"));
+    if (isTesting) {
+      return SparkLauncher.NO_RESOURCE;
+    } else {
+      for (String exampleJar : findExamplesJars()) {
+        if (new File(exampleJar).getName().startsWith("spark-examples")) {
+          return exampleJar;
+        }
       }
+      throw new IllegalStateException("Failed to find examples' main app jar.");
     }
-    throw new IllegalStateException("Failed to find examples' main app jar.");
   }
 
   private List<String> findExamplesJars() {

--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
@@ -259,8 +259,8 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
             findArgValue(cmd, parser.CLASS));
     assertEquals("cluster", findArgValue(cmd, parser.DEPLOY_MODE));
     String primaryResource = cmd.get(cmd.size() - 2);
-    assertTrue(new File(primaryResource).getName().startsWith("spark-examples"));
-    assertFalse(cmd.contains(SparkLauncher.NO_RESOURCE));
+    assertTrue(primaryResource.equals(SparkLauncher.NO_RESOURCE)
+            || new File(primaryResource).getName().startsWith("spark-examples"));
   }
 
   @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
It's a followup of https://github.com/apache/spark/pull/29653.
Tests in `SparkSubmitCommandBuilderSuite` may fail if you didn't build first and have jars before test, 
so if `isTesting` we should set a dummy `SparkLauncher.NO_RESOURCE`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix tests failure.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
mvn clean test (test without jars built first).