### PR TITLE
[WIP][SPARK-32899][CORE] Support submit application with user-defined cluster manager

### DIFF
--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -47,6 +47,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.UI._
 import org.apache.spark.launcher.SparkLauncher
+import org.apache.spark.scheduler.{DummySchedulerBackend, DummyTaskScheduler}
 import org.apache.spark.util.{CommandLineUtils, ResetSystemProperties, Utils}
 
 trait TestPrematureExit {
@@ -1495,6 +1496,16 @@ class SparkSubmitSuite
       conf.get(k) should be (v)
     }
   }
+
+  test("spark submit with user defined ExternalClusterManager") {
+    val unusedJar = TestUtils.createJarWithClasses(Seq.empty)
+    val args = Seq(
+      "--class", ExternalClusterManagerApplicationTest.getClass.getName.stripSuffix("$"),
+      "--name", "testApp",
+      "--master", "myclusterManager",
+      unusedJar.toString)
+    runSparkSubmit(args)
+  }
 }
 
 object SparkSubmitSuite extends SparkFunSuite with TimeLimits {
@@ -1572,6 +1583,21 @@ object SimpleApplicationTest {
         throw new SparkException(
           s"Master had $config=$masterValue but executor had $config=$executorValue")
       }
+    }
+    sc.stop()
+  }
+}
+
+object ExternalClusterManagerApplicationTest {
+  def main(args: Array[String]): Unit = {
+    val conf = new SparkConf()
+    val sc = new SparkContext(conf)
+    if (!sc.schedulerBackend.isInstanceOf[DummySchedulerBackend]) {
+      throw new SparkException(s"wrong scheduler backend: ${sc.schedulerBackend}")
+    }
+
+    if (!sc.taskScheduler.isInstanceOf[DummyTaskScheduler]) {
+      throw new SparkException(s"wrong task scheduler: ${sc.taskScheduler}")
     }
     sc.stop()
   }

--- a/core/src/test/scala/org/apache/spark/scheduler/ExternalClusterManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/ExternalClusterManagerSuite.scala
@@ -48,7 +48,7 @@ class ExternalClusterManagerSuite extends SparkFunSuite with LocalSparkContext {
  * Note that if you want a special ClusterManager for tests, you are probably much more interested
  * in [[MockExternalClusterManager]] and the corresponding [[SchedulerIntegrationSuite]]
  */
-private class DummyExternalClusterManager extends ExternalClusterManager {
+class DummyExternalClusterManager extends ExternalClusterManager {
 
   def canCreate(masterURL: String): Boolean = masterURL == "myclusterManager"
 
@@ -66,7 +66,7 @@ private class DummyExternalClusterManager extends ExternalClusterManager {
 
 }
 
-private class DummySchedulerBackend extends SchedulerBackend {
+class DummySchedulerBackend extends SchedulerBackend {
   var initialized = false
   def start(): Unit = {}
   def stop(): Unit = {}
@@ -75,7 +75,7 @@ private class DummySchedulerBackend extends SchedulerBackend {
   def maxNumConcurrentTasks(rp: ResourceProfile): Int = 0
 }
 
-private class DummyTaskScheduler extends TaskScheduler {
+class DummyTaskScheduler extends TaskScheduler {
   var initialized = false
   override def schedulingMode: SchedulingMode = SchedulingMode.FIFO
   override def rootPool: Pool = new Pool("", schedulingMode, 0, 0)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Add the support to submit applications with user-defined cluster manager.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

We have supported users to define the customed cluster manager with `ExternalClusterManager` trait. However, we can not submit the application with `SparkSubmit`. And also we can set the user-defined master with pyspark. The reason is that we check the master whether is the natively support one in `SparkSubmit`. However, the customed cluster manager is checked in `SparkContext`. This patch fixes the problem.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

New UT.
