### PR TITLE
[SPARK-32903][SQL] GeneratePredicate should be able to eliminate common sub-expressions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GeneratePredicate.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GeneratePredicate.scala
@@ -30,9 +30,17 @@ object GeneratePredicate extends CodeGenerator[Expression, BasePredicate] {
   protected def bind(in: Expression, inputSchema: Seq[Attribute]): Expression =
     BindReferences.bindReference(in, inputSchema)
 
-  protected def create(predicate: Expression): BasePredicate = {
+  def generate(expressions: Expression, useSubexprElimination: Boolean): BasePredicate =
+    create(canonicalize(expressions), useSubexprElimination)
+
+  protected def create(predicate: Expression): BasePredicate = create(predicate, false)
+
+  protected def create(predicate: Expression, useSubexprElimination: Boolean): BasePredicate = {
     val ctx = newCodeGenContext()
-    val eval = predicate.genCode(ctx)
+
+    // Do sub-expression elimination for predicates.
+    val eval = ctx.generateExpressions(Seq(predicate), useSubexprElimination)(0)
+    val evalSubexpr = ctx.subexprFunctionsCode
 
     val codeBody = s"""
       public SpecificPredicate generate(Object[] references) {
@@ -53,6 +61,7 @@ object GeneratePredicate extends CodeGenerator[Expression, BasePredicate] {
         }
 
         public boolean eval(InternalRow ${ctx.INPUT_ROW}) {
+          $evalSubexpr
           ${eval.code}
           return !${eval.isNull} && ${eval.value};
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GeneratePredicate.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GeneratePredicate.scala
@@ -39,7 +39,7 @@ object GeneratePredicate extends CodeGenerator[Expression, BasePredicate] {
     val ctx = newCodeGenContext()
 
     // Do sub-expression elimination for predicates.
-    val eval = ctx.generateExpressions(Seq(predicate), useSubexprElimination)(0)
+    val eval = ctx.generateExpressions(Seq(predicate), useSubexprElimination).head
     val evalSubexpr = ctx.subexprFunctionsCode
 
     val codeBody = s"""

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -73,7 +73,7 @@ trait Predicate extends Expression {
 object Predicate extends CodeGeneratorWithInterpretedFallback[Expression, BasePredicate] {
 
   override protected def createCodeGeneratedObject(in: Expression): BasePredicate = {
-    GeneratePredicate.generate(in)
+    GeneratePredicate.generate(in, SQLConf.get.subexpressionEliminationEnabled)
   }
 
   override protected def createInterpretedObject(in: Expression): BasePredicate = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodegenExpressionCachingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodegenExpressionCachingSuite.scala
@@ -85,12 +85,12 @@ class CodegenExpressionCachingSuite extends SparkFunSuite {
     assert(instance2.eval(null))
   }
 
-  test("GeneratePredicate should eliminate sub-expressions") {
+  test("SPARK-32903: GeneratePredicate should eliminate sub-expressions") {
     Seq(true, false).foreach { enabled =>
-      val leaf1 = MutableExpression2()
-      val leaf2 = MutableExpression2()
-      val leaf3 = MutableExpression2()
-      val leaf4 = MutableExpression2()
+      val leaf1 = ExprWithEvaluatedState()
+      val leaf2 = ExprWithEvaluatedState()
+      val leaf3 = ExprWithEvaluatedState()
+      val leaf4 = ExprWithEvaluatedState()
 
       val expr1 = And(leaf1, leaf2)
       val expr2 = And(leaf3, leaf4)
@@ -143,7 +143,7 @@ case class MutableExpression() extends LeafExpression with CodegenFallback {
 /**
  * An expression with evaluated state so we can know whether it is evaluated.
  */
-case class MutableExpression2() extends LeafExpression with CodegenFallback {
+case class ExprWithEvaluatedState() extends LeafExpression with CodegenFallback {
   var evaluated: Boolean = false
   override def eval(input: InternalRow): Any = {
     evaluated = true

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodegenExpressionCachingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodegenExpressionCachingSuite.scala
@@ -85,6 +85,36 @@ class CodegenExpressionCachingSuite extends SparkFunSuite {
     assert(instance2.eval(null))
   }
 
+  test("GeneratePredicate should eliminate sub-expressions") {
+    Seq(true, false).foreach { enabled =>
+      val leaf1 = MutableExpression2()
+      val leaf2 = MutableExpression2()
+      val leaf3 = MutableExpression2()
+      val leaf4 = MutableExpression2()
+
+      val expr1 = And(leaf1, leaf2)
+      val expr2 = And(leaf3, leaf4)
+      val cond = Or(expr1, expr2)
+      val instance = GeneratePredicate.generate(cond, useSubexprElimination = enabled)
+      instance.initialize(0)
+      assert(instance.eval(null) === false)
+
+      if (enabled) {
+        // When we do sub-expression elimination, Spark thought `expr1` and `expr2` are
+        // the same, so when it wants to evaluate `expr2`, it gets previous evaluation of `expr1`.
+        assert(leaf1.evaluated == true)
+        assert(leaf2.evaluated == false)
+        assert(leaf3.evaluated == false)
+        assert(leaf4.evaluated == false)
+      } else {
+        assert(leaf1.evaluated == true)
+        assert(leaf2.evaluated == false)
+        assert(leaf3.evaluated == true)
+        assert(leaf4.evaluated == false)
+      }
+    }
+  }
+
 }
 
 /**
@@ -105,6 +135,20 @@ case class NondeterministicExpression()
 case class MutableExpression() extends LeafExpression with CodegenFallback {
   var mutableState: Boolean = false
   override def eval(input: InternalRow): Any = mutableState
+
+  override def nullable: Boolean = false
+  override def dataType: DataType = BooleanType
+}
+
+/**
+ * An expression with evaluated state so we can know whether it is evaluated.
+ */
+case class MutableExpression2() extends LeafExpression with CodegenFallback {
+  var evaluated: Boolean = false
+  override def eval(input: InternalRow): Any = {
+    evaluated = true
+    false
+  }
 
   override def nullable: Boolean = false
   override def dataType: DataType = BooleanType

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodegenSubexpressionEliminationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodegenSubexpressionEliminationSuite.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions.codegen
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.types.{BooleanType, DataType}
+
+/**
+ * A test suite that makes sure code generation handles sub-expression elimination correctly.
+ */
+class CodegenSubexpressionEliminationSuite extends SparkFunSuite {
+
+  test("SPARK-32903: GeneratePredicate should eliminate sub-expressions") {
+    Seq(true, false).foreach { useSubexprElimination =>
+      val leaf1 = ExprWithEvaluatedState()
+      val leaf2 = ExprWithEvaluatedState()
+      val leaf3 = ExprWithEvaluatedState()
+      val leaf4 = ExprWithEvaluatedState()
+
+      val cond = Or(And(leaf1, leaf2), And(leaf3, leaf4))
+      val instance = GeneratePredicate.generate(cond, useSubexprElimination = useSubexprElimination)
+      instance.initialize(0)
+      assert(instance.eval(null) === false)
+
+      if (useSubexprElimination) {
+        // When we do sub-expression elimination, Spark thought left and right side of
+        // the `Or` expression are the same. So only left side was evaluated, and Spark
+        // reused the evaluation for right side.
+        assert(leaf1.evaluated == true)
+        assert(leaf2.evaluated == false)
+        assert(leaf3.evaluated == false)
+        assert(leaf4.evaluated == false)
+      } else {
+        assert(leaf1.evaluated == true)
+        assert(leaf2.evaluated == false)
+        assert(leaf3.evaluated == true)
+        assert(leaf4.evaluated == false)
+      }
+    }
+  }
+
+}
+
+/**
+ * An expression with evaluated state so we can know whether it is evaluated.
+ */
+case class ExprWithEvaluatedState() extends LeafExpression with CodegenFallback {
+  var evaluated: Boolean = false
+  override def eval(input: InternalRow): Any = {
+    evaluated = true
+    false
+  }
+
+  override def nullable: Boolean = false
+  override def dataType: DataType = BooleanType
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This patch proposes to make GeneratePredicate eliminate common sub-expressions.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Both GenerateMutableProjection and GenerateUnsafeProjection, such codegen objects can eliminate common sub-expressions. But GeneratePredicate currently doesn't do it.

We encounter a customer issue that a Filter pushed down through a Project causes performance issue, compared with not pushed down case. The issue is one expression used in Filter predicates are run many times. Due to the complex schema, the query nodes are not wholestage codegen, so it runs Filter.doExecute and then call GeneratePredicate. The common expression was run many time and became performance bottleneck. GeneratePredicate should be able to eliminate common sub-expressions for such case.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Unit tests.