### PR TITLE
[SPARK-32932][SQL] Do not use local shuffle reader at final stage on write command

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -104,7 +104,7 @@ case class AdaptiveSparkPlanExec(
     OptimizeLocalShuffleReader(conf)
   )
 
-  @transient private val finalStageOptimizerRules: Seq[Rule[SparkPlan]] =
+  private def finalStageOptimizerRules: Seq[Rule[SparkPlan]] =
     context.qe.sparkPlan match {
       case _: DataWritingCommandExec | _: V2TableWriteExec =>
         // SPARK-32932: Local shuffle reader could break partitioning that works best

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -109,7 +109,7 @@ case class AdaptiveSparkPlanExec(
       case _: DataWritingCommandExec | _: V2TableWriteExec =>
         // SPARK-32932: Local shuffle reader could break partitioning that works best
         // for the following writing command
-       queryStageOptimizerRules.filterNot(_.isInstanceOf[OptimizeLocalShuffleReader])
+        queryStageOptimizerRules.filterNot(_.isInstanceOf[OptimizeLocalShuffleReader])
       case _ =>
         queryStageOptimizerRules
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -1298,14 +1298,11 @@ class AdaptiveQueryExecSuite
       }
 
       // Test DataSource v2
-      withTempPath { f =>
-        val path = f.getCanonicalPath
-        val format = classOf[NoopDataSource].getName
-        df.write.format(format).mode("overwrite").save(path)
-        sparkContext.listenerBus.waitUntilEmpty()
-        assert(noLocalReader)
-        noLocalReader = false
-      }
+      val format = classOf[NoopDataSource].getName
+      df.write.format(format).mode("overwrite").save()
+      sparkContext.listenerBus.waitUntilEmpty()
+      assert(noLocalReader)
+      noLocalReader = false
 
       spark.listenerManager.unregister(listener)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.adaptive
 
-import java.io.{File, FilenameFilter}
+import java.io.File
 import java.net.URI
 
 import org.apache.log4j.Level


### PR DESCRIPTION
### What changes were proposed in this pull request?
Do not use local shuffle reader at final stage if the root node is write command.  

### Why are the changes needed?
Users usually repartition with partition column on dynamic partition overwrite. AQE could break it by removing physical shuffle with local shuffle reader. That could lead to a large number of output files, even exceeding the file system limit. 

### Does this PR introduce _any_ user-facing change?
Yes.


### How was this patch tested?
Add test.
