### PR TITLE
[WIP][SPARK-32939][SQL]Avoid re-compute expensive expression

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -247,6 +247,10 @@ trait PredicateHelper extends Logging {
         None
       }
   }
+
+  def extractExpensiveExprs(e: Expression): Seq[Expression] = e.collect {
+    case gjo: GetJsonObject => gjo
+  }
 }
 
 @ExpressionDescription(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlanner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlanner.scala
@@ -31,12 +31,6 @@ class SparkPlanner(
     val experimentalMethods: ExperimentalMethods)
   extends SparkStrategies {
 
-  private val EXPENSIVE_EXPR_PREFIX = "expensive_col_"
-
-  def extractExpensiveExprs(e: Expression): Seq[Expression] = e.collect {
-    case gjo: GetJsonObject => gjo
-  }
-
   def numPartitions: Int = conf.numShufflePartitions
 
   override def strategies: Seq[Strategy] =


### PR DESCRIPTION
### What changes were proposed in this pull request?
```
 test("SPARK-32939: Expensive expr re-compute demo") {
    withTable("t") {
      withTempDir { loc =>
        sql(
          s"""CREATE TABLE t(c1 INT, s STRING) PARTITIONED BY(P1 STRING)
             | LOCATION '${loc.getAbsolutePath}'
             |""".stripMargin)
        sql(
          """
            |SELECT c1,
            |case
            |  when get_json_object(s,'$.a')=1 then "a"
            |  when get_json_object(s,'$.a')=2 then "b"
            |end as s_type
            |FROM t
            |WHERE get_json_object(s,'$.a') in (1, 2)
          """.stripMargin).explain(true)
         }
    }
}
```
will got plan as 
```
== Physical Plan ==
*(1) Project [c1#1, CASE WHEN (cast(get_json_object(s#2, $.a) as int) = 1) THEN a WHEN (cast(get_json_object(s#2, $.a) as int) = 2) THEN b END AS s_type#0]
+- *(1) Filter get_json_object(s#2, $.a) IN (1,2)
   +- Scan hive default.t [c1#1, s#2], HiveTableRelation `default`.`t`, org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe, [c1#1, s#2], [P1#3], Statistics(sizeInBytes=8.0 EiB)
```
we can see that  get_json_object(s#2, $.a) will be computed tree times
Always there are expensive expressions are re-computed many times in such grammar。
This case is frequent in SQL in production environments and expr is complex and same.
So after judgement, we can compute these duplicated complex expression first with a projection.
The result plan like 
```
== Physical Plan ==
*(1) Project [c1#1, CASE WHEN (cast(expensive_col_6#6 as int) = 1) THEN a WHEN (cast(expensive_col_6#6 as int) = 2) THEN b END AS s_type#0]
+- *(1) Filter expensive_col_6#6 IN (1,2)
   +- Project [c1#1, s#2, get_json_object(s#2, $.a) AS expensive_col_6#6]
      +- Scan hive default.t [c1#1, s#2], HiveTableRelation `default`.`t`, org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe, [c1#1, s#2], [P1#3], Statistics(sizeInBytes=8.0 EiB)
```
The ProjectExec near Scan not contained by WholeStageCodegen since it not match this case now(won't occur in current code)

### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Need add UT
