### PR TITLE
[SPARK-32957][INFRA] Add a GitHub Actions job to run WebUI tests with Chrome

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -283,9 +283,9 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.m2/repository
-        key: java11-maven-${{ hashFiles('**/pom.xml') }}
+        key: webui-tests-with-chrome-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          java11-maven-
+          webui-tests-with-chrome-maven-
     - name: Install Java 11
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -273,6 +273,50 @@ jobs:
         cd docs
         jekyll build
 
+  webui-tests-with-chrome:
+    name: WebUI tests with chrome
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Spark repository
+      uses: actions/checkout@v2
+    - name: Cache Maven local repository
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: java11-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          java11-maven-
+    - name: Install Java 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Install Chrome and ChromeDriver
+      run: |
+        sudo apt update
+        sudo apt install google-chrome-stable
+        sudo apt install chromium-chromedriver
+    - name: Run WebUI tests with Maven
+      run: |
+        export MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=1g -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
+        export MAVEN_CLI_OPTS="--no-transfer-progress"
+        mkdir -p ~/.m2
+        ./build/mvn -Dspark.test.webdriver.chrome.driver=/usr/bin/chromedriver \
+          -Dguava.version=25.0-jre -Djava.version=11 -Dtest.default.exclude.tags=  -Dtest=none \
+          -DwildcardSuites="org.apache.spark.ui.ChromeUISeleniumSuite,org.apache.spark.deploy.history.ChromeUIHistoryServerSuite" test
+        rm -rf ~/.m2/repository/org/apache/spark
+    - name: Upload test results to report
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-results-webui
+        path: "**/target/test-reports/*.xml"
+    - name: Upload unit tests log files
+      if: failure()
+      uses: actions/upload-artifact@v2
+      with:
+        name: unit-tests-log-webui
+        path: "**/target/unit-tests.log"
+
   java11:
     name: Java 11 build
     runs-on: ubuntu-latest

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -304,12 +304,6 @@ jobs:
           -Dguava.version=25.0-jre -Djava.version=11 -Dtest.default.exclude.tags=  -Dtest=none \
           -DwildcardSuites="org.apache.spark.ui.ChromeUISeleniumSuite,org.apache.spark.deploy.history.ChromeUIHistoryServerSuite" test
         rm -rf ~/.m2/repository/org/apache/spark
-    - name: Upload test results to report
-      if: always()
-      uses: actions/upload-artifact@v2
-      with:
-        name: test-results-webui
-        path: "**/target/test-reports/*.xml"
     - name: Upload unit tests log files
       if: failure()
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
 ### What changes were proposed in this pull request?

This PR adds a GitHub Actions job to run WebUI tests with Chrome.
`ChromeUISeleniumSuite` and `ChromeUIHistoryServerSuite` are added to test WebUI with better JavaScript support but they are disabled on the CI environment.
Now that we use GitHub Actions, let's add a job to run them.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To ensure WebUI related changes can work properly and don't make regressions.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
I confirmed the new job works on my repository.
I also confirmed we can download `unit-tests.log` if the WebUI tests fails.
![unit-tests-log-webui](https://user-images.githubusercontent.com/4736016/93814795-01912100-fc90-11ea-9bc5-d8ed08519645.png)