### PR TITLE
[SPARK-32312][DOC][FOLLOWUP] Fix the minimum version of PyArrow in the installation guide.

### DIFF
--- a/python/docs/source/getting_started/install.rst
+++ b/python/docs/source/getting_started/install.rst
@@ -129,7 +129,7 @@ Package       Minimum supported version Note
 ============= ========================= ================
 `pandas`      0.23.2                    Optional for SQL
 `NumPy`       1.7                       Required for ML 
-`pyarrow`     0.15.1                    Optional for SQL
+`pyarrow`     1.0.0                     Optional for SQL
 `Py4J`        0.10.9                    Required
 ============= ========================= ================
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Now that the minimum version of PyArrow is `1.0.0`, we should update the version in the installation guide.

### Why are the changes needed?

The minimum version of PyArrow was upgraded to `1.0.0`.

### Does this PR introduce _any_ user-facing change?

Users see the correct minimum version in the installation guide.

### How was this patch tested?

N/A
