### PR TITLE
[SPARK-32960][SQL] Provide better exception on temporary view against DataFrameWriterV2

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriterV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriterV2.scala
@@ -153,6 +153,7 @@ final class DataFrameWriterV2[T] private[sql](table: String, ds: Dataset[T])
    */
   @throws(classOf[NoSuchTableException])
   def append(): Unit = {
+    assertNoTempView("append")
     val append = loadTable(catalog, identifier) match {
       case Some(t) =>
         AppendData.byName(
@@ -177,6 +178,7 @@ final class DataFrameWriterV2[T] private[sql](table: String, ds: Dataset[T])
    */
   @throws(classOf[NoSuchTableException])
   def overwrite(condition: Column): Unit = {
+    assertNoTempView("overwrite")
     val overwrite = loadTable(catalog, identifier) match {
       case Some(t) =>
         OverwriteByExpression.byName(
@@ -204,6 +206,7 @@ final class DataFrameWriterV2[T] private[sql](table: String, ds: Dataset[T])
    */
   @throws(classOf[NoSuchTableException])
   def overwritePartitions(): Unit = {
+    assertNoTempView("overwritePartitions")
     val dynamicOverwrite = loadTable(catalog, identifier) match {
       case Some(t) =>
         OverwritePartitionsDynamic.byName(
@@ -214,6 +217,12 @@ final class DataFrameWriterV2[T] private[sql](table: String, ds: Dataset[T])
     }
 
     runCommand("overwritePartitions")(dynamicOverwrite)
+  }
+
+  private def assertNoTempView(name: String): Unit = {
+    if (sparkSession.sessionState.catalog.isTempView(tableName)) {
+      throw new AnalysisException(s"Temporary view $table doesn't support $name")
+    }
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWriterV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWriterV2Suite.scala
@@ -144,6 +144,26 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
     assert(exc.getMessage.contains("table_name"))
   }
 
+  test("Append: fail if it writes to the temp view") {
+    spark.sql("CREATE TABLE testcat.table_name (id bigint, data string) USING foo")
+    spark.table("testcat.table_name").createOrReplaceTempView("temp_view")
+
+    val exc = intercept[AnalysisException] {
+      spark.table("source").writeTo("temp_view").append()
+    }
+    assert(exc.getMessage.contains("temp_view"))
+  }
+
+  test("Append: fail if it writes to the view") {
+    spark.sql("CREATE TABLE testcat.table_name (id bigint, data string) USING foo")
+    spark.sql("CREATE OR REPLACE VIEW table_view AS SELECT id, data FROM testcat.table_name")
+
+    val exc = intercept[AnalysisException] {
+      spark.table("source").writeTo("table_view").append()
+    }
+    assert(exc.getMessage.contains("table_view"))
+  }
+
   test("Overwrite: overwrite by expression: true") {
     spark.sql(
       "CREATE TABLE testcat.table_name (id bigint, data string) USING foo PARTITIONED BY (id)")
@@ -208,6 +228,26 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
     assert(exc.getMessage.contains("table_name"))
   }
 
+  test("Overwrite: fail if it writes to the temp view") {
+    spark.sql("CREATE TABLE testcat.table_name (id bigint, data string) USING foo")
+    spark.table("testcat.table_name").createOrReplaceTempView("temp_view")
+
+    val exc = intercept[AnalysisException] {
+      spark.table("source").writeTo("temp_view").overwrite(lit(true))
+    }
+    assert(exc.getMessage.contains("temp_view"))
+  }
+
+  test("Overwrite: fail if it writes to the view") {
+    spark.sql("CREATE TABLE testcat.table_name (id bigint, data string) USING foo")
+    spark.sql("CREATE OR REPLACE VIEW table_view AS SELECT id, data FROM testcat.table_name")
+
+    val exc = intercept[AnalysisException] {
+      spark.table("source").writeTo("table_view").overwrite(lit(true))
+    }
+    assert(exc.getMessage.contains("table_view"))
+  }
+
   test("OverwritePartitions: overwrite conflicting partitions") {
     spark.sql(
       "CREATE TABLE testcat.table_name (id bigint, data string) USING foo PARTITIONED BY (id)")
@@ -270,6 +310,26 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
     }
 
     assert(exc.getMessage.contains("table_name"))
+  }
+
+  test("OverwritePartitions: fail if it writes to the temp view") {
+    spark.sql("CREATE TABLE testcat.table_name (id bigint, data string) USING foo")
+    spark.table("testcat.table_name").createOrReplaceTempView("temp_view")
+
+    val exc = intercept[AnalysisException] {
+      spark.table("source").writeTo("temp_view").overwritePartitions()
+    }
+    assert(exc.getMessage.contains("temp_view"))
+  }
+
+  test("OverwritePartitions: fail if it writes to the view") {
+    spark.sql("CREATE TABLE testcat.table_name (id bigint, data string) USING foo")
+    spark.sql("CREATE OR REPLACE VIEW table_view AS SELECT id, data FROM testcat.table_name")
+
+    val exc = intercept[AnalysisException] {
+      spark.table("source").writeTo("table_view").overwritePartitions()
+    }
+    assert(exc.getMessage.contains("table_view"))
   }
 
   test("Create: basic behavior") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds additional check on temp view in prior to loadTable in DataFrameWriterV2, and fail-fast with better exception.

### Why are the changes needed?

This PR would provide better exception and its message - see below section.

### Does this PR introduce _any_ user-facing change?

Yes - previously using temp view in DataFrameWriterV2 throws NoSuchTableException without any information on temp view. Now it throws AnalysisException with exception message that it's a temporary view which doesn't support write operations in DataFrameWriterV2.

### How was this patch tested?

New UTs