### PR TITLE
[SPARK-32964][DSTREAMS] Pass all `streaming` module UTs in Scala 2.13

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/DStreamGraph.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/DStreamGraph.scala
@@ -19,7 +19,6 @@ package org.apache.spark.streaming
 
 import java.io.{IOException, ObjectInputStream, ObjectOutputStream}
 
-import scala.collection.mutable.ArrayBuffer
 import scala.collection.parallel.immutable.ParVector
 
 import org.apache.spark.internal.Logging
@@ -29,8 +28,8 @@ import org.apache.spark.util.Utils
 
 final private[streaming] class DStreamGraph extends Serializable with Logging {
 
-  private val inputStreams = new ArrayBuffer[InputDStream[_]]()
-  private val outputStreams = new ArrayBuffer[DStream[_]]()
+  private var inputStreams = Array.empty[InputDStream[_]]
+  private var outputStreams = Array.empty[DStream[_]]
 
   @volatile private var inputStreamNameAndID: Seq[(String, Int)] = Nil
 
@@ -91,14 +90,14 @@ final private[streaming] class DStreamGraph extends Serializable with Logging {
   def addInputStream(inputStream: InputDStream[_]): Unit = {
     this.synchronized {
       inputStream.setGraph(this)
-      inputStreams += inputStream
+      inputStreams = inputStreams :+ inputStream
     }
   }
 
   def addOutputStream(outputStream: DStream[_]): Unit = {
     this.synchronized {
       outputStream.setGraph(this)
-      outputStreams += outputStream
+      outputStreams = outputStreams :+ outputStream
     }
   }
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/DStreamGraph.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/DStreamGraph.scala
@@ -19,6 +19,7 @@ package org.apache.spark.streaming
 
 import java.io.{IOException, ObjectInputStream, ObjectOutputStream}
 
+import scala.collection.mutable
 import scala.collection.parallel.immutable.ParVector
 
 import org.apache.spark.internal.Logging
@@ -28,8 +29,8 @@ import org.apache.spark.util.Utils
 
 final private[streaming] class DStreamGraph extends Serializable with Logging {
 
-  private var inputStreams = Array.empty[InputDStream[_]]
-  private var outputStreams = Array.empty[DStream[_]]
+  private var inputStreams = mutable.ArraySeq.empty[InputDStream[_]]
+  private var outputStreams = mutable.ArraySeq.empty[DStream[_]]
 
   @volatile private var inputStreamNameAndID: Seq[(String, Int)] = Nil
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

There is only one failed case of `streaming` module in Scala 2.13: `start with non-serializable DStream checkpoint ` in `StreamingContextSuite`. 

`StackOverflowError` is thrown here when `SerializationDebugger#visit` method is called. 

I found that `inputStreams` and `outputStreams` in `DStreamGraph` can not be matched in `SerializationDebugger#visit` method because `ArrayBuffer` in not `Array` in Scala 2.13.

The main change of this pr is use `mutable.ArraySeq` instead of `ArrayBuffer` to store `inputStreams` and `outputStreams` in `DStreamGraph`, then it can be matched in `SerializationDebugger#visit` method.

### Why are the changes needed?
We need to support a Scala 2.13 build.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

- Scala 2.12: Pass the Jenkins or GitHub Action

- Scala 2.13: Pass GitHub 2.13 Build Action

Do the following:

```
dev/change-scala-version.sh 2.13
mvn clean install -DskipTests  -pl streaming -Pscala-2.13 -am
mvn test -pl streaming -Pscala-2.13
mvn test -pl core -Pscala-2.13
```

streaming module:

```
Tests: succeeded 339, failed 0, canceled 0, ignored 2, pending 0
All tests passed.
```

core module:

```
Tests: succeeded 2648, failed 0, canceled 4, ignored 7, pending 0
All tests passed.
```
