### PR TITLE
[SPARK-32970][SQL][TEST] Reduce the runtime of an UT for SPARK-32019

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -529,37 +529,39 @@ class FileSourceStrategySuite extends QueryTest with SharedSparkSession with Pre
   }
 
   test("SPARK-32019: Add spark.sql.files.minPartitionNum config") {
-    withSQLConf(SQLConf.FILES_MIN_PARTITION_NUM.key -> "1") {
-      val table =
-        createTable(files = Seq(
-          "file1" -> 1,
-          "file2" -> 1,
-          "file3" -> 1
-        ))
-      assert(table.rdd.partitions.length == 1)
-    }
+    withSQLConf(SQLConf.FILES_MAX_PARTITION_BYTES.key -> "2MB") {
+      withSQLConf(SQLConf.FILES_MIN_PARTITION_NUM.key -> "1") {
+        val table =
+          createTable(files = Seq(
+            "file1" -> 1,
+            "file2" -> 1,
+            "file3" -> 1
+          ))
+        assert(table.rdd.partitions.length == 3)
+      }
 
-    withSQLConf(SQLConf.FILES_MIN_PARTITION_NUM.key -> "10") {
-      val table =
-        createTable(files = Seq(
-          "file1" -> 1,
-          "file2" -> 1,
-          "file3" -> 1
-        ))
-      assert(table.rdd.partitions.length == 3)
-    }
+      withSQLConf(SQLConf.FILES_MIN_PARTITION_NUM.key -> "10") {
+        val table =
+          createTable(files = Seq(
+            "file1" -> 1,
+            "file2" -> 1,
+            "file3" -> 1
+          ))
+        assert(table.rdd.partitions.length == 3)
+      }
 
-    withSQLConf(SQLConf.FILES_MIN_PARTITION_NUM.key -> "16") {
-      val partitions = (1 to 100).map(i => s"file$i" -> 128 * 1024 * 1024)
-      val table = createTable(files = partitions)
-      // partition is limited by filesMaxPartitionBytes(128MB)
-      assert(table.rdd.partitions.length == 100)
-    }
+      withSQLConf(SQLConf.FILES_MIN_PARTITION_NUM.key -> "8") {
+        val partitions = (1 to 12).map(i => s"file$i" -> 2 * 1024 * 1024)
+        val table = createTable(files = partitions)
+        // partition is limited by filesMaxPartitionBytes(2MB)
+        assert(table.rdd.partitions.length == 12)
+      }
 
-    withSQLConf(SQLConf.FILES_MIN_PARTITION_NUM.key -> "32") {
-      val partitions = (1 to 800).map(i => s"file$i" -> 4 * 1024 * 1024)
-      val table = createTable(files = partitions)
-      assert(table.rdd.partitions.length == 50)
+      withSQLConf(SQLConf.FILES_MIN_PARTITION_NUM.key -> "8") {
+        val partitions = (1 to 12).map(i => s"file$i" -> 4 * 1024 * 1024)
+        val table = createTable(files = partitions)
+        assert(table.rdd.partitions.length == 24)
+      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -560,7 +560,7 @@ class FileSourceStrategySuite extends QueryTest with SharedSparkSession with Pre
         assert(table.rdd.partitions.length == 12)
       }
 
-      withSQLConf(SQLConf.FILES_MIN_PARTITION_NUM.key -> "8") {
+      withSQLConf(SQLConf.FILES_MIN_PARTITION_NUM.key -> "16") {
         val partitions = (1 to 12).map(i => s"file$i" -> 4 * 1024 * 1024)
         val table = createTable(files = partitions)
         assert(table.rdd.partitions.length == 24)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -529,29 +529,29 @@ class FileSourceStrategySuite extends QueryTest with SharedSparkSession with Pre
   }
 
   test("SPARK-32019: Add spark.sql.files.minPartitionNum config") {
+    withSQLConf(SQLConf.FILES_MIN_PARTITION_NUM.key -> "1") {
+      val table =
+        createTable(files = Seq(
+          "file1" -> 1,
+          "file2" -> 1,
+          "file3" -> 1
+        ))
+      assert(table.rdd.partitions.length == 1)
+    }
+
+    withSQLConf(SQLConf.FILES_MIN_PARTITION_NUM.key -> "10") {
+      val table =
+        createTable(files = Seq(
+          "file1" -> 1,
+          "file2" -> 1,
+          "file3" -> 1
+        ))
+      assert(table.rdd.partitions.length == 3)
+    }
+
     withSQLConf(
       SQLConf.FILES_MAX_PARTITION_BYTES.key -> "2MB",
       SQLConf.FILES_OPEN_COST_IN_BYTES.key -> String.valueOf(4 * 1024 * 1024)) {
-
-      withSQLConf(SQLConf.FILES_MIN_PARTITION_NUM.key -> "1") {
-        val table =
-          createTable(files = Seq(
-            "file1" -> 1,
-            "file2" -> 1,
-            "file3" -> 1
-          ))
-        assert(table.rdd.partitions.length == 3)
-      }
-
-      withSQLConf(SQLConf.FILES_MIN_PARTITION_NUM.key -> "10") {
-        val table =
-          createTable(files = Seq(
-            "file1" -> 1,
-            "file2" -> 1,
-            "file3" -> 1
-          ))
-        assert(table.rdd.partitions.length == 3)
-      }
 
       withSQLConf(SQLConf.FILES_MIN_PARTITION_NUM.key -> "8") {
         val partitions = (1 to 12).map(i => s"file$i" -> 2 * 1024 * 1024)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -529,7 +529,10 @@ class FileSourceStrategySuite extends QueryTest with SharedSparkSession with Pre
   }
 
   test("SPARK-32019: Add spark.sql.files.minPartitionNum config") {
-    withSQLConf(SQLConf.FILES_MAX_PARTITION_BYTES.key -> "2MB") {
+    withSQLConf(
+      SQLConf.FILES_MAX_PARTITION_BYTES.key -> "2MB",
+      SQLConf.FILES_OPEN_COST_IN_BYTES.key -> String.valueOf(4 * 1024 * 1024)) {
+
       withSQLConf(SQLConf.FILES_MIN_PARTITION_NUM.key -> "1") {
         val table =
           createTable(files = Seq(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
The UT for SPARK-32019 (#28853) tries to write about 16GB of data do the disk. We must change the value of `spark.sql.files.maxPartitionBytes` to a smaller value do check the correct behavior with less data. By default it is `128MB`.
The other parameters in this UT are also changed to smaller values to keep the behavior the same.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The runtime of this one UT can be over 7 minutes on Jenkins. After the change it is few seconds.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Existing UT