### PR TITLE
[SPARK-32974][ML] FeatureHasher transform optimization

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/FeatureHasher.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/FeatureHasher.scala
@@ -133,7 +133,10 @@ class FeatureHasher(@Since("2.3.0") override val uid: String) extends Transforme
 
     var catCols = dataset.schema(localInputCols.toSet)
       .filterNot(_.dataType.isInstanceOf[NumericType]).map(_.name).toArray
-    if (isSet(categoricalCols)) catCols = (catCols ++ $(categoricalCols)).distinct
+    if (isSet(categoricalCols)) {
+      // categoricalCols may contain columns not set in inputCols
+      catCols = (catCols ++ $(categoricalCols).intersect(localInputCols)).distinct
+    }
     val catIndices = catCols.map(c => localInputCols.indexOf(c))
 
     val realCols = (localInputCols.toSet -- catCols).toArray

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/FeatureHasher.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/FeatureHasher.scala
@@ -138,8 +138,8 @@ class FeatureHasher(@Since("2.3.0") override val uid: String) extends Transforme
 
     val realCols = (localInputCols.toSet -- catCols).toArray
     val realIndices = realCols.map(localInputCols.indexOf)
-    // hash of "column_name" of real columns can be pre-computed
-    val realHashes = realCols.map(hashFunc)
+    // pre-compute output indices of real columns
+    val realOutputIndices = realCols.map(c => Utils.nonNegativeMod(hashFunc(c), n))
 
     def getDouble(x: Any): Double = {
       x match {
@@ -160,8 +160,7 @@ class FeatureHasher(@Since("2.3.0") override val uid: String) extends Transforme
         if (!row.isNullAt(realIdx)) {
           // numeric values are kept as is, with vector index based on hash of "column_name"
           val value = getDouble(row.get(realIdx))
-          val rawIdx = realHashes(i)
-          val idx = Utils.nonNegativeMod(rawIdx, n)
+          val idx = realOutputIndices(i)
           map.changeValue(idx, value, v => v + value)
         }
         i += 1

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/FeatureHasher.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/FeatureHasher.scala
@@ -133,7 +133,7 @@ class FeatureHasher(@Since("2.3.0") override val uid: String) extends Transforme
 
     var catCols = dataset.schema(localInputCols.toSet)
       .filterNot(_.dataType.isInstanceOf[NumericType]).map(_.name).toArray
-    if (isSet(categoricalCols)) catCols = (catCols.toSet ++ $(categoricalCols)).toArray
+    if (isSet(categoricalCols)) catCols = (catCols ++ $(categoricalCols)).distinct
     val catIndices = catCols.map(localInputCols.indexOf)
 
     val realCols = (localInputCols.toSet -- catCols).toArray

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/FeatureHasher.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/FeatureHasher.scala
@@ -134,10 +134,10 @@ class FeatureHasher(@Since("2.3.0") override val uid: String) extends Transforme
     var catCols = dataset.schema(localInputCols.toSet)
       .filterNot(_.dataType.isInstanceOf[NumericType]).map(_.name).toArray
     if (isSet(categoricalCols)) catCols = (catCols ++ $(categoricalCols)).distinct
-    val catIndices = catCols.map(localInputCols.indexOf)
+    val catIndices = catCols.map(c => localInputCols.indexOf(c))
 
     val realCols = (localInputCols.toSet -- catCols).toArray
-    val realIndices = realCols.map(localInputCols.indexOf)
+    val realIndices = realCols.map(c => localInputCols.indexOf(c))
     // pre-compute output indices of real columns
     val realOutputIndices = realCols.map(c => Utils.nonNegativeMod(hashFunc(c), n))
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
pre-compute the output indices of numerical columns, instead of computing them on each row.


### Why are the changes needed?
for a numerical column, its output index is a hash of its `col_name`, we can pre-compute it at first, instead of computing it on each row.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
existing testsuites
