### PR TITLE
[SPARK-32984][TESTS][SQL] Improve showing the differences between approved and actual plans of PlanStabilitySuite

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/PlanStabilitySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/PlanStabilitySuite.scala
@@ -178,6 +178,7 @@ trait PlanStabilitySuite extends TPCDSBase with DisableAdaptiveExecutionSuite {
    */
   private def addDiffHint(approvedSimplified: String, actualSimplified: String)
     : (String, String) = {
+    // reverse the plan so we can compare the node from the bottom to top
     val approvedLines = approvedSimplified.split("\n").reverse
     val actualLines = actualSimplified.split("\n").reverse
     val approvedBuilder = new mutable.ArrayStack[String]()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR proposes to add the caret hints, e.g., `^^^^^`,  to the approved and actual plans where they first become different.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

It's hard to find the difference between the approved and actual plan since the plans of TPC-DS queries are often huge. Adding the hints would help developers to locate the plan differences quickly.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, after this change, there're hits added to the plans to highlight the differences. For example,

```scala
[info]   last approved simplified plan: /Users/yi.wu/IdeaProjects/spark/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q41.sf100/simplified.txt
[info]   last approved explain plan: /Users/yi.wu/IdeaProjects/spark/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q41.sf100/explain.txt
[info]   
[info]   TakeOrderedAndProject [i_product_name]
[info]     WholeStageCodegen (4)
[info]       HashAggregate [i_product_name]
[info]         InputAdapter
[info]           Exchange [i_product_name] #1
[info]             WholeStageCodegen (3)
[info]               HashAggregate [i_product_name]
[info]                 Project [i_product_name]
[info]                   BroadcastHashJoin [i_manufact,i_manufact]
[info]                     Project [i_manufact,i_product_name]
[info]                       Filter [i_manufact_id,i_manufact]
[info]                         ColumnarToRow
[info]                           InputAdapter
[info]                             Scan parquet default.item [i_manufact_id,i_manufact,i_product_name]
[info]                     InputAdapter
[info]                       BroadcastExchange #2
[info]                         WholeStageCodegen (2)
[info]                           Project [i_manufact]
[info]                             Filter [item_cnt]
[info]                               HashAggregate [i_manufact,count] [count(1),item_cnt,i_manufact,count]
[info]                                                                                              ^^^^^^
[info]                                 InputAdapter
[info]                                   Exchange [i_manufact] #3
[info]                                     WholeStageCodegen (1)
[info]                                       HashAggregate [i_manufact] [count,count]
[info]                                         Project [i_manufact]
[info]                                           Filter [i_category,i_color,i_units,i_size,i_manufact]
[info]                                             ColumnarToRow
[info]                                               InputAdapter
[info]                                                 Scan parquet default.item [i_category,i_manufact,i_size,i_color,i_units]
[info]   
[info]   actual simplified plan: /Users/yi.wu/IdeaProjects/spark/target/tmp/q41.sf100.actual.simplified.txt
[info]   actual explain plan: /Users/yi.wu/IdeaProjects/spark/target/tmp/q41.sf100.actual.explain.txt
[info]   
[info]   TakeOrderedAndProject [i_product_name]
[info]     WholeStageCodegen (4)
[info]       HashAggregate [i_product_name]
[info]         InputAdapter
[info]           Exchange [i_product_name] #1
[info]             WholeStageCodegen (3)
[info]               HashAggregate [i_product_name]
[info]                 Project [i_product_name]
[info]                   BroadcastHashJoin [i_manufact,i_manufact]
[info]                     Project [i_manufact,i_product_name]
[info]                       Filter [i_manufact_id,i_manufact]
[info]                         ColumnarToRow
[info]                           InputAdapter
[info]                             Scan parquet default.item [i_manufact_id,i_manufact,i_product_name]
[info]                     InputAdapter
[info]                       BroadcastExchange #2
[info]                         WholeStageCodegen (2)
[info]                           Project [i_manufact]
[info]                             Filter [alwaysTrue,item_cnt]
[info]                               HashAggregate [i_manufact,count] [count(1),item_cnt,i_manufact,alwaysTrue,count]
[info]                                                                                              ^^^^^^
[info]                                 InputAdapter
[info]                                   Exchange [i_manufact] #3
[info]                                     WholeStageCodegen (1)
[info]                                       HashAggregate [i_manufact] [count,count]
[info]                                         Project [i_manufact]
[info]                                           Filter [i_category,i_color,i_units,i_size,i_manufact]
[info]                                             ColumnarToRow
[info]                                               InputAdapter
[info]                                                 Scan parquet default.item [i_category,i_manufact,i_size,i_color,i_units] 

```

To be honest, the result is still not perfect when plans are super huge and your monitor can not hold it. But at least now we can have a way to search the differences.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Tested manually.
