### PR TITLE
[SPARK-32971][K8S][FOLLOWUP] Fix k8s-core module compilation in Scala 2.13

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/MountVolumesFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/MountVolumesFeatureStep.scala
@@ -114,7 +114,7 @@ private[spark] class MountVolumesFeatureStep(conf: KubernetesConf)
   }
 
   override def getAdditionalKubernetesResources(): Seq[HasMetadata] = {
-    additionalResources
+    additionalResources.toSeq
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Manual call `toSeq` of `MountVolumesFeatureStep.getAdditionalKubernetesResources` method because `ArrayBuffer` not a `Seq` in Scala 2.13

### Why are the changes needed?
We need to support a Scala 2.13 build.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

- Scala 2.12: Pass the Jenkins or GitHub Action

- Scala 2.13: Pass GitHub 2.13 Build Action
