### PR TITLE
[SPARK-32956][SQL] Ensure that the generated and existing headers are not duplicated in CSV DataSource

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVUtils.scala
@@ -76,7 +76,7 @@ object CSVUtils {
         headerNames.diff(headerNames.distinct).distinct
       }
 
-      row.zipWithIndex.map { case (value, index) =>
+      val header = row.zipWithIndex.map { case (value, index) =>
         if (value == null || value.isEmpty || value == options.nullValue) {
           // When there are empty strings or the values set in `nullValue`, put the
           // index as the suffix.
@@ -92,6 +92,12 @@ object CSVUtils {
         } else {
           value
         }
+      }
+      if (header.sameElements(row)) {
+        header
+      } else {
+        // Ensure that the newly generated and existing headers are not duplicated.
+        makeSafeHeader(header, caseSensitive, options)
       }
     } else {
       row.zipWithIndex.map { case (_, index) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVUtils.scala
@@ -79,12 +79,12 @@ object CSVUtils {
           value
         }
       }
-      val duplicatesSet = {
+      val duplicatesSet = mutable.Set() ++ {
         // scalastyle:off caselocale
         val headerNames = header.map(name => if (caseSensitive) name else name.toLowerCase)
         // scalastyle:on caselocale
         headerNames.diff(headerNames.distinct)
-      }.to[mutable.Set]
+      }
       header.zipWithIndex.map { case (value, index) =>
         var name = value
         // scalastyle:off caselocale

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -1144,13 +1144,13 @@ abstract class CSVSuite extends QueryTest with SharedSparkSession with TestCsvDa
   test("SPARK-32956 Ensure that the generated and existing headers are not duplicated") {
     withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
       withTempPath { path =>
-        Seq("a3,A,c,A,,_c4,_c44").toDF().write.text(path.getAbsolutePath)
+        Seq("a,A3,a33,A,,_c4").toDF().write.text(path.getAbsolutePath)
         val actualSchema = spark.read
           .format("csv")
           .option("header", true)
           .load(path.getAbsolutePath)
           .schema
-        val fields = Seq("a30", "A1", "c", "A33", "_c444", "_c45", "_c446")
+        val fields = Seq("a0", "A3", "a33", "A333", "_c44", "_c45")
           .map(StructField(_, StringType, true))
         val expectedSchema = StructType(fields)
         assert(actualSchema == expectedSchema)


### PR DESCRIPTION
### What changes were proposed in this pull request?
In [SPARK-16896](https://issues.apache.org/jira/browse/SPARK-16896) (headerFlag=true), some new column names are generated to replace duplicate column names or empty string column names in the CSV data source.

> The behavior of SPARK-16896 is as follows:
>
> 1. Empty string name -> `s"_c$index"`
> E.g: `", , a, "` -> `"_c0, _c1, a, _c3"`
> 2. Duplicate name -> `s"$name$index"`
> E.g: `"c, a, b, a"` -> `"c, a1, b, a3"`
>

In this PR [SPARK-32956](https://issues.apache.org/jira/browse/SPARK-32956), on the basis of keeping the user-facing behavior of SPARK-16896 unchanged, the column name generation logic is modified to ensure that the newly generated column name will not duplicate the existing column name.


### Why are the changes needed?
When the CSV data source has duplicate column names, Spark will generate some new column names based on the original column names, and use the index as the suffix.

When the newly generated column name is duplicated with the existing column name, Spark will throw an exception message that is difficult for users to understand.

E.g: `a, a, a, a1` ( -> `a0, a1, a2, a1`)

> AnalysisException: Duplicate column found in data schema a1

E.g: `a, , _c1` ( -> `a, _c1, _c1`)
> AnalysisException: Duplicate column found in data schema _c1


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added a unit test case