### PR TITLE
[SPARK-32994][CORE] Update external heavy accumulators before they entering into listener event loop

### DIFF
--- a/core/src/main/scala/org/apache/spark/InternalAccumulator.scala
+++ b/core/src/main/scala/org/apache/spark/InternalAccumulator.scala
@@ -77,3 +77,10 @@ private[spark] object InternalAccumulator {
 
   // scalastyle:on
 }
+
+object ExternalHeavyAccumulator {
+  // An accumulator which start with this prefix will be handled
+  // before entering into listener event processing loop.
+  // This kind accumulator won't be store in Spark UI and will be GC ASAP.
+  val HEAVY_PREFIX = "external.heavy."
+}

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -837,6 +837,15 @@ package object config {
       .timeConf(TimeUnit.NANOSECONDS)
       .createWithDefaultString("1s")
 
+  private[spark] val LISTENER_BUS_ALLOW_EXTERNAL_ACCUMULATORS_ENTER_EVENT =
+    ConfigBuilder("spark.scheduler.listenerbus.externalAccumulatorsEnterEvent.allowed")
+      .doc("When true, external accumulators allowed to enter into spark listener event loop. " +
+        "Otherwise, external accumulators will be updated before entering event loop. " +
+        "It will save driver memory and avoid full GC when false.")
+      .version("3.1.0")
+      .booleanConf
+      .createWithDefault(false)
+
   // This property sets the root namespace for metrics reporting
   private[spark] val METRICS_NAMESPACE = ConfigBuilder("spark.metrics.namespace")
     .version("2.1.0")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -837,15 +837,6 @@ package object config {
       .timeConf(TimeUnit.NANOSECONDS)
       .createWithDefaultString("1s")
 
-  private[spark] val LISTENER_BUS_ALLOW_EXTERNAL_ACCUMULATORS_ENTER_EVENT =
-    ConfigBuilder("spark.scheduler.listenerbus.externalAccumulatorsEnterEvent.allowed")
-      .doc("When true, external accumulators allowed to enter into spark listener event loop. " +
-        "Otherwise, external accumulators will be updated before entering event loop. " +
-        "It will save driver memory and avoid full GC when false.")
-      .version("3.1.0")
-      .booleanConf
-      .createWithDefault(false)
-
   // This property sets the root namespace for metrics reporting
   private[spark] val METRICS_NAMESPACE = ConfigBuilder("spark.metrics.namespace")
     .version("2.1.0")

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -274,8 +274,41 @@ private[spark] class DAGScheduler(
       accumUpdates: Seq[AccumulatorV2[_, _]],
       metricPeaks: Array[Long],
       taskInfo: TaskInfo): Unit = {
+    val newAccumUpdates =
+      if (sc.conf.get(config.LISTENER_BUS_ALLOW_EXTERNAL_ACCUMULATORS_ENTER_EVENT)) {
+        accumUpdates
+      } else {
+        // It may cause heavy full GC problem if external accumulators keep in memory.
+        // We update external accumulators before they entering into Spark listener event loop.
+        val (internal, external) = accumUpdates.partition { acc =>
+          acc.name.exists(_.startsWith(InternalAccumulator.METRICS_PREFIX))
+        }
+        external.foreach { updates =>
+          val id = updates.id
+          try {
+            // Find the corresponding accumulator on the driver and update it
+            val acc: AccumulatorV2[Any, Any] = AccumulatorContext.get(id) match {
+              case Some(accum) => accum.asInstanceOf[AccumulatorV2[Any, Any]]
+              case None =>
+                throw new SparkException(s"attempted to access non-existent accumulator $id")
+            }
+            acc.merge(updates.asInstanceOf[AccumulatorV2[Any, Any]])
+          } catch {
+            case NonFatal(e) =>
+              // Log the class name to make it easy to find the bad implementation
+              val accumClassName = AccumulatorContext.get(id) match {
+                case Some(accum) => accum.getClass.getName
+                case None => "Unknown class"
+              }
+              logError(
+                s"Failed to update accumulator $id ($accumClassName) for task ${task.partitionId}",
+                e)
+          }
+        }
+        internal
+      }
     eventProcessLoop.post(
-      CompletionEvent(task, reason, result, accumUpdates, metricPeaks, taskInfo))
+      CompletionEvent(task, reason, result, newAccumUpdates, metricPeaks, taskInfo))
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/InternalAccumulatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/InternalAccumulatorSuite.scala
@@ -20,7 +20,6 @@ package org.apache.spark
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.executor.TaskMetrics
-import org.apache.spark.internal.config
 import org.apache.spark.scheduler.AccumulableInfo
 import org.apache.spark.shuffle.FetchFailedException
 import org.apache.spark.util.{AccumulatorContext, AccumulatorMetadata, AccumulatorV2, LongAccumulator}
@@ -204,11 +203,10 @@ class InternalAccumulatorSuite extends SparkFunSuite with LocalSparkContext {
     val listener = new SaveInfoListener
     val numPartitions = 10
     sc = new SparkContext("local", "test")
-    sc.conf.set(config.LISTENER_BUS_ALLOW_EXTERNAL_ACCUMULATORS_ENTER_EVENT, false)
     sc.addSparkListener(listener)
     // Have each task add 1 to the internal accumulator
     val internal = InternalAccumulator.METRICS_PREFIX + "a"
-    val external = "a"
+    val external = ExternalHeavyAccumulator.HEAVY_PREFIX + "a"
     val internalAccum = createLongAccum(internal)
     val externalAccum = createLongAccum(external)
     val rdd = sc.parallelize(1 to 100, numPartitions).mapPartitions { iter =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a new accumulator prefix `external.heavy.` to determine the heavy accumulators. These accumulators will be handled before entering into `eventProcessLoop`. This could avoid the driver holding the heavy accumulators in the event loop for a long time. Then the driver memory could be release in young GC.


### Why are the changes needed?
We use Spark + Delta Lake, recently we find our Spark driver faced full GC problem (very heavy) when users submit a MERGE INTO query. The driver held over 100GB memory (depends on how much the max heap size set) and can not be GC forever. By making a heap dump we found the root cause. More details about the issue and the patch testing result, see [SPARK-32994](https://issues.apache.org/jira/browse/SPARK-32994)

<img width="839" alt="Screen Shot 2020-09-25 at 11 35 01 AM" src="https://user-images.githubusercontent.com/1853780/94225514-c3159380-ff27-11ea-9b29-22bb4fa77533.png">

From above heap dump, Delta uses a SetAccumulator to records touched files names
```scala
    // Accumulator to collect all the distinct touched files
    val touchedFilesAccum = new SetAccumulator[String]()
    spark.sparkContext.register(touchedFilesAccum, TOUCHED_FILES_ACCUM_NAME)

    // UDFs to records touched files names and add them to the accumulator
    val recordTouchedFileName = udf { (fileName: String) => {
      touchedFilesAccum.add(fileName)
      1
    }}.asNondeterministic()
```

In a big query, each task may hold thousands of file names, and if a stage contains dozens of thousands of tasks, DAGscheduler may hold millions of `CompletionEvent`. And each `CompletionEvent` holds the thousands of file names in its `accumUpdates`. All accumulator objects will use Spark listener event to deliver to the event loop and even a full GC can not release memory.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add a UT
