### PR TITLE
[SPARK-33010][SQL]Make DataFrameWriter.jdbc work for DataSource V2

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -809,7 +809,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
     // connectionProperties should override settings in extraOptions.
     this.extraOptions ++= connectionProperties.asScala
     // explicit url should override all
-    this.extraOptions ++= Seq("url" -> url)
+    this.extraOptions += "url" -> url
 
     import df.sparkSession.sessionState.analyzer.NonSessionCatalogAndIdentifier
     import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
@@ -823,7 +823,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
 
       case _ =>
         // explicit dbtable should override all
-        this.extraOptions ++= Seq("dbtable" -> table)
+        this.extraOptions += "dbtable" -> table
         saveToV1Source(None)
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -811,7 +811,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
     // explicit url should override all
     this.extraOptions ++= Seq("url" -> url)
 
-    import df.sparkSession.sessionState.analyzer.{AsTableIdentifier, NonSessionCatalogAndIdentifier}
+    import df.sparkSession.sessionState.analyzer.NonSessionCatalogAndIdentifier
     import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 
     val session = df.sparkSession

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -808,9 +808,26 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
     assertNotBucketed("jdbc")
     // connectionProperties should override settings in extraOptions.
     this.extraOptions ++= connectionProperties.asScala
-    // explicit url and dbtable should override all
-    this.extraOptions ++= Seq("url" -> url, "dbtable" -> table)
-    format("jdbc").save()
+    this.extraOptions ++= Seq("url" -> url)
+
+    import df.sparkSession.sessionState.analyzer.{AsTableIdentifier, NonSessionCatalogAndIdentifier}
+    import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+    val session = df.sparkSession
+    format("jdbc")
+
+    session.sessionState.sqlParser.parseMultipartIdentifier(table) match {
+      case nameParts @ NonSessionCatalogAndIdentifier(catalog, tableIdentifier) =>
+        saveAsTable(catalog.asTableCatalog, tableIdentifier, nameParts)
+
+      case AsTableIdentifier(_) =>
+        this.extraOptions ++= Seq("dbtable" -> table)
+        saveToV1Source(None)
+
+      case other =>
+        throw new AnalysisException(
+          s"Couldn't find a catalog to handle the identifier ${other.quoted}.")
+    }
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -232,7 +232,8 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession {
       df1.write
         .mode("append")
         .jdbc(url, "h2.test.abc", properties)
-      checkAnswer(sql("SELECT name, id FROM h2.test.abc"),
+      checkAnswer(
+        sql("SELECT name, id FROM h2.test.abc"),
         Seq(Row("fred", 1), Row("mary", 2), Row("evan", 3)))
 
       df2.write

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -222,7 +222,7 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("dfwriter.jdbc") {
+  test("DataFrameWriter: jdbc") {
     withTable("h2.test.abc") {
       sql("CREATE TABLE h2.test.abc USING _ AS SELECT * FROM h2.test.people")
       val df1 = Seq(("evan", 3)).toDF("NAME", "ID")


### PR DESCRIPTION

### What changes were proposed in this pull request?
Support multiple catalogs in the following use case:
```
DataFrameWriter.jdbc(url, "catalog.db.tbl", properties)
```


### Why are the changes needed?
Make DataFrameWriter.jdbc work for DataSource V2


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
New test
