### PR TITLE
[SPARK-33011][ML] Promote the stability annotation to Evolving for MLEvent traits/classes

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/events.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/events.scala
@@ -20,7 +20,7 @@ package org.apache.spark.ml
 import com.fasterxml.jackson.annotation.JsonIgnore
 
 import org.apache.spark.SparkContext
-import org.apache.spark.annotation.Unstable
+import org.apache.spark.annotation.Evolving
 import org.apache.spark.internal.Logging
 import org.apache.spark.ml.util.{MLReader, MLWriter}
 import org.apache.spark.scheduler.SparkListenerEvent
@@ -31,10 +31,8 @@ import org.apache.spark.sql.{DataFrame, Dataset}
  * after each operation (the event should document this).
  *
  * @note This is supported via [[Pipeline]] and [[PipelineModel]].
- * @note This is experimental and unstable. Do not use this unless you fully
- *   understand what `Unstable` means.
  */
-@Unstable
+@Evolving
 sealed trait MLEvent extends SparkListenerEvent {
   // Do not log ML events in event log. It should be revisited to see
   // how it works with history server.
@@ -44,7 +42,7 @@ sealed trait MLEvent extends SparkListenerEvent {
 /**
  * Event fired before `Transformer.transform`.
  */
-@Unstable
+@Evolving
 case class TransformStart() extends MLEvent {
   @JsonIgnore var transformer: Transformer = _
   @JsonIgnore var input: Dataset[_] = _
@@ -53,7 +51,7 @@ case class TransformStart() extends MLEvent {
 /**
  * Event fired after `Transformer.transform`.
  */
-@Unstable
+@Evolving
 case class TransformEnd() extends MLEvent {
   @JsonIgnore var transformer: Transformer = _
   @JsonIgnore var output: Dataset[_] = _
@@ -62,7 +60,7 @@ case class TransformEnd() extends MLEvent {
 /**
  * Event fired before `Estimator.fit`.
  */
-@Unstable
+@Evolving
 case class FitStart[M <: Model[M]]() extends MLEvent {
   @JsonIgnore var estimator: Estimator[M] = _
   @JsonIgnore var dataset: Dataset[_] = _
@@ -71,7 +69,7 @@ case class FitStart[M <: Model[M]]() extends MLEvent {
 /**
  * Event fired after `Estimator.fit`.
  */
-@Unstable
+@Evolving
 case class FitEnd[M <: Model[M]]() extends MLEvent {
   @JsonIgnore var estimator: Estimator[M] = _
   @JsonIgnore var model: M = _
@@ -80,7 +78,7 @@ case class FitEnd[M <: Model[M]]() extends MLEvent {
 /**
  * Event fired before `MLReader.load`.
  */
-@Unstable
+@Evolving
 case class LoadInstanceStart[T](path: String) extends MLEvent {
   @JsonIgnore var reader: MLReader[T] = _
 }
@@ -88,7 +86,7 @@ case class LoadInstanceStart[T](path: String) extends MLEvent {
 /**
  * Event fired after `MLReader.load`.
  */
-@Unstable
+@Evolving
 case class LoadInstanceEnd[T]() extends MLEvent {
   @JsonIgnore var reader: MLReader[T] = _
   @JsonIgnore var instance: T = _
@@ -97,7 +95,7 @@ case class LoadInstanceEnd[T]() extends MLEvent {
 /**
  * Event fired before `MLWriter.save`.
  */
-@Unstable
+@Evolving
 case class SaveInstanceStart(path: String) extends MLEvent {
   @JsonIgnore var writer: MLWriter = _
 }
@@ -105,7 +103,7 @@ case class SaveInstanceStart(path: String) extends MLEvent {
 /**
  * Event fired after `MLWriter.save`.
  */
-@Unstable
+@Evolving
 case class SaveInstanceEnd(path: String) extends MLEvent {
   @JsonIgnore var writer: MLWriter = _
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to promote the stability annotation to `Evolving` for MLEvent traits/classes.

### Why are the changes needed?

The feature is released in Spark 3.0.0 having SPARK-26818 as the last change in Feb. 2020, and haven't changed in Spark 3.0.1. (There's no change more than a half of year.)

While we'd better to wait for some minor releases to consider the API as stable, it would worth to promote to Evolving so that we clearly state that we support the API.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Just changed the annotation, no tests required.