### PR TITLE
[SPARK-33014][SQL] Support multiple bucket columns in DataSourceV2 table

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/expressions/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/expressions/expressions.scala
@@ -115,11 +115,10 @@ private[sql] final case class BucketTransform(
 }
 
 private[sql] object BucketTransform {
-  def unapply(transform: Transform): Option[(Int, NamedReference)] = transform match {
-    case NamedTransform("bucket", Seq(
-        Lit(value: Int, IntegerType),
-        Ref(seq: Seq[String]))) =>
-      Some((value, FieldReference(seq)))
+  def unapply(transform: Transform): Option[(Int, Seq[NamedReference])] = transform match {
+    case NamedTransform("bucket", Lit(value: Int, IntegerType) :: refs) =>
+      val fieldReferences = refs.collect { case Ref(seq: Seq[String]) => FieldReference(seq) }
+      Some((value, fieldReferences))
     case _ =>
       None
   }
@@ -162,8 +161,8 @@ private object Ref {
  * Convenience extractor for any Transform.
  */
 private[sql] object NamedTransform {
-  def unapply(transform: Transform): Some[(String, Seq[Expression])] = {
-    Some((transform.name, transform.arguments))
+  def unapply(transform: Transform): Some[(String, List[Expression])] = {
+    Some((transform.name, transform.arguments.toList))
   }
 }
 
@@ -176,7 +175,7 @@ private[sql] final case class IdentityTransform(
 
 private[sql] object IdentityTransform {
   def unapply(transform: Transform): Option[FieldReference] = transform match {
-    case NamedTransform("identity", Seq(Ref(parts))) =>
+    case NamedTransform("identity", List(Ref(parts))) =>
       Some(FieldReference(parts))
     case _ =>
       None
@@ -191,7 +190,7 @@ private[sql] final case class YearsTransform(
 
 private[sql] object YearsTransform {
   def unapply(transform: Transform): Option[FieldReference] = transform match {
-    case NamedTransform("years", Seq(Ref(parts))) =>
+    case NamedTransform("years", List(Ref(parts))) =>
       Some(FieldReference(parts))
     case _ =>
       None
@@ -206,7 +205,7 @@ private[sql] final case class MonthsTransform(
 
 private[sql] object MonthsTransform {
   def unapply(transform: Transform): Option[FieldReference] = transform match {
-    case NamedTransform("months", Seq(Ref(parts))) =>
+    case NamedTransform("months", List(Ref(parts))) =>
       Some(FieldReference(parts))
     case _ =>
       None
@@ -221,7 +220,7 @@ private[sql] final case class DaysTransform(
 
 private[sql] object DaysTransform {
   def unapply(transform: Transform): Option[FieldReference] = transform match {
-    case NamedTransform("days", Seq(Ref(parts))) =>
+    case NamedTransform("days", List(Ref(parts))) =>
       Some(FieldReference(parts))
     case _ =>
       None
@@ -236,7 +235,7 @@ private[sql] final case class HoursTransform(
 
 private[sql] object HoursTransform {
   def unapply(transform: Transform): Option[FieldReference] = transform match {
-    case NamedTransform("hours", Seq(Ref(parts))) =>
+    case NamedTransform("hours", List(Ref(parts))) =>
       Some(FieldReference(parts))
     case _ =>
       None

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/expressions/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/expressions/expressions.scala
@@ -116,7 +116,7 @@ private[sql] final case class BucketTransform(
 
 private[sql] object BucketTransform {
   def unapply(transform: Transform): Option[(Int, Seq[NamedReference])] = transform match {
-    case NamedTransform("bucket", Lit(value: Int, IntegerType) :: refs) =>
+    case NamedTransform("bucket", Seq(Lit(value: Int, IntegerType), refs @ _*)) =>
       val fieldReferences = refs.collect { case Ref(seq: Seq[String]) => FieldReference(seq) }
       Some((value, fieldReferences))
     case _ =>
@@ -161,8 +161,8 @@ private object Ref {
  * Convenience extractor for any Transform.
  */
 private[sql] object NamedTransform {
-  def unapply(transform: Transform): Some[(String, List[Expression])] = {
-    Some((transform.name, transform.arguments.toList))
+  def unapply(transform: Transform): Some[(String, Seq[Expression])] = {
+    Some((transform.name, transform.arguments))
   }
 }
 
@@ -175,7 +175,7 @@ private[sql] final case class IdentityTransform(
 
 private[sql] object IdentityTransform {
   def unapply(transform: Transform): Option[FieldReference] = transform match {
-    case NamedTransform("identity", List(Ref(parts))) =>
+    case NamedTransform("identity", Seq(Ref(parts))) =>
       Some(FieldReference(parts))
     case _ =>
       None
@@ -190,7 +190,7 @@ private[sql] final case class YearsTransform(
 
 private[sql] object YearsTransform {
   def unapply(transform: Transform): Option[FieldReference] = transform match {
-    case NamedTransform("years", List(Ref(parts))) =>
+    case NamedTransform("years", Seq(Ref(parts))) =>
       Some(FieldReference(parts))
     case _ =>
       None
@@ -205,7 +205,7 @@ private[sql] final case class MonthsTransform(
 
 private[sql] object MonthsTransform {
   def unapply(transform: Transform): Option[FieldReference] = transform match {
-    case NamedTransform("months", List(Ref(parts))) =>
+    case NamedTransform("months", Seq(Ref(parts))) =>
       Some(FieldReference(parts))
     case _ =>
       None
@@ -220,7 +220,7 @@ private[sql] final case class DaysTransform(
 
 private[sql] object DaysTransform {
   def unapply(transform: Transform): Option[FieldReference] = transform match {
-    case NamedTransform("days", List(Ref(parts))) =>
+    case NamedTransform("days", Seq(Ref(parts))) =>
       Some(FieldReference(parts))
     case _ =>
       None
@@ -235,7 +235,7 @@ private[sql] final case class HoursTransform(
 
 private[sql] object HoursTransform {
   def unapply(transform: Transform): Option[FieldReference] = transform match {
-    case NamedTransform("hours", List(Ref(parts))) =>
+    case NamedTransform("hours", Seq(Ref(parts))) =>
       Some(FieldReference(parts))
     case _ =>
       None

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryTable.scala
@@ -29,7 +29,7 @@ import org.scalatest.Assertions._
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.connector.catalog._
-import org.apache.spark.sql.connector.expressions.{BucketTransform, DaysTransform, HoursTransform, IdentityTransform, MonthsTransform, Transform, YearsTransform}
+import org.apache.spark.sql.connector.expressions.{BucketTransform, DaysTransform, FieldReference, HoursTransform, IdentityTransform, MonthsTransform, Transform, YearsTransform}
 import org.apache.spark.sql.connector.read._
 import org.apache.spark.sql.connector.write._
 import org.apache.spark.sql.sources.{And, EqualTo, Filter, IsNotNull}
@@ -128,7 +128,8 @@ class InMemoryTable(
             ChronoUnit.HOURS.between(Instant.EPOCH, DateTimeUtils.microsToInstant(micros))
         }
       case BucketTransform(numBuckets, ref) =>
-        (extractor(ref.fieldNames, schema, row).hashCode() & Integer.MAX_VALUE) % numBuckets
+        val cols = ref.collect { case FieldReference(Seq(col)) => col }.toArray
+        (extractor(cols, schema, row).hashCode() & Integer.MAX_VALUE) % numBuckets
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalog.scala
@@ -287,8 +287,10 @@ private[sql] object V2SessionCatalog {
       case IdentityTransform(FieldReference(Seq(col))) =>
         identityCols += col
 
-      case BucketTransform(numBuckets, FieldReference(Seq(col))) =>
-        bucketSpec = Some(BucketSpec(numBuckets, col :: Nil, Nil))
+      case BucketTransform(numBuckets, fieldReferences) =>
+        // CLUSTERED BY multipartIdentifierList is not supported
+        val bucketColumns = fieldReferences.collect { case FieldReference(Seq(col)) => col }
+        bucketSpec = Some(BucketSpec(numBuckets, bucketColumns, Nil))
 
       case transform =>
         throw new UnsupportedOperationException(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalog.scala
@@ -288,8 +288,9 @@ private[sql] object V2SessionCatalog {
         identityCols += col
 
       case BucketTransform(numBuckets, fieldReferences) =>
-        // CLUSTERED BY multipartIdentifierList is not supported
-        val bucketColumns = fieldReferences.collect { case FieldReference(Seq(col)) => col }
+        val bucketColumns = fieldReferences.collect {
+          case FieldReference(parts) => parts.mkString(".")
+        }
         bucketSpec = Some(BucketSpec(numBuckets, bucketColumns, Nil))
 
       case transform =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -1668,7 +1668,6 @@ class DataSourceV2SQLSuite
         """
           |CREATE TABLE testcat.t (id int, `a.b` string, c string) USING foo
           |CLUSTERED BY (`a.b`, c) INTO 4 BUCKETS
-          |OPTIONS ('allow-unsupported-transforms'=true)
         """.stripMargin)
 
       val testCatalog = catalog("testcat").asTableCatalog.asInstanceOf[InMemoryTableCatalog]


### PR DESCRIPTION
### What changes were proposed in this pull request?
In `V2SessionCatalog.convertTransforms()`, partitions only match one bucket column by
`case BucketTransform(numBuckets, FieldReference(Seq(col))) =>`
It should be a bug since there is no comment to explain the reason.
This PR accepts more than one bucket columns for V2 table.


### Why are the changes needed?
Create a data source V2 table only accept one bucket column, two or more bucket columns in V2 table will show exception `SessionCatalog does not support partition transform ...`.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Add UT.
