### PR TITLE
[SPARK-32958][SQL] Prune unnecessary columns from JsonToStructs

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeJsonExprs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeJsonExprs.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.optimizer
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{ArrayType, StructType}
 
 /**
  * Simplify redundant json related expressions.
@@ -47,6 +47,11 @@ object OptimizeJsonExprs extends Rule[LogicalPlan] {
       case g @ GetStructField(jsonToStructs: JsonToStructs, ordinal, _) =>
         val prunedSchema = StructType(Seq(jsonToStructs.schema.asInstanceOf[StructType](ordinal)))
         g.copy(child = jsonToStructs.copy(schema = prunedSchema), ordinal = 0)
+
+      case g @ GetArrayStructFields(jsonToStructs: JsonToStructs, _, _, _, _) =>
+        val prunedSchema = ArrayType(StructType(Seq(g.field)), g.containsNull)
+        g.copy(child = jsonToStructs.copy(schema = prunedSchema), ordinal = 0, numFields = 1)
+
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeJsonExprs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeJsonExprs.scala
@@ -26,8 +26,8 @@ import org.apache.spark.sql.types.{ArrayType, StructType}
  * Simplify redundant json related expressions.
  *
  * The optimization includes:
- * 1. JsonToStructs(StructsToJson(child)) => child
- * 2. Prune unnecessary columns from GetStructField + JsonToStructs.
+ * 1. JsonToStructs(StructsToJson(child)) => child.
+ * 2. Prune unnecessary columns from GetStructField/GetArrayStructFields + JsonToStructs.
  */
 object OptimizeJsonExprs extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan = plan transform {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeJsonExprsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeJsonExprsSuite.scala
@@ -165,4 +165,38 @@ class OptimizeJsonExprsSuite extends PlanTest with ExpressionEvalHelper {
       .select(GetStructField(JsonToStructs(prunedSchema2, options, 'json), 0)).analyze
     comparePlans(optimized2, expected2)
   }
+
+  test("SPARK-32958: prune unnecessary columns from GetArrayStructFields + from_json") {
+    val options = Map.empty[String, String]
+    val schema1 = ArrayType(StructType.fromDDL("a int, b int"), containsNull = true)
+    val field1 = schema1.elementType.asInstanceOf[StructType](0)
+
+    val query1 = testRelation2
+      .select(GetArrayStructFields(
+        JsonToStructs(schema1, options, 'json), field1, 0, 2, true).as("a"))
+    val optimized1 = Optimizer.execute(query1.analyze)
+
+    val prunedSchema1 = ArrayType(StructType.fromDDL("a int"), containsNull = true)
+    val expected1 = testRelation2
+      .select(GetArrayStructFields(
+        JsonToStructs(prunedSchema1, options, 'json), field1, 0, 1, true).as("a")).analyze
+    comparePlans(optimized1, expected1)
+
+    val schema2 = ArrayType(
+      StructType(
+        StructField("a", IntegerType, false) ::
+          StructField("b", IntegerType, false) :: Nil), containsNull = false)
+    val field2 = schema2.elementType.asInstanceOf[StructType](1)
+    val query2 = testRelation2
+      .select(GetArrayStructFields(
+        JsonToStructs(schema2, options, 'json), field2, 1, 2, false).as("b"))
+    val optimized2 = Optimizer.execute(query2.analyze)
+
+    val prunedSchema2 = ArrayType(
+      StructType(StructField("b", IntegerType, false) :: Nil), containsNull = false)
+    val expected2 = testRelation2
+      .select(GetArrayStructFields(
+        JsonToStructs(prunedSchema2, options, 'json), field2, 0, 1, false).as("b")).analyze
+    comparePlans(optimized2, expected2)
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This patch proposes to do column pruning for `JsonToStructs` expression if we only require some fields from it.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

`JsonToStructs` takes a schema parameter used to tell `JacksonParser` what fields are needed to parse. If `JsonToStructs` is followed by `GetStructField`. We can prune the schema to only parse certain field.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Unit test