### PR TITLE
[SPARK-33015][SQL][FOLLOWUP][3.0] Use millisToDays() in the ComputeCurrentTime rule

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
@@ -82,7 +82,7 @@ object ComputeCurrentTime extends Rule[LogicalPlan] {
       case currentDate @ CurrentDate(Some(timeZoneId)) =>
         currentDates.getOrElseUpdate(timeZoneId, {
           Literal.create(
-            DateTimeUtils.microsToDays(timestamp, currentDate.zoneId),
+            DateTimeUtils.millisToDays(DateTimeUtils.toMillis(timestamp), currentDate.zoneId),
             DateType)
         })
       case CurrentTimestamp() | Now() => currentTime


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use `millisToDays()` instead of `microsToDays()` because the former one is not available in `branch-3.0`.

### Why are the changes needed?
To fix the build failure:
```
[ERROR] [Error] /home/jenkins/workspace/spark-branch-3.0-maven-snapshots/spark/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala:85: value microsToDays is not a member of object org.apache.spark.sql.catalyst.util.DateTimeUtils
```

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
By running `./build/sbt clean package` and `ComputeCurrentTimeSuite`.