### PR TITLE
[SPARK-33033][WEBUI] display time series view for task metrics in history server

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/statisticspage.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/statisticspage.css
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.axis path, .axis line {
+    fill: none;
+    stroke: black;
+    stroke-width: 1;
+    shape-rendering: crispEdges;
+}
+
+.axis text {
+    font-size: 9px;
+    fill: #555;
+    pointer-events: none;
+}
+
+.brush .extent {
+    stroke: #fff;
+    fill-opacity: .125;
+    shape-rendering: crispEdges;
+}

--- a/core/src/main/resources/org/apache/spark/ui/static/statisticspage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/statisticspage.js
@@ -1,0 +1,392 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var colorPool = ["#1f77b4",
+    "#aec7e8",
+    "#ff7f0e",
+    "#ffbb78",
+    "#2ca02c",
+    "#98df8a",
+    "#d62728",
+    "#ff9896",
+    "#9467bd",
+    "#c5b0d5",
+    "#8c564b",
+    "#c49c94",
+    "#e377c2",
+    "#f7b6d2",
+    "#7f7f7f",
+    "#c7c7c7",
+    "#bcbd22",
+    "#dbdb8d",
+    "#17becf",
+    "#9edae5"];
+
+var bisectDate = d3.bisector(function (d) {
+    return +d.key;
+}).left;
+
+var formatYValue = d3.format(",.2f");
+
+function formatStyle(name) {
+    return 's' + name.replace(' ', '').replace('-', '').replace('%', '');
+}
+
+function getTimeWithServerZone(v, serverTimezoneOffset) {
+    return v + new Date().getTimezoneOffset() * 60 * 1000 + serverTimezoneOffset * 60 * 1000
+}
+
+function addBrushArea(svg, line, lineId, x, y, xAxis, minX, maxX, width, height, updateLineFunc) {
+    var brush = d3.svg.brush()
+        .x(x).y(y)
+        .extent([[0, 0], [width, height]])
+        .on("brushend", updateChart);
+
+    var idleTimeout
+    function idled() { idleTimeout = null; }
+
+    function updateChart() {
+        var extent = brush.extent();
+
+        if (brush.empty()) {
+            if (!idleTimeout) return idleTimeout = setTimeout(idled, 350);
+            x.domain([minX, maxX])
+        } else {
+            x.domain([extent[0][0].getTime(), extent[1][0].getTime()])
+            line.select(".brush").call(brush.clear())
+        }
+
+        xAxis.transition().duration(1000).call(d3.svg.axis().scale(x).orient("bottom"))
+        line
+            .selectAll(lineId)
+            .transition()
+            .duration(1000)
+            .attr("d", updateLineFunc)
+    }
+
+    svg.on("dblclick", function () {
+        x.domain([minX, maxX])
+        xAxis.transition().call(d3.svg.axis().scale(x).orient("bottom"))
+        line
+            .selectAll(lineId)
+            .transition()
+            .attr("d", updateLineFunc)
+    });
+    return brush;
+}
+
+function addToolTip(svg, context, x, nestY, height, unit, timezoneOffset, tooltipData) {
+    var focus = svg.append("g")
+        .style("display", "none");
+    var tooltipLine = focus.append("line")
+        .attr("class", "x")
+        .style("stroke", "blue")
+        .style("stroke-dasharray", "3,3")
+        .style("opacity", 0.5)
+        .attr("y1", height)
+        .attr("y2", 0);
+    context.select(".background")
+        .attr("height", height)
+        .on("mouseover.tooltip", function () {
+            focus.style("display", null);
+        })
+        .on("mouseout.tooltip", function () {
+            focus.style("display", "none");
+            hideBootstrapTooltip(tooltipLine.node());
+        })
+        .on("mousemove.tooltip", mousemove);
+
+    function mousemove() {
+        var x0 = x.invert(d3.mouse(this)[0]).getTime();
+        var i = bisectDate(nestY, x0, 1);
+        var d0 = nestY[i - 1];
+        var d1 = nestY[i];
+        var d = x0 - d0.key > d1.key - x0 ? d1 : d0;
+        tooltipLine
+            .attr("transform",
+                "translate(" + x(d.key) + "," +
+                0 + ")");
+        var stageIds = tooltipData.find(function(t) {
+            return +d.key == getTimeWithServerZone(+t.x, timezoneOffset);
+        });
+        var stageIdStr = "";
+        if (stageIds != undefined) stageIdStr = stageIds.id;
+        var tip = "Time: " + d3.time.format("%X")(new Date(+d.key)) + ";\n " +
+            "Associated stages: (" + stageIdStr + ");\n" +
+            d.values.map(function (d) {
+            var tip = d.name + ": " + formatYValue(d.y);
+            if (unit == "%" || unit == "ms" || unit.includes("/")) {
+                tip += unit;
+            } else {
+                tip += "(" + unit + ")";
+            }
+            return tip;
+        }).sort().join("; ");
+        hideBootstrapTooltip(tooltipLine.node());
+        showBootstrapTooltip(tooltipLine.node(), tip);
+    }
+}
+
+function addLegends(svg, line, lineId, res, height, legendMarginX, legendMarginY, legendSize, legendTextSize, legendCountInLine, colors) {
+    var highlight = function (d) {
+        line.selectAll(lineId).style("opacity", .1)
+        line.select("." + formatStyle(d)).style("opacity", 1)
+    }
+
+    var noHighlight = function (d) {
+        line.selectAll(lineId).style("opacity", 1)
+    }
+
+    svg.selectAll("myrect")
+        .data(res)
+        .enter()
+        .append("rect")
+        .attr("x", function (d, i) { return legendMarginX * 3 + (i % legendCountInLine) * (legendMarginX * 2 + legendSize); })
+        .attr("y", function (d, i) { return height + legendMarginY * 3 + Math.floor((i / legendCountInLine)) * (legendSize + legendTextSize + legendMarginY); })
+        .attr("width", legendSize)
+        .attr("height", legendSize)
+        .style("fill", function (d, i) { return colors(i); })
+        .on("mouseover", highlight)
+        .on("mouseleave", noHighlight);
+
+    svg.selectAll("mylabels")
+        .data(res)
+        .enter()
+        .append("text")
+        .attr("x", function (d, i) { return legendMarginX * 3 + (i % legendCountInLine) * (legendMarginX * 2 + legendSize); })
+        .attr("y", function (d, i) { return height + legendMarginY * 3 + legendSize + legendMarginY + Math.floor((i / legendCountInLine)) * (legendSize + legendTextSize + legendMarginY); })
+        .style("fill", function (d, i) { return colors(i); })
+        .text(function (d) { return d })
+        .attr("font-size", "10px")
+        .attr("text-anchor", "right")
+        .style("alignment-baseline", "middle")
+        .on("mouseover", highlight)
+        .on("mouseleave", noHighlight);
+}
+
+function renderBrushMultiLineChart(data, id, unit, longLegend, timezoneOffset, tooltipData) {
+    var nest = d3.nest()
+        .key(function (d) { return d.name; })
+        .rollup(function (v) {
+            return v.map(function (e) {
+                return { x: +getTimeWithServerZone(e.x, timezoneOffset), y: e.y };
+            })
+        })
+        .entries(data);
+    var nestY = d3.nest().key(function (d) { return +getTimeWithServerZone(d.x, timezoneOffset); })
+        .entries(data);
+    var res = nest.map(function (d) { return d.key });
+    var resX = nestY.map(function (d) { return +d.key });
+    var maxY = d3.max(nest, function (d) { return d3.max(d.values, function (d) { return +d.y; }) });
+    var minY = d3.min(nest, function (d) { return d3.min(d.values, function (d) { return +d.y; }) });
+    var maxX = d3.max(resX);
+    var minX = d3.min(resX);
+    var colors = d3.scale.ordinal()
+        .domain(res)
+        .range(colorPool);
+    var legendSize = 20;
+    var legendMarginY = 10;
+    var legendMarginX = 10;
+    if (longLegend) {
+        legendMarginX = 30;
+    }
+    var legendTextSize = 10;
+
+    var margin = { top: 10, right: 30, bottom: 30, left: 60 };
+    var width = 1000 - margin.left - margin.right;
+    var height = 400 - margin.top - margin.bottom;
+    var legendCountInLine = Math.floor((width - legendMarginX * 3) / (legendSize + 2 * legendMarginX));
+
+    var legendHeight = legendMarginY * 3 + (1 + res.length / legendCountInLine) * (legendSize + legendMarginY + legendTextSize);
+
+    var svg = d3.select(id)
+        .append("svg")
+        .attr("width", width + margin.left + margin.right)
+        .attr("height", height + margin.top + margin.bottom + legendHeight)
+        .append("g")
+        .attr("transform",
+            "translate(" + margin.left + "," + margin.top + ")");
+
+    var x = d3.time.scale()
+        .domain([minX, maxX])
+        .range([0, width]);
+
+    xAxis = svg.append("g")
+        .attr("class", "x axis")
+        .attr("transform", "translate(0," + height + ")")
+        .call(d3.svg.axis().scale(x).orient("bottom"));
+
+    var yMargin = Math.floor((maxY - minY) / 20);
+    if (minY > yMargin) {
+        minY = minY - yMargin;
+    }
+    var y = d3.scale.linear()
+        .domain([minY, maxY + yMargin])
+        .range([height, 0]);
+
+    yAxis = svg.append("g")
+        .attr("class", "y axis")
+        .call(d3.svg.axis().scale(y).orient("left").tickFormat(formatYValue))
+        .append("text")
+        .text(unit);
+
+    var clip = svg.append("defs").append("svg:clipPath")
+        .attr("id", "clip")
+        .append("svg:rect")
+        .attr("width", width)
+        .attr("height", height + legendHeight)
+        .attr("x", 0)
+        .attr("y", 0);
+
+    var line = svg.append('g')
+        .attr("clip-path", "url(#clip)")
+
+    line.selectAll("nest")
+        .data(nest)
+        .enter().append("path")
+        .attr("class", function (d) { return "line " + formatStyle(d.key); })
+        .attr("fill", "none")
+        .attr("stroke",
+            function (d, i) { return colors(i); })
+        .attr("stroke-width", 1.5)
+        .attr("d", function (d) {
+            return d3.svg.line()
+                .x(function (d) { return x(d.x); })
+                .y(function (d) { return y(+d.y); })
+                (d.values)
+        });
+
+    var context = line
+        .append("g")
+        .attr("class", "brush");
+    var brush = addBrushArea(svg, line, ".line", x, y, xAxis, minX, maxX, width, height, function (d) {
+        return d3.svg.line()
+            .x(function (d) { return x(d.x); })
+            .y(function (d) { return y(+d.y); })
+            (d.values)
+    });
+    context.call(brush);
+
+    addToolTip(svg, context, x, nestY, height, unit, timezoneOffset, tooltipData);
+
+    addLegends(svg, line, ".line", res, height, legendMarginX, legendMarginY, legendSize, legendTextSize, legendCountInLine, colors);
+}
+
+function renderBrushStackAreaChart(data, id, unit, longLegend, timezoneOffset, tooltipData) {
+    var nest = d3.nest()
+        .key(function (d) { return d.name; })
+        .rollup(function (v) {
+            return v.map(function (e) {
+                return { x: +getTimeWithServerZone(e.x, timezoneOffset), y: e.y };
+            })
+        })
+        .entries(data);
+    var res = nest.map(function (d) { return d.key });
+    var nestY = d3.nest().key(function (d) { return +getTimeWithServerZone(d.x, timezoneOffset); })
+        .entries(data);
+    var resX = nestY.map(function (d) { return +d.key });
+    var maxY = d3.max(nestY, function (d) { return d3.sum(d.values, function (d) { return +d.y; }) });
+    var minY = d3.min(nest, function (d) { return d3.min(d.values, function (d) { return +d.y; }) });
+    var maxX = d3.max(resX);
+    var minX = d3.min(resX);
+    var colors = d3.scale.ordinal()
+        .domain(res)
+        .range(colorPool);
+    var legendSize = 20;
+    var legendMarginY = 10;
+    var legendMarginX = 10;
+    if (longLegend) {
+        legendMarginX = 30;
+    }
+    var legendTextSize = 10;
+
+    var margin = { top: 10, right: 30, bottom: 30, left: 60 };
+    var width = 1000 - margin.left - margin.right;
+    var height = 400 - margin.top - margin.bottom;
+    var legendCountInLine = Math.floor((width - legendMarginX * 3) / (legendSize + 2 * legendMarginX));
+
+    var legendHeight = legendMarginY * 3 + (1 + res.length / legendCountInLine) * (legendSize + legendMarginY + legendTextSize);
+
+    var svg = d3.select(id)
+        .append("svg")
+        .attr("width", width + margin.left + margin.right)
+        .attr("height", height + margin.top + margin.bottom + legendHeight)
+        .append("g")
+        .attr("transform",
+            "translate(" + margin.left + "," + margin.top + ")");
+
+    var stack = d3.layout.stack()
+        .values(function (d) { return d.values; });
+    var dataset = stack(nest);
+    var x = d3.time.scale()
+        .domain([minX, maxX])
+        .range([0, width]);
+
+    var yMargin = Math.floor((maxY - minY) / 20);
+    if (minY > yMargin) {
+        minY = minY - yMargin;
+    }
+    var y = d3.scale.linear()
+        .domain([minY, maxY + yMargin])
+        .range([height, 0]);
+
+    xAxis = svg.append("g")
+        .attr("class", "x axis")
+        .attr("transform", "translate(0," + height + ")")
+        .call(d3.svg.axis().scale(x).orient("bottom"));
+    yAxis = svg.append("g")
+        .attr("class", "y axis")
+        .call(d3.svg.axis().scale(y).orient("left").tickFormat(formatYValue))
+        .append("text")
+        .text(unit);
+    var clip = svg.append("defs").append("svg:clipPath")
+        .attr("id", "clip")
+        .append("svg:rect")
+        .attr("width", width)
+        .attr("height", height + legendHeight)
+        .attr("x", 0)
+        .attr("y", 0);
+
+    var areaChart = svg.append('g')
+        .attr("clip-path", "url(#clip)")
+    var area = d3.svg.area()
+        .x(function (d) { return x(d.x); })
+        .y0(function (d) { return y(d.y0); })
+        .y1(function (d) { return y(d.y0 + d.y); });
+
+    areaChart.selectAll("path")
+        .data(dataset)
+        .enter()
+        .append("path")
+        .attr("class", function (d) { return "myArea " + formatStyle(d.key); })
+        .style("fill", function (d, i) { return colors(i); })
+        .attr("d", function (d) { return area(d.values); })
+        .append("title")
+        .text(function (d) { return d.key; });
+
+    var context = areaChart
+        .append("g")
+        .attr("class", "brush");
+    var brush = addBrushArea(svg, areaChart, "path", x, y, xAxis, minX, maxX, width, height, function (d) {
+        return area(d.values);
+    });
+    context.call(brush);
+
+    addToolTip(svg, context, x, nestY, height, unit, timezoneOffset, tooltipData);
+
+    addLegends(svg, areaChart, ".myArea", res, height, legendMarginX, legendMarginY, legendSize, legendTextSize, legendCountInLine, colors);
+}

--- a/core/src/main/scala/org/apache/spark/internal/config/History.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/History.scala
@@ -211,4 +211,21 @@ private[spark] object History {
     .version("3.1.0")
     .bytesConf(ByteUnit.BYTE)
     .createWithDefaultString("2g")
+
+  val TASK_METRICS_AGGREGATION_ENABLED =
+    ConfigBuilder("spark.history.ui.task.metrics.aggregation.enabled")
+    .doc("Whether to aggregate task metrics when parsing event log. When this config is enabled," +
+      "time series aggregated information is generated and stored in history server KVStore. " +
+      "Application statistics page is visible and application level metrics displaying in " +
+      "the page.")
+    .version("3.1.0")
+    .booleanConf
+    .createWithDefault(true)
+
+  val TASK_METRICS_AGGREGATION_PERIOD =
+    ConfigBuilder("spark.history.ui.task.metrics.aggregation.period")
+      .doc("Task metrics aggregation period, when task metrics aggregation is enabled.")
+      .version("3.1.0")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("60s")
 }

--- a/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
@@ -435,6 +435,11 @@ private[spark] class AppStatusStore(
       .asScala.map { exec => (exec.executorId -> exec.info) }.toMap
   }
 
+  def applicationStatistics(): Array[ApplicationStatisticsData] = {
+    store.view(classOf[ApplicationStatisticsData])
+      .asScala.toArray
+  }
+
   def rddList(cachedOnly: Boolean = true): Seq[v1.RDDStorageInfo] = {
     store.view(classOf[RDDStorageInfoWrapper]).asScala.map(_.info).filter { rdd =>
       !cachedOnly || rdd.numCachedPartitions > 0

--- a/core/src/main/scala/org/apache/spark/status/storeTypes.scala
+++ b/core/src/main/scala/org/apache/spark/status/storeTypes.scala
@@ -451,6 +451,27 @@ private[spark] class PoolData(
     @KVIndexParam val name: String,
     val stageIds: Set[Int])
 
+
+private[spark] class ApplicationStatisticsData(
+    @KVIndexParam val endTimeStamp: Long,
+    val taskCount: Long,
+    val stageCount: Long,
+    val jobCount: Long,
+    val executorDeserializeTimeSum: Long,
+    val executorRunTimeSum: Long,
+    val jvmGCTimeSum: Long,
+    val resultSerializationTimeSum: Long,
+    val shuffleFetchWaitTimeSum: Long,
+    val shuffleWriteTimeSum: Long,
+    val gettingResultTimeSum: Long,
+    val durationSum: Long,
+    val shuffleTotalReadBytesSum: Long,
+    val shuffleWriteBytesSum: Long,
+    val readBytesSum: Long,
+    val durationP50: Double,
+    val durationP90: Double,
+    val associatedStageIds: String)
+
 /**
  * A class with information about an app, to be used by the UI. There's only one instance of
  * this summary per application, so its ID in the store is the class name.

--- a/core/src/main/scala/org/apache/spark/ui/GraphUIData.scala
+++ b/core/src/main/scala/org/apache/spark/ui/GraphUIData.scala
@@ -21,6 +21,7 @@ import java.{util => ju}
 import java.lang.{Long => JLong}
 
 import scala.collection.JavaConverters._
+import scala.collection.immutable
 import scala.collection.mutable.ArrayBuffer
 import scala.xml.{Node, Unparsed}
 
@@ -115,6 +116,42 @@ private[spark] class GraphUIData(
     jsCollector.addPreparedStatement(s"var $labels = $jsForLabels;")
     jsCollector.addStatement(
       s"drawAreaStack('#$timelineDivId', $labels, $dataJavaScriptName, $minX, $maxX, $minY, $maxY)")
+    <div id={timelineDivId}></div>
+  }
+
+  def generateBrushAreaStackHtmlWithData(
+      jsCollector: JsCollector,
+      values: Map[String, Seq[(Long, Double)]],
+      stageIdJSName: String,
+      longLegend: Boolean = false): Seq[Node] = {
+    val jsForData = values.flatMap(v => {
+      v._2.map {t =>
+        s"""{x:${t._1},y:${t._2},name:'${v._1}'}"""
+      }
+    }).mkString("[", ",", "]")
+    dataJavaScriptName = jsCollector.nextVariableName
+    jsCollector.addPreparedStatement(s"var $dataJavaScriptName = $jsForData;")
+    jsCollector.addStatement(
+      s"renderBrushStackAreaChart($dataJavaScriptName, '#$timelineDivId', '$unitY', $longLegend," +
+        s" ${UIUtils.getTimeZoneOffset()}, ${stageIdJSName})")
+    <div id={timelineDivId}></div>
+  }
+
+  def generateBrushMultiTimelineHtmlWithData(
+      jsCollector: JsCollector,
+      values: Map[String, Seq[(Long, Double)]],
+      stageIdJSName: String,
+      longLegend: Boolean = false): Seq[Node] = {
+    val jsForData = values.flatMap(v => {
+      v._2.map {t =>
+        s"""{x:${t._1},y:${t._2},name:'${v._1}'}"""
+      }
+    }).mkString("[", ",", "]")
+    dataJavaScriptName = jsCollector.nextVariableName
+    jsCollector.addPreparedStatement(s"var $dataJavaScriptName = $jsForData;")
+    jsCollector.addStatement(
+      s"renderBrushMultiLineChart($dataJavaScriptName, '#$timelineDivId', '$unitY', $longLegend," +
+        s" ${UIUtils.getTimeZoneOffset()}, ${stageIdJSName})")
     <div id={timelineDivId}></div>
   }
 }

--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -683,4 +683,10 @@ private[spark] object UIUtils extends Logging {
       Seq.empty[Node]
     }
   }
+
+  def timePointDiscretized(time: Long, interval: Long): Long = {
+    (math.ceil(time * 1.0 / interval) * interval)
+      .toLong
+  }
+
 }

--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
@@ -36,7 +36,10 @@ import org.apache.spark.ui._
 import org.apache.spark.util.Utils
 
 /** Page showing list of all ongoing and recently finished jobs */
-private[ui] class AllJobsPage(parent: JobsTab, store: AppStatusStore) extends WebUIPage("") {
+private[ui] class AllJobsPage(
+    parent: JobsTab,
+    store: AppStatusStore,
+    jobsMetricsGroupingEnabled: Boolean) extends WebUIPage("") {
 
   import ApiHelper._
 
@@ -323,6 +326,15 @@ private[ui] class AllJobsPage(parent: JobsTab, store: AppStatusStore) extends We
               <li>
                 <a href="#failed"><strong>Failed Jobs:</strong></a>
                 {failedJobs.size}
+              </li>
+            }
+          }
+          {
+            if (jobsMetricsGroupingEnabled) {
+              val metricsPagePath =
+                s"${UIUtils.prependBaseUri(request, parent.basePath)}/jobs/statistics/"
+              <li>
+                <a href={metricsPagePath}><strong>Application Statistics</strong></a>
               </li>
             }
           }

--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobStatisticsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobStatisticsPage.scala
@@ -274,7 +274,7 @@ private[ui] class JobStatisticsPage(
           <td style="vertical-align: middle;">
             <div style="width: 160px;">
               <div>
-                <strong>Cluster Throughput
+                <strong>Execution Throughput
                   {UIUtils.tooltip("The sum of completed tasks, stages, and jobs per minute.", "right")}
                 </strong>
               </div>

--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobStatisticsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobStatisticsPage.scala
@@ -1,0 +1,347 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.ui.jobs
+
+import javax.servlet.http.HttpServletRequest
+
+import scala.collection.mutable
+import scala.xml.Node
+
+import org.apache.spark.SparkConf
+import org.apache.spark.internal.config.History.TASK_METRICS_AGGREGATION_PERIOD
+import org.apache.spark.status.{ApplicationStatisticsData, AppStatusStore}
+import org.apache.spark.ui.{GraphUIData, JsCollector, SparkUITab, UIUtils, WebUIPage}
+
+private[ui] class JobStatisticsPage(
+    parent: SparkUITab,
+    store: AppStatusStore,
+    conf: SparkConf) extends WebUIPage("statistics") {
+  private val taskMetricsAggregationPeriod = conf.get(TASK_METRICS_AGGREGATION_PERIOD)
+
+  def generateLoadResources(request: HttpServletRequest): Seq[Node] = {
+    // scalastyle:off
+    <script src={UIUtils.prependBaseUri(request, "/static/d3.min.js")}></script>
+        <link rel="stylesheet" href={UIUtils.prependBaseUri(request, "/static/statisticspage.css")} type="text/css"/>
+      <script src={UIUtils.prependBaseUri(request, "/static/streaming-page.js")}></script>
+      <script src={UIUtils.prependBaseUri(request, "/static/statisticspage.js")}></script>
+    // scalastyle:on
+  }
+
+  def generateBasicInfo(
+    appStartTime: Long,
+    appEndTime: Long,
+    appStatisticsData: Array[ApplicationStatisticsData]): Seq[Node] = {
+    // scalastyle:off
+    <div>
+      <strong>Total Uptime: </strong>{if (appEndTime < 0) {
+      UIUtils.formatDuration(System.currentTimeMillis() - appStartTime)
+    } else if (appEndTime > 0) {
+      UIUtils.formatDuration(appEndTime - appStartTime)
+    }} <strong> from </strong> {UIUtils.formatDate(appStartTime)}
+    </div>
+    <div>
+      <strong>Completed Jobs: </strong>{appStatisticsData.foldLeft(0L) {(r, d) => r + d.jobCount}}
+    </div>
+      <div>
+        <strong>Completed Stages: </strong>{appStatisticsData.foldLeft(0L) {(r, d) => r + d.stageCount}}
+      </div>
+    <div>
+      <strong>Completed Tasks: </strong>{appStatisticsData.foldLeft(0L) {(r, d) => r + d.taskCount}}
+    </div>
+        <br/>
+    // scalastyle:on
+  }
+
+  def render(request: HttpServletRequest): Seq[Node] = {
+    val app = store.applicationInfo()
+    val appStatisticsData = store.applicationStatistics()
+    val basicInfoContent = generateLoadResources(request) ++
+      generateBasicInfo(
+        app.attempts.head.getStartTimeEpoch,
+        app.attempts.head.getEndTimeEpoch,
+        appStatisticsData)
+    val tableContent = if (appStatisticsData.length == 0) {
+      <div id="empty-information-message">
+        <b>No visualization information available.</b>
+      </div>
+    } else {
+      generateStatTable(
+        app.attempts.head.getStartTimeEpoch,
+        app.attempts.head.getEndTimeEpoch,
+        appStatisticsData)
+    }
+
+    UIUtils.headerSparkPage(
+      request,
+      s"Statistics for application",
+      basicInfoContent ++ tableContent,
+      parent)
+  }
+
+  def generateStatTable(
+    appStartTime: Long,
+    appEndTime: Long,
+    appStatisticsData: Array[ApplicationStatisticsData]): Seq[Node] = {
+    val jsCollector = new JsCollector
+    val minStatisticsTime = appStartTime
+    val maxStatisticsTime = appEndTime
+    val stageIdJSData = appStatisticsData
+      .map {d => s"""{x:${d.endTimeStamp},id:'${d.associatedStageIds}'}"""}
+      .mkString("[", ",", "]")
+    val stageIdJSName = jsCollector.nextVariableName
+    jsCollector.addPreparedStatement(s"var $stageIdJSName = $stageIdJSData;")
+    val tempData = (new collection.mutable.ArrayBuffer()) ++ appStatisticsData
+    val keySet = tempData.map(_.endTimeStamp).toSet
+    for (i <- minStatisticsTime to maxStatisticsTime
+      by taskMetricsAggregationPeriod) {
+      val tempTimeStamp = UIUtils.timePointDiscretized(i, taskMetricsAggregationPeriod)
+      if (!keySet.exists(_ == tempTimeStamp)) {
+        tempData += new ApplicationStatisticsData(
+          tempTimeStamp,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0.0,
+          0.0,
+        "")
+      }
+    }
+    val data = tempData.sortBy(_.endTimeStamp).toSeq
+    val clusterThroughPut = new mutable.HashMap[String, Seq[(Long, Double)]]()
+    clusterThroughPut.update("Jobs", data.map{d => (d.endTimeStamp, d.jobCount.toDouble)})
+    clusterThroughPut.update("Stages", data.map{d => (d.endTimeStamp, d.stageCount.toDouble)})
+    clusterThroughPut.update("Tasks", data.map{d => (d.endTimeStamp, d.taskCount.toDouble)})
+    val graphUIDataForThroughput =
+      new GraphUIData(
+        "cluster-through-put-multi-line",
+        "",
+        Seq.empty[(Long, Double)],
+        0L,
+        0L,
+        0L,
+        0L,
+        "count")
+
+    val taskDurations = new mutable.HashMap[String, Seq[(Long, Double)]]()
+    taskDurations.update("P50", data.map{d => (d.endTimeStamp, d.durationP50)})
+    taskDurations.update("P90", data.map{d => (d.endTimeStamp, d.durationP90)})
+    val graphUIDataForTaskDuration =
+      new GraphUIData(
+        "task-duration-multi-line",
+        "",
+        Seq.empty[(Long, Double)],
+        0L,
+        0L,
+        0L,
+        0L,
+        "ms")
+
+    val ioData = new mutable.HashMap[String, Seq[(Long, Double)]]()
+    ioData.update("ShuffleRead",
+      data.map{d => (d.endTimeStamp, d.shuffleTotalReadBytesSum.toDouble)})
+    ioData.update("ShuffleWrite",
+      data.map{d => (d.endTimeStamp, d.shuffleWriteBytesSum.toDouble)})
+    ioData.update("Read",
+      data.map{d => (d.endTimeStamp, d.readBytesSum.toDouble)})
+    val graphUIDataForIOData =
+      new GraphUIData(
+        "io-data-multi-line",
+        "",
+        Seq.empty[(Long, Double)],
+        0L,
+        0L,
+        0L,
+        0L,
+        "bytes")
+
+    val taskTimeData = new mutable.HashMap[String, Seq[(Long, Double)]]()
+    taskTimeData.update("SchedulerDelay", data.map {d =>
+      (d.endTimeStamp,
+        if (d.durationSum > 0 && d.executorRunTimeSum > 0) {
+          val temp = d.durationSum - d.executorRunTimeSum -
+            d.executorDeserializeTimeSum - d.resultSerializationTimeSum - d.gettingResultTimeSum
+          if (temp > 0) {
+            100.0 * temp / d.durationSum
+          } else 0.0
+
+        } else 0.0)
+    })
+    taskTimeData.update("ComputingTime", data.map {d =>
+      (d.endTimeStamp,
+        if (d.durationSum > 0 && d.executorRunTimeSum > 0) {
+          val temp = d.executorRunTimeSum - d.shuffleFetchWaitTimeSum - d.shuffleWriteTimeSum/1e6
+          if (temp > 0) {
+            100.0 * temp / d.durationSum
+          } else 0.0
+        } else 0.0)
+    })
+    taskTimeData.update("GetResultTime", data.map {d =>
+      (d.endTimeStamp,
+        if (d.durationSum > 0) {
+          100.0 * d.gettingResultTimeSum / d.durationSum
+        } else 0.0)
+    })
+    taskTimeData.update("TaskDeserialization", data.map {d =>
+      (d.endTimeStamp,
+        if (d.durationSum > 0) {
+          100.0 * d.executorDeserializeTimeSum / d.durationSum
+        } else 0.0)
+    })
+    taskTimeData.update("ResultSerialization", data.map {d =>
+      (d.endTimeStamp,
+        if (d.durationSum > 0) {
+          100.0 * d.resultSerializationTimeSum / d.durationSum
+        } else 0.0)
+    })
+    taskTimeData.update("ShuffleRead", data.map {d =>
+      (d.endTimeStamp,
+        if (d.durationSum > 0) {
+          100.0 * d.shuffleFetchWaitTimeSum / d.durationSum
+        } else 0.0)
+    })
+    taskTimeData.update("ShuffleWrite", data.map {d =>
+      (d.endTimeStamp,
+        if (d.durationSum > 0) {
+          100.0 * d.shuffleWriteTimeSum / (d.durationSum  * 1e6)
+        } else 0.0)
+    })
+
+    val graphUIDataForTaskTime =
+      new GraphUIData(
+        "task-time-multi-line",
+        "",
+        Seq.empty[(Long, Double)],
+        0L,
+        0L,
+        0L,
+        0L,
+        "%")
+
+    val taskGCData = new mutable.HashMap[String, Seq[(Long, Double)]]()
+
+    taskGCData.update("GC%", data.map {d =>
+      (d.endTimeStamp,
+        if (d.executorRunTimeSum > 0) {
+          100.0 * d.jvmGCTimeSum / d.durationSum
+        } else 0.0)
+    })
+
+    val graphUIDataForTaskGC =
+      new GraphUIData(
+        "task-gc-multi-line",
+        "",
+        Seq.empty[(Long, Double)],
+        0L,
+        0L,
+        0L,
+        0L,
+        "%")
+    // scalastyle:off
+    <table id="stat-table" class="table table-bordered" style="width: auto">
+      <thead>
+        <tr>
+          <th style="width: 160px;"></th>
+          <th style="width: 1000px;">Statistics</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td style="vertical-align: middle;">
+            <div style="width: 160px;">
+              <div>
+                <strong>Cluster Throughput
+                  {UIUtils.tooltip("The sum of completed tasks, stages, and jobs per minute.", "right")}
+                </strong>
+              </div>
+            </div>
+          </td>
+          <td class="timeline">
+            {graphUIDataForThroughput.generateBrushMultiTimelineHtmlWithData(jsCollector, clusterThroughPut.toMap, stageIdJSName)}
+          </td>
+        </tr>
+        <tr>
+          <td style="vertical-align: middle;">
+            <div style="width: 160px;">
+              <div>
+                <strong>IO (Shuffle and Read) Data
+                  {UIUtils.tooltip("The sum of total shuffle read bytes, shuffle write bytes and read bytes per minute.", "right")}
+                </strong>
+              </div>
+            </div>
+          </td>
+          <td class="timeline">
+            {graphUIDataForIOData.generateBrushMultiTimelineHtmlWithData(jsCollector, ioData.toMap, stageIdJSName, true)}
+          </td>
+        </tr>
+        <tr>
+          <td style="vertical-align: middle;">
+            <div style="width: 160px;">
+              <div>
+                <strong>Task Duration Time
+                  {UIUtils.tooltip("The 50% and 90% percentile of task duration per minute.", "right")}
+                </strong>
+              </div>
+            </div>
+          </td>
+          <td class="timeline">
+            {graphUIDataForTaskDuration.generateBrushMultiTimelineHtmlWithData(jsCollector, taskDurations.toMap, stageIdJSName, true)}
+          </td>
+        </tr>
+        <tr>
+          <td style="vertical-align: middle;">
+            <div style="width: 160px;">
+              <div>
+                <strong>Task Duration Time Component %
+                  {UIUtils.tooltip("The percentage of scheduler delay, computing time, shuffle read, task deserialization, result serialization, shuffle write, get result time by task duration per minute. For task time details, please check stage page.", "right")}
+                </strong>
+              </div>
+            </div>
+          </td>
+          <td class="timeline">
+            {graphUIDataForTaskTime.generateBrushAreaStackHtmlWithData(jsCollector, taskTimeData.toMap, stageIdJSName, true)}
+          </td>
+        </tr>
+        <tr>
+          <td style="vertical-align: middle;">
+            <div style="width: 160px;">
+              <div>
+                <strong>Task JVM GC Time %
+                  {UIUtils.tooltip("The percentage of JVM GC time by task duration per minute.", "right")}
+                </strong>
+              </div>
+            </div>
+          </td>
+          <td class="timeline">
+            {graphUIDataForTaskGC.generateBrushMultiTimelineHtmlWithData(jsCollector, taskGCData.toMap, stageIdJSName)}
+          </td>
+        </tr>
+      </tbody>
+    </table> ++ jsCollector.toHtml
+    // scalastyle:on
+  }
+}

--- a/core/src/test/scala/org/apache/spark/ui/UIUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UIUtilsSuite.scala
@@ -178,6 +178,12 @@ class UIUtilsSuite extends SparkFunSuite {
     assert(trim(generated(0)) == trim(expected))
   }
 
+  test("SPARK-33033: test time point discretization") {
+    assert(UIUtils.timePointDiscretized(1600839214763L, 60 * 1000) == 1600839240000L)
+    assert(UIUtils.timePointDiscretized(1600839240000L, 60 * 1000) == 1600839240000L)
+    assert(UIUtils.timePointDiscretized(1600839240001L, 60 * 1000) == 1600839300000L)
+  }
+
   private def verify(
       desc: String,
       expected: Node,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Event log contains all tasks' metrics data, which are useful for performance debugging. By now, spark UI only displays final aggregation results, much information is hidden by this way. If spark UI could provide time series data view, it would be more helpful to performance debugging problems. We would like to build application statistics page in history server based on task metrics to provide more straight forward insight for spark application.
Below are views in application statistics page:
**Execution Throughput**: sum of completed tasks, stages, and jobs per minute. (associated stage Ids can be viewed in tool tip message.)
![cluster throughput](https://user-images.githubusercontent.com/10524738/94762037-77b21980-035b-11eb-8cd1-22a56a5a88c7.JPG)

**IO (Shuffle and Read) Data**: sum of total shuffle read bytes, shuffle write bytes and read bytes per minute.
![IOData](https://user-images.githubusercontent.com/10524738/94659699-8a741200-02b9-11eb-80e6-9271828fc3b1.JPG)

**Task Duration Time**: application level 50% and 90% percentile of task duration per minute.
![taskduration](https://user-images.githubusercontent.com/10524738/94659768-a37cc300-02b9-11eb-8147-c6ff1c2dfc1f.JPG)

**Task Duration Time Component %**: percentage of scheduler delay, computing time, shuffle read, task deserialization, result serialization, shuffle write, get result time by task duration per minute.
![taskdurationpercentile](https://user-images.githubusercontent.com/10524738/94659888-cd35ea00-02b9-11eb-8c82-5ddf26a7c9ff.JPG)

**Task JVM GC Time %**: percentage of task JVM GC time by task duration per minute.
![taskgcpercentile](https://user-images.githubusercontent.com/10524738/94659984-f48cb700-02b9-11eb-819a-d35f3529f68c.JPG)

Application statistics page is only available in spark history server. Aggregated data is generated when parsing event log file and store in KVStore. Metrics data is aggregated to one data instance per minute (based on task finish time). For example, if task a finish time is in (t1 - 1minute, t1],a's data is added to data instance t1. This follows same approach of executors metrics.
From my test there is no much increasing for kv store size and replaying time. Here is my local test result. Impact to replay time may be little different for different applications, but it should be too big.
![data](https://user-images.githubusercontent.com/10524738/94762386-5ef63380-035c-11eb-800a-c4cf0c69caa6.JPG)



### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
User facing change compared to master: Add application statistics page under jobs tab and new page link in jobs page.
Entry point:
![entrypoint](https://user-images.githubusercontent.com/10524738/94660218-40d7f700-02ba-11eb-878e-c02de9e11a9d.JPG)

Application statistics page:
![screencapture-localhost-19090-history-application-1598927142852-0002-1-jobs-statistics-2020-09-30-20_34_04](https://user-images.githubusercontent.com/10524738/94762404-6fa6a980-035c-11eb-86e7-d42d3921169d.png)


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
1. manual test
2. add new unit test