### PR TITLE
[SPARK-33042][SQL][TEST] Add a test case to ensure changes to spark.sql.optimizer.maxIterations take effect at runtime

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizerMaxIterationsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizerMaxIterationsSuite.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.errors.TreeNodeException
+import org.apache.spark.sql.catalyst.expressions.{Alias, IntegerLiteral, Literal}
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, OneRowRelation, Project}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * A dummy optimizer rule for testing that decrements integer literals until 0.
+ */
+object DecrementLiterals extends Rule[LogicalPlan] {
+  def apply(plan: LogicalPlan): LogicalPlan = plan transformExpressions {
+    case IntegerLiteral(i) if i > 0 => Literal(i - 1)
+  }
+}
+
+class OptimizerMaxIterationsSuite extends PlanTest {
+  test("Adjust maxIterations") {
+    val iterations = 5
+    val maxIterationsNotEnough = 3
+    val maxIterationsEnough = 10
+    val analyzed = Project(Alias(Literal(iterations), "attr")() :: Nil, OneRowRelation()).analyze
+
+    conf.setConf(SQLConf.OPTIMIZER_MAX_ITERATIONS, maxIterationsNotEnough)
+    val optimizer = new SimpleTestOptimizer() {
+      override def defaultBatches: Seq[Batch] =
+        Batch("test", fixedPoint,
+          DecrementLiterals) :: Nil
+    }
+
+    val message1 = intercept[TreeNodeException[LogicalPlan]] {
+      optimizer.execute(analyzed)
+    }.getMessage
+    assert(message1.startsWith(s"Max iterations ($maxIterationsNotEnough) reached for batch " +
+      s"test, please set '${SQLConf.OPTIMIZER_MAX_ITERATIONS.key}' to a larger value."))
+
+    conf.setConf(SQLConf.OPTIMIZER_MAX_ITERATIONS, maxIterationsEnough)
+    try {
+      optimizer.execute(analyzed)
+    } catch {
+      case ex: TreeNodeException[LogicalPlan]
+        if ex.getMessage.contains(s"${SQLConf.OPTIMIZER_MAX_ITERATIONS.key}") =>
+        fail("optimizer.execute should not reach max iterations.")
+    }
+
+    conf.setConf(SQLConf.OPTIMIZER_MAX_ITERATIONS, maxIterationsNotEnough)
+    val message2 = intercept[TreeNodeException[LogicalPlan]] {
+      optimizer.execute(analyzed)
+    }.getMessage
+    assert(message2.startsWith(s"Max iterations ($maxIterationsNotEnough) reached for batch " +
+      s"test, please set '${SQLConf.OPTIMIZER_MAX_ITERATIONS.key}' to a larger value."))
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizerSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizerSuite.scala
@@ -35,7 +35,7 @@ object DecrementLiterals extends Rule[LogicalPlan] {
 }
 
 class OptimizerSuite extends PlanTest {
-  test("Adjust maxIterations") {
+  test("Optimizer exceeds max iterations") {
     val iterations = 5
     val maxIterationsNotEnough = 3
     val maxIterationsEnough = 10


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a test case to ensure changes to `spark.sql.optimizer.maxIterations` take effect at runtime.

### Why are the changes needed?

Currently, there is only one related test case: https://github.com/apache/spark/blob/master/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala#L156

However, this test case only checks the value of the conf can be changed at runtime. It does not check the updated value is actually used by the Optimizer.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

unit test