### PR TITLE
[SPARK-33047][BUILD] Upgrade hive-storage-api to 2.7.2

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.7-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-2.3
@@ -92,7 +92,7 @@ hive-shims-0.23/2.3.7//hive-shims-0.23-2.3.7.jar
 hive-shims-common/2.3.7//hive-shims-common-2.3.7.jar
 hive-shims-scheduler/2.3.7//hive-shims-scheduler-2.3.7.jar
 hive-shims/2.3.7//hive-shims-2.3.7.jar
-hive-storage-api/2.7.1//hive-storage-api-2.7.1.jar
+hive-storage-api/2.7.2//hive-storage-api-2.7.2.jar
 hive-vector-code-gen/2.3.7//hive-vector-code-gen-2.3.7.jar
 hk2-api/2.6.1//hk2-api-2.6.1.jar
 hk2-locator/2.6.1//hk2-locator-2.6.1.jar

--- a/dev/deps/spark-deps-hadoop-3.2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3.2-hive-2.3
@@ -91,7 +91,7 @@ hive-shims-0.23/2.3.7//hive-shims-0.23-2.3.7.jar
 hive-shims-common/2.3.7//hive-shims-common-2.3.7.jar
 hive-shims-scheduler/2.3.7//hive-shims-scheduler-2.3.7.jar
 hive-shims/2.3.7//hive-shims-2.3.7.jar
-hive-storage-api/2.7.1//hive-storage-api-2.7.1.jar
+hive-storage-api/2.7.2//hive-storage-api-2.7.2.jar
 hive-vector-code-gen/2.3.7//hive-vector-code-gen-2.3.7.jar
 hk2-api/2.6.1//hk2-api-2.6.1.jar
 hk2-locator/2.6.1//hk2-locator-2.6.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
     <hadoop.deps.scope>compile</hadoop.deps.scope>
     <hive.deps.scope>compile</hive.deps.scope>
     <hive.parquet.scope>provided</hive.parquet.scope>
-    <hive.storage.version>2.7.1</hive.storage.version>
+    <hive.storage.version>2.7.2</hive.storage.version>
     <hive.storage.scope>compile</hive.storage.scope>
     <hive.common.scope>compile</hive.common.scope>
     <hive.llap.scope>compile</hive.llap.scope>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Apache Hive `hive-storage-api` library from 2.7.1 to 2.7.2.

### Why are the changes needed?

[storage-api 2.7.2](https://github.com/apache/hive/commits/rel/storage-release-2.7.2/storage-api) has the following extension and can be used when users uses a provided orc dependency.

[HIVE-22959](https://github.com/apache/hive/commit/dade9919d904f8a4bff12a9130c150301a4713ed#diff-ccfc9dd7584117f531322cda3a29f3c3) : Extend storage-api to expose FilterContext
[HIVE-23215](https://github.com/apache/hive/commit/361925d2f3675bb9c6566b615a4b53faee335385#diff-ccfc9dd7584117f531322cda3a29f3c3) : Make FilterContext and MutableFilterContext interfaces

### Does this PR introduce _any_ user-facing change?

Yes. This is a dependency change.

### How was this patch tested?

Pass the existing tests.