### PR TITLE
[SPARK-33050][BUILD] Upgrade Apache ORC to 1.5.12

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.7-hive-1.2
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-1.2
@@ -180,9 +180,9 @@ okhttp/3.12.12//okhttp-3.12.12.jar
 okio/1.14.0//okio-1.14.0.jar
 opencsv/2.3//opencsv-2.3.jar
 openshift-model/4.10.3//openshift-model-4.10.3.jar
-orc-core/1.5.10/nohive/orc-core-1.5.10-nohive.jar
-orc-mapreduce/1.5.10/nohive/orc-mapreduce-1.5.10-nohive.jar
-orc-shims/1.5.10//orc-shims-1.5.10.jar
+orc-core/1.5.12/nohive/orc-core-1.5.12-nohive.jar
+orc-mapreduce/1.5.12/nohive/orc-mapreduce-1.5.12-nohive.jar
+orc-shims/1.5.12//orc-shims-1.5.12.jar
 oro/2.0.8//oro-2.0.8.jar
 osgi-resource-locator/1.0.3//osgi-resource-locator-1.0.3.jar
 paranamer/2.8//paranamer-2.8.jar

--- a/dev/deps/spark-deps-hadoop-2.7-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-2.3
@@ -195,9 +195,9 @@ okhttp/3.12.12//okhttp-3.12.12.jar
 okio/1.14.0//okio-1.14.0.jar
 opencsv/2.3//opencsv-2.3.jar
 openshift-model/4.10.3//openshift-model-4.10.3.jar
-orc-core/1.5.10//orc-core-1.5.10.jar
-orc-mapreduce/1.5.10//orc-mapreduce-1.5.10.jar
-orc-shims/1.5.10//orc-shims-1.5.10.jar
+orc-core/1.5.12//orc-core-1.5.12.jar
+orc-mapreduce/1.5.12//orc-mapreduce-1.5.12.jar
+orc-shims/1.5.12//orc-shims-1.5.12.jar
 oro/2.0.8//oro-2.0.8.jar
 osgi-resource-locator/1.0.3//osgi-resource-locator-1.0.3.jar
 paranamer/2.8//paranamer-2.8.jar

--- a/dev/deps/spark-deps-hadoop-3.2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3.2-hive-2.3
@@ -209,9 +209,9 @@ okhttp/3.12.12//okhttp-3.12.12.jar
 okio/1.14.0//okio-1.14.0.jar
 opencsv/2.3//opencsv-2.3.jar
 openshift-model/4.10.3//openshift-model-4.10.3.jar
-orc-core/1.5.10//orc-core-1.5.10.jar
-orc-mapreduce/1.5.10//orc-mapreduce-1.5.10.jar
-orc-shims/1.5.10//orc-shims-1.5.10.jar
+orc-core/1.5.12//orc-core-1.5.12.jar
+orc-mapreduce/1.5.12//orc-mapreduce-1.5.12.jar
+orc-shims/1.5.12//orc-shims-1.5.12.jar
 oro/2.0.8//oro-2.0.8.jar
 osgi-resource-locator/1.0.3//osgi-resource-locator-1.0.3.jar
 paranamer/2.8//paranamer-2.8.jar

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
     <kafka.version>2.6.0</kafka.version>
     <derby.version>10.12.1.1</derby.version>
     <parquet.version>1.10.1</parquet.version>
-    <orc.version>1.5.10</orc.version>
+    <orc.version>1.5.12</orc.version>
     <orc.classifier></orc.classifier>
     <hive.parquet.group>com.twitter</hive.parquet.group>
     <hive.parquet.version>1.6.0</hive.parquet.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Apache ORC to 1.5.12.

### Why are the changes needed?

This brings us the latest bug patches like the followings.
- ORC-644 nested struct evolution does not respect to orc.force.positional.evolution
- ORC-667 Positional mapping for nested struct types should not applied by default

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CI.