### PR TITLE
[SPARK-33062][SQL] Make DataFrameReader.jdbc work for DataSource V2

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -930,7 +930,7 @@ class Analyzer(
 
       case i @ InsertIntoStatement(u @ UnresolvedRelation(_, _, false, _), _, _, _, _)
           if i.query.resolved =>
-        lookupV2Relation(u.multipartIdentifier, u.options, false, Array.empty[Partition])
+        lookupV2Relation(u.multipartIdentifier, u.options, false, Seq.empty[Partition])
           .map(v2Relation => i.copy(table = v2Relation))
           .getOrElse(i)
 
@@ -950,7 +950,7 @@ class Analyzer(
         identifier: Seq[String],
         options: CaseInsensitiveStringMap,
         isStreaming: Boolean,
-        partitions: Array[Partition]): Option[LogicalPlan] =
+        partitions: Seq[Partition]): Option[LogicalPlan] =
       expandRelationName(identifier) match {
         case NonSessionCatalogAndIdentifier(catalog, ident) =>
           CatalogV2Util.loadTable(catalog, ident) match {
@@ -1080,7 +1080,7 @@ class Analyzer(
                 SubqueryAlias(
                   catalog.name +: ident.asMultipartIdentifier,
                   DataSourceV2Relation.create(table, Some(catalog), Some(ident), options,
-                    Array.empty[Partition]))
+                    Seq.empty[Partition]))
               }
           }
           val key = catalog.name +: ident.namespace :+ ident.name

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -959,7 +959,11 @@ class Analyzer(
                 Some(StreamingRelationV2(None, table.name, table, options,
                   table.schema.toAttributes, Some(catalog), Some(ident), None))
               } else {
-                Some(DataSourceV2Relation.create(table, Some(catalog), Some(ident), options,
+                Some(DataSourceV2Relation.create(
+                  table,
+                  Some(catalog),
+                  Some(ident),
+                  options,
                   partitions))
               }
             case None => None

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CTESubstitution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CTESubstitution.scala
@@ -171,7 +171,7 @@ object CTESubstitution extends Rule[LogicalPlan] {
       plan: LogicalPlan,
       cteRelations: Seq[(String, LogicalPlan)]): LogicalPlan =
     plan resolveOperatorsUp {
-      case u @ UnresolvedRelation(Seq(table), _, _) =>
+      case u @ UnresolvedRelation(Seq(table), _, _, _) =>
         cteRelations.find(r => plan.conf.resolver(r._1, table)).map(_._2).getOrElse(u)
 
       case other =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
@@ -105,7 +105,7 @@ object ResolveHints {
 
       val newNode = CurrentOrigin.withOrigin(plan.origin) {
         plan match {
-          case ResolvedHint(u @ UnresolvedRelation(ident, _, _), hint)
+          case ResolvedHint(u @ UnresolvedRelation(ident, _, _, _), hint)
               if matchedIdentifierInHint(ident) =>
             ResolvedHint(u, createHintInfo(hintName).merge(hint, hintErrorHandler))
 
@@ -113,7 +113,7 @@ object ResolveHints {
               if matchedIdentifierInHint(extractIdentifier(r)) =>
             ResolvedHint(r, createHintInfo(hintName).merge(hint, hintErrorHandler))
 
-          case UnresolvedRelation(ident, _, _) if matchedIdentifierInHint(ident) =>
+          case UnresolvedRelation(ident, _, _, _) if matchedIdentifierInHint(ident) =>
             ResolvedHint(plan, createHintInfo(hintName))
 
           case r: SubqueryAlias if matchedIdentifierInHint(extractIdentifier(r)) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
+import org.apache.spark.Partition
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, InternalRow, TableIdentifier}
 import org.apache.spark.sql.catalyst.errors.TreeNodeException
@@ -46,7 +47,8 @@ class UnresolvedException[TreeType <: TreeNode[_]](tree: TreeType, function: Str
 case class UnresolvedRelation(
     multipartIdentifier: Seq[String],
     options: CaseInsensitiveStringMap = CaseInsensitiveStringMap.empty(),
-    override val isStreaming: Boolean = false)
+    override val isStreaming: Boolean = false,
+    partitions: Array[Partition] = Array.empty[Partition])
   extends LeafNode with NamedRelation {
   import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 
@@ -64,9 +66,10 @@ object UnresolvedRelation {
   def apply(
       tableIdentifier: TableIdentifier,
       extraOptions: CaseInsensitiveStringMap,
-      isStreaming: Boolean): UnresolvedRelation = {
-    UnresolvedRelation(
-      tableIdentifier.database.toSeq :+ tableIdentifier.table, extraOptions, isStreaming)
+      isStreaming: Boolean,
+      partitions: Array[Partition]): UnresolvedRelation = {
+    UnresolvedRelation(tableIdentifier.database.toSeq :+ tableIdentifier.table,
+      extraOptions, isStreaming, partitions)
   }
 
   def apply(tableIdentifier: TableIdentifier): UnresolvedRelation =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -48,7 +48,7 @@ case class UnresolvedRelation(
     multipartIdentifier: Seq[String],
     options: CaseInsensitiveStringMap = CaseInsensitiveStringMap.empty(),
     override val isStreaming: Boolean = false,
-    partitions: Array[Partition] = Array.empty[Partition])
+    partitions: Seq[Partition] = Seq.empty[Partition])
   extends LeafNode with NamedRelation {
   import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 
@@ -67,7 +67,7 @@ object UnresolvedRelation {
       tableIdentifier: TableIdentifier,
       extraOptions: CaseInsensitiveStringMap,
       isStreaming: Boolean,
-      partitions: Array[Partition]): UnresolvedRelation = {
+      partitions: Seq[Partition]): UnresolvedRelation = {
     UnresolvedRelation(tableIdentifier.database.toSeq :+ tableIdentifier.table,
       extraOptions, isStreaming, partitions)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources.v2
 
+import org.apache.spark.Partition
 import org.apache.spark.sql.catalyst.analysis.{MultiInstanceRelation, NamedRelation}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
 import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LogicalPlan, Statistics}
@@ -43,7 +44,8 @@ case class DataSourceV2Relation(
     output: Seq[AttributeReference],
     catalog: Option[CatalogPlugin],
     identifier: Option[Identifier],
-    options: CaseInsensitiveStringMap)
+    options: CaseInsensitiveStringMap,
+    partitions: Array[Partition] = Array.empty[Partition])
   extends LeafNode with MultiInstanceRelation with NamedRelation {
 
   import DataSourceV2Implicits._
@@ -146,16 +148,17 @@ object DataSourceV2Relation {
       table: Table,
       catalog: Option[CatalogPlugin],
       identifier: Option[Identifier],
-      options: CaseInsensitiveStringMap): DataSourceV2Relation = {
+      options: CaseInsensitiveStringMap,
+      partitions: Array[Partition]): DataSourceV2Relation = {
     val output = table.schema().toAttributes
-    DataSourceV2Relation(table, output, catalog, identifier, options)
+    DataSourceV2Relation(table, output, catalog, identifier, options, partitions)
   }
 
   def create(
       table: Table,
       catalog: Option[CatalogPlugin],
       identifier: Option[Identifier]): DataSourceV2Relation =
-    create(table, catalog, identifier, CaseInsensitiveStringMap.empty)
+    create(table, catalog, identifier, CaseInsensitiveStringMap.empty, Array.empty[Partition])
 
   /**
    * This is used to transform data source v2 statistics to logical.Statistics.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
@@ -45,7 +45,7 @@ case class DataSourceV2Relation(
     catalog: Option[CatalogPlugin],
     identifier: Option[Identifier],
     options: CaseInsensitiveStringMap,
-    partitions: Array[Partition] = Array.empty[Partition])
+    partitions: Seq[Partition])
   extends LeafNode with MultiInstanceRelation with NamedRelation {
 
   import DataSourceV2Implicits._
@@ -149,7 +149,7 @@ object DataSourceV2Relation {
       catalog: Option[CatalogPlugin],
       identifier: Option[Identifier],
       options: CaseInsensitiveStringMap,
-      partitions: Array[Partition]): DataSourceV2Relation = {
+      partitions: Seq[Partition]): DataSourceV2Relation = {
     val output = table.schema().toAttributes
     DataSourceV2Relation(table, output, catalog, identifier, options, partitions)
   }
@@ -158,7 +158,7 @@ object DataSourceV2Relation {
       table: Table,
       catalog: Option[CatalogPlugin],
       identifier: Option[Identifier]): DataSourceV2Relation =
-    create(table, catalog, identifier, CaseInsensitiveStringMap.empty, Array.empty[Partition])
+    create(table, catalog, identifier, CaseInsensitiveStringMap.empty, Seq.empty[Partition])
 
   /**
    * This is used to transform data source v2 statistics to logical.Statistics.

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -334,7 +334,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
     // properties should override settings in extraOptions.
     this.extraOptions ++= properties.asScala
     // explicit url should override all
-    this.extraOptions ++= Seq(JDBCOptions.JDBC_URL -> url)
+    this.extraOptions += JDBCOptions.JDBC_URL -> url
 
     import sparkSession.sessionState.analyzer.NonSessionCatalogAndIdentifier
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -341,7 +341,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
     this.source = "jdbc"
     if (table.contains(" ")) { // if table is not a table name, e.g. a SELECT statement
       // explicit dbtable should override all
-      this.extraOptions ++= Seq(JDBCOptions.JDBC_TABLE_NAME -> table)
+      this.extraOptions += JDBCOptions.JDBC_TABLE_NAME -> table
       load
     } else {
       sparkSession.sessionState.sqlParser.parseMultipartIdentifier(table) match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -345,7 +345,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
       load
     } else {
       sparkSession.sessionState.sqlParser.parseMultipartIdentifier(table) match {
-        case nameParts@NonSessionCatalogAndIdentifier(_, _) =>
+        case _ @ NonSessionCatalogAndIdentifier(_, _) =>
           this.table(table)
         case _ =>
           // explicit dbtable should override all

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -298,7 +298,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
         case _: SupportsRead if table.supports(BATCH_READ) =>
           Dataset.ofRows(
             sparkSession,
-            DataSourceV2Relation.create(table, catalog, ident, dsOptions, Array.empty[Partition]))
+            DataSourceV2Relation.create(table, catalog, ident, dsOptions, Seq.empty[Partition]))
 
         case _ => loadV1Source(paths: _*)
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -349,7 +349,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
           this.table(table)
         case _ =>
           // explicit dbtable should override all
-          this.extraOptions ++= Seq(JDBCOptions.JDBC_TABLE_NAME -> table)
+          this.extraOptions += JDBCOptions.JDBC_TABLE_NAME -> table
           load
       }
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -336,8 +336,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
     // explicit url should override all
     this.extraOptions ++= Seq(JDBCOptions.JDBC_URL -> url)
 
-    import sparkSession.sessionState.analyzer.{AsTableIdentifier, NonSessionCatalogAndIdentifier}
-    import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+    import sparkSession.sessionState.analyzer.NonSessionCatalogAndIdentifier
 
     this.source = "jdbc"
     if (table.contains(" ")) { // if table is not a table name, e.g. a SELECT statement
@@ -428,8 +427,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
       JDBCPartition(part, i) : Partition
     }
 
-    import sparkSession.sessionState.analyzer.{AsTableIdentifier, NonSessionCatalogAndIdentifier}
-    import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+    import sparkSession.sessionState.analyzer.NonSessionCatalogAndIdentifier
 
     sparkSession.sessionState.sqlParser.parseMultipartIdentifier(table) match {
       case nameParts @ NonSessionCatalogAndIdentifier(_, _) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -364,7 +364,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
           }
 
           val relation = DataSourceV2Relation.create(table, catalog, ident, dsOptions,
-            Array.empty[Partition])
+            Seq.empty[Partition])
           checkPartitioningMatchesV2Table(table)
           if (mode == SaveMode.Append) {
             runCommand(df.sparkSession, "save") {

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -21,6 +21,7 @@ import java.util.{Locale, Properties}
 
 import scala.collection.JavaConverters._
 
+import org.apache.spark.Partition
 import org.apache.spark.annotation.Stable
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, NoSuchTableException, UnresolvedRelation}
@@ -362,7 +363,8 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
               }
           }
 
-          val relation = DataSourceV2Relation.create(table, catalog, ident, dsOptions)
+          val relation = DataSourceV2Relation.create(table, catalog, ident, dsOptions,
+            Array.empty[Partition])
           checkPartitioningMatchesV2Table(table)
           if (mode == SaveMode.Append) {
             runCommand(df.sparkSession, "save") {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
@@ -271,7 +271,7 @@ class CacheManager extends Logging with AdaptiveSparkPlanHelper {
         case _ => false
       }
 
-      case DataSourceV2Relation(fileTable: FileTable, _, _, _, _) =>
+      case DataSourceV2Relation(fileTable: FileTable, _, _, _, _, _) =>
         refreshFileIndexIfNecessary(fileTable.fileIndex, fs, qualifiedPath)
 
       case _ => false

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
@@ -174,7 +174,7 @@ case class CreateViewCommand(
       def verify(child: LogicalPlan) {
         child.collect {
           // Disallow creating permanent views based on temporary views.
-          case UnresolvedRelation(nameParts, _, _) if catalog.isTempView(nameParts) =>
+          case UnresolvedRelation(nameParts, _, _, _) if catalog.isTempView(nameParts) =>
             throw new AnalysisException(s"Not allowed to create a permanent view $name by " +
               s"referencing a temporary view ${nameParts.quoted}. " +
               "Please create a temp view instead by CREATE TEMP VIEW")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FallBackFileSourceV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FallBackFileSourceV2.scala
@@ -33,8 +33,8 @@ import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, File
  */
 class FallBackFileSourceV2(sparkSession: SparkSession) extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
-    case i @
-        InsertIntoStatement(d @ DataSourceV2Relation(table: FileTable, _, _, _, _), _, _, _, _) =>
+    case i @ InsertIntoStatement(d @ DataSourceV2Relation(
+      table: FileTable, _, _, _, _, _), _, _, _, _) =>
       val v1FileFormat = table.fallbackFileFormat.newInstance()
       val relation = HadoopFsRelation(
         table.fileIndex,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -32,9 +32,10 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] {
 
   override def apply(plan: LogicalPlan): LogicalPlan = plan transformDown {
     case ScanOperation(project, filters, relation: DataSourceV2Relation) =>
-      val scanBuilder = relation.table.asReadable.newScanBuilder(relation.options)
+      var scanBuilder = relation.table.asReadable.newScanBuilder(relation.options)
       scanBuilder match {
-        case jdbcScanBuilder: JDBCScanBuilder => jdbcScanBuilder.partition = relation.partitions
+        case jdbcScanBuilder: JDBCScanBuilder =>
+          scanBuilder = jdbcScanBuilder.copy(partitions = relation.partitions)
         case _ =>
       }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -35,6 +35,7 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] {
       val scanBuilder = relation.table.asReadable.newScanBuilder(relation.options)
       scanBuilder match {
         case jdbcScanBuilder: JDBCScanBuilder => jdbcScanBuilder.partition = relation.partitions
+        case _ =>
       }
 
       val normalizedFilters = DataSourceStrategy.normalizeExprs(filters, relation.output)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTable.scala
@@ -20,6 +20,7 @@ import java.util
 
 import scala.collection.JavaConverters._
 
+import org.apache.spark.Partition
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.connector.catalog.TableCapability._
@@ -41,7 +42,7 @@ case class JDBCTable(ident: Identifier, schema: StructType, jdbcOptions: JDBCOpt
   override def newScanBuilder(options: CaseInsensitiveStringMap): JDBCScanBuilder = {
     val mergedOptions = new JDBCOptions(
       jdbcOptions.parameters.originalMap ++ options.asCaseSensitiveMap().asScala)
-    JDBCScanBuilder(SparkSession.active, schema, mergedOptions)
+    JDBCScanBuilder(SparkSession.active, schema, mergedOptions, Seq.empty[Partition])
   }
 
   override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/TableCapabilityCheckSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/TableCapabilityCheckSuite.scala
@@ -58,7 +58,7 @@ class TableCapabilityCheckSuite extends AnalysisSuite with SharedSparkSession {
   test("batch scan: check missing capabilities") {
     val e = intercept[AnalysisException] {
       TableCapabilityCheck.apply(
-        DataSourceV2Relation.create(CapabilityTable(), None, None, emptyMap, Array.empty)
+        DataSourceV2Relation.create(CapabilityTable(), None, None, emptyMap, Seq.empty)
       )
     }
     assert(e.message.contains("does not support batch scan"))
@@ -92,7 +92,7 @@ class TableCapabilityCheckSuite extends AnalysisSuite with SharedSparkSession {
 
   test("AppendData: check missing capabilities") {
     val plan = AppendData.byName(
-      DataSourceV2Relation.create(CapabilityTable(), None, None, emptyMap, Array.empty),
+      DataSourceV2Relation.create(CapabilityTable(), None, None, emptyMap, Seq.empty),
       TestRelation)
 
     val exc = intercept[AnalysisException]{
@@ -105,7 +105,7 @@ class TableCapabilityCheckSuite extends AnalysisSuite with SharedSparkSession {
   test("AppendData: check correct capabilities") {
     Seq(BATCH_WRITE, V1_BATCH_WRITE).foreach { write =>
       val plan = AppendData.byName(
-        DataSourceV2Relation.create(CapabilityTable(write), None, None, emptyMap, Array.empty),
+        DataSourceV2Relation.create(CapabilityTable(write), None, None, emptyMap, Seq.empty),
         TestRelation)
 
       TableCapabilityCheck.apply(plan)
@@ -120,7 +120,7 @@ class TableCapabilityCheckSuite extends AnalysisSuite with SharedSparkSession {
       CapabilityTable(OVERWRITE_BY_FILTER)).foreach { table =>
 
       val plan = OverwriteByExpression.byName(
-        DataSourceV2Relation.create(table, None, None, emptyMap, Array.empty),
+        DataSourceV2Relation.create(table, None, None, emptyMap, Seq.empty),
         TestRelation,
         Literal(true))
 
@@ -139,7 +139,7 @@ class TableCapabilityCheckSuite extends AnalysisSuite with SharedSparkSession {
       CapabilityTable(V1_BATCH_WRITE, OVERWRITE_BY_FILTER)).foreach { table =>
 
       val plan = OverwriteByExpression.byName(
-        DataSourceV2Relation.create(table, None, None, emptyMap, Array.empty),
+        DataSourceV2Relation.create(table, None, None, emptyMap, Seq.empty),
         TestRelation,
         Literal(true))
 
@@ -154,7 +154,7 @@ class TableCapabilityCheckSuite extends AnalysisSuite with SharedSparkSession {
       CapabilityTable(OVERWRITE_BY_FILTER)).foreach { table =>
 
       val plan = OverwriteByExpression.byName(
-        DataSourceV2Relation.create(table, None, None, emptyMap, Array.empty),
+        DataSourceV2Relation.create(table, None, None, emptyMap, Seq.empty),
         TestRelation,
         EqualTo(AttributeReference("x", LongType)(), Literal(5)))
 
@@ -170,7 +170,7 @@ class TableCapabilityCheckSuite extends AnalysisSuite with SharedSparkSession {
     Seq(BATCH_WRITE, V1_BATCH_WRITE).foreach { write =>
       val table = CapabilityTable(write, OVERWRITE_BY_FILTER)
       val plan = OverwriteByExpression.byName(
-        DataSourceV2Relation.create(table, None, None, emptyMap, Array.empty),
+        DataSourceV2Relation.create(table, None, None, emptyMap, Seq.empty),
         TestRelation,
         EqualTo(AttributeReference("x", LongType)(), Literal(5)))
 
@@ -184,7 +184,7 @@ class TableCapabilityCheckSuite extends AnalysisSuite with SharedSparkSession {
       CapabilityTable(OVERWRITE_DYNAMIC)).foreach { table =>
 
       val plan = OverwritePartitionsDynamic.byName(
-        DataSourceV2Relation.create(table, None, None, emptyMap, Array.empty),
+        DataSourceV2Relation.create(table, None, None, emptyMap, Seq.empty),
         TestRelation)
 
       val exc = intercept[AnalysisException] {
@@ -198,7 +198,7 @@ class TableCapabilityCheckSuite extends AnalysisSuite with SharedSparkSession {
   test("OverwritePartitionsDynamic: check correct capabilities") {
     val table = CapabilityTable(BATCH_WRITE, OVERWRITE_DYNAMIC)
     val plan = OverwritePartitionsDynamic.byName(
-      DataSourceV2Relation.create(table, None, None, emptyMap, Array.empty),
+      DataSourceV2Relation.create(table, None, None, emptyMap, Seq.empty),
       TestRelation)
 
     TableCapabilityCheck.apply(plan)

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/TableCapabilityCheckSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/TableCapabilityCheckSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.analysis.{AnalysisSuite, NamedRelation}
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, Literal}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.streaming.StreamingRelationV2
-import org.apache.spark.sql.connector.catalog.{CatalogPlugin, Identifier, Table, TableCapability, TableProvider}
+import org.apache.spark.sql.connector.catalog.{Table, TableCapability}
 import org.apache.spark.sql.connector.catalog.TableCapability._
 import org.apache.spark.sql.execution.datasources.DataSource
 import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, TableCapabilityCheck}
@@ -58,7 +58,7 @@ class TableCapabilityCheckSuite extends AnalysisSuite with SharedSparkSession {
   test("batch scan: check missing capabilities") {
     val e = intercept[AnalysisException] {
       TableCapabilityCheck.apply(
-        DataSourceV2Relation.create(CapabilityTable(), None, None, emptyMap)
+        DataSourceV2Relation.create(CapabilityTable(), None, None, emptyMap, Array.empty)
       )
     }
     assert(e.message.contains("does not support batch scan"))
@@ -92,7 +92,7 @@ class TableCapabilityCheckSuite extends AnalysisSuite with SharedSparkSession {
 
   test("AppendData: check missing capabilities") {
     val plan = AppendData.byName(
-      DataSourceV2Relation.create(CapabilityTable(), None, None, emptyMap),
+      DataSourceV2Relation.create(CapabilityTable(), None, None, emptyMap, Array.empty),
       TestRelation)
 
     val exc = intercept[AnalysisException]{
@@ -105,7 +105,7 @@ class TableCapabilityCheckSuite extends AnalysisSuite with SharedSparkSession {
   test("AppendData: check correct capabilities") {
     Seq(BATCH_WRITE, V1_BATCH_WRITE).foreach { write =>
       val plan = AppendData.byName(
-        DataSourceV2Relation.create(CapabilityTable(write), None, None, emptyMap),
+        DataSourceV2Relation.create(CapabilityTable(write), None, None, emptyMap, Array.empty),
         TestRelation)
 
       TableCapabilityCheck.apply(plan)
@@ -120,7 +120,7 @@ class TableCapabilityCheckSuite extends AnalysisSuite with SharedSparkSession {
       CapabilityTable(OVERWRITE_BY_FILTER)).foreach { table =>
 
       val plan = OverwriteByExpression.byName(
-        DataSourceV2Relation.create(table, None, None, emptyMap),
+        DataSourceV2Relation.create(table, None, None, emptyMap, Array.empty),
         TestRelation,
         Literal(true))
 
@@ -139,7 +139,7 @@ class TableCapabilityCheckSuite extends AnalysisSuite with SharedSparkSession {
       CapabilityTable(V1_BATCH_WRITE, OVERWRITE_BY_FILTER)).foreach { table =>
 
       val plan = OverwriteByExpression.byName(
-        DataSourceV2Relation.create(table, None, None, emptyMap),
+        DataSourceV2Relation.create(table, None, None, emptyMap, Array.empty),
         TestRelation,
         Literal(true))
 
@@ -154,7 +154,7 @@ class TableCapabilityCheckSuite extends AnalysisSuite with SharedSparkSession {
       CapabilityTable(OVERWRITE_BY_FILTER)).foreach { table =>
 
       val plan = OverwriteByExpression.byName(
-        DataSourceV2Relation.create(table, None, None, emptyMap),
+        DataSourceV2Relation.create(table, None, None, emptyMap, Array.empty),
         TestRelation,
         EqualTo(AttributeReference("x", LongType)(), Literal(5)))
 
@@ -170,7 +170,7 @@ class TableCapabilityCheckSuite extends AnalysisSuite with SharedSparkSession {
     Seq(BATCH_WRITE, V1_BATCH_WRITE).foreach { write =>
       val table = CapabilityTable(write, OVERWRITE_BY_FILTER)
       val plan = OverwriteByExpression.byName(
-        DataSourceV2Relation.create(table, None, None, emptyMap),
+        DataSourceV2Relation.create(table, None, None, emptyMap, Array.empty),
         TestRelation,
         EqualTo(AttributeReference("x", LongType)(), Literal(5)))
 
@@ -184,7 +184,7 @@ class TableCapabilityCheckSuite extends AnalysisSuite with SharedSparkSession {
       CapabilityTable(OVERWRITE_DYNAMIC)).foreach { table =>
 
       val plan = OverwritePartitionsDynamic.byName(
-        DataSourceV2Relation.create(table, None, None, emptyMap),
+        DataSourceV2Relation.create(table, None, None, emptyMap, Array.empty),
         TestRelation)
 
       val exc = intercept[AnalysisException] {
@@ -198,7 +198,7 @@ class TableCapabilityCheckSuite extends AnalysisSuite with SharedSparkSession {
   test("OverwritePartitionsDynamic: check correct capabilities") {
     val table = CapabilityTable(BATCH_WRITE, OVERWRITE_DYNAMIC)
     val plan = OverwritePartitionsDynamic.byName(
-      DataSourceV2Relation.create(table, None, None, emptyMap),
+      DataSourceV2Relation.create(table, None, None, emptyMap, Array.empty),
       TestRelation)
 
     TableCapabilityCheck.apply(plan)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetPartitionDiscoverySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetPartitionDiscoverySuite.scala
@@ -1283,7 +1283,7 @@ class ParquetV2PartitionDiscoverySuite extends ParquetPartitionDiscoverySuite {
       (1 to 10).map(i => (i, i.toString)).toDF("a", "b").write.parquet(dir.getCanonicalPath)
       val queryExecution = spark.read.parquet(dir.getCanonicalPath).queryExecution
       queryExecution.analyzed.collectFirst {
-        case DataSourceV2Relation(fileTable: FileTable, _, _, _, _) =>
+        case DataSourceV2Relation(fileTable: FileTable, _, _, _, _, _) =>
           assert(fileTable.fileIndex.partitionSpec() === PartitionSpec.emptySpec)
       }.getOrElse {
         fail(s"Expecting a matching DataSourceV2Relation, but got:\n$queryExecution")

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSinkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSinkSuite.scala
@@ -659,7 +659,7 @@ class FileStreamSinkV2Suite extends FileStreamSinkSuite {
     // Verify that MetadataLogFileIndex is being used and the correct partitioning schema has
     // been inferred
     val table = df.queryExecution.analyzed.collect {
-      case DataSourceV2Relation(table: FileTable, _, _, _, _) => table
+      case DataSourceV2Relation(table: FileTable, _, _, _, _, _) => table
     }
     assert(table.size === 1)
     assert(table.head.fileIndex.isInstanceOf[MetadataLogFileIndex])

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
@@ -601,7 +601,7 @@ private[hive] class TestHiveQueryExecution(
     // Make sure any test tables referenced are loaded.
     val referencedTables =
       describedTables ++
-        logical.collect { case UnresolvedRelation(ident, _, _) => ident.asTableIdentifier }
+        logical.collect { case UnresolvedRelation(ident, _, _, _) => ident.asTableIdentifier }
     val resolver = sparkSession.sessionState.conf.resolver
     val referencedTestTables = referencedTables.flatMap { tbl =>
       val testTableOpt = sparkSession.testTables.keys.find(resolver(_, tbl.table))


### PR DESCRIPTION


### What changes were proposed in this pull request?
Support multiple catalogs in the following use case:
```
DataFrameReader.jdbc(url, "catalog.db.tbl", properties)
DataFrameReader.jdbc(url, "catalog.db.tbl", columnName, lowerBound, upperBound, numPartitions, properties)
DataFrameReader.jdbc(url, "catalog.db.tbl",  predicates, properties)
```


### Why are the changes needed?

Make DataFrameWriter.jdbc work for DataSource V2


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
new tests
