### PR TITLE
[SPARK-33063][K8S] Improve error message for insufficient K8s volume confs

### DIFF
--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesVolumeUtilsSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesVolumeUtilsSuite.scala
@@ -96,7 +96,7 @@ class KubernetesVolumeUtilsSuite extends SparkFunSuite {
     assert(volumeSpec.mountReadOnly === false)
   }
 
-  test("Fails on missing mount key") {
+  test("Fails on missing mount key in emptyDir") {
     val sparkConf = new SparkConf(false)
     sparkConf.set("test.emptyDir.volumeName.mnt.path", "/path")
 
@@ -106,7 +106,7 @@ class KubernetesVolumeUtilsSuite extends SparkFunSuite {
     assert(e.getMessage.contains("emptyDir.volumeName.mount.path"))
   }
 
-  test("Fails on missing option key") {
+  test("Fails on missing option key in hostPath") {
     val sparkConf = new SparkConf(false)
     sparkConf.set("test.hostPath.volumeName.mount.path", "/path")
     sparkConf.set("test.hostPath.volumeName.mount.readOnly", "true")
@@ -116,6 +116,18 @@ class KubernetesVolumeUtilsSuite extends SparkFunSuite {
       KubernetesVolumeUtils.parseVolumesWithPrefix(sparkConf, "test.")
     }
     assert(e.getMessage.contains("hostPath.volumeName.options.path"))
+  }
+
+  test("Fails on missing option key in persistentVolumeClaim") {
+    val sparkConf = new SparkConf(false)
+    sparkConf.set("test.persistentVolumeClaim.volumeName.mount.path", "/path")
+    sparkConf.set("test.persistentVolumeClaim.volumeName.mount.readOnly", "true")
+    sparkConf.set("test.persistentVolumeClaim.volumeName.options.clamName", "claimeName")
+
+    val e = intercept[NoSuchElementException] {
+      KubernetesVolumeUtils.parseVolumesWithPrefix(sparkConf, "test.")
+    }
+    assert(e.getMessage.contains("persistentVolumeClaim.volumeName.options.claimName"))
   }
 
   test("Parses read-only nfs volumes correctly") {
@@ -148,7 +160,7 @@ class KubernetesVolumeUtilsSuite extends SparkFunSuite {
       KubernetesNFSVolumeConf("/share", "nfs.example.com"))
   }
 
-  test("Fails on missing path option") {
+  test("Fails on missing path option in nfs") {
     val sparkConf = new SparkConf(false)
     sparkConf.set("test.nfs.volumeName.mount.path", "/path")
     sparkConf.set("test.nfs.volumeName.mount.readOnly", "true")
@@ -160,7 +172,7 @@ class KubernetesVolumeUtilsSuite extends SparkFunSuite {
     assert(e.getMessage.contains("nfs.volumeName.options.path"))
   }
 
-  test("Fails on missing server option") {
+  test("Fails on missing server option in nfs") {
     val sparkConf = new SparkConf(false)
     sparkConf.set("test.nfs.volumeName.mount.path", "/path")
     sparkConf.set("test.nfs.volumeName.mount.readOnly", "true")

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesVolumeUtilsSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesVolumeUtilsSuite.scala
@@ -96,7 +96,7 @@ class KubernetesVolumeUtilsSuite extends SparkFunSuite {
     assert(volumeSpec.mountReadOnly === false)
   }
 
-  test("Fails on missing mount key in emptyDir") {
+  test("Fails on missing mount key") {
     val sparkConf = new SparkConf(false)
     sparkConf.set("test.emptyDir.volumeName.mnt.path", "/path")
 
@@ -106,7 +106,7 @@ class KubernetesVolumeUtilsSuite extends SparkFunSuite {
     assert(e.getMessage.contains("emptyDir.volumeName.mount.path"))
   }
 
-  test("Fails on missing option key in hostPath") {
+  test("Fails on missing option key") {
     val sparkConf = new SparkConf(false)
     sparkConf.set("test.hostPath.volumeName.mount.path", "/path")
     sparkConf.set("test.hostPath.volumeName.mount.readOnly", "true")
@@ -118,11 +118,10 @@ class KubernetesVolumeUtilsSuite extends SparkFunSuite {
     assert(e.getMessage.contains("hostPath.volumeName.options.path"))
   }
 
-  test("Fails on missing option key in persistentVolumeClaim") {
+  test("SPARK-33063: Fails on missing option key in persistentVolumeClaim") {
     val sparkConf = new SparkConf(false)
     sparkConf.set("test.persistentVolumeClaim.volumeName.mount.path", "/path")
     sparkConf.set("test.persistentVolumeClaim.volumeName.mount.readOnly", "true")
-    sparkConf.set("test.persistentVolumeClaim.volumeName.options.clamName", "claimeName")
 
     val e = intercept[NoSuchElementException] {
       KubernetesVolumeUtils.parseVolumesWithPrefix(sparkConf, "test.")
@@ -160,7 +159,7 @@ class KubernetesVolumeUtilsSuite extends SparkFunSuite {
       KubernetesNFSVolumeConf("/share", "nfs.example.com"))
   }
 
-  test("Fails on missing path option in nfs") {
+  test("Fails on missing path option") {
     val sparkConf = new SparkConf(false)
     sparkConf.set("test.nfs.volumeName.mount.path", "/path")
     sparkConf.set("test.nfs.volumeName.mount.readOnly", "true")
@@ -172,7 +171,7 @@ class KubernetesVolumeUtilsSuite extends SparkFunSuite {
     assert(e.getMessage.contains("nfs.volumeName.options.path"))
   }
 
-  test("Fails on missing server option in nfs") {
+  test("Fails on missing server option") {
     val sparkConf = new SparkConf(false)
     sparkConf.set("test.nfs.volumeName.mount.path", "/path")
     sparkConf.set("test.nfs.volumeName.mount.readOnly", "true")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Provide error handling when creating kubernetes volumes. Right now they keys are expected to be there and if not it fails with a `key not found` error, but not knowing why do you need that `key`.

Also I renamed some tests that didn't indicate the kind of kubernetes volume

### Why are the changes needed?

Easier for the users to understand why `spark-submit` command is failing if not providing they right kubernetes volumes properties.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
It was tested with the current tests plus added one more.


[Jira ticket](https://issues.apache.org/jira/browse/SPARK-33063)