### PR TITLE
[SPARK-33007][SQL] Simplify named_struct + get struct field + from_json expression chain

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeJsonExprs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeJsonExprs.scala
@@ -29,8 +29,9 @@ import org.apache.spark.sql.types.{ArrayType, StructType}
  * 1. JsonToStructs(StructsToJson(child)) => child.
  * 2. Prune unnecessary columns from GetStructField/GetArrayStructFields + JsonToStructs.
  * 3. CreateNamedStruct(JsonToStructs(json).col1, JsonToStructs(json).col2, ...) =>
- *      CreateNamedStruct(JsonToStructs(json)) if JsonToStructs(json) is shared among all
- *      fields of CreateNamedStruct.
+ *      If(IsNull(json), nullStruct, KnownNotNull(JsonToStructs(prunedSchema, ..., json)))
+ *      if JsonToStructs(json) is shared among all fields of CreateNamedStruct. `prunedSchema`
+ *      contains all accessed fields in original CreateNamedStruct.
  */
 object OptimizeJsonExprs extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan = plan transform {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeJsonExprs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeJsonExprs.scala
@@ -55,7 +55,7 @@ object OptimizeJsonExprs extends Rule[LogicalPlan] {
         val duplicateFields = c.names.map(_.toString).distinct.length != c.names.length
 
         // If we create struct from various fields of the same `JsonToStructs` and we don't
-        // alias field names and there is not duplicated fields in the struct.
+        // alias field names and there is not duplicated field in the struct.
         if (sameFieldName && !duplicateFields) {
           val fromJson = jsonToStructs.head.asInstanceOf[JsonToStructs].copy(schema = c.dataType)
           val nullFields = c.children.grouped(2).flatMap {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeJsonExprs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeJsonExprs.scala
@@ -55,7 +55,7 @@ object OptimizeJsonExprs extends Rule[LogicalPlan] {
         val duplicateFields = c.names.map(_.toString).distinct.length != c.names.length
 
         // If we create struct from various fields of the same `JsonToStructs` and we don't
-        // alias field names and there is not duplicated field in the struct.
+        // alias field names and there is no duplicated field in the struct.
         if (sameFieldName && !duplicateFields) {
           val fromJson = jsonToStructs.head.asInstanceOf[JsonToStructs].copy(schema = c.dataType)
           val nullFields = c.children.grouped(2).flatMap {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeJsonExprsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeJsonExprsSuite.scala
@@ -233,5 +233,17 @@ class OptimizeJsonExprsSuite extends PlanTest with ExpressionEvalHelper {
         "a1", GetStructField(JsonToStructs(field1, options, 'json), 0),
         "b", GetStructField(JsonToStructs(field2, options, 'json), 0)).as("struct")).analyze
     comparePlans(optimized2, expected2)
+
+    val query3 = testRelation2
+      .select(namedStruct(
+        "a", GetStructField(JsonToStructs(schema, options, 'json), 0),
+        "a", GetStructField(JsonToStructs(schema, options, 'json), 0)).as("struct"))
+    val optimized3 = Optimizer.execute(query3.analyze)
+
+    val expected3 = testRelation2
+      .select(namedStruct(
+        "a", GetStructField(JsonToStructs(field1, options, 'json), 0),
+        "a", GetStructField(JsonToStructs(field1, options, 'json), 0)).as("struct")).analyze
+    comparePlans(optimized3, expected3)
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This proposes to simplify named_struct + get struct field + from_json expression chain from `struct(from_json.col1, from_json.col2, from_json.col3...)` to `struct(from_json)`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Simplify complex expression tree that could be produced by query optimization or user.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Unit test.