### PR TITLE
[SPARK-32047][SQL]Add JDBC connection provider disable possibility

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2775,6 +2775,15 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val DISABLED_JDBC_CONN_PROVIDER_LIST =
+    buildConf("spark.sql.sources.disabledJdbcConnProviderList")
+    .internal()
+    .doc("Configures a list of JDBC connection providers, which are disabled. " +
+      "The list contains the name of the JDBC connection providers separated by comma.")
+    .version("3.1.0")
+    .stringConf
+    .createWithDefault("")
+
   /**
    * Holds information about keys that have been deprecated.
    *
@@ -3398,6 +3407,8 @@ class SQLConf extends Serializable with Logging {
   def legacyPathOptionBehavior: Boolean = getConf(SQLConf.LEGACY_PATH_OPTION_BEHAVIOR)
 
   def truncateTrashEnabled: Boolean = getConf(SQLConf.TRUNCATE_TRASH_ENABLED)
+
+  def disabledJdbcConnectionProviders: String = getConf(SQLConf.DISABLED_JDBC_CONN_PROVIDER_LIST)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/BasicConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/BasicConnectionProvider.scala
@@ -30,6 +30,8 @@ private[jdbc] class BasicConnectionProvider extends JdbcConnectionProvider with 
    */
   def getAdditionalProperties(options: JDBCOptions): Properties = new Properties()
 
+  override def name: String = "basic"
+
   override def canHandle(driver: Driver, options: Map[String, String]): Boolean = {
     val jdbcOptions = new JDBCOptions(options)
     jdbcOptions.keytab == null || jdbcOptions.principal == null

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/BasicConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/BasicConnectionProvider.scala
@@ -30,7 +30,7 @@ private[jdbc] class BasicConnectionProvider extends JdbcConnectionProvider with 
    */
   def getAdditionalProperties(options: JDBCOptions): Properties = new Properties()
 
-  override def name: String = "basic"
+  override val name: String = "basic"
 
   override def canHandle(driver: Driver, options: Map[String, String]): Boolean = {
     val jdbcOptions = new JDBCOptions(options)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProvider.scala
@@ -48,7 +48,7 @@ private[jdbc] object ConnectionProvider extends Logging {
       }
     }
 
-    val disabledProviders = SQLConf.get.disabledJdbcConnectionProviders.split(",")
+    val disabledProviders = Utils.stringToSeq(SQLConf.get.disabledJdbcConnectionProviders)
     // toSeq seems duplicate but it's needed for Scala 2.13
     providers.filterNot(p => disabledProviders.contains(p.name)).toSeq
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/DB2ConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/DB2ConnectionProvider.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 private[sql] class DB2ConnectionProvider extends SecureConnectionProvider {
   override val driverClass = "com.ibm.db2.jcc.DB2Driver"
 
-  override def name: String = "db2"
+  override val name: String = "db2"
 
   override def appEntry(driver: Driver, options: JDBCOptions): String = "JaasClient"
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/DB2ConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/DB2ConnectionProvider.scala
@@ -28,6 +28,8 @@ import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 private[sql] class DB2ConnectionProvider extends SecureConnectionProvider {
   override val driverClass = "com.ibm.db2.jcc.DB2Driver"
 
+  override def name: String = "db2"
+
   override def appEntry(driver: Driver, options: JDBCOptions): String = "JaasClient"
 
   override def getConnection(driver: Driver, options: Map[String, String]): Connection = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/MSSQLConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/MSSQLConnectionProvider.scala
@@ -29,6 +29,8 @@ private[sql] class MSSQLConnectionProvider extends SecureConnectionProvider {
   override val driverClass = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
   val parserMethod: String = "parseAndMergeProperties"
 
+  override def name: String = "mssql"
+
   override def appEntry(driver: Driver, options: JDBCOptions): String = {
     val configName = "jaasConfigurationName"
     val appEntryDefault = "SQLJDBCDriver"

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/MSSQLConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/MSSQLConnectionProvider.scala
@@ -29,7 +29,7 @@ private[sql] class MSSQLConnectionProvider extends SecureConnectionProvider {
   override val driverClass = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
   val parserMethod: String = "parseAndMergeProperties"
 
-  override def name: String = "mssql"
+  override val name: String = "mssql"
 
   override def appEntry(driver: Driver, options: JDBCOptions): String = {
     val configName = "jaasConfigurationName"

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/MariaDBConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/MariaDBConnectionProvider.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 private[jdbc] class MariaDBConnectionProvider extends SecureConnectionProvider {
   override val driverClass = "org.mariadb.jdbc.Driver"
 
-  override def name: String = "mariadb"
+  override val name: String = "mariadb"
 
   override def appEntry(driver: Driver, options: JDBCOptions): String =
     "Krb5ConnectorContext"

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/MariaDBConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/MariaDBConnectionProvider.scala
@@ -24,6 +24,8 @@ import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 private[jdbc] class MariaDBConnectionProvider extends SecureConnectionProvider {
   override val driverClass = "org.mariadb.jdbc.Driver"
 
+  override def name: String = "mariadb"
+
   override def appEntry(driver: Driver, options: JDBCOptions): String =
     "Krb5ConnectorContext"
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/OracleConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/OracleConnectionProvider.scala
@@ -28,6 +28,8 @@ import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 private[sql] class OracleConnectionProvider extends SecureConnectionProvider {
   override val driverClass = "oracle.jdbc.OracleDriver"
 
+  override def name: String = "oracle"
+
   override def appEntry(driver: Driver, options: JDBCOptions): String = "kprb5module"
 
   override def getConnection(driver: Driver, options: Map[String, String]): Connection = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/OracleConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/OracleConnectionProvider.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 private[sql] class OracleConnectionProvider extends SecureConnectionProvider {
   override val driverClass = "oracle.jdbc.OracleDriver"
 
-  override def name: String = "oracle"
+  override val name: String = "oracle"
 
   override def appEntry(driver: Driver, options: JDBCOptions): String = "kprb5module"
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProvider.scala
@@ -25,6 +25,8 @@ import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 private[jdbc] class PostgresConnectionProvider extends SecureConnectionProvider {
   override val driverClass = "org.postgresql.Driver"
 
+  override def name: String = "postgres"
+
   override def appEntry(driver: Driver, options: JDBCOptions): String = {
     val parseURL = driver.getClass.getMethod("parseURL", classOf[String], classOf[Properties])
     val properties = parseURL.invoke(driver, options.url, null).asInstanceOf[Properties]

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProvider.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 private[jdbc] class PostgresConnectionProvider extends SecureConnectionProvider {
   override val driverClass = "org.postgresql.Driver"
 
-  override def name: String = "postgres"
+  override val name: String = "postgres"
 
   override def appEntry(driver: Driver, options: JDBCOptions): String = {
     val parseURL = driver.getClass.getMethod("parseURL", classOf[String], classOf[Properties])

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcConnectionProvider.scala
@@ -35,6 +35,12 @@ import org.apache.spark.annotation.{DeveloperApi, Unstable}
 @Unstable
 abstract class JdbcConnectionProvider {
   /**
+   * Name of the service to provide JDBC connections. This name should be unique. Spark will
+   * internally use this name to differentiate JDBC connection providers.
+   */
+  def name: String
+
+  /**
    * Checks if this connection provider instance can handle the connection initiated by the driver.
    * There must be exactly one active connection provider which can handle the connection for a
    * specific driver. If this requirement doesn't met then `IllegalArgumentException`

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcConnectionProvider.scala
@@ -38,7 +38,7 @@ abstract class JdbcConnectionProvider {
    * Name of the service to provide JDBC connections. This name should be unique. Spark will
    * internally use this name to differentiate JDBC connection providers.
    */
-  def name: String
+  val name: String
 
   /**
    * Checks if this connection provider instance can handle the connection initiated by the driver.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProviderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProviderSuite.scala
@@ -19,38 +19,11 @@ package org.apache.spark.sql.execution.datasources.jdbc.connection
 
 import javax.security.auth.login.Configuration
 
-import org.mockito.Mockito.mock
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
 
-import org.apache.spark.{SparkConf, SparkEnv}
-
-class ConnectionProviderSuite extends ConnectionProviderSuiteBase {
-
-  private def doReturn(value: Any) = org.mockito.Mockito.doReturn(value, Seq.empty: _*)
-
-  private var savedSparkEnv: SparkEnv = _
-
-  override def beforeEach(): Unit = {
-    super.beforeEach()
-    savedSparkEnv = SparkEnv.get
-  }
-
-  override def afterEach(): Unit = {
-    try {
-      SparkEnv.set(savedSparkEnv)
-    } finally {
-      super.afterEach()
-    }
-  }
-
-  private def setSparkEnv(settings: Iterable[(String, String)]): Unit = {
-    val conf = new SparkConf().setAll(settings)
-    val env = mock(classOf[SparkEnv])
-    doReturn(conf).when(env).conf
-    SparkEnv.set(env)
-  }
-
+class ConnectionProviderSuite extends ConnectionProviderSuiteBase with SharedSparkSession {
   test("All built-in providers must be loaded") {
-    setSparkEnv(Map())
     IntentionallyFaultyConnectionProvider.constructed = false
     val providers = ConnectionProvider.loadProviders()
     assert(providers.exists(_.isInstanceOf[BasicConnectionProvider]))
@@ -65,10 +38,11 @@ class ConnectionProviderSuite extends ConnectionProviderSuiteBase {
   }
 
   test("Disabled provider must not be loaded") {
-    setSparkEnv(Map("spark.security.jdbc.connection.provider.db2.enabled" -> "false"))
-    val providers = ConnectionProvider.loadProviders()
-    assert(!providers.exists(_.isInstanceOf[DB2ConnectionProvider]))
-    assert(providers.size === 5)
+    withSQLConf(SQLConf.DISABLED_JDBC_CONN_PROVIDER_LIST.key -> "db2") {
+      val providers = ConnectionProvider.loadProviders()
+      assert(!providers.exists(_.isInstanceOf[DB2ConnectionProvider]))
+      assert(providers.size === 5)
+    }
   }
 
   test("Multiple security configs must be reachable") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProviderSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProviderSuiteBase.scala
@@ -42,7 +42,7 @@ abstract class ConnectionProviderSuiteBase extends SparkFunSuite with BeforeAndA
     JDBCOptions.JDBC_PRINCIPAL -> "principal"
   ))
 
-  override def afterEach(): Unit = {
+  protected override def afterEach(): Unit = {
     try {
       Configuration.setConfiguration(null)
     } finally {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/IntentionallyFaultyConnectionProvider.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/IntentionallyFaultyConnectionProvider.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.jdbc.JdbcConnectionProvider
 private class IntentionallyFaultyConnectionProvider extends JdbcConnectionProvider {
   IntentionallyFaultyConnectionProvider.constructed = true
   throw new IllegalArgumentException("Intentional Exception")
-  override def name: String = "IntentionallyFaultyConnectionProvider"
+  override val name: String = "IntentionallyFaultyConnectionProvider"
   override def canHandle(driver: Driver, options: Map[String, String]): Boolean = true
   override def getConnection(driver: Driver, options: Map[String, String]): Connection = null
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/IntentionallyFaultyConnectionProvider.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/IntentionallyFaultyConnectionProvider.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.jdbc.JdbcConnectionProvider
 private class IntentionallyFaultyConnectionProvider extends JdbcConnectionProvider {
   IntentionallyFaultyConnectionProvider.constructed = true
   throw new IllegalArgumentException("Intentional Exception")
+  override def name: String = "IntentionallyFaultyConnectionProvider"
   override def canHandle(driver: Driver, options: Map[String, String]): Boolean = true
   override def getConnection(driver: Driver, options: Map[String, String]): Connection = null
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
At the moment there is no possibility to turn off JDBC authentication providers which exists on the classpath. This can be problematic because service providers are loaded with service loader. In this PR I've added `spark.sql.sources.disabledJdbcConnProviderList` configuration possibility (default: empty).

### Why are the changes needed?
No possibility to turn off JDBC authentication providers. There are 2 main use-cases where it could be useful:
* The built-in provider works fine for a specific database (for example MSSQL) but the user wants different authentication functionality which is not able to be done with the built-in one. Such case the user implements a new provider but when added then 2 providers will be in place to handle MSSQL authentication (the binding is class name based). Such case the built-in one must be turned off to use the new one.
* The built-in provider contains a bug for a specific database. Such case full Spark patch build can be provided in normal case but this configuration opens new ways in testing and patching. Namely one can easily send a custom provider to proof/solve provider related issues (of course temporarily).

### Does this PR introduce _any_ user-facing change?
Yes, it introduces new configuration option.

### How was this patch tested?
* Existing + newly added unit tests.
* Existing integration tests.
