### PR TITLE
[SPARK-21195][CORE] MetricSystem should pick up dynamically registered metrics in sources

### DIFF
--- a/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit
 
 import scala.collection.mutable
 
-import com.codahale.metrics.{Metric, MetricRegistry}
+import com.codahale.metrics._
 import org.eclipse.jetty.servlet.ServletContextHandler
 
 import org.apache.spark.{SecurityManager, SparkConf}
@@ -70,14 +70,14 @@ import org.apache.spark.util.Utils
 private[spark] class MetricsSystem private (
     val instance: String,
     conf: SparkConf,
-    securityMgr: SecurityManager)
+    securityMgr: SecurityManager,
+    registry: MetricRegistry)
   extends Logging {
 
   private[this] val metricsConfig = new MetricsConfig(conf)
 
   private val sinks = new mutable.ArrayBuffer[Sink]
-  private val sources = new mutable.ArrayBuffer[Source]
-  private val registry = new MetricRegistry()
+  private val sourceToListeners = new mutable.HashMap[Source, MetricRegistryListener]
 
   private var running: Boolean = false
 
@@ -111,6 +111,7 @@ private[spark] class MetricsSystem private (
     if (running) {
       sinks.foreach(_.stop)
       registry.removeMatching((_: String, _: Metric) => true)
+      sourceToListeners.keySet.foreach(removeSource)
     } else {
       logWarning("Stopping a MetricsSystem that is not running")
     }
@@ -156,22 +157,23 @@ private[spark] class MetricsSystem private (
   }
 
   def getSourcesByName(sourceName: String): Seq[Source] =
-    sources.filter(_.sourceName == sourceName).toSeq
+    sourceToListeners.keySet.filter(_.sourceName == sourceName).toSeq
 
   def registerSource(source: Source): Unit = {
-    sources += source
     try {
-      val regName = buildRegistryName(source)
-      registry.register(regName, source.metricRegistry)
+      val listener = new MetricsSystemListener(buildRegistryName(source))
+      source.metricRegistry.addListener(listener)
+      sourceToListeners += source -> listener
     } catch {
       case e: IllegalArgumentException => logInfo("Metrics already registered", e)
     }
   }
 
   def removeSource(source: Source): Unit = {
-    sources -= source
     val regName = buildRegistryName(source)
     registry.removeMatching((name: String, _: Metric) => name.startsWith(regName))
+    sourceToListeners.get(source).foreach(source.metricRegistry.removeListener)
+    sourceToListeners.remove(source)
   }
 
   private def registerSources(): Unit = {
@@ -225,6 +227,41 @@ private[spark] class MetricsSystem private (
       }
     }
   }
+
+  private[spark] class MetricsSystemListener(prefix: String)
+      extends MetricRegistryListener {
+    def metricName(name: String): String = MetricRegistry.name(prefix, name)
+
+    override def onHistogramAdded(name: String, histogram: Histogram): Unit =
+      registry.register(metricName(name), histogram)
+
+    override def onCounterAdded(name: String, counter: Counter): Unit =
+      registry.register(metricName(name), counter)
+
+    override def onHistogramRemoved(name: String): Unit =
+      registry.remove(metricName(name))
+
+    override def onGaugeRemoved(name: String): Unit =
+      registry.remove(metricName(name))
+
+    override def onMeterRemoved(name: String): Unit =
+      registry.remove(metricName(name))
+
+    override def onTimerAdded(name: String, timer: Timer): Unit =
+      registry.register(metricName(name), timer)
+
+    override def onCounterRemoved(name: String): Unit =
+      registry.remove(metricName(name))
+
+    override def onGaugeAdded(name: String, gauge: Gauge[_]): Unit =
+      registry.register(metricName(name), gauge)
+
+    override def onTimerRemoved(name: String): Unit =
+      registry.remove(metricName(name))
+
+    override def onMeterAdded(name: String, meter: Meter): Unit =
+      registry.register(metricName(name), meter)
+  }
 }
 
 private[spark] object MetricsSystem {
@@ -244,7 +281,15 @@ private[spark] object MetricsSystem {
 
   def createMetricsSystem(
       instance: String, conf: SparkConf, securityMgr: SecurityManager): MetricsSystem = {
-    new MetricsSystem(instance, conf, securityMgr)
+    new MetricsSystem(instance, conf, securityMgr, new MetricRegistry())
+  }
+
+  def createMetricsSystem(
+     instance: String,
+     conf: SparkConf,
+     securityMgr: SecurityManager,
+     registry: MetricRegistry): MetricsSystem = {
+    new MetricsSystem(instance, conf, securityMgr, registry)
   }
 }
 

--- a/core/src/test/scala/org/apache/spark/metrics/MetricsSystemSuite.scala
+++ b/core/src/test/scala/org/apache/spark/metrics/MetricsSystemSuite.scala
@@ -43,7 +43,7 @@ class MetricsSystemSuite extends SparkFunSuite with BeforeAndAfter with PrivateM
   test("MetricsSystem with default config") {
     val metricsSystem = MetricsSystem.createMetricsSystem("default", conf, securityMgr)
     metricsSystem.start()
-    val sources = PrivateMethod[mutable.HashMap[Source, MetricRegistryListener]](Symbol("sources"))
+    val sources = PrivateMethod[mutable.HashMap[Source, MetricRegistryListener]](Symbol("sourceToListeners"))
     val sinks = PrivateMethod[ArrayBuffer[Sink]](Symbol("sinks"))
 
     assert(metricsSystem.invokePrivate(sources()).size === StaticSources.allSources.length)
@@ -54,7 +54,7 @@ class MetricsSystemSuite extends SparkFunSuite with BeforeAndAfter with PrivateM
   test("MetricsSystem with sources add") {
     val metricsSystem = MetricsSystem.createMetricsSystem("test", conf, securityMgr)
     metricsSystem.start()
-    val sources = PrivateMethod[mutable.HashMap[Source, MetricRegistryListener]](Symbol("sources"))
+    val sources = PrivateMethod[mutable.HashMap[Source, MetricRegistryListener]](Symbol("sourceToListeners"))
     val sinks = PrivateMethod[ArrayBuffer[Sink]](Symbol("sinks"))
 
     assert(metricsSystem.invokePrivate(sources()).size === StaticSources.allSources.length)

--- a/core/src/test/scala/org/apache/spark/metrics/MetricsSystemSuite.scala
+++ b/core/src/test/scala/org/apache/spark/metrics/MetricsSystemSuite.scala
@@ -43,7 +43,8 @@ class MetricsSystemSuite extends SparkFunSuite with BeforeAndAfter with PrivateM
   test("MetricsSystem with default config") {
     val metricsSystem = MetricsSystem.createMetricsSystem("default", conf, securityMgr)
     metricsSystem.start()
-    val sources = PrivateMethod[mutable.HashMap[Source, MetricRegistryListener]](Symbol("sourceToListeners"))
+    val sources = PrivateMethod[mutable.HashMap[Source, MetricRegistryListener]](
+      Symbol("sourcesWithListeners"))
     val sinks = PrivateMethod[ArrayBuffer[Sink]](Symbol("sinks"))
 
     assert(metricsSystem.invokePrivate(sources()).size === StaticSources.allSources.length)
@@ -54,7 +55,8 @@ class MetricsSystemSuite extends SparkFunSuite with BeforeAndAfter with PrivateM
   test("MetricsSystem with sources add") {
     val metricsSystem = MetricsSystem.createMetricsSystem("test", conf, securityMgr)
     metricsSystem.start()
-    val sources = PrivateMethod[mutable.HashMap[Source, MetricRegistryListener]](Symbol("sourceToListeners"))
+    val sources = PrivateMethod[mutable.HashMap[Source, MetricRegistryListener]](
+      Symbol("sourcesWithListeners"))
     val sinks = PrivateMethod[ArrayBuffer[Sink]](Symbol("sinks"))
 
     assert(metricsSystem.invokePrivate(sources()).size === StaticSources.allSources.length)

--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -22,9 +22,10 @@ import java.util.Locale
 import java.util.concurrent.{CountDownLatch, TimeUnit}
 import java.util.concurrent.atomic.AtomicInteger
 
-import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable
 import scala.collection.mutable.Queue
 
+import com.codahale.metrics.MetricRegistryListener
 import org.apache.commons.io.FileUtils
 import org.scalatest.{Assertions, PrivateMethodTester}
 import org.scalatest.concurrent.{Signaler, ThreadSignaler, TimeLimits}
@@ -1027,8 +1028,10 @@ object testPackage extends Assertions {
  * This includes methods to access private methods and fields in StreamingContext and MetricsSystem
  */
 private object StreamingContextSuite extends PrivateMethodTester {
-  private val _sources = PrivateMethod[ArrayBuffer[Source]](Symbol("sources"))
-  private def getSources(metricsSystem: MetricsSystem): ArrayBuffer[Source] = {
+  private val _sources =
+    PrivateMethod[mutable.HashMap[Source, MetricRegistryListener]](Symbol("sources"))
+  private def getSources(metricsSystem: MetricsSystem):
+      mutable.HashMap[Source, MetricRegistryListener] = {
     metricsSystem.invokePrivate(_sources())
   }
   private val _streamingSource = PrivateMethod[StreamingSource](Symbol("streamingSource"))

--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -1029,7 +1029,7 @@ object testPackage extends Assertions {
  */
 private object StreamingContextSuite extends PrivateMethodTester {
   private val _sources =
-    PrivateMethod[mutable.HashMap[Source, MetricRegistryListener]](Symbol("sources"))
+    PrivateMethod[mutable.HashMap[Source, MetricRegistryListener]](Symbol("sourceToListeners"))
   private def getSources(metricsSystem: MetricsSystem):
       mutable.HashMap[Source, MetricRegistryListener] = {
     metricsSystem.invokePrivate(_sources())

--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -1029,7 +1029,7 @@ object testPackage extends Assertions {
  */
 private object StreamingContextSuite extends PrivateMethodTester {
   private val _sources =
-    PrivateMethod[mutable.HashMap[Source, MetricRegistryListener]](Symbol("sourceToListeners"))
+    PrivateMethod[mutable.HashMap[Source, MetricRegistryListener]](Symbol("sourcesWithListeners"))
   private def getSources(metricsSystem: MetricsSystem):
       mutable.HashMap[Source, MetricRegistryListener] = {
     metricsSystem.invokePrivate(_sources())


### PR DESCRIPTION
### What changes were proposed in this pull request?
MetricSystem picks up new metrics from sources that are added throughout execution. If you do measurements via dynamic proxies you might not want to redeclare all metrics that the proxies will create and you'd prefer them to get populated as they're being produced. Right now all sources are processed only onceat startup and metrics are picked up only if they have been registered statically at compile time. Behaviour I am proposing lets you not have to declare metrics in two places.

This had been previously suggested in https://github.com/apache/spark/pull/18406. I have reduced the scope of the change to just dynamic metric registration.

### Why are the changes needed?
Currently there's no way to access MetricRegistry that MetricsSystem uses to hold its state and as such it's not possible to reprocess a source. MetricsSystem throws if any metric had already been registered previously.

n.b. the MetricRegistry is added as a constructor argument to make testing easier but could as well be accessed via reflection as a private variable.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added tests