### PR TITLE
[SPARK-33100][SQL] Ignore a semicolon inside a bracketed comment in spark-sql

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -583,7 +583,7 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
           // Ignores '/' in any case of quotes
         } else if (insideBracketedComment && line.charAt(index - 1) == '*' ) {
           bracketedCommentLevel -= 1
-        } else if (hasNext && line.charAt(index + 1) == '*') {
+        } else if (hasNext && !insideBracketedComment && line.charAt(index + 1) == '*') {
           bracketedCommentLevel += 1
         }
       }

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -519,7 +519,7 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
   // Note: [SPARK-31595] if there is a `'` in a double quoted string, or a `"` in a single quoted
   // string, the origin implementation from Hive will not drop the trailing semicolon as expected,
   // hence we refined this function a little bit.
-  // Note: [SPARK-33110] Ignore the content inside bracketed comment and ignore the comment without
+  // Note: [SPARK-33100] Ignore the content inside bracketed comment and ignore the comment without
   // content.
   private def splitSemiColon(line: String): JList[String] = {
     var insideSingleQuote = false

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -581,14 +581,10 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
         val hasNext = index + 1 < line.length
         if (insideSingleQuote || insideDoubleQuote) {
           // Ignores '/' in any case of quotes
-        } else if (hasNext && line.charAt(index + 1) == '*') {
-          // ignore quotes and ; in bracketed comment
-          bracketedCommentLevel += 1
-        }
-      } else if (line.charAt(index) == '/' && insideBracketedComment) {
-        if (line.charAt(index - 1) == '*') {
-          // record the right bound of bracketed comment
+        } else if (insideBracketedComment && line.charAt(index - 1) == '*' ) {
           bracketedCommentLevel -= 1
+        } else if (hasNext && line.charAt(index + 1) == '*') {
+          bracketedCommentLevel += 1
         }
       }
       // set the escape

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -524,24 +524,18 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
     var insideSingleQuote = false
     var insideDoubleQuote = false
     var insideSimpleComment = false
-    var insideBracketedComment = false
-    var bracketedCommentRightBound = -1
+    var bracketedCommentLevel = 0
     var escape = false
     var beginIndex = 0
     var includingStatement = false
     val ret = new JArrayList[String]
 
+    def insideBracketedComment: Boolean = bracketedCommentLevel > 0
     def insideComment: Boolean = insideSimpleComment || insideBracketedComment
     def statementBegin(index: Int): Boolean = includingStatement || (!insideComment &&
       index > beginIndex && !s"${line.charAt(index)}".trim.isEmpty)
 
     for (index <- 0 until line.length) {
-      if (insideBracketedComment && index == bracketedCommentRightBound + 1) {
-        // end bracketed comment
-        insideBracketedComment = false
-        bracketedCommentRightBound = -1
-      }
-
       if (line.charAt(index) == '\'' && !insideComment) {
         // take a look to see if it is escaped
         // See the comment above about SPARK-31595
@@ -583,18 +577,18 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
         if (!escape) {
           insideSimpleComment = false
         }
-      } else if (line.charAt(index) == '/' && !insideComment) {
+      } else if (line.charAt(index) == '/' && !insideSimpleComment) {
         val hasNext = index + 1 < line.length
         if (insideSingleQuote || insideDoubleQuote) {
           // Ignores '/' in any case of quotes
         } else if (hasNext && line.charAt(index + 1) == '*') {
           // ignore quotes and ; in bracketed comment
-          insideBracketedComment = true
+          bracketedCommentLevel += 1
         }
       } else if (line.charAt(index) == '/' && insideBracketedComment) {
         if (line.charAt(index - 1) == '*') {
           // record the right bound of bracketed comment
-          bracketedCommentRightBound = index
+          bracketedCommentLevel -= 1
         }
       }
       // set the escape

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -571,8 +571,10 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
         if (insideSingleQuote || insideDoubleQuote || insideComment) {
           // do not split
         } else {
-          // split, do not include ; itself
-          ret.add(line.substring(beginIndex, index))
+          if (contentBegin) {
+            // split, do not include ; itself
+            ret.add(line.substring(beginIndex, index))
+          }
           beginIndex = index + 1
           contentBegin = false
         }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -583,6 +583,5 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
     runCliWithin(1.minute)("/*$meta chars{^\\;}*/ SELECT 'test';" -> "test")
     runCliWithin(1.minute)("/*\nmulti-line\n*/ SELECT 'test';" -> "test")
     runCliWithin(1.minute)("/*/* multi-level bracketed*/*/ SELECT 'test';" -> "test")
-
   }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -582,6 +582,6 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
     runCliWithin(1.minute)("SELECT 'test'; /* SELECT 'test';*/" -> "")
     runCliWithin(1.minute)("/*$meta chars{^\\;}*/ SELECT 'test';" -> "test")
     runCliWithin(1.minute)("/*\nmulti-line\n*/ SELECT 'test';" -> "test")
-    runCliWithin(1.minute)("/*/* multi-level bracketed*/*/ SELECT 'test';" -> "test")
+    runCliWithin(1.minute)("/*/* multi-level bracketed*/ SELECT 'test';" -> "test")
   }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -574,13 +574,11 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
     runCliWithin(1.minute)("SELECT MAKE_DATE(-44, 3, 15);" -> "-0044-03-15")
   }
 
-  test("SPARK-33100: Ignore the content inside bracketed comment and ignore the comment without" +
-    " content.") {
-    runCliWithin(1.minute)("/* SELECT 1;*/ SELECT 1;" -> "1" )
-    runCliWithin(1.minute)(";;/* SELECT 1;*/ SELECT 1;" -> "1" )
-    runCliWithin(1.minute)("/* SELECT 1;*/;; SELECT 1;" -> "1" )
-    runCliWithin(1.minute)("SELECT '1'; -- SELECT '1';" -> "")
-    runCliWithin(1.minute)("SELECT '1'; /* SELECT '1';*/" -> "")
-    runCliWithin(1.minute)("/* SELECT 1;*/;; SELECT 1; /* SELECT '1';*/" -> "" )
+  test("SPARK-33100: Ignore a semicolon inside a bracketed comment in spark-sql") {
+    runCliWithin(1.minute)("/* SELECT 'test';*/ SELECT 1;" -> "test" )
+    runCliWithin(1.minute)(";;/* SELECT 'test';*/ SELECT 'test';" -> "test" )
+    runCliWithin(1.minute)("/* SELECT 'test';*/;; SELECT 'test';" -> "test" )
+    runCliWithin(1.minute)("SELECT 'test'; -- SELECT 'test';" -> "")
+    runCliWithin(1.minute)("SELECT 'test'; /* SELECT 'test';*/" -> "")
   }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -583,5 +583,6 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
     runCliWithin(1.minute)("/*$meta chars{^\\;}*/ SELECT 'test';" -> "test")
     runCliWithin(1.minute)("/*\nmulti-line\n*/ SELECT 'test';" -> "test")
     runCliWithin(1.minute)("/*/* multi-level bracketed*/*/ SELECT 'test';" -> "test")
+
   }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -580,5 +580,8 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
     runCliWithin(1.minute)("/* SELECT 'test';*/;; SELECT 'test';" -> "test" )
     runCliWithin(1.minute)("SELECT 'test'; -- SELECT 'test';" -> "")
     runCliWithin(1.minute)("SELECT 'test'; /* SELECT 'test';*/" -> "")
+    runCliWithin(1.minute)("/*$meta chars{^\\;}*/ SELECT 'test';" -> "test")
+    runCliWithin(1.minute)("/*\nmulti-line\n*/ SELECT 'test';" -> "test")
+    runCliWithin(1.minute)("/*/* multi-level bracketed*/*/ SELECT 'test';" -> "test")
   }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -573,4 +573,8 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
     // the date formatter for `java.sql.LocalDate` must output negative years with sign.
     runCliWithin(1.minute)("SELECT MAKE_DATE(-44, 3, 15);" -> "-0044-03-15")
   }
+
+  test("SPARK-33110: Support parse the sql statements with c-style comments") {
+    runCliWithin(1.minute)("/* SELECT 'test';*/ SELECT 'test';" -> "test" )
+  }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -574,13 +574,13 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
     runCliWithin(1.minute)("SELECT MAKE_DATE(-44, 3, 15);" -> "-0044-03-15")
   }
 
-  test("SPARK-33110: Ignore the content inside bracketed comment and ignore the comment without" +
+  test("SPARK-33100: Ignore the content inside bracketed comment and ignore the comment without" +
     " content.") {
     runCliWithin(1.minute)("/* SELECT 1;*/ SELECT 1;" -> "1" )
     runCliWithin(1.minute)(";;/* SELECT 1;*/ SELECT 1;" -> "1" )
     runCliWithin(1.minute)("/* SELECT 1;*/;; SELECT 1;" -> "1" )
     runCliWithin(1.minute)("SELECT '1'; -- SELECT '1';" -> "")
     runCliWithin(1.minute)("SELECT '1'; /* SELECT '1';*/" -> "")
-    runCliWithin(1.minute)("/* SELECT 1;*/;; SELECT 1; /*\n SELECT '1';\n*/" -> "" )
+    runCliWithin(1.minute)("/* SELECT 1;*/;; SELECT 1; /* SELECT '1';*/" -> "" )
   }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -574,7 +574,8 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
     runCliWithin(1.minute)("SELECT MAKE_DATE(-44, 3, 15);" -> "-0044-03-15")
   }
 
-  test("SPARK-33110: Fix the issue when parsing sql statements with bracketed comments") {
+  test("SPARK-33110: Ignore the content inside bracketed comment and ignore the comment without" +
+    " content.") {
     runCliWithin(1.minute)("/* SELECT 1;*/ SELECT 1;" -> "1" )
     runCliWithin(1.minute)(";;/* SELECT 1;*/ SELECT 1;" -> "1" )
     runCliWithin(1.minute)("/* SELECT 1;*/;; SELECT 1;" -> "1" )

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -576,5 +576,7 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
 
   test("SPARK-33110: Support parse the sql statements with c-style comments") {
     runCliWithin(1.minute)("/* SELECT 'test';*/ SELECT 'test';" -> "test" )
+    runCliWithin(1.minute)("SELECT 'test'; -- SELECT 'test'" -> "test")
+    runCliWithin(1.minute)("SELECT 'test'; /* SELECT 'test';*/" -> "test")
   }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -576,7 +576,7 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
 
   test("SPARK-33110: Support parse the sql statements with c-style comments") {
     runCliWithin(1.minute)("/* SELECT 'test';*/ SELECT 'test';" -> "test" )
-    runCliWithin(1.minute)("SELECT 'test'; -- SELECT 'test'" -> "test")
-    runCliWithin(1.minute)("SELECT 'test'; /* SELECT 'test';*/" -> "test")
+    runCliWithin(1.minute)("SELECT 'test'; -- SELECT 'test'" -> "")
+    runCliWithin(1.minute)("SELECT 'test'; /* SELECT 'test';*/" -> "")
   }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -574,9 +574,12 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
     runCliWithin(1.minute)("SELECT MAKE_DATE(-44, 3, 15);" -> "-0044-03-15")
   }
 
-  test("SPARK-33110: Support parse the sql statements with c-style comments") {
-    runCliWithin(1.minute)("/* SELECT 'test';*/ SELECT 'test';" -> "test" )
-    runCliWithin(1.minute)("SELECT 'test'; -- SELECT 'test'" -> "")
-    runCliWithin(1.minute)("SELECT 'test'; /* SELECT 'test';*/" -> "")
+  test("SPARK-33110: Fix the issue when parsing sql statements with bracketed comments") {
+    runCliWithin(1.minute)("/* SELECT 1;*/ SELECT 1;" -> "1" )
+    runCliWithin(1.minute)(";;/* SELECT 1;*/ SELECT 1;" -> "1" )
+    runCliWithin(1.minute)("/* SELECT 1;*/;; SELECT 1;" -> "1" )
+    runCliWithin(1.minute)("SELECT '1'; -- SELECT '1';" -> "")
+    runCliWithin(1.minute)("SELECT '1'; /* SELECT '1';*/" -> "")
+    runCliWithin(1.minute)("/* SELECT 1;*/;; SELECT 1; /*\n SELECT '1';\n*/" -> "" )
   }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -575,7 +575,7 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
   }
 
   test("SPARK-33100: Ignore a semicolon inside a bracketed comment in spark-sql") {
-    runCliWithin(1.minute)("/* SELECT 'test';*/ SELECT 1;" -> "test" )
+    runCliWithin(1.minute)("/* SELECT 'test';*/ SELECT 'test';" -> "test" )
     runCliWithin(1.minute)(";;/* SELECT 'test';*/ SELECT 'test';" -> "test" )
     runCliWithin(1.minute)("/* SELECT 'test';*/;; SELECT 'test';" -> "test" )
     runCliWithin(1.minute)("SELECT 'test'; -- SELECT 'test';" -> "")

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -586,36 +586,39 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
 
     val dataFilePath =
       Thread.currentThread().getContextClassLoader.getResource("data/files/small_kv.txt")
-    val hiveContribJar = HiveTestJars.getHiveHcatalogCoreJar().getCanonicalPath
     val testHintTablePath = Utils.createTempDir()
-    runCliWithin(
-      3.minute,
-      Seq("--conf", s"spark.hadoop.${ConfVars.HIVEAUXJARS}=$hiveContribJar"))(
-      """CREATE TABLE test(key string, val string)
-        |ROW FORMAT SERDE 'org.apache.hive.hcatalog.data.JsonSerDe';""".stripMargin
+
+    runCliWithin(3.minute)(
+      "CREATE TABLE test(key INT, val STRING) USING hive;"
         -> "",
-      s"""LOAD DATA LOCAL INPATH '$dataFilePath'
-        |OVERWRITE INTO TABLE test;""".stripMargin
+      s"""LOAD DATA LOCAL INPATH '$dataFilePath' OVERWRITE INTO TABLE test;""".stripMargin
         -> "",
-      s"""CREATE TABLE testHint(key string, val string) USING parquet
-        |LOCATION '${testHintTablePath.getAbsolutePath}';""".stripMargin
-        -> "",
-      "INSERT OVERWRITE TABLE testHint SELECT /*+ REPARTITION(3) */ * FROM test;"
+      s"""CREATE TABLE testHint(key string, val string) USING hive
+         |LOCATION '${testHintTablePath.getAbsolutePath}';""".stripMargin
         -> ""
     )
 
-    val dataFiles = testHintTablePath.listFiles().filterNot{ file =>
+    runCliWithin(2.minutes)(
+      "INSERT OVERWRITE TABLE testHint SELECT key, val FROM test;"
+        -> ""
+    )
+    var dataFiles = testHintTablePath.listFiles().filterNot{ file =>
+      file.getName.startsWith(".") || file.getName.startsWith("_")
+    }
+    assert(dataFiles.size == 1)
+
+    runCliWithin(2.minutes)(
+      "INSERT OVERWRITE TABLE testHint SELECT /*+ REPARTITION(3) */ key, val FROM test;"
+        -> ""
+    )
+    dataFiles = testHintTablePath.listFiles().filterNot{ file =>
       file.getName.startsWith(".") || file.getName.startsWith("_")
     }
     assert(dataFiles.size == 3)
 
-    runCliWithin(
-      2.minute,
-      Seq("--conf", s"spark.hadoop.${ConfVars.HIVEAUXJARS}=$hiveContribJar"))(
-      "DROP TABLE test;"
-        -> "",
-      "DROP TABLE testHint;"
-        -> ""
+    runCliWithin(2.minute)(
+      "DROP TABLE test;" -> "",
+      "DROP TABLE testHint;" -> ""
     )
     Utils.deleteRecursively(testHintTablePath)
   }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -575,24 +575,23 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
   }
 
   test("SPARK-33100: Ignore a semicolon inside a bracketed comment in spark-sql") {
-    runCliWithin(1.minute)("/* SELECT 'test';*/ SELECT 'test';" -> "test")
-    runCliWithin(1.minute)(";;/* SELECT 'test';*/ SELECT 'test';" -> "test")
-    runCliWithin(1.minute)("/* SELECT 'test';*/;; SELECT 'test';" -> "test")
-    runCliWithin(1.minute)("SELECT 'test'; -- SELECT 'test';" -> "")
-    runCliWithin(1.minute)("SELECT 'test'; /* SELECT 'test';*/" -> "")
-    runCliWithin(1.minute)("/*$meta chars{^\\;}*/ SELECT 'test';" -> "test")
-    runCliWithin(1.minute)("/*\nmulti-line\n*/ SELECT 'test';" -> "test")
-    runCliWithin(1.minute)("/*/* multi-level bracketed*/ SELECT 'test';" -> "test")
+    runCliWithin(4.minute)(
+      "/* SELECT 'test';*/ SELECT 'test';" -> "test",
+      ";;/* SELECT 'test';*/ SELECT 'test';" -> "test",
+      "/* SELECT 'test';*/;; SELECT 'test';" -> "test",
+      "SELECT 'test'; -- SELECT 'test';" -> "",
+      "SELECT 'test'; /* SELECT 'test';*/;" -> "",
+      "/*$meta chars{^\\;}*/ SELECT 'test';" -> "test",
+      "/*\nmulti-line\n*/ SELECT 'test';" -> "test",
+      "/*/* multi-level bracketed*/ SELECT 'test';" -> "test"
+    )
   }
 
   test("SPARK-33100: test sql statements with hint in bracketed comment") {
     runCliWithin(2.minute)(
-      "CREATE TEMPORARY VIEW t1 AS SELECT * FROM VALUES(1, 2) AS t1(k, v);"
-        -> "",
-      "CREATE TEMPORARY VIEW t2 AS SELECT * FROM VALUES(2, 1) AS t2(k, v);"
-        -> "",
-      "EXPLAIN SELECT /*+ MERGEJOIN(t1) */ t1.* FROM t1 JOIN t2 ON t1.k = t2.v;"
-        -> "SortMergeJoin",
+      "CREATE TEMPORARY VIEW t1 AS SELECT * FROM VALUES(1, 2) AS t1(k, v);" -> "",
+      "CREATE TEMPORARY VIEW t2 AS SELECT * FROM VALUES(2, 1) AS t2(k, v);" -> "",
+      "EXPLAIN SELECT /*+ MERGEJOIN(t1) */ t1.* FROM t1 JOIN t2 ON t1.k = t2.v;" -> "SortMergeJoin",
       "EXPLAIN SELECT /* + MERGEJOIN(t1) */ t1.* FROM t1 JOIN t2 ON t1.k = t2.v;"
         -> "BroadcastHashJoin"
     )

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -587,8 +587,12 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
 
   test("SPARK-33100: test sql statements with hint in bracketed comment") {
     runCliWithin(2.minute)(
-      "CREATE TEMPORARY VIEW t AS SELECT * FROM VALUES(1, 2) AS t(k, v);" -> "",
-      "EXPLAIN EXTENDED SELECT /*+ broadcast(t) */ * from t;" -> "ResolvedHint (strategy=broadcast)"
+      "CREATE TEMPORARY VIEW t AS SELECT * FROM VALUES(1, 2) AS t(k, v);"
+        -> "",
+      "EXPLAIN EXTENDED SELECT /*+ broadcast(t) */ * from t;"
+        -> "ResolvedHint (strategy=broadcast)",
+      "EXPLAIN EXTENDED SELECT /* + broadcast(t) */ * from t;"
+        -> "ResolvedHint (strategy=broadcast)"
     )
   }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -583,5 +583,6 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
     runCliWithin(1.minute)("/*$meta chars{^\\;}*/ SELECT 'test';" -> "test")
     runCliWithin(1.minute)("/*\nmulti-line\n*/ SELECT 'test';" -> "test")
     runCliWithin(1.minute)("/*/* multi-level bracketed*/ SELECT 'test';" -> "test")
+    runCliWithin(1.minute)("SELECT /*+ COALESCE(3) */ * FROM (SELECT 'test')t;" -> "test")
   }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -595,7 +595,7 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
         |ROW FORMAT SERDE 'org.apache.hive.hcatalog.data.JsonSerDe';""".stripMargin
         -> "",
       s"""LOAD DATA LOCAL INPATH '$dataFilePath'
-        |OVERWRITE INTO TABLE testHint;""".stripMargin
+        |OVERWRITE INTO TABLE test;""".stripMargin
         -> "",
       s"""CREATE TABLE testHint(key string, val string) USING parquet
         |LOCATION '$testTablePath';""".stripMargin

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -597,12 +597,10 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
       s"""LOAD DATA LOCAL INPATH '$dataFilePath'
         |OVERWRITE INTO TABLE test;""".stripMargin
         -> "",
-      s"""CREATE TABLE testHint(key string, val string) USING parquet
+      s"""CREATE TABLE testHints(key string, val string) USING parquet
         |LOCATION '$testTablePath';""".stripMargin
         -> "",
-      s"""set spark.sql.shuffle.partitions=100;"""
-        -> "100",
-      "INSERT OVERWRITE TABLE testHint SELECT /*+ COALESCE(3) */ * FROM test DISTRIBUTE BY key;"
+      "INSERT OVERWRITE TABLE testHints SELECT /*+ REPARTITION(3) */ * FROM test;"
         -> ""
     )
 
@@ -616,7 +614,7 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
       Seq("--conf", s"spark.hadoop.${ConfVars.HIVEAUXJARS}=$hiveContribJar"))(
       "DROP TABLE test;"
         -> "",
-      "DROP TABLE testHint;"
+      "DROP TABLE testHints;"
         -> ""
     )
     Utils.deleteRecursively(testTablePath)

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -597,12 +597,12 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
       s"""LOAD DATA LOCAL INPATH '$dataFilePath'
         |OVERWRITE INTO TABLE testHint;""".stripMargin
         -> "",
-      s"""CREATE TABLE testHint(key string, val string) using parquet
-        |location '$testTablePath';""".stripMargin
+      s"""CREATE TABLE testHint(key string, val string) USING parquet
+        |LOCATION '$testTablePath';""".stripMargin
         -> "",
-      s"""set spark.sql.shuffle.partitions=100"""
+      s"""set spark.sql.shuffle.partitions=100;"""
         -> "100",
-      "INSERT OVERWRITE TABLE testHint SELECT /*+ COALESCE(3) */ * FROM test distributed by key;"
+      "INSERT OVERWRITE TABLE testHint SELECT /*+ COALESCE(3) */ * FROM test DISTRIBUTE BY key;"
         -> ""
     )
 

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -591,9 +591,9 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
         -> "",
       "CREATE TEMPORARY VIEW t2 AS SELECT * FROM VALUES(2, 1) AS t2(k, v);"
         -> "",
-      "EXPLAIN EXTENDED SELECT /*+ MERGEJOIN(t1) */ t1.* FROM t1 JOIN t2 ON t1.k = t2.v;"
+      "EXPLAIN SELECT /*+ MERGEJOIN(t1) */ t1.* FROM t1 JOIN t2 ON t1.k = t2.v;"
         -> "SortMergeJoin",
-      "EXPLAIN EXTENDED SELECT /* + MERGEJOIN(t1) */ t1.* FROM t1 JOIN t2 ON t1.k = t2.v;"
+      "EXPLAIN SELECT /* + MERGEJOIN(t1) */ t1.* FROM t1 JOIN t2 ON t1.k = t2.v;"
         -> "BroadcastHashJoin"
     )
   }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -584,5 +584,6 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
     runCliWithin(1.minute)("/*\nmulti-line\n*/ SELECT 'test';" -> "test")
     runCliWithin(1.minute)("/*/* multi-level bracketed*/ SELECT 'test';" -> "test")
     runCliWithin(1.minute)("SELECT /*+ COALESCE(3) */ * FROM (SELECT 'test')t;" -> "test")
+
   }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -584,6 +584,5 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
     runCliWithin(1.minute)("/*\nmulti-line\n*/ SELECT 'test';" -> "test")
     runCliWithin(1.minute)("/*/* multi-level bracketed*/ SELECT 'test';" -> "test")
     runCliWithin(1.minute)("SELECT /*+ COALESCE(3) */ * FROM (SELECT 'test')t;" -> "test")
-
   }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -585,13 +585,10 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
     runCliWithin(1.minute)("/*/* multi-level bracketed*/ SELECT 'test';" -> "test")
   }
 
-  test("SPARK-33100: test statements with hint in bracketed comment in spark-sql") {
+  test("SPARK-33100: test sql statements with hint in bracketed comment") {
     runCliWithin(2.minute)(
-      "CREATE TEMPORARY VIEW t AS SELECT * FROM VALUES(1, 2), (2, 3), (3, 4), (4, 5), (5, 6)" +
-        " AS t(key, val);"
-        -> "",
-      "EXPLAIN EXTENDED SELECT /*+ broadcast(t) */ a.* FROM t a JOIN t b ON a.key=b.val;"
-        -> "'UnresolvedHint broadcast, ['t]"
+      "CREATE TEMPORARY VIEW t AS SELECT * FROM VALUES(1, 2) AS t(k, v);" -> "",
+      "EXPLAIN EXTENDED SELECT /*+ broadcast(t) */ * from t;" -> "ResolvedHint (strategy=broadcast)"
     )
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Now the spark-sql does not support parse the sql statements with bracketed comments.
For the sql statements:
```
/* SELECT 'test'; */
SELECT 'test';
```
Would be split to two statements:
The first one: `/* SELECT 'test'`
The second one: `*/ SELECT 'test'`

Then it would throw an exception because the first one is illegal.
In this PR, we ignore the content in bracketed comments while splitting the sql statements.
Besides, we ignore the comment without any content.

### Why are the changes needed?
Spark-sql might split the statements inside bracketed comments and it is not correct.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Added UT.