### PR TITLE
[SPARK-33094][SQL][2.4] Make ORC format propagate Hadoop config from DS options to underlying HDFS file system

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -94,7 +94,7 @@ class OrcFileFormat
       sparkSession: SparkSession,
       options: Map[String, String],
       files: Seq[FileStatus]): Option[StructType] = {
-    OrcUtils.readSchema(sparkSession, files)
+    OrcUtils.readSchema(sparkSession, files, options)
   }
 
   override def prepareWrite(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
@@ -77,10 +77,10 @@ object OrcUtils extends Logging {
     }
   }
 
-  def readSchema(sparkSession: SparkSession, files: Seq[FileStatus])
+  def readSchema(sparkSession: SparkSession, files: Seq[FileStatus], options: Map[String, String])
       : Option[StructType] = {
     val ignoreCorruptFiles = sparkSession.sessionState.conf.ignoreCorruptFiles
-    val conf = sparkSession.sessionState.newHadoopConf()
+    val conf = sparkSession.sessionState.newHadoopConfWithOptions(options)
     // TODO: We need to support merge schema. Please see SPARK-11412.
     files.toIterator.map(file => readSchema(file.getPath, conf, ignoreCorruptFiles)).collectFirst {
       case Some(schema) =>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcFileFormat.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcFileFormat.scala
@@ -67,8 +67,8 @@ class OrcFileFormat extends FileFormat with DataSourceRegister with Serializable
     OrcFileOperator.readSchema(
       files.map(_.getPath.toString),
       Some(sparkSession.sessionState.newHadoopConfWithOptions(options)),
-      ignoreCorruptFiles,
-      options)
+      ignoreCorruptFiles
+    )
   }
 
   override def prepareWrite(

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcFileFormat.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcFileFormat.scala
@@ -67,8 +67,8 @@ class OrcFileFormat extends FileFormat with DataSourceRegister with Serializable
     OrcFileOperator.readSchema(
       files.map(_.getPath.toString),
       Some(sparkSession.sessionState.newHadoopConfWithOptions(options)),
-      ignoreCorruptFiles
-    )
+      ignoreCorruptFiles,
+      options)
   }
 
   override def prepareWrite(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Propagate ORC options to Hadoop configs in Hive `OrcFileFormat` and in the regular ORC datasource.

### Why are the changes needed?
There is a bug that when running:
```scala
spark.read.format("orc").options(conf).load(path)
```
The underlying file system will not receive the conf options.

### Does this PR introduce _any_ user-facing change?
Yes

### How was this patch tested?
Added UT to `OrcSourceSuite`.