### PR TITLE
[WIP][SPARK-33098][SQL] Fix In expression casts

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -511,9 +511,18 @@ object TypeCoercion {
           i
         }
 
-      case i @ In(a, b) if b.exists(_.dataType != a.dataType) =>
-        findWiderCommonType(i.children.map(_.dataType)) match {
-          case Some(finalDataType) => i.withNewChildren(i.children.map(Cast(_, finalDataType)))
+      case i @ In(value, list) if list.exists(_.dataType != value.dataType) =>
+        findWiderCommonType(list.map(_.dataType)) match {
+          case Some(listWiderCommonType) =>
+            findCommonTypeForBinaryComparison(value.dataType, listWiderCommonType, conf).map {
+              finalDataType => i.withNewChildren(i.children.map(Cast(_, finalDataType)))
+            }.getOrElse {
+              findWiderCommonType(Seq(value.dataType, listWiderCommonType)) match {
+                case Some(finalDataType) =>
+                  i.withNewChildren(i.children.map(Cast(_, finalDataType)))
+                case None => i
+              }
+            }
           case None => i
         }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix `InConversion` rule by finding the common wider type of list expressions first and then the final common type for comparison between the value and the list expressions.

Before this PR the query `SELECT * FROM t WHERE c IN ('2')` where c is `Int` generated the following filter:
```
Filter cast(c#31 as string) IN (cast(2 as string))
```
After this PR it generates:
```
Filter cast(c#31 as int) IN (cast(2 as int))
```
that is identical to what a `WHERE c = '2'` would do.

### Why are the changes needed?
To make `In` behave like `=` and avoid issues described in https://issues.apache.org/jira/browse/SPARK-33098 

### Does this PR introduce _any_ user-facing change?
Yes, some queries will not fail.

### How was this patch tested?
Existing UTs and I will add some new ones as well.