### PR TITLE
[SPARK-33080][BUILD] Replace fatal warnings snippet

### DIFF
--- a/core/src/test/scala/org/apache/spark/shuffle/HostLocalShuffleReadingSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/HostLocalShuffleReadingSuite.scala
@@ -58,6 +58,7 @@ class HostLocalShuffleReadingSuite extends SparkFunSuite with Matchers with Loca
     val conf = new SparkConf()
       .set(SHUFFLE_HOST_LOCAL_DISK_READING_ENABLED, true)
 
+    import scala.language.existentials
     val (essStatus, blockStoreClientClass) = if (isESSEnabled) {
       // LocalSparkCluster will disable the ExternalShuffleService by default. Therefore,
       // we have to manually setup an server which embedded with ExternalBlockHandler to

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -240,7 +240,7 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
     val driverEndpoint = rpcEnv.setupEndpoint(CoarseGrainedSchedulerBackend.ENDPOINT_NAME,
       new RpcEndpoint {
         private val executorSet = mutable.HashSet[String]()
-        override val rpcEnv: RpcEnv = this.rpcEnv
+        override val rpcEnv: RpcEnv = BlockManagerSuite.this.rpcEnv
         override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {
           case CoarseGrainedClusterMessages.RegisterExecutor(executorId, _, _, _, _, _, _, _) =>
             executorSet += executorId
@@ -254,7 +254,7 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
     def createAndRegisterBlockManager(timeout: Boolean): BlockManagerId = {
       val id = if (timeout) "timeout" else "normal"
       val bmRef = rpcEnv.setupEndpoint(s"bm-$id", new RpcEndpoint {
-        override val rpcEnv: RpcEnv = this.rpcEnv
+        override val rpcEnv: RpcEnv = BlockManagerSuite.this.rpcEnv
         private def reply[T](context: RpcCallContext, response: T): Unit = {
           if (timeout) {
             Thread.sleep(conf.getTimeAsMs(Network.RPC_ASK_TIMEOUT.key) + 1000)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizerSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizerSuite.scala
@@ -58,7 +58,7 @@ class OptimizerSuite extends PlanTest {
         try {
           optimizer.execute(analyzed)
         } catch {
-          case ex: TreeNodeException[LogicalPlan]
+          case ex: TreeNodeException[_]
             if ex.getMessage.contains(SQLConf.OPTIMIZER_MAX_ITERATIONS.key) =>
               fail("optimizer.execute should not reach max iterations.")
         }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/UnsafeArraySuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/UnsafeArraySuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.catalyst.util
 
 import java.time.{ZoneId, ZoneOffset}
 
-import scala.reflect.Manifest
+import scala.reflect.runtime.universe.TypeTag
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.serializer.{JavaSerializer, KryoSerializer}
@@ -72,9 +72,8 @@ class UnsafeArraySuite extends SparkFunSuite {
     arrayData
   }
 
-  private def toUnsafeArray[T: Manifest](array: Array[T]): ArrayData = {
+  private def toUnsafeArray[T: TypeTag](array: Array[T]): ArrayData = {
     val converted = ExpressionEncoder[Array[T]].createSerializer().apply(array).getArray(0)
-    assert(manifest[T].runtimeClass.isInstance(converted))
     assert(converted.numElements == array.length)
     converted
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/UnsafeArraySuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/UnsafeArraySuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.catalyst.util
 
 import java.time.{ZoneId, ZoneOffset}
 
-import scala.reflect.runtime.universe.TypeTag
+import scala.reflect.Manifest
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.serializer.{JavaSerializer, KryoSerializer}
@@ -72,9 +72,9 @@ class UnsafeArraySuite extends SparkFunSuite {
     arrayData
   }
 
-  private def toUnsafeArray[T : TypeTag](array: Array[T]): ArrayData = {
+  private def toUnsafeArray[T: Manifest](array: Array[T]): ArrayData = {
     val converted = ExpressionEncoder[Array[T]].createSerializer().apply(array).getArray(0)
-    assert(converted.isInstanceOf[T])
+    assert(manifest[T].runtimeClass.isInstance(converted))
     assert(converted.numElements == array.length)
     converted
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryTable.scala
@@ -107,6 +107,18 @@ class InMemoryTable(
           case (micros: Long, TimestampType) =>
             val localDate = DateTimeUtils.microsToInstant(micros).atZone(UTC).toLocalDate
             ChronoUnit.YEARS.between(EPOCH_LOCAL_DATE, localDate)
+          case _ => throw new Exception("""match may not be exhaustive.
+            t would fail on the following inputs:
+            ((_ : Int), TimestampType),
+            ((_ : Int), _),
+            ((_ : Long), DateType),
+            ((_ : Long), _),
+            (??, _),
+            (_, DataType()),
+            (_, DateType),
+            (_, TimestampType),
+            (_, _)
+            """)
         }
       case MonthsTransform(ref) =>
         extractor(ref.fieldNames, schema, row) match {
@@ -115,6 +127,18 @@ class InMemoryTable(
           case (micros: Long, TimestampType) =>
             val localDate = DateTimeUtils.microsToInstant(micros).atZone(UTC).toLocalDate
             ChronoUnit.MONTHS.between(EPOCH_LOCAL_DATE, localDate)
+          case _ => throw new Exception("""match may not be exhaustive.
+            It would fail on the following inputs:
+            ((_ : Int), TimestampType),
+            ((_ : Int), _),
+            ((_ : Long), DateType),
+            ((_ : Long), _),
+            (??, _),
+            (_, DataType()),
+            (_, DateType),
+            (_, TimestampType),
+            (_, _)"""
+          )
         }
       case DaysTransform(ref) =>
         extractor(ref.fieldNames, schema, row) match {
@@ -122,11 +146,15 @@ class InMemoryTable(
             days
           case (micros: Long, TimestampType) =>
             ChronoUnit.DAYS.between(Instant.EPOCH, DateTimeUtils.microsToInstant(micros))
+          case _ => throw new Exception("""match may not be exhaustive.
+            It would fail on the following inputs: ((_ : Long), _), (_, TimestampType), (_, _)""")
         }
       case HoursTransform(ref) =>
         extractor(ref.fieldNames, schema, row) match {
           case (micros: Long, TimestampType) =>
             ChronoUnit.HOURS.between(Instant.EPOCH, DateTimeUtils.microsToInstant(micros))
+          case _ => throw new Exception("""match may not be exhaustive.
+            It would fail on the following inputs: ((_ : Long), _), (_, TimestampType), (_, _)""")
         }
       case BucketTransform(numBuckets, ref) =>
         (extractor(ref.fieldNames, schema, row).hashCode() & Integer.MAX_VALUE) % numBuckets

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryTable.scala
@@ -107,18 +107,7 @@ class InMemoryTable(
           case (micros: Long, TimestampType) =>
             val localDate = DateTimeUtils.microsToInstant(micros).atZone(UTC).toLocalDate
             ChronoUnit.YEARS.between(EPOCH_LOCAL_DATE, localDate)
-          case _ => throw new Exception("""match may not be exhaustive.
-            t would fail on the following inputs:
-            ((_ : Int), TimestampType),
-            ((_ : Int), _),
-            ((_ : Long), DateType),
-            ((_ : Long), _),
-            (??, _),
-            (_, DataType()),
-            (_, DateType),
-            (_, TimestampType),
-            (_, _)
-            """)
+          case _ => throw new IllegalArgumentException("Match: unsupported argument(s) type")
         }
       case MonthsTransform(ref) =>
         extractor(ref.fieldNames, schema, row) match {
@@ -127,18 +116,7 @@ class InMemoryTable(
           case (micros: Long, TimestampType) =>
             val localDate = DateTimeUtils.microsToInstant(micros).atZone(UTC).toLocalDate
             ChronoUnit.MONTHS.between(EPOCH_LOCAL_DATE, localDate)
-          case _ => throw new Exception("""match may not be exhaustive.
-            It would fail on the following inputs:
-            ((_ : Int), TimestampType),
-            ((_ : Int), _),
-            ((_ : Long), DateType),
-            ((_ : Long), _),
-            (??, _),
-            (_, DataType()),
-            (_, DateType),
-            (_, TimestampType),
-            (_, _)"""
-          )
+          case _ => throw new IllegalArgumentException("Match: unsupported argument(s) type")
         }
       case DaysTransform(ref) =>
         extractor(ref.fieldNames, schema, row) match {
@@ -146,15 +124,13 @@ class InMemoryTable(
             days
           case (micros: Long, TimestampType) =>
             ChronoUnit.DAYS.between(Instant.EPOCH, DateTimeUtils.microsToInstant(micros))
-          case _ => throw new Exception("""match may not be exhaustive.
-            It would fail on the following inputs: ((_ : Long), _), (_, TimestampType), (_, _)""")
+          case _ => throw new IllegalArgumentException("Match: unsupported argument(s) type")
         }
       case HoursTransform(ref) =>
         extractor(ref.fieldNames, schema, row) match {
           case (micros: Long, TimestampType) =>
             ChronoUnit.HOURS.between(Instant.EPOCH, DateTimeUtils.microsToInstant(micros))
-          case _ => throw new Exception("""match may not be exhaustive.
-            It would fail on the following inputs: ((_ : Long), _), (_, TimestampType), (_, _)""")
+          case _ => throw new IllegalArgumentException("Match: unsupported argument(s) type")
         }
       case BucketTransform(numBuckets, ref) =>
         (extractor(ref.fieldNames, schema, row).hashCode() & Integer.MAX_VALUE) % numBuckets

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryTable.scala
@@ -107,7 +107,8 @@ class InMemoryTable(
           case (micros: Long, TimestampType) =>
             val localDate = DateTimeUtils.microsToInstant(micros).atZone(UTC).toLocalDate
             ChronoUnit.YEARS.between(EPOCH_LOCAL_DATE, localDate)
-          case _ => throw new IllegalArgumentException("Match: unsupported argument(s) type")
+          case (v, t) =>
+            throw new IllegalArgumentException("Match: unsupported argument(s) type - ($v, $t)")
         }
       case MonthsTransform(ref) =>
         extractor(ref.fieldNames, schema, row) match {
@@ -116,7 +117,8 @@ class InMemoryTable(
           case (micros: Long, TimestampType) =>
             val localDate = DateTimeUtils.microsToInstant(micros).atZone(UTC).toLocalDate
             ChronoUnit.MONTHS.between(EPOCH_LOCAL_DATE, localDate)
-          case _ => throw new IllegalArgumentException("Match: unsupported argument(s) type")
+          case (v, t) =>
+            throw new IllegalArgumentException("Match: unsupported argument(s) type - ($v, $t)")
         }
       case DaysTransform(ref) =>
         extractor(ref.fieldNames, schema, row) match {
@@ -124,13 +126,15 @@ class InMemoryTable(
             days
           case (micros: Long, TimestampType) =>
             ChronoUnit.DAYS.between(Instant.EPOCH, DateTimeUtils.microsToInstant(micros))
-          case _ => throw new IllegalArgumentException("Match: unsupported argument(s) type")
+          case (v, t) =>
+            throw new IllegalArgumentException("Match: unsupported argument(s) type - ($v, $t)")
         }
       case HoursTransform(ref) =>
         extractor(ref.fieldNames, schema, row) match {
           case (micros: Long, TimestampType) =>
             ChronoUnit.HOURS.between(Instant.EPOCH, DateTimeUtils.microsToInstant(micros))
-          case _ => throw new IllegalArgumentException("Match: unsupported argument(s) type")
+          case (v, t) =>
+            throw new IllegalArgumentException("Match: unsupported argument(s) type - ($v, $t)")
         }
       case BucketTransform(numBuckets, ref) =>
         (extractor(ref.fieldNames, schema, row).hashCode() & Integer.MAX_VALUE) % numBuckets

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryTable.scala
@@ -108,7 +108,7 @@ class InMemoryTable(
             val localDate = DateTimeUtils.microsToInstant(micros).atZone(UTC).toLocalDate
             ChronoUnit.YEARS.between(EPOCH_LOCAL_DATE, localDate)
           case (v, t) =>
-            throw new IllegalArgumentException("Match: unsupported argument(s) type - ($v, $t)")
+            throw new IllegalArgumentException(s"Match: unsupported argument(s) type - ($v, $t)")
         }
       case MonthsTransform(ref) =>
         extractor(ref.fieldNames, schema, row) match {
@@ -118,7 +118,7 @@ class InMemoryTable(
             val localDate = DateTimeUtils.microsToInstant(micros).atZone(UTC).toLocalDate
             ChronoUnit.MONTHS.between(EPOCH_LOCAL_DATE, localDate)
           case (v, t) =>
-            throw new IllegalArgumentException("Match: unsupported argument(s) type - ($v, $t)")
+            throw new IllegalArgumentException(s"Match: unsupported argument(s) type - ($v, $t)")
         }
       case DaysTransform(ref) =>
         extractor(ref.fieldNames, schema, row) match {
@@ -127,14 +127,14 @@ class InMemoryTable(
           case (micros: Long, TimestampType) =>
             ChronoUnit.DAYS.between(Instant.EPOCH, DateTimeUtils.microsToInstant(micros))
           case (v, t) =>
-            throw new IllegalArgumentException("Match: unsupported argument(s) type - ($v, $t)")
+            throw new IllegalArgumentException(s"Match: unsupported argument(s) type - ($v, $t)")
         }
       case HoursTransform(ref) =>
         extractor(ref.fieldNames, schema, row) match {
           case (micros: Long, TimestampType) =>
             ChronoUnit.HOURS.between(Instant.EPOCH, DateTimeUtils.microsToInstant(micros))
           case (v, t) =>
-            throw new IllegalArgumentException("Match: unsupported argument(s) type - ($v, $t)")
+            throw new IllegalArgumentException(s"Match: unsupported argument(s) type - ($v, $t)")
         }
       case BucketTransform(numBuckets, ref) =>
         (extractor(ref.fieldNames, schema, row).hashCode() & Integer.MAX_VALUE) % numBuckets

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
@@ -705,7 +705,7 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging wi
     val q2 = startQuery(input(1).toDS.map { i =>
       // Emulate that `StreamingQuery` get captured with normal usage unintentionally.
       // It should not fail the query.
-      q1
+      val q = q1
       i
     }, "stream_serializable_test_2")
     val q3 = startQuery(input(2).toDS.map { i =>

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -98,10 +98,8 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
           Seq(answer)
         } else {
           // spark-sql echoes the submitted queries
-          val queryEcho = query.split("\n").toList match {
-            case firstLine :: tail =>
-              s"spark-sql> $firstLine" :: tail.map(l => s"         > $l")
-          }
+          val xs = query.split("\n").toList
+          val queryEcho = s"spark-sql> ${xs.head}" :: xs.tail.map(l => s"         > $l")
           // longer lines sometimes get split in the output,
           // match the first 60 characters of each query line
           queryEcho.map(_.take(60)) :+ answer


### PR DESCRIPTION
### What changes were proposed in this pull request?

Current solution in build file to enable build failure on compilation warnings with exclusion of deprecation ones is not portable after SBT version 1.3.13 (build import fails with compilation error with SBT 1.4) and could be replaced with more robust and maintainable, especially since Scala 2.13.2 with similar built-in functionality.

Additionally, warnings were fixed to pass the build, with as few changes as possible:
warnings in 2.12 compilation fixed in code,
warnings in 2.13 compilation covered by configuration to be addressed separately

### Why are the changes needed?

Unblocks upgrade to SBT after 1.3.13.
Enhances build file maintainability.
Allows fine tune of warnings configuration in scope of Scala 2.13 compilation.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`build/sbt`'s `compile` and `Test/compile` for both Scala 2.12 and 2.13 profiles.