### PR TITLE
[SPARK-32281][SQL] Spark keep SORTED spec in metastore

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -125,6 +125,7 @@ case class CreateTableLikeCommand(
         provider = newProvider,
         partitionColumnNames = sourceTableDesc.partitionColumnNames,
         bucketSpec = sourceTableDesc.bucketSpec,
+        metaBucketSpec = sourceTableDesc.metaBucketSpec,
         properties = properties,
         tracksPartitionsInCatalog = sourceTableDesc.tracksPartitionsInCatalog)
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -453,8 +453,8 @@ private[hive] class HiveClientImpl(
       val sortColumnOrders = h.getSortCols.asScala
         .map { col =>
           (col.getCol, col.getOrder)
-        }
-      Some(HiveMetaBucketSpec(h.getNumBuckets, h.getBucketCols.asScala, sortColumnOrders))
+        }.toSeq
+      Some(HiveMetaBucketSpec(h.getNumBuckets, h.getBucketCols.asScala.toSeq, sortColumnOrders))
     } else {
       None
     }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveShowCreateTableSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveShowCreateTableSuite.scala
@@ -254,7 +254,8 @@ class HiveShowCreateTableSuite extends ShowCreateTableSuite with TestHiveSinglet
       // Creates Spark datasource table using generated Spark DDL.
       sql(sparkDDL)
       val sparkTable = spark.sharedState.externalCatalog.getTable(db, table.table)
-      checkHiveCatalogTables(hiveTable, sparkTable)
+      checkHiveCatalogTables(hiveTable.copy(metaBucketSpec = None),
+        sparkTable.copy(metaBucketSpec = None))
     } finally {
       sql(s"DROP TABLE IF EXISTS ${table.table}")
     }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveShowCreateTableSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveShowCreateTableSuite.scala
@@ -253,9 +253,9 @@ class HiveShowCreateTableSuite extends ShowCreateTableSuite with TestHiveSinglet
     try {
       // Creates Spark datasource table using generated Spark DDL.
       sql(sparkDDL)
+      println(sparkDDL)
       val sparkTable = spark.sharedState.externalCatalog.getTable(db, table.table)
-      checkHiveCatalogTables(hiveTable.copy(metaBucketSpec = None),
-        sparkTable.copy(metaBucketSpec = None))
+      checkHiveCatalogTables(hiveTable, sparkTable)
     } finally {
       sql(s"DROP TABLE IF EXISTS ${table.table}")
     }
@@ -281,6 +281,7 @@ class HiveShowCreateTableSuite extends ShowCreateTableSuite with TestHiveSinglet
         createTime = 0L,
         lastAccessTime = 0L,
         properties = table.properties.filterKeys(!nondeterministicProps.contains(_)).toMap,
+        metaBucketSpec = None,
         stats = None,
         ignoredProperties = Map.empty,
         storage = table.storage.copy(properties = Map.empty),

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveShowCreateTableSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveShowCreateTableSuite.scala
@@ -253,7 +253,6 @@ class HiveShowCreateTableSuite extends ShowCreateTableSuite with TestHiveSinglet
     try {
       // Creates Spark datasource table using generated Spark DDL.
       sql(sparkDDL)
-      println(sparkDDL)
       val sparkTable = spark.sharedState.externalCatalog.getTable(db, table.table)
       checkHiveCatalogTables(hiveTable, sparkTable)
     } finally {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Since Spark only support all ASC ordering bucket cols, and in `CatalogTable` meta it lose hive BUCKET sort info, after some command, spark update metadata, then SORT meta loss.


### Why are the changes needed?
Spark shouldn't change Hive table meta of SORT BY


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
WIP