### PR TITLE
[SPARK-XXX][INFRA] Rebalance GitHub Action jobs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -42,9 +42,11 @@ jobs:
             mllib-local, mllib,
             yarn, mesos, kubernetes, hadoop-cloud, spark-ganglia-lgpl
           - >-
-            pyspark-sql, pyspark-mllib, pyspark-resource
+            pyspark-sql
           - >-
-            pyspark-core, pyspark-streaming, pyspark-ml
+            pyspark-core, pyspark-streaming, pyspark-resource
+          - >-
+            pyspark-mllib, pyspark-ml
           - >-
             sparkr
         # Here, we split Hive and SQL tests into some of slow ones and the rest of them.
@@ -79,6 +81,7 @@ jobs:
             excluded-tags: org.apache.spark.tags.ExtendedSQLTest
             comment: "- other tests"
     env:
+      NOLINT_ON_COMPILE: 1
       MODULES_TO_TEST: ${{ matrix.modules }}
       EXCLUDED_TAGS: ${{ matrix.excluded-tags }}
       INCLUDED_TAGS: ${{ matrix.included-tags }}
@@ -186,7 +189,7 @@ jobs:
         # Hive tests become flaky when running in parallel as it's too intensive.
         if [[ "$MODULES_TO_TEST" == "hive" ]]; then export SERIAL_SBT_TESTS=1; fi
         mkdir -p ~/.m2
-        ./dev/run-tests --parallelism 2 --modules "$MODULES_TO_TEST" --included-tags "$INCLUDED_TAGS" --excluded-tags "$EXCLUDED_TAGS"
+        ./dev/run-tests --parallelism 3 --modules "$MODULES_TO_TEST" --included-tags "$INCLUDED_TAGS" --excluded-tags "$EXCLUDED_TAGS"
         rm -rf ~/.m2/repository/org/apache/spark
     - name: Upload test results to report
       if: always()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -45,6 +45,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.ParquetOutputTimestampType
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
+import org.apache.spark.tags.ExtendedSQLTest
 import org.apache.spark.util.{AccumulatorContext, AccumulatorV2}
 
 /**
@@ -1571,6 +1572,7 @@ abstract class ParquetFilterSuite extends QueryTest with ParquetTest with Shared
   }
 }
 
+@ExtendedSQLTest
 class ParquetV1FilterSuite extends ParquetFilterSuite {
   override protected def sparkConf: SparkConf =
     super
@@ -1650,6 +1652,7 @@ class ParquetV1FilterSuite extends ParquetFilterSuite {
   }
 }
 
+@ExtendedSQLTest
 class ParquetV2FilterSuite extends ParquetFilterSuite {
   // TODO: enable Parquet V2 write path after file source V2 writers are workable.
   override protected def sparkConf: SparkConf =


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to rebalance GitHub Action jobs to achieve `70 minutes` testing time.

### Why are the changes needed?

- [x] **Parallelism**: Increase the test parallelism from 2 to 3.
- [x] **Scalastyle**: Disable SBT scalastyle in building for UTs because we have `lint` job separately and Jenkins PRBuilder also do the same thing.
- [x] **SQL**: This has a longest job still. We can move some jobs from `sql - other tests` to `sql - slow tests` because there is a room in `sql - slow tests`.
- [x] **Python**: The sum of total execution time of two Python GitHub Action jobs is 3 hour 14 minutes. We had better split it.
    - https://github.com/apache/spark/runs/1240470628 (1 hour 35 min)
    - https://github.com/apache/spark/runs/1240470634 (1 hour 39 min)
- [ ] **Hive**: Rebalance `hive - slow tests`

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Check the GitHub Action job runtime in this PR.