### PR TITLE
[SPARK-32455][ML][Follow-Up] LogisticRegressionModel prediction optimization - fix incorrect initialization

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -1104,6 +1104,7 @@ class LogisticRegressionModel private[spark] (
   private var _rawThreshold = Double.NaN
 
   updateBinaryThreshold()
+  log.warn(s"_threshold=${_threshold}, _rawThreshold=${_rawThreshold}")
 
   private def updateBinaryThreshold(): Unit = {
     if (!isMultinomial) {
@@ -1205,6 +1206,7 @@ class LogisticRegressionModel private[spark] (
     super.predict(features)
   } else {
     // Note: We should use _threshold instead of $(threshold) since getThreshold is overridden.
+    log.warn(s"_threshold=${_threshold}, _rawThreshold=${_rawThreshold}")
     if (score(features) > _threshold) 1 else 0
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -1100,21 +1100,24 @@ class LogisticRegressionModel private[spark] (
 
   private lazy val _intercept = interceptVector(0)
   private lazy val _interceptVector = interceptVector.toDense
-  private var _threshold = Double.NaN
-  private var _rawThreshold = Double.NaN
+  private lazy val _binaryThresholdArray = {
+    val array = Array(Double.NaN, Double.NaN)
+    updateBinaryThresholds(array)
+    array
+  }
+  private def _threshold: Double = _binaryThresholdArray(0)
+  private def _rawThreshold: Double = _binaryThresholdArray(1)
 
-  updateBinaryThreshold()
-  log.warn(s"_threshold=${_threshold}, _rawThreshold=${_rawThreshold}")
-
-  private def updateBinaryThreshold(): Unit = {
+  private def updateBinaryThresholds(array: Array[Double]): Unit = {
     if (!isMultinomial) {
-      _threshold = getThreshold
+      val _threshold = getThreshold
+      array(0) = _threshold
       if (_threshold == 0.0) {
-        _rawThreshold = Double.NegativeInfinity
+        array(1) = Double.NegativeInfinity
       } else if (_threshold == 1.0) {
-        _rawThreshold = Double.PositiveInfinity
+        array(1) = Double.PositiveInfinity
       } else {
-        _rawThreshold = math.log(_threshold / (1.0 - _threshold))
+        array(1) = math.log(_threshold / (1.0 - _threshold))
       }
     }
   }
@@ -1122,7 +1125,7 @@ class LogisticRegressionModel private[spark] (
   @Since("1.5.0")
   override def setThreshold(value: Double): this.type = {
     super.setThreshold(value)
-    updateBinaryThreshold()
+    updateBinaryThresholds(_binaryThresholdArray)
     this
   }
 
@@ -1132,7 +1135,7 @@ class LogisticRegressionModel private[spark] (
   @Since("1.5.0")
   override def setThresholds(value: Array[Double]): this.type = {
     super.setThresholds(value)
-    updateBinaryThreshold()
+    updateBinaryThresholds(_binaryThresholdArray)
     this
   }
 
@@ -1206,7 +1209,6 @@ class LogisticRegressionModel private[spark] (
     super.predict(features)
   } else {
     // Note: We should use _threshold instead of $(threshold) since getThreshold is overridden.
-    log.warn(s"_threshold=${_threshold}, _rawThreshold=${_rawThreshold}")
     if (score(features) > _threshold) 1 else 0
   }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -400,10 +400,9 @@ class LogisticRegressionSuite extends MLTest with DefaultReadWriteTest {
   }
 
   test("thresholds prediction") {
-    val blr = new LogisticRegression().setFamily("binomial")
+    val blr = new LogisticRegression().setFamily("binomial").setThreshold(1.0)
     val binaryModel = blr.fit(smallBinaryDataset)
 
-    binaryModel.setThreshold(1.0)
     testTransformer[(Double, Vector)](smallBinaryDataset.toDF(), binaryModel, "prediction") {
       row => assert(row.getDouble(0) === 0.0)
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
use `lazy array` instead of `var` for auxiliary variables in binary lor

### Why are the changes needed?
In https://github.com/apache/spark/pull/29255, I made a mistake:
the `private var _threshold` and `_rawThreshold`  are initialized by defaut values of `threshold`, that is beacuse: 
1, param `threshold` is set default value at first;
2, `_threshold` and `_rawThreshold` are initialized based on the default value;
3, param `threshold` is updated by the value from estimator, by `copyValues` method:
```
      if (map.contains(param) && to.hasParam(param.name)) {
        to.set(param.name, map(param))
      }
```

We can update `_threshold` and `_rawThreshold` in `setThreshold` and `setThresholds`, but we can not update them in `set`/`copyValues` so their values are kept until methods `setThreshold` and `setThresholds` are called.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
test in repl
