### PR TITLE
[SPARK-33119][SQL] ScalarSubquery should returns the first two rows to avoid Driver OOM

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/subquery.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/subquery.scala
@@ -80,7 +80,8 @@ case class ScalarSubquery(
   @volatile private var updated: Boolean = false
 
   def updateResult(): Unit = {
-    val rows = plan.executeCollect()
+    // Only return the first two rows as an array to avoid Driver OOM.
+    val rows = plan.executeTake(2)
     if (rows.length > 1) {
       sys.error(s"more than one row returned by a subquery used as an expression:\n$plan")
     }


### PR DESCRIPTION

### What changes were proposed in this pull request?

`ScalarSubquery` should returns the first two rows.


### Why are the changes needed?

To avoid Driver OOM.



### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Existing test: https://github.com/apache/spark/blob/d6f3138352042e33a2291e11c325b8eadb8dd5f2/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala#L147-L154 
