### PR TITLE
[SPARK-33135][CORE] Use listLocatedStatus from FileSystem implementations

### DIFF
--- a/R/run-tests.sh
+++ b/R/run-tests.sh
@@ -23,7 +23,7 @@ FAILED=0
 LOGFILE=$FWDIR/unit-tests.out
 rm -f $LOGFILE
 
-SPARK_TESTING=1 NOT_CRAN=true $FWDIR/../bin/spark-submit --driver-java-options "-Dlog4j.configuration=file:$FWDIR/log4j.properties" --conf spark.hadoop.fs.defaultFS="file:///" --conf spark.driver.extraJavaOptions="-Dio.netty.tryReflectionSetAccessible=true" --conf spark.executor.extraJavaOptions="-Dio.netty.tryReflectionSetAccessible=true" $FWDIR/pkg/tests/run-all.R 2>&1 | tee -a $LOGFILE
+SPARK_TESTING=1 NOT_CRAN=true $FWDIR/../bin/spark-submit --driver-java-options "-Dlog4j.configuration=file:$FWDIR/log4j.properties" --conf spark.hadoop.fs.defaultFS="file:///" --conf spark.driver.extraJavaOptions="-Dio.netty.tryReflectionSetAccessible=true" --conf spark.executor.extraJavaOptions="-Dio.netty.tryReflectionSetAccessible=true" --conf spark.sql.sources.ignoreDataLocality="true" $FWDIR/pkg/tests/run-all.R 2>&1 | tee -a $LOGFILE
 FAILED=$((PIPESTATUS[0]||$FAILED))
 
 NUM_TEST_WARNING="$(grep -c -e 'Warnings ----------------' $LOGFILE)"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
@@ -214,9 +214,9 @@ class FileIndexSuite extends SharedSparkSession {
               assert(leafFiles.isEmpty)
             } else {
               assert(raceCondition == classOf[FileDeletionRaceFileSystem])
-              // One of the two leaf files was missing, but we should still list the other:
-              assert(leafFiles.size == 1)
-              assert(leafFiles.head.getPath == nonDeletedLeafFilePath)
+              // listLocatedStatus will fail as a whole because the default impl calls
+              // getFileBlockLocations
+              assert(leafFiles.isEmpty)
             }
           } else {
             // We're NOT ignoring missing files, so catalog construction should fail

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -1282,6 +1282,7 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
     // This is to avoid running a spark job to list of files in parallel
     // by the InMemoryFileIndex.
     spark.sessionState.conf.setConf(SQLConf.PARALLEL_PARTITION_DISCOVERY_THRESHOLD, numFiles * 2)
+    spark.sessionState.conf.setConf(SQLConf.IGNORE_DATA_LOCALITY, true)
 
     withTempDirs { case (root, tmp) =>
       val src = new File(root, "a=1")
@@ -1946,6 +1947,7 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
     val originClassForLocalFileSystem = spark.conf.getOption(optionKey)
     try {
       spark.conf.set(optionKey, classOf[CountListingLocalFileSystem].getName)
+      spark.conf.set(SQLConf.IGNORE_DATA_LOCALITY.key, "true")
       body
     } finally {
       originClassForLocalFileSystem match {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR removes the restriction in `HadoopFSUtils.parallelListLeafFiles` which only calls `listLocatedStatus` when the `FileSystem` is either `DistributedFileSystem` or `ViewFileSystem`. Instead, this checks locality flag and calls `listLocatedStatus` when that is set.

Consequently, this also removes the special handling when locality info is required but the file system impl is neither above. Currently in this case we'd call `getFileBlockLocations` on each `FileStatus` obtained, and do some handling on missing files as well.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

`HadoopFsUtils.parallelListLeafFiles` currently only calls `listLocatedStatus` when the `FileSystem` impl is `DistributedFileSystem` or `ViewFileSystem`. For other types of `FileSystem`, it calls `listStatus` and then subsequently calls `getFileBlockLocations` on all the result `FileStatus`es. 

In Hadoop client, `listLocatedStatus` is a well-defined API and in fact it is often overridden by specific file system implementations, such as S3A. The default `listLocatedStatus` also has similar behavior as it's done in Spark.

Therefore, instead of re-implement the logic in Spark itself, it's better to rely on the `FileSystem`-specific implementation for `listLocatedStatus`, which could include its own optimizations in the code path.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

There could be some behavior change when `spark.sql.files.ignoreMissingFiles` is set and there are race conditions during listing. 

For instance, assume locality info is required and some files in the listing result _were deleted right after the listing op, but before the subsequent `getFileBlockLocations` calls_ .  in the previous code. The previous implementation would return partial listing result, but the current impl will return an empty set, since the default `FileSystem.listLocatedStatus` will call `getFileBlockLocations` internally which will cause it fail as a whole.

On the other hand, it's also possible that new implementation returns a full list rather than a partial list in the previous impl, since we don't call `getFileBlockLocations` as a separate step now which eliminates some possibility that a file was deleted before the `getFileBlockLocations` as in the previous impl.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Relying on existing tests.