### PR TITLE
[SPARK-33123][INFRA] Ignore GitHub only changes in Amplab Jenkins build

### DIFF
--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -55,6 +55,9 @@ def determine_modules_for_files(filenames):
     for filename in filenames:
         if filename in ("appveyor.yml",):
             continue
+        if (os.environ.get("AMPLAB_JENKINS") and
+                filename in (".github/workflows/build_and_test.yml",)):
+            continue
         matched_at_least_one_module = False
         for module in modules.all_modules:
             if module.contains_file(filename):

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -42,8 +42,8 @@ def determine_modules_for_files(filenames):
     """
     Given a list of filenames, return the set of modules that contain those files.
     If a file is not associated with a more specific submodule, then this method will consider that
-    file to belong to the 'root' module. `.github` directory is ignored if AMPLAB_JENKINS is defined
-    and Appveyor files are ignored always.
+    file to belong to the 'root' module. `.github` directory is counted only in GitHub Actions,
+    and `appveyor.yml` is always ignored because this file is dedicated only to AppVeyor builds.
 
     >>> sorted(x.name for x in determine_modules_for_files(["python/pyspark/a.py", "sql/core/foo"]))
     ['pyspark-core', 'sql']

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -42,7 +42,8 @@ def determine_modules_for_files(filenames):
     """
     Given a list of filenames, return the set of modules that contain those files.
     If a file is not associated with a more specific submodule, then this method will consider that
-    file to belong to the 'root' module. GitHub Action and Appveyor files are ignored.
+    file to belong to the 'root' module. `.github` directory is ignored if AMPLAB_JENKINS is defined
+    and Appveyor files are ignored always.
 
     >>> sorted(x.name for x in determine_modules_for_files(["python/pyspark/a.py", "sql/core/foo"]))
     ['pyspark-core', 'sql']

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -56,7 +56,8 @@ def determine_modules_for_files(filenames):
         if filename in ("appveyor.yml",):
             continue
         if (os.environ.get("AMPLAB_JENKINS") and
-                filename in (".github/workflows/build_and_test.yml",)):
+                filename in (".github/workflows/build_and_test.yml",
+                             ".github/workflows/stale.yml", ".github/workflows/test_report.yml",)):
             continue
         matched_at_least_one_module = False
         for module in modules.all_modules:

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -55,9 +55,7 @@ def determine_modules_for_files(filenames):
     for filename in filenames:
         if filename in ("appveyor.yml",):
             continue
-        if (os.environ.get("AMPLAB_JENKINS") and
-                filename in (".github/workflows/build_and_test.yml",
-                             ".github/workflows/stale.yml", ".github/workflows/test_report.yml",)):
+        if (os.environ.get("AMPLAB_JENKINS") and filename.startswith(".github")):
             continue
         matched_at_least_one_module = False
         for module in modules.all_modules:

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -56,7 +56,7 @@ def determine_modules_for_files(filenames):
     for filename in filenames:
         if filename in ("appveyor.yml",):
             continue
-        if (os.environ.get("AMPLAB_JENKINS") and filename.startswith(".github")):
+        if ("GITHUB_ACTIONS" not in os.environ) and filename.startswith(".github"):
             continue
         matched_at_least_one_module = False
         for module in modules.all_modules:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to ignore GitHub only changes in Amplab Jenkins build.

### Why are the changes needed?

This will save server resources.

### Does this PR introduce _any_ user-facing change?

No, this is a dev-only change. 

### How was this patch tested?

Manually. I used the following doctest during testing and removed it at the clean-up.

E2E tests:

```
cd dev
cat test.py
```

```python
import importlib
runtests = importlib.import_module("run-tests")
print([x.name for x in runtests.determine_modules_for_files([".github/workflows/build_and_test.yml"])])
```

```python
$ GITHUB_ACTIONS=1 python test.py
['root']
$ python test.py
[]
```

Unittests:

```bash
$ GITHUN_ACTIONS=1 python3 -m doctest dev/run-tests.py
$ python3 -m doctest dev/run-tests.py
```