### PR TITLE
[SPARK-33090][BUILD][test-hadoop2.7] Upgrade Google Guava to 29.0-jre

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -299,6 +299,7 @@ org.apache.kerby:kerby-xdr
 org.apache.kerby:token-provider
 org.apache.orc:orc-core
 org.apache.orc:orc-mapreduce
+org.checkerframework:checker-qual
 org.mortbay.jetty:jetty
 org.mortbay.jetty:jetty-util
 com.jolbox:bonecp
@@ -321,10 +322,14 @@ com.github.mifmif:generex
 com.github.stephenc.jcip:jcip-annotations
 com.google.code.findbugs:jsr305
 com.google.code.gson:gson
+com.google.errorprone:error_prone_annotations
 com.google.flatbuffers:flatbuffers-java
+com.google.guava:failureaccess
 com.google.guava:guava
+com.google.guava:listenablefuture
 com.google.inject:guice
 com.google.inject.extensions:guice-servlet
+com.google.j2objc:j2objc-annotations
 com.nimbusds:nimbus-jose-jwt
 com.twitter:parquet-hadoop-bundle
 commons-cli:commons-cli

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -78,7 +78,7 @@
     <!--
       Because we don't shade dependencies anymore, we need to restore Guava to compile scope so
       that the libraries Spark depend on have it available. We'll package the version that Spark
-      uses (14.0.1) which is not the same as Hadoop dependencies, but works.
+      uses (29.0-jre) which is not the same as Hadoop dependencies, but works.
     -->
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -510,7 +510,7 @@
               <overWriteIfNewer>true</overWriteIfNewer>
               <useSubDirectoryPerType>true</useSubDirectoryPerType>
               <includeArtifactIds>
-                guava,jetty-io,jetty-servlet,jetty-servlets,jetty-continuation,jetty-http,jetty-plus,jetty-util,jetty-server,jetty-security,jetty-proxy,jetty-client
+                failureaccess,guava,jetty-io,jetty-servlet,jetty-servlets,jetty-continuation,jetty-http,jetty-plus,jetty-util,jetty-server,jetty-security,jetty-proxy,jetty-client
               </includeArtifactIds>
               <silent>true</silent>
             </configuration>

--- a/dev/deps/spark-deps-hadoop-2.7-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-2.3
@@ -28,6 +28,7 @@ bonecp/0.8.0.RELEASE//bonecp-0.8.0.RELEASE.jar
 breeze-macros_2.12/1.0//breeze-macros_2.12-1.0.jar
 breeze_2.12/1.0//breeze_2.12-1.0.jar
 cats-kernel_2.12/2.0.0-M4//cats-kernel_2.12-2.0.0-M4.jar
+checker-qual/2.11.1//checker-qual-2.11.1.jar
 chill-java/0.9.5//chill-java-0.9.5.jar
 chill_2.12/0.9.5//chill_2.12-0.9.5.jar
 commons-beanutils/1.9.4//commons-beanutils-1.9.4.jar
@@ -59,10 +60,12 @@ datanucleus-core/4.1.17//datanucleus-core-4.1.17.jar
 datanucleus-rdbms/4.1.19//datanucleus-rdbms-4.1.19.jar
 derby/10.12.1.1//derby-10.12.1.1.jar
 dropwizard-metrics-hadoop-metrics2-reporter/0.1.2//dropwizard-metrics-hadoop-metrics2-reporter-0.1.2.jar
+error_prone_annotations/2.3.4//error_prone_annotations-2.3.4.jar
+failureaccess/1.0.1//failureaccess-1.0.1.jar
 flatbuffers-java/1.9.0//flatbuffers-java-1.9.0.jar
 generex/1.0.2//generex-1.0.2.jar
 gson/2.2.4//gson-2.2.4.jar
-guava/14.0.1//guava-14.0.1.jar
+guava/29.0-jre//guava-29.0-jre.jar
 guice-servlet/3.0//guice-servlet-3.0.jar
 guice/3.0//guice-3.0.jar
 hadoop-annotations/2.7.4//hadoop-annotations-2.7.4.jar
@@ -102,6 +105,7 @@ httpclient/4.5.6//httpclient-4.5.6.jar
 httpcore/4.4.12//httpcore-4.4.12.jar
 istack-commons-runtime/3.0.8//istack-commons-runtime-3.0.8.jar
 ivy/2.4.0//ivy-2.4.0.jar
+j2objc-annotations/1.3//j2objc-annotations-1.3.jar
 jackson-annotations/2.10.0//jackson-annotations-2.10.0.jar
 jackson-core-asl/1.9.13//jackson-core-asl-1.9.13.jar
 jackson-core/2.10.0//jackson-core-2.10.0.jar
@@ -177,6 +181,7 @@ kubernetes-model-storageclass/4.10.3//kubernetes-model-storageclass-4.10.3.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 libfb303/0.9.3//libfb303-0.9.3.jar
 libthrift/0.12.0//libthrift-0.12.0.jar
+listenablefuture/9999.0-empty-to-avoid-conflict-with-guava//listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
 log4j/1.2.17//log4j-1.2.17.jar
 logging-interceptor/3.12.12//logging-interceptor-3.12.12.jar
 lz4-java/1.7.1//lz4-java-1.7.1.jar

--- a/dev/deps/spark-deps-hadoop-3.2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3.2-hive-2.3
@@ -25,6 +25,7 @@ bonecp/0.8.0.RELEASE//bonecp-0.8.0.RELEASE.jar
 breeze-macros_2.12/1.0//breeze-macros_2.12-1.0.jar
 breeze_2.12/1.0//breeze_2.12-1.0.jar
 cats-kernel_2.12/2.0.0-M4//cats-kernel_2.12-2.0.0-M4.jar
+checker-qual/2.11.1//checker-qual-2.11.1.jar
 chill-java/0.9.5//chill-java-0.9.5.jar
 chill_2.12/0.9.5//chill_2.12-0.9.5.jar
 commons-beanutils/1.9.4//commons-beanutils-1.9.4.jar
@@ -58,11 +59,13 @@ derby/10.12.1.1//derby-10.12.1.1.jar
 dnsjava/2.1.7//dnsjava-2.1.7.jar
 dropwizard-metrics-hadoop-metrics2-reporter/0.1.2//dropwizard-metrics-hadoop-metrics2-reporter-0.1.2.jar
 ehcache/3.3.1//ehcache-3.3.1.jar
+error_prone_annotations/2.3.4//error_prone_annotations-2.3.4.jar
+failureaccess/1.0.1//failureaccess-1.0.1.jar
 flatbuffers-java/1.9.0//flatbuffers-java-1.9.0.jar
 generex/1.0.2//generex-1.0.2.jar
 geronimo-jcache_1.0_spec/1.0-alpha-1//geronimo-jcache_1.0_spec-1.0-alpha-1.jar
 gson/2.2.4//gson-2.2.4.jar
-guava/14.0.1//guava-14.0.1.jar
+guava/29.0-jre//guava-29.0-jre.jar
 guice-servlet/4.0//guice-servlet-4.0.jar
 guice/4.0//guice-4.0.jar
 hadoop-annotations/3.2.0//hadoop-annotations-3.2.0.jar
@@ -101,6 +104,7 @@ httpclient/4.5.6//httpclient-4.5.6.jar
 httpcore/4.4.12//httpcore-4.4.12.jar
 istack-commons-runtime/3.0.8//istack-commons-runtime-3.0.8.jar
 ivy/2.4.0//ivy-2.4.0.jar
+j2objc-annotations/1.3//j2objc-annotations-1.3.jar
 jackson-annotations/2.10.0//jackson-annotations-2.10.0.jar
 jackson-core-asl/1.9.13//jackson-core-asl-1.9.13.jar
 jackson-core/2.10.0//jackson-core-2.10.0.jar
@@ -189,6 +193,7 @@ kubernetes-model-storageclass/4.10.3//kubernetes-model-storageclass-4.10.3.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 libfb303/0.9.3//libfb303-0.9.3.jar
 libthrift/0.12.0//libthrift-0.12.0.jar
+listenablefuture/9999.0-empty-to-avoid-conflict-with-guava//listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
 log4j/1.2.17//log4j-1.2.17.jar
 logging-interceptor/3.12.12//logging-interceptor-3.12.12.jar
 lz4-java/1.7.1//lz4-java-1.7.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
     <!-- org.apache.commons/commons-pool2/-->
     <commons-pool2.version>2.6.2</commons-pool2.version>
     <datanucleus-core.version>4.1.17</datanucleus-core.version>
-    <guava.version>14.0.1</guava.version>
+    <guava.version>29.0-jre</guava.version>
     <janino.version>3.0.16</janino.version>
     <jersey.version>2.30</jersey.version>
     <joda.version>2.10.5</joda.version>
@@ -2877,6 +2877,7 @@
               <include>org.eclipse.jetty:jetty-security</include>
               <include>org.eclipse.jetty:jetty-util</include>
               <include>org.eclipse.jetty:jetty-server</include>
+              <include>com.google.guava:failureaccess</include>
               <include>com.google.guava:guava</include>
               <include>org.jpmml:*</include>
             </includes>


### PR DESCRIPTION
 * Compatible with Hadoop > 3.2.0
 * Future proof for a while

### What changes were proposed in this pull request?

Upgrade the Google Guava dependency for compatibility with Hadoop 3.2.1 and Hadoop 3.3.0. 

### Why are the changes needed?

Spark fails at runtime with NoSuchMethodExceptions when built/run in conjunction with these versions, which make use of com.google.common.base.Preconditions methods that are not present in the version of Guava currently specified for Spark.


### Does this PR introduce _any_ user-facing change?
This change introduces new dependencies into the build which are imported by the guava pom file.

### How was this patch tested?
We are currently running ETL production processes using Spark builds with this Guava version (based on the 3.0.1 tag).

