### PR TITLE
[SPARK-32978][SQL] Make sure the number of dynamic part metric is correct

### DIFF
--- a/sql/core/benchmarks/InsertTableWithDynamicPartitionsBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/InsertTableWithDynamicPartitionsBenchmark-jdk11-results.txt
@@ -1,0 +1,8 @@
+OpenJDK 64-Bit Server VM 11.0.8+10-LTS on Mac OS X 10.15.7
+Intel(R) Core(TM) i5-7360U CPU @ 2.30GHz
+dynamic insert table benchmark, totalRows = 200000:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+----------------------------------------------------------------------------------------------------------------------------------
+one partition column, 100 partitions                        16396          16688         413          0.0       81978.3       1.0X
+two partition columns, 500 partitions                       50356          50924         804          0.0      251777.9       0.3X
+three partition columns, 2000 partitions                   144342         144850         718          0.0      721710.9       0.1X
+

--- a/sql/core/benchmarks/InsertTableWithDynamicPartitionsBenchmark-results.txt
+++ b/sql/core/benchmarks/InsertTableWithDynamicPartitionsBenchmark-results.txt
@@ -1,0 +1,8 @@
+OpenJDK 64-Bit Server VM 1.8.0_232-b18 on Mac OS X 10.15.7
+Intel(R) Core(TM) i5-7360U CPU @ 2.30GHz
+dynamic insert table benchmark, totalRows = 200000:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+----------------------------------------------------------------------------------------------------------------------------------
+one partition column, 100 partitions                        23370          23588         309          0.0      116848.3       1.0X
+two partition columns, 500 partitions                       37686          38079         555          0.0      188432.2       0.6X
+three partition columns, 2000 partitions                   112489         113049         792          0.0      562446.1       0.2X
+

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/BasicWriteStatsTracker.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/BasicWriteStatsTracker.scala
@@ -50,7 +50,7 @@ case class BasicWriteTaskStats(
 class BasicWriteTaskStatsTracker(hadoopConf: Configuration)
   extends WriteTaskStatsTracker with Logging {
 
-  private[this] var partitions: mutable.ArraySeq[InternalRow] = mutable.ArraySeq.empty
+  private[this] val partitions: mutable.ArrayBuffer[InternalRow] = mutable.ArrayBuffer.empty
   private[this] var numFiles: Int = 0
   private[this] var submittedFiles: Int = 0
   private[this] var numBytes: Long = 0L
@@ -78,7 +78,7 @@ class BasicWriteTaskStatsTracker(hadoopConf: Configuration)
 
 
   override def newPartition(partitionValues: InternalRow): Unit = {
-    partitions = partitions :+ partitionValues
+    partitions.append(partitionValues)
   }
 
   override def newBucket(bucketId: Int): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/BasicWriteStatsTracker.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/BasicWriteStatsTracker.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql.execution.datasources
 
 import java.io.FileNotFoundException
 
+import scala.collection.mutable
+
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
@@ -30,12 +32,13 @@ import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.util.SerializableConfiguration
 
 
+
 /**
  * Simple metrics collected during an instance of [[FileFormatDataWriter]].
  * These were first introduced in https://github.com/apache/spark/pull/18159 (SPARK-20703).
  */
 case class BasicWriteTaskStats(
-    numPartitions: Int,
+    partitions: Seq[InternalRow],
     numFiles: Int,
     numBytes: Long,
     numRows: Long)
@@ -48,7 +51,7 @@ case class BasicWriteTaskStats(
 class BasicWriteTaskStatsTracker(hadoopConf: Configuration)
   extends WriteTaskStatsTracker with Logging {
 
-  private[this] var numPartitions: Int = 0
+  private[this] var partitions: mutable.ArraySeq[InternalRow] = mutable.ArraySeq.empty
   private[this] var numFiles: Int = 0
   private[this] var submittedFiles: Int = 0
   private[this] var numBytes: Long = 0L
@@ -76,7 +79,7 @@ class BasicWriteTaskStatsTracker(hadoopConf: Configuration)
 
 
   override def newPartition(partitionValues: InternalRow): Unit = {
-    numPartitions += 1
+    partitions = partitions :+ partitionValues
   }
 
   override def newBucket(bucketId: Int): Unit = {
@@ -117,7 +120,7 @@ class BasicWriteTaskStatsTracker(hadoopConf: Configuration)
         "This could be due to the output format not writing empty files, " +
         "or files being not immediately visible in the filesystem.")
     }
-    BasicWriteTaskStats(numPartitions, numFiles, numBytes, numRows)
+    BasicWriteTaskStats(partitions.toSeq, numFiles, numBytes, numRows)
   }
 }
 
@@ -139,7 +142,7 @@ class BasicWriteJobStatsTracker(
 
   override def processStats(stats: Seq[WriteTaskStats]): Unit = {
     val sparkContext = SparkContext.getActive.get
-    var numPartitions: Long = 0L
+    var partitionsSet: mutable.Set[InternalRow] = mutable.HashSet.empty
     var numFiles: Long = 0L
     var totalNumBytes: Long = 0L
     var totalNumOutput: Long = 0L
@@ -147,11 +150,13 @@ class BasicWriteJobStatsTracker(
     val basicStats = stats.map(_.asInstanceOf[BasicWriteTaskStats])
 
     basicStats.foreach { summary =>
-      numPartitions += summary.numPartitions
+      partitionsSet ++= summary.partitions
       numFiles += summary.numFiles
       totalNumBytes += summary.numBytes
       totalNumOutput += summary.numRows
     }
+
+    val numPartitions: Long = partitionsSet.size
 
     metrics(BasicWriteJobStatsTracker.NUM_FILES_KEY).add(numFiles)
     metrics(BasicWriteJobStatsTracker.NUM_OUTPUT_BYTES_KEY).add(totalNumBytes)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/BasicWriteStatsTracker.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/BasicWriteStatsTracker.scala
@@ -32,7 +32,6 @@ import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.util.SerializableConfiguration
 
 
-
 /**
  * Simple metrics collected during an instance of [[FileFormatDataWriter]].
  * These were first introduced in https://github.com/apache/spark/pull/18159 (SPARK-20703).
@@ -156,12 +155,10 @@ class BasicWriteJobStatsTracker(
       totalNumOutput += summary.numRows
     }
 
-    val numPartitions: Long = partitionsSet.size
-
     metrics(BasicWriteJobStatsTracker.NUM_FILES_KEY).add(numFiles)
     metrics(BasicWriteJobStatsTracker.NUM_OUTPUT_BYTES_KEY).add(totalNumBytes)
     metrics(BasicWriteJobStatsTracker.NUM_OUTPUT_ROWS_KEY).add(totalNumOutput)
-    metrics(BasicWriteJobStatsTracker.NUM_PARTS_KEY).add(numPartitions)
+    metrics(BasicWriteJobStatsTracker.NUM_PARTS_KEY).add(partitionsSet.size)
 
     val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
     SQLMetrics.postDriverMetricUpdates(sparkContext, executionId, metrics.values.toList)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/InsertTableWithDynamicPartitionsBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/InsertTableWithDynamicPartitionsBenchmark.scala
@@ -37,7 +37,7 @@ object InsertTableWithDynamicPartitionsBenchmark extends DataSourceWriteBenchmar
     SparkSession.builder().master("local[4]").getOrCreate()
   }
 
-  def prepareSourceTableAndGetTotalRowsCount(numberRows: Long,
+  def prepareSourceTableAndGetTotalRows(numberRows: Long, sourceTable: String,
       part1Step: Int, part2Step: Int, part3Step: Int): Long = {
     val dataFrame = spark.range(0, numberRows, 1, 4)
     val dataFrame1 = spark.range(0, numberRows, part1Step, 4)
@@ -46,74 +46,48 @@ object InsertTableWithDynamicPartitionsBenchmark extends DataSourceWriteBenchmar
 
     val data = dataFrame.join(dataFrame1).join(dataFrame2).join(dataFrame3)
       .toDF("id", "part1", "part2", "part3")
-
-    data.createOrReplaceTempView("tmpTable")
-
-    spark.sql("create table " +
-      "sourceTable(id bigint, part1 bigint, part2 bigint, part3 bigint) " +
-      "using parquet")
-
-    spark.sql("insert overwrite table sourceTable " +
-      s"select id, " +
-      s"part1, " +
-      s"part2, " +
-      s"part3 " +
-      s"from tmpTable")
-
-    spark.catalog.dropTempView("tmpTable")
+    data.write.saveAsTable(sourceTable)
     data.count()
   }
 
-  def prepareTable(): Unit = {
-    spark.sql("create table " +
-      "tableOnePartitionColumn(i bigint, part bigint) " +
+  def writeOnePartitionColumnTable(tableName: String,
+      partitionNumber: Long, benchmark: Benchmark): Unit = {
+    spark.sql(s"create table $tableName(i bigint, part bigint) " +
       "using parquet partitioned by (part)")
-    spark.sql("create table " +
-      "tableTwoPartitionColumn(i bigint, part1 bigint, part2 bigint) " +
-      "using parquet partitioned by (part1, part2)")
-    spark.sql("create table " +
-      "tableThreePartitionColumn(i bigint, part1 bigint, part2 bigint, part3 bigint) " +
-      "using parquet partitioned by (part1, part2, part3)")
-  }
-
-  def writeOnePartitionColumnTable(partitionNumber: Long, benchmark: Benchmark): Unit = {
     benchmark.addCase(s"one partition column, $partitionNumber partitions") { _ =>
       spark.sql("insert overwrite table " +
-        "tableOnePartitionColumn partition(part) " +
-        s"select id, " +
-        s"part1 as part " +
-        s"from sourceTable")
+        s"$tableName partition(part) " +
+        "select id, part1 as part from sourceTable")
     }
   }
 
-  def writeTwoPartitionColumnTable(partitionNumber: Long, benchmark: Benchmark): Unit = {
+  def writeTwoPartitionColumnTable(tableName: String,
+      partitionNumber: Long, benchmark: Benchmark): Unit = {
+    spark.sql(s"create table $tableName(i bigint, part1 bigint, part2 bigint) " +
+      "using parquet partitioned by (part1, part2)")
     benchmark.addCase(s"two partition columns, $partitionNumber partitions") { _ =>
       spark.sql("insert overwrite table " +
-        "tableTwoPartitionColumn partition(part1, part2) " +
-        s"select id, " +
-        s"part1, " +
-        s"part2 " +
-        s"from sourceTable")
+        s"$tableName partition(part1, part2) " +
+        "select id, part1, part2 from sourceTable")
     }
   }
 
-  def writeThreePartitionColumnTable(partitionNumber: Long, benchmark: Benchmark): Unit = {
+  def writeThreePartitionColumnTable(tableName: String,
+      partitionNumber: Long, benchmark: Benchmark): Unit = {
+    spark.sql(s"create table $tableName(i bigint, part1 bigint, part2 bigint, part3 bigint) " +
+      "using parquet partitioned by (part1, part2, part3)")
     benchmark.addCase(s"three partition columns, $partitionNumber partitions") { _ =>
       spark.sql("insert overwrite table " +
-        "tableThreePartitionColumn partition(part1, part2, part3) " +
-        s"select id, " +
-        s"part1, " +
-        s"part2, " +
-        s"part3 " +
-        s"from sourceTable")
+        s"$tableName partition(part1, part2, part3) " +
+        "select id, part1, part2, part3 from sourceTable")
     }
   }
 
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
     val sourceTable = "sourceTable"
-    val tableOnePartitionColumn = "tableOnePartitionColumn"
-    val tableTwoPartitionColumn = "tableTwoPartitionColumn"
-    val tableThreePartitionColumn = "tableThreePartitionColumn"
+    val onePartColTable = "onePartColTable"
+    val twoPartColTable = "twoPartColTable"
+    val threePartColTable = "threePartColTable"
     val numberRows = 100L
     val part1Step = 1
     val part2Step = 20
@@ -121,17 +95,16 @@ object InsertTableWithDynamicPartitionsBenchmark extends DataSourceWriteBenchmar
     val part1Number = numberRows / part1Step
     val part2Number = numberRows / part2Step *  part1Number
     val part3Number = numberRows / part3Step *  part2Number
-    withTable(sourceTable, tableOnePartitionColumn, tableTwoPartitionColumn,
-      tableThreePartitionColumn) {
+
+    withTable(sourceTable, onePartColTable, twoPartColTable, threePartColTable) {
       val totalRows =
-        prepareSourceTableAndGetTotalRowsCount(numberRows, part1Step, part2Step, part3Step)
-      prepareTable()
+        prepareSourceTableAndGetTotalRows(numberRows, sourceTable, part1Step, part2Step, part3Step)
       val benchmark =
         new Benchmark(s"dynamic insert table benchmark, totalRows = $totalRows",
           totalRows, output = output)
-      writeOnePartitionColumnTable(part1Number, benchmark)
-      writeTwoPartitionColumnTable(part2Number, benchmark)
-      writeThreePartitionColumnTable(part3Number, benchmark)
+      writeOnePartitionColumnTable(onePartColTable, part1Number, benchmark)
+      writeTwoPartitionColumnTable(twoPartColTable, part2Number, benchmark)
+      writeThreePartitionColumnTable(threePartColTable, part3Number, benchmark)
       benchmark.run()
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/InsertTableWithDynamicPartitionsBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/InsertTableWithDynamicPartitionsBenchmark.scala
@@ -52,8 +52,7 @@ object InsertTableWithDynamicPartitionsBenchmark extends DataSourceWriteBenchmar
   def writeOnePartitionColumnTable(
       numberRows: Int, partitionNumberSeeds: Seq[Int], benchmark: Benchmark): Unit = {
     partitionNumberSeeds.foreach { partitionNumber =>
-      benchmark.addCase(s"insert table with $numberRows rows, " +
-        s"one partition column, $partitionNumber partitions") { _ =>
+      benchmark.addCase(s"one partition column, $partitionNumber partitions") { _ =>
         spark.sql("insert overwrite table " +
           "tableOnePartitionColumn partition(part) " +
           s"select id, " +
@@ -66,8 +65,7 @@ object InsertTableWithDynamicPartitionsBenchmark extends DataSourceWriteBenchmar
   def writeTwoPartitionColumnTable(
       numberRows: Int, partitionNumberSeeds: Seq[Int], benchmark: Benchmark): Unit = {
     partitionNumberSeeds.foreach { partitionNumber =>
-      benchmark.addCase(s"insert table with $numberRows rows, " +
-        s"two partition columns, $partitionNumber partitions") { _ =>
+      benchmark.addCase(s"two partition columns, $partitionNumber partitions") { _ =>
         spark.sql("insert overwrite table " +
           "tableTwoPartitionColumn partition(part1, part2) " +
           s"select id, " +
@@ -81,8 +79,7 @@ object InsertTableWithDynamicPartitionsBenchmark extends DataSourceWriteBenchmar
   def writeThreePartitionColumnTable(
       numberRows: Int, partitionNumberSeeds: Seq[Int], benchmark: Benchmark): Unit = {
     partitionNumberSeeds.foreach { partitionNumber =>
-      benchmark.addCase(s"insert table with $numberRows rows, " +
-        s"three partition columns, $partitionNumber partitions") { _ =>
+      benchmark.addCase(s"three partition columns, $partitionNumber partitions") { _ =>
         spark.sql("insert overwrite table " +
           "tableThreePartitionColumn partition(part1, part2, part3) " +
           s"select id, " +

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/InsertTableWithDynamicPartitionsBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/InsertTableWithDynamicPartitionsBenchmark.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.execution.benchmark
 
 import org.apache.spark.benchmark.Benchmark
-import org.apache.spark.sql.SparkSession
 
 /**
  * Benchmark to measure insert into table with dynamic partition columns.
@@ -32,10 +31,6 @@ import org.apache.spark.sql.SparkSession
  * }}}
  */
 object InsertTableWithDynamicPartitionsBenchmark extends DataSourceWriteBenchmark {
-
-  override def getSparkSession: SparkSession = {
-    SparkSession.builder().master("local[4]").getOrCreate()
-  }
 
   def prepareSourceTableAndGetTotalRows(numberRows: Long, sourceTable: String,
       part1Step: Int, part2Step: Int, part3Step: Int): Long = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/InsertTableWithDynamicPartitionsBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/InsertTableWithDynamicPartitionsBenchmark.scala
@@ -55,8 +55,7 @@ object InsertTableWithDynamicPartitionsBenchmark extends DataSourceWriteBenchmar
     spark.sql(s"create table $tableName(i bigint, part bigint) " +
       "using parquet partitioned by (part)")
     benchmark.addCase(s"one partition column, $partitionNumber partitions") { _ =>
-      spark.sql("insert overwrite table " +
-        s"$tableName partition(part) " +
+      spark.sql(s"insert overwrite table $tableName partition(part) " +
         "select id, part1 as part from sourceTable")
     }
   }
@@ -66,8 +65,7 @@ object InsertTableWithDynamicPartitionsBenchmark extends DataSourceWriteBenchmar
     spark.sql(s"create table $tableName(i bigint, part1 bigint, part2 bigint) " +
       "using parquet partitioned by (part1, part2)")
     benchmark.addCase(s"two partition columns, $partitionNumber partitions") { _ =>
-      spark.sql("insert overwrite table " +
-        s"$tableName partition(part1, part2) " +
+      spark.sql(s"insert overwrite table $tableName partition(part1, part2) " +
         "select id, part1, part2 from sourceTable")
     }
   }
@@ -77,8 +75,7 @@ object InsertTableWithDynamicPartitionsBenchmark extends DataSourceWriteBenchmar
     spark.sql(s"create table $tableName(i bigint, part1 bigint, part2 bigint, part3 bigint) " +
       "using parquet partitioned by (part1, part2, part3)")
     benchmark.addCase(s"three partition columns, $partitionNumber partitions") { _ =>
-      spark.sql("insert overwrite table " +
-        s"$tableName partition(part1, part2, part3) " +
+      spark.sql(s"insert overwrite table $tableName partition(part1, part2, part3) " +
         "select id, part1, part2, part3 from sourceTable")
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/InsertTableWithDynamicPartitionsBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/InsertTableWithDynamicPartitionsBenchmark.scala
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.benchmark
+
+import org.apache.spark.benchmark.Benchmark
+import org.apache.spark.sql.SparkSession
+
+/**
+ * Benchmark to measure insert into table with dynamic partition columns.
+ * To run this benchmark:
+ * {{{
+ *   1. without sbt: bin/spark-submit --class <this class> <spark sql test jar>
+ *   2. build/sbt "sql/test:runMain <this class>"
+ *   3. generate result: SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/test:runMain <this class>"
+ *      Results will be written to
+ *      "benchmarks/InsertTableWithDynamicPartitionsBenchmark-results.txt".
+ * }}}
+ */
+object InsertTableWithDynamicPartitionsBenchmark extends DataSourceWriteBenchmark {
+
+  override def getSparkSession: SparkSession = {
+    SparkSession.builder().master("local[4]").getOrCreate()
+  }
+
+  def prepareTable(): Unit = {
+    spark.sql("create table " +
+      "tableOnePartitionColumn(i bigint, part bigint) " +
+      "using parquet partitioned by (part)")
+    spark.sql("create table " +
+      "tableTwoPartitionColumn(i bigint, part1 bigint, part2 bigint) " +
+      "using parquet partitioned by (part1, part2)")
+    spark.sql("create table " +
+      "tableThreePartitionColumn(i bigint, part1 bigint, part2 bigint, part3 bigint) " +
+      "using parquet partitioned by (part1, part2, part3)")
+  }
+
+  def writeOnePartitionColumnTable(
+      numberRows: Int, partitionNumberSeeds: Seq[Int], benchmark: Benchmark): Unit = {
+    partitionNumberSeeds.foreach { partitionNumber =>
+      benchmark.addCase(s"insert table with $numberRows rows, " +
+        s"one partition column, $partitionNumber partitions") { _ =>
+        spark.sql("insert overwrite table " +
+          "tableOnePartitionColumn partition(part) " +
+          s"select id, " +
+          s"id % $partitionNumber as part " +
+          s"from range($numberRows)")
+      }
+    }
+  }
+
+  def writeTwoPartitionColumnTable(
+      numberRows: Int, partitionNumberSeeds: Seq[Int], benchmark: Benchmark): Unit = {
+    partitionNumberSeeds.foreach { partitionNumber =>
+      benchmark.addCase(s"insert table with $numberRows rows, " +
+        s"two partition columns, $partitionNumber partitions") { _ =>
+        spark.sql("insert overwrite table " +
+          "tableTwoPartitionColumn partition(part1, part2) " +
+          s"select id, " +
+          s"id % $partitionNumber as part1, " +
+          s"id % $partitionNumber as part2 " +
+          s"from range($numberRows)")
+      }
+    }
+  }
+
+  def writeThreePartitionColumnTable(
+      numberRows: Int, partitionNumberSeeds: Seq[Int], benchmark: Benchmark): Unit = {
+    partitionNumberSeeds.foreach { partitionNumber =>
+      benchmark.addCase(s"insert table with $numberRows rows, " +
+        s"three partition columns, $partitionNumber partitions") { _ =>
+        spark.sql("insert overwrite table " +
+          "tableThreePartitionColumn partition(part1, part2, part3) " +
+          s"select id, " +
+          s"id % $partitionNumber as part1, " +
+          s"id % $partitionNumber as part2, " +
+          s"id % $partitionNumber as part3 " +
+          s"from range($numberRows)")
+      }
+    }
+  }
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    val tableOnePartitionColumn = "tableOnePartitionColumn"
+    val tableTwoPartitionColumn = "tableTwoPartitionColumn"
+    val tableThreePartitionColumn = "tableThreePartitionColumn"
+    val numberRows = 10000
+    val partitionNumberSeeds = Seq(10, 50, 100, 200, 500)
+    withTable(tableOnePartitionColumn, tableTwoPartitionColumn, tableThreePartitionColumn) {
+      prepareTable()
+      val benchmark = new Benchmark(s"dynamic insert table benchmark", numberRows, output = output)
+      writeOnePartitionColumnTable(numberRows, partitionNumberSeeds, benchmark)
+      writeTwoPartitionColumnTable(numberRows, partitionNumberSeeds, benchmark)
+      writeThreePartitionColumnTable(numberRows, partitionNumberSeeds, benchmark)
+      benchmark.run()
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/BasicWriteJobStatsTrackerMetricSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/BasicWriteJobStatsTrackerMetricSuite.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.{LocalSparkSession, SparkSession}
+
+class BasicWriteJobStatsTrackerMetricSuite extends SparkFunSuite with LocalSparkSession {
+
+  test("SPARK-32978: make sure the number of dynamic part metric is correct") {
+    try {
+      val partitions = "50"
+      spark = SparkSession.builder().master("local[4]").getOrCreate()
+      val statusStore = spark.sharedState.statusStore
+      val oldExecutionsSize = statusStore.executionsList().size
+
+      spark.sql("create table dynamic_partition(i bigint, part bigint) " +
+        "using parquet partitioned by (part)").collect()
+      spark.sql("insert overwrite table dynamic_partition partition(part) " +
+        s"select id, id % $partitions as part from range(10000)").collect()
+
+      // Wait for listener to finish computing the metrics for the executions.
+      while (statusStore.executionsList().size - oldExecutionsSize < 4 ||
+        statusStore.executionsList().last.metricValues == null) {
+        Thread.sleep(100)
+      }
+
+      // There should be 4 SQLExecutionUIData in executionsList and the 3rd item is we need,
+      // but the executionId is indeterminate in maven test,
+      // so the `statusStore.execution(executionId)` API is not used.
+      assert(statusStore.executionsCount() == 4)
+      val executionData = statusStore.executionsList()(2)
+      val accumulatorIdOpt =
+        executionData.metrics.find(_.name == "number of dynamic part").map(_.accumulatorId)
+      assert(accumulatorIdOpt.isDefined)
+      val numPartsOpt = executionData.metricValues.get(accumulatorIdOpt.get)
+      assert(numPartsOpt.isDefined && numPartsOpt.get == partitions)
+
+    } finally {
+      spark.sql("drop table if exists dynamic_partition")
+      spark.stop()
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

The purpose of this pr is to resolve SPARK-32978.

The main reason of bad case describe in SPARK-32978 is the `BasicWriteTaskStatsTracker` directly reports the new added partition number of each task, which makes it impossible to remove duplicate data in driver side.

The main of this pr is change to report partitionValues to driver and remove duplicate data at driver side to make sure the number of dynamic part metric is correct.
 
### Why are the changes needed?
The the number of dynamic part metric we display on the UI should be correct.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add a new test case refer to described in SPARK-32978
