### PR TITLE
[SPARK-33134][SQL][3.0] Return partial results only for root JSON objects

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -712,4 +712,17 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
          | """.stripMargin)
     checkAnswer(toDF("yyyy-MM-dd'T'HH:mm:ss.SSSXXX"), toDF("yyyy-MM-dd'T'HH:mm:ss[.SSS][XXX]"))
   }
+
+  test("SPARK-XXXXX: ") {
+    val pokerhand_raw = Seq("""[{"cards": [11], "playerId": 583651}]""").toDF("events")
+    val event = new StructType()
+      .add("playerId", LongType)
+      .add("cards", ArrayType(
+        new StructType()
+          .add("id", LongType)
+          .add("rank", StringType)))
+    val pokerhand_events = pokerhand_raw
+      .select(explode(from_json($"events", ArrayType(event))).as("event"))
+    assert(pokerhand_events.count() === 0)
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -715,18 +715,15 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
 
   test("SPARK-33134: return partial results only for root JSON objects") {
     val st = new StructType()
-      .add("playerId", LongType)
-      .add("cards", ArrayType(
-        new StructType()
-          .add("id", LongType)
-          .add("rank", StringType)))
-    val df1 = Seq("""{"cards": [11], "playerId": 583651}""").toDF("events")
-    checkAnswer(df1.select(from_json($"events", st)), Row(Row(583651, null)))
-    val df2 = Seq("""{"data": {"cards": [11], "playerId": 583651}}""").toDF("events")
-    checkAnswer(df2.select(from_json($"events", new StructType().add("data", st))), Row(Row(null)))
-    val df3 = Seq("""[{"cards": [11], "playerId": 583651}]""").toDF("events")
-    checkAnswer(df3.select(from_json($"events", ArrayType(st))), Row(null))
-    val df4 = Seq("""{"cards": [11]}""").toDF("events")
-    checkAnswer(df4.select(from_json($"events", MapType(StringType, st))), Row(null))
+      .add("c1", LongType)
+      .add("c2", ArrayType(new StructType().add("c3", LongType).add("c4", StringType)))
+    val df1 = Seq("""{"c2": [19], "c1": 123456}""").toDF("c0")
+    checkAnswer(df1.select(from_json($"c0", st)), Row(Row(123456, null)))
+    val df2 = Seq("""{"data": {"c2": [19], "c1": 123456}}""").toDF("c0")
+    checkAnswer(df2.select(from_json($"c0", new StructType().add("data", st))), Row(Row(null)))
+    val df3 = Seq("""[{"c2": [19], "c1": 583651}]""").toDF("c0")
+    checkAnswer(df3.select(from_json($"c0", ArrayType(st))), Row(null))
+    val df4 = Seq("""{"c2": [19]}""").toDF("c0")
+    checkAnswer(df4.select(from_json($"c0", MapType(StringType, st))), Row(null))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -713,16 +713,14 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
     checkAnswer(toDF("yyyy-MM-dd'T'HH:mm:ss.SSSXXX"), toDF("yyyy-MM-dd'T'HH:mm:ss[.SSS][XXX]"))
   }
 
-  test("SPARK-XXXXX: ") {
-    val pokerhand_raw = Seq("""[{"cards": [11], "playerId": 583651}]""").toDF("events")
+  test("SPARK-33134: ignore nested JSON fields not matched to the specified schema") {
+    val df = Seq("""[{"cards": [11], "playerId": 583651}]""").toDF("events")
     val event = new StructType()
       .add("playerId", LongType)
       .add("cards", ArrayType(
         new StructType()
           .add("id", LongType)
           .add("rank", StringType)))
-    val pokerhand_events = pokerhand_raw
-      .select(explode(from_json($"events", ArrayType(event))).as("event"))
-    checkAnswer(pokerhand_events, Seq.empty)
+    checkAnswer(df.select(from_json($"events", ArrayType(event))), Row(null))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -721,7 +721,7 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
     checkAnswer(df1.select(from_json($"c0", st)), Row(Row(123456, null)))
     val df2 = Seq("""{"data": {"c2": [19], "c1": 123456}}""").toDF("c0")
     checkAnswer(df2.select(from_json($"c0", new StructType().add("data", st))), Row(Row(null)))
-    val df3 = Seq("""[{"c2": [19], "c1": 583651}]""").toDF("c0")
+    val df3 = Seq("""[{"c2": [19], "c1": 123456}]""").toDF("c0")
     checkAnswer(df3.select(from_json($"c0", ArrayType(st))), Row(null))
     val df4 = Seq("""{"c2": [19]}""").toDF("c0")
     checkAnswer(df4.select(from_json($"c0", MapType(StringType, st))), Row(null))

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -723,6 +723,6 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
           .add("rank", StringType)))
     val pokerhand_events = pokerhand_raw
       .select(explode(from_json($"events", ArrayType(event))).as("event"))
-    assert(pokerhand_events.count() === 0)
+    checkAnswer(pokerhand_events, Seq.empty)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to restrict the partial result feature only by root JSON objects. JSON datasource as well as `from_json()` will return `null` for malformed nested JSON objects.

### Why are the changes needed?
1. To not raise exception to users in the PERMISSIVE mode
2. To fix a regression and to have the same behavior as Spark 2.4.x has
3. Current implementation of partial result is supposed to work only for root (top-level) JSON objects, and not tested for bad nested complex JSON fields.

### Does this PR introduce _any_ user-facing change?
Yes. Before the changes, the code below:
```scala
    val pokerhand_raw = Seq("""[{"cards": [19], "playerId": 123456}]""").toDF("events")
    val event = new StructType().add("playerId", LongType).add("cards", ArrayType(new StructType().add("id", LongType).add("rank", StringType)))
    val pokerhand_events = pokerhand_raw.select(from_json($"events", ArrayType(event)).as("event"))
    pokerhand_events.show
```
throws the exception even in the default **PERMISSIVE** mode:
```java
java.lang.ClassCastException: java.lang.Long cannot be cast to org.apache.spark.sql.catalyst.util.ArrayData
  at org.apache.spark.sql.catalyst.expressions.BaseGenericInternalRow.getArray(rows.scala:48)
  at org.apache.spark.sql.catalyst.expressions.BaseGenericInternalRow.getArray$(rows.scala:48)
  at org.apache.spark.sql.catalyst.expressions.GenericInternalRow.getArray(rows.scala:195)
```

After the changes:
```
+-----+
|event|
+-----+
| null|
+-----+
```

### How was this patch tested?
Added a test to `JsonFunctionsSuite`.