### PR TITLE
[SPARK-33145] [WEBUI] Fix when `Succeeded Jobs` has many child url elements,they will extend over the edge of the page. 

### DIFF
--- a/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.css
+++ b/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.css
@@ -52,3 +52,8 @@
 .tooltip-inner {
   word-wrap:break-word;
 }
+
+/* Breaks the long job url list when showing Details for Query in SQL */
+.job-url {
+  word-wrap: break-word;
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
@@ -45,7 +45,7 @@ class ExecutionPage(parent: SQLTab) extends WebUIPage("execution") with Logging 
           if (jobStatus == status) Some(jobId) else None
         }
         if (jobs.nonEmpty) {
-          <li>
+          <li class="job-url">
             <strong>{label} </strong>
             {jobs.toSeq.sorted.map { jobId =>
               <a href={jobURL(request, jobId.intValue())}>{jobId.toString}</a><span>&nbsp;</span>


### PR DESCRIPTION
### What changes were proposed in this pull request?
In Execution web page, when `Succeeded Job`(or Failed Jobs) has many child url elements,they will extend over the edge of the page. 


### Why are the changes needed?
To make the page more friendly.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

Munual test result shows  as below:

![fixed](https://user-images.githubusercontent.com/52202080/95977319-50734600-0e4b-11eb-93c0-b8deb565bcd8.png)


