### PR TITLE
[SPARK-33147][CORE] Avoid distribute user jar from driver in yarn client mode

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/DependencyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/DependencyUtils.scala
@@ -169,12 +169,14 @@ private[deploy] object DependencyUtils extends Logging {
   }
 
   /**
-   * Merge a sequence of comma-separated file lists, some of which may be null to indicate
-   * no files, into a single comma-separated string.
+   * Merge and de-duplicate a sequence of comma-separated file lists,
+   * some of which may be null to indicate no files,
+   * into a single comma-separated string.
    */
   def mergeFileLists(lists: String*): String = {
     val merged = lists.filterNot(StringUtils.isBlank)
       .flatMap(Utils.stringToSeq)
+      .to[scala.collection.mutable.LinkedHashSet]
     if (merged.nonEmpty) merged.mkString(",") else null
   }
 

--- a/core/src/main/scala/org/apache/spark/deploy/DependencyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/DependencyUtils.scala
@@ -175,8 +175,7 @@ private[deploy] object DependencyUtils extends Logging {
    */
   def mergeFileLists(lists: String*): String = {
     val merged = lists.filterNot(StringUtils.isBlank)
-      .flatMap(Utils.stringToSeq)
-      .to[scala.collection.mutable.LinkedHashSet]
+      .flatMap(Utils.stringToSeq).distinct
     if (merged.nonEmpty) merged.mkString(",") else null
   }
 

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -547,6 +547,10 @@ private[spark] class SparkSubmit extends Logging {
       args.files = mergeFileLists(args.files, args.primaryResource)
     }
 
+    if (clusterManager == YARN && deployMode == CLIENT && isUserJar(args.primaryResource)) {
+      args.jars = mergeFileLists(args.jars, args.primaryResource)
+    }
+
     // Special flag to avoid deprecation warnings at the client
     sys.props("SPARK_SUBMIT") = "true"
 

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -329,8 +329,8 @@ class SparkSubmitSuite
     conf.get("spark.executor.instances") should be ("6")
     conf.get("spark.yarn.dist.files") should include regex (".*file1.txt,.*file2.txt")
     conf.get("spark.yarn.dist.archives") should include regex (".*archive1.txt,.*archive2.txt")
-    conf.get("spark.yarn.dist.jars") should include
-      regex (".*one.jar,.*two.jar,.*three.jar,.*thejar.jar")
+    conf.get("spark.yarn.dist.jars") should
+      include regex (".*one.jar,.*two.jar,.*three.jar,.*thejar.jar")
     conf.get(UI_ENABLED) should be (false)
     sys.props("SPARK_SUBMIT") should be ("true")
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Avoid distribute user jar from driver in yarn client mode.
Add the user's jar to `--jars`, this can be automatically uploaded to `spark.yarn.stagingDir`, usually hdfs.
Download user jar from stagingDir when executor is initialized.

### Why are the changes needed?
When the number of applied executors is large and the jar size is large, the executor pulls the jar from the driver, and the driver network traffic is high, and a timeout may occur. The driver and the executor of the yarn cluster may not be in the same data center.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
exist UT
