### PR TITLE
[SPARK-33136][SQL][2.4] Fix mistakenly swapped parameter in V2WriteCommand.outputResolved

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -378,7 +378,7 @@ case class AppendData(
           case (inAttr, outAttr) =>
             // names and types must match, nullability must be compatible
             inAttr.name == outAttr.name &&
-                DataType.equalsIgnoreCompatibleNullability(outAttr.dataType, inAttr.dataType) &&
+                DataType.equalsIgnoreCompatibleNullability(inAttr.dataType, outAttr.dataType) &&
                 (outAttr.nullable || !inAttr.nullable)
         }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to fix a bug on calling `DataType.equalsIgnoreCompatibleNullability` with mistakenly swapped parameters in `AppendData.outputResolved`. The order of parameters for `DataType.equalsIgnoreCompatibleNullability` are `from` and `to`, which says that the right order of matching variables are `inAttr` and `outAttr`.

### Why are the changes needed?

Although the problematic part is a dead code, once we know there's a bug, preferably we'd like to fix that.

### Does this PR introduce _any_ user-facing change?

No, as this fixes the dead code.

### How was this patch tested?

This patch fixes the dead code, which is not easy to craft a test. (The test in original commit is no longer valid here.)