### PR TITLE
[MINOR][PYTHON] Fix the typo in the docstring of method agg()

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1514,7 +1514,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
     @since(1.3)
     def agg(self, *exprs):
         """ Aggregate on the entire :class:`DataFrame` without groups
-        (shorthand for ``df.groupBy.agg()``).
+        (shorthand for ``df.groupBy().agg()``).
 
         >>> df.agg({"age": "max"}).collect()
         [Row(max(age)=5)]


### PR DESCRIPTION
### What changes were proposed in this pull request?
Change `df.groupBy.agg()` to `df.groupBy().agg()` in the docstring of `agg()`

### Why are the changes needed?
Fix typo in a docstring

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
No
