### PR TITLE
[SPARK-32402][SQL][FOLLOW-UP] Add case sensitivity tests for column resolution in ALTER TABLE

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
@@ -170,22 +170,23 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
   }
 
   test("ALTER TABLE ... add column") {
-    withTable("h2.test.alt_table") {
-      sql("CREATE TABLE h2.test.alt_table (ID INTEGER) USING _")
-      sql("ALTER TABLE h2.test.alt_table ADD COLUMNS (C1 INTEGER, C2 STRING)")
-      var t = spark.table("h2.test.alt_table")
+    val tableName = "h2.test.alt_table"
+    withTable(tableName) {
+      sql(s"CREATE TABLE $tableName (ID INTEGER) USING _")
+      sql(s"ALTER TABLE $tableName ADD COLUMNS (C1 INTEGER, C2 STRING)")
+      var t = spark.table(tableName)
       var expectedSchema = new StructType()
         .add("ID", IntegerType)
         .add("C1", IntegerType)
         .add("C2", StringType)
       assert(t.schema === expectedSchema)
-      sql("ALTER TABLE h2.test.alt_table ADD COLUMNS (c3 DOUBLE)")
-      t = spark.table("h2.test.alt_table")
+      sql(s"ALTER TABLE $tableName ADD COLUMNS (c3 DOUBLE)")
+      t = spark.table(tableName)
       expectedSchema = expectedSchema.add("c3", DoubleType)
       assert(t.schema === expectedSchema)
       // Add already existing column
       val msg = intercept[AnalysisException] {
-        sql("ALTER TABLE h2.test.alt_table ADD COLUMNS (c3 DOUBLE)")
+        sql(s"ALTER TABLE $tableName ADD COLUMNS (c3 DOUBLE)")
       }.getMessage
       assert(msg.contains("Cannot add column, because c3 already exists"))
     }
@@ -199,17 +200,18 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
   }
 
   test("ALTER TABLE ... rename column") {
-    withTable("h2.test.alt_table") {
-      sql("CREATE TABLE h2.test.alt_table (id INTEGER, C0 INTEGER) USING _")
-      sql("ALTER TABLE h2.test.alt_table RENAME COLUMN id TO C")
-      val t = spark.table("h2.test.alt_table")
+    val tableName = "h2.test.alt_table"
+    withTable(tableName) {
+      sql(s"CREATE TABLE $tableName (id INTEGER, C0 INTEGER) USING _")
+      sql(s"ALTER TABLE $tableName RENAME COLUMN id TO C")
+      val t = spark.table(tableName)
       val expectedSchema = new StructType()
         .add("C", IntegerType)
         .add("C0", IntegerType)
       assert(t.schema === expectedSchema)
       // Rename to already existing column
       val msg = intercept[AnalysisException] {
-        sql("ALTER TABLE h2.test.alt_table RENAME COLUMN C TO C0")
+        sql(s"ALTER TABLE $tableName RENAME COLUMN C TO C0")
       }.getMessage
       assert(msg.contains("Cannot rename column, because C0 already exists"))
     }
@@ -223,16 +225,17 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
   }
 
   test("ALTER TABLE ... drop column") {
-    withTable("h2.test.alt_table") {
-      sql("CREATE TABLE h2.test.alt_table (C1 INTEGER, C2 INTEGER, c3 INTEGER) USING _")
-      sql("ALTER TABLE h2.test.alt_table DROP COLUMN C1")
-      sql("ALTER TABLE h2.test.alt_table DROP COLUMN c3")
-      val t = spark.table("h2.test.alt_table")
+    val tableName = "h2.test.alt_table"
+    withTable(tableName) {
+      sql(s"CREATE TABLE $tableName (C1 INTEGER, C2 INTEGER, c3 INTEGER) USING _")
+      sql(s"ALTER TABLE $tableName DROP COLUMN C1")
+      sql(s"ALTER TABLE $tableName DROP COLUMN c3")
+      val t = spark.table(tableName)
       val expectedSchema = new StructType().add("C2", IntegerType)
       assert(t.schema === expectedSchema)
       // Drop not existing column
       val msg = intercept[AnalysisException] {
-        sql("ALTER TABLE h2.test.alt_table DROP COLUMN bad_column")
+        sql(s"ALTER TABLE $tableName DROP COLUMN bad_column")
       }.getMessage
       assert(msg.contains("Cannot delete missing field bad_column in test.alt_table schema"))
     }
@@ -246,21 +249,22 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
   }
 
   test("ALTER TABLE ... update column type") {
-    withTable("h2.test.alt_table") {
-      sql("CREATE TABLE h2.test.alt_table (ID INTEGER, deptno INTEGER) USING _")
-      sql("ALTER TABLE h2.test.alt_table ALTER COLUMN id TYPE DOUBLE")
-      sql("ALTER TABLE h2.test.alt_table ALTER COLUMN deptno TYPE DOUBLE")
-      val t = spark.table("h2.test.alt_table")
+    val tableName = "h2.test.alt_table"
+    withTable(tableName) {
+      sql(s"CREATE TABLE $tableName (ID INTEGER, deptno INTEGER) USING _")
+      sql(s"ALTER TABLE $tableName ALTER COLUMN id TYPE DOUBLE")
+      sql(s"ALTER TABLE $tableName ALTER COLUMN deptno TYPE DOUBLE")
+      val t = spark.table(tableName)
       val expectedSchema = new StructType().add("ID", DoubleType).add("deptno", DoubleType)
       assert(t.schema === expectedSchema)
       // Update not existing column
       val msg1 = intercept[AnalysisException] {
-        sql("ALTER TABLE h2.test.alt_table ALTER COLUMN bad_column TYPE DOUBLE")
+        sql(s"ALTER TABLE $tableName ALTER COLUMN bad_column TYPE DOUBLE")
       }.getMessage
       assert(msg1.contains("Cannot update missing field bad_column in test.alt_table schema"))
       // Update column to wrong type
       val msg2 = intercept[ParseException] {
-        sql("ALTER TABLE h2.test.alt_table ALTER COLUMN id TYPE bad_type")
+        sql(s"ALTER TABLE $tableName ALTER COLUMN id TYPE bad_type")
       }.getMessage
       assert(msg2.contains("DataType bad_type is not supported"))
     }
@@ -274,17 +278,18 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
   }
 
   test("ALTER TABLE ... update column nullability") {
-    withTable("h2.test.alt_table") {
-      sql("CREATE TABLE h2.test.alt_table (ID INTEGER NOT NULL, deptno INTEGER NOT NULL) USING _")
-      sql("ALTER TABLE h2.test.alt_table ALTER COLUMN ID DROP NOT NULL")
-      sql("ALTER TABLE h2.test.alt_table ALTER COLUMN deptno DROP NOT NULL")
-      val t = spark.table("h2.test.alt_table")
+    val tableName = "h2.test.alt_table"
+    withTable(tableName) {
+      sql(s"CREATE TABLE $tableName (ID INTEGER NOT NULL, deptno INTEGER NOT NULL) USING _")
+      sql(s"ALTER TABLE $tableName ALTER COLUMN ID DROP NOT NULL")
+      sql(s"ALTER TABLE $tableName ALTER COLUMN deptno DROP NOT NULL")
+      val t = spark.table(tableName)
       val expectedSchema = new StructType()
         .add("ID", IntegerType, nullable = true).add("deptno", IntegerType, nullable = true)
       assert(t.schema === expectedSchema)
       // Update nullability of not existing column
       val msg = intercept[AnalysisException] {
-        sql("ALTER TABLE h2.test.alt_table ALTER COLUMN bad_column DROP NOT NULL")
+        sql(s"ALTER TABLE $tableName ALTER COLUMN bad_column DROP NOT NULL")
       }.getMessage
       assert(msg.contains("Cannot update missing field bad_column in test.alt_table"))
     }
@@ -298,16 +303,17 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
   }
 
   test("ALTER TABLE ... update column comment not supported") {
-    withTable("h2.test.alt_table") {
-      sql("CREATE TABLE h2.test.alt_table (ID INTEGER) USING _")
+    val tableName = "h2.test.alt_table"
+    withTable(tableName) {
+      sql(s"CREATE TABLE $tableName (ID INTEGER) USING _")
       val exp = intercept[AnalysisException] {
-        sql("ALTER TABLE h2.test.alt_table ALTER COLUMN ID COMMENT 'test'")
+        sql(s"ALTER TABLE $tableName ALTER COLUMN ID COMMENT 'test'")
       }
       assert(exp.getMessage.contains("Failed table altering: test.alt_table"))
       assert(exp.cause.get.getMessage.contains("Unsupported TableChange"))
       // Update comment for not existing column
       val msg = intercept[AnalysisException] {
-        sql("ALTER TABLE h2.test.alt_table ALTER COLUMN bad_column COMMENT 'test'")
+        sql(s"ALTER TABLE $tableName ALTER COLUMN bad_column COMMENT 'test'")
       }.getMessage
       assert(msg.contains("Cannot update missing field bad_column in test.alt_table"))
     }
@@ -321,65 +327,66 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
   }
 
   test("ALTER TABLE case sensitivity") {
-    withTable("h2.test.alt_table") {
-      sql("CREATE TABLE h2.test.alt_table (c1 INTEGER NOT NULL, c2 INTEGER) USING _")
-      var t = spark.table("h2.test.alt_table")
+    val tableName = "h2.test.alt_table"
+    withTable(tableName) {
+      sql(s"CREATE TABLE $tableName (c1 INTEGER NOT NULL, c2 INTEGER) USING _")
+      var t = spark.table(tableName)
       var expectedSchema = new StructType().add("c1", IntegerType).add("c2", IntegerType)
       assert(t.schema === expectedSchema)
 
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
         val msg = intercept[AnalysisException] {
-          sql("ALTER TABLE h2.test.alt_table RENAME COLUMN C2 TO c3")
+          sql(s"ALTER TABLE $tableName RENAME COLUMN C2 TO c3")
         }.getMessage
         assert(msg.contains("Cannot rename missing field C2 in test.alt_table schema"))
       }
 
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
-        sql("ALTER TABLE h2.test.alt_table RENAME COLUMN C2 TO c3")
+        sql(s"ALTER TABLE $tableName RENAME COLUMN C2 TO c3")
         expectedSchema = new StructType().add("c1", IntegerType).add("c3", IntegerType)
-        t = spark.table("h2.test.alt_table")
+        t = spark.table(tableName)
         assert(t.schema === expectedSchema)
       }
 
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
         val msg = intercept[AnalysisException] {
-          sql("ALTER TABLE h2.test.alt_table DROP COLUMN C3")
+          sql(s"ALTER TABLE $tableName DROP COLUMN C3")
         }.getMessage
         assert(msg.contains("Cannot delete missing field C3 in test.alt_table schema"))
       }
 
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
-        sql("ALTER TABLE h2.test.alt_table DROP COLUMN C3")
+        sql(s"ALTER TABLE $tableName DROP COLUMN C3")
         expectedSchema = new StructType().add("c1", IntegerType)
-        t = spark.table("h2.test.alt_table")
+        t = spark.table(tableName)
         assert(t.schema === expectedSchema)
       }
 
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
         val msg = intercept[AnalysisException] {
-        sql("ALTER TABLE h2.test.alt_table ALTER COLUMN C1 TYPE DOUBLE")
+          sql(s"ALTER TABLE $tableName ALTER COLUMN C1 TYPE DOUBLE")
         }.getMessage
         assert(msg.contains("Cannot update missing field C1 in test.alt_table schema"))
       }
 
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
-        sql("ALTER TABLE h2.test.alt_table ALTER COLUMN C1 TYPE DOUBLE")
+        sql(s"ALTER TABLE $tableName ALTER COLUMN C1 TYPE DOUBLE")
         expectedSchema = new StructType().add("c1", DoubleType)
-        t = spark.table("h2.test.alt_table")
+        t = spark.table(tableName)
         assert(t.schema === expectedSchema)
       }
 
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
         val msg = intercept[AnalysisException] {
-        sql("ALTER TABLE h2.test.alt_table ALTER COLUMN C1 DROP NOT NULL")
+          sql(s"ALTER TABLE $tableName ALTER COLUMN C1 DROP NOT NULL")
         }.getMessage
         assert(msg.contains("Cannot update missing field C1 in test.alt_table schema"))
       }
 
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
-        sql("ALTER TABLE h2.test.alt_table ALTER COLUMN C1 DROP NOT NULL")
+        sql(s"ALTER TABLE $tableName ALTER COLUMN C1 DROP NOT NULL")
         expectedSchema = new StructType().add("c1", DoubleType, nullable = true)
-        t = spark.table("h2.test.alt_table")
+        t = spark.table(tableName)
         assert(t.schema === expectedSchema)
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add case sensitivity tests for column resolution in ALTER TABLE

### Why are the changes needed?
To make sure `spark.sql.caseSensitive` works for `ResolveAlterTableChanges`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
new test
