### PR TITLE
[SPARK-33165][SQL][TESTS][FOLLOW-UP] Use scala.Predef.assert instead

### DIFF
--- a/core/src/test/scala/org/apache/spark/benchmark/Benchmark.scala
+++ b/core/src/test/scala/org/apache/spark/benchmark/Benchmark.scala
@@ -161,6 +161,7 @@ private[spark] class Benchmark(
     // scalastyle:off
     println(s"  Stopped after $i iterations, ${NANOSECONDS.toMillis(runTimes.sum)} ms")
     // scalastyle:on
+    assert(runTimes.nonEmpty)
     val best = runTimes.min
     val avg = runTimes.sum / runTimes.size
     val stdev = if (runTimes.size > 1) {
@@ -182,15 +183,18 @@ private[spark] object Benchmark {
     private var timeStart: Long = 0L
 
     def startTiming(): Unit = {
+      assert(timeStart == 0L, "Already started timing.")
       timeStart = System.nanoTime
     }
 
     def stopTiming(): Unit = {
+      assert(timeStart != 0L, "Have not started timing.")
       accumulatedTime += System.nanoTime - timeStart
       timeStart = 0L
     }
 
     def totalTime(): Long = {
+      assert(timeStart == 0L, "Have not stopped timing.")
       accumulatedTime
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to use `scala.Predef.assert` instead of `org.scalatest.Assertions.assert` removed at https://github.com/apache/spark/pull/30064

### Why are the changes needed?

Just to keep the same behaviour.

### Does this PR introduce _any_ user-facing change?

No, dev-only

### How was this patch tested?

Recover the existing asserts.