### PR TITLE
[SPARK-32862][SS] Left semi stream-stream join

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
@@ -297,8 +297,8 @@ object UnsupportedOperationChecker extends Logging {
                     "on the right are not supported")
               }
 
-            // We support streaming left outer joins with static on the right always, and with
-            // stream on both sides under the appropriate conditions.
+            // We support streaming left outer and left semi joins with static on the right always,
+            // and with stream on both sides under the appropriate conditions.
             case LeftOuter | LeftSemi =>
               if (!left.isStreaming && right.isStreaming) {
                 throwError(s"$joinType join with a streaming DataFrame/Dataset " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
@@ -291,17 +291,17 @@ object UnsupportedOperationChecker extends Logging {
                 throwError("Full outer joins with streaming DataFrames/Datasets are not supported")
               }
 
-            case LeftSemi | LeftAnti =>
+            case LeftAnti =>
               if (right.isStreaming) {
-                throwError("Left semi/anti joins with a streaming DataFrame/Dataset " +
+                throwError("Left anti joins with a streaming DataFrame/Dataset " +
                     "on the right are not supported")
               }
 
             // We support streaming left outer joins with static on the right always, and with
             // stream on both sides under the appropriate conditions.
-            case LeftOuter =>
+            case LeftOuter | LeftSemi =>
               if (!left.isStreaming && right.isStreaming) {
-                throwError("Left outer join with a streaming DataFrame/Dataset " +
+                throwError(s"$joinType join with a streaming DataFrame/Dataset " +
                   "on the right and a static DataFrame/Dataset on the left is not supported")
               } else if (left.isStreaming && right.isStreaming) {
                 val watermarkInJoinKeys = StreamingJoinHelper.isWatermarkInJoinKeys(subPlan)
@@ -311,7 +311,8 @@ object UnsupportedOperationChecker extends Logging {
                     left.outputSet, right.outputSet, condition, Some(1000000)).isDefined
 
                 if (!watermarkInJoinKeys && !hasValidWatermarkRange) {
-                  throwError("Stream-stream outer join between two streaming DataFrame/Datasets " +
+                  throwError(
+                    s"Stream-stream $joinType join between two streaming DataFrame/Datasets " +
                     "is not supported without a watermark in the join keys, or a watermark on " +
                     "the nullable side and an appropriate range condition")
                 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/JoinedRow.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/JoinedRow.scala
@@ -55,6 +55,16 @@ class JoinedRow extends InternalRow {
     this
   }
 
+  /** Gets this JoinedRow's left base row. */
+  def getLeft: InternalRow = {
+    row1
+  }
+
+  /** Gets this JoinedRow's right base row. */
+  def getRight: InternalRow = {
+    row2
+  }
+
   override def toSeq(fieldTypes: Seq[DataType]): Seq[Any] = {
     assert(fieldTypes.length == row1.numFields + row2.numFields)
     val (left, right) = fieldTypes.splitAt(row1.numFields)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
@@ -523,7 +523,7 @@ class UnsupportedOperationsSuite extends SparkFunSuite {
     streamRelation.join(streamRelation, joinType = LeftSemi,
       condition = Some(attribute === attribute)),
     OutputMode.Append(),
-    Seq("watermark in the join keys"))
+    Seq("without a watermark in the join keys"))
 
   // Left semi joins: stream-stream allowed with range condition yielding state value watermark
   assertSupportedInStreamingPlan(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
@@ -506,7 +506,7 @@ class UnsupportedOperationsSuite extends SparkFunSuite {
     OutputMode.Complete(),
     Seq("is not supported in Complete output mode"))
 
-  // Left ousemiter joins: stream-stream allowed with join on watermark attribute
+  // Left semi joins: stream-stream allowed with join on watermark attribute
   // Note that the attribute need not be watermarked on both sides.
   assertSupportedInStreamingPlan(
     s"left semi join with stream-stream relations and join on attribute with left watermark",

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
@@ -494,13 +494,13 @@ class UnsupportedOperationsSuite extends SparkFunSuite {
 
   // Left semi joins: update and complete mode not allowed
   assertNotSupportedInStreamingPlan(
-    s"left semi join with stream-stream relations and update mode",
+    "left semi join with stream-stream relations and update mode",
     streamRelation.join(streamRelation, joinType = LeftSemi,
       condition = Some(attribute === attribute)),
     OutputMode.Update(),
     Seq("is not supported in Update output mode"))
   assertNotSupportedInStreamingPlan(
-    s"left semi join with stream-stream relations and complete mode",
+    "left semi join with stream-stream relations and complete mode",
     Aggregate(Nil, aggExprs("d"), streamRelation.join(streamRelation, joinType = LeftSemi,
       condition = Some(attribute === attribute))),
     OutputMode.Complete(),
@@ -509,17 +509,17 @@ class UnsupportedOperationsSuite extends SparkFunSuite {
   // Left semi joins: stream-stream allowed with join on watermark attribute
   // Note that the attribute need not be watermarked on both sides.
   assertSupportedInStreamingPlan(
-    s"left semi join with stream-stream relations and join on attribute with left watermark",
+    "left semi join with stream-stream relations and join on attribute with left watermark",
     streamRelation.join(streamRelation, joinType = LeftSemi,
       condition = Some(attributeWithWatermark === attribute)),
     OutputMode.Append())
   assertSupportedInStreamingPlan(
-    s"left semi join with stream-stream relations and join on attribute with right watermark",
+    "left semi join with stream-stream relations and join on attribute with right watermark",
     streamRelation.join(streamRelation, joinType = LeftSemi,
       condition = Some(attribute === attributeWithWatermark)),
     OutputMode.Append())
   assertNotSupportedInStreamingPlan(
-    s"left semi join with stream-stream relations and join on non-watermarked attribute",
+    "left semi join with stream-stream relations and join on non-watermarked attribute",
     streamRelation.join(streamRelation, joinType = LeftSemi,
       condition = Some(attribute === attribute)),
     OutputMode.Append(),
@@ -527,7 +527,7 @@ class UnsupportedOperationsSuite extends SparkFunSuite {
 
   // Left semi joins: stream-stream allowed with range condition yielding state value watermark
   assertSupportedInStreamingPlan(
-    s"left semi join with stream-stream relations and state value watermark", {
+    "left semi join with stream-stream relations and state value watermark", {
       val leftRelation = streamRelation
       val rightTimeWithWatermark =
         AttributeReference("b", IntegerType)().withMetadata(watermarkMetadata)
@@ -541,7 +541,7 @@ class UnsupportedOperationsSuite extends SparkFunSuite {
 
   // Left semi joins: stream-stream not allowed with insufficient range condition
   assertNotSupportedInStreamingPlan(
-    s"left semi join with stream-stream relations and state value watermark", {
+    "left semi join with stream-stream relations and state value watermark", {
       val leftRelation = streamRelation
       val rightTimeWithWatermark =
         AttributeReference("b", IntegerType)().withMetadata(watermarkMetadata)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
@@ -151,9 +151,8 @@ case class StreamingSymmetricHashJoinExec(
       stateWatermarkPredicates = JoinStateWatermarkPredicates(), stateFormatVersion, left, right)
   }
 
-  if (stateFormatVersion < 2 && joinType != Inner) {
-    throw new IllegalArgumentException(
-      s"The query is using stream-stream $joinType join with state" +
+  if (stateFormatVersion < 2 && (joinType == LeftOuter || joinType == RightOuter)) {
+    throw new IllegalArgumentException("The query is using stream-stream outer join with state" +
       s" format version ${stateFormatVersion} - correctness issue is discovered. Please discard" +
       " the checkpoint and rerun the query. See SPARK-26154 for more details.")
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/SymmetricHashJoinStateManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/SymmetricHashJoinStateManager.scala
@@ -110,11 +110,11 @@ class SymmetricHashJoinStateManager(
       predicate: JoinedRow => Boolean,
       joinOnlyFirstTimeMatchedRow: Boolean = false): Iterator[JoinedRow] = {
     val numValues = keyToNumValues.get(key)
-    keyWithIndexToValue.getAll(key, numValues).map { keyIdxToValue =>
+    keyWithIndexToValue.getAll(key, numValues).filterNot { keyIdxToValue =>
+      joinOnlyFirstTimeMatchedRow && keyIdxToValue.matched
+    }.map { keyIdxToValue =>
       val joinedRow = generateJoinedRow(keyIdxToValue.value)
-      if (joinOnlyFirstTimeMatchedRow && keyIdxToValue.matched) {
-        null
-      } else if (predicate(joinedRow)) {
+      if (predicate(joinedRow)) {
         if (!keyIdxToValue.matched) {
           keyWithIndexToValue.put(key, keyIdxToValue.valueIndex, keyIdxToValue.value,
             matched = true)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/SymmetricHashJoinStateManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/SymmetricHashJoinStateManager.scala
@@ -100,18 +100,18 @@ class SymmetricHashJoinStateManager(
    * Get all the matched values for given join condition, with marking matched.
    * This method is designed to mark joined rows properly without exposing internal index of row.
    *
-   * @param joinOnlyFirstTimeMatchedRow Only join with first-time matched row.
-   *                                    This is used for right side of left semi join in
-   *                                    [[StreamingSymmetricHashJoinExec]] only.
+   * @param excludeRowsAlreadyMatched Do not join with rows already matched previously.
+   *                                  This is used for right side of left semi join in
+   *                                  [[StreamingSymmetricHashJoinExec]] only.
    */
   def getJoinedRows(
       key: UnsafeRow,
       generateJoinedRow: InternalRow => JoinedRow,
       predicate: JoinedRow => Boolean,
-      joinOnlyFirstTimeMatchedRow: Boolean = false): Iterator[JoinedRow] = {
+      excludeRowsAlreadyMatched: Boolean = false): Iterator[JoinedRow] = {
     val numValues = keyToNumValues.get(key)
     keyWithIndexToValue.getAll(key, numValues).filterNot { keyIdxToValue =>
-      joinOnlyFirstTimeMatchedRow && keyIdxToValue.matched
+      excludeRowsAlreadyMatched && keyIdxToValue.matched
     }.map { keyIdxToValue =>
       val joinedRow = generateJoinedRow(keyIdxToValue.value)
       if (predicate(joinedRow)) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
@@ -1213,19 +1213,19 @@ class StreamingLeftSemiJoinSuite extends StreamingJoinSuite {
       // left: (1, 5), (3, 5)
       // right: (1, 10), (2, 5)
       assertNumStateRows(total = 4, updated = 2),
-      AddData(rightInput, (1, 11)),
+      AddData(rightInput, (1, 9)),
       // No match as left time is too low and left row is already matched.
       CheckNewAnswer(),
       // states
       // left: (1, 5), (3, 5)
-      // right: (1, 10), (2, 5), (1, 11)
+      // right: (1, 10), (2, 5), (1, 9)
       assertNumStateRows(total = 5, updated = 1),
       // Increase event time watermark to 20s by adding data with time = 30s on both inputs.
       AddData(leftInput, (1, 7), (1, 30)),
       CheckNewAnswer((1, 7)),
       // states
       // left: (1, 5), (3, 5), (1, 30)
-      // right: (1, 10), (2, 5), (1, 11)
+      // right: (1, 10), (2, 5), (1, 9)
       assertNumStateRows(total = 6, updated = 1),
       // Watermark = 30 - 10 = 20, no matched row.
       AddData(rightInput, (0, 30)),
@@ -1236,7 +1236,7 @@ class StreamingLeftSemiJoinSuite extends StreamingJoinSuite {
       //
       // states evicted
       // left: (1, 5), (3, 5) (below watermark = 20)
-      // right: (1, 10), (2, 5), (1, 11) (below watermark = 20)
+      // right: (1, 10), (2, 5), (1, 9) (below watermark = 20)
       assertNumStateRows(total = 2, updated = 1)
     )
   }
@@ -1250,8 +1250,9 @@ class StreamingLeftSemiJoinSuite extends StreamingJoinSuite {
       // batch 1 - global watermark = 0
       // states
       // left: (2, 2L), (4, 4L)
-      //       (left rows with value % 2 != 0 is filtered per [[PushDownLeftSemiAntiJoin]])
+      //       (left rows with value % 2 != 0 is filtered per [[PushPredicateThroughJoin]])
       // right: (2, 2L), (4, 4L)
+      //       (right rows with value % 2 != 0 is filtered per [[PushPredicateThroughJoin]])
       assertNumStateRows(total = 4, updated = 4),
       AddData(inputStream, (6, 6L), (7, 7L), (8, 8L), (9, 9L), (10, 10L)),
       CheckNewAnswer((6, 6), (8, 8), (10, 10)),

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
@@ -974,7 +974,7 @@ class StreamingOuterJoinSuite extends StreamingJoinSuite {
       throw writer.exception.get
     }
     assert(e.getMessage.toLowerCase(Locale.ROOT)
-      .contains("the query is using stream-stream outer join with state format version 1"))
+      .contains("the query is using stream-stream leftouter join with state format version 1"))
   }
 
   test("SPARK-29438: ensure UNION doesn't lead stream-stream join to use shifted partition IDs") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
@@ -1214,7 +1214,7 @@ class StreamingLeftSemiJoinSuite extends StreamingJoinSuite {
       // right: (1, 10), (2, 5)
       assertNumStateRows(total = 4, updated = 2),
       AddData(rightInput, (1, 9)),
-      // No match as left time is too low and left row is already matched.
+      // No match as left row is already matched.
       CheckNewAnswer(),
       // states
       // left: (1, 5), (3, 5)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
@@ -41,17 +41,173 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 
+abstract class StreamingJoinSuite
+  extends StreamTest with StateStoreMetricsTest with BeforeAndAfter {
 
-class StreamingInnerJoinSuite extends StreamTest with StateStoreMetricsTest with BeforeAndAfter {
+  import testImplicits._
 
   before {
-    SparkSession.setActiveSessionInternal(spark)  // set this before force initializing 'joinExec'
-    spark.streams.stateStoreCoordinator   // initialize the lazy coordinator
+    SparkSession.setActiveSessionInternal(spark) // set this before force initializing 'joinExec'
+    spark.streams.stateStoreCoordinator // initialize the lazy coordinator
   }
 
   after {
     StateStore.stop()
   }
+
+  protected def setupStream(prefix: String, multiplier: Int): (MemoryStream[Int], DataFrame) = {
+    val input = MemoryStream[Int]
+    val df = input.toDF
+      .select(
+        'value as "key",
+        timestamp_seconds($"value")  as s"${prefix}Time",
+        ('value * multiplier) as s"${prefix}Value")
+      .withWatermark(s"${prefix}Time", "10 seconds")
+
+    (input, df)
+  }
+
+  protected def setupWindowedJoin(joinType: String)
+    : (MemoryStream[Int], MemoryStream[Int], DataFrame) = {
+
+    val (input1, df1) = setupStream("left", 2)
+    val (input2, df2) = setupStream("right", 3)
+    val windowed1 = df1.select('key, window('leftTime, "10 second"), 'leftValue)
+    val windowed2 = df2.select('key, window('rightTime, "10 second"), 'rightValue)
+    val joined = windowed1.join(windowed2, Seq("key", "window"), joinType)
+    val select = if (joinType == "left_semi") {
+      joined.select('key, $"window.end".cast("long"), 'leftValue)
+    } else {
+      joined.select('key, $"window.end".cast("long"), 'leftValue, 'rightValue)
+    }
+
+    (input1, input2, select)
+  }
+
+  protected def setupWindowedJoinWithLeftCondition(joinType: String)
+    : (MemoryStream[Int], MemoryStream[Int], DataFrame) = {
+
+    val (leftInput, df1) = setupStream("left", 2)
+    val (rightInput, df2) = setupStream("right", 3)
+    // Use different schemas to ensure the null row is being generated from the correct side.
+    val left = df1.select('key, window('leftTime, "10 second"), 'leftValue)
+    val right = df2.select('key, window('rightTime, "10 second"), 'rightValue.cast("string"))
+
+    val joined = left.join(
+      right,
+      left("key") === right("key")
+        && left("window") === right("window")
+        && 'leftValue > 4,
+      joinType)
+
+    val select = if (joinType == "left_semi") {
+      joined.select(left("key"), left("window.end").cast("long"), 'leftValue)
+    } else if (joinType == "left_outer") {
+      joined.select(left("key"), left("window.end").cast("long"), 'leftValue, 'rightValue)
+    } else if (joinType == "right_outer") {
+      joined.select(right("key"), right("window.end").cast("long"), 'leftValue, 'rightValue)
+    } else {
+      joined
+    }
+
+    (leftInput, rightInput, select)
+  }
+
+  protected def setupWindowedJoinWithRightCondition(joinType: String)
+    : (MemoryStream[Int], MemoryStream[Int], DataFrame) = {
+
+    val (leftInput, df1) = setupStream("left", 2)
+    val (rightInput, df2) = setupStream("right", 3)
+    // Use different schemas to ensure the null row is being generated from the correct side.
+    val left = df1.select('key, window('leftTime, "10 second"), 'leftValue)
+    val right = df2.select('key, window('rightTime, "10 second"), 'rightValue.cast("string"))
+
+    val joined = left.join(
+      right,
+      left("key") === right("key")
+        && left("window") === right("window")
+        && 'rightValue.cast("int") > 7,
+      joinType)
+
+    val select = if (joinType == "left_semi") {
+      joined.select(left("key"), left("window.end").cast("long"), 'leftValue)
+    } else if (joinType == "left_outer") {
+      joined.select(left("key"), left("window.end").cast("long"), 'leftValue, 'rightValue)
+    } else if (joinType == "right_outer") {
+      joined.select(right("key"), right("window.end").cast("long"), 'leftValue, 'rightValue)
+    } else {
+      joined
+    }
+
+    (leftInput, rightInput, select)
+  }
+
+  protected def setupWindowedJoinWithRangeCondition(joinType: String)
+    : (MemoryStream[(Int, Int)], MemoryStream[(Int, Int)], DataFrame) = {
+
+    val leftInput = MemoryStream[(Int, Int)]
+    val rightInput = MemoryStream[(Int, Int)]
+
+    val df1 = leftInput.toDF.toDF("leftKey", "time")
+      .select('leftKey, timestamp_seconds($"time") as "leftTime", ('leftKey * 2) as "leftValue")
+      .withWatermark("leftTime", "10 seconds")
+
+    val df2 = rightInput.toDF.toDF("rightKey", "time")
+      .select('rightKey, timestamp_seconds($"time") as "rightTime",
+        ('rightKey * 3) as "rightValue")
+      .withWatermark("rightTime", "10 seconds")
+
+    val joined =
+      df1.join(
+        df2,
+        expr("leftKey = rightKey AND " +
+          "leftTime BETWEEN rightTime - interval 5 seconds AND rightTime + interval 5 seconds"),
+        joinType)
+
+    val select = if (joinType == "left_semi") {
+      joined.select('leftKey, 'leftTime.cast("int"))
+    } else {
+      joined.select('leftKey, 'rightKey, 'leftTime.cast("int"), 'rightTime.cast("int"))
+    }
+
+    (leftInput, rightInput, select)
+  }
+
+  protected def setupWindowedSelfJoin(joinType: String)
+    : (MemoryStream[(Int, Long)], DataFrame) = {
+
+    val inputStream = MemoryStream[(Int, Long)]
+
+    val df = inputStream.toDS()
+      .select(col("_1").as("value"), timestamp_seconds($"_2").as("timestamp"))
+
+    val leftStream = df.select(col("value").as("leftId"), col("timestamp").as("leftTime"))
+
+    val rightStream = df
+      // Introduce misses for ease of debugging
+      .where(col("value") % 2 === 0)
+      .select(col("value").as("rightId"), col("timestamp").as("rightTime"))
+
+    val joined = leftStream
+      .withWatermark("leftTime", "5 seconds")
+      .join(
+        rightStream.withWatermark("rightTime", "5 seconds"),
+        expr("leftId = rightId AND rightTime >= leftTime AND " +
+          "rightTime <= leftTime + interval 5 seconds"),
+        joinType)
+
+    val select = if (joinType == "left_semi") {
+      joined.select(col("leftId"), col("leftTime").cast("int"))
+    } else {
+      joined.select(col("leftId"), col("leftTime").cast("int"),
+        col("rightId"), col("rightTime").cast("int"))
+    }
+
+    (inputStream, select)
+  }
+}
+
+class StreamingInnerJoinSuite extends StreamingJoinSuite {
 
   import testImplicits._
   test("stream stream inner join on non-time column") {
@@ -486,58 +642,13 @@ class StreamingInnerJoinSuite extends StreamTest with StateStoreMetricsTest with
 }
 
 
-class StreamingOuterJoinSuite extends StreamTest with StateStoreMetricsTest with BeforeAndAfter {
+class StreamingOuterJoinSuite extends StreamingJoinSuite {
 
   import testImplicits._
   import org.apache.spark.sql.functions._
 
-  before {
-    SparkSession.setActiveSessionInternal(spark) // set this before force initializing 'joinExec'
-    spark.streams.stateStoreCoordinator // initialize the lazy coordinator
-  }
-
-  after {
-    StateStore.stop()
-  }
-
-  private def setupStream(prefix: String, multiplier: Int): (MemoryStream[Int], DataFrame) = {
-    val input = MemoryStream[Int]
-    val df = input.toDF
-      .select(
-        'value as "key",
-        timestamp_seconds($"value")  as s"${prefix}Time",
-        ('value * multiplier) as s"${prefix}Value")
-      .withWatermark(s"${prefix}Time", "10 seconds")
-
-    return (input, df)
-  }
-
-  private def setupWindowedJoin(joinType: String):
-  (MemoryStream[Int], MemoryStream[Int], DataFrame) = {
-    val (input1, df1) = setupStream("left", 2)
-    val (input2, df2) = setupStream("right", 3)
-    val windowed1 = df1.select('key, window('leftTime, "10 second"), 'leftValue)
-    val windowed2 = df2.select('key, window('rightTime, "10 second"), 'rightValue)
-    val joined = windowed1.join(windowed2, Seq("key", "window"), joinType)
-      .select('key, $"window.end".cast("long"), 'leftValue, 'rightValue)
-
-    (input1, input2, joined)
-  }
-
   test("left outer early state exclusion on left") {
-    val (leftInput, df1) = setupStream("left", 2)
-    val (rightInput, df2) = setupStream("right", 3)
-    // Use different schemas to ensure the null row is being generated from the correct side.
-    val left = df1.select('key, window('leftTime, "10 second"), 'leftValue)
-    val right = df2.select('key, window('rightTime, "10 second"), 'rightValue.cast("string"))
-
-    val joined = left.join(
-        right,
-        left("key") === right("key")
-          && left("window") === right("window")
-          && 'leftValue > 4,
-        "left_outer")
-        .select(left("key"), left("window.end").cast("long"), 'leftValue, 'rightValue)
+    val (leftInput, rightInput, joined) = setupWindowedJoinWithLeftCondition("left_outer")
 
     testStream(joined)(
       MultiAddData(leftInput, 1, 2, 3)(rightInput, 3, 4, 5),
@@ -554,19 +665,7 @@ class StreamingOuterJoinSuite extends StreamTest with StateStoreMetricsTest with
   }
 
   test("left outer early state exclusion on right") {
-    val (leftInput, df1) = setupStream("left", 2)
-    val (rightInput, df2) = setupStream("right", 3)
-    // Use different schemas to ensure the null row is being generated from the correct side.
-    val left = df1.select('key, window('leftTime, "10 second"), 'leftValue)
-    val right = df2.select('key, window('rightTime, "10 second"), 'rightValue.cast("string"))
-
-    val joined = left.join(
-      right,
-      left("key") === right("key")
-        && left("window") === right("window")
-        && 'rightValue.cast("int") > 7,
-      "left_outer")
-      .select(left("key"), left("window.end").cast("long"), 'leftValue, 'rightValue)
+    val (leftInput, rightInput, joined) = setupWindowedJoinWithRightCondition("left_outer")
 
     testStream(joined)(
       MultiAddData(leftInput, 3, 4, 5)(rightInput, 1, 2, 3),
@@ -583,19 +682,7 @@ class StreamingOuterJoinSuite extends StreamTest with StateStoreMetricsTest with
   }
 
   test("right outer early state exclusion on left") {
-    val (leftInput, df1) = setupStream("left", 2)
-    val (rightInput, df2) = setupStream("right", 3)
-    // Use different schemas to ensure the null row is being generated from the correct side.
-    val left = df1.select('key, window('leftTime, "10 second"), 'leftValue)
-    val right = df2.select('key, window('rightTime, "10 second"), 'rightValue.cast("string"))
-
-    val joined = left.join(
-      right,
-      left("key") === right("key")
-        && left("window") === right("window")
-        && 'leftValue > 4,
-      "right_outer")
-      .select(right("key"), right("window.end").cast("long"), 'leftValue, 'rightValue)
+    val (leftInput, rightInput, joined) = setupWindowedJoinWithLeftCondition("right_outer")
 
     testStream(joined)(
       MultiAddData(leftInput, 1, 2, 3)(rightInput, 3, 4, 5),
@@ -612,19 +699,7 @@ class StreamingOuterJoinSuite extends StreamTest with StateStoreMetricsTest with
   }
 
   test("right outer early state exclusion on right") {
-    val (leftInput, df1) = setupStream("left", 2)
-    val (rightInput, df2) = setupStream("right", 3)
-    // Use different schemas to ensure the null row is being generated from the correct side.
-    val left = df1.select('key, window('leftTime, "10 second"), 'leftValue)
-    val right = df2.select('key, window('rightTime, "10 second"), 'rightValue.cast("string"))
-
-    val joined = left.join(
-      right,
-      left("key") === right("key")
-        && left("window") === right("window")
-        && 'rightValue.cast("int") > 7,
-      "right_outer")
-      .select(right("key"), right("window.end").cast("long"), 'leftValue, 'rightValue)
+    val (leftInput, rightInput, joined) = setupWindowedJoinWithRightCondition("right_outer")
 
     testStream(joined)(
       MultiAddData(leftInput, 3, 4, 5)(rightInput, 1, 2, 3),
@@ -681,27 +756,8 @@ class StreamingOuterJoinSuite extends StreamTest with StateStoreMetricsTest with
     ("right_outer", Row(null, 2, null, 5))
   ).foreach { case (joinType: String, outerResult) =>
     test(s"${joinType.replaceAllLiterally("_", " ")} with watermark range condition") {
-      import org.apache.spark.sql.functions._
+      val (leftInput, rightInput, joined) = setupWindowedJoinWithRangeCondition(joinType)
 
-      val leftInput = MemoryStream[(Int, Int)]
-      val rightInput = MemoryStream[(Int, Int)]
-
-      val df1 = leftInput.toDF.toDF("leftKey", "time")
-        .select('leftKey, timestamp_seconds($"time") as "leftTime", ('leftKey * 2) as "leftValue")
-        .withWatermark("leftTime", "10 seconds")
-
-      val df2 = rightInput.toDF.toDF("rightKey", "time")
-        .select('rightKey, timestamp_seconds($"time") as "rightTime",
-          ('rightKey * 3) as "rightValue")
-        .withWatermark("rightTime", "10 seconds")
-
-      val joined =
-        df1.join(
-          df2,
-          expr("leftKey = rightKey AND " +
-            "leftTime BETWEEN rightTime - interval 5 seconds AND rightTime + interval 5 seconds"),
-          joinType)
-          .select('leftKey, 'rightKey, 'leftTime.cast("int"), 'rightTime.cast("int"))
       testStream(joined)(
         AddData(leftInput, (1, 5), (3, 5)),
         CheckAnswer(),
@@ -780,27 +836,7 @@ class StreamingOuterJoinSuite extends StreamTest with StateStoreMetricsTest with
   }
 
   test("SPARK-26187 self left outer join should not return outer nulls for already matched rows") {
-    val inputStream = MemoryStream[(Int, Long)]
-
-    val df = inputStream.toDS()
-      .select(col("_1").as("value"), timestamp_seconds($"_2").as("timestamp"))
-
-    val leftStream = df.select(col("value").as("leftId"), col("timestamp").as("leftTime"))
-
-    val rightStream = df
-      // Introduce misses for ease of debugging
-      .where(col("value") % 2 === 0)
-      .select(col("value").as("rightId"), col("timestamp").as("rightTime"))
-
-    val query = leftStream
-      .withWatermark("leftTime", "5 seconds")
-      .join(
-        rightStream.withWatermark("rightTime", "5 seconds"),
-        expr("leftId = rightId AND rightTime >= leftTime AND " +
-          "rightTime <= leftTime + interval 5 seconds"),
-        joinType = "leftOuter")
-      .select(col("leftId"), col("leftTime").cast("int"),
-        col("rightId"), col("rightTime").cast("int"))
+    val (inputStream, query) = setupWindowedSelfJoin("left_outer")
 
     testStream(query)(
       AddData(inputStream, (1, 1L), (2, 2L), (3, 3L), (4, 4L), (5, 5L)),
@@ -1038,6 +1074,107 @@ class StreamingOuterJoinSuite extends StreamTest with StateStoreMetricsTest with
     testStream(joined)(
       MultiAddData((input1, inputDataForInput1), (input2, inputDataForInput2)),
       CheckNewAnswer(expectedOutput.head, expectedOutput.tail: _*)
+    )
+  }
+}
+
+class StreamingLeftSemiJoinSuite extends StreamingJoinSuite {
+
+  import testImplicits._
+
+  test("windowed left semi join") {
+    val (leftInput, rightInput, joined) = setupWindowedJoin("left_semi")
+
+    testStream(joined)(
+      MultiAddData(leftInput, 1, 2, 3, 4, 5)(rightInput, 3, 4, 5, 6, 7),
+      CheckNewAnswer(Row(3, 10, 6), Row(4, 10, 8), Row(5, 10, 10)),
+      MultiAddData(leftInput, 21)(rightInput, 22),
+      // Watermark = 11, should remove rows having window=[0,10]
+      CheckNewAnswer(),
+      assertNumStateRows(total = 2, updated = 12),
+      AddData(leftInput, 22),
+      CheckNewAnswer(Row(22, 30, 44)),
+      assertNumStateRows(total = 2, updated = 0),
+      StopStream,
+      StartStream(),
+
+      AddData(leftInput, 1),
+      // Row not add as 1 < state key watermark = 12
+      CheckNewAnswer(),
+      AddData(rightInput, 11),
+      // Row not add as 11 < state key watermark = 12
+      CheckNewAnswer()
+    )
+  }
+
+  test("left semi early state exclusion on left") {
+    val (leftInput, rightInput, joined) = setupWindowedJoinWithLeftCondition("left_semi")
+
+    testStream(joined)(
+      MultiAddData(leftInput, 1, 2, 3)(rightInput, 1, 2, 3, 4, 5),
+      // The left rows with leftValue <= 4 should not generate their semi join row and
+      // not get added to the state.
+      CheckNewAnswer(Row(3, 10, 6)),
+      assertNumStateRows(total = 4, updated = 4),
+      // We shouldn't get more semi join rows when the watermark advances.
+      MultiAddData(leftInput, 20)(rightInput, 21),
+      CheckNewAnswer(),
+      AddData(rightInput, 20),
+      CheckNewAnswer((20, 30, 40))
+    )
+  }
+
+  test("left semi early state exclusion on right") {
+    val (leftInput, rightInput, joined) = setupWindowedJoinWithRightCondition("left_semi")
+
+    testStream(joined)(
+      MultiAddData(leftInput, 3, 4, 5)(rightInput, 1, 2, 3),
+      // The right rows with rightValue <= 7 should never be added to the state.
+      // The right row with rightValue = 9 > 7, hence joined and added to state.
+      CheckNewAnswer(Row(3, 10, 6)),
+      assertNumStateRows(total = 4, updated = 4),
+      // We shouldn't get more semi join rows when the watermark advances.
+      MultiAddData(leftInput, 20)(rightInput, 21),
+      CheckNewAnswer(),
+      AddData(rightInput, 20),
+      CheckNewAnswer((20, 30, 40))
+    )
+  }
+
+  test("left semi join with watermark range condition") {
+    val (leftInput, rightInput, joined) = setupWindowedJoinWithRangeCondition("left_semi")
+
+    testStream(joined)(
+      AddData(leftInput, (1, 5), (3, 5)),
+      CheckAnswer(),
+      AddData(rightInput, (1, 10), (2, 5)),
+      CheckNewAnswer((1, 5)),
+      AddData(rightInput, (1, 11)),
+      // No match as left time is too low and left row is already matched.
+      CheckNewAnswer(),
+      assertNumStateRows(total = 5, updated = 5),
+
+      // Increase event time watermark to 20s by adding data with time = 30s on left input.
+      AddData(leftInput, (1, 7), (1, 30)),
+      CheckNewAnswer((1, 7)),
+      assertNumStateRows(total = 6, updated = 1),
+      // Watermark = 30 - 10 = 20, no matched row.
+      AddData(rightInput, (0, 30)),
+      CheckNewAnswer(),
+      assertNumStateRows(total = 2, updated = 1)
+    )
+  }
+
+  test("self left semi join") {
+    val (inputStream, query) = setupWindowedSelfJoin("left_semi")
+
+    testStream(query)(
+      AddData(inputStream, (1, 1L), (2, 2L), (3, 3L), (4, 4L), (5, 5L)),
+      CheckNewAnswer((2, 2), (4, 4)),
+      AddData(inputStream, (6, 6L), (7, 7L), (8, 8L), (9, 9L), (10, 10L)),
+      CheckNewAnswer((6, 6), (8, 8), (10, 10)),
+      AddData(inputStream, (11, 11L), (12, 12L), (13, 13L), (14, 14L), (15, 15L)),
+      CheckNewAnswer((12, 12), (14, 14))
     )
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This is to support left semi join in stream-stream join. The implementation of left semi join is (mostly in `StreamingSymmetricHashJoinExec` and `SymmetricHashJoinStateManager`):
* For left side input row, check if there's a match on right side state store.
  * if there's a match, output the left side row, but do not put the row in left side state store (no need to put in state store).
  * if there's no match, output nothing, but put the row in left side state store (with "matched" field to set to false in state store).
* For right side input row, check if there's a match on left side state store.
  * For all matched left rows in state store, output the rows with "matched" field as false. Set all left rows with "matched" field to be true. Only output the left side rows matched for the first time to guarantee left semi join semantics.
* State store eviction: evict rows from left/right side state store below watermark, same as inner join.

Note a followup optimization can be to evict matched left side rows from state store earlier, even when the rows are still above watermark. However this needs more change in `SymmetricHashJoinStateManager`, so will leave this as a followup.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Current stream-stream join supports inner, left outer and right outer join (https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala#L166 ). We do see internally a lot of users are using left semi stream-stream join (not spark structured streaming), e.g. I want to get the ad impression (join left side) which has click (joint right side), but I don't care how many clicks per ad (left semi semantics).

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Added unit tests in `UnsupportedOperationChecker.scala` and `StreamingJoinSuite.scala`.