### PR TITLE
[SPARK-33109][BUILD][FOLLOW-UP] Remove the obsolete comment about bringing sbt-dependency-graph back

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -45,5 +45,3 @@ libraryDependencies += "org.ow2.asm"  % "asm-commons" % "7.2"
 addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.2")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-pom-reader" % "2.2.0")
-
-// TODO(SPARK-33109) Upgrade to SBT 1.4 and support `dependencyTree` back


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to remove an obsolete comment about adding the `sbt-dependency-graph` back in SBT plugins.

### Why are the changes needed?

sbt-dependency-graph is now built-in from SBT 1.4.0, see https://github.com/sbt/sbt/releases/tag/v1.4.0.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually tested `./build/sbt dependencyTree`.