### PR TITLE
[SPARK-33180][INFRA] Enables 'fail_if_no_tests' when reporting test results in GitHub Actions

### DIFF
--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -15,19 +15,11 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         workflow: ${{ github.event.workflow_run.workflow_id }}
         commit: ${{ github.event.workflow_run.head_commit.id }}
-    - name: Check if JUnit report XML files exist
-      run: |
-        if ls **/target/test-reports/*.xml > /dev/null 2>&1; then
-          echo '::set-output name=FILE_EXISTS::true'
-        else
-          echo '::set-output name=FILE_EXISTS::false'
-        fi
-      id: check-junit-file
     - name: Publish test report
-      if: steps.check-junit-file.outputs.FILE_EXISTS == 'true'
       uses: scacap/action-surefire-report@v1
       with:
         check_name: Report test results
         github_token: ${{ secrets.GITHUB_TOKEN }}
         report_paths: "**/target/test-reports/*.xml"
+        fail_if_no_tests: false
         commit: ${{ github.event.workflow_run.head_commit.id }}

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -54,7 +54,10 @@ def determine_modules_for_files(filenames):
     """
     changed_modules = set()
     for filename in filenames:
-        continue
+        if filename in ("appveyor.yml",):
+            continue
+        if ("GITHUB_ACTIONS" not in os.environ) and filename.startswith(".github"):
+            continue
         matched_at_least_one_module = False
         for module in modules.all_modules:
             if module.contains_file(filename):
@@ -776,11 +779,10 @@ def main():
 
 
 def _test():
-    # import doctest
-    # failure_count = doctest.testmod()[0]
-    # if failure_count:
-    #     sys.exit(-1)
-    pass
+    import doctest
+    failure_count = doctest.testmod()[0]
+    if failure_count:
+        sys.exit(-1)
 
 
 if __name__ == "__main__":

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -54,10 +54,7 @@ def determine_modules_for_files(filenames):
     """
     changed_modules = set()
     for filename in filenames:
-        if filename in ("appveyor.yml",):
-            continue
-        if ("GITHUB_ACTIONS" not in os.environ) and filename.startswith(".github"):
-            continue
+        continue
         matched_at_least_one_module = False
         for module in modules.all_modules:
             if module.contains_file(filename):
@@ -779,10 +776,11 @@ def main():
 
 
 def _test():
-    import doctest
-    failure_count = doctest.testmod()[0]
-    if failure_count:
-        sys.exit(-1)
+    # import doctest
+    # failure_count = doctest.testmod()[0]
+    # if failure_count:
+    #     sys.exit(-1)
+    pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to use `fail_if_no_tests` option at `action-surefire-report` plugin, see also https://github.com/ScaCap/action-surefire-report/issues/29.

https://github.com/apache/spark/pull/29946 introduced the manual skipping in Apache Spark itself. After that, the plugin introduced the feature. Now, this PR reverts #29946 and enable that option.

### Why are the changes needed?

To remove manual skipping and avoid maintenance cost.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

I will push a commit to show in this PR because this change is specific to GitHub Actions: https://github.com/apache/spark/actions/runs/314900487