### PR TITLE
[SPARK-33139][SQL][FOLLOW-UP] Avoid using reflect call on session.py

### DIFF
--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -230,9 +230,7 @@ class SparkSession(SparkConversionMixin):
             SparkSession._instantiatedSession = self
             SparkSession._activeSession = self
             self._jvm.SparkSession.setDefaultSession(self._jsparkSession)
-            self._jvm.java.lang.Class.forName("org.apache.spark.sql.SparkSession$")\
-                .getDeclaredField("MODULE$")\
-                .get(None)\
+            getattr(getattr(self._jvm, "SparkSession$"), "MODULE$")\
                 .setActiveSessionInternal(self._jsparkSession)
 
     def _repr_html_(self):
@@ -564,9 +562,7 @@ class SparkSession(SparkConversionMixin):
         Py4JJavaError: ...
         """
         SparkSession._activeSession = self
-        self._jvm.java.lang.Class.forName("org.apache.spark.sql.SparkSession$")\
-            .getDeclaredField("MODULE$")\
-            .get(None)\
+        getattr(getattr(self._jvm, "SparkSession$"), "MODULE$")\
             .setActiveSessionInternal(self._jsparkSession)
         if isinstance(data, DataFrame):
             raise TypeError("data is already a DataFrame")
@@ -689,10 +685,7 @@ class SparkSession(SparkConversionMixin):
         self._sc.stop()
         # We should clean the default session up. See SPARK-23228.
         self._jvm.SparkSession.clearDefaultSession()
-        self._jvm.java.lang.Class.forName("org.apache.spark.sql.SparkSession$")\
-            .getDeclaredField("MODULE$")\
-            .get(None)\
-            .clearActiveSessionInternal()
+        getattr(getattr(self._jvm, "SparkSession$"), "MODULE$").clearActiveSessionInternal()
         SparkSession._instantiatedSession = None
         SparkSession._activeSession = None
         SQLContext._instantiatedContext = None


### PR DESCRIPTION
### What changes were proposed in this pull request?

In [SPARK-33139](https://github.com/apache/spark/pull/30042), I was using reflect "Class.forName" in python code to invoke method in SparkSession which is not recommended. using getattr to access "SparkSession$.Module$" instead. 

### Why are the changes needed?

Code refine.


### Does this PR introduce any user-facing change?
No.


### How was this patch tested?

Existing tests.
