### PR TITLE
[SPARK-33185][YARN] Set up yarn.Client to print direct links to driver stdout/stderr

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.deploy.yarn
 
 import java.io.{FileSystem => _, _}
-import java.net.{HttpURLConnection, InetAddress, URI, UnknownHostException, URL => JURL}
+import java.net.{InetAddress, UnknownHostException, URI}
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import java.util.{Locale, Properties, UUID}
@@ -27,13 +27,14 @@ import java.util.zip.{ZipEntry, ZipOutputStream}
 import scala.collection.JavaConverters._
 import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet, ListBuffer, Map}
 import scala.util.control.NonFatal
+
 import com.google.common.base.Objects
 import com.google.common.io.Files
 import javax.ws.rs.client.ClientBuilder
-import javax.ws.rs.core.{GenericType, MediaType}
+import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response.Status.Family
-import net.minidev.json.parser.JSONParser
 import net.minidev.json.{JSONArray, JSONObject}
+import net.minidev.json.parser.JSONParser
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs._
 import org.apache.hadoop.fs.permission.FsPermission
@@ -51,6 +52,7 @@ import org.apache.hadoop.yarn.exceptions.ApplicationNotFoundException
 import org.apache.hadoop.yarn.security.AMRMTokenIdentifier
 import org.apache.hadoop.yarn.util.Records
 import org.apache.hadoop.yarn.webapp.util.WebAppUtils
+
 import org.apache.spark.{SecurityManager, SparkConf, SparkException}
 import org.apache.spark.api.python.PythonUtils
 import org.apache.spark.deploy.{SparkApplication, SparkHadoopUtil}
@@ -63,8 +65,6 @@ import org.apache.spark.internal.config.Python._
 import org.apache.spark.launcher.{LauncherBackend, SparkAppHandle, YarnCommandBuilderUtils}
 import org.apache.spark.rpc.RpcEnv
 import org.apache.spark.util.{CallerContext, Utils}
-import org.glassfish.jersey.client.ClientResponse
-
 
 private[spark] class Client(
     val args: ClientArguments,

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1191,10 +1191,10 @@ private[spark] class Client(
   /**
    * Fetch links to the logs of the driver for the given application ID. This requires hitting the
    * RM REST API. Returns an empty map if the links could not be fetched. If this feature is
-   * disabled via [[CLIENT_REPORT_INCLUDE_DRIVER_LOGS_LINK]], an empty map is returned immediately.
+   * disabled via [[CLIENT_INCLUDE_DRIVER_LOGS_LINK]], an empty map is returned immediately.
    */
   private def getDriverLogsLink(appId: ApplicationId): IMap[String, String] = {
-    if (!sparkConf.get(CLIENT_REPORT_INCLUDE_DRIVER_LOGS_LINK)) {
+    if (!sparkConf.get(CLIENT_INCLUDE_DRIVER_LOGS_LINK)) {
       return IMap()
     }
     val baseRmUrl = WebAppUtils.getRMWebAppURLWithScheme(hadoopConf)

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1621,11 +1621,11 @@ private object Client extends Logging {
     // which allows for safe continuation of chaining. The `elements()` call will be empty,
     // and None will get returned.
     objectMapper.readTree(jsonString)
-        .path("appAttempts").path("appAttempt")
-        .elements().asScala.toList.takeRight(1).headOption
-        .flatMap(node => Option(node.get("logsLink")))
-        .map(_.asText())
-        .map(baseUrl => (s"$baseUrl/stdout?start=-4096", s"$baseUrl/stderr?start=-4096"))
+      .path("appAttempts").path("appAttempt")
+      .elements().asScala.toList.takeRight(1).headOption
+      .flatMap(node => Option(node.get("logsLink")))
+      .map(_.asText())
+      .map(baseUrl => (s"$baseUrl/stdout?start=-4096", s"$baseUrl/stderr?start=-4096"))
   }
 }
 

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
@@ -189,6 +189,15 @@ package object config extends Logging {
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("1s")
 
+  private[spark] val CLIENT_REPORT_INCLUDE_DRIVER_LOGS_LINK =
+    ConfigBuilder("spark.yarn.report.includeDriverLogsLink")
+      .doc("In cluster mode, whether print include links to the driver container's logs alongside "
+          + "application reports. This requires polling the ResourceManager's REST API, so it "
+          + "places some additional load on the RM.")
+      .version("3.1.0")
+      .booleanConf
+      .createWithDefault(false)
+
   /* Shared Client-mode AM / Driver configuration. */
 
   private[spark] val AM_MAX_WAIT_TIME = ConfigBuilder("spark.yarn.am.waitTime")

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
@@ -189,10 +189,10 @@ package object config extends Logging {
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("1s")
 
-  private[spark] val CLIENT_REPORT_INCLUDE_DRIVER_LOGS_LINK =
-    ConfigBuilder("spark.yarn.report.includeDriverLogsLink")
-      .doc("In cluster mode, whether print include links to the driver container's logs alongside "
-          + "application reports. This requires polling the ResourceManager's REST API, so it "
+  private[spark] val CLIENT_INCLUDE_DRIVER_LOGS_LINK =
+    ConfigBuilder("spark.yarn.includeDriverLogsLink")
+      .doc("In cluster mode, whether the client application report includes links to the driver "
+          + "container's logs. This requires polling the ResourceManager's REST API, so it "
           + "places some additional load on the RM.")
       .version("3.1.0")
       .booleanConf

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
@@ -604,29 +604,30 @@ class ClientSuite extends SparkFunSuite with Matchers {
         |  }]
         |}}
         |""".stripMargin
-    val (stdout, stderr) = Client.parseAppAttemptsJsonResponse(jsonString).get
-    assert(stdout ===
+    val logLinkMap = Client.parseAppAttemptsJsonResponse(jsonString)
+    assert(logLinkMap.keySet === Set("stdout", "stderr"))
+    assert(logLinkMap("stdout") ===
         s"http://$nodeHost:8042/node/containerlogs/$containerId/username/stdout?start=-4096")
-    assert(stderr ===
+    assert(logLinkMap("stderr") ===
         s"http://$nodeHost:8042/node/containerlogs/$containerId/username/stderr?start=-4096")
   }
 
   test("SPARK-33185 Parse YARN AppAttempts invalid JSON response") {
     // No "appAttempt" present
-    assert(Client.parseAppAttemptsJsonResponse("""{"appAttempts": { } }""") === None)
+    assert(Client.parseAppAttemptsJsonResponse("""{"appAttempts": { } }""") === Map())
 
     // "appAttempt" is empty
-    assert(
-      Client.parseAppAttemptsJsonResponse("""{"appAttempts": { "appAttempt": [ ] } }""") === None)
+    assert(Client.parseAppAttemptsJsonResponse("""{"appAttempts": { "appAttempt": [ ] } }""")
+        === Map())
 
     // logsLink is missing
-    assert(
-      Client.parseAppAttemptsJsonResponse("""{"appAttempts":{"appAttempt":[{"id":1}]}}""") === None)
+    assert(Client.parseAppAttemptsJsonResponse("""{"appAttempts":{"appAttempt":[{"id":1}]}}""")
+        === Map())
 
     // logsLink is present but empty
     assert(
       Client.parseAppAttemptsJsonResponse("""{"appAttempts":{"appAttempt":[{"logsLink":""}]}}""")
-          === None)
+          === Map())
   }
 
   private val matching = Seq(

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
@@ -622,6 +622,11 @@ class ClientSuite extends SparkFunSuite with Matchers {
     // logsLink is missing
     assert(
       Client.parseAppAttemptsJsonResponse("""{"appAttempts":{"appAttempt":[{"id":1}]}}""") === None)
+
+    // logsLink is present but empty
+    assert(
+      Client.parseAppAttemptsJsonResponse("""{"appAttempts":{"appAttempt":[{"logsLink":""}]}}""")
+          === None)
   }
 
   private val matching = Seq(

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
@@ -583,6 +583,47 @@ class ClientSuite extends SparkFunSuite with Matchers {
     }
   }
 
+  test("SPARK-33185 Parse YARN AppAttempts valid JSON response") {
+    val appIdSuffix = "1500000000000_1234567"
+    val containerId = s"container_e1_${appIdSuffix}_01_000001"
+    val nodeHost = "node.example.com"
+    val jsonString =
+      s"""
+        |{"appAttempts": {
+        |  "appAttempt": [ {
+        |    "id":1,
+        |    "startTime":1600000000000,
+        |    "finishedTime":1600000100000,
+        |    "containerId":"$containerId",
+        |    "nodeHttpAddress":"$nodeHost:8042",
+        |    "nodeId":"node.example.com:8041",
+        |    "logsLink":"http://$nodeHost:8042/node/containerlogs/$containerId/username",
+        |    "blacklistedNodes":"",
+        |    "nodesBlacklistedBySystem":"",
+        |    "appAttemptId":"appattempt_${appIdSuffix}_000001"
+        |  }]
+        |}}
+        |""".stripMargin
+    val (stdout, stderr) = Client.parseAppAttemptsJsonResponse(jsonString).get
+    assert(stdout ===
+        s"http://$nodeHost:8042/node/containerlogs/$containerId/username/stdout?start=-4096")
+    assert(stderr ===
+        s"http://$nodeHost:8042/node/containerlogs/$containerId/username/stderr?start=-4096")
+  }
+
+  test("SPARK-33185 Parse YARN AppAttempts invalid JSON response") {
+    // No "appAttempt" present
+    assert(Client.parseAppAttemptsJsonResponse("""{"appAttempts": { } }""") === None)
+
+    // "appAttempt" is empty
+    assert(
+      Client.parseAppAttemptsJsonResponse("""{"appAttempts": { "appAttempt": [ ] } }""") === None)
+
+    // logsLink is missing
+    assert(
+      Client.parseAppAttemptsJsonResponse("""{"appAttempts":{"appAttempt":[{"id":1}]}}""") === None)
+  }
+
   private val matching = Seq(
     ("files URI match test1", "file:///file1", "file:///file2"),
     ("files URI match test2", "file:///c:file1", "file://c:file2"),


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently when run in `cluster` mode on YARN, the Spark `yarn.Client` will print out the application report into the logs, to be easily viewed by users. For example:
```
INFO yarn.Client: 
 	 client token: Token { kind: YARN_CLIENT_TOKEN, service:  }
 	 diagnostics: N/A
 	 ApplicationMaster host: X.X.X.X
 	 ApplicationMaster RPC port: 0
 	 queue: default
 	 start time: 1602782566027
 	 final status: UNDEFINED
 	 tracking URL: http://hostname:8888/proxy/application_<id>/
 	 user: xkrogen
```

I propose adding, alongside the application report, some additional lines like:
```
         Driver Logs (stdout): http://hostname:8042/node/containerlogs/container_<id>/xkrogen/stdout?start=-4096
         Driver Logs (stderr): http://hostname:8042/node/containerlogs/container_<id>/xkrogen/stderr?start=-4096
```

This information isn't contained in the `ApplicationReport`, so it's necessary to query the ResourceManager REST API. For now I have added this as an always-on feature, but if there is any concern about adding this REST dependency, I think hiding this feature behind an off-by-default flag is reasonable.

### Why are the changes needed?
Typically, the tracking URL can be used to find the logs of the ApplicationMaster/driver while the application is running. Later, the Spark History Server can be used to track this information down, using the stdout/stderr links on the Executors page.

However, in the situation when the driver crashed _before_ writing out a history file, the SHS may not be aware of this application, and thus does not contain links to the driver logs. When this situation arises, it can be difficult for users to debug further, since they can't easily find their driver logs.

It is possible to reach the logs by using the `yarn logs` commands, but the average Spark user isn't aware of this and shouldn't have to be.

With this information readily available in the logs, users can quickly jump to their driver logs, even if it crashed before the SHS became aware of the application. This has the additional benefit of providing a quick way to access driver logs, which often contain useful information, in a single click (instead of navigating through the Spark UI).

### Does this PR introduce _any_ user-facing change?
Yes, some additional print statements will be created in the application report when using YARN in cluster mode.

### How was this patch tested?
Added unit tests for the parsing logic in `yarn.ClientSuite`. Also tested against a live cluster. When the driver is running:
```
INFO Client: Application report for application_XXXXXXXXX_YYYYYY (state: RUNNING)
INFO Client:
         client token: Token { kind: YARN_CLIENT_TOKEN, service:  }
         diagnostics: N/A
         ApplicationMaster host: host.example.com
         ApplicationMaster RPC port: ######
         queue: queue_name
         start time: 1604529046091
         final status: UNDEFINED
         tracking URL: http://host.example.com:8080/proxy/application_XXXXXXXXX_YYYYYY/
         user: xkrogen
         Driver Logs (stdout): http://host.example.com:8042/node/containerlogs/container_e07_XXXXXXXXX_YYYYYY_01_000001/xkrogen/stdout?start=-4096
         Driver Logs (stderr): http://host.example.com:8042/node/containerlogs/container_e07_XXXXXXXXX_YYYYYY_01_000001/xkrogen/stderr?start=-4096
INFO Client: Application report for application_XXXXXXXXX_YYYYYY (state: RUNNING)
```
I confirmed that when the driver has not yet launched, the report does not include the two Driver Logs items. Will omit the output here for brevity since it looks the same.