### PR TITLE
[SPARK-33140][SQL] remove SQLConf and SparkSession in all sub-class of Rule[QueryPlan]

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -182,7 +182,7 @@ class Analyzer(
 
   private def executeSameContext(plan: LogicalPlan): LogicalPlan = super.execute(plan)
 
-  def resolver: Resolver = SQLConf.get.resolver
+  def resolver: Resolver = conf.resolver
 
   /**
    * If the plan cannot be resolved within maxIterations, analyzer will throw exception to inform
@@ -739,7 +739,7 @@ class Analyzer(
               s"value data type ${value.dataType.simpleString} does not match " +
               s"pivot column data type ${pivotColumn.dataType.catalogString}")
           }
-          Cast(value, pivotColumn.dataType, Some(SQLConf.get.sessionLocalTimeZone)).eval(EmptyRow)
+          Cast(value, pivotColumn.dataType, Some(conf.sessionLocalTimeZone)).eval(EmptyRow)
         }
         // Group-by expressions coming from SQL are implicit and need to be deduced.
         val groupByExprs = groupByExprsOpt.getOrElse {
@@ -752,7 +752,7 @@ class Analyzer(
             case n: NamedExpression => n.name
             case _ =>
               val utf8Value =
-                Cast(value, StringType, Some(SQLConf.get.sessionLocalTimeZone)).eval(EmptyRow)
+                Cast(value, StringType, Some(conf.sessionLocalTimeZone)).eval(EmptyRow)
               Option(utf8Value).map(_.toString).getOrElse("null")
           }
           if (singleAgg) {
@@ -795,7 +795,7 @@ class Analyzer(
               If(
                 EqualNullSafe(
                   pivotColumn,
-                  Cast(value, pivotColumn.dataType, Some(SQLConf.get.sessionLocalTimeZone))),
+                  Cast(value, pivotColumn.dataType, Some(conf.sessionLocalTimeZone))),
                 e, Literal(null))
             }
             aggregates.map { aggregate =>
@@ -988,11 +988,11 @@ class Analyzer(
       case view @ View(desc, _, child) if !child.resolved =>
         // Resolve all the UnresolvedRelations and Views in the child.
         val newChild = AnalysisContext.withAnalysisContext(desc.viewCatalogAndNamespace) {
-          if (AnalysisContext.get.nestedViewDepth > SQLConf.get.maxNestedViewDepth) {
+          if (AnalysisContext.get.nestedViewDepth > conf.maxNestedViewDepth) {
             view.failAnalysis(s"The depth of view ${desc.identifier} exceeds the maximum " +
-              s"view resolution depth (${SQLConf.get.maxNestedViewDepth}). " +
-              s"Analysis is aborted to avoid errors. " +
-              s"Increase the value of ${SQLConf.MAX_NESTED_VIEW_DEPTH.key} to work around this.")
+              s"view resolution depth (${conf.maxNestedViewDepth}). Analysis is aborted to " +
+              s"avoid errors. Increase the value of ${SQLConf.MAX_NESTED_VIEW_DEPTH.key} to work " +
+              "around this.")
           }
           executeSameContext(child)
         }
@@ -1114,7 +1114,7 @@ class Analyzer(
 
         if (!i.overwrite) {
           AppendData.byPosition(r, query)
-        } else if (SQLConf.get.partitionOverwriteMode == PartitionOverwriteMode.DYNAMIC) {
+        } else if (conf.partitionOverwriteMode == PartitionOverwriteMode.DYNAMIC) {
           OverwritePartitionsDynamic.byPosition(r, query)
         } else {
           OverwriteByExpression.byPosition(r, query, staticDeleteExpression(r, staticPartitions))
@@ -1137,7 +1137,7 @@ class Analyzer(
         partitionSpec: Map[String, Option[String]]): Unit = {
       // check that each partition name is a partition column. otherwise, it is not valid
       partitionSpec.keySet.foreach { partitionName =>
-        partitionColumnNames.find(name => SQLConf.get.resolver(name, partitionName)) match {
+        partitionColumnNames.find(name => conf.resolver(name, partitionName)) match {
           case Some(_) =>
           case None =>
             throw new AnalysisException(
@@ -1159,7 +1159,7 @@ class Analyzer(
         val withStaticPartitionValues = {
           // for each static name, find the column name it will replace and check for unknowns.
           val outputNameToStaticName = staticPartitions.keySet.map(staticName =>
-            relation.output.find(col => SQLConf.get.resolver(col.name, staticName)) match {
+            relation.output.find(col => conf.resolver(col.name, staticName)) match {
               case Some(attr) =>
                 attr.name -> staticName
               case _ =>
@@ -1196,7 +1196,7 @@ class Analyzer(
         Literal(true)
       } else {
         staticPartitions.map { case (name, value) =>
-          relation.output.find(col => SQLConf.get.resolver(col.name, name)) match {
+          relation.output.find(col => conf.resolver(col.name, name)) match {
             case Some(attr) =>
               // the delete expression must reference the table's column names, but these attributes
               // are not available when CheckAnalysis runs because the relation is not a child of
@@ -1811,12 +1811,12 @@ class Analyzer(
 
     override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsUp {
       case agg @ Aggregate(groups, aggs, child)
-          if SQLConf.get.groupByAliases && child.resolved && aggs.forall(_.resolved) &&
+          if conf.groupByAliases && child.resolved && aggs.forall(_.resolved) &&
             groups.exists(!_.resolved) =>
         agg.copy(groupingExpressions = mayResolveAttrByAggregateExprs(groups, aggs, child))
 
       case gs @ GroupingSets(selectedGroups, groups, child, aggs)
-          if SQLConf.get.groupByAliases && child.resolved && aggs.forall(_.resolved) &&
+          if conf.groupByAliases && child.resolved && aggs.forall(_.resolved) &&
             groups.exists(_.isInstanceOf[UnresolvedAttribute]) =>
         gs.copy(
           selectedGroupByExprs = selectedGroups.map(mayResolveAttrByAggregateExprs(_, aggs, child)),
@@ -1947,7 +1947,7 @@ class Analyzer(
     }
 
     def normalizeFuncName(name: FunctionIdentifier): FunctionIdentifier = {
-      val funcName = if (SQLConf.get.caseSensitiveAnalysis) {
+      val funcName = if (conf.caseSensitiveAnalysis) {
         name.funcName
       } else {
         name.funcName.toLowerCase(Locale.ROOT)
@@ -1962,7 +1962,7 @@ class Analyzer(
     }
 
     protected def formatDatabaseName(name: String): String = {
-      if (SQLConf.get.caseSensitiveAnalysis) name else name.toLowerCase(Locale.ROOT)
+      if (conf.caseSensitiveAnalysis) name else name.toLowerCase(Locale.ROOT)
     }
   }
 
@@ -3082,7 +3082,7 @@ class Analyzer(
 
   private def validateStoreAssignmentPolicy(): Unit = {
     // SPARK-28730: LEGACY store assignment policy is disallowed in data source v2.
-    if (SQLConf.get.storeAssignmentPolicy == StoreAssignmentPolicy.LEGACY) {
+    if (conf.storeAssignmentPolicy == StoreAssignmentPolicy.LEGACY) {
       val configKey = SQLConf.STORE_ASSIGNMENT_POLICY.key
       throw new AnalysisException(s"""
         |"LEGACY" store assignment policy is disallowed in Spark data source V2.
@@ -3338,8 +3338,7 @@ class Analyzer(
             val parent = add.fieldNames().init
             if (parent.nonEmpty) {
               // Adding a nested field, need to normalize the parent column and position
-              val target = schema.findNestedField(
-                parent, includeCollections = true, SQLConf.get.resolver)
+              val target = schema.findNestedField(parent, includeCollections = true, conf.resolver)
               if (target.isEmpty) {
                 // Leave unresolved. Throws error in CheckAnalysis
                 Some(add)
@@ -3360,7 +3359,7 @@ class Analyzer(
           case typeChange: UpdateColumnType =>
             // Hive style syntax provides the column type, even if it may not have changed
             val fieldOpt = schema.findNestedField(
-              typeChange.fieldNames(), includeCollections = true, SQLConf.get.resolver)
+              typeChange.fieldNames(), includeCollections = true, conf.resolver)
 
             if (fieldOpt.isEmpty) {
               // We couldn't resolve the field. Leave it to CheckAnalysis
@@ -3387,16 +3386,14 @@ class Analyzer(
               case after: After =>
                 // Need to resolve column as well as position reference
                 val fieldOpt = schema.findNestedField(
-                  position.fieldNames(), includeCollections = true, SQLConf.get.resolver)
+                  position.fieldNames(), includeCollections = true, conf.resolver)
 
                 if (fieldOpt.isEmpty) {
                   Some(position)
                 } else {
                   val (normalizedPath, field) = fieldOpt.get
                   val targetCol = schema.findNestedField(
-                    normalizedPath :+ after.column(),
-                    includeCollections = true,
-                    SQLConf.get.resolver)
+                    normalizedPath :+ after.column(), includeCollections = true, conf.resolver)
                   if (targetCol.isEmpty) {
                     // Leave unchanged to CheckAnalysis
                     Some(position)
@@ -3449,7 +3446,7 @@ class Analyzer(
         fieldNames: Array[String],
         copy: Array[String] => TableChange): Option[TableChange] = {
       val fieldOpt = schema.findNestedField(
-        fieldNames, includeCollections = true, SQLConf.get.resolver)
+        fieldNames, includeCollections = true, conf.resolver)
       fieldOpt.map { case (path, field) => copy((path :+ field.name).toArray) }
     }
 
@@ -3461,8 +3458,7 @@ class Analyzer(
       position match {
         case null => null
         case after: After =>
-          (struct.fieldNames ++ fieldsAdded)
-            .find(n => SQLConf.get.resolver(n, after.column())) match {
+          (struct.fieldNames ++ fieldsAdded).find(n => conf.resolver(n, after.column())) match {
             case Some(colName) =>
               ColumnPosition.after(colName)
             case None =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -136,8 +136,6 @@ class Analyzer(
     maxIterations: Int)
   extends RuleExecutor[LogicalPlan] with CheckAnalysis with LookupCatalog {
 
-  SQLConf.get.withSQLConf(conf)
-
   private val v1SessionCatalog: SessionCatalog = catalogManager.v1SessionCatalog
 
   override protected def isPlanIntegral(plan: LogicalPlan): Boolean = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -136,6 +136,8 @@ class Analyzer(
     maxIterations: Int)
   extends RuleExecutor[LogicalPlan] with CheckAnalysis with LookupCatalog {
 
+  SQLConf.get.withSQLConf(conf)
+
   private val v1SessionCatalog: SessionCatalog = catalogManager.v1SessionCatalog
 
   override protected def isPlanIntegral(plan: LogicalPlan): Boolean = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -216,12 +216,12 @@ class Analyzer(
       CTESubstitution,
       WindowsSubstitution,
       EliminateUnions,
-      new SubstituteUnresolvedOrdinals(conf)),
+      SubstituteUnresolvedOrdinals),
     Batch("Disable Hints", Once,
-      new ResolveHints.DisableHints(conf)),
+      new ResolveHints.DisableHints),
     Batch("Hints", fixedPoint,
-      new ResolveHints.ResolveJoinStrategyHints(conf),
-      new ResolveHints.ResolveCoalesceHints(conf)),
+      ResolveHints.ResolveJoinStrategyHints,
+      ResolveHints.ResolveCoalesceHints),
     Batch("Simple Sanity Check", Once,
       LookupFunctions),
     Batch("Resolution", fixedPoint,
@@ -255,19 +255,19 @@ class Analyzer(
       GlobalAggregates ::
       ResolveAggregateFunctions ::
       TimeWindowing ::
-      ResolveInlineTables(conf) ::
+      ResolveInlineTables ::
       ResolveHigherOrderFunctions(v1SessionCatalog) ::
-      ResolveLambdaVariables(conf) ::
-      ResolveTimeZone(conf) ::
+      ResolveLambdaVariables ::
+      ResolveTimeZone ::
       ResolveRandomSeed ::
       ResolveBinaryArithmetic ::
       ResolveUnion ::
-      TypeCoercion.typeCoercionRules(conf) ++
+      TypeCoercion.typeCoercionRules ++
       extendedResolutionRules : _*),
     Batch("Post-Hoc Resolution", Once, postHocResolutionRules: _*),
     Batch("Normalize Alter Table", Once, ResolveAlterTableChanges),
     Batch("Remove Unresolved Hints", Once,
-      new ResolveHints.RemoveAllHints(conf)),
+      new ResolveHints.RemoveAllHints),
     Batch("Nondeterministic", Once,
       PullOutNondeterministic),
     Batch("UDF", Once,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
@@ -53,9 +53,9 @@ object ResolveHints {
   object ResolveJoinStrategyHints extends Rule[LogicalPlan] {
     private val STRATEGY_HINT_NAMES = JoinStrategyHint.strategies.flatMap(_.hintAliases)
 
-    private val hintErrorHandler = SQLConf.get.hintErrorHandler
+    private val hintErrorHandler = conf.hintErrorHandler
 
-    def resolver: Resolver = SQLConf.get.resolver
+    def resolver: Resolver = conf.resolver
 
     private def createHintInfo(hintName: String): HintInfo = {
       HintInfo(strategy =
@@ -268,7 +268,7 @@ object ResolveHints {
    */
   class RemoveAllHints extends Rule[LogicalPlan] {
 
-    private val hintErrorHandler = SQLConf.get.hintErrorHandler
+    private val hintErrorHandler = conf.hintErrorHandler
 
     def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperatorsUp {
       case h: UnresolvedHint =>
@@ -284,7 +284,7 @@ object ResolveHints {
    */
   class DisableHints extends RemoveAllHints {
     override def apply(plan: LogicalPlan): LogicalPlan = {
-      if (SQLConf.get.getConf(SQLConf.DISABLE_HINTS)) super.apply(plan) else plan
+      if (conf.getConf(SQLConf.DISABLE_HINTS)) super.apply(plan) else plan
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveInlineTables.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveInlineTables.scala
@@ -22,14 +22,12 @@ import scala.util.control.NonFatal
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{StructField, StructType}
 
 /**
  * An analyzer rule that replaces [[UnresolvedInlineTable]] with [[LocalRelation]].
  */
 object ResolveInlineTables extends Rule[LogicalPlan] with CastSupport {
-  override def conf: SQLConf = SQLConf.get
   override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
     case table: UnresolvedInlineTable if table.expressionsResolved =>
       validateInputDimension(table)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveInlineTables.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveInlineTables.scala
@@ -28,7 +28,8 @@ import org.apache.spark.sql.types.{StructField, StructType}
 /**
  * An analyzer rule that replaces [[UnresolvedInlineTable]] with [[LocalRelation]].
  */
-case class ResolveInlineTables(conf: SQLConf) extends Rule[LogicalPlan] with CastSupport {
+object ResolveInlineTables extends Rule[LogicalPlan] with CastSupport {
+  override def conf: SQLConf = SQLConf.get
   override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
     case table: UnresolvedInlineTable if table.expressionsResolved =>
       validateInputDimension(table)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -443,10 +443,8 @@ object TypeCoercion {
         p.makeCopy(Array(left, Cast(right, TimestampType)))
 
       case p @ BinaryComparison(left, right)
-          if findCommonTypeForBinaryComparison(
-            left.dataType, right.dataType, SQLConf.get).isDefined =>
-        val commonType =
-          findCommonTypeForBinaryComparison(left.dataType, right.dataType, SQLConf.get).get
+          if findCommonTypeForBinaryComparison(left.dataType, right.dataType, conf).isDefined =>
+        val commonType = findCommonTypeForBinaryComparison(left.dataType, right.dataType, conf).get
         p.makeCopy(Array(castExpr(left, commonType), castExpr(right, commonType)))
 
       case Abs(e @ StringType()) => Abs(Cast(e, DoubleType))
@@ -795,7 +793,7 @@ object TypeCoercion {
         p transformExpressionsUp {
           // Skip nodes if unresolved or empty children
           case c @ Concat(children) if !c.childrenResolved || children.isEmpty => c
-          case c @ Concat(children) if SQLConf.get.concatBinaryAsString ||
+          case c @ Concat(children) if conf.concatBinaryAsString ||
             !children.map(_.dataType).forall(_ == BinaryType) =>
             val newChildren = c.children.map { e =>
               ImplicitTypeCasts.implicitCast(e, StringType).getOrElse(e)
@@ -846,7 +844,7 @@ object TypeCoercion {
           case c @ Elt(children) =>
             val index = children.head
             val newIndex = ImplicitTypeCasts.implicitCast(index, IntegerType).getOrElse(index)
-            val newInputs = if (SQLConf.get.eltOutputAsString ||
+            val newInputs = if (conf.eltOutputAsString ||
               !children.tail.map(_.dataType).forall(_ == BinaryType)) {
               children.tail.map { e =>
                 ImplicitTypeCasts.implicitCast(e, StringType).getOrElse(e)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/higherOrderFunctions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/higherOrderFunctions.scala
@@ -70,12 +70,12 @@ case class ResolveHigherOrderFunctions(catalog: SessionCatalog) extends Rule[Log
  *      be a lambda function defined in an outer scope, or a attribute in produced by the plan's
  *      child. If names are duplicate, the name defined in the most inner scope is used.
  */
-case class ResolveLambdaVariables(conf: SQLConf) extends Rule[LogicalPlan] {
+object ResolveLambdaVariables extends Rule[LogicalPlan] {
 
   type LambdaVariableMap = Map[String, NamedExpression]
 
   private val canonicalizer = {
-    if (!conf.caseSensitiveAnalysis) {
+    if (!SQLConf.get.caseSensitiveAnalysis) {
       // scalastyle:off caselocale
       s: String => s.toLowerCase
       // scalastyle:on caselocale
@@ -157,7 +157,7 @@ case class ResolveLambdaVariables(conf: SQLConf) extends Rule[LogicalPlan] {
       parentLambdaMap.get(canonicalizer(name)) match {
         case Some(lambda) =>
           nestedFields.foldLeft(lambda: Expression) { (expr, fieldName) =>
-            ExtractValue(expr, Literal(fieldName), conf.resolver)
+            ExtractValue(expr, Literal(fieldName), SQLConf.get.resolver)
           }
         case None =>
           UnresolvedAttribute(u.nameParts)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/higherOrderFunctions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/higherOrderFunctions.scala
@@ -75,7 +75,7 @@ object ResolveLambdaVariables extends Rule[LogicalPlan] {
   type LambdaVariableMap = Map[String, NamedExpression]
 
   private val canonicalizer = {
-    if (!SQLConf.get.caseSensitiveAnalysis) {
+    if (!conf.caseSensitiveAnalysis) {
       // scalastyle:off caselocale
       s: String => s.toLowerCase
       // scalastyle:on caselocale
@@ -157,7 +157,7 @@ object ResolveLambdaVariables extends Rule[LogicalPlan] {
       parentLambdaMap.get(canonicalizer(name)) match {
         case Some(lambda) =>
           nestedFields.foldLeft(lambda: Expression) { (expr, fieldName) =>
-            ExtractValue(expr, Literal(fieldName), SQLConf.get.resolver)
+            ExtractValue(expr, Literal(fieldName), conf.resolver)
           }
         case None =>
           UnresolvedAttribute(u.nameParts)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/timeZoneAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/timeZoneAnalysis.scala
@@ -26,10 +26,10 @@ import org.apache.spark.sql.types.DataType
  * Replace [[TimeZoneAwareExpression]] without timezone id by its copy with session local
  * time zone.
  */
-case class ResolveTimeZone(conf: SQLConf) extends Rule[LogicalPlan] {
+object ResolveTimeZone extends Rule[LogicalPlan] {
   private val transformTimeZoneExprs: PartialFunction[Expression, Expression] = {
     case e: TimeZoneAwareExpression if e.timeZoneId.isEmpty =>
-      e.withTimeZone(conf.sessionLocalTimeZone)
+      e.withTimeZone(SQLConf.get.sessionLocalTimeZone)
     // Casts could be added in the subquery plan through the rule TypeCoercion while coercing
     // the types between the value expression and list query expression of IN expression.
     // We need to subject the subquery plan through ResolveTimeZone again to setup timezone

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/timeZoneAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/timeZoneAnalysis.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.types.DataType
 object ResolveTimeZone extends Rule[LogicalPlan] {
   private val transformTimeZoneExprs: PartialFunction[Expression, Expression] = {
     case e: TimeZoneAwareExpression if e.timeZoneId.isEmpty =>
-      e.withTimeZone(SQLConf.get.sessionLocalTimeZone)
+      e.withTimeZone(conf.sessionLocalTimeZone)
     // Casts could be added in the subquery plan through the rule TypeCoercion while coercing
     // the types between the value expression and list query expression of IN expression.
     // We need to subject the subquery plan through ResolveTimeZone again to setup timezone

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -68,6 +68,8 @@ class SessionCatalog(
   import SessionCatalog._
   import CatalogTypes.TablePartitionSpec
 
+  SQLConf.get.withSQLConf(conf)
+
   // For testing only.
   def this(
       externalCatalog: ExternalCatalog,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -68,6 +68,8 @@ class SessionCatalog(
   import SessionCatalog._
   import CatalogTypes.TablePartitionSpec
 
+  SQLConf.get.withSQLConf(conf)
+
   // For testing only.
   def this(
       externalCatalog: ExternalCatalog,
@@ -125,19 +127,19 @@ class SessionCatalog(
    * Format table name, taking into account case sensitivity.
    */
   protected[this] def formatTableName(name: String): String = {
-    if (conf.caseSensitiveAnalysis) name else name.toLowerCase(Locale.ROOT)
+    if (SQLConf.get.caseSensitiveAnalysis) name else name.toLowerCase(Locale.ROOT)
   }
 
   /**
    * Format database name, taking into account case sensitivity.
    */
   protected[this] def formatDatabaseName(name: String): String = {
-    if (conf.caseSensitiveAnalysis) name else name.toLowerCase(Locale.ROOT)
+    if (SQLConf.get.caseSensitiveAnalysis) name else name.toLowerCase(Locale.ROOT)
   }
 
   private val tableRelationCache: Cache[QualifiedTableName, LogicalPlan] = {
-    val cacheSize = conf.tableRelationCacheSize
-    val cacheTTL = conf.metadataCacheTTL
+    val cacheSize = SQLConf.get.tableRelationCacheSize
+    val cacheTTL = SQLConf.get.metadataCacheTTL
 
     var builder = CacheBuilder.newBuilder()
       .maximumSize(cacheSize)
@@ -229,7 +231,7 @@ class SessionCatalog(
     if (locationUri.isAbsolute) {
       locationUri
     } else {
-      val fullPath = new Path(conf.warehousePath, CatalogUtils.URIToString(locationUri))
+      val fullPath = new Path(SQLConf.get.warehousePath, CatalogUtils.URIToString(locationUri))
       makeQualifiedPath(fullPath.toUri)
     }
   }
@@ -433,7 +435,7 @@ class SessionCatalog(
   }
 
   private def columnNameResolved(schema: StructType, colName: String): Boolean = {
-    schema.fields.map(_.name).exists(conf.resolver(_, colName))
+    schema.fields.map(_.name).exists(SQLConf.get.resolver(_, colName))
   }
 
   /**
@@ -1127,7 +1129,7 @@ class SessionCatalog(
     val table = formatTableName(tableName.table)
     requireDbExists(db)
     requireTableExists(TableIdentifier(table, Option(db)))
-    externalCatalog.listPartitionsByFilter(db, table, predicates, conf.sessionLocalTimeZone)
+    externalCatalog.listPartitionsByFilter(db, table, predicates, SQLConf.get.sessionLocalTimeZone)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -68,8 +68,6 @@ class SessionCatalog(
   import SessionCatalog._
   import CatalogTypes.TablePartitionSpec
 
-  SQLConf.get.withSQLConf(conf)
-
   // For testing only.
   def this(
       externalCatalog: ExternalCatalog,
@@ -127,19 +125,19 @@ class SessionCatalog(
    * Format table name, taking into account case sensitivity.
    */
   protected[this] def formatTableName(name: String): String = {
-    if (SQLConf.get.caseSensitiveAnalysis) name else name.toLowerCase(Locale.ROOT)
+    if (conf.caseSensitiveAnalysis) name else name.toLowerCase(Locale.ROOT)
   }
 
   /**
    * Format database name, taking into account case sensitivity.
    */
   protected[this] def formatDatabaseName(name: String): String = {
-    if (SQLConf.get.caseSensitiveAnalysis) name else name.toLowerCase(Locale.ROOT)
+    if (conf.caseSensitiveAnalysis) name else name.toLowerCase(Locale.ROOT)
   }
 
   private val tableRelationCache: Cache[QualifiedTableName, LogicalPlan] = {
-    val cacheSize = SQLConf.get.tableRelationCacheSize
-    val cacheTTL = SQLConf.get.metadataCacheTTL
+    val cacheSize = conf.tableRelationCacheSize
+    val cacheTTL = conf.metadataCacheTTL
 
     var builder = CacheBuilder.newBuilder()
       .maximumSize(cacheSize)
@@ -231,7 +229,7 @@ class SessionCatalog(
     if (locationUri.isAbsolute) {
       locationUri
     } else {
-      val fullPath = new Path(SQLConf.get.warehousePath, CatalogUtils.URIToString(locationUri))
+      val fullPath = new Path(conf.warehousePath, CatalogUtils.URIToString(locationUri))
       makeQualifiedPath(fullPath.toUri)
     }
   }
@@ -435,7 +433,7 @@ class SessionCatalog(
   }
 
   private def columnNameResolved(schema: StructType, colName: String): Boolean = {
-    schema.fields.map(_.name).exists(SQLConf.get.resolver(_, colName))
+    schema.fields.map(_.name).exists(conf.resolver(_, colName))
   }
 
   /**
@@ -1129,7 +1127,7 @@ class SessionCatalog(
     val table = formatTableName(tableName.table)
     requireDbExists(db)
     requireTableExists(TableIdentifier(table, Option(db)))
-    externalCatalog.listPartitionsByFilter(db, table, predicates, SQLConf.get.sessionLocalTimeZone)
+    externalCatalog.listPartitionsByFilter(db, table, predicates, conf.sessionLocalTimeZone)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -68,8 +68,6 @@ class SessionCatalog(
   import SessionCatalog._
   import CatalogTypes.TablePartitionSpec
 
-  SQLConf.get.withSQLConf(conf)
-
   // For testing only.
   def this(
       externalCatalog: ExternalCatalog,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CostBasedJoinReorder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CostBasedJoinReorder.scala
@@ -34,8 +34,6 @@ import org.apache.spark.sql.internal.SQLConf
  */
 object CostBasedJoinReorder extends Rule[LogicalPlan] with PredicateHelper {
 
-  private def conf = SQLConf.get
-
   def apply(plan: LogicalPlan): LogicalPlan = {
     if (!conf.cboEnabled || !conf.joinReorderEnabled) {
       plan

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/Rule.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/Rule.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.catalyst.rules
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.trees.TreeNode
+import org.apache.spark.sql.internal.SQLConf
 
 abstract class Rule[TreeType <: TreeNode[_]] extends Logging {
 
@@ -29,4 +30,6 @@ abstract class Rule[TreeType <: TreeNode[_]] extends Logging {
   }
 
   def apply(plan: TreeType): TreeType
+
+  def conf: SQLConf = SQLConf.get
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
@@ -44,15 +44,13 @@ class CatalogManager(
   import CatalogManager.SESSION_CATALOG_NAME
   import CatalogV2Util._
 
-  SQLConf.get.withSQLConf(conf)
-
   private val catalogs = mutable.HashMap.empty[String, CatalogPlugin]
 
   def catalog(name: String): CatalogPlugin = synchronized {
     if (name.equalsIgnoreCase(SESSION_CATALOG_NAME)) {
       v2SessionCatalog
     } else {
-      catalogs.getOrElseUpdate(name, Catalogs.load(name, SQLConf.get))
+      catalogs.getOrElseUpdate(name, Catalogs.load(name, conf))
     }
   }
 
@@ -66,7 +64,7 @@ class CatalogManager(
   }
 
   private def loadV2SessionCatalog(): CatalogPlugin = {
-    Catalogs.load(SESSION_CATALOG_NAME, SQLConf.get) match {
+    Catalogs.load(SESSION_CATALOG_NAME, conf) match {
       case extension: CatalogExtension =>
         extension.setDelegateCatalog(defaultSessionCatalog)
         extension
@@ -84,7 +82,7 @@ class CatalogManager(
    * in the fallback configuration, spark.sql.sources.write.useV1SourceList
    */
   private[sql] def v2SessionCatalog: CatalogPlugin = {
-    SQLConf.get.getConf(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION).map { customV2SessionCatalog =>
+    conf.getConf(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION).map { customV2SessionCatalog =>
       try {
         catalogs.getOrElseUpdate(SESSION_CATALOG_NAME, loadV2SessionCatalog())
       } catch {
@@ -124,7 +122,7 @@ class CatalogManager(
   private var _currentCatalogName: Option[String] = None
 
   def currentCatalog: CatalogPlugin = synchronized {
-    catalog(_currentCatalogName.getOrElse(SQLConf.get.getConf(SQLConf.DEFAULT_CATALOG)))
+    catalog(_currentCatalogName.getOrElse(conf.getConf(SQLConf.DEFAULT_CATALOG)))
   }
 
   def setCurrentCatalog(catalogName: String): Unit = synchronized {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
@@ -44,8 +44,6 @@ class CatalogManager(
   import CatalogManager.SESSION_CATALOG_NAME
   import CatalogV2Util._
 
-  SQLConf.get.withSQLConf(conf)
-
   private val catalogs = mutable.HashMap.empty[String, CatalogPlugin]
 
   def catalog(name: String): CatalogPlugin = synchronized {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
@@ -44,6 +44,8 @@ class CatalogManager(
   import CatalogManager.SESSION_CATALOG_NAME
   import CatalogV2Util._
 
+  SQLConf.get.withSQLConf(conf)
+
   private val catalogs = mutable.HashMap.empty[String, CatalogPlugin]
 
   def catalog(name: String): CatalogPlugin = synchronized {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3520,30 +3520,6 @@ class SQLConf extends Serializable with Logging {
     setConfWithCheck(entry.key, entry.stringConverter(value))
   }
 
-  def withConf(props: Properties): SQLConf = settings.synchronized {
-    props.asScala.foreach { case (k, v) => setConfString(k, v) }
-    this
-  }
-
-  def withConfString(key: String, value: String): SQLConf = {
-    setConfString(key, value)
-    this
-  }
-
-  def withConf[T](entry: ConfigEntry[T], value: T): SQLConf = {
-    setConf(entry, value)
-    this
-  }
-
-  def withSQLConf(conf: SQLConf): SQLConf = {
-    if (!conf.equals(this)) {
-      conf.getAllConfs.foreach {
-        case (k, v) => if (v ne null) this.setConfString(k, v)
-      }
-    }
-    this
-  }
-
   /** Return the value of Spark SQL configuration property for the given key. */
   @throws[NoSuchElementException]("if key is not set")
   def getConfString(key: String): String = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3520,6 +3520,30 @@ class SQLConf extends Serializable with Logging {
     setConfWithCheck(entry.key, entry.stringConverter(value))
   }
 
+  def withConf(props: Properties): SQLConf = settings.synchronized {
+    props.asScala.foreach { case (k, v) => setConfString(k, v) }
+    this
+  }
+
+  def withConfString(key: String, value: String): SQLConf = {
+    setConfString(key, value)
+    this
+  }
+
+  def withConf[T](entry: ConfigEntry[T], value: T): SQLConf = {
+    setConf(entry, value)
+    this
+  }
+
+  def withSQLConf(conf: SQLConf): SQLConf = {
+    if (!conf.equals(this)) {
+      conf.getAllConfs.foreach {
+        case (k, v) => if (v ne null) this.setConfString(k, v)
+      }
+    }
+    this
+  }
+
   /** Return the value of Spark SQL configuration property for the given key. */
   @throws[NoSuchElementException]("if key is not set")
   def getConfString(key: String): String = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -771,22 +771,23 @@ class AnalysisSuite extends AnalysisTest with Matchers {
     // RuleExecutor only throw exception or log warning when the rule is supposed to run
     // more than once.
     val maxIterations = 2
-    val conf = new SQLConf().copy(SQLConf.ANALYZER_MAX_ITERATIONS -> maxIterations)
-    val testAnalyzer = new Analyzer(
-      new SessionCatalog(new InMemoryCatalog, FunctionRegistry.builtin, conf), conf)
+    withSQLConf(SQLConf.ANALYZER_MAX_ITERATIONS.key -> maxIterations.toString) {
+      val testAnalyzer = new Analyzer(
+        new SessionCatalog(new InMemoryCatalog, FunctionRegistry.builtin, conf), conf)
 
-    val plan = testRelation2.select(
-      $"a" / Literal(2) as "div1",
-      $"a" / $"b" as "div2",
-      $"a" / $"c" as "div3",
-      $"a" / $"d" as "div4",
-      $"e" / $"e" as "div5")
+      val plan = testRelation2.select(
+        $"a" / Literal(2) as "div1",
+        $"a" / $"b" as "div2",
+        $"a" / $"c" as "div3",
+        $"a" / $"d" as "div4",
+        $"e" / $"e" as "div5")
 
-    val message = intercept[TreeNodeException[LogicalPlan]] {
-      testAnalyzer.execute(plan)
-    }.getMessage
-    assert(message.startsWith(s"Max iterations ($maxIterations) reached for batch Resolution, " +
-      s"please set '${SQLConf.ANALYZER_MAX_ITERATIONS.key}' to a larger value."))
+      val message = intercept[TreeNodeException[LogicalPlan]] {
+        testAnalyzer.execute(plan)
+      }.getMessage
+      assert(message.startsWith(s"Max iterations ($maxIterations) reached for batch Resolution, " +
+        s"please set '${SQLConf.ANALYZER_MAX_ITERATIONS.key}' to a larger value."))
+    }
   }
 
   test("SPARK-30886 Deprecate two-parameter TRIM/LTRIM/RTRIM") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisTest.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisTest.scala
@@ -51,9 +51,8 @@ trait AnalysisTest extends PlanTest {
   protected def checkAnalysis(
       inputPlan: LogicalPlan,
       expectedPlan: LogicalPlan,
-      caseSensitive: Boolean = true,
-      extraConf: Map[String, String] = Map()): Unit = {
-    withSQLConf((extraConf + (SQLConf.CASE_SENSITIVE.key -> caseSensitive.toString)).toSeq: _*) {
+      caseSensitive: Boolean = true): Unit = {
+    withSQLConf(SQLConf.CASE_SENSITIVE.key -> caseSensitive.toString) {
       val analyzer = getAnalyzer
       val actualPlan = analyzer.executeAndCheck(inputPlan, new QueryPlanningTracker)
       comparePlans(actualPlan, expectedPlan)
@@ -70,9 +69,8 @@ trait AnalysisTest extends PlanTest {
 
   protected def assertAnalysisSuccess(
       inputPlan: LogicalPlan,
-      caseSensitive: Boolean = true,
-      extraConf: Map[String, String] = Map()): Unit = {
-    withSQLConf((extraConf + (SQLConf.CASE_SENSITIVE.key -> caseSensitive.toString)).toSeq: _*) {
+      caseSensitive: Boolean = true): Unit = {
+    withSQLConf(SQLConf.CASE_SENSITIVE.key -> caseSensitive.toString) {
       val analyzer = getAnalyzer
       val analysisAttempt = analyzer.execute(inputPlan)
       try analyzer.checkAnalysis(analysisAttempt) catch {
@@ -92,9 +90,8 @@ trait AnalysisTest extends PlanTest {
   protected def assertAnalysisError(
       inputPlan: LogicalPlan,
       expectedErrors: Seq[String],
-      caseSensitive: Boolean = true,
-      extraConf: Map[String, String] = Map()): Unit = {
-    withSQLConf((extraConf + (SQLConf.CASE_SENSITIVE.key -> caseSensitive.toString)).toSeq: _*) {
+      caseSensitive: Boolean = true): Unit = {
+    withSQLConf(SQLConf.CASE_SENSITIVE.key -> caseSensitive.toString) {
       val analyzer = getAnalyzer
       val e = intercept[AnalysisException] {
         analyzer.checkAnalysis(analyzer.execute(inputPlan))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisTest.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisTest.scala
@@ -31,8 +31,8 @@ import org.apache.spark.sql.internal.SQLConf
 
 trait AnalysisTest extends PlanTest {
 
-  protected lazy val caseSensitiveAnalyzer = makeAnalyzer(caseSensitive = true)
-  protected lazy val caseInsensitiveAnalyzer = makeAnalyzer(caseSensitive = false)
+  protected def caseSensitiveAnalyzer = makeAnalyzer(caseSensitive = true)
+  protected def caseInsensitiveAnalyzer = makeAnalyzer(caseSensitive = false)
 
   protected def extendedAnalysisRules: Seq[Rule[LogicalPlan]] = Nil
 
@@ -53,7 +53,7 @@ trait AnalysisTest extends PlanTest {
   }
 
   protected def getAnalyzer(caseSensitive: Boolean) = {
-    if (caseSensitive) caseSensitiveAnalyzer else caseInsensitiveAnalyzer
+    makeAnalyzer(caseSensitive)
   }
 
   protected def checkAnalysis(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/DataSourceV2AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/DataSourceV2AnalysisSuite.scala
@@ -114,9 +114,11 @@ case class TestRelationAcceptAnySchema(output: Seq[AttributeReference])
 }
 
 abstract class DataSourceV2ANSIAnalysisSuite extends DataSourceV2AnalysisBaseSuite {
-  override def getSQLConf(caseSensitive: Boolean): SQLConf =
-    super.getSQLConf(caseSensitive)
-      .copy(SQLConf.STORE_ASSIGNMENT_POLICY -> StoreAssignmentPolicy.ANSI)
+  override def getSQLConf(caseSensitive: Boolean): SQLConf = {
+    SQLConf.get.setConf(SQLConf.CASE_SENSITIVE, caseSensitive)
+    SQLConf.get.setConf(SQLConf.STORE_ASSIGNMENT_POLICY, StoreAssignmentPolicy.ANSI.toString)
+    SQLConf.get
+  }
 
 
   // For Ansi store assignment policy, expression `AnsiCast` is used instead of `Cast`.
@@ -133,9 +135,11 @@ abstract class DataSourceV2ANSIAnalysisSuite extends DataSourceV2AnalysisBaseSui
 }
 
 abstract class DataSourceV2StrictAnalysisSuite extends DataSourceV2AnalysisBaseSuite {
-  override def getSQLConf(caseSensitive: Boolean): SQLConf =
-    super.getSQLConf(caseSensitive)
-      .copy(SQLConf.STORE_ASSIGNMENT_POLICY -> StoreAssignmentPolicy.STRICT)
+  override def getSQLConf(caseSensitive: Boolean): SQLConf = {
+    SQLConf.get.setConf(SQLConf.CASE_SENSITIVE, caseSensitive)
+    SQLConf.get.setConf(SQLConf.STORE_ASSIGNMENT_POLICY, StoreAssignmentPolicy.STRICT.toString)
+    SQLConf.get
+  }
 
   test("byName: fail canWrite check") {
     val parsedPlan = byName(table, widerTable)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/DataSourceV2AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/DataSourceV2AnalysisSuite.scala
@@ -119,23 +119,24 @@ abstract class DataSourceV2ANSIAnalysisSuite extends DataSourceV2AnalysisBaseSui
   override def checkAnalysis(
       inputPlan: LogicalPlan,
       expectedPlan: LogicalPlan,
-      caseSensitive: Boolean = true,
-      extraConf: Map[String, String] = Map()): Unit = {
+      caseSensitive: Boolean = true): Unit = {
     val expectedPlanWithAnsiCast = expectedPlan transformAllExpressions {
       case c: Cast => AnsiCast(c.child, c.dataType, c.timeZoneId)
       case other => other
     }
-    super.checkAnalysis(inputPlan, expectedPlanWithAnsiCast, caseSensitive,
-      Map(SQLConf.STORE_ASSIGNMENT_POLICY.key -> StoreAssignmentPolicy.ANSI.toString))
+
+    withSQLConf(SQLConf.STORE_ASSIGNMENT_POLICY.key -> StoreAssignmentPolicy.ANSI.toString) {
+      super.checkAnalysis(inputPlan, expectedPlanWithAnsiCast, caseSensitive)
+    }
   }
 
   override def assertAnalysisError(
       inputPlan: LogicalPlan,
       expectedErrors: Seq[String],
-      caseSensitive: Boolean = true,
-      extraConf: Map[String, String] = Map()): Unit = {
-    super.assertAnalysisError(inputPlan, expectedErrors, caseSensitive,
-      Map(SQLConf.STORE_ASSIGNMENT_POLICY.key -> StoreAssignmentPolicy.ANSI.toString))
+      caseSensitive: Boolean = true): Unit = {
+    withSQLConf(SQLConf.STORE_ASSIGNMENT_POLICY.key -> StoreAssignmentPolicy.ANSI.toString) {
+      super.assertAnalysisError(inputPlan, expectedErrors, caseSensitive)
+    }
   }
 }
 
@@ -143,19 +144,19 @@ abstract class DataSourceV2StrictAnalysisSuite extends DataSourceV2AnalysisBaseS
   override def checkAnalysis(
       inputPlan: LogicalPlan,
       expectedPlan: LogicalPlan,
-      caseSensitive: Boolean = true,
-      extraConf: Map[String, String] = Map()): Unit = {
-    super.checkAnalysis(inputPlan, expectedPlan, caseSensitive,
-      Map(SQLConf.STORE_ASSIGNMENT_POLICY.key -> StoreAssignmentPolicy.STRICT.toString))
+      caseSensitive: Boolean = true): Unit = {
+    withSQLConf(SQLConf.STORE_ASSIGNMENT_POLICY.key -> StoreAssignmentPolicy.STRICT.toString) {
+      super.checkAnalysis(inputPlan, expectedPlan, caseSensitive)
+    }
   }
 
   override def assertAnalysisError(
       inputPlan: LogicalPlan,
       expectedErrors: Seq[String],
-      caseSensitive: Boolean = true,
-      extraConf: Map[String, String] = Map()): Unit = {
-    super.assertAnalysisError(inputPlan, expectedErrors, caseSensitive,
-      Map(SQLConf.STORE_ASSIGNMENT_POLICY.key -> StoreAssignmentPolicy.STRICT.toString))
+      caseSensitive: Boolean = true): Unit = {
+    withSQLConf(SQLConf.STORE_ASSIGNMENT_POLICY.key -> StoreAssignmentPolicy.STRICT.toString) {
+      super.assertAnalysisError(inputPlan, expectedErrors, caseSensitive)
+    }
   }
 
   test("byName: fail canWrite check") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveGroupingAnalyticsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveGroupingAnalyticsSuite.scala
@@ -23,7 +23,6 @@ import org.apache.spark.sql.catalyst.QueryPlanningTracker
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical._
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
 class ResolveGroupingAnalyticsSuite extends AnalysisTest {
@@ -111,16 +110,14 @@ class ResolveGroupingAnalyticsSuite extends AnalysisTest {
       Seq(UnresolvedAlias(Multiply(unresolved_a, Literal(2))),
         unresolved_b, UnresolvedAlias(count(unresolved_c))))
 
-    withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
-      val resultPlan = getAnalyzer.executeAndCheck(originalPlan2, new QueryPlanningTracker)
-      val gExpressions = resultPlan.asInstanceOf[Aggregate].groupingExpressions
-      assert(gExpressions.size == 3)
-      val firstGroupingExprAttrName =
-        gExpressions(0).asInstanceOf[AttributeReference].name.replaceAll("#[0-9]*", "#0")
-      assert(firstGroupingExprAttrName == "(a#0 * 2)")
-      assert(gExpressions(1).asInstanceOf[AttributeReference].name == "b")
-      assert(gExpressions(2).asInstanceOf[AttributeReference].name == VirtualColumn.groupingIdName)
-    }
+    val resultPlan = getAnalyzer.executeAndCheck(originalPlan2, new QueryPlanningTracker)
+    val gExpressions = resultPlan.asInstanceOf[Aggregate].groupingExpressions
+    assert(gExpressions.size == 3)
+    val firstGroupingExprAttrName =
+      gExpressions(0).asInstanceOf[AttributeReference].name.replaceAll("#[0-9]*", "#0")
+    assert(firstGroupingExprAttrName == "(a#0 * 2)")
+    assert(gExpressions(1).asInstanceOf[AttributeReference].name == "b")
+    assert(gExpressions(2).asInstanceOf[AttributeReference].name == VirtualColumn.groupingIdName)
   }
 
   test("cube") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveGroupingAnalyticsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveGroupingAnalyticsSuite.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.catalyst.QueryPlanningTracker
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
 class ResolveGroupingAnalyticsSuite extends AnalysisTest {
@@ -110,14 +111,16 @@ class ResolveGroupingAnalyticsSuite extends AnalysisTest {
       Seq(UnresolvedAlias(Multiply(unresolved_a, Literal(2))),
         unresolved_b, UnresolvedAlias(count(unresolved_c))))
 
-    val resultPlan = getAnalyzer(true).executeAndCheck(originalPlan2, new QueryPlanningTracker)
-    val gExpressions = resultPlan.asInstanceOf[Aggregate].groupingExpressions
-    assert(gExpressions.size == 3)
-    val firstGroupingExprAttrName =
-      gExpressions(0).asInstanceOf[AttributeReference].name.replaceAll("#[0-9]*", "#0")
-    assert(firstGroupingExprAttrName == "(a#0 * 2)")
-    assert(gExpressions(1).asInstanceOf[AttributeReference].name == "b")
-    assert(gExpressions(2).asInstanceOf[AttributeReference].name == VirtualColumn.groupingIdName)
+    withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
+      val resultPlan = getAnalyzer.executeAndCheck(originalPlan2, new QueryPlanningTracker)
+      val gExpressions = resultPlan.asInstanceOf[Aggregate].groupingExpressions
+      assert(gExpressions.size == 3)
+      val firstGroupingExprAttrName =
+        gExpressions(0).asInstanceOf[AttributeReference].name.replaceAll("#[0-9]*", "#0")
+      assert(firstGroupingExprAttrName == "(a#0 * 2)")
+      assert(gExpressions(1).asInstanceOf[AttributeReference].name == "b")
+      assert(gExpressions(2).asInstanceOf[AttributeReference].name == VirtualColumn.groupingIdName)
+    }
   }
 
   test("cube") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveLambdaVariablesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveLambdaVariablesSuite.scala
@@ -32,7 +32,7 @@ class ResolveLambdaVariablesSuite extends PlanTest {
   import org.apache.spark.sql.catalyst.dsl.plans._
 
   object Analyzer extends RuleExecutor[LogicalPlan] {
-    val batches = Batch("Resolution", FixedPoint(4), ResolveLambdaVariables(conf)) :: Nil
+    val batches = Batch("Resolution", FixedPoint(4), ResolveLambdaVariables) :: Nil
   }
 
   private val key = 'key.int

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolvedUuidExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolvedUuidExpressionsSuite.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
+import org.apache.spark.sql.internal.SQLConf
 
 /**
  * Test suite for resolving Uuid expressions.
@@ -36,7 +37,6 @@ class ResolvedUuidExpressionsSuite extends AnalysisTest {
   private lazy val uuid1Ref = uuid1.toAttribute
 
   private val tracker = new QueryPlanningTracker
-  private val analyzer = getAnalyzer(caseSensitive = true)
 
   private def getUuidExpressions(plan: LogicalPlan): Seq[Uuid] = {
     plan.flatMap {
@@ -48,28 +48,35 @@ class ResolvedUuidExpressionsSuite extends AnalysisTest {
   }
 
   test("analyzed plan sets random seed for Uuid expression") {
-    val plan = r.select(a, uuid1)
-    val resolvedPlan = analyzer.executeAndCheck(plan, tracker)
-    getUuidExpressions(resolvedPlan).foreach { u =>
-      assert(u.resolved)
-      assert(u.randomSeed.isDefined)
+    withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
+      val plan = r.select(a, uuid1)
+      val resolvedPlan = getAnalyzer.executeAndCheck(plan, tracker)
+      getUuidExpressions(resolvedPlan).foreach { u =>
+        assert(u.resolved)
+        assert(u.randomSeed.isDefined)
+      }
     }
   }
 
   test("Uuid expressions should have different random seeds") {
-    val plan = r.select(a, uuid1).groupBy(uuid1Ref)(uuid2, uuid3)
-    val resolvedPlan = analyzer.executeAndCheck(plan, tracker)
-    assert(getUuidExpressions(resolvedPlan).map(_.randomSeed.get).distinct.length == 3)
+    withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
+      val plan = r.select(a, uuid1).groupBy(uuid1Ref)(uuid2, uuid3)
+      val resolvedPlan = getAnalyzer.executeAndCheck(plan, tracker)
+      assert(getUuidExpressions(resolvedPlan).map(_.randomSeed.get).distinct.length == 3)
+    }
   }
 
   test("Different analyzed plans should have different random seeds in Uuids") {
-    val plan = r.select(a, uuid1).groupBy(uuid1Ref)(uuid2, uuid3)
-    val resolvedPlan1 = analyzer.executeAndCheck(plan, tracker)
-    val resolvedPlan2 = analyzer.executeAndCheck(plan, tracker)
-    val uuids1 = getUuidExpressions(resolvedPlan1)
-    val uuids2 = getUuidExpressions(resolvedPlan2)
-    assert(uuids1.distinct.length == 3)
-    assert(uuids2.distinct.length == 3)
-    assert(uuids1.intersect(uuids2).length == 0)
+    withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
+      val analyzer = getAnalyzer
+      val plan = r.select(a, uuid1).groupBy(uuid1Ref)(uuid2, uuid3)
+      val resolvedPlan1 = analyzer.executeAndCheck(plan, tracker)
+      val resolvedPlan2 = analyzer.executeAndCheck(plan, tracker)
+      val uuids1 = getUuidExpressions(resolvedPlan1)
+      val uuids2 = getUuidExpressions(resolvedPlan2)
+      assert(uuids1.distinct.length == 3)
+      assert(uuids2.distinct.length == 3)
+      assert(uuids1.intersect(uuids2).length == 0)
+    }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/SubstituteUnresolvedOrdinalsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/SubstituteUnresolvedOrdinalsSuite.scala
@@ -21,7 +21,6 @@ import org.apache.spark.sql.catalyst.analysis.TestRelations.testRelation2
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions.Literal
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.internal.SQLConf
 
 class SubstituteUnresolvedOrdinalsSuite extends AnalysisTest {
@@ -44,14 +43,11 @@ class SubstituteUnresolvedOrdinalsSuite extends AnalysisTest {
     checkAnalysis(plan, testRelation2.orderBy(a.asc, b.asc))
 
     // order by ordinal can be turned off by config
-    var newPlan: LogicalPlan = null
     withSQLConf(SQLConf.ORDER_BY_ORDINAL.key -> "false") {
-      newPlan = SubstituteUnresolvedOrdinals.apply(plan)
+      comparePlans(
+        SubstituteUnresolvedOrdinals.apply(plan),
+        testRelation2.orderBy(Literal(1).asc, Literal(2).asc))
     }
-
-    comparePlans(
-      newPlan,
-      testRelation2.orderBy(Literal(1).asc, Literal(2).asc))
   }
 
   test("group by ordinal") {
@@ -65,12 +61,10 @@ class SubstituteUnresolvedOrdinalsSuite extends AnalysisTest {
     checkAnalysis(plan2, testRelation2.groupBy(a, b)(a, b))
 
     // group by ordinal can be turned off by config
-    var newPlan2: LogicalPlan = null
     withSQLConf(SQLConf.GROUP_BY_ORDINAL.key -> "false") {
-      newPlan2 = SubstituteUnresolvedOrdinals.apply(plan2)
+      comparePlans(
+        SubstituteUnresolvedOrdinals.apply(plan2),
+        testRelation2.groupBy(Literal(1), Literal(2))('a, 'b))
     }
-    comparePlans(
-      newPlan2,
-      testRelation2.groupBy(Literal(1), Literal(2))('a, 'b))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
@@ -1103,7 +1103,7 @@ class TypeCoercionSuite extends AnalysisTest {
   }
 
   test("type coercion for Concat") {
-    val rule = TypeCoercion.ConcatCoercion(conf)
+    val rule = TypeCoercion.ConcatCoercion
 
     ruleTest(rule,
       Concat(Seq(Literal("ab"), Literal("cde"))),
@@ -1157,7 +1157,7 @@ class TypeCoercionSuite extends AnalysisTest {
   }
 
   test("type coercion for Elt") {
-    val rule = TypeCoercion.EltCoercion(conf)
+    val rule = TypeCoercion.EltCoercion
 
     ruleTest(rule,
       Elt(Seq(Literal(1), Literal("ab"), Literal("cde"))),
@@ -1284,7 +1284,7 @@ class TypeCoercionSuite extends AnalysisTest {
     }
   }
 
-  private val timeZoneResolver = ResolveTimeZone(new SQLConf)
+  private val timeZoneResolver = ResolveTimeZone
 
   private def widenSetOperationTypes(plan: LogicalPlan): LogicalPlan = {
     timeZoneResolver(TypeCoercion.WidenSetOperationTypes(plan))
@@ -1437,7 +1437,7 @@ class TypeCoercionSuite extends AnalysisTest {
    */
   test("make sure rules do not fire early") {
     // InConversion
-    val inConversion = TypeCoercion.InConversion(conf)
+    val inConversion = TypeCoercion.InConversion
     ruleTest(inConversion,
       In(UnresolvedAttribute("a"), Seq(Literal(1))),
       In(UnresolvedAttribute("a"), Seq(Literal(1)))
@@ -1481,7 +1481,7 @@ class TypeCoercionSuite extends AnalysisTest {
   }
 
   test("binary comparison with string promotion") {
-    val rule = TypeCoercion.PromoteStrings(conf)
+    val rule = TypeCoercion.PromoteStrings
     ruleTest(rule,
       GreaterThan(Literal("123"), Literal(1)),
       GreaterThan(Cast(Literal("123"), IntegerType), Literal(1)))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvalHelper.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvalHelper.scala
@@ -74,7 +74,7 @@ trait ExpressionEvalHelper extends ScalaCheckDrivenPropertyChecks with PlanTestB
 
   private def prepareEvaluation(expression: Expression): Expression = {
     val serializer = new JavaSerializer(new SparkConf()).newInstance
-    val resolver = ResolveTimeZone(new SQLConf)
+    val resolver = ResolveTimeZone
     val expr = resolver.resolveTimeZones(expression)
     assert(expr.resolved)
     serializer.deserialize(serializer.serialize(expr))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
@@ -270,7 +270,7 @@ class ObjectExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
   private def checkObjectExprEvaluation(
       expression: => Expression, expected: Any, inputRow: InternalRow = EmptyRow): Unit = {
     val serializer = new JavaSerializer(new SparkConf()).newInstance
-    val resolver = ResolveTimeZone(new SQLConf)
+    val resolver = ResolveTimeZone
     val expr = resolver.resolveTimeZones(serializer.deserialize(serializer.serialize(expression)))
     checkEvaluationWithoutCodegen(expr, expected, inputRow)
     checkEvaluationWithMutableProjection(expr, expected, inputRow)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SelectedFieldSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SelectedFieldSuite.scala
@@ -23,7 +23,6 @@ import org.apache.spark.sql.catalyst.analysis.AnalysisTest
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
 class SelectedFieldSuite extends AnalysisTest {
@@ -533,14 +532,10 @@ class SelectedFieldSuite extends AnalysisTest {
   }
 
   private def unapplySelect(expr: String, relation: LocalRelation) = {
-    var selectedField: Option[StructField] = None
-    withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
-      val parsedExpr = parseAsCatalystExpression(Seq(expr)).head
-      val select = relation.select(parsedExpr)
-      val analyzed = getAnalyzer.execute(select)
-      selectedField = SelectedField.unapply(analyzed.expressions.head)
-    }
-    selectedField
+    val parsedExpr = parseAsCatalystExpression(Seq(expr)).head
+    val select = relation.select(parsedExpr)
+    val analyzed = getAnalyzer.execute(select)
+    SelectedField.unapply(analyzed.expressions.head)
   }
 
   private def parseAsCatalystExpression(exprs: Seq[String]) = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/AggregateOptimizeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/AggregateOptimizeSuite.scala
@@ -17,22 +17,16 @@
 
 package org.apache.spark.sql.catalyst.optimizer
 
-import org.apache.spark.sql.catalyst.analysis.{Analyzer, EmptyFunctionRegistry}
-import org.apache.spark.sql.catalyst.catalog.{InMemoryCatalog, SessionCatalog}
+import org.apache.spark.sql.catalyst.analysis.AnalysisTest
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions.Literal
-import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.{CASE_SENSITIVE, GROUP_BY_ORDINAL}
 
-class AggregateOptimizeSuite extends PlanTest {
-  SQLConf.get.setConf(CASE_SENSITIVE, false)
-  SQLConf.get.setConf(GROUP_BY_ORDINAL, false)
-  val catalog = new SessionCatalog(new InMemoryCatalog, EmptyFunctionRegistry, conf)
-  val analyzer = new Analyzer(catalog, conf)
+class AggregateOptimizeSuite extends AnalysisTest {
+  val analyzer = getAnalyzer
 
   object Optimize extends RuleExecutor[LogicalPlan] {
     val batches = Batch("Aggregate", FixedPoint(100),
@@ -52,11 +46,14 @@ class AggregateOptimizeSuite extends PlanTest {
   }
 
   test("do not remove all grouping expressions if they are all literals") {
-    val query = testRelation.groupBy(Literal("1"), Literal(1) + Literal(2))(sum('b))
-    val optimized = Optimize.execute(analyzer.execute(query))
-    val correctAnswer = analyzer.execute(testRelation.groupBy(Literal(0))(sum('b)))
+    withSQLConf(CASE_SENSITIVE.key -> "false", GROUP_BY_ORDINAL.key -> "false") {
+      val analyzer = getAnalyzer
+      val query = testRelation.groupBy(Literal("1"), Literal(1) + Literal(2))(sum('b))
+      val optimized = Optimize.execute(analyzer.execute(query))
+      val correctAnswer = analyzer.execute(testRelation.groupBy(Literal(0))(sum('b)))
 
-    comparePlans(optimized, correctAnswer)
+      comparePlans(optimized, correctAnswer)
+    }
   }
 
   test("Remove aliased literals") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/AggregateOptimizeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/AggregateOptimizeSuite.scala
@@ -29,7 +29,8 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.{CASE_SENSITIVE, GROUP_BY_ORDINAL}
 
 class AggregateOptimizeSuite extends PlanTest {
-  override val conf = new SQLConf().copy(CASE_SENSITIVE -> false, GROUP_BY_ORDINAL -> false)
+  SQLConf.get.setConf(CASE_SENSITIVE, false)
+  SQLConf.get.setConf(GROUP_BY_ORDINAL, false)
   val catalog = new SessionCatalog(new InMemoryCatalog, EmptyFunctionRegistry, conf)
   val analyzer = new Analyzer(catalog, conf)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/EliminateSortsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/EliminateSortsSuite.scala
@@ -18,8 +18,7 @@
 package org.apache.spark.sql.catalyst.optimizer
 
 import org.apache.spark.api.python.PythonEvalType
-import org.apache.spark.sql.catalyst.analysis.{Analyzer, EmptyFunctionRegistry}
-import org.apache.spark.sql.catalyst.catalog.{InMemoryCatalog, SessionCatalog}
+import org.apache.spark.sql.catalyst.analysis.AnalysisTest
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
@@ -27,15 +26,11 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules._
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.{CASE_SENSITIVE, ORDER_BY_ORDINAL}
 import org.apache.spark.sql.types.IntegerType
 
-class EliminateSortsSuite extends PlanTest {
-  SQLConf.get.setConf(CASE_SENSITIVE, true)
-  SQLConf.get.setConf(ORDER_BY_ORDINAL, false)
-  val catalog = new SessionCatalog(new InMemoryCatalog, EmptyFunctionRegistry, conf)
-  val analyzer = new Analyzer(catalog, conf)
+class EliminateSortsSuite extends AnalysisTest {
+  val analyzer = getAnalyzer
 
   object Optimize extends RuleExecutor[LogicalPlan] {
     val batches =
@@ -67,23 +62,29 @@ class EliminateSortsSuite extends PlanTest {
   }
 
   test("All the SortOrder are no-op") {
-    val x = testRelation
+    withSQLConf(CASE_SENSITIVE.key -> "true", ORDER_BY_ORDINAL.key -> "false") {
+      val x = testRelation
+      val analyzer = getAnalyzer
 
-    val query = x.orderBy(SortOrder(3, Ascending), SortOrder(-1, Ascending))
-    val optimized = Optimize.execute(analyzer.execute(query))
-    val correctAnswer = analyzer.execute(x)
+      val query = x.orderBy(SortOrder(3, Ascending), SortOrder(-1, Ascending))
+      val optimized = Optimize.execute(analyzer.execute(query))
+      val correctAnswer = analyzer.execute(x)
 
-    comparePlans(optimized, correctAnswer)
+      comparePlans(optimized, correctAnswer)
+    }
   }
 
   test("Partial order-by clauses contain no-op SortOrder") {
-    val x = testRelation
+    withSQLConf(CASE_SENSITIVE.key -> "true", ORDER_BY_ORDINAL.key -> "false") {
+      val x = testRelation
+      val analyzer = getAnalyzer
 
-    val query = x.orderBy(SortOrder(3, Ascending), 'a.asc)
-    val optimized = Optimize.execute(analyzer.execute(query))
-    val correctAnswer = analyzer.execute(x.orderBy('a.asc))
+      val query = x.orderBy(SortOrder(3, Ascending), 'a.asc)
+      val optimized = Optimize.execute(analyzer.execute(query))
+      val correctAnswer = analyzer.execute(x.orderBy('a.asc))
 
-    comparePlans(optimized, correctAnswer)
+      comparePlans(optimized, correctAnswer)
+    }
   }
 
   test("Remove no-op alias") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/EliminateSortsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/EliminateSortsSuite.scala
@@ -32,7 +32,8 @@ import org.apache.spark.sql.internal.SQLConf.{CASE_SENSITIVE, ORDER_BY_ORDINAL}
 import org.apache.spark.sql.types.IntegerType
 
 class EliminateSortsSuite extends PlanTest {
-  override val conf = new SQLConf().copy(CASE_SENSITIVE -> true, ORDER_BY_ORDINAL -> false)
+  SQLConf.get.setConf(CASE_SENSITIVE, true)
+  SQLConf.get.setConf(ORDER_BY_ORDINAL, false)
   val catalog = new SessionCatalog(new InMemoryCatalog, EmptyFunctionRegistry, conf)
   val analyzer = new Analyzer(catalog, conf)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -38,7 +38,6 @@ import org.apache.spark.sql.types.{HIVE_TYPE_STRING, HiveStringType, MetadataBui
  */
 class ResolveSessionCatalog(
     val catalogManager: CatalogManager,
-    conf: SQLConf,
     isTempView: Seq[String] => Boolean,
     isTempFunction: String => Boolean)
   extends Rule[LogicalPlan] with LookupCatalog {
@@ -126,7 +125,7 @@ class ResolveSessionCatalog(
           a.comment.map(c => builder.putString("comment", c))
           val colName = a.column(0)
           val dataType = a.dataType.getOrElse {
-            v1Table.schema.findNestedField(Seq(colName), resolver = conf.resolver)
+            v1Table.schema.findNestedField(Seq(colName), resolver = SQLConf.get.resolver)
               .map(_._2.dataType)
               .getOrElse {
                 throw new AnalysisException(
@@ -276,7 +275,7 @@ class ResolveSessionCatalog(
     case c @ CreateTableStatement(
          SessionCatalogAndTable(catalog, tbl), _, _, _, _, _, _, _, _, _) =>
       assertNoNullTypeInSchema(c.tableSchema)
-      val provider = c.provider.getOrElse(conf.defaultDataSourceName)
+      val provider = c.provider.getOrElse(SQLConf.get.defaultDataSourceName)
       if (!isV2Provider(provider)) {
         if (!DDLUtils.isHiveTable(Some(provider))) {
           assertNoCharTypeInSchema(c.tableSchema)
@@ -303,7 +302,7 @@ class ResolveSessionCatalog(
       if (c.asSelect.resolved) {
         assertNoNullTypeInSchema(c.asSelect.schema)
       }
-      val provider = c.provider.getOrElse(conf.defaultDataSourceName)
+      val provider = c.provider.getOrElse(SQLConf.get.defaultDataSourceName)
       if (!isV2Provider(provider)) {
         val tableDesc = buildCatalogTable(tbl.asTableIdentifier, new StructType,
           c.partitioning, c.bucketSpec, c.properties, provider, c.options, c.location,
@@ -333,7 +332,7 @@ class ResolveSessionCatalog(
     case c @ ReplaceTableStatement(
          SessionCatalogAndTable(catalog, tbl), _, _, _, _, _, _, _, _, _) =>
       assertNoNullTypeInSchema(c.tableSchema)
-      val provider = c.provider.getOrElse(conf.defaultDataSourceName)
+      val provider = c.provider.getOrElse(SQLConf.get.defaultDataSourceName)
       if (!isV2Provider(provider)) {
         throw new AnalysisException("REPLACE TABLE is only supported with v2 tables.")
       } else {
@@ -353,7 +352,7 @@ class ResolveSessionCatalog(
       if (c.asSelect.resolved) {
         assertNoNullTypeInSchema(c.asSelect.schema)
       }
-      val provider = c.provider.getOrElse(conf.defaultDataSourceName)
+      val provider = c.provider.getOrElse(SQLConf.get.defaultDataSourceName)
       if (!isV2Provider(provider)) {
         throw new AnalysisException("REPLACE TABLE AS SELECT is only supported with v2 tables.")
       } else {
@@ -487,7 +486,7 @@ class ResolveSessionCatalog(
       }
       val sql = "SHOW COLUMNS"
       val v1TableName = parseTempViewOrV1Table(nameParts, sql).asTableIdentifier
-      val resolver = conf.resolver
+      val resolver = SQLConf.get.resolver
       val db = ns match {
         case Some(db) if v1TableName.database.exists(!resolver(_, db.head)) =>
           throw new AnalysisException(
@@ -722,7 +721,7 @@ class ResolveSessionCatalog(
   }
 
   private def isV2Provider(provider: String): Boolean = {
-    DataSource.lookupDataSourceV2(provider, conf) match {
+    DataSource.lookupDataSourceV2(provider, SQLConf.get) match {
       // TODO(SPARK-28396): Currently file source v2 can't work with tables.
       case Some(_: FileDataSourceV2) => false
       case Some(_) => true

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -125,7 +125,7 @@ class ResolveSessionCatalog(
           a.comment.map(c => builder.putString("comment", c))
           val colName = a.column(0)
           val dataType = a.dataType.getOrElse {
-            v1Table.schema.findNestedField(Seq(colName), resolver = SQLConf.get.resolver)
+            v1Table.schema.findNestedField(Seq(colName), resolver = conf.resolver)
               .map(_._2.dataType)
               .getOrElse {
                 throw new AnalysisException(
@@ -275,7 +275,7 @@ class ResolveSessionCatalog(
     case c @ CreateTableStatement(
          SessionCatalogAndTable(catalog, tbl), _, _, _, _, _, _, _, _, _) =>
       assertNoNullTypeInSchema(c.tableSchema)
-      val provider = c.provider.getOrElse(SQLConf.get.defaultDataSourceName)
+      val provider = c.provider.getOrElse(conf.defaultDataSourceName)
       if (!isV2Provider(provider)) {
         if (!DDLUtils.isHiveTable(Some(provider))) {
           assertNoCharTypeInSchema(c.tableSchema)
@@ -302,7 +302,7 @@ class ResolveSessionCatalog(
       if (c.asSelect.resolved) {
         assertNoNullTypeInSchema(c.asSelect.schema)
       }
-      val provider = c.provider.getOrElse(SQLConf.get.defaultDataSourceName)
+      val provider = c.provider.getOrElse(conf.defaultDataSourceName)
       if (!isV2Provider(provider)) {
         val tableDesc = buildCatalogTable(tbl.asTableIdentifier, new StructType,
           c.partitioning, c.bucketSpec, c.properties, provider, c.options, c.location,
@@ -332,7 +332,7 @@ class ResolveSessionCatalog(
     case c @ ReplaceTableStatement(
          SessionCatalogAndTable(catalog, tbl), _, _, _, _, _, _, _, _, _) =>
       assertNoNullTypeInSchema(c.tableSchema)
-      val provider = c.provider.getOrElse(SQLConf.get.defaultDataSourceName)
+      val provider = c.provider.getOrElse(conf.defaultDataSourceName)
       if (!isV2Provider(provider)) {
         throw new AnalysisException("REPLACE TABLE is only supported with v2 tables.")
       } else {
@@ -352,7 +352,7 @@ class ResolveSessionCatalog(
       if (c.asSelect.resolved) {
         assertNoNullTypeInSchema(c.asSelect.schema)
       }
-      val provider = c.provider.getOrElse(SQLConf.get.defaultDataSourceName)
+      val provider = c.provider.getOrElse(conf.defaultDataSourceName)
       if (!isV2Provider(provider)) {
         throw new AnalysisException("REPLACE TABLE AS SELECT is only supported with v2 tables.")
       } else {
@@ -486,7 +486,7 @@ class ResolveSessionCatalog(
       }
       val sql = "SHOW COLUMNS"
       val v1TableName = parseTempViewOrV1Table(nameParts, sql).asTableIdentifier
-      val resolver = SQLConf.get.resolver
+      val resolver = conf.resolver
       val db = ns match {
         case Some(db) if v1TableName.database.exists(!resolver(_, db.head)) =>
           throw new AnalysisException(
@@ -721,7 +721,7 @@ class ResolveSessionCatalog(
   }
 
   private def isV2Provider(provider: String): Boolean = {
-    DataSource.lookupDataSourceV2(provider, SQLConf.get) match {
+    DataSource.lookupDataSourceV2(provider, conf) match {
       // TODO(SPARK-28396): Currently file source v2 can't work with tables.
       case Some(_: FileDataSourceV2) => false
       case Some(_) => true

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
@@ -29,7 +29,6 @@ import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.execution.vectorized.{OffHeapColumnVector, OnHeapColumnVector, WritableColumnVector}
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
 
@@ -439,7 +438,7 @@ case class RowToColumnarExec(child: SparkPlan) extends RowToColumnarTransition {
   )
 
   override def doExecuteColumnar(): RDD[ColumnarBatch] = {
-    val enableOffHeapColumnVector = sqlContext.conf.offHeapColumnVectorEnabled
+    val enableOffHeapColumnVector = conf.offHeapColumnVectorEnabled
     val numInputRows = longMetric("numInputRows")
     val numOutputBatches = longMetric("numOutputBatches")
     // Instead of creating a new config we are reusing columnBatchSize. In the future if we do
@@ -494,7 +493,6 @@ case class RowToColumnarExec(child: SparkPlan) extends RowToColumnarTransition {
  * to/from columnar formatted data.
  */
 case class ApplyColumnarRulesAndInsertTransitions(
-    conf: SQLConf,
     columnarRules: Seq[ColumnarRule])
   extends Rule[SparkPlan] {
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
@@ -438,7 +438,7 @@ case class RowToColumnarExec(child: SparkPlan) extends RowToColumnarTransition {
   )
 
   override def doExecuteColumnar(): RDD[ColumnarBatch] = {
-    val enableOffHeapColumnVector = conf.offHeapColumnVectorEnabled
+    val enableOffHeapColumnVector = sqlContext.conf.offHeapColumnVectorEnabled
     val numInputRows = longMetric("numInputRows")
     val numOutputBatches = longMetric("numOutputBatches")
     // Instead of creating a new config we are reusing columnBatchSize. In the future if we do

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -339,17 +339,16 @@ object QueryExecution {
     // as the original plan is hidden behind `AdaptiveSparkPlanExec`.
     adaptiveExecutionRule.toSeq ++
     Seq(
-      CoalesceBucketsInJoin(sparkSession.sessionState.conf),
-      PlanDynamicPruningFilters(sparkSession),
-      PlanSubqueries(sparkSession),
-      RemoveRedundantProjects(sparkSession.sessionState.conf),
-      EnsureRequirements(sparkSession.sessionState.conf),
-      DisableUnnecessaryBucketedScan(sparkSession.sessionState.conf),
-      ApplyColumnarRulesAndInsertTransitions(sparkSession.sessionState.conf,
-        sparkSession.sessionState.columnarRules),
-      CollapseCodegenStages(sparkSession.sessionState.conf),
-      ReuseExchange(sparkSession.sessionState.conf),
-      ReuseSubquery(sparkSession.sessionState.conf)
+      CoalesceBucketsInJoin,
+      PlanDynamicPruningFilters,
+      PlanSubqueries,
+      RemoveRedundantProjects,
+      EnsureRequirements,
+      DisableUnnecessaryBucketedScan,
+      ApplyColumnarRulesAndInsertTransitions(sparkSession.sessionState.columnarRules),
+      CollapseCodegenStages(),
+      ReuseExchange,
+      ReuseSubquery
     )
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/RemoveRedundantProjects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/RemoveRedundantProjects.scala
@@ -35,9 +35,9 @@ import org.apache.spark.sql.internal.SQLConf
  * optimization to prune data. During physical planning, redundant project nodes can be removed
  * to simplify the query plan.
  */
-case class RemoveRedundantProjects(conf: SQLConf) extends Rule[SparkPlan] {
+object RemoveRedundantProjects extends Rule[SparkPlan] {
   def apply(plan: SparkPlan): SparkPlan = {
-    if (!conf.getConf(SQLConf.REMOVE_REDUNDANT_PROJECTS_ENABLED)) {
+    if (!SQLConf.get.getConf(SQLConf.REMOVE_REDUNDANT_PROJECTS_ENABLED)) {
       plan
     } else {
       removeProject(plan, true)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/RemoveRedundantProjects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/RemoveRedundantProjects.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.internal.SQLConf
  */
 object RemoveRedundantProjects extends Rule[SparkPlan] {
   def apply(plan: SparkPlan): SparkPlan = {
-    if (!SQLConf.get.getConf(SQLConf.REMOVE_REDUNDANT_PROJECTS_ENABLED)) {
+    if (!conf.getConf(SQLConf.REMOVE_REDUNDANT_PROJECTS_ENABLED)) {
       plan
     } else {
       removeProject(plan, true)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
@@ -888,9 +888,9 @@ case class CollapseCodegenStages(
       val willFallback = plan.expressions.exists(_.find(e => !supportCodegen(e)).isDefined)
       // the generated code will be huge if there are too many columns
       val hasTooManyOutputFields =
-        WholeStageCodegenExec.isTooManyFields(SQLConf.get, plan.schema)
+        WholeStageCodegenExec.isTooManyFields(conf, plan.schema)
       val hasTooManyInputFields =
-        plan.children.exists(p => WholeStageCodegenExec.isTooManyFields(SQLConf.get, p.schema))
+        plan.children.exists(p => WholeStageCodegenExec.isTooManyFields(conf, p.schema))
       !willFallback && !hasTooManyOutputFields && !hasTooManyInputFields
     case _ => false
   }
@@ -939,7 +939,7 @@ case class CollapseCodegenStages(
   }
 
   def apply(plan: SparkPlan): SparkPlan = {
-    if (SQLConf.get.wholeStageEnabled) {
+    if (conf.wholeStageEnabled) {
       insertWholeStageCodegen(plan)
     } else {
       plan

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQEOptimizer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQEOptimizer.scala
@@ -28,7 +28,7 @@ import org.apache.spark.util.Utils
 class AQEOptimizer(conf: SQLConf) extends RuleExecutor[LogicalPlan] {
   private val defaultBatches = Seq(
     Batch("Demote BroadcastHashJoin", Once,
-      DemoteBroadcastHashJoin(conf)),
+      DemoteBroadcastHashJoin),
     Batch("Eliminate Join to Empty Relation", Once, EliminateJoinToEmptyRelation)
   )
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
@@ -26,8 +26,8 @@ import org.apache.spark.sql.internal.SQLConf
  * A rule to coalesce the shuffle partitions based on the map output statistics, which can
  * avoid many small reduce tasks that hurt performance.
  */
-case class CoalesceShufflePartitions(session: SparkSession) extends Rule[SparkPlan] {
-  private def conf = session.sessionState.conf
+object CoalesceShufflePartitions extends Rule[SparkPlan] {
+  private def conf = SQLConf.get
 
   override def apply(plan: SparkPlan): SparkPlan = {
     if (!conf.coalesceShufflePartitionsEnabled) {
@@ -65,7 +65,7 @@ case class CoalesceShufflePartitions(session: SparkSession) extends Rule[SparkPl
         // We fall back to Spark default parallelism if the minimum number of coalesced partitions
         // is not set, so to avoid perf regressions compared to no coalescing.
         val minPartitionNum = conf.getConf(SQLConf.COALESCE_PARTITIONS_MIN_PARTITION_NUM)
-          .getOrElse(session.sparkContext.defaultParallelism)
+          .getOrElse(SparkSession.active.sparkContext.defaultParallelism)
         val partitionSpecs = ShufflePartitionsUtil.coalescePartitions(
           validMetrics.toArray,
           advisoryTargetSize = conf.getConf(SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
@@ -27,8 +27,6 @@ import org.apache.spark.sql.internal.SQLConf
  * avoid many small reduce tasks that hurt performance.
  */
 object CoalesceShufflePartitions extends Rule[SparkPlan] {
-  private def conf = SQLConf.get
-
   override def apply(plan: SparkPlan): SparkPlan = {
     if (!conf.coalesceShufflePartitionsEnabled) {
       return plan

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/DemoteBroadcastHashJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/DemoteBroadcastHashJoin.scala
@@ -34,7 +34,7 @@ object DemoteBroadcastHashJoin extends Rule[LogicalPlan] {
       val partitionCnt = mapStats.bytesByPartitionId.length
       val nonZeroCnt = mapStats.bytesByPartitionId.count(_ > 0)
       partitionCnt > 0 && nonZeroCnt > 0 &&
-        (nonZeroCnt * 1.0 / partitionCnt) < SQLConf.get.nonEmptyPartitionRatioForBroadcastJoin
+        (nonZeroCnt * 1.0 / partitionCnt) < conf.nonEmptyPartitionRatioForBroadcastJoin
     case _ => false
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/DemoteBroadcastHashJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/DemoteBroadcastHashJoin.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.internal.SQLConf
  * This optimization rule detects a join child that has a high ratio of empty partitions and
  * adds a no-broadcast-hash-join hint to avoid it being broadcast.
  */
-case class DemoteBroadcastHashJoin(conf: SQLConf) extends Rule[LogicalPlan] {
+object DemoteBroadcastHashJoin extends Rule[LogicalPlan] {
 
   private def shouldDemote(plan: LogicalPlan): Boolean = plan match {
     case LogicalQueryStage(_, stage: ShuffleQueryStageExec) if stage.resultOption.get().isDefined
@@ -34,7 +34,7 @@ case class DemoteBroadcastHashJoin(conf: SQLConf) extends Rule[LogicalPlan] {
       val partitionCnt = mapStats.bytesByPartitionId.length
       val nonZeroCnt = mapStats.bytesByPartitionId.count(_ > 0)
       partitionCnt > 0 && nonZeroCnt > 0 &&
-        (nonZeroCnt * 1.0 / partitionCnt) < conf.nonEmptyPartitionRatioForBroadcastJoin
+        (nonZeroCnt * 1.0 / partitionCnt) < SQLConf.get.nonEmptyPartitionRatioForBroadcastJoin
     case _ => false
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/InsertAdaptiveSparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/InsertAdaptiveSparkPlan.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.internal.SQLConf
 case class InsertAdaptiveSparkPlan(
     adaptiveExecutionContext: AdaptiveExecutionContext) extends Rule[SparkPlan] {
 
-  private val conf = adaptiveExecutionContext.session.sessionState.conf
+  private def conf = SQLConf.get
 
   override def apply(plan: SparkPlan): SparkPlan = applyInternal(plan, false)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/InsertAdaptiveSparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/InsertAdaptiveSparkPlan.scala
@@ -39,8 +39,6 @@ import org.apache.spark.sql.internal.SQLConf
 case class InsertAdaptiveSparkPlan(
     adaptiveExecutionContext: AdaptiveExecutionContext) extends Rule[SparkPlan] {
 
-  private def conf = SQLConf.get
-
   override def apply(plan: SparkPlan): SparkPlan = applyInternal(plan, false)
 
   private def applyInternal(plan: SparkPlan, isSubquery: Boolean): SparkPlan = plan match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeLocalShuffleReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeLocalShuffleReader.scala
@@ -33,10 +33,9 @@ import org.apache.spark.sql.internal.SQLConf
  * then run `EnsureRequirements` to check whether additional shuffle introduced.
  * If introduced, we will revert all the local readers.
  */
-case class OptimizeLocalShuffleReader(conf: SQLConf) extends Rule[SparkPlan] {
-  import OptimizeLocalShuffleReader._
+object OptimizeLocalShuffleReader extends Rule[SparkPlan] {
 
-  private val ensureRequirements = EnsureRequirements(conf)
+  private val ensureRequirements = EnsureRequirements
 
   // The build side is a broadcast query stage which should have been optimized using local reader
   // already. So we only need to deal with probe side here.
@@ -107,7 +106,7 @@ case class OptimizeLocalShuffleReader(conf: SQLConf) extends Rule[SparkPlan] {
   }
 
   override def apply(plan: SparkPlan): SparkPlan = {
-    if (!conf.getConf(SQLConf.LOCAL_SHUFFLE_READER_ENABLED)) {
+    if (!SQLConf.get.getConf(SQLConf.LOCAL_SHUFFLE_READER_ENABLED)) {
       return plan
     }
 
@@ -118,9 +117,6 @@ case class OptimizeLocalShuffleReader(conf: SQLConf) extends Rule[SparkPlan] {
         createProbeSideLocalReader(s)
     }
   }
-}
-
-object OptimizeLocalShuffleReader {
 
   object BroadcastJoinWithShuffleLeft {
     def unapply(plan: SparkPlan): Option[(SparkPlan, BuildSide)] = plan match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeLocalShuffleReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeLocalShuffleReader.scala
@@ -106,7 +106,7 @@ object OptimizeLocalShuffleReader extends Rule[SparkPlan] {
   }
 
   override def apply(plan: SparkPlan): SparkPlan = {
-    if (!SQLConf.get.getConf(SQLConf.LOCAL_SHUFFLE_READER_ENABLED)) {
+    if (!conf.getConf(SQLConf.LOCAL_SHUFFLE_READER_ENABLED)) {
       return plan
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
@@ -66,8 +66,8 @@ object OptimizeSkewedJoin extends Rule[SparkPlan] {
    * ADVISORY_PARTITION_SIZE_IN_BYTES.
    */
   private def isSkewed(size: Long, medianSize: Long): Boolean = {
-    size > medianSize * SQLConf.get.getConf(SQLConf.SKEW_JOIN_SKEWED_PARTITION_FACTOR) &&
-      size > SQLConf.get.getConf(SQLConf.SKEW_JOIN_SKEWED_PARTITION_THRESHOLD)
+    size > medianSize * conf.getConf(SQLConf.SKEW_JOIN_SKEWED_PARTITION_FACTOR) &&
+      size > conf.getConf(SQLConf.SKEW_JOIN_SKEWED_PARTITION_THRESHOLD)
   }
 
   private def medianSize(stats: MapOutputStatistics): Long = {
@@ -86,7 +86,7 @@ object OptimizeSkewedJoin extends Rule[SparkPlan] {
    * advisory partition size if avg size is smaller than it.
    */
   private def targetSize(sizes: Seq[Long], medianSize: Long): Long = {
-    val advisorySize = SQLConf.get.getConf(SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES)
+    val advisorySize = conf.getConf(SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES)
     val nonSkewSizes = sizes.filterNot(isSkewed(_, medianSize))
     if (nonSkewSizes.isEmpty) {
       advisorySize
@@ -251,7 +251,7 @@ object OptimizeSkewedJoin extends Rule[SparkPlan] {
   }
 
   override def apply(plan: SparkPlan): SparkPlan = {
-    if (!SQLConf.get.getConf(SQLConf.SKEW_JOIN_ENABLED)) {
+    if (!conf.getConf(SQLConf.SKEW_JOIN_ENABLED)) {
       return plan
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ReuseAdaptiveSubquery.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ReuseAdaptiveSubquery.scala
@@ -27,7 +27,7 @@ case class ReuseAdaptiveSubquery(
     reuseMap: TrieMap[SparkPlan, BaseSubqueryExec]) extends Rule[SparkPlan] {
 
   def apply(plan: SparkPlan): SparkPlan = {
-    if (!SQLConf.get.subqueryReuseEnabled) {
+    if (!conf.subqueryReuseEnabled) {
       return plan
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ReuseAdaptiveSubquery.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ReuseAdaptiveSubquery.scala
@@ -24,11 +24,10 @@ import org.apache.spark.sql.execution.{BaseSubqueryExec, ExecSubqueryExpression,
 import org.apache.spark.sql.internal.SQLConf
 
 case class ReuseAdaptiveSubquery(
-    conf: SQLConf,
     reuseMap: TrieMap[SparkPlan, BaseSubqueryExec]) extends Rule[SparkPlan] {
 
   def apply(plan: SparkPlan): SparkPlan = {
-    if (!conf.subqueryReuseEnabled) {
+    if (!SQLConf.get.subqueryReuseEnabled) {
       return plan
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/analysis/DetectAmbiguousSelfJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/analysis/DetectAmbiguousSelfJoin.scala
@@ -40,7 +40,7 @@ import org.apache.spark.sql.internal.SQLConf
  * Note that, this rule removes all the Dataset id related metadata from `AttributeReference`, so
  * that they don't exist after analyzer.
  */
-class DetectAmbiguousSelfJoin(conf: SQLConf) extends Rule[LogicalPlan] {
+object DetectAmbiguousSelfJoin extends Rule[LogicalPlan] {
 
   // Dataset column reference is an `AttributeReference` with 2 special metadata.
   private def isColumnReference(a: AttributeReference): Boolean = {
@@ -71,7 +71,7 @@ class DetectAmbiguousSelfJoin(conf: SQLConf) extends Rule[LogicalPlan] {
   }
 
   override def apply(plan: LogicalPlan): LogicalPlan = {
-    if (!conf.getConf(SQLConf.FAIL_AMBIGUOUS_SELF_JOIN_ENABLED)) return plan
+    if (!SQLConf.get.getConf(SQLConf.FAIL_AMBIGUOUS_SELF_JOIN_ENABLED)) return plan
 
     // We always remove the special metadata from `AttributeReference` at the end of this rule, so
     // Dataset column reference only exists in the root node via Dataset transformations like

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/analysis/DetectAmbiguousSelfJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/analysis/DetectAmbiguousSelfJoin.scala
@@ -71,7 +71,7 @@ object DetectAmbiguousSelfJoin extends Rule[LogicalPlan] {
   }
 
   override def apply(plan: LogicalPlan): LogicalPlan = {
-    if (!SQLConf.get.getConf(SQLConf.FAIL_AMBIGUOUS_SELF_JOIN_ENABLED)) return plan
+    if (!conf.getConf(SQLConf.FAIL_AMBIGUOUS_SELF_JOIN_ENABLED)) return plan
 
     // We always remove the special metadata from `AttributeReference` at the end of this rule, so
     // Dataset column reference only exists in the root node via Dataset transformations like

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/bucketing/CoalesceBucketsInJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/bucketing/CoalesceBucketsInJoin.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.internal.SQLConf
  *   - The ratio of the number of buckets is less than the value set in
  *     COALESCE_BUCKETS_IN_JOIN_MAX_BUCKET_RATIO.
  */
-case class CoalesceBucketsInJoin(conf: SQLConf) extends Rule[SparkPlan] {
+object CoalesceBucketsInJoin extends Rule[SparkPlan] {
   private def updateNumCoalescedBucketsInScan(
       plan: SparkPlan,
       numCoalescedBuckets: Int): SparkPlan = {
@@ -83,14 +83,14 @@ case class CoalesceBucketsInJoin(conf: SQLConf) extends Rule[SparkPlan] {
   }
 
   def apply(plan: SparkPlan): SparkPlan = {
-    if (!conf.coalesceBucketsInJoinEnabled) {
+    if (!SQLConf.get.coalesceBucketsInJoinEnabled) {
       return plan
     }
 
     plan transform {
       case ExtractJoinWithBuckets(join, numLeftBuckets, numRightBuckets)
         if math.max(numLeftBuckets, numRightBuckets) / math.min(numLeftBuckets, numRightBuckets) <=
-          conf.coalesceBucketsInJoinMaxBucketRatio =>
+          SQLConf.get.coalesceBucketsInJoinMaxBucketRatio =>
         val numCoalescedBuckets = math.min(numLeftBuckets, numRightBuckets)
         join match {
           case j: SortMergeJoinExec =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/bucketing/CoalesceBucketsInJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/bucketing/CoalesceBucketsInJoin.scala
@@ -83,14 +83,14 @@ object CoalesceBucketsInJoin extends Rule[SparkPlan] {
   }
 
   def apply(plan: SparkPlan): SparkPlan = {
-    if (!SQLConf.get.coalesceBucketsInJoinEnabled) {
+    if (!conf.coalesceBucketsInJoinEnabled) {
       return plan
     }
 
     plan transform {
       case ExtractJoinWithBuckets(join, numLeftBuckets, numRightBuckets)
         if math.max(numLeftBuckets, numRightBuckets) / math.min(numLeftBuckets, numRightBuckets) <=
-          SQLConf.get.coalesceBucketsInJoinMaxBucketRatio =>
+          conf.coalesceBucketsInJoinMaxBucketRatio =>
         val numCoalescedBuckets = math.min(numLeftBuckets, numRightBuckets)
         join match {
           case j: SortMergeJoinExec =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/bucketing/DisableUnnecessaryBucketedScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/bucketing/DisableUnnecessaryBucketedScan.scala
@@ -75,7 +75,7 @@ import org.apache.spark.sql.internal.SQLConf
  * the paper "Access Path Selection in a Relational Database Management System"
  * (https://dl.acm.org/doi/10.1145/582095.582099).
  */
-case class DisableUnnecessaryBucketedScan(conf: SQLConf) extends Rule[SparkPlan] {
+object DisableUnnecessaryBucketedScan extends Rule[SparkPlan] {
 
   /**
    * Disable bucketed table scan with pre-order traversal of plan.
@@ -152,7 +152,9 @@ case class DisableUnnecessaryBucketedScan(conf: SQLConf) extends Rule[SparkPlan]
       case _ => false
     }.isDefined
 
-    if (!conf.bucketingEnabled || !conf.autoBucketedScanEnabled || !hasBucketedScanWithoutFilter) {
+    if (!SQLConf.get.bucketingEnabled ||
+      !SQLConf.get.autoBucketedScanEnabled ||
+      !hasBucketedScanWithoutFilter) {
       plan
     } else {
       disableBucketWithInterestingPartition(plan, false, false, true)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/bucketing/DisableUnnecessaryBucketedScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/bucketing/DisableUnnecessaryBucketedScan.scala
@@ -152,9 +152,7 @@ object DisableUnnecessaryBucketedScan extends Rule[SparkPlan] {
       case _ => false
     }.isDefined
 
-    if (!SQLConf.get.bucketingEnabled ||
-      !SQLConf.get.autoBucketedScanEnabled ||
-      !hasBucketedScanWithoutFilter) {
+    if (!conf.bucketingEnabled || !conf.autoBucketedScanEnabled || !hasBucketedScanWithoutFilter) {
       plan
     } else {
       disableBucketWithInterestingPartition(plan, false, false, true)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -60,8 +60,7 @@ import org.apache.spark.unsafe.types.UTF8String
  */
 object DataSourceAnalysis extends Rule[LogicalPlan] with CastSupport {
 
-  def conf: SQLConf = SQLConf.get
-  def resolver: Resolver = SQLConf.get.resolver
+  def resolver: Resolver = conf.resolver
 
   // Visible for testing.
   def convertStaticPartitions(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -58,9 +58,10 @@ import org.apache.spark.unsafe.types.UTF8String
  * Note that, this rule must be run after `PreprocessTableCreation` and
  * `PreprocessTableInsertion`.
  */
-case class DataSourceAnalysis(conf: SQLConf) extends Rule[LogicalPlan] with CastSupport {
+object DataSourceAnalysis extends Rule[LogicalPlan] with CastSupport {
 
-  def resolver: Resolver = conf.resolver
+  def conf: SQLConf = SQLConf.get
+  def resolver: Resolver = SQLConf.get.resolver
 
   // Visible for testing.
   def convertStaticPartitions(
@@ -243,16 +244,16 @@ case class DataSourceAnalysis(conf: SQLConf) extends Rule[LogicalPlan] with Cast
  * TODO: we should remove the special handling for hive tables after completely making hive as a
  * data source.
  */
-class FindDataSourceTable(sparkSession: SparkSession) extends Rule[LogicalPlan] {
+object FindDataSourceTable extends Rule[LogicalPlan] {
   private def readDataSourceTable(
       table: CatalogTable, extraOptions: CaseInsensitiveStringMap): LogicalPlan = {
     val qualifiedTableName = QualifiedTableName(table.database, table.identifier.table)
-    val catalog = sparkSession.sessionState.catalog
+    val catalog = SparkSession.active.sessionState.catalog
     val dsOptions = DataSourceUtils.generateDatasourceOptions(extraOptions, table)
     catalog.getCachedPlan(qualifiedTableName, () => {
       val dataSource =
         DataSource(
-          sparkSession,
+          SparkSession.active,
           // In older version(prior to 2.1) of Spark, the table schema can be empty and should be
           // inferred at runtime. We should still support it.
           userSpecifiedSchema = if (table.schema.isEmpty) None else Some(table.schema),
@@ -270,7 +271,7 @@ class FindDataSourceTable(sparkSession: SparkSession) extends Rule[LogicalPlan] 
       extraOptions: CaseInsensitiveStringMap): StreamingRelation = {
     val dsOptions = DataSourceUtils.generateDatasourceOptions(extraOptions, table)
     val dataSource = DataSource(
-      sparkSession,
+      SparkSession.active,
       className = table.provider.get,
       userSpecifiedSchema = Some(table.schema),
       options = dsOptions)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FallBackFileSourceV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FallBackFileSourceV2.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, File
  * This is a temporary hack for making current data source V2 work. It should be
  * removed when Catalog support of file data source v2 is finished.
  */
-class FallBackFileSourceV2(sparkSession: SparkSession) extends Rule[LogicalPlan] {
+object FallBackFileSourceV2 extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
     case i @
         InsertIntoStatement(d @ DataSourceV2Relation(table: FileTable, _, _, _, _), _, _, _, _) =>
@@ -42,7 +42,7 @@ class FallBackFileSourceV2(sparkSession: SparkSession) extends Rule[LogicalPlan]
         table.schema,
         None,
         v1FileFormat,
-        d.options.asScala.toMap)(sparkSession)
+        d.options.asScala.toMap)(SparkSession.active)
       i.copy(table = LogicalRelation(relation))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
@@ -38,16 +38,16 @@ import org.apache.spark.sql.util.SchemaUtils
 /**
  * Replaces [[UnresolvedRelation]]s if the plan is for direct query on files.
  */
-class ResolveSQLOnFile(sparkSession: SparkSession) extends Rule[LogicalPlan] {
+object ResolveSQLOnFile extends Rule[LogicalPlan] {
   private def maybeSQLFile(u: UnresolvedRelation): Boolean = {
-    sparkSession.sessionState.conf.runSQLonFile && u.multipartIdentifier.size == 2
+    SQLConf.get.runSQLonFile && u.multipartIdentifier.size == 2
   }
 
   def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
     case u: UnresolvedRelation if maybeSQLFile(u) =>
       try {
         val dataSource = DataSource(
-          sparkSession,
+          SparkSession.active,
           paths = u.multipartIdentifier.last :: Nil,
           className = u.multipartIdentifier.head)
 
@@ -73,9 +73,9 @@ class ResolveSQLOnFile(sparkSession: SparkSession) extends Rule[LogicalPlan] {
 /**
  * Preprocess [[CreateTable]], to do some normalization and checking.
  */
-case class PreprocessTableCreation(sparkSession: SparkSession) extends Rule[LogicalPlan] {
+object PreprocessTableCreation extends Rule[LogicalPlan] {
   // catalog is a def and not a val/lazy val as the latter would introduce a circular reference
-  private def catalog = sparkSession.sessionState.catalog
+  private def catalog = SparkSession.active.sessionState.catalog
 
   def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
     // When we CREATE TABLE without specifying the table schema, we should fail the query if
@@ -112,9 +112,8 @@ case class PreprocessTableCreation(sparkSession: SparkSession) extends Rule[Logi
       }
 
       // Check if the specified data source match the data source of the existing table.
-      val conf = sparkSession.sessionState.conf
-      val existingProvider = DataSource.lookupDataSource(existingTable.provider.get, conf)
-      val specifiedProvider = DataSource.lookupDataSource(tableDesc.provider.get, conf)
+      val existingProvider = DataSource.lookupDataSource(existingTable.provider.get, SQLConf.get)
+      val specifiedProvider = DataSource.lookupDataSource(tableDesc.provider.get, SQLConf.get)
       // TODO: Check that options from the resolved relation match the relation that we are
       // inserting into (i.e. using the same compression).
       // If the one of the provider is [[FileDataSourceV2]] and the other one is its corresponding
@@ -140,7 +139,7 @@ case class PreprocessTableCreation(sparkSession: SparkSession) extends Rule[Logi
             s"(${query.schema.catalogString})")
       }
 
-      val resolver = sparkSession.sessionState.conf.resolver
+      val resolver = SQLConf.get.resolver
       val tableCols = existingTable.schema.map(_.name)
 
       // As we are inserting into an existing table, we should respect the existing schema and
@@ -194,7 +193,7 @@ case class PreprocessTableCreation(sparkSession: SparkSession) extends Rule[Logi
         tableDesc = existingTable,
         query = Some(TableOutputResolver.resolveOutputColumns(
           tableDesc.qualifiedName, existingTable.schema.toAttributes, newQuery,
-          byName = true, conf)))
+          byName = true, SQLConf.get)))
 
     // Here we normalize partition, bucket and sort column names, w.r.t. the case sensitivity
     // config, and do various checks:
@@ -245,7 +244,7 @@ case class PreprocessTableCreation(sparkSession: SparkSession) extends Rule[Logi
       val schema = create.tableSchema
       val partitioning = create.partitioning
       val identifier = create.tableName
-      val isCaseSensitive = sparkSession.sessionState.conf.caseSensitiveAnalysis
+      val isCaseSensitive = SQLConf.get.caseSensitiveAnalysis
       // Check that columns are not duplicated in the schema
       val flattenedSchema = SchemaUtils.explodeNestedFieldNames(schema)
       SchemaUtils.checkColumnNameDuplication(
@@ -266,7 +265,7 @@ case class PreprocessTableCreation(sparkSession: SparkSession) extends Rule[Logi
         create
       } else {
         // Resolve and normalize partition columns as necessary
-        val resolver = sparkSession.sessionState.conf.resolver
+        val resolver = SQLConf.get.resolver
         val normalizedPartitions = partitioning.map {
           case transform: RewritableTransform =>
             val rewritten = transform.references().map { ref =>
@@ -291,7 +290,7 @@ case class PreprocessTableCreation(sparkSession: SparkSession) extends Rule[Logi
     SchemaUtils.checkSchemaColumnNameDuplication(
       schema,
       "in the table definition of " + table.identifier,
-      sparkSession.sessionState.conf.caseSensitiveAnalysis)
+      SQLConf.get.caseSensitiveAnalysis)
 
     assertNoNullTypeInSchema(schema)
 
@@ -317,12 +316,12 @@ case class PreprocessTableCreation(sparkSession: SparkSession) extends Rule[Logi
       tableName = table.identifier.unquotedString,
       tableCols = schema.map(_.name),
       partCols = table.partitionColumnNames,
-      resolver = sparkSession.sessionState.conf.resolver)
+      resolver = SQLConf.get.resolver)
 
     SchemaUtils.checkColumnNameDuplication(
       normalizedPartitionCols,
       "in the partition schema",
-      sparkSession.sessionState.conf.resolver)
+      SQLConf.get.resolver)
 
     if (schema.nonEmpty && normalizedPartitionCols.length == schema.length) {
       if (DDLUtils.isHiveTable(table)) {
@@ -351,16 +350,16 @@ case class PreprocessTableCreation(sparkSession: SparkSession) extends Rule[Logi
           tableName = table.identifier.unquotedString,
           tableCols = schema.map(_.name),
           bucketSpec = bucketSpec,
-          resolver = sparkSession.sessionState.conf.resolver)
+          resolver = SQLConf.get.resolver)
 
         SchemaUtils.checkColumnNameDuplication(
           normalizedBucketSpec.bucketColumnNames,
           "in the bucket definition",
-          sparkSession.sessionState.conf.resolver)
+          SQLConf.get.resolver)
         SchemaUtils.checkColumnNameDuplication(
           normalizedBucketSpec.sortColumnNames,
           "in the sort definition",
-          sparkSession.sessionState.conf.resolver)
+          SQLConf.get.resolver)
 
         normalizedBucketSpec.sortColumnNames.map(schema(_)).map(_.dataType).foreach {
           case dt if RowOrdering.isOrderable(dt) => // OK
@@ -382,7 +381,7 @@ case class PreprocessTableCreation(sparkSession: SparkSession) extends Rule[Logi
  * table. It also does data type casting and field renaming, to make sure that the columns to be
  * inserted have the correct data type and fields have the correct names.
  */
-case class PreprocessTableInsertion(conf: SQLConf) extends Rule[LogicalPlan] {
+object PreprocessTableInsertion extends Rule[LogicalPlan] {
   private def preprocess(
       insert: InsertIntoStatement,
       tblName: String,
@@ -390,7 +389,7 @@ case class PreprocessTableInsertion(conf: SQLConf) extends Rule[LogicalPlan] {
       catalogTable: Option[CatalogTable]): InsertIntoStatement = {
 
     val normalizedPartSpec = PartitioningUtils.normalizePartitionSpec(
-      insert.partitionSpec, partColNames, tblName, conf.resolver)
+      insert.partitionSpec, partColNames, tblName, SQLConf.get.resolver)
 
     val staticPartCols = normalizedPartSpec.filter(_._2.isDefined).keySet
     val expectedColumns = insert.table.output.filterNot(a => staticPartCols.contains(a.name))
@@ -416,7 +415,7 @@ case class PreprocessTableInsertion(conf: SQLConf) extends Rule[LogicalPlan] {
     }
 
     val newQuery = TableOutputResolver.resolveOutputColumns(
-      tblName, expectedColumns, insert.query, byName = false, conf)
+      tblName, expectedColumns, insert.query, byName = false, SQLConf.get)
     if (normalizedPartSpec.nonEmpty) {
       if (normalizedPartSpec.size != partColNames.length) {
         throw new AnalysisException(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -51,7 +51,7 @@ object EnsureRequirements extends Rule[SparkPlan] {
         BroadcastExchangeExec(mode, child)
       case (child, distribution) =>
         val numPartitions = distribution.requiredNumPartitions
-          .getOrElse(SQLConf.get.numShufflePartitions)
+          .getOrElse(conf.numShufflePartitions)
         ShuffleExchangeExec(distribution.createPartitioning(numPartitions), child)
     }
 
@@ -93,7 +93,7 @@ object EnsureRequirements extends Rule[SparkPlan] {
           // expected number of shuffle partitions. However, if it's smaller than
           // `conf.numShufflePartitions`, we pick `conf.numShufflePartitions` as the
           // expected number of shuffle partitions.
-          math.max(nonShuffleChildrenNumPartitions.max, SQLConf.get.defaultNumShufflePartitions)
+          math.max(nonShuffleChildrenNumPartitions.max, conf.defaultNumShufflePartitions)
         }
       } else {
         childrenNumPartitions.max

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.internal.SQLConf
  * each operator by inserting [[ShuffleExchangeExec]] Operators where required.  Also ensure that
  * the input partition ordering requirements are met.
  */
-case class EnsureRequirements(conf: SQLConf) extends Rule[SparkPlan] {
+object EnsureRequirements extends Rule[SparkPlan] {
 
   private def ensureDistributionAndOrdering(operator: SparkPlan): SparkPlan = {
     val requiredChildDistributions: Seq[Distribution] = operator.requiredChildDistribution
@@ -51,7 +51,7 @@ case class EnsureRequirements(conf: SQLConf) extends Rule[SparkPlan] {
         BroadcastExchangeExec(mode, child)
       case (child, distribution) =>
         val numPartitions = distribution.requiredNumPartitions
-          .getOrElse(conf.numShufflePartitions)
+          .getOrElse(SQLConf.get.numShufflePartitions)
         ShuffleExchangeExec(distribution.createPartitioning(numPartitions), child)
     }
 
@@ -93,7 +93,7 @@ case class EnsureRequirements(conf: SQLConf) extends Rule[SparkPlan] {
           // expected number of shuffle partitions. However, if it's smaller than
           // `conf.numShufflePartitions`, we pick `conf.numShufflePartitions` as the
           // expected number of shuffle partitions.
-          math.max(nonShuffleChildrenNumPartitions.max, conf.defaultNumShufflePartitions)
+          math.max(nonShuffleChildrenNumPartitions.max, SQLConf.get.defaultNumShufflePartitions)
         }
       } else {
         childrenNumPartitions.max

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
@@ -103,7 +103,7 @@ case class ReusedExchangeExec(override val output: Seq[Attribute], child: Exchan
 object ReuseExchange extends Rule[SparkPlan] {
 
   def apply(plan: SparkPlan): SparkPlan = {
-    if (!SQLConf.get.exchangeReuseEnabled) {
+    if (!conf.exchangeReuseEnabled) {
       return plan
     }
     // Build a hash map using schema of exchanges to avoid O(N*N) sameResult calls.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
@@ -100,10 +100,10 @@ case class ReusedExchangeExec(override val output: Seq[Attribute], child: Exchan
  * Find out duplicated exchanges in the spark plan, then use the same exchange for all the
  * references.
  */
-case class ReuseExchange(conf: SQLConf) extends Rule[SparkPlan] {
+object ReuseExchange extends Rule[SparkPlan] {
 
   def apply(plan: SparkPlan): SparkPlan = {
-    if (!conf.exchangeReuseEnabled) {
+    if (!SQLConf.get.exchangeReuseEnabled) {
       return plan
     }
     // Build a hash map using schema of exchanges to avoid O(N*N) sameResult calls.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/subquery.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/subquery.scala
@@ -203,7 +203,7 @@ object PlanSubqueries extends Rule[SparkPlan] {
 object ReuseSubquery extends Rule[SparkPlan] {
 
   def apply(plan: SparkPlan): SparkPlan = {
-    if (!SQLConf.get.subqueryReuseEnabled) {
+    if (!conf.subqueryReuseEnabled) {
       return plan
     }
     // Build a hash map using schema of subqueries to avoid O(N*N) sameResult calls.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/subquery.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/subquery.scala
@@ -172,11 +172,11 @@ case class InSubqueryExec(
 /**
  * Plans subqueries that are present in the given [[SparkPlan]].
  */
-case class PlanSubqueries(sparkSession: SparkSession) extends Rule[SparkPlan] {
+object PlanSubqueries extends Rule[SparkPlan] {
   def apply(plan: SparkPlan): SparkPlan = {
     plan.transformAllExpressions {
       case subquery: expressions.ScalarSubquery =>
-        val executedPlan = QueryExecution.prepareExecutedPlan(sparkSession, subquery.plan)
+        val executedPlan = QueryExecution.prepareExecutedPlan(SparkSession.active, subquery.plan)
         ScalarSubquery(
           SubqueryExec(s"scalar-subquery#${subquery.exprId.id}", executedPlan),
           subquery.exprId)
@@ -190,7 +190,7 @@ case class PlanSubqueries(sparkSession: SparkSession) extends Rule[SparkPlan] {
             }
           )
         }
-        val executedPlan = QueryExecution.prepareExecutedPlan(sparkSession, query)
+        val executedPlan = QueryExecution.prepareExecutedPlan(SparkSession.active, query)
         InSubqueryExec(expr, SubqueryExec(s"subquery#${exprId.id}", executedPlan), exprId)
     }
   }
@@ -200,10 +200,10 @@ case class PlanSubqueries(sparkSession: SparkSession) extends Rule[SparkPlan] {
  * Find out duplicated subqueries in the spark plan, then use the same subquery result for all the
  * references.
  */
-case class ReuseSubquery(conf: SQLConf) extends Rule[SparkPlan] {
+object ReuseSubquery extends Rule[SparkPlan] {
 
   def apply(plan: SparkPlan): SparkPlan = {
-    if (!conf.subqueryReuseEnabled) {
+    if (!SQLConf.get.subqueryReuseEnabled) {
       return plan
     }
     // Build a hash map using schema of subqueries to avoid O(N*N) sameResult calls.

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
@@ -177,19 +177,19 @@ abstract class BaseSessionStateBuilder(
    */
   protected def analyzer: Analyzer = new Analyzer(catalogManager, conf) {
     override val extendedResolutionRules: Seq[Rule[LogicalPlan]] =
-      new FindDataSourceTable(session) +:
-        new ResolveSQLOnFile(session) +:
-        new FallBackFileSourceV2(session) +:
+      FindDataSourceTable +:
+        ResolveSQLOnFile +:
+        FallBackFileSourceV2 +:
         ResolveEncodersInScalaAgg +:
         new ResolveSessionCatalog(
-          catalogManager, conf, catalog.isTempView, catalog.isTempFunction) +:
+          catalogManager, catalog.isTempView, catalog.isTempFunction) +:
         customResolutionRules
 
     override val postHocResolutionRules: Seq[Rule[LogicalPlan]] =
-      new DetectAmbiguousSelfJoin(conf) +:
-        PreprocessTableCreation(session) +:
-        PreprocessTableInsertion(conf) +:
-        DataSourceAnalysis(conf) +:
+      DetectAmbiguousSelfJoin +:
+        PreprocessTableCreation +:
+        PreprocessTableInsertion +:
+        DataSourceAnalysis +:
         customPostHocResolutionRules
 
     override val extendedCheckRules: Seq[LogicalPlan => Unit] =

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/V2CommandsCaseSensitivitySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/V2CommandsCaseSensitivitySuite.scala
@@ -34,7 +34,7 @@ class V2CommandsCaseSensitivitySuite extends SharedSparkSession with AnalysisTes
   import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 
   override protected def extendedAnalysisRules: Seq[Rule[LogicalPlan]] = {
-    Seq(PreprocessTableCreation(spark))
+    Seq(PreprocessTableCreation)
   }
 
   test("CreateTableAsSelect: using top level field for partitioning") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ColumnarRulesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ColumnarRulesSuite.scala
@@ -27,7 +27,7 @@ class ColumnarRulesSuite extends PlanTest with SharedSparkSession {
 
   test("Idempotency of columnar rules - RowToColumnar/ColumnarToRow") {
     val rules = ApplyColumnarRulesAndInsertTransitions(
-      spark.sessionState.conf, spark.sessionState.columnarRules)
+      spark.sessionState.columnarRules)
 
     val plan = UnaryOp(UnaryOp(LeafOp(false), true), false)
     val expected =
@@ -40,7 +40,7 @@ class ColumnarRulesSuite extends PlanTest with SharedSparkSession {
 
   test("Idempotency of columnar rules - ColumnarToRow/RowToColumnar") {
     val rules = ApplyColumnarRulesAndInsertTransitions(
-      spark.sessionState.conf, spark.sessionState.columnarRules)
+      spark.sessionState.columnarRules)
 
     val plan = UnaryOp(UnaryOp(LeafOp(true), false), true)
     val expected = ColumnarToRowExec(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantProjectsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantProjectsSuite.scala
@@ -141,7 +141,7 @@ abstract class RemoveRedundantProjectsSuiteBase
       }
 
       // Re-apply remove redundant project rule.
-      val rule = RemoveRedundantProjects(spark.sessionState.conf)
+      val rule = RemoveRedundantProjects
       val newExecutedPlan = rule.apply(newPlan)
       // The manually added ProjectExec node shouldn't be removed.
       assert(collectWithSubqueries(newExecutedPlan) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/bucketing/CoalesceBucketsInJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/bucketing/CoalesceBucketsInJoinSuite.scala
@@ -99,7 +99,7 @@ class CoalesceBucketsInJoinSuite extends SQLTestUtils with SharedSparkSession {
           s.leftKeys, s.rightKeys, Inner, BuildLeft, None, lScan, rScan)
       }
 
-      val plan = CoalesceBucketsInJoin(spark.sessionState.conf)(join)
+      val plan = CoalesceBucketsInJoin(join)
 
       def verify(expected: Option[Int], subPlan: SparkPlan): Unit = {
         val coalesced = subPlan.collect {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -155,10 +155,10 @@ class PlanResolutionSuite extends AnalysisTest {
     // TODO: run the analyzer directly.
     val rules = Seq(
       CTESubstitution,
-      ResolveInlineTables(conf),
+      ResolveInlineTables,
       analyzer.ResolveRelations,
       new ResolveCatalogs(catalogManager),
-      new ResolveSessionCatalog(catalogManager, conf, _ == Seq("v"), _ => false),
+      new ResolveSessionCatalog(catalogManager, _ == Seq("v"), _ => false),
       analyzer.ResolveTables,
       analyzer.ResolveReferences,
       analyzer.ResolveSubqueryColumnAliases,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/EnsureRequirementsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/EnsureRequirementsSuite.scala
@@ -39,7 +39,7 @@ class EnsureRequirementsSuite extends SharedSparkSession {
     // Test PartitioningCollection on the left side of join.
     val smjExec1 = SortMergeJoinExec(
       exprB :: exprA :: Nil, exprA :: exprB :: Nil, Inner, None, plan1, plan2)
-    EnsureRequirements(spark.sessionState.conf).apply(smjExec1) match {
+    EnsureRequirements.apply(smjExec1) match {
       case SortMergeJoinExec(leftKeys, rightKeys, _, _,
         SortExec(_, _, DummySparkPlan(_, _, _: PartitioningCollection, _, _), _),
         SortExec(_, _, ShuffleExchangeExec(_: HashPartitioning, _, _), _), _) =>
@@ -51,7 +51,7 @@ class EnsureRequirementsSuite extends SharedSparkSession {
     // Test PartitioningCollection on the right side of join.
     val smjExec2 = SortMergeJoinExec(
       exprA :: exprB :: Nil, exprB :: exprA :: Nil, Inner, None, plan2, plan1)
-    EnsureRequirements(spark.sessionState.conf).apply(smjExec2) match {
+    EnsureRequirements.apply(smjExec2) match {
       case SortMergeJoinExec(leftKeys, rightKeys, _, _,
         SortExec(_, _, ShuffleExchangeExec(_: HashPartitioning, _, _), _),
         SortExec(_, _, DummySparkPlan(_, _, _: PartitioningCollection, _, _), _), _) =>
@@ -64,7 +64,7 @@ class EnsureRequirementsSuite extends SharedSparkSession {
     // and it should fall back to the right side.
     val smjExec3 = SortMergeJoinExec(
       exprA :: exprC :: Nil, exprB :: exprA :: Nil, Inner, None, plan1, plan1)
-    EnsureRequirements(spark.sessionState.conf).apply(smjExec3) match {
+    EnsureRequirements.apply(smjExec3) match {
       case SortMergeJoinExec(leftKeys, rightKeys, _, _,
         SortExec(_, _, ShuffleExchangeExec(_: HashPartitioning, _, _), _),
         SortExec(_, _, DummySparkPlan(_, _, _: PartitioningCollection, _, _), _), _) =>
@@ -83,7 +83,7 @@ class EnsureRequirementsSuite extends SharedSparkSession {
     // Test fallback to the right side, which has HashPartitioning.
     val smjExec1 = SortMergeJoinExec(
       exprA :: exprB :: Nil, exprC :: exprB :: Nil, Inner, None, plan1, plan2)
-    EnsureRequirements(spark.sessionState.conf).apply(smjExec1) match {
+    EnsureRequirements.apply(smjExec1) match {
       case SortMergeJoinExec(leftKeys, rightKeys, _, _,
         SortExec(_, _, ShuffleExchangeExec(_: HashPartitioning, _, _), _),
         SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _), _), _) =>
@@ -97,7 +97,7 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       outputPartitioning = PartitioningCollection(Seq(HashPartitioning(exprB :: exprC :: Nil, 5))))
     val smjExec2 = SortMergeJoinExec(
       exprA :: exprB :: Nil, exprC :: exprB :: Nil, Inner, None, plan1, plan3)
-    EnsureRequirements(spark.sessionState.conf).apply(smjExec2) match {
+    EnsureRequirements.apply(smjExec2) match {
       case SortMergeJoinExec(leftKeys, rightKeys, _, _,
         SortExec(_, _, ShuffleExchangeExec(_: HashPartitioning, _, _), _),
         SortExec(_, _, DummySparkPlan(_, _, _: PartitioningCollection, _, _), _), _) =>
@@ -110,7 +110,7 @@ class EnsureRequirementsSuite extends SharedSparkSession {
     // found, and it should fall back to the left side, which has a PartitioningCollection.
     val smjExec3 = SortMergeJoinExec(
       exprC :: exprB :: Nil, exprA :: exprB :: Nil, Inner, None, plan3, plan1)
-    EnsureRequirements(spark.sessionState.conf).apply(smjExec3) match {
+    EnsureRequirements.apply(smjExec3) match {
       case SortMergeJoinExec(leftKeys, rightKeys, _, _,
         SortExec(_, _, DummySparkPlan(_, _, _: PartitioningCollection, _, _), _),
         SortExec(_, _, ShuffleExchangeExec(_: HashPartitioning, _, _), _), _) =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/BroadcastJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/BroadcastJoinSuite.scala
@@ -91,7 +91,7 @@ abstract class BroadcastJoinSuiteBase extends QueryTest with SQLTestUtils
     } else {
       df1.join(df2, joinExpression, joinType)
     }
-    val plan = EnsureRequirements(spark.sessionState.conf).apply(df3.queryExecution.sparkPlan)
+    val plan = EnsureRequirements.apply(df3.queryExecution.sparkPlan)
     assert(plan.collect { case p: T => p }.size === 1)
     plan
   }
@@ -171,7 +171,7 @@ abstract class BroadcastJoinSuiteBase extends QueryTest with SQLTestUtils
       val df4 = Seq((1, "5"), (2, "5")).toDF("key", "value")
       val df5 = df4.join(df3, Seq("key"), "inner")
 
-      val plan = EnsureRequirements(spark.sessionState.conf).apply(df5.queryExecution.sparkPlan)
+      val plan = EnsureRequirements.apply(df5.queryExecution.sparkPlan)
 
       assert(plan.collect { case p: BroadcastHashJoinExec => p }.size === 1)
       assert(plan.collect { case p: SortMergeJoinExec => p }.size === 1)
@@ -182,7 +182,7 @@ abstract class BroadcastJoinSuiteBase extends QueryTest with SQLTestUtils
     val df1 = Seq((1, "4"), (2, "2")).toDF("key", "value")
     val joined = df1.join(df, Seq("key"), "inner")
 
-    val plan = EnsureRequirements(spark.sessionState.conf).apply(joined.queryExecution.sparkPlan)
+    val plan = EnsureRequirements.apply(joined.queryExecution.sparkPlan)
 
     assert(plan.collect { case p: BroadcastHashJoinExec => p }.size === 1)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/ExistenceJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/ExistenceJoinSuite.scala
@@ -107,13 +107,13 @@ class ExistenceJoinSuite extends SparkPlanTest with SharedSparkSession {
       extractJoinParts().foreach { case (_, leftKeys, rightKeys, boundCondition, _, _, _) =>
         withSQLConf(SQLConf.SHUFFLE_PARTITIONS.key -> "1") {
           checkAnswer2(leftRows, rightRows, (left: SparkPlan, right: SparkPlan) =>
-            EnsureRequirements(left.sqlContext.sessionState.conf).apply(
+            EnsureRequirements.apply(
               ShuffledHashJoinExec(
                 leftKeys, rightKeys, joinType, BuildRight, boundCondition, left, right)),
             expectedAnswer,
             sortAnswers = true)
           checkAnswer2(leftRows, rightRows, (left: SparkPlan, right: SparkPlan) =>
-            EnsureRequirements(left.sqlContext.sessionState.conf).apply(
+            EnsureRequirements.apply(
               createLeftSemiPlusJoin(ShuffledHashJoinExec(
                 leftKeys, rightKeys, leftSemiPlus, BuildRight, boundCondition, left, right))),
             expectedAnswer,
@@ -126,13 +126,13 @@ class ExistenceJoinSuite extends SparkPlanTest with SharedSparkSession {
       extractJoinParts().foreach { case (_, leftKeys, rightKeys, boundCondition, _, _, _) =>
         withSQLConf(SQLConf.SHUFFLE_PARTITIONS.key -> "1") {
           checkAnswer2(leftRows, rightRows, (left: SparkPlan, right: SparkPlan) =>
-            EnsureRequirements(left.sqlContext.sessionState.conf).apply(
+            EnsureRequirements.apply(
               BroadcastHashJoinExec(
                 leftKeys, rightKeys, joinType, BuildRight, boundCondition, left, right)),
             expectedAnswer,
             sortAnswers = true)
           checkAnswer2(leftRows, rightRows, (left: SparkPlan, right: SparkPlan) =>
-            EnsureRequirements(left.sqlContext.sessionState.conf).apply(
+            EnsureRequirements.apply(
               createLeftSemiPlusJoin(BroadcastHashJoinExec(
                 leftKeys, rightKeys, leftSemiPlus, BuildRight, boundCondition, left, right))),
             expectedAnswer,
@@ -145,12 +145,12 @@ class ExistenceJoinSuite extends SparkPlanTest with SharedSparkSession {
       extractJoinParts().foreach { case (_, leftKeys, rightKeys, boundCondition, _, _, _) =>
         withSQLConf(SQLConf.SHUFFLE_PARTITIONS.key -> "1") {
           checkAnswer2(leftRows, rightRows, (left: SparkPlan, right: SparkPlan) =>
-            EnsureRequirements(left.sqlContext.sessionState.conf).apply(
+            EnsureRequirements.apply(
               SortMergeJoinExec(leftKeys, rightKeys, joinType, boundCondition, left, right)),
             expectedAnswer,
             sortAnswers = true)
           checkAnswer2(leftRows, rightRows, (left: SparkPlan, right: SparkPlan) =>
-            EnsureRequirements(left.sqlContext.sessionState.conf).apply(
+            EnsureRequirements.apply(
               createLeftSemiPlusJoin(SortMergeJoinExec(
                 leftKeys, rightKeys, leftSemiPlus, boundCondition, left, right))),
             expectedAnswer,
@@ -162,12 +162,12 @@ class ExistenceJoinSuite extends SparkPlanTest with SharedSparkSession {
     test(s"$testName using BroadcastNestedLoopJoin build left") {
       withSQLConf(SQLConf.SHUFFLE_PARTITIONS.key -> "1") {
         checkAnswer2(leftRows, rightRows, (left: SparkPlan, right: SparkPlan) =>
-          EnsureRequirements(left.sqlContext.sessionState.conf).apply(
+          EnsureRequirements.apply(
             BroadcastNestedLoopJoinExec(left, right, BuildLeft, joinType, Some(condition))),
           expectedAnswer,
           sortAnswers = true)
         checkAnswer2(leftRows, rightRows, (left: SparkPlan, right: SparkPlan) =>
-          EnsureRequirements(left.sqlContext.sessionState.conf).apply(
+          EnsureRequirements.apply(
             createLeftSemiPlusJoin(BroadcastNestedLoopJoinExec(
               left, right, BuildLeft, leftSemiPlus, Some(condition)))),
           expectedAnswer,
@@ -178,12 +178,12 @@ class ExistenceJoinSuite extends SparkPlanTest with SharedSparkSession {
     test(s"$testName using BroadcastNestedLoopJoin build right") {
       withSQLConf(SQLConf.SHUFFLE_PARTITIONS.key -> "1") {
         checkAnswer2(leftRows, rightRows, (left: SparkPlan, right: SparkPlan) =>
-          EnsureRequirements(left.sqlContext.sessionState.conf).apply(
+          EnsureRequirements.apply(
             BroadcastNestedLoopJoinExec(left, right, BuildRight, joinType, Some(condition))),
           expectedAnswer,
           sortAnswers = true)
         checkAnswer2(leftRows, rightRows, (left: SparkPlan, right: SparkPlan) =>
-          EnsureRequirements(left.sqlContext.sessionState.conf).apply(
+          EnsureRequirements.apply(
             createLeftSemiPlusJoin(BroadcastNestedLoopJoinExec(
               left, right, BuildRight, leftSemiPlus, Some(condition)))),
           expectedAnswer,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/InnerJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/InnerJoinSuite.scala
@@ -101,7 +101,7 @@ class InnerJoinSuite extends SparkPlanTest with SharedSparkSession {
         boundCondition,
         leftPlan,
         rightPlan)
-      EnsureRequirements(spark.sessionState.conf).apply(broadcastJoin)
+      EnsureRequirements.apply(broadcastJoin)
     }
 
     def makeShuffledHashJoin(
@@ -115,7 +115,7 @@ class InnerJoinSuite extends SparkPlanTest with SharedSparkSession {
         side, None, leftPlan, rightPlan)
       val filteredJoin =
         boundCondition.map(FilterExec(_, shuffledHashJoin)).getOrElse(shuffledHashJoin)
-      EnsureRequirements(spark.sessionState.conf).apply(filteredJoin)
+      EnsureRequirements.apply(filteredJoin)
     }
 
     def makeSortMergeJoin(
@@ -126,7 +126,7 @@ class InnerJoinSuite extends SparkPlanTest with SharedSparkSession {
         rightPlan: SparkPlan) = {
       val sortMergeJoin = joins.SortMergeJoinExec(leftKeys, rightKeys, Inner, boundCondition,
         leftPlan, rightPlan)
-      EnsureRequirements(spark.sessionState.conf).apply(sortMergeJoin)
+      EnsureRequirements.apply(sortMergeJoin)
     }
 
     testWithWholeStageCodegenOnAndOff(s"$testName using BroadcastHashJoin (build=left)") { _ =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/OuterJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/OuterJoinSuite.scala
@@ -110,7 +110,7 @@ class OuterJoinSuite extends SparkPlanTest with SharedSparkSession {
           withSQLConf(SQLConf.SHUFFLE_PARTITIONS.key -> "1") {
             val buildSide = if (joinType == LeftOuter) BuildRight else BuildLeft
             checkAnswer2(leftRows, rightRows, (left: SparkPlan, right: SparkPlan) =>
-              EnsureRequirements(spark.sessionState.conf).apply(
+              EnsureRequirements.apply(
                 ShuffledHashJoinExec(
                   leftKeys, rightKeys, joinType, buildSide, boundCondition, left, right)),
               expectedAnswer.map(Row.fromTuple),
@@ -143,7 +143,7 @@ class OuterJoinSuite extends SparkPlanTest with SharedSparkSession {
       extractJoinParts().foreach { case (_, leftKeys, rightKeys, boundCondition, _, _, _) =>
         withSQLConf(SQLConf.SHUFFLE_PARTITIONS.key -> "1") {
           checkAnswer2(leftRows, rightRows, (left: SparkPlan, right: SparkPlan) =>
-            EnsureRequirements(spark.sessionState.conf).apply(
+            EnsureRequirements.apply(
               SortMergeJoinExec(leftKeys, rightKeys, joinType, boundCondition, left, right)),
             expectedAnswer.map(Row.fromTuple),
             sortAnswers = true)

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/DataSourceAnalysisSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/DataSourceAnalysisSuite.scala
@@ -60,7 +60,7 @@ class DataSourceAnalysisSuite extends SparkFunSuite with BeforeAndAfterAll {
           Cast(e, dt, Option(conf.sessionLocalTimeZone))
       }
     }
-    val rule = DataSourceAnalysis(conf)
+    val rule = DataSourceAnalysis
     test(
       s"convertStaticPartitions only handle INSERT having at least static partitions " +
         s"(caseSensitive: $caseSensitive)") {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
@@ -75,22 +75,22 @@ class HiveSessionStateBuilder(
    */
   override protected def analyzer: Analyzer = new Analyzer(catalogManager, conf) {
     override val extendedResolutionRules: Seq[Rule[LogicalPlan]] =
-      new ResolveHiveSerdeTable(session) +:
-        new FindDataSourceTable(session) +:
-        new ResolveSQLOnFile(session) +:
-        new FallBackFileSourceV2(session) +:
+      ResolveHiveSerdeTable +:
+        FindDataSourceTable +:
+        ResolveSQLOnFile +:
+        FallBackFileSourceV2 +:
         ResolveEncodersInScalaAgg +:
         new ResolveSessionCatalog(
-          catalogManager, conf, catalog.isTempView, catalog.isTempFunction) +:
+          catalogManager, catalog.isTempView, catalog.isTempFunction) +:
         customResolutionRules
 
     override val postHocResolutionRules: Seq[Rule[LogicalPlan]] =
-      new DetectAmbiguousSelfJoin(conf) +:
-        new DetermineTableStats(session) +:
-        RelationConversions(conf, catalog) +:
-        PreprocessTableCreation(session) +:
-        PreprocessTableInsertion(conf) +:
-        DataSourceAnalysis(conf) +:
+      DetectAmbiguousSelfJoin +:
+        DetermineTableStats +:
+        RelationConversions(catalog) +:
+        PreprocessTableCreation +:
+        PreprocessTableInsertion +:
+        DataSourceAnalysis +:
         HiveAnalysis +:
         customPostHocResolutionRules
 
@@ -103,7 +103,7 @@ class HiveSessionStateBuilder(
   }
 
   override def customEarlyScanPushDownRules: Seq[Rule[LogicalPlan]] =
-    Seq(new PruneHiveTablePartitions(session))
+    Seq(PruneHiveTablePartitions)
 
   /**
    * Planner that takes into account Hive-specific strategies.

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -41,7 +41,7 @@ import org.apache.spark.sql.internal.{HiveSerDe, SQLConf}
  * Determine the database, serde/format and schema of the Hive serde table, according to the storage
  * properties.
  */
-class ResolveHiveSerdeTable(session: SparkSession) extends Rule[LogicalPlan] {
+object ResolveHiveSerdeTable extends Rule[LogicalPlan] {
   private def determineHiveSerde(table: CatalogTable): CatalogTable = {
     if (table.storage.serde.nonEmpty) {
       table
@@ -50,7 +50,7 @@ class ResolveHiveSerdeTable(session: SparkSession) extends Rule[LogicalPlan] {
         throw new AnalysisException("Creating bucketed Hive serde table is not supported yet.")
       }
 
-      val defaultStorage = HiveSerDe.getDefaultStorage(session.sessionState.conf)
+      val defaultStorage = HiveSerDe.getDefaultStorage(SQLConf.get)
       val options = new HiveOptions(table.storage.properties)
 
       val fileStorage = if (options.fileFormat.isDefined) {
@@ -90,7 +90,7 @@ class ResolveHiveSerdeTable(session: SparkSession) extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
     case c @ CreateTable(t, _, query) if DDLUtils.isHiveTable(t) =>
       // Finds the database name if the name does not exist.
-      val dbName = t.identifier.database.getOrElse(session.catalog.currentDatabase)
+      val dbName = t.identifier.database.getOrElse(SparkSession.active.catalog.currentDatabase)
       val table = t.copy(identifier = t.identifier.copy(database = Some(dbName)))
 
       // Determines the serde/format of Hive tables
@@ -113,26 +113,25 @@ class ResolveHiveSerdeTable(session: SparkSession) extends Rule[LogicalPlan] {
   }
 }
 
-class DetermineTableStats(session: SparkSession) extends Rule[LogicalPlan] {
+object DetermineTableStats extends Rule[LogicalPlan] {
   private def hiveTableWithStats(relation: HiveTableRelation): HiveTableRelation = {
     val table = relation.tableMeta
     val partitionCols = relation.partitionCols
-    val conf = session.sessionState.conf
     // For partitioned tables, the partition directory may be outside of the table directory.
     // Which is expensive to get table size. Please see how we implemented it in the AnalyzeTable.
-    val sizeInBytes = if (conf.fallBackToHdfsForStatsEnabled && partitionCols.isEmpty) {
+    val sizeInBytes = if (SQLConf.get.fallBackToHdfsForStatsEnabled && partitionCols.isEmpty) {
       try {
-        val hadoopConf = session.sessionState.newHadoopConf()
+        val hadoopConf = SparkSession.active.sessionState.newHadoopConf()
         val tablePath = new Path(table.location)
         val fs: FileSystem = tablePath.getFileSystem(hadoopConf)
         fs.getContentSummary(tablePath).getLength
       } catch {
         case e: IOException =>
           logWarning("Failed to get table size from HDFS.", e)
-          conf.defaultSizeInBytes
+          SQLConf.get.defaultSizeInBytes
       }
     } else {
-      conf.defaultSizeInBytes
+      SQLConf.get.defaultSizeInBytes
     }
 
     val stats = Some(Statistics(sizeInBytes = BigInt(sizeInBytes)))
@@ -191,7 +190,6 @@ object HiveAnalysis extends Rule[LogicalPlan] {
  * `PreprocessTableCreation`, `PreprocessTableInsertion`, `DataSourceAnalysis` and `HiveAnalysis`.
  */
 case class RelationConversions(
-    conf: SQLConf,
     sessionCatalog: HiveSessionCatalog) extends Rule[LogicalPlan] {
   private def isConvertible(relation: HiveTableRelation): Boolean = {
     isConvertible(relation.tableMeta)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/PruneHiveTablePartitions.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/PruneHiveTablePartitions.scala
@@ -28,8 +28,6 @@ import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Project
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.datasources.DataSourceStrategy
 
-private[sql] class PruneHiveTablePartitions
-
 /**
  * Prune hive table partitions using partition filters on [[HiveTableRelation]]. The pruned
  * partitions will be kept in [[HiveTableRelation.prunedPartitions]], and the statistics of
@@ -41,6 +39,8 @@ private[sql] class PruneHiveTablePartitions
  *
  * TODO: merge this with PruneFileSourcePartitions after we completely make hive as a data source.
  */
+private[sql] class PruneHiveTablePartitions
+
 private[sql] object PruneHiveTablePartitions
   extends Rule[LogicalPlan] with CastSupport with PredicateHelper {
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/PruneHiveTablePartitions.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/PruneHiveTablePartitions.scala
@@ -27,8 +27,20 @@ import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.datasources.DataSourceStrategy
-import org.apache.spark.sql.internal.SQLConf
 
+private[sql] class PruneHiveTablePartitions
+
+/**
+ * Prune hive table partitions using partition filters on [[HiveTableRelation]]. The pruned
+ * partitions will be kept in [[HiveTableRelation.prunedPartitions]], and the statistics of
+ * the hive table relation will be updated based on pruned partitions.
+ *
+ * This rule is executed in optimization phase, so the statistics can be updated before physical
+ * planning, which is useful for some spark strategy, eg.
+ * [[org.apache.spark.sql.execution.SparkStrategies.JoinSelection]].
+ *
+ * TODO: merge this with PruneFileSourcePartitions after we completely make hive as a data source.
+ */
 private[sql] object PruneHiveTablePartitions
   extends Rule[LogicalPlan] with CastSupport with PredicateHelper {
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/PruneHiveTablePartitions.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/PruneHiveTablePartitions.scala
@@ -32,8 +32,6 @@ import org.apache.spark.sql.internal.SQLConf
 private[sql] object PruneHiveTablePartitions
   extends Rule[LogicalPlan] with CastSupport with PredicateHelper {
 
-  override def conf: SQLConf = SQLConf.get
-
   /**
    * Extract the partition filters from the filters on the table.
    */

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/PruneHiveTablePartitions.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/PruneHiveTablePartitions.scala
@@ -40,10 +40,10 @@ import org.apache.spark.sql.internal.SQLConf
  *
  * TODO: merge this with PruneFileSourcePartitions after we completely make hive as a data source.
  */
-private[sql] class PruneHiveTablePartitions(session: SparkSession)
+private[sql] object PruneHiveTablePartitions
   extends Rule[LogicalPlan] with CastSupport with PredicateHelper {
 
-  override val conf: SQLConf = session.sessionState.conf
+  override def conf: SQLConf = SQLConf.get
 
   /**
    * Extract the partition filters from the filters on the table.
@@ -65,11 +65,11 @@ private[sql] class PruneHiveTablePartitions(session: SparkSession)
       relation: HiveTableRelation,
       partitionFilters: ExpressionSet): Seq[CatalogTablePartition] = {
     if (conf.metastorePartitionPruning) {
-      session.sessionState.catalog.listPartitionsByFilter(
+      SparkSession.active.sessionState.catalog.listPartitionsByFilter(
         relation.tableMeta.identifier, partitionFilters.toSeq)
     } else {
       ExternalCatalogUtils.prunePartitionsByFilter(relation.tableMeta,
-        session.sessionState.catalog.listPartitions(relation.tableMeta.identifier),
+        SparkSession.active.sessionState.catalog.listPartitions(relation.tableMeta.identifier),
         partitionFilters.toSeq, conf.sessionLocalTimeZone)
     }
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/PruneHiveTablePartitions.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/PruneHiveTablePartitions.scala
@@ -29,17 +29,6 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.datasources.DataSourceStrategy
 import org.apache.spark.sql.internal.SQLConf
 
-/**
- * Prune hive table partitions using partition filters on [[HiveTableRelation]]. The pruned
- * partitions will be kept in [[HiveTableRelation.prunedPartitions]], and the statistics of
- * the hive table relation will be updated based on pruned partitions.
- *
- * This rule is executed in optimization phase, so the statistics can be updated before physical
- * planning, which is useful for some spark strategy, eg.
- * [[org.apache.spark.sql.execution.SparkStrategies.JoinSelection]].
- *
- * TODO: merge this with PruneFileSourcePartitions after we completely make hive as a data source.
- */
 private[sql] object PruneHiveTablePartitions
   extends Rule[LogicalPlan] with CastSupport with PredicateHelper {
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/PruneHiveTablePartitionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/PruneHiveTablePartitionsSuite.scala
@@ -29,7 +29,7 @@ class PruneHiveTablePartitionsSuite extends PrunePartitionSuiteBase {
   object Optimize extends RuleExecutor[LogicalPlan] {
     val batches =
       Batch("PruneHiveTablePartitions", Once,
-        EliminateSubqueryAliases, new PruneHiveTablePartitions(spark)) :: Nil
+        EliminateSubqueryAliases, PruneHiveTablePartitions) :: Nil
   }
 
   test("SPARK-15616: statistics pruned after going through PruneHiveTablePartitions") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Since Issue [SPARK-33139](https://issues.apache.org/jira/browse/SPARK-33139) has been done, and SQLConf.get and SparkSession.active are more reliable. We are trying to refine the existing code usage of passing SQLConf and SparkSession into sub-class of Rule[QueryPlan].

In this PR.

* remove SQLConf from ctor-parameter of all sub-class of Rule[QueryPlan].
* using SQLConf.get to replace the original SQLConf instance.
* remove SparkSession from ctor-parameter of all sub-class of Rule[QueryPlan].
* using SparkSession.active to replace the original SparkSession instance.

### Why are the changes needed?

Code refine.


### Does this PR introduce any user-facing change?
No.


### How was this patch tested?

Existing test
