### PR TITLE
[SPARK-33196][SQL] Expose filtered aggregations in spark.sql.functions

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -4534,6 +4534,41 @@ object functions {
     Bucket(Literal(numBuckets), e.expr)
   }
 
+
+  /**
+   * Filter an aggregate function: only values matching the where clause will be aggregated
+   *
+   * @group agg_funcs
+   * @since 3.1.0
+   */
+  def filtered(aggregation: Column, where: Column): Column = {
+    aggregation.expr match {
+      case aggregation: AggregateExpression =>
+        Column(AggregateExpression(
+          aggregation.aggregateFunction,
+          aggregation.mode,
+          aggregation.isDistinct,
+          Some(where.expr)
+        ))
+      case other: Expression => throw new AnalysisException(
+        "filtered() is used to convert an aggregation to a filtered aggregation " +
+          "and can only be used as such " +
+          s"but it was called on a column which is not an aggregation: ${other.toString}"
+      )
+    }
+  }
+
+
+  /**
+   * Filter an aggregate function: only values matching the where clause will be aggregated
+   *
+   * @group agg_funcs
+   * @since 3.1.0
+   */
+  def filtered(aggregation: Column, where: String): Column = {
+    filtered(aggregation, Column(where))
+  }
+
   // scalastyle:off line.size.limit
   // scalastyle:off parameter.number
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -349,6 +349,11 @@ class DataFrameAggregateSuite extends QueryTest
     checkAnswer(
       testData2.agg(count($"a"), sumDistinct($"a")), // non-partial
       Row(6, 6.0))
+
+    checkAnswer(
+      testData2.agg(filtered(count($"a"), col("b") === 1)),
+      Row(3))
+
   }
 
   test("null count") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Spark already supports filtered aggregations (explanation of their behavior [here](https://modern-sql.com/feature/filter)):

```scala
scala> val df = spark.range(100)
scala> df.registerTempTable("df")
scala> spark.sql("select count(1) as classic_cnt, count(1) FILTER (WHERE id < 50) from df").show()
+-----------+-------------------------------------------------+ 
|classic_cnt|count(1) FILTER (WHERE (id < CAST(50 AS BIGINT)))|
+-----------+-------------------------------------------------+
|        100|                                               50|
+-----------+-------------------------------------------------+
```

But this syntax is not exposed when manipulating columns and functions.

This PRs adds the `filtered` function and allows the following syntax with the same behaviour as above:
```
df.select(filtered(count(lit(1)), where=df("id") < 50)).show()
```

### Why are the changes needed?
These aggregations are especially useful when filtering on overlapping datasets (where a pivot would not work):

```sql
SELECT 
 AVG(revenue) FILTER (WHERE age < 25),
 AVG(revenue) FILTER (WHERE age < 35),
 AVG(revenue) FILTER (WHERE age < 45)
FROM people;
```


### Does this PR introduce _any_ user-facing change?
Yes, a new function and a simplification of filtered aggregations definition (see above)

### How was this patch tested?
Test was added.
