### PR TITLE
[SPARK-33198][CORE] getMigrationBlocks should not fail at missing files

### DIFF
--- a/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
@@ -246,9 +246,9 @@ private[spark] class IndexShuffleBlockResolver(
 
       List((indexBlockId, indexBlockData), (dataBlockId, dataBlockData))
     } catch {
-      case e: Exception => // If we can't load the blocks ignore them.
-        logWarning(s"Failed to resolve shuffle block ${shuffleBlockInfo}, skipping migration" +
-          "this is expected to occure if a block is removed after decommissioning has started.")
+      case _: Exception | _: AssertionError => // If we can't load the blocks ignore them.
+        logWarning(s"Failed to resolve shuffle block ${shuffleBlockInfo}, skipping migration. " +
+          "This is expected to occur if a block is removed after decommissioning has started.")
         List.empty[(BlockId, ManagedBuffer)]
     }
   }

--- a/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
@@ -241,12 +241,14 @@ private[spark] class IndexShuffleBlockResolver(
       val dataBlockData = new FileSegmentManagedBuffer(
         transportConf, dataFile, 0, dataFile.length())
 
-      // Make sure the files exist
-      assert(indexFile.exists() && dataFile.exists())
+      // Make sure the index exist.
+      if (!indexFile.exists()) {
+        throw new FileNotFoundException("Index file is deleted already.")
+      }
 
       List((indexBlockId, indexBlockData), (dataBlockId, dataBlockData))
     } catch {
-      case _: Exception | _: AssertionError => // If we can't load the blocks ignore them.
+      case _: Exception => // If we can't load the blocks ignore them.
         logWarning(s"Failed to resolve shuffle block ${shuffleBlockInfo}, skipping migration. " +
           "This is expected to occur if a block is removed after decommissioning has started.")
         List.empty[(BlockId, ManagedBuffer)]

--- a/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
@@ -245,8 +245,11 @@ private[spark] class IndexShuffleBlockResolver(
       if (!indexFile.exists()) {
         throw new FileNotFoundException("Index file is deleted already.")
       }
-
-      List((indexBlockId, indexBlockData), (dataBlockId, dataBlockData))
+      if (dataFile.exists()) {
+        List((indexBlockId, indexBlockData), (dataBlockId, dataBlockData))
+      } else {
+        List((indexBlockId, indexBlockData))
+      }
     } catch {
       case _: Exception => // If we can't load the blocks ignore them.
         logWarning(s"Failed to resolve shuffle block ${shuffleBlockInfo}, skipping migration. " +

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/IndexShuffleBlockResolverSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/IndexShuffleBlockResolverSuite.scala
@@ -156,4 +156,9 @@ class IndexShuffleBlockResolverSuite extends SparkFunSuite with BeforeAndAfterEa
       indexIn2.close()
     }
   }
+
+  test("SPARK-33198 getMigrationBlocks should not fail at missing files") {
+    val resolver = new IndexShuffleBlockResolver(conf, blockManager)
+    assert(resolver.getMigrationBlocks(ShuffleBlockInfo(Int.MaxValue, Long.MaxValue)).isEmpty)
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `getMigrationBlocks` error handling and to add test coverage.
1. `getMigrationBlocks` should not fail at indexFile only case.
2. `assert` causes `java.lang.AssertionError` which is not an `Exception`.

### Why are the changes needed?

To handle the exception correctly.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CI with the newly added test case.