### PR TITLE
[SPARK-33199][MESOS] Mesos Task Failed when pyFiles and docker image option used together

### DIFF
--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -515,14 +515,14 @@ private[spark] class MesosClusterScheduler(
 
   private def generateCmdOption(desc: MesosDriverDescription, sandboxPath: String): Seq[String] = {
     var options = Seq(
-      "--name", desc.conf.get("spark.app.name"),
+      "--name", shellEscape(desc.conf.get("spark.app.name")),
       "--master", s"mesos://${conf.get("spark.master")}",
       "--driver-cores", desc.cores.toString,
       "--driver-memory", s"${desc.mem}M")
 
     // Assume empty main class means we're running python
     if (!desc.command.mainClass.equals("")) {
-      options ++= Seq("--class", desc.command.mainClass)
+      options ++= Seq("--class", shellEscape(desc.command.mainClass))
     }
 
     desc.conf.getOption(EXECUTOR_MEMORY.key).foreach { v =>
@@ -551,9 +551,9 @@ private[spark] class MesosClusterScheduler(
       .filter { case (key, _) => !replicatedOptionsExcludeList.contains(key) }
       .toMap
     (defaultConf ++ driverConf).toSeq.sortBy(_._1).foreach { case (key, value) =>
-      options ++= Seq("--conf", s"${key}=${value}") }
+      options ++= Seq("--conf", s"${key}=${shellEscape(value)}") }
 
-    options.map(shellEscape)
+    options
   }
 
   /**

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -551,7 +551,7 @@ private[spark] class MesosClusterScheduler(
       .filter { case (key, _) => !replicatedOptionsExcludeList.contains(key) }
       .toMap
     (defaultConf ++ driverConf).toSeq.sortBy(_._1).foreach { case (key, value) =>
-      options ++= Seq("--conf", s"${key}=${shellEscape(value)}") }
+      options ++= Seq("--conf", shellEscape(s"${key}=${value}")) }
 
     options
   }

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
@@ -64,8 +64,8 @@ class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext wi
   }
 
   private def testDriverDescription(
-       submissionId: String,
-       schedulerProps: Map[String, String]): MesosDriverDescription = {
+      submissionId: String,
+      schedulerProps: Map[String, String]): MesosDriverDescription = {
     new MesosDriverDescription(
       "d1",
       "jar",

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
@@ -33,7 +33,7 @@ import org.apache.spark.{LocalSparkContext, SparkConf, SparkFunSuite}
 import org.apache.spark.deploy.Command
 import org.apache.spark.deploy.mesos.MesosDriverDescription
 import org.apache.spark.deploy.mesos.config
-import org.apache.spark.internal.config._
+import org.apache.spark.internal.{config => internalConfig}
 
 class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext with MockitoSugar {
 
@@ -239,7 +239,7 @@ class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext wi
     val driverDesc = testDriverDescription("s1", Map[String, String](
       "spark.app.name" -> "app.py",
       config.EXECUTOR_DOCKER_IMAGE.key -> "test/spark:01",
-      SUBMIT_PYTHON_FILES.key -> "http://site.com/extraPythonFile.py"
+      internalConfig.SUBMIT_PYTHON_FILES.key -> "http://site.com/extraPythonFile.py"
     ))
 
     val cmdString = scheduler.getDriverCommandValue(driverDesc)

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
@@ -30,10 +30,10 @@ import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 
 import org.apache.spark.{LocalSparkContext, SparkConf, SparkFunSuite}
-import org.apache.spark.internal.config._
 import org.apache.spark.deploy.Command
 import org.apache.spark.deploy.mesos.MesosDriverDescription
 import org.apache.spark.deploy.mesos.config
+import org.apache.spark.internal.config._
 
 class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext with MockitoSugar {
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR removes generic `shellEscape` and put it in specific places. More specifically shell-escape only appName, mainClass, default, and driverConf.

### Why are the changes needed?
Changes are needed because we see PySpark jobs fail to launch when 1) run with docker and 2) including --py-files

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- Unit Test