### PR TITLE
[SPARK-33202][CORE] Fix BlockManagerDecommissioner to return the correct migration status

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
@@ -130,6 +130,7 @@ private[storage] class BlockManagerDecommissioner(
             case Some((shuffleMap, retryCount)) =>
               logError(s"Error during migration, adding ${shuffleMap} back to migration queue", e)
               shufflesToMigrate.add((shuffleMap, retryCount + 1))
+              running = false
             case None =>
               logError(s"Error while waiting for block to migrate", e)
           }

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
@@ -84,7 +84,7 @@ private[storage] class BlockManagerDecommissioner(
             case Some((shuffleBlockInfo, retryCount)) =>
               if (retryCount < maxReplicationFailuresForDecommission) {
                 logInfo(s"Trying to migrate shuffle ${shuffleBlockInfo} to ${peer} " +
-                  "($retryCount / $maxReplicationFailuresForDecommission)")
+                  s"($retryCount / $maxReplicationFailuresForDecommission)")
                 val blocks = bm.migratableResolver.getMigrationBlocks(shuffleBlockInfo)
                 logInfo(s"Got migration sub-blocks ${blocks}")
 
@@ -246,7 +246,7 @@ private[storage] class BlockManagerDecommissioner(
     shufflesToMigrate.addAll(newShufflesToMigrate.map(x => (x, 0)).asJava)
     migratingShuffles ++= newShufflesToMigrate
     logInfo(s"${newShufflesToMigrate.size} of ${localShuffles.size} local shuffles " +
-      "are added. In total, ${migratingShuffles.size} shuffles are remained.")
+      s"are added. In total, ${migratingShuffles.size} shuffles are remained.")
 
     // Update the threads doing migrations
     val livePeerSet = bm.getPeers(false).toSet
@@ -268,7 +268,7 @@ private[storage] class BlockManagerDecommissioner(
       stoppedShuffle = true
     }
     // If we found any new shuffles to migrate or otherwise have not migrated everything.
-    newShufflesToMigrate.nonEmpty || migratingShuffles.size < numMigratedShuffles.get()
+    newShufflesToMigrate.nonEmpty || migratingShuffles.size > numMigratedShuffles.get()
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerDecommissionUnitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerDecommissionUnitSuite.scala
@@ -208,7 +208,7 @@ class BlockManagerDecommissionUnitSuite extends SparkFunSuite with Matchers {
 
     // Verify the decom manager handles this correctly
     val bmDecomManager = new BlockManagerDecommissioner(sparkConf, bm)
-    validateDecommissionTimestampsOnManager(bmDecomManager, fail = false)
+    validateDecommissionTimestampsOnManager(bmDecomManager, fail = false, assertDone = false)
   }
 
   test("block decom manager short circuits removed blocks") {

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerDecommissionUnitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerDecommissionUnitSuite.scala
@@ -63,20 +63,20 @@ class BlockManagerDecommissionUnitSuite extends SparkFunSuite with Matchers {
    * a constant Long.MaxValue timestamp.
    */
   private def validateDecommissionTimestamps(conf: SparkConf, bm: BlockManager,
-      fail: Boolean = false) = {
+      fail: Boolean = false, assertDone: Boolean = true) = {
     // Verify the decommissioning manager timestamps and status
     val bmDecomManager = new BlockManagerDecommissioner(conf, bm)
-    validateDecommissionTimestampsOnManager(bmDecomManager, fail)
+    validateDecommissionTimestampsOnManager(bmDecomManager, fail, assertDone)
   }
 
   private def validateDecommissionTimestampsOnManager(bmDecomManager: BlockManagerDecommissioner,
-      fail: Boolean = false, numShuffles: Option[Int] = None) = {
+      fail: Boolean = false, assertDone: Boolean = true, numShuffles: Option[Int] = None) = {
     var previousTime: Option[Long] = None
     try {
       bmDecomManager.start()
       eventually(timeout(100.second), interval(10.milliseconds)) {
         val (currentTime, done) = bmDecomManager.lastMigrationInfo()
-        assert(done)
+        assert(!assertDone || done)
         // Make sure the time stamp starts moving forward.
         if (!fail) {
           previousTime match {
@@ -98,7 +98,7 @@ class BlockManagerDecommissionUnitSuite extends SparkFunSuite with Matchers {
         // Wait 5 seconds and assert times keep moving forward.
         Thread.sleep(5000)
         val (currentTime, done) = bmDecomManager.lastMigrationInfo()
-        assert(done && currentTime > previousTime.get)
+        assert((!assertDone || done) && currentTime > previousTime.get)
       }
     } finally {
       bmDecomManager.stop()
@@ -167,7 +167,7 @@ class BlockManagerDecommissionUnitSuite extends SparkFunSuite with Matchers {
       .thenReturn(Seq(BlockManagerId("exec2", "host2", 12345)))
 
     // Verify the decom manager handles this correctly
-    validateDecommissionTimestamps(sparkConf, bm)
+    validateDecommissionTimestamps(sparkConf, bm, fail = false, assertDone = false)
   }
 
   test("block decom manager does not re-add removed shuffle files") {
@@ -183,7 +183,7 @@ class BlockManagerDecommissionUnitSuite extends SparkFunSuite with Matchers {
     val bmDecomManager = new BlockManagerDecommissioner(sparkConf, bm)
     bmDecomManager.migratingShuffles += ShuffleBlockInfo(10, 10)
 
-    validateDecommissionTimestampsOnManager(bmDecomManager)
+    validateDecommissionTimestampsOnManager(bmDecomManager, fail = false, assertDone = false)
   }
 
   test("block decom manager handles IO failures") {

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerDecommissionUnitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerDecommissionUnitSuite.scala
@@ -167,7 +167,7 @@ class BlockManagerDecommissionUnitSuite extends SparkFunSuite with Matchers {
       .thenReturn(Seq(BlockManagerId("exec2", "host2", 12345)))
 
     // Verify the decom manager handles this correctly
-    validateDecommissionTimestamps(sparkConf, bm, fail = false, assertDone = false)
+    validateDecommissionTimestamps(sparkConf, bm)
   }
 
   test("block decom manager does not re-add removed shuffle files") {
@@ -208,7 +208,7 @@ class BlockManagerDecommissionUnitSuite extends SparkFunSuite with Matchers {
 
     // Verify the decom manager handles this correctly
     val bmDecomManager = new BlockManagerDecommissioner(sparkConf, bm)
-    validateDecommissionTimestampsOnManager(bmDecomManager, fail = false, assertDone = false)
+    validateDecommissionTimestampsOnManager(bmDecomManager, fail = false)
   }
 
   test("block decom manager short circuits removed blocks") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR changes `<` into `>` in the following to fix data loss during storage migrations.

```scala
// If we found any new shuffles to migrate or otherwise have not migrated everything.
- newShufflesToMigrate.nonEmpty || migratingShuffles.size < numMigratedShuffles.get()
+ newShufflesToMigrate.nonEmpty || migratingShuffles.size > numMigratedShuffles.get()
```

### Why are the changes needed?

`refreshOffloadingShuffleBlocks` should return `true` when the migration is still on-going.

Since `migratingShuffles` is defined like the following, `migratingShuffles.size > numMigratedShuffles.get()` means the migration is not finished.
```scala
// Shuffles which are either in queue for migrations or migrated
protected[storage] val migratingShuffles = mutable.HashSet[ShuffleBlockInfo]()
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CI with the updated test cases.