### PR TITLE
[SPARK-33189][FOLLOWUP][3.0] Fix syntax error in python/run-tests.py

### DIFF
--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -75,9 +75,9 @@ def run_individual_python_test(target_dir, test_name, pyspark_python):
         'SPARK_PREPEND_CLASSES': '1',
         'PYSPARK_PYTHON': which(pyspark_python),
         'PYSPARK_DRIVER_PYTHON': which(pyspark_python),
-        'PYSPARK_ROW_FIELD_SORTING_ENABLED': 'true'
+        'PYSPARK_ROW_FIELD_SORTING_ENABLED': 'true',
         # Preserve legacy nested timezone behavior for pyarrow>=2, remove after SPARK-32285
-        'PYARROW_IGNORE_TIMEZONE': '1',
+        'PYARROW_IGNORE_TIMEZONE': '1'
     })
 
     # Create a unique temp directory under 'target/' for each run. The TMPDIR variable is


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix syntax error.

### Why are the changes needed?

```
========================================================================
Running Python style checks
========================================================================
pycodestyle checks failed.
*** Error compiling './python/run-tests.py'...
  File "./python/run-tests.py", line 80
    'PYARROW_IGNORE_TIMEZONE': '1',
                            ^
SyntaxError: invalid syntax
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the Jenkins.