### PR TITLE
[SPARK-33216][INFRA][PYTHON][2.4] Set upper bound of Pandas version in GitHub Actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -131,16 +131,16 @@ jobs:
       # PyArrow is not supported in PyPy yet, see ARROW-2651.
       # TODO(SPARK-32247): scipy installation with PyPy fails for an unknown reason.
       run: |
-        python3.6 -m pip install numpy 'pyarrow<3.0.0' pandas scipy xmlrunner
+        python3.6 -m pip install numpy 'pyarrow<3.0.0' 'pandas<1.1.0' scipy xmlrunner
         python3.6 -m pip list
         # PyPy does not have xmlrunner
-        pypy3 -m pip install numpy pandas
+        pypy3 -m pip install numpy 'pandas<1.1.0'
         pypy3 -m pip list
     - name: Install Python packages (Python 2.7)
       if: contains(matrix.modules, 'pyspark') || (contains(matrix.modules, 'sql') && !contains(matrix.modules, 'sql-'))
       run: |
         # Some tests do not pass in PySpark with PyArrow, for example, pyspark.sql.tests.ArrowTests.
-        python2.7 -m pip install numpy pandas scipy xmlrunner
+        python2.7 -m pip install numpy 'pandas<1.1.0' scipy xmlrunner
         python2.7 -m pip list
     # SparkR
     - name: Install R 4.0

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -131,16 +131,16 @@ jobs:
       # PyArrow is not supported in PyPy yet, see ARROW-2651.
       # TODO(SPARK-32247): scipy installation with PyPy fails for an unknown reason.
       run: |
-        python3.6 -m pip install numpy 'pyarrow<3.0.0' 'pandas<1.1.0' scipy xmlrunner
+        python3.6 -m pip install numpy 'pyarrow<3.0.0' 'pandas<1.1.1' scipy xmlrunner
         python3.6 -m pip list
         # PyPy does not have xmlrunner
-        pypy3 -m pip install numpy 'pandas<1.1.0'
+        pypy3 -m pip install numpy 'pandas<1.1.1'
         pypy3 -m pip list
     - name: Install Python packages (Python 2.7)
       if: contains(matrix.modules, 'pyspark') || (contains(matrix.modules, 'sql') && !contains(matrix.modules, 'sql-'))
       run: |
         # Some tests do not pass in PySpark with PyArrow, for example, pyspark.sql.tests.ArrowTests.
-        python2.7 -m pip install numpy 'pandas<1.1.0' scipy xmlrunner
+        python2.7 -m pip install numpy 'pandas<1.1.1' scipy xmlrunner
         python2.7 -m pip list
     # SparkR
     - name: Install R 4.0


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to pin `Pandas` version up to `1.1.0` released on `July 28`.

### Why are the changes needed?

`branch-2.4` GitHub Action was broken since `Aug 26` due to Pandas API incompatibility.
- https://github.com/apache/spark/runs/1034685663

The following is just one example.
```
File "/home/runner/work/spark/spark/python/pyspark/sql/tests.py", line 5948, in change_col_order
    return pd.DataFrame.from_items([
AttributeError: type object 'DataFrame' has no attribute 'from_items'
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the GitHub Action.