### PR TITLE
[SPARK-33218][CORE] Update misleading log messages for removed shuffle blocks

### DIFF
--- a/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
@@ -252,7 +252,7 @@ private[spark] class IndexShuffleBlockResolver(
       }
     } catch {
       case _: Exception => // If we can't load the blocks ignore them.
-        logWarning(s"Failed to resolve shuffle block ${shuffleBlockInfo}, skipping migration. " +
+        logWarning(s"Failed to resolve shuffle block ${shuffleBlockInfo}. " +
           "This is expected to occur if a block is removed after decommissioning has started.")
         List.empty[(BlockId, ManagedBuffer)]
     }

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
@@ -83,38 +83,42 @@ private[storage] class BlockManagerDecommissioner(
               Thread.sleep(SLEEP_TIME_SECS * 1000L)
             case Some((shuffleBlockInfo, retryCount)) =>
               if (retryCount < maxReplicationFailuresForDecommission) {
-                logInfo(s"Trying to migrate shuffle ${shuffleBlockInfo} to ${peer} " +
-                  s"($retryCount / $maxReplicationFailuresForDecommission)")
                 val blocks = bm.migratableResolver.getMigrationBlocks(shuffleBlockInfo)
-                logInfo(s"Got migration sub-blocks ${blocks}")
+                if (blocks.isEmpty) {
+                  logInfo(s"Ignore empty shuffle block $shuffleBlockInfo")
+                } else {
+                  logInfo(s"Got migration sub-blocks ${blocks}")
+                  logInfo(s"Trying to migrate shuffle ${shuffleBlockInfo} to ${peer} " +
+                    s"($retryCount / $maxReplicationFailuresForDecommission)")
 
-                // Migrate the components of the blocks.
-                try {
-                  blocks.foreach { case (blockId, buffer) =>
-                    logDebug(s"Migrating sub-block ${blockId}")
-                    bm.blockTransferService.uploadBlockSync(
-                      peer.host,
-                      peer.port,
-                      peer.executorId,
-                      blockId,
-                      buffer,
-                      StorageLevel.DISK_ONLY,
-                      null)// class tag, we don't need for shuffle
-                    logDebug(s"Migrated sub block ${blockId}")
-                  }
-                  logInfo(s"Migrated ${shuffleBlockInfo} to ${peer}")
-                } catch {
-                  case e: IOException =>
-                    // If a block got deleted before netty opened the file handle, then trying to
-                    // load the blocks now will fail. This is most likely to occur if we start
-                    // migrating blocks and then the shuffle TTL cleaner kicks in. However this
-                    // could also happen with manually managed shuffles or a GC event on the driver
-                    // a no longer referenced RDD with shuffle files.
-                    if (bm.migratableResolver.getMigrationBlocks(shuffleBlockInfo).isEmpty) {
-                      logWarning(s"Skipping block ${shuffleBlockInfo}, block deleted.")
-                    } else {
-                      throw e
+                  // Migrate the components of the blocks.
+                  try {
+                    blocks.foreach { case (blockId, buffer) =>
+                      logDebug(s"Migrating sub-block ${blockId}")
+                      bm.blockTransferService.uploadBlockSync(
+                        peer.host,
+                        peer.port,
+                        peer.executorId,
+                        blockId,
+                        buffer,
+                        StorageLevel.DISK_ONLY,
+                        null) // class tag, we don't need for shuffle
+                      logDebug(s"Migrated sub block ${blockId}")
                     }
+                    logInfo(s"Migrated ${shuffleBlockInfo} to ${peer}")
+                  } catch {
+                    case e: IOException =>
+                      // If a block got deleted before netty opened the file handle, then trying to
+                      // load the blocks now will fail. This is most likely to occur if we start
+                      // migrating blocks and then the shuffle TTL cleaner kicks in. However this
+                      // could also happen with manually managed shuffles or a GC event on the driver
+                      // a no longer referenced RDD with shuffle files.
+                      if (bm.migratableResolver.getMigrationBlocks(shuffleBlockInfo).isEmpty) {
+                        logWarning(s"Skipping block ${shuffleBlockInfo}, block deleted.")
+                      } else {
+                        throw e
+                      }
+                  }
                 }
               } else {
                 logError(s"Skipping block ${shuffleBlockInfo} because it has failed ${retryCount}")

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
@@ -111,8 +111,8 @@ private[storage] class BlockManagerDecommissioner(
                       // If a block got deleted before netty opened the file handle, then trying to
                       // load the blocks now will fail. This is most likely to occur if we start
                       // migrating blocks and then the shuffle TTL cleaner kicks in. However this
-                      // could also happen with manually managed shuffles or a GC event on the driver
-                      // a no longer referenced RDD with shuffle files.
+                      // could also happen with manually managed shuffles or a GC event on the
+                      // driver a no longer referenced RDD with shuffle files.
                       if (bm.migratableResolver.getMigrationBlocks(shuffleBlockInfo).isEmpty) {
                         logWarning(s"Skipping block ${shuffleBlockInfo}, block deleted.")
                       } else {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This updates the misleading log messages for removed shuffle block during migration.

### Why are the changes needed?

1. For the deleted shuffle blocks, `IndexShuffleBlockResolver` shows users WARN message saying `skipping migration`. However, `BlockManagerDecommissioner` shows users INFO message including `Migrated ShuffleBlockInfo(...)` inconsistently. Technically, we didn't migrated. We should not show `Migrated` message in this case.

```
INFO BlockManagerDecommissioner: Trying to migrate shuffle ShuffleBlockInfo(109,18924) to BlockManagerId(...) (2 / 3)
WARN IndexShuffleBlockResolver: Failed to resolve shuffle block ShuffleBlockInfo(109,18924), skipping migration. This is expected to occur if a block is removed after decommissioning has started.
INFO BlockManagerDecommissioner: Got migration sub-blocks List()
...
INFO BlockManagerDecommissioner: Migrated ShuffleBlockInfo(109,18924) to BlockManagerId(...)
```

2. In addition, if the shuffle file is deleted while the information is in the queue, the above messages are repeated multiple times, `spark.storage.decommission.maxReplicationFailuresPerBlock`. We had better use one line instead of the group of messages for that case.
```
INFO BlockManagerDecommissioner: Trying to migrate shuffle ShuffleBlockInfo(109,18924) to BlockManagerId(...) (0 / 3)
...
INFO BlockManagerDecommissioner: Trying to migrate shuffle ShuffleBlockInfo(109,18924) to BlockManagerId(...) (1 / 3)
...
INFO BlockManagerDecommissioner: Trying to migrate shuffle ShuffleBlockInfo(109,18924) to BlockManagerId(...) (2 / 3)
```

3. Skipping or not is a role of `BlockManagerDecommissioner` class. `IndexShuffleBlockResolver.getMigrationBlocks` is used twice differently like the following. We had better inform users at `BlockManagerDecommissioner` once.
    - At the beginning, to get the sub-blocks.
    - In case of `IOException`, to determine whether ignoring it or re-throwing. And, `BlockManagerDecommissioner` shows WARN message (`Skipping block ...`) again.

### Does this PR introduce _any_ user-facing change?

No. This is an update for log message info to be consistent.

### How was this patch tested?

Manually.
