### PR TITLE
[SPARK-31069][CORE] Avoid repeat compute `chunksBeingTransferred` cause hight cpu cost in external shuffle service when  `maxChunksBeingTransferred`  use default value.

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/server/ChunkFetchRequestHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/ChunkFetchRequestHandler.java
@@ -88,12 +88,14 @@ public class ChunkFetchRequestHandler extends SimpleChannelInboundHandler<ChunkF
       logger.trace("Received req from {} to fetch block {}", getRemoteAddress(channel),
         msg.streamChunkId);
     }
-    long chunksBeingTransferred = streamManager.chunksBeingTransferred();
-    if (chunksBeingTransferred >= maxChunksBeingTransferred) {
-      logger.warn("The number of chunks being transferred {} is above {}, close the connection.",
-        chunksBeingTransferred, maxChunksBeingTransferred);
-      channel.close();
-      return;
+    if (maxChunksBeingTransferred < Long.MAX_VALUE) {
+      long chunksBeingTransferred = streamManager.chunksBeingTransferred();
+      if (chunksBeingTransferred >= maxChunksBeingTransferred) {
+        logger.warn("The number of chunks being transferred {} is above {}, close the connection.",
+            chunksBeingTransferred, maxChunksBeingTransferred);
+        channel.close();
+        return;
+      }
     }
     ManagedBuffer buf;
     try {

--- a/common/network-common/src/main/java/org/apache/spark/network/server/ChunkFetchRequestHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/ChunkFetchRequestHandler.java
@@ -92,7 +92,7 @@ public class ChunkFetchRequestHandler extends SimpleChannelInboundHandler<ChunkF
       long chunksBeingTransferred = streamManager.chunksBeingTransferred();
       if (chunksBeingTransferred >= maxChunksBeingTransferred) {
         logger.warn("The number of chunks being transferred {} is above {}, close the connection.",
-            chunksBeingTransferred, maxChunksBeingTransferred);
+          chunksBeingTransferred, maxChunksBeingTransferred);
         channel.close();
         return;
       }

--- a/common/network-common/src/main/java/org/apache/spark/network/server/OneForOneStreamManager.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/OneForOneStreamManager.java
@@ -43,7 +43,7 @@ public class OneForOneStreamManager extends StreamManager {
 
   private final AtomicLong nextStreamId;
   private final ConcurrentHashMap<Long, StreamState> streams;
-  private Long numChunksBeingTransferred = 0l;
+  private Long numChunksBeingTransferred = 0L;
   private final Object lock = new Object();
 
   /** State of a single stream. */

--- a/common/network-common/src/main/java/org/apache/spark/network/server/OneForOneStreamManager.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/OneForOneStreamManager.java
@@ -43,7 +43,7 @@ public class OneForOneStreamManager extends StreamManager {
 
   private final AtomicLong nextStreamId;
   private final ConcurrentHashMap<Long, StreamState> streams;
-  private final AtomicLong totalChunksBeingTransferred = new AtomicLong(0);
+  private final AtomicLong numChunksBeingTransferred = new AtomicLong(0);
 
   /** State of a single stream. */
   private static class StreamState {
@@ -125,7 +125,7 @@ public class OneForOneStreamManager extends StreamManager {
       StreamState state = entry.getValue();
       if (state.associatedChannel == channel) {
         streams.remove(entry.getKey());
-        totalChunksBeingTransferred.addAndGet((-state.chunksBeingTransferred.get()));
+        numChunksBeingTransferred.addAndGet((-state.chunksBeingTransferred.get()));
 
         try {
           // Release all remaining buffers.
@@ -170,7 +170,7 @@ public class OneForOneStreamManager extends StreamManager {
     StreamState streamState = streams.get(streamId);
     if (streamState != null) {
       streamState.chunksBeingTransferred.incrementAndGet();
-      totalChunksBeingTransferred.incrementAndGet();
+      numChunksBeingTransferred.incrementAndGet();
     }
 
   }
@@ -185,7 +185,7 @@ public class OneForOneStreamManager extends StreamManager {
     StreamState streamState = streams.get(streamId);
     if (streamState != null) {
       streamState.chunksBeingTransferred.decrementAndGet();
-      totalChunksBeingTransferred.decrementAndGet();
+      numChunksBeingTransferred.decrementAndGet();
     }
   }
 
@@ -196,7 +196,7 @@ public class OneForOneStreamManager extends StreamManager {
 
   @Override
   public long chunksBeingTransferred() {
-    return totalChunksBeingTransferred.get();
+    return numChunksBeingTransferred.get();
   }
 
   /**

--- a/common/network-common/src/main/java/org/apache/spark/network/server/OneForOneStreamManager.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/OneForOneStreamManager.java
@@ -43,7 +43,7 @@ public class OneForOneStreamManager extends StreamManager {
 
   private final AtomicLong nextStreamId;
   private final ConcurrentHashMap<Long, StreamState> streams;
-  private Long numChunksBeingTransferred = 0L;
+  private long numChunksBeingTransferred = 0L;
   private final Object lock = new Object();
 
   /** State of a single stream. */

--- a/common/network-common/src/main/java/org/apache/spark/network/server/OneForOneStreamManager.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/OneForOneStreamManager.java
@@ -169,6 +169,7 @@ public class OneForOneStreamManager extends StreamManager {
   public void chunkBeingSent(long streamId) {
     StreamState streamState = streams.get(streamId);
     if (streamState != null) {
+      streamState.chunksBeingTransferred.incrementAndGet();
       totalChunksBeingTransferred.incrementAndGet();
     }
 
@@ -183,6 +184,7 @@ public class OneForOneStreamManager extends StreamManager {
   public void chunkSent(long streamId) {
     StreamState streamState = streams.get(streamId);
     if (streamState != null) {
+      streamState.chunksBeingTransferred.decrementAndGet();
       totalChunksBeingTransferred.decrementAndGet();
     }
   }

--- a/common/network-common/src/main/java/org/apache/spark/network/server/TransportRequestHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/TransportRequestHandler.java
@@ -124,12 +124,14 @@ public class TransportRequestHandler extends MessageHandler<RequestMessage> {
         req.streamId);
     }
 
-    long chunksBeingTransferred = streamManager.chunksBeingTransferred();
-    if (chunksBeingTransferred >= maxChunksBeingTransferred) {
-      logger.warn("The number of chunks being transferred {} is above {}, close the connection.",
-        chunksBeingTransferred, maxChunksBeingTransferred);
-      channel.close();
-      return;
+    if (maxChunksBeingTransferred < Long.MAX_VALUE) {
+      long chunksBeingTransferred = streamManager.chunksBeingTransferred();
+      if (chunksBeingTransferred >= maxChunksBeingTransferred) {
+        logger.warn("The number of chunks being transferred {} is above {}, close the connection.",
+            chunksBeingTransferred, maxChunksBeingTransferred);
+        channel.close();
+        return;
+      }
     }
     ManagedBuffer buf;
     try {

--- a/common/network-common/src/main/java/org/apache/spark/network/server/TransportRequestHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/TransportRequestHandler.java
@@ -128,7 +128,7 @@ public class TransportRequestHandler extends MessageHandler<RequestMessage> {
       long chunksBeingTransferred = streamManager.chunksBeingTransferred();
       if (chunksBeingTransferred >= maxChunksBeingTransferred) {
         logger.warn("The number of chunks being transferred {} is above {}, close the connection.",
-            chunksBeingTransferred, maxChunksBeingTransferred);
+          chunksBeingTransferred, maxChunksBeingTransferred);
         channel.close();
         return;
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Followup from #27831 , origin author @chrysan.

Each request it will check `chunksBeingTransferred `
```
public long chunksBeingTransferred() {
    long sum = 0L;
    for (StreamState streamState: streams.values()) {
      sum += streamState.chunksBeingTransferred.get();
    }
    return sum;
  }
```
  such as 
```
long chunksBeingTransferred = streamManager.chunksBeingTransferred();
    if (chunksBeingTransferred >= maxChunksBeingTransferred) {
      logger.warn("The number of chunks being transferred {} is above {}, close the connection.",
        chunksBeingTransferred, maxChunksBeingTransferred);
      channel.close();
      return;
    }
```
It will  traverse `streams` repeatedly and we know that fetch data chunk will access `stream` too,  there cause two problem:

1. repeated traverse `streams`, the longer the length, the longer the time
2. lock race in ConcurrentHashMap `streams`

In this PR, when `maxChunksBeingTransferred` use default value, we avoid compute `chunksBeingTransferred ` since we don't  care about this.  If user want to set this configuration and meet performance problem,  you can also backport PR #27831 


### Why are the changes needed?
Speed up  getting `chunksBeingTransferred`  and avoid lock race in object `streams`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existed UT