### PR TITLE
[SPARK-33095] Follow up, support alter table column rename.

### DIFF
--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
@@ -85,11 +85,12 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationSuite with V2JDBCTest {
   override def testRenameColumn(tbl: String): Unit = {
     assert(mySQLVersion > 0)
     if (mySQLVersion < 8) {
-      sql(s"CREATE TABLE $tbl (ID STRING NOT NULL) USING _")
       // Rename is unsupported for mysql versions < 8.0.
-      val msg = intercept[AnalysisException] {
-        sql(s"ALTER TABLE $tbl RENAME COLUMN ID TO ID2")
-      }.getCause.asInstanceOf[SQLFeatureNotSupportedException].getMessage
+      val exception = intercept[AnalysisException] {
+        sql(s"ALTER TABLE $tbl RENAME COLUMN ID TO RENAMED")
+      }
+      assert(exception.getCause != null, s"Unexcpected exception: $exception")
+      val msg = exception.getCause.asInstanceOf[SQLFeatureNotSupportedException].getMessage
       assert(msg.contains("Rename column is only supported for MySQL version 8.0 and above."))
     } else {
       super.testRenameColumn(tbl)

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
@@ -55,8 +55,8 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationSuite with V2JDBCTest {
   }
 
   override def sparkConf: SparkConf = super.sparkConf
-      .set("spark.sql.catalog.mysql", classOf[JDBCTableCatalog].getName)
-      .set("spark.sql.catalog.mysql.url", db.getJdbcUrl(dockerIp, externalPort))
+    .set("spark.sql.catalog.mysql", classOf[JDBCTableCatalog].getName)
+    .set("spark.sql.catalog.mysql.url", db.getJdbcUrl(dockerIp, externalPort))
 
   override val connectionTimeout = timeout(7.minutes)
 
@@ -89,7 +89,7 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationSuite with V2JDBCTest {
       val exception = intercept[AnalysisException] {
         sql(s"ALTER TABLE $tbl RENAME COLUMN ID TO RENAMED")
       }
-      assert(exception.getCause != null, s"Unexcpected exception: $exception")
+      assert(exception.getCause != null, s"Wrong exception thrown: $exception")
       val msg = exception.getCause.asInstanceOf[SQLFeatureNotSupportedException].getMessage
       assert(msg.contains("Rename column is only supported for MySQL version 8.0 and above."))
     } else {

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
@@ -54,11 +54,9 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationSuite with V2JDBCTest {
         s"mysql?user=root&password=rootpass&allowPublicKeyRetrieval=true&useSSL=false"
   }
 
-  override def sparkConf: SparkConf = {
-    super.sparkConf
+  override def sparkConf: SparkConf = super.sparkConf
       .set("spark.sql.catalog.mysql", classOf[JDBCTableCatalog].getName)
       .set("spark.sql.catalog.mysql.url", db.getJdbcUrl(dockerIp, externalPort))
-  }
 
   override val connectionTimeout = timeout(7.minutes)
 
@@ -85,7 +83,7 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationSuite with V2JDBCTest {
   }
 
   override def testRenameColumn(tbl: String): Unit = {
-    assert( mySQLVersion > 0)
+    assert(mySQLVersion > 0)
     if (mySQLVersion < 8) {
       sql(s"CREATE TABLE $tbl (ID STRING NOT NULL) USING _")
       // Rename is unsupported for mysql versions < 8.0.

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
@@ -24,7 +24,6 @@ import org.scalatest.time.SpanSugar._
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.jdbc.{DatabaseOnDocker, DockerJDBCIntegrationSuite}
 import org.apache.spark.sql.types._
 import org.apache.spark.tags.DockerTest

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -128,16 +128,6 @@ private[v2] trait V2JDBCTest extends SharedSparkSession {
         sql(s"ALTER TABLE $catalogName.alt_table RENAME COLUMN ID1 TO ID2")
       }.getMessage
       assert(msg.contains("Cannot rename column, because ID2 already exists"))
-      // Rename to a missing column
-      val msg2 = intercept[AnalysisException] {
-        sql(s"ALTER TABLE $catalogName.alt_table RENAME COLUMN ID2 TO MISSING")
-      }.getMessage
-      assert(msg.contains("Cannot rename column, because ID2 already exists"))
-      // Rename a missing column
-      val msg3 = intercept[AnalysisException] {
-        sql(s"ALTER TABLE $catalogName.alt_table RENAME COLUMN MISSING TO ID2")
-      }.getMessage
-      assert(msg.contains("Cannot rename column, because ID2 already exists"))
     }
     // Rename a column in a not existing table
     val msg = intercept[AnalysisException] {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2865,14 +2865,6 @@ object SQLConf {
     .stringConf
     .createWithDefault("")
 
-  val JDBC_MYSQL_VERSION =
-    buildConf("spark.sql.jdbc.mysql.version")
-      .internal()
-      .doc("Mysql version for jdbc connection.")
-      .version("3.1.0")
-      .stringConf
-      .createWithDefault("5.7")
-
   /**
    * Holds information about keys that have been deprecated.
    *
@@ -3507,8 +3499,6 @@ class SQLConf extends Serializable with Logging {
   def truncateTrashEnabled: Boolean = getConf(SQLConf.TRUNCATE_TRASH_ENABLED)
 
   def disabledJdbcConnectionProviders: String = getConf(SQLConf.DISABLED_JDBC_CONN_PROVIDER_LIST)
-
-  def jdbcMySQLVersion: String = getConf(SQLConf.JDBC_MYSQL_VERSION)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2865,6 +2865,14 @@ object SQLConf {
     .stringConf
     .createWithDefault("")
 
+  val JDBC_MYSQL_VERSION =
+    buildConf("spark.sql.jdbc.mysql.version")
+      .internal()
+      .doc("Mysql version for jdbc connection.")
+      .version("3.1.0")
+      .stringConf
+      .createWithDefault("5.7")
+
   /**
    * Holds information about keys that have been deprecated.
    *
@@ -3499,6 +3507,8 @@ class SQLConf extends Serializable with Logging {
   def truncateTrashEnabled: Boolean = getConf(SQLConf.TRUNCATE_TRASH_ENABLED)
 
   def disabledJdbcConnectionProviders: String = getConf(SQLConf.DISABLED_JDBC_CONN_PROVIDER_LIST)
+
+  def jdbcMySQLVersion: String = getConf(SQLConf.JDBC_MYSQL_VERSION)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -205,7 +205,10 @@ abstract class JdbcDialect extends Serializable {
    * @param changes Changes to apply to the table.
    * @return The SQL statements to use for altering the table.
    */
-  def alterTable(tableName: String, changes: Seq[TableChange]): Array[String] = {
+  def alterTable(
+      tableName: String,
+      changes: Seq[TableChange],
+      dbMajorVersion: Int): Array[String] = {
     val updateClause = ArrayBuilder.make[String]
     for (change <- changes) {
       change match {
@@ -215,7 +218,7 @@ abstract class JdbcDialect extends Serializable {
           updateClause += getAddColumnQuery(tableName, name(0), dataType)
         case rename: RenameColumn if rename.fieldNames.length == 1 =>
           val name = rename.fieldNames
-          updateClause += getRenameColumnQuery(tableName, name(0), rename.newName)
+          updateClause += getRenameColumnQuery(tableName, name(0), rename.newName, dbMajorVersion)
         case delete: DeleteColumn if delete.fieldNames.length == 1 =>
           val name = delete.fieldNames
           updateClause += getDeleteColumnQuery(tableName, name(0))
@@ -237,7 +240,11 @@ abstract class JdbcDialect extends Serializable {
   def getAddColumnQuery(tableName: String, columnName: String, dataType: String): String =
     s"ALTER TABLE $tableName ADD COLUMN ${quoteIdentifier(columnName)} $dataType"
 
-  def getRenameColumnQuery(tableName: String, columnName: String, newName: String): String =
+  def getRenameColumnQuery(
+      tableName: String,
+      columnName: String,
+      newName: String,
+      dbMajorVersion: Int): String =
     s"ALTER TABLE $tableName RENAME COLUMN ${quoteIdentifier(columnName)} TO" +
       s" ${quoteIdentifier(newName)}"
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -62,18 +62,18 @@ private case object MySQLDialect extends JdbcDialect {
   // According to https://dev.mysql.com/worklog/task/?id=10761 old syntax works for
   // both versions of MySQL i.e. 5.x and 8.0
   // The old syntax requires us to have type definition. Since we do not have type
-  // information, we throw the exception.
+  // information, we throw the exception for old version.
   override def getRenameColumnQuery(
       tableName: String,
       columnName: String,
-      newName: String): String = {
-    if (SQLConf.get.jdbcMySQLVersion.matches("^8\\.[0-9].*")) {
+      newName: String,
+      dbMajorVersion: Int): String = {
+    if (dbMajorVersion >= 8) {
       s"ALTER TABLE $tableName RENAME COLUMN ${quoteIdentifier(columnName)} TO" +
         s" ${quoteIdentifier(newName)}"
     } else {
       throw new SQLFeatureNotSupportedException(
-        s"Rename column is only supported for Mysql version 8.0 and above. " +
-        s"To fix this error, please configure the mysql version, ${SQLConf.JDBC_MYSQL_VERSION.key}")
+        s"Rename column is only supported for MySQL version 8.0 and above.")
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.jdbc
 import java.sql.{SQLFeatureNotSupportedException, Types}
 import java.util.Locale
 
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{BooleanType, DataType, LongType, MetadataBuilder}
 
 private case object MySQLDialect extends JdbcDialect {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.jdbc
 import java.sql.{SQLFeatureNotSupportedException, Types}
 import java.util.Locale
 
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{BooleanType, DataType, LongType, MetadataBuilder}
 
 private case object MySQLDialect extends JdbcDialect {
@@ -55,6 +56,25 @@ private case object MySQLDialect extends JdbcDialect {
       columnName: String,
       newDataType: String): String = {
     s"ALTER TABLE $tableName MODIFY COLUMN ${quoteIdentifier(columnName)} $newDataType"
+  }
+
+  // See Old Syntax: https://dev.mysql.com/doc/refman/5.6/en/alter-table.html
+  // According to https://dev.mysql.com/worklog/task/?id=10761 old syntax works for
+  // both versions of MySQL i.e. 5.x and 8.0
+  // The old syntax requires us to have type definition. Since we do not have type
+  // information, we throw the exception.
+  override def getRenameColumnQuery(
+      tableName: String,
+      columnName: String,
+      newName: String): String = {
+    if (SQLConf.get.jdbcMySQLVersion.matches("^8\\.[0-9].*")) {
+      s"ALTER TABLE $tableName RENAME COLUMN ${quoteIdentifier(columnName)} TO" +
+        s" ${quoteIdentifier(newName)}"
+    } else {
+      throw new SQLFeatureNotSupportedException(
+        s"Rename column is only supported for Mysql version 8.0 and above. " +
+        s"To fix this error, please configure the mysql version, ${SQLConf.JDBC_MYSQL_VERSION.key}")
+    }
   }
 
   // See https://dev.mysql.com/doc/refman/8.0/en/alter-table.html


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Support rename column for mysql dialect.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
At the moment, it does not work for mysql version 5.x. So, we should throw proper exception for that case.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, `column rename` with mysql dialect should work correctly.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added tests for rename column.
Ran the tests to pass with both versions of mysql.

* `export MYSQL_DOCKER_IMAGE_NAME=mysql:5.7.31`

* `export MYSQL_DOCKER_IMAGE_NAME=mysql:8.0`