### PR TITLE
[SPARK-32188][PYTHON][DOCS][FOLLOW-UP] Document Column APIs in API reference

### DIFF
--- a/python/docs/source/reference/pyspark.sql.rst
+++ b/python/docs/source/reference/pyspark.sql.rst
@@ -217,6 +217,45 @@ DataFrame APIs
     DataFrameStatFunctions.freqItems
     DataFrameStatFunctions.sampleBy
 
+Column APIs
+-----------
+
+.. currentmodule:: pyspark.sql
+
+.. autosummary::
+    :toctree: api/
+
+    Column.alias
+    Column.asc
+    Column.asc_nulls_first
+    Column.asc_nulls_last
+    Column.astype
+    Column.between
+    Column.bitwiseAND
+    Column.bitwiseOR
+    Column.bitwiseXOR
+    Column.cast
+    Column.contains
+    Column.desc
+    Column.desc_nulls_first
+    Column.desc_nulls_last
+    Column.dropFields
+    Column.endswith
+    Column.eqNullSafe
+    Column.getField
+    Column.getItem
+    Column.isNotNull
+    Column.isNull
+    Column.isin
+    Column.like
+    Column.name
+    Column.otherwise
+    Column.over
+    Column.rlike
+    Column.startswith
+    Column.substr
+    Column.when
+    Column.withField
 
 Data Types
 ----------


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to document the APIs in `Column` as well in API reference of PySpark documentation.

### Why are the changes needed?

To document common APIs in PySpark.

### Does this PR introduce _any_ user-facing change?

Yes, `Column.*` will be shown in API reference page.

### How was this patch tested?

Manually tested via `cd python` and `make clean html`.