### PR TITLE
[SPARK-32405][SQL] Apply table options while creating tables in JDBC Table Catalog

### DIFF
--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/DB2IntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/DB2IntegrationSuite.scala
@@ -73,4 +73,12 @@ class DB2IntegrationSuite extends DockerJDBCIntegrationSuite with V2JDBCTest {
     }.getMessage
     assert(msg1.contains("Cannot update alt_table field ID: double cannot be cast to varchar"))
   }
+
+  override def testCreateTableWithProperty(tbl: String): Unit = {
+    sql(s"CREATE TABLE $tbl (ID INT) USING _" +
+      s" TBLPROPERTIES('CCSID'='UNICODE')")
+    var t = spark.table(tbl)
+    var expectedSchema = new StructType().add("ID", IntegerType)
+    assert(t.schema === expectedSchema)
+  }
 }

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerIntegrationSuite.scala
@@ -62,6 +62,8 @@ class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationSuite with V2JDBC
 
   override def dataPreparation(conn: Connection): Unit = {}
 
+  override def notSupportsTableComment: Boolean = true
+
   override def testUpdateColumnType(tbl: String): Unit = {
     sql(s"CREATE TABLE $tbl (ID INTEGER) USING _")
     var t = spark.table(tbl)

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
@@ -106,4 +106,12 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationSuite with V2JDBCTest {
 
     assert(msg.contains("UpdateColumnNullability is not supported"))
   }
+
+  override def testCreateTableWithProperty(tbl: String): Unit = {
+    sql(s"CREATE TABLE $tbl (ID INT) USING _" +
+      s" TBLPROPERTIES('ENGINE'='InnoDB', 'DEFAULT CHARACTER SET'='utf8')")
+    var t = spark.table(tbl)
+    var expectedSchema = new StructType().add("ID", IntegerType)
+    assert(t.schema === expectedSchema)
+  }
 }

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresIntegrationSuite.scala
@@ -66,4 +66,12 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationSuite with V2JDBCTes
     }.getMessage
     assert(msg.contains("Cannot update alt_table field ID: string cannot be cast to int"))
   }
+
+  override def testCreateTableWithProperty(tbl: String): Unit = {
+    sql(s"CREATE TABLE $tbl (ID INT) USING _" +
+      s" TBLPROPERTIES('TABLESPACE'='pg_default')")
+    var t = spark.table(tbl)
+    var expectedSchema = new StructType().add("ID", IntegerType)
+    assert(t.schema === expectedSchema)
+  }
 }

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.jdbc.v2
 
+import org.apache.log4j.Level
+
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -58,6 +58,14 @@ private[v2] trait V2JDBCTest extends SharedSparkSession {
     assert(t.schema === expectedSchema)
   }
 
+  def testCreateTableWithProperty(tbl: String): Unit = {
+    val m = intercept[AnalysisException] {
+      sql(s"CREATE TABLE $tbl (i INT) USING _" +
+        " TBLPROPERTIES('ENGINE'='InnoDB', 'CHARACTER SET'='utf8')")
+    }.message
+    assert(m.contains("Failed table creation"))
+  }
+
   test("SPARK-33034: ALTER TABLE ... add new columns") {
     withTable(s"$catalogName.alt_table") {
       sql(s"CREATE TABLE $catalogName.alt_table (ID STRING) USING _")
@@ -162,6 +170,12 @@ private[v2] trait V2JDBCTest extends SharedSparkSession {
         .map(_.getRenderedMessage)
         .exists(_.contains("Cannot create JDBC table comment"))
       assert(createCommentWarning === notSupportsTableComment)
+    }
+  }
+
+  test("CREATE TABLE with table property") {
+    withTable(s"$catalogName.new_table") {
+      testCreateTableWithProperty(s"$catalogName.new_table")
     }
   }
 }

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -30,6 +30,8 @@ private[v2] trait V2JDBCTest extends SharedSparkSession {
   // dialect specific update column type test
   def testUpdateColumnType(tbl: String): Unit
 
+  def notSupportsTableComment: Boolean = false
+
   def testUpdateColumnNullability(tbl: String): Unit = {
     sql(s"CREATE TABLE $catalogName.alt_table (ID STRING NOT NULL) USING _")
     var t = spark.table(s"$catalogName.alt_table")
@@ -159,7 +161,7 @@ private[v2] trait V2JDBCTest extends SharedSparkSession {
         .filter(_.getLevel == Level.WARN)
         .map(_.getRenderedMessage)
         .exists(_.contains("Cannot create JDBC table comment"))
-      assert(createCommentWarning === false)
+      assert(createCommentWarning === notSupportsTableComment)
     }
   }
 }

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -58,13 +58,7 @@ private[v2] trait V2JDBCTest extends SharedSparkSession {
     assert(t.schema === expectedSchema)
   }
 
-  def testCreateTableWithProperty(tbl: String): Unit = {
-    val m = intercept[AnalysisException] {
-      sql(s"CREATE TABLE $tbl (i INT) USING _" +
-        " TBLPROPERTIES('ENGINE'='InnoDB', 'CHARACTER SET'='utf8')")
-    }.message
-    assert(m.contains("Failed table creation"))
-  }
+  def testCreateTableWithProperty(tbl: String): Unit = {}
 
   test("SPARK-33034: ALTER TABLE ... add new columns") {
     withTable(s"$catalogName.alt_table") {
@@ -175,6 +169,10 @@ private[v2] trait V2JDBCTest extends SharedSparkSession {
 
   test("CREATE TABLE with table property") {
     withTable(s"$catalogName.new_table") {
+      val m = intercept[AnalysisException] {
+        sql(s"CREATE TABLE $catalogName.new_table (i INT) USING _ TBLPROPERTIES('a'='1')")
+      }.message
+      assert(m.contains("Failed table creation"))
       testCreateTableWithProperty(s"$catalogName.new_table")
     }
   }

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -146,5 +146,19 @@ private[v2] trait V2JDBCTest extends SharedSparkSession {
     }.getMessage
     assert(msg.contains("Table not found"))
   }
+
+  test("CREATE TABLE with table comment") {
+    withTable(s"$catalogName.new_table") {
+      val logAppender = new LogAppender("table comment")
+      withLogAppender(logAppender) {
+        sql(s"CREATE TABLE $catalogName.new_table(i INT) USING _ COMMENT 'this is a comment'")
+      }
+      val createCommentWarning = logAppender.loggingEvents
+        .filter(_.getLevel == Level.WARN)
+        .map(_.getRenderedMessage)
+        .exists(_.contains("Cannot create JDBC table comment"))
+      assert(createCommentWarning === false)
+    }
+  }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -207,7 +207,7 @@ class JDBCOptions(
   // The principal name of user's keytab file
   val principal = parameters.getOrElse(JDBC_PRINCIPAL, null)
 
-  val tableComment = parameters.get(JDBC_TABLE_COMMENT).toString
+  val tableComment = parameters.getOrElse(JDBC_TABLE_COMMENT, "").toString
 }
 
 class JdbcOptionsInWrite(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -206,6 +206,8 @@ class JDBCOptions(
   }
   // The principal name of user's keytab file
   val principal = parameters.getOrElse(JDBC_PRINCIPAL, null)
+
+  val tableComment = parameters.get(JDBC_TABLE_COMMENT)
 }
 
 class JdbcOptionsInWrite(
@@ -260,4 +262,5 @@ object JDBCOptions {
   val JDBC_PUSHDOWN_PREDICATE = newOption("pushDownPredicate")
   val JDBC_KEYTAB = newOption("keytab")
   val JDBC_PRINCIPAL = newOption("principal")
+  val JDBC_TABLE_COMMENT = newOption("tableComment")
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -207,7 +207,7 @@ class JDBCOptions(
   // The principal name of user's keytab file
   val principal = parameters.getOrElse(JDBC_PRINCIPAL, null)
 
-  val tableComment = parameters.get(JDBC_TABLE_COMMENT)
+  val tableComment = parameters.get(JDBC_TABLE_COMMENT).toString
 }
 
 class JdbcOptionsInWrite(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -863,6 +863,7 @@ object JdbcUtils extends Logging {
       schema: StructType,
       caseSensitive: Boolean,
       options: JdbcOptionsInWrite): Unit = {
+    val dialect = JdbcDialects.get(options.url)
     val strSchema = schemaString(
       schema, caseSensitive, options.url, options.createTableColumnTypes)
     val createTableOptions = options.createTableOptions
@@ -872,6 +873,15 @@ object JdbcUtils extends Logging {
     // E.g., "CREATE TABLE t (name string) ENGINE=InnoDB DEFAULT CHARSET=utf8"
     val sql = s"CREATE TABLE $tableName ($strSchema) $createTableOptions"
     executeStatement(conn, options, sql)
+    if (options.tableComment.nonEmpty) {
+      try {
+        executeStatement(
+          conn, options, dialect.getTableCommentQuery(tableName, options.tableComment.get))
+      } catch {
+        case e: Exception =>
+          logWarning("Cannot create JDBC table comment. The table comment will be ignored.")
+      }
+    }
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -876,7 +876,7 @@ object JdbcUtils extends Logging {
     if (options.tableComment.nonEmpty) {
       try {
         executeStatement(
-          conn, options, dialect.getTableCommentQuery(tableName, options.tableComment.get))
+          conn, options, dialect.getTableCommentQuery(tableName, options.tableComment))
       } catch {
         case e: Exception =>
           logWarning("Cannot create JDBC table comment. The table comment will be ignored.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -871,12 +871,11 @@ object JdbcUtils extends Logging {
     // To allow certain options to append when create a new table, which can be
     // table_options or partition_options.
     // E.g., "CREATE TABLE t (name string) ENGINE=InnoDB DEFAULT CHARSET=utf8"
-    val sql = s"CREATE TABLE $tableName ($strSchema) $createTableOptions"
-    executeStatement(conn, options, sql)
-    if (options.tableComment.nonEmpty) {
+    val sql = dialect.createTable(tableName, strSchema, createTableOptions, options.tableComment)
+    executeStatement(conn, options, sql(0))
+    if (sql.length > 1) {
       try {
-        executeStatement(
-          conn, options, dialect.getTableCommentQuery(tableName, options.tableComment))
+        executeStatement(conn, options, sql(1))
       } catch {
         case e: Exception =>
           logWarning("Cannot create JDBC table comment. The table comment will be ignored.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -871,11 +871,12 @@ object JdbcUtils extends Logging {
     // To allow certain options to append when create a new table, which can be
     // table_options or partition_options.
     // E.g., "CREATE TABLE t (name string) ENGINE=InnoDB DEFAULT CHARSET=utf8"
-    val sql = dialect.createTable(tableName, strSchema, createTableOptions, options.tableComment)
-    executeStatement(conn, options, sql(0))
-    if (sql.length > 1) {
+    val sql = s"CREATE TABLE $tableName ($strSchema) $createTableOptions"
+    executeStatement(conn, options, sql)
+    if (options.tableComment.nonEmpty) {
       try {
-        executeStatement(conn, options, sql(1))
+        executeStatement(
+          conn, options, dialect.getTableCommentQuery(tableName, options.tableComment))
       } catch {
         case e: Exception =>
           logWarning("Cannot create JDBC table comment. The table comment will be ignored.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
@@ -125,7 +125,7 @@ class JDBCTableCatalog extends TableCatalog with Logging {
       properties.asScala.map {
         case (k, v) => k match {
           case "comment" => tableComment = v
-          case "provider" | "owner" | "location" => // ignore provider, owner, and location
+          case "provider" | "owner" | "location" => // provider, owner and location can't be set.
           case _ => tableProperties = tableProperties + " " + s"$k=$v"
         }
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
@@ -123,8 +123,14 @@ class JDBCTableCatalog extends TableCatalog with Logging {
         "ignored: " + properties.asScala.map { case (k, v) => s"$k=$v" }.mkString("[", ", ", "]"))
     }
 
-    val writeOptions = new JdbcOptionsInWrite(
-      options.parameters + (JDBCOptions.JDBC_TABLE_NAME -> getTableName(ident)))
+    val tableComment = properties.get("comment")
+    val tableOptions = if (tableComment != null) {
+      options.parameters + (JDBCOptions.JDBC_TABLE_NAME -> getTableName(ident)) +
+        (JDBCOptions.JDBC_TABLE_COMMENT -> properties.get("comment"))
+    } else {
+      options.parameters + (JDBCOptions.JDBC_TABLE_NAME -> getTableName(ident))
+    }
+    val writeOptions = new JdbcOptionsInWrite(tableOptions)
     val caseSensitive = SQLConf.get.caseSensitiveAnalysis
     withConnection { conn =>
       classifyException(s"Failed table creation: $ident") {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
@@ -130,7 +130,8 @@ class JDBCTableCatalog extends TableCatalog with Logging {
           case "provider" =>
           case "owner" => // owner is ignored. It is default to current user name.
           case "location" =>
-            throw new AnalysisException("Cannot create JDBC table with property location.")
+            throw new AnalysisException("CREATE TABLE ... LOCATION ... is not supported in" +
+              " JDBC catalog.")
           case _ => tableProperties = tableProperties + " " + s"$k $v"
         }
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
@@ -126,7 +126,7 @@ class JDBCTableCatalog extends TableCatalog with Logging {
         case (k, v) => k match {
           case "comment" => tableComment = v
           case "provider" | "owner" | "location" => // provider, owner and location can't be set.
-          case _ => tableProperties = tableProperties + " " + s"$k=$v"
+          case _ => tableProperties = tableProperties + " " + s"$k $v"
         }
       }
     }
@@ -137,7 +137,7 @@ class JDBCTableCatalog extends TableCatalog with Logging {
     if (tableProperties != "") {
       // table property is set in JDBC_CREATE_TABLE_OPTIONS, which will be appended
       // to CREATE TABLE statement.
-      // E.g., "CREATE TABLE t (name string) ENGINE=InnoDB DEFAULT CHARSET=utf8"
+      // E.g., "CREATE TABLE t (name string) ENGINE InnoDB DEFAULT CHARACTER SET utf8"
       // Spark doesn't check if these table properties are supported by databases. If
       // table property is invalid, database will fail the table creation.
       tableOptions = tableOptions + (JDBCOptions.JDBC_CREATE_TABLE_OPTIONS -> tableProperties)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
@@ -21,6 +21,7 @@ import java.sql.{Connection, SQLException}
 import scala.collection.JavaConverters._
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.analysis.{NoSuchNamespaceException, NoSuchTableException}
 import org.apache.spark.sql.connector.catalog.{Identifier, Table, TableCatalog, TableChange}
 import org.apache.spark.sql.connector.expressions.Transform
@@ -125,7 +126,11 @@ class JDBCTableCatalog extends TableCatalog with Logging {
       properties.asScala.map {
         case (k, v) => k match {
           case "comment" => tableComment = v
-          case "provider" | "owner" | "location" => // provider, owner and location can't be set.
+          // ToDo: have a follow up to fail provider once unify create table syntax PR is merged
+          case "provider" =>
+          case "owner" => // owner is ignored. It is default to current user name.
+          case "location" =>
+            throw new AnalysisException("Cannot create JDBC table with property location.")
           case _ => tableProperties = tableProperties + " " + s"$k $v"
         }
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DerbyDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DerbyDialect.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.jdbc
 
-import java.sql.Types
+import java.sql.{SQLFeatureNotSupportedException, Types}
 import java.util.Locale
 
 import org.apache.spark.sql.types._
@@ -49,5 +49,11 @@ private object DerbyDialect extends JdbcDialect {
   // See https://db.apache.org/derby/docs/10.5/ref/rrefsqljrenametablestatement.html
   override def renameTable(oldTable: String, newTable: String): String = {
     s"RENAME TABLE $oldTable TO $newTable"
+  }
+
+  // Derby currently doesn't support comment on table. Here is the ticket to add the support
+  // https://issues.apache.org/jira/browse/DERBY-7008
+  override def getTableCommentQuery(table: String, comment: String): String = {
+    throw new SQLFeatureNotSupportedException(s"comment on table is not supported")
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DerbyDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DerbyDialect.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.jdbc
 
-import java.sql.Types
+import java.sql.{SQLFeatureNotSupportedException, Types}
 import java.util.Locale
 
 import org.apache.spark.sql.types._
@@ -53,14 +53,7 @@ private object DerbyDialect extends JdbcDialect {
 
   // Derby currently doesn't support comment on table. Here is the ticket to add the support
   // https://issues.apache.org/jira/browse/DERBY-7008
-  override def createTable(
-      table: String,
-      strSchema: String,
-      createTableOptions: String,
-      tableComment: String): Array[String] = {
-    if (!tableComment.isEmpty) {
-      logWarning("Cannot create JDBC table comment. The table comment will be ignored.")
-    }
-    Array(s"CREATE TABLE $table ($strSchema) $createTableOptions")
+  override def getTableCommentQuery(table: String, comment: String): String = {
+    throw new SQLFeatureNotSupportedException(s"comment on table is not supported")
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DerbyDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DerbyDialect.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.jdbc
 
-import java.sql.{SQLFeatureNotSupportedException, Types}
+import java.sql.Types
 import java.util.Locale
 
 import org.apache.spark.sql.types._
@@ -53,7 +53,14 @@ private object DerbyDialect extends JdbcDialect {
 
   // Derby currently doesn't support comment on table. Here is the ticket to add the support
   // https://issues.apache.org/jira/browse/DERBY-7008
-  override def getTableCommentQuery(table: String, comment: String): String = {
-    throw new SQLFeatureNotSupportedException(s"comment on table is not supported")
+  override def createTable(
+      table: String,
+      strSchema: String,
+      createTableOptions: String,
+      tableComment: String): Array[String] = {
+    if (!tableComment.isEmpty) {
+      logWarning("Cannot create JDBC table comment. The table comment will be ignored.")
+    }
+    Array(s"CREATE TABLE $table ($strSchema) $createTableOptions")
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -265,6 +265,10 @@ abstract class JdbcDialect extends Serializable {
     s"ALTER TABLE $tableName ALTER COLUMN ${quoteIdentifier(columnName)} SET $nullable"
   }
 
+  def getTableCommentQuery(table: String, comment: String): String = {
+    s"COMMENT ON TABLE $table IS '$comment'"
+  }
+
   /**
    * Gets a dialect exception, classifies it and wraps it by `AnalysisException`.
    * @param message The error message to be placed to the returned exception.

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -266,18 +266,8 @@ abstract class JdbcDialect extends Serializable with Logging{
     s"ALTER TABLE $tableName ALTER COLUMN ${quoteIdentifier(columnName)} SET $nullable"
   }
 
-  def createTable(
-      table: String,
-      strSchema: String,
-      createTableOptions: String,
-      tableComment: String): Array[String] = {
-    val createTable = s"CREATE TABLE $table ($strSchema) $createTableOptions"
-    if (!tableComment.isEmpty) {
-      val comment = s"COMMENT ON TABLE $table IS '$tableComment'"
-      Array(createTable, comment)
-    } else {
-      Array(createTable)
-    }
+  def getTableCommentQuery(table: String, comment: String): String = {
+    s"COMMENT ON TABLE $table IS '$comment'"
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
@@ -102,4 +102,12 @@ private object MsSqlServerDialect extends JdbcDialect {
       isNullable: Boolean): String = {
     throw new SQLFeatureNotSupportedException(s"UpdateColumnNullability is not supported")
   }
+
+  // scalastyle:off line.size.limit
+  // https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-addextendedproperty-transact-sql?redirectedfrom=MSDN&view=sql-server-ver15
+  // scalastyle:on line.size.limit
+  // need to use the stored procedure called sp_addextendedproperty to add comments to tables
+  override def getTableCommentQuery(table: String, comment: String): String = {
+    throw new SQLFeatureNotSupportedException(s"comment on table is not supported")
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -89,4 +89,9 @@ private case object MySQLDialect extends JdbcDialect {
       isNullable: Boolean): String = {
     throw new SQLFeatureNotSupportedException(s"UpdateColumnNullability is not supported")
   }
+
+  // See https://dev.mysql.com/doc/refman/8.0/en/alter-table.html
+  override def getTableCommentQuery(table: String, comment: String): String = {
+    s"ALTER TABLE $table COMMENT = '$comment'"
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -91,7 +91,17 @@ private case object MySQLDialect extends JdbcDialect {
   }
 
   // See https://dev.mysql.com/doc/refman/8.0/en/alter-table.html
-  override def getTableCommentQuery(table: String, comment: String): String = {
-    s"ALTER TABLE $table COMMENT = '$comment'"
+  override def createTable(
+      table: String,
+      strSchema: String,
+      createTableOptions: String,
+      tableComment: String): Array[String] = {
+    val createTable = s"CREATE TABLE $table ($strSchema) $createTableOptions"
+    if (!tableComment.isEmpty) {
+      val comment = s"ALTER TABLE $table COMMENT = '$tableComment'"
+      Array(createTable, comment)
+    } else {
+      Array(createTable)
+    }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -91,17 +91,7 @@ private case object MySQLDialect extends JdbcDialect {
   }
 
   // See https://dev.mysql.com/doc/refman/8.0/en/alter-table.html
-  override def createTable(
-      table: String,
-      strSchema: String,
-      createTableOptions: String,
-      tableComment: String): Array[String] = {
-    val createTable = s"CREATE TABLE $table ($strSchema) $createTableOptions"
-    if (!tableComment.isEmpty) {
-      val comment = s"ALTER TABLE $table COMMENT = '$tableComment'"
-      Array(createTable, comment)
-    } else {
-      Array(createTable)
-    }
+  override def getTableCommentQuery(table: String, comment: String): String = {
+    s"ALTER TABLE $table COMMENT = '$comment'"
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
@@ -407,4 +407,14 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       assert(createCommentWarning === false)
     }
   }
+
+  test("CREATE TABLE with table property") {
+    withTable("h2.test.new_table") {
+      val m = intercept[AnalysisException] {
+        sql("CREATE TABLE h2.test.new_table(i INT, j STRING) USING _" +
+          " TBLPROPERTIES('ENGINE'='tableEngineName')")
+      }.cause.get.getMessage
+      assert(m.contains("Feature not supported: \"TABLEENGINENAME\""))
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql.execution.datasources.v2.jdbc
 import java.sql.{Connection, DriverManager}
 import java.util.Properties
 
+import org.apache.log4j.Level
+
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.catalyst.analysis.{NoSuchNamespaceException, NoSuchTableException, TableAlreadyExistsException}
@@ -389,6 +391,20 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
         t = spark.table(tableName)
         assert(t.schema === expectedSchema)
       }
+    }
+  }
+
+  test("CREATE TABLE with table comment") {
+    withTable("h2.test.new_table") {
+      val logAppender = new LogAppender("table comment")
+      withLogAppender(logAppender) {
+        sql("CREATE TABLE h2.test.new_table(i INT, j STRING) USING _ COMMENT 'this is a comment'")
+      }
+      val createCommentWarning = logAppender.loggingEvents
+        .filter(_.getLevel == Level.WARN)
+        .map(_.getRenderedMessage)
+        .exists(_.contains("Cannot create JDBC table comment"))
+      assert(createCommentWarning === false)
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
@@ -414,7 +414,7 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
         sql("CREATE TABLE h2.test.new_table(i INT, j STRING) USING _" +
           " TBLPROPERTIES('ENGINE'='tableEngineName')")
       }.cause.get.getMessage
-      assert(m.contains("Feature not supported: \"TABLEENGINENAME\""))
+      assert(m.contains("\"TABLEENGINENAME\" not found"))
     }
   }
 }


### PR DESCRIPTION

### What changes were proposed in this pull request?
Currently in JDBCTableCatalog, we ignore the table options when creating table.
```
    // TODO (SPARK-32405): Apply table options while creating tables in JDBC Table Catalog
    if (!properties.isEmpty) {
      logWarning("Cannot create JDBC table with properties, these properties will be " +
        "ignored: " + properties.asScala.map { case (k, v) => s"$k=$v" }.mkString("[", ", ", "]"))
    }
```

### Why are the changes needed?
need to apply the table options when we create table


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
add new test
