### PR TITLE
[SPARK-33249][CORE][UI] Add status plugin for live application

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1221,6 +1221,12 @@ package object config {
       .toSequence
       .createWithDefault(Nil)
 
+  private[spark] val APP_LIVE_STATUS_PLUGINS = ConfigBuilder("spark.appLiveStatusPlugins")
+    .doc("Class names of AppLiveStatusPlugin to add to SparkContext during initialization")
+    .stringConf
+    .toSequence
+    .createOptional
+
   private[spark] val EXTRA_LISTENERS = ConfigBuilder("spark.extraListeners")
     .doc("Class names of listeners to add to SparkContext during initialization.")
     .version("1.3.0")

--- a/core/src/main/scala/org/apache/spark/status/AppLiveStatusPlugin.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppLiveStatusPlugin.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.status
+
+import org.apache.spark.SparkConf
+import org.apache.spark.scheduler.SparkListener
+
+/**
+ * An interface for creating live app listeners defined in other modules.
+ */
+private[spark] trait AppLiveStatusPlugin {
+  /**
+   * Creates listeners to collect data about the running application and populate the given store.
+   *
+   * @param conf  The Spark configuration.
+   * @param store The store where to keep application data.
+   */
+  def createListeners(conf: SparkConf, store: ElementTrackingStore): Seq[SparkListener]
+}

--- a/core/src/test/scala/org/apache/spark/status/AppLiveStatusPluginSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/AppLiveStatusPluginSuite.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.status
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.{LocalSparkContext, SparkConf, SparkContext, SparkFunSuite}
+import org.apache.spark.internal.config.APP_LIVE_STATUS_PLUGINS
+import org.apache.spark.scheduler.SparkListener
+
+class AppLiveStatusPluginSuite extends SparkFunSuite with LocalSparkContext {
+  test("SPARK-33249: Should be able to add listeners") {
+    val plugins = Seq(
+      classOf[SomePluginA],
+      classOf[SomePluginB]
+    )
+    val conf = new SparkConf()
+      .setMaster("local")
+      .setAppName("test")
+      .set(APP_LIVE_STATUS_PLUGINS, plugins.map(_.getName))
+    sc = new SparkContext(conf)
+
+    assert(sc.listenerBus.listeners.asScala.count(_.isInstanceOf[SomeListenerA]) == 1)
+    assert(sc.listenerBus.listeners.asScala.count(_.isInstanceOf[SomeListenerB]) == 1)
+    assert(sc.listenerBus.listeners.asScala.count(_.isInstanceOf[SomeListenerC]) == 1)
+  }
+
+  test("SPARK-33249: Only load plugins in conf") {
+    val plugins = Seq(
+      classOf[SomePluginB],
+      classOf[SomePluginC]
+    )
+    val conf = new SparkConf()
+      .setMaster("local")
+      .setAppName("test")
+      .set(APP_LIVE_STATUS_PLUGINS, plugins.map(_.getName))
+    sc = new SparkContext(conf)
+
+    assert(sc.listenerBus.listeners.asScala.count(_.isInstanceOf[SomeListenerC]) == 1)
+    assert(sc.listenerBus.listeners.asScala.count(_.isInstanceOf[SomeListenerD]) == 0)
+  }
+}
+
+private class SomePluginA extends AppLiveStatusPlugin {
+  override def createListeners(conf: SparkConf, store: ElementTrackingStore): Seq[SparkListener] = {
+    Seq(new SomeListenerA(), new SomeListenerB())
+  }
+}
+
+private class SomePluginB extends AppLiveStatusPlugin {
+  override def createListeners(conf: SparkConf, store: ElementTrackingStore): Seq[SparkListener] = {
+    Seq(new SomeListenerC())
+  }
+}
+
+private class SomePluginC extends AppLiveStatusPlugin {
+  throw new UnsupportedOperationException("do not init")
+
+  override def createListeners(conf: SparkConf, store: ElementTrackingStore): Seq[SparkListener] = {
+    Seq(new SomeListenerD())
+  }
+}
+
+private class SomeListenerA extends SparkListener
+private class SomeListenerB extends SparkListener
+private class SomeListenerC extends SparkListener
+private class SomeListenerD extends SparkListener


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Add an interface called `AppLiveStatusPlugin` for live application to create extra listeners that can write a given store.
- Add a configuration called `spark.appLiveStatusPlugins`, to specify what `AppLiveStatusPlugin` should be loaded.
- In SparkContext, load `AppLiveStatusPlugin` using `Utils.loadExtensions`, then create and register listeners.

### Why are the changes needed?

There are cases that developers may want to extend the current REST API of Web UI. In most of these cases, adding external module is a better option than directly editing the original Spark code.

For an external module, to extend the REST API of the Web UI, 2 things may need to be done:
 * Add extra API to provide extra status info. This can be simply done by implementing another `ApiRequestContext` which will be automatically loaded.
 * If the info can not be calculated from the original data in the store, add extra listeners to generate them.

For history server, there is an interface called `AppHistoryServerPlugin`, which is loaded based on SPI, providing a method to create listeners. In live application, the only way is `spark.extraListeners` based on `Utils.loadExtensions`. But this is not enough for the cases.

To let the API get the status info, the data need to be written to the `AppStatusStore`, which is the only store that an API can get by accessing `ui.store` or `ui.sc.statusStore`. But listeners created by `Utils.loadExtensions` only get a `SparkConf` in construction, and are unable to write the `AppStatusStore`.

So I think we still need plugin like `AppHistorySever` for live UI. For concerns like [SPARK-22786](https://github.com/apache/spark/pull/19981), the plugin for live app can be separated from the history server one, and also loaded using Utils.loadExtensions with an extra configurations. So by default, nothing will be loaded.

### Does this PR introduce _any_ user-facing change?

Yes, a new configuration property called `spark.appLiveStatusPlugins`, indicating all `AppLiveStatusPlugin` to load.

### How was this patch tested?

Tested using existed UT.

Also add tests for `AppLiveStatusPlugin` to make sure plugins in `spark.appLiveStatusPlugins` will be loaded and listeners will be created and registered.
