### PR TITLE
[SPARK-33290][SQL] REFRESH TABLE should invalidate cache even though the table itself may not be cached

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -524,13 +524,16 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
     // If this table is cached as an InMemoryRelation, drop the original
     // cached version and make the new version cached lazily.
     val cache = sparkSession.sharedState.cacheManager.lookupCachedData(table)
+
+    // uncache the logical plan.
+    // note this is a no-op for the table itself if it's not cached, but will invalidate all
+    // caches referencing this table.
+    sparkSession.sharedState.cacheManager.uncacheQuery(table, cascade = true)
+
     if (cache.nonEmpty) {
       // save the cache name and cache level for recreation
       val cacheName = cache.get.cachedRepresentation.cacheBuilder.tableName
       val cacheLevel = cache.get.cachedRepresentation.cacheBuilder.storageLevel
-
-      // uncache the logical plan.
-      sparkSession.sharedState.cacheManager.uncacheQuery(table, cascade = true)
 
       // recache with the same name and cache level.
       sparkSession.sharedState.cacheManager.cacheQuery(table, cacheName, cacheLevel)

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -504,6 +504,9 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
    * If this table is cached as an InMemoryRelation, drop the original cached version and make the
    * new version cached lazily.
    *
+   * In addition, refreshing a table also invalidate all caches that have reference to the table
+   * in a cascading manner. This is to prevent incorrect result from the otherwise staled caches.
+   *
    * @group cachemgmt
    * @since 2.0.0
    */

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -1212,18 +1212,39 @@ class CachedTableSuite extends QueryTest with SQLTestUtils
   test("SPARK-33290: REFRESH TABLE should invalidate all caches referencing the table") {
     withTable("t") {
       withTempPath { path =>
-        withTempView("view1", "view2") {
+        withTempView("tempView1", "tempView2") {
           Seq((1 -> "a")).toDF("i", "j").write.parquet(path.getCanonicalPath)
           sql(s"CREATE TABLE t USING parquet LOCATION '${path.toURI}'")
-          sql("CREATE TEMPORARY VIEW view1 AS SELECT * FROM t")
-          sql("CACHE TABLE view2 AS SELECT i FROM view1")
-          checkAnswer(sql("SELECT * FROM view1"), Seq(Row(1, "a")))
-          checkAnswer(sql("SELECT * FROM view2"), Seq(Row(1)))
+          sql("CREATE TEMPORARY VIEW tempView1 AS SELECT * FROM t")
+          sql("CACHE TABLE tempView2 AS SELECT i FROM tempView1")
+          checkAnswer(sql("SELECT * FROM tempView1"), Seq(Row(1, "a")))
+          checkAnswer(sql("SELECT * FROM tempView2"), Seq(Row(1)))
 
           Utils.deleteRecursively(path)
-          sql("REFRESH TABLE view1")
-          checkAnswer(sql("SELECT * FROM view1"), Seq.empty)
-          checkAnswer(sql("SELECT * FROM view2"), Seq.empty)
+          sql("REFRESH TABLE tempView1")
+          checkAnswer(sql("SELECT * FROM tempView1"), Seq.empty)
+          checkAnswer(sql("SELECT * FROM tempView2"), Seq.empty)
+        }
+      }
+    }
+  }
+
+  test("SPARK-33290: querying cached view after REFRESH TABLE fails with FNFE") {
+    withTable("t") {
+      withTempPath { path =>
+        withTempView("tempView1") {
+          Seq((1 -> "a")).toDF("i", "j").write.parquet(path.getCanonicalPath)
+          sql(s"CREATE TABLE t USING parquet LOCATION '${path.toURI}'")
+          sql("CREATE TEMPORARY VIEW tempView1 AS SELECT * FROM t")
+          checkAnswer(sql("SELECT * FROM tempView1"), Seq(Row(1, "a")))
+
+          Utils.deleteRecursively(path)
+          sql("REFRESH TABLE t")
+          val exception = intercept[Exception] {
+            checkAnswer(sql("SELECT * FROM tempView1"), Seq.empty)
+          }
+          assert(exception.getMessage.contains("FileNotFoundException"))
+          assert(exception.getMessage.contains("REFRESH TABLE"))
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -1240,6 +1240,7 @@ class CachedTableSuite extends QueryTest with SQLTestUtils
 
           Utils.deleteRecursively(path)
           sql("REFRESH TABLE t")
+          checkAnswer(sql("SELECT * FROM t"), Seq.empty)
           val exception = intercept[Exception] {
             checkAnswer(sql("SELECT * FROM tempView1"), Seq.empty)
           }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -1212,18 +1212,18 @@ class CachedTableSuite extends QueryTest with SQLTestUtils
   test("SPARK-33290: REFRESH TABLE should invalidate all caches referencing the table") {
     withTable("t") {
       withTempPath { path =>
-        withTempView("tempView1", "tempView2") {
+        withTempView("view1", "view2") {
           Seq((1 -> "a")).toDF("i", "j").write.parquet(path.getCanonicalPath)
           sql(s"CREATE TABLE t USING parquet LOCATION '${path.toURI}'")
-          sql("CREATE VIEW tempView1 AS SELECT * FROM t")
-          sql("CACHE TABLE tempView2 AS SELECT i FROM tempView1")
-          checkAnswer(sql("SELECT * FROM tempView1"), Seq(Row(1, "a")))
-          checkAnswer(sql("SELECT * FROM tempView2"), Seq(Row(1)))
+          sql("CREATE TEMPORARY VIEW view1 AS SELECT * FROM t")
+          sql("CACHE TABLE view2 AS SELECT i FROM view1")
+          checkAnswer(sql("SELECT * FROM view1"), Seq(Row(1, "a")))
+          checkAnswer(sql("SELECT * FROM view2"), Seq(Row(1)))
 
           Utils.deleteRecursively(path)
-          sql("REFRESH TABLE tempView1")
-          checkAnswer(sql("SELECT * FROM tempView1"), Seq.empty)
-          checkAnswer(sql("SELECT * FROM tempView2"), Seq.empty)
+          sql("REFRESH TABLE view1")
+          checkAnswer(sql("SELECT * FROM view1"), Seq.empty)
+          checkAnswer(sql("SELECT * FROM view2"), Seq.empty)
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -1229,7 +1229,7 @@ class CachedTableSuite extends QueryTest with SQLTestUtils
     }
   }
 
-  test("SPARK-33290: querying cached view after REFRESH TABLE fails with FNFE") {
+  test("SPARK-33290: querying temporary view after REFRESH TABLE fails with FNFE") {
     withTable("t") {
       withTempPath { path =>
         withTempView("tempView1") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -1212,18 +1212,18 @@ class CachedTableSuite extends QueryTest with SQLTestUtils
   test("SPARK-33290: REFRESH TABLE should invalidate all caches referencing the table") {
     withTable("t") {
       withTempPath { path =>
-        withTempView("t1", "t2") {
+        withTempView("tempView1", "tempView2") {
           Seq((1 -> "a")).toDF("i", "j").write.parquet(path.getCanonicalPath)
           sql(s"CREATE TABLE t USING parquet LOCATION '${path.toURI}'")
-          sql("CREATE VIEW t1 AS SELECT * FROM t")
-          sql("CACHE TABLE t2 AS SELECT i FROM t1")
-          checkAnswer(sql("SELECT * FROM t1"), Seq(Row(1, "a")))
-          checkAnswer(sql("SELECT * FROM t2"), Seq(Row(1)))
+          sql("CREATE VIEW tempView1 AS SELECT * FROM t")
+          sql("CACHE TABLE tempView2 AS SELECT i FROM tempView1")
+          checkAnswer(sql("SELECT * FROM tempView1"), Seq(Row(1, "a")))
+          checkAnswer(sql("SELECT * FROM tempView2"), Seq(Row(1)))
 
           Utils.deleteRecursively(path)
-          sql("REFRESH TABLE t1")
-          checkAnswer(sql("SELECT * FROM t1"), Seq.empty)
-          checkAnswer(sql("SELECT * FROM t2"), Seq.empty)
+          sql("REFRESH TABLE tempView1")
+          checkAnswer(sql("SELECT * FROM tempView1"), Seq.empty)
+          checkAnswer(sql("SELECT * FROM tempView2"), Seq.empty)
         }
       }
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

In `CatalogImpl.refreshTable`, this moves the `uncacheQuery` call out of the condition `if (cache.nonEmpty)` so that it will be called whether the table itself is cached or not. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

In the case like the following:
```sql
CREATE TABLE t ...;
CREATE VIEW t1 AS SELECT * FROM t;
REFRESH TABLE t;
```

If the table `t` is refreshed, the view `t1` which is depending on `t` will not be invalidated. This could lead to incorrect result and is similar to [SPARK-19765](https://issues.apache.org/jira/browse/SPARK-19765). 

On the other hand, if we have:

```sql 
CREATE TABLE t ...;
CACHE TABLE t;
CREATE VIEW t1 AS SELECT * FROM t;
REFRESH TABLE t;
```

Then the view `t1` will be refreshed. The behavior is somewhat inconsistent.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, with the change any cache that are depending on the table refreshed will be invalidated with the change. Previously this only happens if the table itself is cached.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Added a new UT for the case.