### PR TITLE
[SPARK-33297][BUILD] Switch to use flat class loader strategy in SBT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 
   <mailingLists>
     <mailingList>
-      <name>Dev Mailing List</name>
+      <name>Dev Mailing List!</name>
       <post>dev@spark.apache.org</post>
       <subscribe>dev-subscribe@spark.apache.org</subscribe>
       <unsubscribe>dev-unsubscribe@spark.apache.org</unsubscribe>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     </mailingList>
 
     <mailingList>
-      <name>User Mailing List</name>
+      <name>User Mailing List!</name>
       <post>user@spark.apache.org</post>
       <subscribe>user-subscribe@spark.apache.org</subscribe>
       <unsubscribe>user-unsubscribe@spark.apache.org</unsubscribe>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 
   <mailingLists>
     <mailingList>
-      <name>Dev Mailing List!</name>
+      <name>Dev Mailing List</name>
       <post>dev@spark.apache.org</post>
       <subscribe>dev-subscribe@spark.apache.org</subscribe>
       <unsubscribe>dev-unsubscribe@spark.apache.org</unsubscribe>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     </mailingList>
 
     <mailingList>
-      <name>User Mailing List!</name>
+      <name>User Mailing List</name>
       <post>user@spark.apache.org</post>
       <subscribe>user-subscribe@spark.apache.org</subscribe>
       <unsubscribe>user-unsubscribe@spark.apache.org</unsubscribe>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -79,6 +79,8 @@ object BuildCommons {
   val testTempDir = s"$sparkHome/target/tmp"
 
   val javaVersion = settingKey[String]("source and target JVM version for javac and scalac")
+
+  Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat
 }
 
 object SparkBuild extends PomBuild {

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -79,8 +79,6 @@ object BuildCommons {
   val testTempDir = s"$sparkHome/target/tmp"
 
   val javaVersion = settingKey[String]("source and target JVM version for javac and scalac")
-
-  Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat
 }
 
 object SparkBuild extends PomBuild {
@@ -324,7 +322,11 @@ object SparkBuild extends PomBuild {
 
     // disable Mima check for all modules,
     // to be enabled in specific ones that have previous artifacts
-    MimaKeys.mimaFailOnNoPrevious := false
+    MimaKeys.mimaFailOnNoPrevious := false,
+
+    // To prevent intermittent compliation failures, see also SPARK-33297
+    // Apparently we can remove this when we use JDK 11.
+    Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat
   )
 
   def enable(settings: Seq[Setting[_]])(projectRef: ProjectRef) = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to switch the class loader strategy from `ScalaLibrary` to `Flat` (see https://www.scala-sbt.org/1.x/docs/In-Process-Classloaders.html):

https://github.com/apache/spark/runs/1314691686

```
Error:  java.util.MissingResourceException: Can't find bundle for base name org.scalactic.ScalacticBundle, locale en
Error:  	at java.util.ResourceBundle.throwMissingResourceException(ResourceBundle.java:1581)
Error:  	at java.util.ResourceBundle.getBundleImpl(ResourceBundle.java:1396)
Error:  	at java.util.ResourceBundle.getBundle(ResourceBundle.java:782)
Error:  	at org.scalactic.Resources$.resourceBundle$lzycompute(Resources.scala:8)
Error:  	at org.scalactic.Resources$.resourceBundle(Resources.scala:8)
Error:  	at org.scalactic.Resources$.pleaseDefineScalacticFillFilePathnameEnvVar(Resources.scala:256)
Error:  	at org.scalactic.source.PositionMacro$PositionMacroImpl.apply(PositionMacro.scala:65)
Error:  	at org.scalactic.source.PositionMacro$.genPosition(PositionMacro.scala:85)
Error:  	at sun.reflect.GeneratedMethodAccessor34.invoke(Unknown Source)
Error:  	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
Error:  	at java.lang.reflect.Method.invoke(Method.java:498)
```

See also https://github.com/sbt/sbt/issues/5736

### Why are the changes needed?

To make the build unflaky.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

GitHub Actions build in this test.