### PR TITLE
[SPARK-33248][SQL][FOLLOWUP] Update migration guide to make clear what behavior changed and make variable names and configuration name more clearer

### DIFF
--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -52,7 +52,7 @@ license: |
   
   - In Spark 3.1, the `schema_of_json` and `schema_of_csv` functions return the schema in the SQL format in which field names are quoted. In Spark 3.0, the function returns a catalog string without field quoting and in lower case. 
  
-  - In Spark 3.1, when `spark.sql.legacy.transformationPadNullWhenValueLessThenSchema` is true, Spark will pad NULL value when script transformation's output value size less then schema size in default-serde mode(script transformation with row format of `ROW FORMAT DELIMITED`). If false, Spark will keep original behavior to throw `ArrayIndexOutOfBoundsException`.
+  - In Spark 3.1, when script transformation output's value size less then schema size in default-serde mode(script transformation with row format of `ROW FORMAT DELIMITED`), Spark will pad NUll value to supplement data. In Spark 3.0 or earlier, Spark will do nothing and throw `ArrayIndexOutOfBoundsException`. To restore the behavior before Spark 3.1, you can set `spark.sql.legacy.transformationNotPadNullToSupplementData.enabled` to `true`.
 
 ## Upgrading from Spark SQL 3.0 to 3.0.1
 

--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -52,7 +52,7 @@ license: |
   
   - In Spark 3.1, the `schema_of_json` and `schema_of_csv` functions return the schema in the SQL format in which field names are quoted. In Spark 3.0, the function returns a catalog string without field quoting and in lower case. 
  
-  - In Spark 3.1, when script transformation output's value size less then schema size in default-serde mode(script transformation with row format of `ROW FORMAT DELIMITED`), Spark will pad NUll value to supplement data. In Spark 3.0 or earlier, Spark will do nothing and throw `ArrayIndexOutOfBoundsException`. To restore the behavior before Spark 3.1, you can set `spark.sql.legacy.transformationNotPadNullToSupplementData.enabled` to `true`.
+  - In Spark 3.1, when script transformation output's value size is less then schema size in default-serde mode(script transformation with row format of `ROW FORMAT DELIMITED`), Spark will pad NUll value to supplement data. In Spark 3.0 or earlier, Spark will do nothing and throw `ArrayIndexOutOfBoundsException`. To restore the behavior before Spark 3.1, you can set `spark.sql.legacy.transformationNotPadNullToSupplementData.enabled` to `true`.
 
 ## Upgrading from Spark SQL 3.0 to 3.0.1
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2768,8 +2768,8 @@ object SQLConf {
   val LEGACY_SCRIPT_TRANSFORM_NOT_PAD_NULL =
     buildConf("spark.sql.legacy.transformationNotPadNullToSupplementData.enabled")
       .internal()
-      .doc("Whether pad null value when script transformation output's value size less then " +
-        "schema size in default-serde mode(script transformation with row format of " +
+      .doc("Whether pad null value when script transformation output's value size is less " +
+        "then schema size in default-serde mode(script transformation with row format of " +
         "`ROW FORMAT DELIMITED`)." +
         "When false, Spark will pad NULL value to keep same behavior with hive." +
         "When true, Spark keep original behavior to throw `ArrayIndexOutOfBoundsException`")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2765,17 +2765,17 @@ object SQLConf {
       .checkValue(_ > 0, "The timeout value must be positive")
       .createWithDefault(10L)
 
-  val LEGACY_SCRIPT_TRANSFORM_PAD_NULL =
-    buildConf("spark.sql.legacy.transformationPadNullWhenValueLessThenSchema")
+  val LEGACY_SCRIPT_TRANSFORM_NOT_PAD_NULL =
+    buildConf("spark.sql.legacy.transformationNotPadNullToSupplementData.enabled")
       .internal()
-      .doc("Whether pad null value when transformation output's value size less then " +
+      .doc("Whether pad null value when script transformation output's value size less then " +
         "schema size in default-serde mode(script transformation with row format of " +
         "`ROW FORMAT DELIMITED`)." +
-        "When true, Spark will pad NULL value to keep same behavior with hive." +
-        "When false, Spark keep original behavior to throw `ArrayIndexOutOfBoundsException`")
+        "When false, Spark will pad NULL value to keep same behavior with hive." +
+        "When true, Spark keep original behavior to throw `ArrayIndexOutOfBoundsException`")
       .version("3.1.0")
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(false)
 
   val LEGACY_ALLOW_CAST_NUMERIC_TO_TIMESTAMP =
     buildConf("spark.sql.legacy.allowCastNumericToTimestamp")
@@ -3505,8 +3505,8 @@ class SQLConf extends Serializable with Logging {
   def legacyAllowModifyActiveSession: Boolean =
     getConf(StaticSQLConf.LEGACY_ALLOW_MODIFY_ACTIVE_SESSION)
 
-  def legacyPadNullWhenValueLessThenSchema: Boolean =
-    getConf(SQLConf.LEGACY_SCRIPT_TRANSFORM_PAD_NULL)
+  def legacyNotPadNullWhenValueLessThenSchema: Boolean =
+    getConf(SQLConf.LEGACY_SCRIPT_TRANSFORM_NOT_PAD_NULL)
 
   def legacyAllowCastNumericToTimestamp: Boolean =
     getConf(SQLConf.LEGACY_ALLOW_CAST_NUMERIC_TO_TIMESTAMP)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/BaseScriptTransformationExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/BaseScriptTransformationExec.scala
@@ -105,7 +105,7 @@ trait BaseScriptTransformationExec extends UnaryExecNode {
 
       val outputRowFormat = ioschema.outputRowFormatMap("TOK_TABLEROWFORMATFIELD")
 
-      val notPadNull = if (conf.legacyNotPadNullWhenValueLessThenSchema) {
+      val supplementDataWrapper = if (conf.legacyNotPadNullWhenValueLessThenSchema) {
         (arr: Array[String], size: Int) => arr.padTo(size, null)
       } else {
         (arr: Array[String], size: Int) => arr
@@ -113,7 +113,7 @@ trait BaseScriptTransformationExec extends UnaryExecNode {
       val processRowWithoutSerde = if (!ioschema.schemaLess) {
         prevLine: String =>
           new GenericInternalRow(
-            notPadNull(prevLine.split(outputRowFormat), outputFieldWriters.size)
+            supplementDataWrapper(prevLine.split(outputRowFormat), outputFieldWriters.size)
               .zip(outputFieldWriters)
               .map { case (data, writer) => writer(data) })
       } else {
@@ -124,7 +124,7 @@ trait BaseScriptTransformationExec extends UnaryExecNode {
         val kvWriter = CatalystTypeConverters.createToCatalystConverter(StringType)
         prevLine: String =>
           new GenericInternalRow(
-            notPadNull(prevLine.split(outputRowFormat).slice(0, 2), 2)
+            supplementDataWrapper(prevLine.split(outputRowFormat).slice(0, 2), 2)
               .map(kvWriter))
       }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/BaseScriptTransformationExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/BaseScriptTransformationExec.scala
@@ -105,7 +105,7 @@ trait BaseScriptTransformationExec extends UnaryExecNode {
 
       val outputRowFormat = ioschema.outputRowFormatMap("TOK_TABLEROWFORMATFIELD")
 
-      val padNull = if (conf.legacyPadNullWhenValueLessThenSchema) {
+      val notPadNull = if (conf.legacyNotPadNullWhenValueLessThenSchema) {
         (arr: Array[String], size: Int) => arr.padTo(size, null)
       } else {
         (arr: Array[String], size: Int) => arr
@@ -113,7 +113,7 @@ trait BaseScriptTransformationExec extends UnaryExecNode {
       val processRowWithoutSerde = if (!ioschema.schemaLess) {
         prevLine: String =>
           new GenericInternalRow(
-            padNull(prevLine.split(outputRowFormat), outputFieldWriters.size)
+            notPadNull(prevLine.split(outputRowFormat), outputFieldWriters.size)
               .zip(outputFieldWriters)
               .map { case (data, writer) => writer(data) })
       } else {
@@ -124,7 +124,7 @@ trait BaseScriptTransformationExec extends UnaryExecNode {
         val kvWriter = CatalystTypeConverters.createToCatalystConverter(StringType)
         prevLine: String =>
           new GenericInternalRow(
-            padNull(prevLine.split(outputRowFormat).slice(0, 2), 2)
+            notPadNull(prevLine.split(outputRowFormat).slice(0, 2), 2)
               .map(kvWriter))
       }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/BaseScriptTransformationExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/BaseScriptTransformationExec.scala
@@ -106,9 +106,9 @@ trait BaseScriptTransformationExec extends UnaryExecNode {
       val outputRowFormat = ioschema.outputRowFormatMap("TOK_TABLEROWFORMATFIELD")
 
       val supplementDataWrapper = if (conf.legacyNotPadNullWhenValueLessThenSchema) {
-        (arr: Array[String], size: Int) => arr.padTo(size, null)
-      } else {
         (arr: Array[String], size: Int) => arr
+      } else {
+        (arr: Array[String], size: Int) => arr.padTo(size, null)
       }
       val processRowWithoutSerde = if (!ioschema.schemaLess) {
         prevLine: String =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Affress comment
https://github.com/apache/spark/pull/30156#discussion_r514894596
https://github.com/apache/spark/pull/30156#discussion_r514894838


### Why are the changes needed?
Make change more readable

### Does this PR introduce _any_ user-facing change?
In Spark 3.1, when script transformation output's value size less then schema size in default-serde mode(script transformation with row format of `ROW FORMAT DELIMITED`), Spark will pad NUll value to supplement data. In Spark 3.0 or earlier, Spark will do nothing and throw `ArrayIndexOutOfBoundsException`. To restore the behavior before Spark 3.1, you can set `spark.sql.legacy.transformationNotPadNullToSupplementData.enabled` to `true`.

### How was this patch tested?
Existed UT