### PR TITLE
[SPARK-33303][SQL] Deduplicate deterministic PythonUDF calls

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExecSuite.scala
@@ -137,6 +137,13 @@ class MyDummyPythonUDF extends UserDefinedPythonFunction(
   pythonEvalType = PythonEvalType.SQL_BATCHED_UDF,
   udfDeterministic = true)
 
+class MyDummyNondeterministicPythonUDF extends UserDefinedPythonFunction(
+  name = "dummyNondeterministicUDF",
+  func = new DummyUDF,
+  dataType = BooleanType,
+  pythonEvalType = PythonEvalType.SQL_BATCHED_UDF,
+  udfDeterministic = false)
+
 class MyDummyGroupedAggPandasUDF extends UserDefinedPythonFunction(
   name = "dummyGroupedAggPandasUDF",
   func = new DummyUDF,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFsSuite.scala
@@ -28,6 +28,7 @@ class ExtractPythonUDFsSuite extends SparkPlanTest with SharedSparkSession {
   import testImplicits._
 
   val batchedPythonUDF = new MyDummyPythonUDF
+  val batchedNondeterministicPythonUDF = new MyDummyNondeterministicPythonUDF
   val scalarPandasUDF = new MyDummyScalarPandasUDF
 
   private def collectBatchExec(plan: SparkPlan): Seq[BatchEvalPythonExec] = plan.collect {
@@ -166,5 +167,31 @@ class ExtractPythonUDFsSuite extends SparkPlanTest with SharedSparkSession {
     }
   }
 
+  test("SPARK-33303: Deterministic UDF calls are deduplicated") {
+    val df = Seq("Hello").toDF("a")
+
+    val df2 = df.withColumn("c", batchedPythonUDF(col("a"))).withColumn("d", col("c"))
+    val pythonEvalNodes2 = collectBatchExec(df2.queryExecution.executedPlan)
+    assert(pythonEvalNodes2.size == 1)
+    assert(pythonEvalNodes2.head.udfs.size == 1)
+
+    val df3 = df.withColumns(Seq("c", "d"),
+      Seq(batchedPythonUDF(col("a")), batchedPythonUDF(col("a"))))
+    val pythonEvalNodes3 = collectBatchExec(df3.queryExecution.executedPlan)
+    assert(pythonEvalNodes3.size == 1)
+    assert(pythonEvalNodes3.head.udfs.size == 1)
+
+    val df4 = df.withColumn("c", batchedNondeterministicPythonUDF(col("a")))
+      .withColumn("d", col("c"))
+    val pythonEvalNodes4 = collectBatchExec(df4.queryExecution.executedPlan)
+    assert(pythonEvalNodes4.size == 1)
+    assert(pythonEvalNodes4.head.udfs.size == 1)
+
+    val df5 = df.withColumns(Seq("c", "d"),
+      Seq(batchedNondeterministicPythonUDF(col("a")), batchedNondeterministicPythonUDF(col("a"))))
+    val pythonEvalNodes5 = collectBatchExec(df5.queryExecution.executedPlan)
+    assert(pythonEvalNodes5.size == 1)
+    assert(pythonEvalNodes5.head.udfs.size == 2)
+  }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR modifies the `ExtractPythonUDFs` rule to deduplicate deterministic PythonUDF calls.

Before this PR the dataframe: `df.withColumn("c", batchedPythonUDF(col("a"))).withColumn("d", col("c"))` has the plan:
```
*(1) Project [value#1 AS a#4, pythonUDF1#15 AS c#7, pythonUDF1#15 AS d#10]
+- BatchEvalPython [dummyUDF(value#1), dummyUDF(value#1)], [pythonUDF0#14, pythonUDF1#15]
   +- LocalTableScan [value#1]
```
After this PR the deterministic PythonUDF calls are deduplicated:
```
*(1) Project [value#1 AS a#4, pythonUDF0#14 AS c#7, pythonUDF0#14 AS d#10]
+- BatchEvalPython [dummyUDF(value#1)], [pythonUDF0#14]
   +- LocalTableScan [value#1]
```

### Why are the changes needed?
To fix a performance issue.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
New and existing UTs.
