### PR TITLE
[SPARK-33098][SQL] Avoid MetaException by not pushing down partition filters with incompatible types

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -770,7 +770,7 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
 
       case op @ SpecialBinaryComparison(
           ExtractableLiteral(value, dt2), ExtractAttribute(SupportedAttribute(name), dt1))
-            if (dt1 == dt2) =>
+          if (dt1 == dt2) =>
         Some(s"$value ${op.symbol} $name")
 
       case And(expr1, expr2) if useAdvanced =>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -808,9 +808,11 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
       hive: Hive,
       table: Table,
       predicates: Seq[Expression]): Seq[Partition] = {
+
     // Hive getPartitionsByFilter() takes a string that represents partition
     // predicates like "str_key=\"value\" and int_key=1 ..."
     val filter = convertFilters(table, predicates)
+
     val partitions =
       if (filter.isEmpty) {
         logDebug(s"Falling back to getting all partitions")

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -764,13 +764,8 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
         Some(s"$name ${op.symbol} $value")
 
       case op @ SpecialBinaryComparison(
-          ExtractAttribute(SupportedAttribute(name), dt1), ExtractableLiteral(value, dt2))
-          if !compatibleTypes(dt1, dt2) =>
-        None
-
-      case op @ SpecialBinaryComparison(
           ExtractableLiteral(value, dt2), ExtractAttribute(SupportedAttribute(name), dt1))
-          if (dt1 == dt2) =>
+          if compatibleTypes(dt1, dt2) =>
         Some(s"$value ${op.symbol} $name")
 
       case And(expr1, expr2) if useAdvanced =>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -766,7 +766,6 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
       case op @ SpecialBinaryComparison(
           ExtractAttribute(SupportedAttribute(name), dt1), ExtractableLiteral(value, dt2))
           if !compatibleTypes(dt1, dt2) =>
-        logWarning(s"Not creating filter because $dt1 not same as $dt2")
         None
 
       case op @ SpecialBinaryComparison(
@@ -809,13 +808,12 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
       hive: Hive,
       table: Table,
       predicates: Seq[Expression]): Seq[Partition] = {
-    logWarning(s"Filters on entry are ${predicates.toList}")
     // Hive getPartitionsByFilter() takes a string that represents partition
     // predicates like "str_key=\"value\" and int_key=1 ..."
     val filter = convertFilters(table, predicates)
-    logWarning(s"Filters after convert are $filter")
     val partitions =
       if (filter.isEmpty) {
+        logDebug(s"Falling back to getting all partitions")
         getAllPartitionsMethod.invoke(hive, table).asInstanceOf[JSet[Partition]]
       } else {
         logDebug(s"Hive metastore filter is '$filter'.")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/FiltersSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/FiltersSuite.scala
@@ -61,7 +61,7 @@ class FiltersSuite extends SparkFunSuite with Logging with PlanTest {
 
   filterTest("int and string filter",
     (Literal(1) === a("intcol", IntegerType)) :: (Literal("a") === a("strcol", IntegerType)) :: Nil,
-    "1 = intcol and \"a\" = strcol")
+    "1 = intcol")
 
   filterTest("skip varchar",
     (Literal("") === a("varchar", StringType)) :: Nil,

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/FiltersSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/FiltersSuite.scala
@@ -68,10 +68,20 @@ class FiltersSuite extends SparkFunSuite with Logging with PlanTest {
       (a("intcol2", IntegerType) === (Literal("a"))) :: Nil,
     "intcol1 = 1")
 
+  filterTest("int and int column/string literal filter with conversion",
+    (a("intcol1", IntegerType) === Literal(1)) ::
+      (a("intcol2", IntegerType) === (Literal("00002"))) :: Nil,
+    "intcol1 = 1 and intcol2 = 2")
+
   filterTest("int and int column/string literal filter backwards",
     (Literal(1) === a("intcol1", IntegerType)) ::
       (Literal("a") === a("intcol2", IntegerType)) :: Nil,
     "1 = intcol1")
+
+  filterTest("int and int column/string literal filter backwards with conversion",
+    (Literal(1) === a("intcol1", IntegerType)) ::
+      (Literal("00002") === a("intcol2", IntegerType)) :: Nil,
+    "1 = intcol1 and 2 = intcol2")
 
   filterTest("int filter with in",
     (a("intcol", IntegerType) in (Literal(1), Literal(2))) :: Nil,

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/FiltersSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/FiltersSuite.scala
@@ -72,9 +72,17 @@ class FiltersSuite extends SparkFunSuite with Logging with PlanTest {
     (a("intcol", IntegerType) in (Literal(1), Literal(2))) :: Nil,
     "(intcol = 1 or intcol = 2)")
 
+  filterTest("int/string filter with in",
+    (a("intcol", IntegerType) in (Literal("1"), Literal("2"))) :: Nil,
+    "")
+
   filterTest("int filter with inset",
     (a("intcol", IntegerType) in ((0 to 11).map(Literal(_)): _*)) :: Nil,
     "(" + (0 to 11).map(x => s"intcol = $x").mkString(" or ") + ")")
+
+  filterTest("int/string filter with inset",
+    (a("intcol", IntegerType) in ((0 to 11).map(x => Literal(x.toString)): _*)) :: Nil,
+    "")
 
   filterTest("string filter with in",
     (a("strcol", StringType) in (Literal("1"), Literal("2"))) :: Nil,

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/FiltersSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/FiltersSuite.scala
@@ -60,8 +60,25 @@ class FiltersSuite extends SparkFunSuite with Logging with PlanTest {
     "1 = intcol")
 
   filterTest("int and string filter",
-    (Literal(1) === a("intcol", IntegerType)) :: (Literal("a") === a("strcol", IntegerType)) :: Nil,
-    "1 = intcol")
+    (Literal(1) === a("intcol", IntegerType)) :: (Literal("a") === a("strcol", StringType)) :: Nil,
+    "1 = intcol and \"a\" = strcol")
+
+  filterTest("int and string/int filter",
+    (Literal(1) === a("intcol1", IntegerType)) ::
+      (Literal("a") === a("intcol2", IntegerType)) :: Nil,
+    "1 = intcol1")
+
+  filterTest("int filter with in",
+    (a("intcol", IntegerType) in (Literal(1), Literal(2))) :: Nil,
+    "(intcol = 1 or intcol = 2)")
+
+  filterTest("int filter with inset",
+    (a("intcol", IntegerType) in ((0 to 11).map(Literal(_)): _*)) :: Nil,
+    "(" + (0 to 11).map(x => s"intcol = $x").mkString(" or ") + ")")
+
+  filterTest("string filter with in",
+    (a("strcol", StringType) in (Literal("1"), Literal("2"))) :: Nil,
+    "(strcol = \"1\" or strcol = \"2\")")
 
   filterTest("skip varchar",
     (Literal("") === a("varchar", StringType)) :: Nil,

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/FiltersSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/FiltersSuite.scala
@@ -63,7 +63,12 @@ class FiltersSuite extends SparkFunSuite with Logging with PlanTest {
     (Literal(1) === a("intcol", IntegerType)) :: (Literal("a") === a("strcol", StringType)) :: Nil,
     "1 = intcol and \"a\" = strcol")
 
-  filterTest("int and string/int filter",
+  filterTest("int and int column/string literal filter",
+    (a("intcol1", IntegerType) === Literal(1)) ::
+      (a("intcol2", IntegerType) === (Literal("a"))) :: Nil,
+    "intcol1 = 1")
+
+  filterTest("int and int column/string literal filter backwards",
     (Literal(1) === a("intcol1", IntegerType)) ::
       (Literal("a") === a("intcol2", IntegerType)) :: Nil,
     "1 = intcol1")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/PruneHiveTablePartitionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/PruneHiveTablePartitionsSuite.scala
@@ -84,11 +84,12 @@ class PruneHiveTablePartitionsSuite extends PrunePartitionSuiteBase {
     withTable("t") {
       sql("create table t (a int) partitioned by (b int) stored as parquet")
 
-      // There's only one test case because TestHiveSparkSession sets
+      // There are only two test cases because TestHiveSparkSession sets
       // hive.metastore.integral.jdo.pushdown=true, which, as a side effect, prevents
-      // the Metaexception for most of the problem cases. Only the case below still throws
-      // a MetaException when Hive is configured this way
-      sql("select * from t where cast(b as string) > '1'").show(false)
+      // the Metaexception for most of the problem cases. Only the two cases below
+      // would still throw a MetaException when Hive is configured this way
+      sql("select cast(b as string) b from t").filter("b > '1'").collect
+      sql("select * from t where cast(b as string) > '1'").collect
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->



This PR checks that the type of the extracted column is compatible with the type of the literal. If they're not compatible, it attempts to make them compatible. If that fails, the binary comparison is not used in the final filter expression.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To avoid unnecessary MetaExceptions.

SPARK-22384 expanded the types of filters that ```Shim_v0_13#convertFilters``` can handle to include filters that contain CAST expressions. This opened up the door for Spark to push down partition filters with mismatched datatypes.

Take this example: Spark passes the filter ```'cast(b as string) = "2"'``` to convertFilters, where b is an integral column. The integral column b is extracted from the CAST expression, but the literal is left as-is, resulting in the following filter getting pushed down to the metastore:

```b = "2"```

Hive throws a MetaException complaining that an integer column is being compared to a string literal (with the very misleading message "Filtering is supported only on partition keys of type string")

Here are some examples that throw a MetaException:

```scala
sql("create table test (a int) partitioned by (b int) stored as parquet")
sql("insert into test values (1, 1), (1, 2), (2, 2)")

// These throw MetaExceptions
sql("select * from test where b in ('2')").show(false)
sql("select * from test where cast(b as string) = '2'").show(false)
sql("select * from test where cast(b as string) in ('2')").show(false)
sql("select * from test where cast(b as string) in (2)").show(false)
sql("select cast(b as string) as b from test where b in ('2')").show(false)
sql("select cast(b as string) as b from test").filter("b = '2'").show(false) // [1]
sql("select cast(b as string) as b from test").filter("b in (2)").show(false) // [2]
sql("select cast(b as string) as b from test").filter("b in ('2')").show(false)
sql("select * from test where cast(b as string) > '1'").show(false)
sql("select cast(b as string) b from test").filter("b > '1'").show(false) // [3]

// [1] but not sql("select cast(b as string) as b from test where b = '2'").show(false)
// [2] but not sql("select cast(b as string) as b from test where b in (2)").show(false)
// [3] but not sql("select cast(b as string) b from test where b > '1'").show(false)
```
In fact, all the failures I could find boil down to the following partition filter getting pushed down to the metastore:

```<col-name-of-integral-column> <binary-comparison> "<string-literal>"```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added tests.