### PR TITLE
[SPARK-30663][SPARK-33313][TESTS][R] Drop testthat 1.x support and add testthat 3.x support

### DIFF
--- a/R/pkg/tests/run-all.R
+++ b/R/pkg/tests/run-all.R
@@ -64,18 +64,19 @@ if (identical(Sys.getenv("NOT_CRAN"), "true")) {
 
     test_runner <- if (packageVersion("testthat")$major == 2) {
       # testthat == 2.0.0
-      testthat:::test_package_dir
-    } else {
-      # testthat >= 3.0.0
-      function(package, test_path, filter, reporter) {
-        testthat::test_dir(
-          path = test_path,
-          filter = filter,
+      function(path, package, reporter, filter) {
+        testthat:::test_package_dir(
+          test_path = path,
           package = package,
+          filter = filter,
           reporter = reporter
         )
       }
+    } else {
+      # testthat >= 3.0.0
+      testthat::test_dir
     }
+
     dir.create("target/test-reports", showWarnings = FALSE)
     reporter <- MultiReporter$new(list(
       SummaryReporter$new(),
@@ -84,10 +85,12 @@ if (identical(Sys.getenv("NOT_CRAN"), "true")) {
       )
     ))
 
-    test_runner("SparkR",
-                file.path(sparkRDir, "pkg", "tests", "fulltests"),
-                NULL,
-                reporter)
+    test_runner(
+      path = file.path(sparkRDir, "pkg", "tests", "fulltests"),
+      package = "SparkR",
+      reporter = reporter,
+      filter = NULL
+    )
   }
 
   SparkR:::uninstallDownloadedSpark()

--- a/R/pkg/tests/run-all.R
+++ b/R/pkg/tests/run-all.R
@@ -63,7 +63,7 @@ if (identical(Sys.getenv("NOT_CRAN"), "true")) {
     if (packageVersion("testthat")$major <= 1) stop("testhat 1.x is not supported")
 
     test_runner <- if (packageVersion("testthat")$major == 2) {
-      # testthat == 2.0.0
+      # testthat >= 2.0.0, < 3.0.0
       function(path, package, reporter, filter) {
         testthat:::test_package_dir(
           test_path = path,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR modifies `R/pkg/tests/run-all.R` by:

- Removing `testthat` 1.x support, as Jenkins has been upgraded to 2.x with SPARK-30637 and this code is no longer relevant.
- Add `testthat` 3.x support to avoid AppVeyor failures.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Currently used internal API has been removed in the latest `testthat` release.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Tests executed against `testthat == 2.3.2` and `testthat == 3.0.0` 
