### PR TITLE
[SPARK-33316][SQL] Support user provided nullable Avro schema for non-nullable catalyst schema in Avro writing

### DIFF
--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/SchemaConverters.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/SchemaConverters.scala
@@ -208,3 +208,5 @@ object SchemaConverters {
 
 private[avro] class IncompatibleSchemaException(
   msg: String, ex: Throwable = null) extends Exception(msg, ex)
+
+private[avro] class InvalidAvroTypeException(msg: String) extends Exception(msg)

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/SchemaConverters.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/SchemaConverters.scala
@@ -209,4 +209,4 @@ object SchemaConverters {
 private[avro] class IncompatibleSchemaException(
   msg: String, ex: Throwable = null) extends Exception(msg, ex)
 
-private[avro] class InvalidAvroTypeException(msg: String) extends Exception(msg)
+private[avro] class UnsupportedAvroTypeException(msg: String) extends Exception(msg)

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroFunctionsSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroFunctionsSuite.scala
@@ -205,36 +205,37 @@ class AvroFunctionsSuite extends QueryTest with SharedSparkSession {
   test("roundtrip in to_avro and from_avro - struct with nullable Avro schema") {
     val df = spark.range(10).select(struct('id, 'id.cast("string").as("str")).as("struct"))
     val avroTypeStruct = s"""
-                            |{
-                            |  "type": "record",
-                            |  "name": "struct",
-                            |  "fields": [
-                            |    {"name": "id", "type": "long"},
-                            |    {"name": "str", "type": ["null", "string"]}
-                            |  ]
-                            |}
+      |{
+      |  "type": "record",
+      |  "name": "struct",
+      |  "fields": [
+      |    {"name": "id", "type": "long"},
+      |    {"name": "str", "type": ["null", "string"]}
+      |  ]
+      |}
     """.stripMargin
     val avroStructDF = df.select(functions.to_avro('struct, avroTypeStruct).as("avro"))
     checkAnswer(avroStructDF.select(
       functions.from_avro('avro, avroTypeStruct)), df)
   }
 
-  test("to_avro with invalid nullable Avro schema") {
+  test("to_avro with unsupported nullable Avro schema") {
     val df = spark.range(10).select(struct('id, 'id.cast("string").as("str")).as("struct"))
-    for (invalidAvroType <- Seq("""["null", "int", "long"]""", """["int", "long"]""")) {
+    for (unsupportedAvroType <- Seq("""["null", "int", "long"]""", """["int", "long"]""")) {
       val avroTypeStruct = s"""
-                              |{
-                              |  "type": "record",
-                              |  "name": "struct",
-                              |  "fields": [
-                              |    {"name": "id", "type": $invalidAvroType},
-                              |    {"name": "str", "type": ["null", "string"]}
-                              |  ]
-                              |}
+        |{
+        |  "type": "record",
+        |  "name": "struct",
+        |  "fields": [
+        |    {"name": "id", "type": $unsupportedAvroType},
+        |    {"name": "str", "type": ["null", "string"]}
+        |  ]
+        |}
       """.stripMargin
-      intercept[SparkException] {
+      val message = intercept[SparkException] {
         df.select(functions.to_avro('struct, avroTypeStruct).as("avro")).show()
-      }
+      }.getCause.getMessage
+      assert(message.contains("Only UNION of a null type and a non-null type is supported"))
     }
   }
 }

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroFunctionsSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroFunctionsSuite.scala
@@ -201,4 +201,40 @@ class AvroFunctionsSuite extends QueryTest with SharedSparkSession {
           Map("avroSchema" -> evolvedAvroSchema).asJava)),
       expected)
   }
+
+  test("roundtrip in to_avro and from_avro - struct with nullable Avro schema") {
+    val df = spark.range(10).select(struct('id, 'id.cast("string").as("str")).as("struct"))
+    val avroTypeStruct = s"""
+                            |{
+                            |  "type": "record",
+                            |  "name": "struct",
+                            |  "fields": [
+                            |    {"name": "id", "type": "long"},
+                            |    {"name": "str", "type": ["null", "string"]}
+                            |  ]
+                            |}
+    """.stripMargin
+    val avroStructDF = df.select(functions.to_avro('struct, avroTypeStruct).as("avro"))
+    checkAnswer(avroStructDF.select(
+      functions.from_avro('avro, avroTypeStruct)), df)
+  }
+
+  test("to_avro with invalid nullable Avro schema") {
+    val df = spark.range(10).select(struct('id, 'id.cast("string").as("str")).as("struct"))
+    for (invalidAvroType <- Seq("""["null", "int", "long"]""", """["int", "long"]""")) {
+      val avroTypeStruct = s"""
+                              |{
+                              |  "type": "record",
+                              |  "name": "struct",
+                              |  "fields": [
+                              |    {"name": "id", "type": $invalidAvroType},
+                              |    {"name": "str", "type": ["null", "string"]}
+                              |  ]
+                              |}
+      """.stripMargin
+      intercept[SparkException] {
+        df.select(functions.to_avro('struct, avroTypeStruct).as("avro")).show()
+      }
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This change is to support user provided nullable Avro schema for data with non-nullable catalyst schema in Avro writing. 

Without this change, when users try to use a nullable Avro schema to write data with a non-nullable catalyst schema, it will throw an `IncompatibleSchemaException` with a message like `Cannot convert Catalyst type StringType to Avro type ["null","string"]`. With this change it will assume that the data is non-nullable, log a warning message for the nullability difference and serialize the data to Avro format with the nullable Avro schema provided.

### Why are the changes needed?
This change is needed because sometimes our users do not have full control over the nullability of the Avro schemas they use, and this change provides them with the flexibility.

### Does this PR introduce _any_ user-facing change?
Yes. Users are allowed to use nullable Avro schemas for data with non-nullable catalyst schemas in Avro writing after the change.

### How was this patch tested?
Added unit tests.
