### PR TITLE
[SPARK-33330][SQL] Add support for Enums on CatalystTypeConverters

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
@@ -291,6 +291,7 @@ object CatalystTypeConverters {
       case str: String => UTF8String.fromString(str)
       case utf8: UTF8String => utf8
       case chr: Char => UTF8String.fromString(chr.toString)
+      case enum if enum.getClass.isEnum => UTF8String.fromString(enum.toString)
       case other => throw new IllegalArgumentException(
         s"The value (${other.toString}) of the type (${other.getClass.getCanonicalName}) "
           + s"cannot be converted to the string type")

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/TestEnum.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/TestEnum.java
@@ -1,0 +1,5 @@
+package org.apache.spark.sql.catalyst;
+
+public enum TestEnum {
+    EXPECTED_VALUE
+}

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/TestEnum.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/TestEnum.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 package org.apache.spark.sql.catalyst;
 
 public enum TestEnum {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystTypeConvertersSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystTypeConvertersSuite.scala
@@ -216,4 +216,11 @@ class CatalystTypeConvertersSuite extends SparkFunSuite with SQLHelper {
       }
     }
   }
+
+  test("convert Enum to String") {
+    val value = TestEnum.EXPECTED_VALUE;
+    val converter = CatalystTypeConverters.createToCatalystConverter(StringType)
+    val expected = UTF8String.fromString("EXPECTED_VALUE")
+    assert(converter(value) === expected)
+  }
 }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaApplySchemaSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaApplySchemaSuite.java
@@ -199,34 +199,4 @@ public class JavaApplySchemaSuite implements Serializable {
     List<Row> actual2 = spark.sql("select * from jsonTable2").collectAsList();
     Assert.assertEquals(expectedResult, actual2);
   }
-
-  @Test
-  public void testEnumDataFrame() {
-    WithEnum v = new WithEnum(TestEnum.ENUM_VALUE);
-    Dataset<Row> dataFrame = spark.createDataFrame(Collections.singletonList(v), WithEnum.class);
-
-    dataFrame.createOrReplaceTempView("enum");
-
-    List<Row> expectedResult = Collections.singletonList(RowFactory.create("ENUM_VALUE"));
-
-    List<Row> actual = spark.sql("select * from enum").collectAsList();
-
-    Assert.assertEquals(expectedResult, actual);
-  }
-
-  enum TestEnum {
-    ENUM_VALUE
-  }
-
-  public static class WithEnum {
-    TestEnum value;
-
-    public WithEnum(TestEnum value) {
-      this.value = value;
-    }
-
-    public TestEnum getValue() {
-      return value;
-    }
-  }
 }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaApplySchemaSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaApplySchemaSuite.java
@@ -21,6 +21,7 @@ import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.After;
@@ -197,5 +198,35 @@ public class JavaApplySchemaSuite implements Serializable {
     df2.createOrReplaceTempView("jsonTable2");
     List<Row> actual2 = spark.sql("select * from jsonTable2").collectAsList();
     Assert.assertEquals(expectedResult, actual2);
+  }
+
+  @Test
+  public void testEnumDataFrame() {
+    WithEnum v = new WithEnum(TestEnum.ENUM_VALUE);
+    Dataset<Row> dataFrame = spark.createDataFrame(Collections.singletonList(v), WithEnum.class);
+
+    dataFrame.createOrReplaceTempView("enum");
+
+    List<Row> expectedResult = Collections.singletonList(RowFactory.create("ENUM_VALUE"));
+
+    List<Row> actual = spark.sql("select * from enum").collectAsList();
+
+    Assert.assertEquals(expectedResult, actual);
+  }
+
+  enum TestEnum {
+    ENUM_VALUE
+  }
+
+  public static class WithEnum {
+    TestEnum value;
+
+    public WithEnum(TestEnum value) {
+      this.value = value;
+    }
+
+    public TestEnum getValue() {
+      return value;
+    }
   }
 }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaApplySchemaSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaApplySchemaSuite.java
@@ -21,7 +21,6 @@ import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.After;

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
@@ -523,4 +523,34 @@ public class JavaDataFrameSuite {
       .map(row -> row.get(0).toString() + row.getString(1)).toArray(String[]::new);
     Assert.assertArrayEquals(expected, result);
   }
+
+  @Test
+  public void testEnumDataFrame() {
+    BeanWithEnum v = new BeanWithEnum(TestEnum.ENUM_VALUE);
+    Dataset<Row> dataFrame = spark.createDataFrame(Collections.singletonList(v), BeanWithEnum.class);
+
+    dataFrame.createOrReplaceTempView("enum");
+
+    List<Row> expectedResult = Collections.singletonList(RowFactory.create("ENUM_VALUE"));
+
+    List<Row> actual = spark.sql("select * from enum").collectAsList();
+
+    Assert.assertEquals(expectedResult, actual);
+  }
+
+  enum TestEnum {
+    ENUM_VALUE
+  }
+
+  public static class BeanWithEnum {
+    TestEnum value;
+
+    public BeanWithEnum(TestEnum value) {
+      this.value = value;
+    }
+
+    public TestEnum getValue() {
+      return value;
+    }
+  }
 }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
@@ -527,9 +527,9 @@ public class JavaDataFrameSuite {
   @Test
   public void testEnumDataFrame() {
     BeanWithEnum v = new BeanWithEnum(TestEnum.ENUM_VALUE);
-    Dataset<Row> dataFrame = spark.createDataFrame(Collections.singletonList(v), BeanWithEnum.class);
+    Dataset<Row> df = spark.createDataFrame(Collections.singletonList(v), BeanWithEnum.class);
 
-    dataFrame.createOrReplaceTempView("enum");
+    df.createOrReplaceTempView("enum");
 
     List<Row> expectedResult = Collections.singletonList(RowFactory.create("ENUM_VALUE"));
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Adds support for Converting Java Enums on CatalystTypeConverters. 


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
https://issues.apache.org/jira/browse/SPARK-33330

Given that:

JavaTypeInference maps [Enums to StringType ](https://github.com/apache/spark/blob/55105a0784459331d5506eee9f37c2e655a2a6a0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala#L135)
The converter for [StringType is StringConverter](https://github.com/apache/spark/blob/55105a0784459331d5506eee9f37c2e655a2a6a0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala#L64)
StringConverter is [unable to convert an Enums to UTF8String](https://github.com/apache/spark/blob/55105a0784459331d5506eee9f37c2e655a2a6a0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala#L294), failing with an InvalidArgumentException
 

It can be argued that CatalystTypeConverters should align with the exprectations set by JavaTypeInference and convert enums to their string representation. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
~~No~~  Yes. Adds support for Java enum handling. Project to demonstrate the bug here https://github.com/malduarte/testEnum



### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added  "convert Enum to String" test on sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystTypeConvertersSuite.scala

Also added end to end test in 
sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java