### PR TITLE
[SPARK-33333][BUILD][3.0] Upgrade Jetty to 9.4.28.v20200408

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
     <orc.classifier></orc.classifier>
     <hive.parquet.group>com.twitter</hive.parquet.group>
     <hive.parquet.version>1.6.0</hive.parquet.version>
-    <jetty.version>9.4.18.v20190429</jetty.version>
+    <jetty.version>9.4.28.v20200408</jetty.version>
     <javaxservlet.version>3.1.0</javaxservlet.version>
     <chill.version>0.9.5</chill.version>
     <ivy.version>2.4.0</ivy.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Jetty to 9.4.28.v20200408 in `branch-3.0` for `Apache Spark 3.0.2` like `master` branch `Apache Spark 3.1`.

### Why are the changes needed?

To bring the bug fixes.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.