### PR TITLE
[SPARK-33333][BUILD][2.4] Upgrade Jetty to 9.4.28.v20200408

### DIFF
--- a/dev/deps/spark-deps-hadoop-3.1
+++ b/dev/deps/spark-deps-hadoop-3.1
@@ -116,8 +116,8 @@ jersey-container-servlet/2.22.2//jersey-container-servlet-2.22.2.jar
 jersey-guava/2.22.2//jersey-guava-2.22.2.jar
 jersey-media-jaxb/2.22.2//jersey-media-jaxb-2.22.2.jar
 jersey-server/2.22.2//jersey-server-2.22.2.jar
-jetty-webapp/9.3.27.v20190418//jetty-webapp-9.3.27.v20190418.jar
-jetty-xml/9.3.27.v20190418//jetty-xml-9.3.27.v20190418.jar
+jetty-webapp/9.4.28.v20200408//jetty-webapp-9.4.28.v20200408.jar
+jetty-xml/9.4.28.v20200408//jetty-xml-9.4.28.v20200408.jar
 jline/2.14.6//jline-2.14.6.jar
 joda-time/2.9.3//joda-time-2.9.3.jar
 jodd-core/3.5.2//jodd-core-3.5.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
     <orc.version>1.5.5</orc.version>
     <orc.classifier>nohive</orc.classifier>
     <hive.parquet.version>1.6.0</hive.parquet.version>
-    <jetty.version>9.3.27.v20190418</jetty.version>
+    <jetty.version>9.4.28.v20200408</jetty.version>
     <javaxservlet.version>3.1.0</javaxservlet.version>
     <chill.version>0.9.3</chill.version>
     <ivy.version>2.4.0</ivy.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Jetty to 9.4.28.v20200408 like `master` branch (Apache Spark 3.1).

### Why are the changes needed?

To bring the bug fixes.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.