### PR TITLE
[SPARK-33341][CORE][SQL][MESOS]Remove unnecessary semicolons in Scala code

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -59,7 +59,7 @@ class HistoryServer(
   private val retainedApplications = conf.get(History.RETAINED_APPLICATIONS)
 
   // How many applications the summary ui displays
-  private[history] val maxApplications = conf.get(HISTORY_UI_MAX_APPS);
+  private[history] val maxApplications = conf.get(HISTORY_UI_MAX_APPS)
 
   // application
   private val appCache = new ApplicationCache(this, retainedApplications, new SystemClock())

--- a/core/src/main/scala/org/apache/spark/deploy/history/HybridStore.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HybridStore.scala
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.collection.JavaConverters._
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.Lists
 
 import org.apache.spark.util.kvstore._
 

--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/ApplicationPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/ApplicationPage.scala
@@ -131,7 +131,7 @@ private[ui] class ApplicationPage(parent: MasterWebUI) extends WebUIPage("app") 
             }
           }
         </div>
-      </div>;
+      </div>
     UIUtils.basicSparkPage(request, content, "Application: " + app.desc.name)
   }
 

--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
@@ -241,7 +241,7 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
               </div>
             }
           }
-        </div>;
+        </div>
 
     UIUtils.basicSparkPage(request, content, "Spark Master at " + state.uri)
   }

--- a/core/src/main/scala/org/apache/spark/deploy/worker/ui/WorkerPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ui/WorkerPage.scala
@@ -154,7 +154,7 @@ private[ui] class WorkerPage(parent: WorkerWebUI) extends WebUIPage("") {
             }
           }
         </div>
-      </div>;
+      </div>
     UIUtils.basicSparkPage(request, content, "Spark Worker at %s:%s".format(
       workerState.host, workerState.port))
   }

--- a/core/src/main/scala/org/apache/spark/executor/ProcfsMetricsGetter.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ProcfsMetricsGetter.scala
@@ -66,7 +66,7 @@ private[spark] class ProcfsMetricsGetter(procfsDir: String = "/proc/") extends L
 
   private def computePid(): Int = {
     if (!isAvailable || testing) {
-      return -1;
+      return -1
     }
     try {
       // This can be simplified in java9:
@@ -86,7 +86,7 @@ private[spark] class ProcfsMetricsGetter(procfsDir: String = "/proc/") extends L
 
   private def computePageSize(): Long = {
     if (testing) {
-      return 4096;
+      return 4096
     }
     try {
       val cmd = Array("getconf", "PAGESIZE")

--- a/core/src/main/scala/org/apache/spark/ui/storage/RDDPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/storage/RDDPage.scala
@@ -122,7 +122,7 @@ private[ui] class RDDPage(parent: SparkUITab, store: AppStatusStore) extends Web
           {rddStorageInfo.partitions.map(_.size).getOrElse(0)} Partitions
         </h4>
         {blockTableHTML ++ jsForScrollingDownToBlockTable}
-      </div>;
+      </div>
 
     UIUtils.headerSparkPage(
       request, "RDD Storage Info for " + rddStorageInfo.name, content, parent)

--- a/core/src/test/scala/org/apache/spark/SecurityManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SecurityManagerSuite.scala
@@ -63,7 +63,7 @@ class SecurityManagerSuite extends SparkFunSuite with ResetSystemProperties {
     conf.set(ACLS_ENABLE, true)
     conf.set(UI_VIEW_ACLS_GROUPS, Seq("group1", "group2"))
     // default ShellBasedGroupsMappingProvider is used to resolve user groups
-    val securityManager = new SecurityManager(conf);
+    val securityManager = new SecurityManager(conf)
     // assuming executing user does not belong to group1,group2
     assert(securityManager.checkUIViewPermissions("user1") === false)
     assert(securityManager.checkUIViewPermissions("user2") === false)
@@ -98,7 +98,7 @@ class SecurityManagerSuite extends SparkFunSuite with ResetSystemProperties {
   test("set security with api") {
     val conf = new SparkConf
     conf.set(UI_VIEW_ACLS, Seq("user1", "user2"))
-    val securityManager = new SecurityManager(conf);
+    val securityManager = new SecurityManager(conf)
     securityManager.setAcls(true)
     assert(securityManager.aclsEnabled())
     securityManager.setAcls(false)
@@ -156,7 +156,7 @@ class SecurityManagerSuite extends SparkFunSuite with ResetSystemProperties {
     val conf = new SparkConf
     conf.set(MODIFY_ACLS, Seq("user1", "user2"))
 
-    val securityManager = new SecurityManager(conf);
+    val securityManager = new SecurityManager(conf)
     securityManager.setAcls(true)
     assert(securityManager.aclsEnabled())
     securityManager.setAcls(false)

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -504,7 +504,7 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
   test("localProperties are inherited by spawned threads.") {
     sc = new SparkContext(new SparkConf().setAppName("test").setMaster("local"))
     sc.setLocalProperty("testProperty", "testValue")
-    var result = "unset";
+    var result = "unset"
     val thread = new Thread() {
       override def run(): Unit = {result = sc.getLocalProperty("testProperty")}
     }
@@ -516,7 +516,7 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
 
   test("localProperties do not cross-talk between threads.") {
     sc = new SparkContext(new SparkConf().setAppName("test").setMaster("local"))
-    var result = "unset";
+    var result = "unset"
     val thread1 = new Thread() {
       override def run(): Unit = {sc.setLocalProperty("testProperty", "testValue")}}
     // testProperty should be unset and thus return null

--- a/core/src/test/scala/org/apache/spark/deploy/history/HybridStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HybridStoreSuite.scala
@@ -223,7 +223,7 @@ class CustomType1(
   }
 
   override def toString: String = {
-    "CustomType1[key=" + key + ",id=" + id + ",name=" + name + ",num=" + num;
+    "CustomType1[key=" + key + ",id=" + id + ",name=" + name + ",num=" + num
   }
 }
 

--- a/core/src/test/scala/org/apache/spark/rpc/RpcEnvSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rpc/RpcEnvSuite.scala
@@ -873,7 +873,7 @@ abstract class RpcEnvSuite extends SparkFunSuite with BeforeAndAfterAll {
         val fileWithSpecialChars = new File(tempDir, "file name")
         Files.write(UUID.randomUUID().toString(), fileWithSpecialChars, UTF_8)
         val empty = new File(tempDir, "empty")
-        Files.write("", empty, UTF_8);
+        Files.write("", empty, UTF_8)
         val jar = new File(tempDir, "jar")
         Files.write(UUID.randomUUID().toString(), jar, UTF_8)
 

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaTestUtils.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaTestUtils.scala
@@ -221,7 +221,7 @@ class KafkaTestUtils(
     kdc.createPrincipal(clientKeytabFile, clientUser)
     logDebug(s"Created keytab file: ${clientKeytabFile.getAbsolutePath()}")
 
-    val file = new File(baseDir, "jaas.conf");
+    val file = new File(baseDir, "jaas.conf")
     val realm = kdc.getRealm()
     val content =
       s"""

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/ui/DriverPage.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/ui/DriverPage.scala
@@ -84,7 +84,7 @@ private[ui] class DriverPage(parent: MesosClusterUI) extends WebUIPage("driver")
             <h4>Retry state</h4>
             {retryTable}
           </div>
-        </div>;
+        </div>
 
     UIUtils.basicSparkPage(request, content, s"Details for Job $driverId")
   }

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/ui/MesosClusterPage.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/ui/MesosClusterPage.scala
@@ -61,7 +61,7 @@ private[mesos] class MesosClusterPage(parent: MesosClusterUI) extends WebUIPage(
           <h4>Supervise drivers waiting for retry:</h4>
           {retryTable}
         </div>
-      </div>;
+      </div>
     UIUtils.basicSparkPage(request, content, "Spark Drivers for Mesos cluster")
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExprUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExprUtils.scala
@@ -90,7 +90,7 @@ object ExprUtils {
         val pos = new ParsePosition(0)
         val result = decimalFormat.parse(s, pos).asInstanceOf[java.math.BigDecimal]
         if (pos.getIndex() != s.length() || pos.getErrorIndex() != -1) {
-          throw new IllegalArgumentException("Cannot parse any decimal");
+          throw new IllegalArgumentException("Cannot parse any decimal")
         } else {
           result
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
@@ -293,7 +293,7 @@ case class StringSplit(str: Expression, regex: Expression, limit: Expression)
   override def inputTypes: Seq[DataType] = Seq(StringType, StringType, IntegerType)
   override def children: Seq[Expression] = str :: regex :: limit :: Nil
 
-  def this(exp: Expression, regex: Expression) = this(exp, regex, Literal(-1));
+  def this(exp: Expression, regex: Expression) = this(exp, regex, Literal(-1))
 
   override def nullSafeEval(string: Any, regex: Any, limit: Any): Any = {
     val strings = string.asInstanceOf[UTF8String].split(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/LookupFunctionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/LookupFunctionsSuite.scala
@@ -81,7 +81,7 @@ class LookupFunctionsSuite extends PlanTest {
 
 class CustomerFunctionRegistry extends SimpleFunctionRegistry {
 
-  private var isRegisteredFunctionCalledTimes: Int = 0;
+  private var isRegisteredFunctionCalledTimes: Int = 0
 
   override def functionExists(funcN: FunctionIdentifier): Boolean = synchronized {
     isRegisteredFunctionCalledTimes = isRegisteredFunctionCalledTimes + 1

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/csv/UnivocityParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/csv/UnivocityParserSuite.scala
@@ -249,7 +249,7 @@ class UnivocityParserSuite extends SparkFunSuite with SQLHelper {
       override def deserialize(datum: Any): NameId = datum match {
         case s: String =>
           val split = s.split("\t")
-          if (split.length != 2) throw new RuntimeException(s"Can't parse $s into NameId");
+          if (split.length != 2) throw new RuntimeException(s"Can't parse $s into NameId")
           NameId(split(0), Integer.parseInt(split(1)))
         case _ => throw new RuntimeException(s"Can't parse $datum into NameId");
       }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryAtomicPartitionTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryAtomicPartitionTable.scala
@@ -69,7 +69,7 @@ class InMemoryAtomicPartitionTable (
 
   override def dropPartitions(idents: Array[InternalRow]): Boolean = {
     if (!idents.forall(partitionExists)) {
-      return false;
+      return false
     }
     idents.forall(dropPartition)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TypedAggregateExpression.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TypedAggregateExpression.scala
@@ -106,7 +106,7 @@ trait TypedAggregateExpression extends AggregateFunction {
 
   // aggregator.getClass.getSimpleName can cause Malformed class name error,
   // call safer `Utils.getSimpleName` instead
-  override def nodeName: String = Utils.getSimpleName(aggregator.getClass).stripSuffix("$");
+  override def nodeName: String = Utils.getSimpleName(aggregator.getClass).stripSuffix("$")
 }
 
 // TODO: merge these 2 implementations once we refactor the `AggregateFunction` interface.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/OracleConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/OracleConnectionProvider.scala
@@ -50,7 +50,7 @@ private[sql] class OracleConnectionProvider extends SecureConnectionProvider {
     // This prop is needed to turn on kerberos authentication in the JDBC driver.
     // The possible values can be found in AnoServices public interface
     // The value is coming from AUTHENTICATION_KERBEROS5 final String in driver version 19.6.0.0
-    result.put("oracle.net.authentication_services", "(KERBEROS5)");
+    result.put("oracle.net.authentication_services", "(KERBEROS5)")
     result
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
@@ -58,7 +58,7 @@ class JDBCTableCatalog extends TableCatalog with Logging {
     withConnection { conn =>
       val schemaPattern = if (namespace.length == 1) namespace.head else null
       val rs = conn.getMetaData
-        .getTables(null, schemaPattern, "%", Array("TABLE"));
+        .getTables(null, schemaPattern, "%", Array("TABLE"))
       new Iterator[Identifier] {
         def hasNext = rs.next()
         def next() = Identifier.of(namespace, rs.getString("TABLE_NAME"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -636,11 +636,11 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
         "select * from (A join B on (A.key = B.key)) join D on (A.key=D.a) join C",
         "select * from ((A join B on (A.key = B.key)) join C) join D on (A.key = D.a)",
         /** Cartesian product involving C, which is not involved in a CROSS join */
-        "select * from ((A join B on (A.key = B.key)) cross join D) join C on (A.key = D.a)");
+        "select * from ((A join B on (A.key = B.key)) cross join D) join C on (A.key = D.a)")
 
       def checkCartesianDetection(query: String): Unit = {
         val e = intercept[Exception] {
-          checkAnswer(sql(query), Nil);
+          checkAnswer(sql(query), Nil)
         }
         assert(e.getMessage.contains("Detected implicit cartesian product"))
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -2044,7 +2044,7 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
 
           val hadoopConf = spark.sessionState.newHadoopConf()
           val fs = tablePath.getFileSystem(hadoopConf)
-          val fileStatus = fs.getFileStatus(tablePath);
+          val fileStatus = fs.getFileStatus(tablePath)
 
           fs.setPermission(tablePath, new FsPermission("777"))
           assert(fileStatus.getPermission().toString() == "rwxrwxrwx")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcTest.scala
@@ -138,7 +138,7 @@ abstract class OrcTest extends QueryTest with FileBasedDataSourceTest with Befor
     val url = Thread.currentThread().getContextClassLoader.getResource(name)
     // Copy to avoid URISyntaxException when `sql/hive` accesses the resources in `sql/core`
     val file = File.createTempFile("orc-test", ".orc")
-    file.deleteOnExit();
+    file.deleteOnExit()
     FileUtils.copyURLToFile(url, file)
     spark.read.orc(file.getAbsolutePath)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -996,7 +996,7 @@ class JDBCSuite extends QueryTest
 
   test("Test DataFrame.where for Date and Timestamp") {
     // Regression test for bug SPARK-11788
-    val timestamp = java.sql.Timestamp.valueOf("2001-02-20 11:22:33.543543");
+    val timestamp = java.sql.Timestamp.valueOf("2001-02-20 11:22:33.543543")
     val date = java.sql.Date.valueOf("1995-01-01")
     val jdbcDf = spark.read.jdbc(urlWithUserAndPass, "TEST.TIMETYPES", new Properties())
     val rows = jdbcDf.where($"B" > date && $"C" > timestamp).collect()

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/continuous/EpochCoordinatorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/continuous/EpochCoordinatorSuite.scala
@@ -289,7 +289,7 @@ class EpochCoordinatorSuite
   }
 
   private def verifyStoppedWithException(msg: String): Unit = {
-    val exceptionCaptor = ArgumentCaptor.forClass(classOf[Throwable]);
+    val exceptionCaptor = ArgumentCaptor.forClass(classOf[Throwable])
     verify(query, atLeastOnce()).stopInNewThread(exceptionCaptor.capture())
 
     import scala.collection.JavaConverters._

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -322,7 +322,7 @@ private[client] class Shim_v0_12 extends Shim with Logging {
         // Ignore this partition since it already exists and ignoreIfExists == true
       } else {
         if (location == null && table.isView()) {
-          throw new HiveException("LOCATION clause illegal for view partition");
+          throw new HiveException("LOCATION clause illegal for view partition")
         }
 
         createPartitionMethod.invoke(


### PR DESCRIPTION
### What changes were proposed in this pull request?
There are some unnecessary semicolons in Spark code because Scala doesn't really need them and most spark code also doesn't use it to split clauses, so this pr clear them globally.

### Why are the changes needed?
Remove unnecessary semicolons to unify the code style

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass the Jenkins or GitHub Action