### PR TITLE
[SPARK-33339][PYTHON] Pyspark application will hang due to non Exception error

### DIFF
--- a/python/pyspark/tests/test_worker.py
+++ b/python/pyspark/tests/test_worker.py
@@ -95,6 +95,14 @@ class WorkerTests(ReusedPySparkTestCase):
             self.assertRaises(Exception, lambda: rdd.foreach(raise_exception))
         self.assertEqual(100, rdd.map(str).count())
 
+    def test_after_non_exception_error(self):
+        def raise_SystemExit(_):
+            raise SystemExit()
+        rdd = self.sc.parallelize(range(100), 1)
+        with QuietTest(self.sc):
+            self.assertRaises(Exception, lambda: rdd.foreach(raise_SystemExit))
+        self.assertEqual(100, rdd.map(str).count())
+
     def test_after_jvm_exception(self):
         tempFile = tempfile.NamedTemporaryFile(delete=False)
         tempFile.write(b"Hello World!")

--- a/python/pyspark/tests/test_worker.py
+++ b/python/pyspark/tests/test_worker.py
@@ -101,7 +101,7 @@ class WorkerTests(ReusedPySparkTestCase):
             raise SystemExit()
         rdd = self.sc.parallelize(range(100), 1)
         with QuietTest(self.sc):
-            self.assertRaises(Exception, lambda: rdd.foreach(raise_SystemExit))
+            self.assertRaises(Exception, lambda: rdd.foreach(raise_system_exit))
         self.assertEqual(100, rdd.map(str).count())
 
     def test_after_jvm_exception(self):

--- a/python/pyspark/tests/test_worker.py
+++ b/python/pyspark/tests/test_worker.py
@@ -96,7 +96,8 @@ class WorkerTests(ReusedPySparkTestCase):
         self.assertEqual(100, rdd.map(str).count())
 
     def test_after_non_exception_error(self):
-        def raise_SystemExit(_):
+        # SPARK-33339: Pyspark application will hang due to non Exception
+        def raise_system_exit(_):
             raise SystemExit()
         rdd = self.sc.parallelize(range(100), 1)
         with QuietTest(self.sc):

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -618,7 +618,7 @@ def main(infile, outfile):
         except IOError:
             # JVM close the socket
             pass
-        except Exception:
+        except BaseException:
             # Write the error to stderr if it happened while serializing
             print("PySpark worker failed with exception:", file=sys.stderr)
             print(traceback.format_exc(), file=sys.stderr)

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -604,7 +604,7 @@ def main(infile, outfile):
         # reuse.
         TaskContext._setTaskContext(None)
         BarrierTaskContext._setTaskContext(None)
-    except Exception:
+    except BaseException:
         try:
             exc_info = traceback.format_exc()
             if isinstance(exc_info, bytes):


### PR DESCRIPTION
### What changes were proposed in this pull request?

When a system.exit exception occurs during the process, the python worker exits abnormally, and then the executor task is still waiting for the worker for reading from socket, causing it to hang.
The system.exit exception may be caused by the user's error code, but spark should at least throw an error to remind the user, not get stuck
we can run a simple test to reproduce this case:

```
from pyspark.sql import SparkSession
def err(line):
  raise SystemExit
spark = SparkSession.builder.appName("test").getOrCreate()
spark.sparkContext.parallelize(range(1,2), 2).map(err).collect()
spark.stop()
``` 

### Why are the changes needed?

to make sure pyspark application won't hang if there's non-Exception error in python worker

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

added a new test and also manually tested the case above