### PR TITLE
[SPARK-33342][WEBUI] fix the wrong url and display name of blocking thread in threadDump page.

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/table.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/table.js
@@ -68,12 +68,31 @@ function collapseAllThreadStackTrace(toggleButton) {
 }
 
 
-// inOrOut - true: over, false: out
-function onMouseOverAndOut(threadId) {
-    $("#" + threadId + "_td_id").toggleClass("threaddump-td-mouseover");
-    $("#" + threadId + "_td_name").toggleClass("threaddump-td-mouseover");
-    $("#" + threadId + "_td_state").toggleClass("threaddump-td-mouseover");
-    $("#" + threadId + "_td_locking").toggleClass("threaddump-td-mouseover");
+function redirectByThreadId(e) {
+    e.preventDefault();
+    var targetId = e.target.href.substring(e.target.href.indexOf("#"))
+    if ($(targetId)) {
+        $(targetId)[0].scrollIntoView({
+            behavior: 'smooth',
+            block: 'center'
+        });
+       $(targetId).mouseover();
+
+    }
+}
+
+function onMouseIn(threadId) {
+    $("#" + threadId + "_td_id").addClass('threaddump-td-mouseover');
+    $("#" + threadId + "_td_name").addClass('threaddump-td-mouseover');
+    $("#" + threadId + "_td_state").addClass('threaddump-td-mouseover');
+    $("#" + threadId + "_td_locking").addClass('threaddump-td-mouseover');
+}
+
+function onMouseOut(threadId) {
+    $("#" + threadId + "_td_id").removeClass('threaddump-td-mouseover');
+    $("#" + threadId + "_td_name").removeClass('threaddump-td-mouseover');
+    $("#" + threadId + "_td_state").removeClass('threaddump-td-mouseover');
+    $("#" + threadId + "_td_locking").removeClass('threaddump-td-mouseover');
 }
 
 function onSearchStringChange() {

--- a/core/src/main/resources/org/apache/spark/ui/static/table.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/table.js
@@ -68,31 +68,12 @@ function collapseAllThreadStackTrace(toggleButton) {
 }
 
 
-function redirectByThreadId(e) {
-    e.preventDefault();
-    var targetId = e.target.href.substring(e.target.href.indexOf("#"))
-    if ($(targetId)) {
-        $(targetId)[0].scrollIntoView({
-            behavior: 'smooth',
-            block: 'center'
-        });
-       $(targetId).mouseover();
-
-    }
-}
-
-function onMouseIn(threadId) {
-    $("#" + threadId + "_td_id").addClass('threaddump-td-mouseover');
-    $("#" + threadId + "_td_name").addClass('threaddump-td-mouseover');
-    $("#" + threadId + "_td_state").addClass('threaddump-td-mouseover');
-    $("#" + threadId + "_td_locking").addClass('threaddump-td-mouseover');
-}
-
-function onMouseOut(threadId) {
-    $("#" + threadId + "_td_id").removeClass('threaddump-td-mouseover');
-    $("#" + threadId + "_td_name").removeClass('threaddump-td-mouseover');
-    $("#" + threadId + "_td_state").removeClass('threaddump-td-mouseover');
-    $("#" + threadId + "_td_locking").removeClass('threaddump-td-mouseover');
+// inOrOut - true: over, false: out
+function onMouseOverAndOut(threadId) {
+    $("#" + threadId + "_td_id").toggleClass("threaddump-td-mouseover");
+    $("#" + threadId + "_td_name").toggleClass("threaddump-td-mouseover");
+    $("#" + threadId + "_td_state").toggleClass("threaddump-td-mouseover");
+    $("#" + threadId + "_td_locking").toggleClass("threaddump-td-mouseover");
 }
 
 function onSearchStringChange() {

--- a/core/src/main/scala/org/apache/spark/ui/exec/ExecutorThreadDumpPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/exec/ExecutorThreadDumpPage.scala
@@ -24,9 +24,8 @@ import scala.xml.{Node, Text}
 import org.apache.spark.SparkContext
 import org.apache.spark.ui.{SparkUITab, UIUtils, WebUIPage}
 
-private[ui] class ExecutorThreadDumpPage(
-    parent: SparkUITab,
-    sc: Option[SparkContext]) extends WebUIPage("threadDump") {
+private[ui] class ExecutorThreadDumpPage(parent: SparkUITab, sc: Option[SparkContext])
+  extends WebUIPage("threadDump") {
 
   def render(request: HttpServletRequest): Seq[Node] = {
     val executorId = Option(request.getParameter("executorId")).map { executorId =>
@@ -41,10 +40,10 @@ private[ui] class ExecutorThreadDumpPage(
       val dumpRows = threadDump.map { thread =>
         val threadId = thread.threadId
         val blockedBy = thread.blockedByThreadId match {
-          case Some(_) =>
+          case Some(blockingThreadId) =>
             <div>
-              Blocked by <a href={s"#${thread.blockedByThreadId}_td_id"}>
-              Thread {thread.blockedByThreadId} {thread.blockedByLock}</a>
+              Blocked by <a href={s"#${blockingThreadId}_td_id"}>
+              Thread {blockingThreadId} {thread.blockedByLock}</a>
             </div>
           case None => Text("")
         }
@@ -52,8 +51,8 @@ private[ui] class ExecutorThreadDumpPage(
 
         <tr id={s"thread_${threadId}_tr"} class="accordion-heading"
             onclick={s"toggleThreadStackTrace($threadId, false)"}
-            onmouseover={s"onMouseOverAndOut($threadId)"}
-            onmouseout={s"onMouseOverAndOut($threadId)"}>
+            onmouseover={s"onMouseIn($threadId)"}
+            onmouseout={s"onMouseOut($threadId)"}>
           <td id={s"${threadId}_td_id"}>{threadId}</td>
           <td id={s"${threadId}_td_name"}>{thread.threadName}</td>
           <td id={s"${threadId}_td_state"}>{thread.threadState}</td>
@@ -62,46 +61,46 @@ private[ui] class ExecutorThreadDumpPage(
         </tr>
       }
 
-    <div class="row">
-      <div class="col-12">
-        <p>Updated at {UIUtils.formatDate(time)}</p>
-        {
+      <div class="row">
+        <div class="col-12">
+          <p>Updated at {UIUtils.formatDate(time)}</p>
+          {
           // scalastyle:off
           <p><a class="expandbutton" onClick="expandAllThreadStackTrace(true)">
             Expand All
           </a></p>
-          <p><a class="expandbutton d-none" onClick="collapseAllThreadStackTrace(true)">
-            Collapse All
-          </a></p>
-          <div class="form-inline">
-            <div class="bs-example" data-example-id="simple-form-inline">
-              <div class="form-group">
-                <div class="input-group">
-                  <label class="mr-2" for="search">Search:</label>
-                  <input type="text" class="form-control" id="search" oninput="onSearchStringChange()"></input>
+            <p><a class="expandbutton d-none" onClick="collapseAllThreadStackTrace(true)">
+              Collapse All
+            </a></p>
+            <div class="form-inline">
+              <div class="bs-example" data-example-id="simple-form-inline">
+                <div class="form-group">
+                  <div class="input-group">
+                    <label class="mr-2" for="search">Search:</label>
+                    <input type="text" class="form-control" id="search" oninput="onSearchStringChange()"></input>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-          <p></p>
+            <p></p>
           // scalastyle:on
-        }
-        <table class={UIUtils.TABLE_CLASS_STRIPED + " accordion-group" + " sortable"}>
-          <thead>
-            <th onClick="collapseAllThreadStackTrace(false)">Thread ID</th>
-            <th onClick="collapseAllThreadStackTrace(false)">Thread Name</th>
-            <th onClick="collapseAllThreadStackTrace(false)">Thread State</th>
-            <th onClick="collapseAllThreadStackTrace(false)">
-              <span data-toggle="tooltip" data-placement="top"
-                    title="Objects whose lock the thread currently holds">
-                Thread Locks
-              </span>
-            </th>
-          </thead>
-          <tbody>{dumpRows}</tbody>
-        </table>
+          }
+          <table class={UIUtils.TABLE_CLASS_STRIPED + " accordion-group" + " sortable"}>
+            <thead>
+              <th onClick="collapseAllThreadStackTrace(false)">Thread ID</th>
+              <th onClick="collapseAllThreadStackTrace(false)">Thread Name</th>
+              <th onClick="collapseAllThreadStackTrace(false)">Thread State</th>
+              <th onClick="collapseAllThreadStackTrace(false)">
+                <span data-toggle="tooltip" data-placement="top"
+                      title="Objects whose lock the thread currently holds">
+                  Thread Locks
+                </span>
+              </th>
+            </thead>
+            <tbody>{dumpRows}</tbody>
+          </table>
+        </div>
       </div>
-    </div>
     }.getOrElse(Text("Error fetching thread dump"))
     UIUtils.headerSparkPage(request, s"Thread dump for executor $executorId", content, parent)
   }

--- a/core/src/main/scala/org/apache/spark/ui/exec/ExecutorThreadDumpPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/exec/ExecutorThreadDumpPage.scala
@@ -52,8 +52,8 @@ private[ui] class ExecutorThreadDumpPage(
 
         <tr id={s"thread_${threadId}_tr"} class="accordion-heading"
             onclick={s"toggleThreadStackTrace($threadId, false)"}
-            onmouseover={s"onMouseIn($threadId)"}
-            onmouseout={s"onMouseIn($threadId)"}>
+            onmouseover={s"onMouseOverAndOut($threadId)"}
+            onmouseout={s"onMouseOverAndOut($threadId)"}>
           <td id={s"${threadId}_td_id"}>{threadId}</td>
           <td id={s"${threadId}_td_name"}>{thread.threadName}</td>
           <td id={s"${threadId}_td_state"}>{thread.threadState}</td>

--- a/core/src/main/scala/org/apache/spark/ui/exec/ExecutorThreadDumpPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/exec/ExecutorThreadDumpPage.scala
@@ -24,8 +24,9 @@ import scala.xml.{Node, Text}
 import org.apache.spark.SparkContext
 import org.apache.spark.ui.{SparkUITab, UIUtils, WebUIPage}
 
-private[ui] class ExecutorThreadDumpPage(parent: SparkUITab, sc: Option[SparkContext])
-  extends WebUIPage("threadDump") {
+private[ui] class ExecutorThreadDumpPage(
+    parent: SparkUITab,
+    sc: Option[SparkContext]) extends WebUIPage("threadDump") {
 
   def render(request: HttpServletRequest): Seq[Node] = {
     val executorId = Option(request.getParameter("executorId")).map { executorId =>
@@ -52,7 +53,7 @@ private[ui] class ExecutorThreadDumpPage(parent: SparkUITab, sc: Option[SparkCon
         <tr id={s"thread_${threadId}_tr"} class="accordion-heading"
             onclick={s"toggleThreadStackTrace($threadId, false)"}
             onmouseover={s"onMouseIn($threadId)"}
-            onmouseout={s"onMouseOut($threadId)"}>
+            onmouseout={s"onMouseIn($threadId)"}>
           <td id={s"${threadId}_td_id"}>{threadId}</td>
           <td id={s"${threadId}_td_name"}>{thread.threadName}</td>
           <td id={s"${threadId}_td_state"}>{thread.threadState}</td>
@@ -61,46 +62,46 @@ private[ui] class ExecutorThreadDumpPage(parent: SparkUITab, sc: Option[SparkCon
         </tr>
       }
 
-      <div class="row">
-        <div class="col-12">
-          <p>Updated at {UIUtils.formatDate(time)}</p>
-          {
+    <div class="row">
+      <div class="col-12">
+        <p>Updated at {UIUtils.formatDate(time)}</p>
+        {
           // scalastyle:off
           <p><a class="expandbutton" onClick="expandAllThreadStackTrace(true)">
             Expand All
           </a></p>
-            <p><a class="expandbutton d-none" onClick="collapseAllThreadStackTrace(true)">
-              Collapse All
-            </a></p>
-            <div class="form-inline">
-              <div class="bs-example" data-example-id="simple-form-inline">
-                <div class="form-group">
-                  <div class="input-group">
-                    <label class="mr-2" for="search">Search:</label>
-                    <input type="text" class="form-control" id="search" oninput="onSearchStringChange()"></input>
-                  </div>
+          <p><a class="expandbutton d-none" onClick="collapseAllThreadStackTrace(true)">
+            Collapse All
+          </a></p>
+          <div class="form-inline">
+            <div class="bs-example" data-example-id="simple-form-inline">
+              <div class="form-group">
+                <div class="input-group">
+                  <label class="mr-2" for="search">Search:</label>
+                  <input type="text" class="form-control" id="search" oninput="onSearchStringChange()"></input>
                 </div>
               </div>
             </div>
-            <p></p>
+          </div>
+          <p></p>
           // scalastyle:on
-          }
-          <table class={UIUtils.TABLE_CLASS_STRIPED + " accordion-group" + " sortable"}>
-            <thead>
-              <th onClick="collapseAllThreadStackTrace(false)">Thread ID</th>
-              <th onClick="collapseAllThreadStackTrace(false)">Thread Name</th>
-              <th onClick="collapseAllThreadStackTrace(false)">Thread State</th>
-              <th onClick="collapseAllThreadStackTrace(false)">
-                <span data-toggle="tooltip" data-placement="top"
-                      title="Objects whose lock the thread currently holds">
-                  Thread Locks
-                </span>
-              </th>
-            </thead>
-            <tbody>{dumpRows}</tbody>
-          </table>
-        </div>
+        }
+        <table class={UIUtils.TABLE_CLASS_STRIPED + " accordion-group" + " sortable"}>
+          <thead>
+            <th onClick="collapseAllThreadStackTrace(false)">Thread ID</th>
+            <th onClick="collapseAllThreadStackTrace(false)">Thread Name</th>
+            <th onClick="collapseAllThreadStackTrace(false)">Thread State</th>
+            <th onClick="collapseAllThreadStackTrace(false)">
+              <span data-toggle="tooltip" data-placement="top"
+                    title="Objects whose lock the thread currently holds">
+                Thread Locks
+              </span>
+            </th>
+          </thead>
+          <tbody>{dumpRows}</tbody>
+        </table>
       </div>
+    </div>
     }.getOrElse(Text("Error fetching thread dump"))
     UIUtils.headerSparkPage(request, s"Thread dump for executor $executorId", content, parent)
   }


### PR DESCRIPTION

### What changes were proposed in this pull request?
fix the wrong url and display name of blocking thread in threadDump page.
The blockingThreadId variable passed to the page should be of string type instead of Option type.

### Why are the changes needed?
blocking threadId in the ui page is not displayed well, and the corresponding  url cannot be redirected normally

### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
The pr  only involves minor changes to the page and does not affect other functions, 
The manual test results are as follows. The thread name displayed on the page is correct, and you can click on the URL to jump to the corresponding url

![shows_ok](https://user-images.githubusercontent.com/52202080/98108177-89488d00-1ed6-11eb-9488-8446c3f38bad.gif)


