### PR TITLE
[SPARK-33356] Remove eliminate mutual recursion in PartitionerAwareUnion

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/PartitionerAwareUnionRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PartitionerAwareUnionRDD.scala
@@ -80,7 +80,7 @@ class PartitionerAwareUnionRDD[T: ClassTag](
     val parentPartitions = s.asInstanceOf[PartitionerAwareUnionRDDPartition].parents
     val locations = rdds.zip(parentPartitions).flatMap {
       case (rdd, part) =>
-        val parentLocations = currPrefLocs(rdd, part)
+        val parentLocations = rdd.preferredLocations(part)
         logDebug("Location of " + rdd + " partition " + part.index + " = " + parentLocations)
         parentLocations
     }
@@ -104,10 +104,5 @@ class PartitionerAwareUnionRDD[T: ClassTag](
   override def clearDependencies(): Unit = {
     super.clearDependencies()
     rdds = null
-  }
-
-  // Get the *current* preferred locations from the DAGScheduler (as opposed to the static ones)
-  private def currPrefLocs(rdd: RDD[_], part: Partition): Seq[String] = {
-    rdd.context.getPreferredLocs(rdd, part.index).map(tl => tl.host)
   }
 }


### PR DESCRIPTION
The current implementation of the `DAGScheduler` exhibits exponential runtime in DAGs with many `PartitionerAwareUnions`. The reason seems to be a mutual recursion between
`PartitionerAwareUnion.getPreferredLocations` and `DAGScheduler.getPreferredLocs`.

A minimal example reproducing the issue:

```
object Example extends App {
  val partitioner = new HashPartitioner(2)
  val sc = new SparkContext(new SparkConf().setAppName("").setMaster("local[*]"))
  val rdd1 = sc.emptyRDD[(Int, Int)].partitionBy(partitioner)
  val rdd2 = (1 to 30).map(_ => rdd1)
  val rdd3 = rdd2.reduce(_ union _)
  rdd3.collect()
}
```

The whole app should take around one second to complete, as no actual work is done. However,  it takes more time to submit the job than I am willing to wait. 

The underlying cause appears to be mutual recursion between `PartitionerAwareUnion.getPreferredLocations` and `DAGScheduler.getPreferredLocs`, which restarts graph traversal at each `PartitionerAwareUnion` with no memoization. Each node of the DAG is visited `O(n!)` (exponentially many) times.

In the pull-request I propose to call rdd.getPreferredLocations instead of DAGScheduler.getPreferredLocs inside PartitionerAwareUnion.