### PR TITLE
[SPARK-33363] Add prompt information related to the current task when pyspark/sparkR starts

### DIFF
--- a/R/pkg/inst/profile/shell.R
+++ b/R/pkg/inst/profile/shell.R
@@ -43,5 +43,8 @@
   cat("      /_/", "\n")
   cat("\n")
 
+  cat("\nSpark context Web UI available at", SparkR::sparkR.uiWebUrl())
+  cat("\nSpark context available as 'sc' (master = ", unlist(SparkR::sparkR.conf("spark.master")), ", app id = ",
+  unlist(SparkR::sparkR.conf("spark.app.id")), ").", sep="")
   cat("\nSparkSession available as 'spark'.\n")
 }

--- a/R/pkg/inst/profile/shell.R
+++ b/R/pkg/inst/profile/shell.R
@@ -43,8 +43,8 @@
   cat("      /_/", "\n")
   cat("\n")
 
-  cat("\nSpark context Web UI available at", SparkR::sparkR.uiWebUrl(), "\n")
+  cat("\nSpark context Web UI available at", SparkR::sparkR.uiWebUrl())
   cat("\nSpark context available as 'sc' (master = ", unlist(SparkR::sparkR.conf("spark.master")),
-    ", app id = ",unlist(SparkR::sparkR.conf("spark.app.id")), ").\n", sep="")
+    ", app id = ",unlist(SparkR::sparkR.conf("spark.app.id")), ").", sep="")
   cat("\nSparkSession available as 'spark'.\n")
 }

--- a/R/pkg/inst/profile/shell.R
+++ b/R/pkg/inst/profile/shell.R
@@ -45,5 +45,5 @@
 
   cat("\nSparkSession Web UI available at", SparkR::sparkR.uiWebUrl())
   cat("\nSparkSession available as 'spark'(master = ", unlist(SparkR::sparkR.conf("spark.master")),
-    ", app id = ",unlist(SparkR::sparkR.conf("spark.app.id")), ").", "\n", sep="")
+    ", app id = ", unlist(SparkR::sparkR.conf("spark.app.id")), ").", "\n", sep = "")
 }

--- a/R/pkg/inst/profile/shell.R
+++ b/R/pkg/inst/profile/shell.R
@@ -43,8 +43,8 @@
   cat("      /_/", "\n")
   cat("\n")
 
-  cat("\nSpark context Web UI available at", SparkR::sparkR.uiWebUrl())
-  cat("\nSpark context available as 'sc' (master = ", unlist(SparkR::sparkR.conf("spark.master")), ", app id = ",
-  unlist(SparkR::sparkR.conf("spark.app.id")), ").", sep="")
+  cat("\nSpark context Web UI available at", sparkR.uiWebUrl(), "\n")
+  cat("\nSpark context available as 'sc' (master = ", unlist(sparkR.conf("spark.master")), ", 
+  app id = ",unlist(sparkR.conf("spark.app.id")), ").\n", sep="")
   cat("\nSparkSession available as 'spark'.\n")
 }

--- a/R/pkg/inst/profile/shell.R
+++ b/R/pkg/inst/profile/shell.R
@@ -45,6 +45,6 @@
 
   cat("\nSpark context Web UI available at", SparkR::sparkR.uiWebUrl())
   cat("\nSpark context available as 'sc' (master = ", unlist(SparkR::sparkR.conf("spark.master")),
-    ", app id = ",unlist(SparkR::sparkR.conf("spark.app.id")), ").", sep="")
+    ", app id = ", unlist(SparkR::sparkR.conf("spark.app.id")), ").", sep = "")
   cat("\nSparkSession available as 'spark'.\n")
 }

--- a/R/pkg/inst/profile/shell.R
+++ b/R/pkg/inst/profile/shell.R
@@ -43,8 +43,8 @@
   cat("      /_/", "\n")
   cat("\n")
 
-  cat("\nSpark context Web UI available at", sparkR.uiWebUrl(), "\n")
-  cat("\nSpark context available as 'sc' (master = ", unlist(sparkR.conf("spark.master")),
-    ", app id = ",unlist(sparkR.conf("spark.app.id")), ").\n", sep="")
+  cat("\nSpark context Web UI available at", SparkR::sparkR.uiWebUrl(), "\n")
+  cat("\nSpark context available as 'sc' (master = ", unlist(SparkR::sparkR.conf("spark.master")),
+    ", app id = ",unlist(SparkR::sparkR.conf("spark.app.id")), ").\n", sep="")
   cat("\nSparkSession available as 'spark'.\n")
 }

--- a/R/pkg/inst/profile/shell.R
+++ b/R/pkg/inst/profile/shell.R
@@ -43,8 +43,7 @@
   cat("      /_/", "\n")
   cat("\n")
 
-  cat("\nSpark context Web UI available at", SparkR::sparkR.uiWebUrl())
-  cat("\nSpark context available as 'sc' (master = ", unlist(SparkR::sparkR.conf("spark.master")),
-    ", app id = ", unlist(SparkR::sparkR.conf("spark.app.id")), ").", sep = "")
-  cat("\nSparkSession available as 'spark'.\n")
+  cat("\nSparkSession Web UI available at", SparkR::sparkR.uiWebUrl())
+  cat("\nSparkSession available as 'spark'(master = ", unlist(SparkR::sparkR.conf("spark.master")),
+    ", app id = ",unlist(SparkR::sparkR.conf("spark.app.id")), ").", "\n", sep="")
 }

--- a/R/pkg/inst/profile/shell.R
+++ b/R/pkg/inst/profile/shell.R
@@ -45,6 +45,6 @@
 
   cat("\nSpark context Web UI available at", sparkR.uiWebUrl(), "\n")
   cat("\nSpark context available as 'sc' (master = ", unlist(sparkR.conf("spark.master")),
-  ", app id = ",unlist(sparkR.conf("spark.app.id")), ").\n", sep="")
+    ", app id = ",unlist(sparkR.conf("spark.app.id")), ").\n", sep="")
   cat("\nSparkSession available as 'spark'.\n")
 }

--- a/R/pkg/inst/profile/shell.R
+++ b/R/pkg/inst/profile/shell.R
@@ -44,7 +44,7 @@
   cat("\n")
 
   cat("\nSpark context Web UI available at", sparkR.uiWebUrl(), "\n")
-  cat("\nSpark context available as 'sc' (master = ", unlist(sparkR.conf("spark.master")), ", 
-  app id = ",unlist(sparkR.conf("spark.app.id")), ").\n", sep="")
+  cat("\nSpark context available as 'sc' (master = ", unlist(sparkR.conf("spark.master")),
+  ", app id = ",unlist(sparkR.conf("spark.app.id")), ").\n", sep="")
   cat("\nSparkSession available as 'spark'.\n")
 }

--- a/python/pyspark/shell.py
+++ b/python/pyspark/shell.py
@@ -62,8 +62,8 @@ print("Using Python version %s (%s, %s)" % (
     platform.python_version(),
     platform.python_build()[0],
     platform.python_build()[1]))
-print("Spark context Web UI available at %s" %(sc.uiWebUrl))
-print("Spark context available as 'sc' (master = %s, app id = %s)." %(sc.master, sc.applicationId))
+print("Spark context Web UI available at %s" % (sc.uiWebUrl))
+print("Spark context available as 'sc' (master = %s, app id = %s)." % (sc.master, sc.applicationId))
 print("SparkSession available as 'spark'.")
 
 # The ./bin/pyspark script stores the old PYTHONSTARTUP value in OLD_PYTHONSTARTUP,

--- a/python/pyspark/shell.py
+++ b/python/pyspark/shell.py
@@ -62,6 +62,8 @@ print("Using Python version %s (%s, %s)" % (
     platform.python_version(),
     platform.python_build()[0],
     platform.python_build()[1]))
+print("Spark context Web UI available at %s" %(sc.uiWebUrl))
+print("Spark context available as 'sc' (master = %s, app id = %s)." %(sc.master, sc.applicationId))
 print("SparkSession available as 'spark'.")
 
 # The ./bin/pyspark script stores the old PYTHONSTARTUP value in OLD_PYTHONSTARTUP,


### PR DESCRIPTION
### What changes were proposed in this pull request?
add prompt information about current applicationId, current URL and master info when pyspark / sparkR starts.



### Why are the changes needed?
The information printed when pyspark/sparkR starts does not prompt the basic information of current application, and it is not convenient when used pyspark/sparkR in dos.


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
manual test result shows below:
![pyspark new print](https://user-images.githubusercontent.com/52202080/98274268-2a663f00-1fce-11eb-88ce-964ce90b439e.png)
![sparkR](https://user-images.githubusercontent.com/52202080/98541235-1a01dd00-22ca-11eb-9304-09bcde87b05e.png)



