### PR TITLE
[SPARK-33374][CORE] Remove unnecessary python path from spark home

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonUtils.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonUtils.scala
@@ -29,14 +29,9 @@ import org.apache.spark.api.java.{JavaRDD, JavaSparkContext}
 private[spark] object PythonUtils {
   val PY4J_ZIP_NAME = "py4j-0.10.9-src.zip"
 
-  /** Get the PYTHONPATH for PySpark, either from SPARK_HOME, if it is set, or from our JAR */
+  /** Get the PYTHONPATH for PySpark from our JAR */
   def sparkPythonPath: String = {
     val pythonPath = new ArrayBuffer[String]
-    for (sparkHome <- sys.env.get("SPARK_HOME")) {
-      pythonPath += Seq(sparkHome, "python", "lib", "pyspark.zip").mkString(File.separator)
-      pythonPath +=
-        Seq(sparkHome, "python", "lib", PY4J_ZIP_NAME).mkString(File.separator)
-    }
     pythonPath ++= SparkContext.jarOfObject(this)
     pythonPath.mkString(File.pathSeparator)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove pyspark and py4j-0.10.9-src.zip under spark home from python path

### Why are the changes needed?
1. Staging folder already contains uploaded pyspark and py4j-0.10.9-src.zip.
2. If local machine has different version of both files, confliction would happen.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
UT
