### PR TITLE
[SPARK-33375][CORE] Add config spark.yarn.pyspark.archives

### DIFF
--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -368,6 +368,14 @@ To use a custom metrics.properties for the application master and executors, upd
   <td>2.0.0</td>
 </tr>
 <tr>
+  <td><code>spark.yarn.pyspark.archives</code></td>
+  <td>(none)</td>
+  <td>
+    An archive containing pyspark.zip and py4j.zip. Like with the previous option, the archive can also be hosted on HDFS to speed up file distribution.
+  </td>
+  <td>3.0.1</td>
+</tr>
+<tr>
   <td><code>spark.yarn.appMasterEnv.[EnvironmentVariableName]</code></td>
   <td>(none)</td>
   <td>

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -880,7 +880,7 @@ private[spark] class Client(
     val appId = newAppResponse.getApplicationId
     val pySparkArchives =
       if (sparkConf.get(IS_PYTHON_APP)) {
-        findPySparkArchives()
+        sparkConf.get(SPARK_PYSPARK_ARCHIVE).getOrElse(findPySparkArchives())
       } else {
         Nil
       }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
@@ -130,6 +130,13 @@ package object config extends Logging {
     .stringConf
     .createOptional
 
+  private[spark] val SPARK_PYSPARK_ARCHIVE = ConfigBuilder("spark.yarn.pyspark.archives")
+    .doc("Location of pyspark.zip and py4j.zip.")
+    .version("3.0.1")
+    .stringConf
+    .toSequence
+    .createOptional
+
   private[spark] val SPARK_JARS = ConfigBuilder("spark.yarn.jars")
     .doc("Location of jars containing Spark classes.")
     .version("2.0.0")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add config spark.yarn.pyspark.archives to provide location of pyspark.zip and py4j.zip.

### Why are the changes needed?
1. If I have different version of `spark.yarn.archive` from current machine, then there is no way to provide matched pyspark version. This happens in version upgrade.
2. This can save effort of uploading pyspark.zip and py4j.zip every time.

### Does this PR introduce _any_ user-facing change?
Yes. Added in yarn doc.


### How was this patch tested?
Manually.
