### PR TITLE
[SPARK-33382][SQL][TESTS] Unify datasource v1 and v2 SHOW TABLES tests

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -1233,55 +1233,6 @@ class DDLParserSuite extends AnalysisTest {
     assert(exc.getMessage.contains("There must be at least one WHEN clause in a MERGE statement"))
   }
 
-  test("show tables") {
-    comparePlans(
-      parsePlan("SHOW TABLES"),
-      ShowTables(UnresolvedNamespace(Seq.empty[String]), None))
-    comparePlans(
-      parsePlan("SHOW TABLES '*test*'"),
-      ShowTables(UnresolvedNamespace(Seq.empty[String]), Some("*test*")))
-    comparePlans(
-      parsePlan("SHOW TABLES LIKE '*test*'"),
-      ShowTables(UnresolvedNamespace(Seq.empty[String]), Some("*test*")))
-    comparePlans(
-      parsePlan("SHOW TABLES FROM testcat.ns1.ns2.tbl"),
-      ShowTables(UnresolvedNamespace(Seq("testcat", "ns1", "ns2", "tbl")), None))
-    comparePlans(
-      parsePlan("SHOW TABLES IN testcat.ns1.ns2.tbl"),
-      ShowTables(UnresolvedNamespace(Seq("testcat", "ns1", "ns2", "tbl")), None))
-    comparePlans(
-      parsePlan("SHOW TABLES IN ns1 '*test*'"),
-      ShowTables(UnresolvedNamespace(Seq("ns1")), Some("*test*")))
-    comparePlans(
-      parsePlan("SHOW TABLES IN ns1 LIKE '*test*'"),
-      ShowTables(UnresolvedNamespace(Seq("ns1")), Some("*test*")))
-  }
-
-  test("show table extended") {
-    comparePlans(
-      parsePlan("SHOW TABLE EXTENDED LIKE '*test*'"),
-      ShowTableStatement(None, "*test*", None))
-    comparePlans(
-      parsePlan("SHOW TABLE EXTENDED FROM testcat.ns1.ns2 LIKE '*test*'"),
-      ShowTableStatement(Some(Seq("testcat", "ns1", "ns2")), "*test*", None))
-    comparePlans(
-      parsePlan("SHOW TABLE EXTENDED IN testcat.ns1.ns2 LIKE '*test*'"),
-      ShowTableStatement(Some(Seq("testcat", "ns1", "ns2")), "*test*", None))
-    comparePlans(
-      parsePlan("SHOW TABLE EXTENDED LIKE '*test*' PARTITION(ds='2008-04-09', hr=11)"),
-      ShowTableStatement(None, "*test*", Some(Map("ds" -> "2008-04-09", "hr" -> "11"))))
-    comparePlans(
-      parsePlan("SHOW TABLE EXTENDED FROM testcat.ns1.ns2 LIKE '*test*' " +
-        "PARTITION(ds='2008-04-09')"),
-      ShowTableStatement(Some(Seq("testcat", "ns1", "ns2")), "*test*",
-        Some(Map("ds" -> "2008-04-09"))))
-    comparePlans(
-      parsePlan("SHOW TABLE EXTENDED IN testcat.ns1.ns2 LIKE '*test*' " +
-        "PARTITION(ds='2008-04-09')"),
-      ShowTableStatement(Some(Seq("testcat", "ns1", "ns2")), "*test*",
-        Some(Map("ds" -> "2008-04-09"))))
-  }
-
   test("show views") {
     comparePlans(
       parsePlan("SHOW VIEWS"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -898,32 +898,6 @@ class DataSourceV2SQLSuite
     }
   }
 
-  test("ShowTables: using v2 catalog with a pattern") {
-    spark.sql("CREATE TABLE testcat.db.table (id bigint, data string) USING foo")
-    spark.sql("CREATE TABLE testcat.db.table_name_1 (id bigint, data string) USING foo")
-    spark.sql("CREATE TABLE testcat.db.table_name_2 (id bigint, data string) USING foo")
-    spark.sql("CREATE TABLE testcat.db2.table_name_2 (id bigint, data string) USING foo")
-
-    runShowTablesSql(
-      "SHOW TABLES FROM testcat.db",
-      Seq(
-        Row("db", "table"),
-        Row("db", "table_name_1"),
-        Row("db", "table_name_2")))
-
-    runShowTablesSql(
-      "SHOW TABLES FROM testcat.db LIKE '*name*'",
-      Seq(Row("db", "table_name_1"), Row("db", "table_name_2")))
-
-    runShowTablesSql(
-      "SHOW TABLES FROM testcat.db LIKE '*2'",
-      Seq(Row("db", "table_name_2")))
-  }
-
-  test("ShowTables: using v2 catalog, namespace doesn't exist") {
-    runShowTablesSql("SHOW TABLES FROM testcat.unknown", Seq())
-  }
-
   test("ShowTables: using v1 catalog") {
     runShowTablesSql(
       "SHOW TABLES FROM default",

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -898,39 +898,6 @@ class DataSourceV2SQLSuite
     }
   }
 
-  test("ShowTables: using v1 catalog") {
-    runShowTablesSql(
-      "SHOW TABLES FROM default",
-      Seq(Row("", "source", true), Row("", "source2", true)),
-      expectV2Catalog = false)
-  }
-
-  test("ShowTables: using v1 catalog, db doesn't exist ") {
-    // 'db' below resolves to a database name for v1 catalog because there is no catalog named
-    // 'db' and there is no default catalog set.
-    val exception = intercept[NoSuchDatabaseException] {
-      runShowTablesSql("SHOW TABLES FROM db", Seq(), expectV2Catalog = false)
-    }
-
-    assert(exception.getMessage.contains("Database 'db' not found"))
-  }
-
-  test("ShowTables: using v1 catalog, db name with multipartIdentifier ('a.b') is not allowed.") {
-    val exception = intercept[AnalysisException] {
-      runShowTablesSql("SHOW TABLES FROM a.b", Seq(), expectV2Catalog = false)
-    }
-
-    assert(exception.getMessage.contains("The database name is not valid: a.b"))
-  }
-
-  test("ShowViews: using v1 catalog, db name with multipartIdentifier ('a.b') is not allowed.") {
-    val exception = intercept[AnalysisException] {
-      sql("SHOW TABLES FROM a.b")
-    }
-
-    assert(exception.getMessage.contains("The database name is not valid: a.b"))
-  }
-
   test("ShowViews: using v2 catalog, command not supported.") {
     val exception = intercept[AnalysisException] {
       sql("SHOW VIEWS FROM testcat")

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -898,20 +898,6 @@ class DataSourceV2SQLSuite
     }
   }
 
-  test("ShowViews: using v2 catalog, command not supported.") {
-    val exception = intercept[AnalysisException] {
-      sql("SHOW VIEWS FROM testcat")
-    }
-
-    assert(exception.getMessage.contains("Catalog testcat doesn't support SHOW VIEWS," +
-      " only SessionCatalog supports this command."))
-  }
-
-  test("ShowTables: using v2 catalog with empty namespace") {
-    spark.sql("CREATE TABLE testcat.table (id bigint, data string) USING foo")
-    runShowTablesSql("SHOW TABLES FROM testcat", Seq(Row("", "table")))
-  }
-
   test("ShowTables: namespace is not specified and default v2 catalog is set") {
     spark.conf.set(SQLConf.DEFAULT_CATALOG.key, "testcat")
     spark.sql("CREATE TABLE testcat.table (id bigint, data string) USING foo")

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -915,23 +915,6 @@ class DataSourceV2SQLSuite
       " only SessionCatalog supports this command."))
   }
 
-  test("ShowTables: change current catalog and namespace with USE statements") {
-    sql("CREATE TABLE testcat.ns1.ns2.table (id bigint) USING foo")
-
-    // Initially, the v2 session catalog (current catalog) is used.
-    runShowTablesSql(
-      "SHOW TABLES", Seq(Row("", "source", true), Row("", "source2", true)),
-      expectV2Catalog = false)
-
-    // Update the current catalog, and no table is matched since the current namespace is Array().
-    sql("USE testcat")
-    runShowTablesSql("SHOW TABLES", Seq())
-
-    // Update the current namespace to match ns1.ns2.table.
-    sql("USE testcat.ns1.ns2")
-    runShowTablesSql("SHOW TABLES", Seq(Row("ns1.ns2", "table")))
-  }
-
   private def runShowTablesSql(
       sqlText: String,
       expected: Seq[Row],

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -898,26 +898,6 @@ class DataSourceV2SQLSuite
     }
   }
 
-  test("ShowTables: namespace is not specified and default v2 catalog is set") {
-    spark.conf.set(SQLConf.DEFAULT_CATALOG.key, "testcat")
-    spark.sql("CREATE TABLE testcat.table (id bigint, data string) USING foo")
-
-    // v2 catalog is used where default namespace is empty for TestInMemoryTableCatalog.
-    runShowTablesSql("SHOW TABLES", Seq(Row("", "table")))
-  }
-
-  test("ShowTables: namespace not specified and default v2 catalog not set - fallback to v1") {
-    runShowTablesSql(
-      "SHOW TABLES",
-      Seq(Row("", "source", true), Row("", "source2", true)),
-      expectV2Catalog = false)
-
-    runShowTablesSql(
-      "SHOW TABLES LIKE '*2'",
-      Seq(Row("", "source2", true)),
-      expectV2Catalog = false)
-  }
-
   test("ShowTables: change current catalog and namespace with USE statements") {
     sql("CREATE TABLE testcat.ns1.ns2.table (id bigint) USING foo")
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -898,17 +898,6 @@ class DataSourceV2SQLSuite
     }
   }
 
-  test("ShowTables: using v2 catalog") {
-    spark.sql("CREATE TABLE testcat.db.table_name (id bigint, data string) USING foo")
-    spark.sql("CREATE TABLE testcat.n1.n2.db.table_name (id bigint, data string) USING foo")
-
-    runShowTablesSql("SHOW TABLES FROM testcat.db", Seq(Row("db", "table_name")))
-
-    runShowTablesSql(
-      "SHOW TABLES FROM testcat.n1.n2.db",
-      Seq(Row("n1.n2.db", "table_name")))
-  }
-
   test("ShowTables: using v2 catalog with a pattern") {
     spark.sql("CREATE TABLE testcat.db.table (id bigint, data string) USING foo")
     spark.sql("CREATE TABLE testcat.db.table_name_1 (id bigint, data string) USING foo")

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -935,33 +935,6 @@ class DataSourceV2SQLSuite
     assert(expected === df.collect())
   }
 
-  test("SHOW TABLE EXTENDED not valid v1 database") {
-    def testV1CommandNamespace(sqlCommand: String, namespace: String): Unit = {
-      val e = intercept[AnalysisException] {
-        sql(sqlCommand)
-      }
-      assert(e.message.contains(s"The database name is not valid: ${namespace}"))
-    }
-
-    val namespace = "testcat.ns1.ns2"
-    val table = "tbl"
-    withTable(s"$namespace.$table") {
-      sql(s"CREATE TABLE $namespace.$table (id bigint, data string) " +
-        s"USING foo PARTITIONED BY (id)")
-
-      testV1CommandNamespace(s"SHOW TABLE EXTENDED FROM $namespace LIKE 'tb*'",
-        namespace)
-      testV1CommandNamespace(s"SHOW TABLE EXTENDED IN $namespace LIKE 'tb*'",
-        namespace)
-      testV1CommandNamespace("SHOW TABLE EXTENDED " +
-        s"FROM $namespace LIKE 'tb*' PARTITION(id=1)",
-        namespace)
-      testV1CommandNamespace("SHOW TABLE EXTENDED " +
-        s"IN $namespace LIKE 'tb*' PARTITION(id=1)",
-        namespace)
-    }
-  }
-
   test("CreateNameSpace: basic tests") {
     // Session catalog is used.
     withNamespace("ns") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -962,23 +962,6 @@ class DataSourceV2SQLSuite
     }
   }
 
-  test("SHOW TABLE EXTENDED valid v1") {
-    val expected = Seq(Row("", "source", true), Row("", "source2", true))
-    val schema = new StructType()
-      .add("database", StringType, nullable = false)
-      .add("tableName", StringType, nullable = false)
-      .add("isTemporary", BooleanType, nullable = false)
-      .add("information", StringType, nullable = false)
-
-    val df = sql("SHOW TABLE EXTENDED FROM default LIKE '*source*'")
-    val result = df.collect()
-    val resultWithoutInfo = result.map{ case Row(db, table, temp, _) => Row(db, table, temp)}
-
-    assert(df.schema === schema)
-    assert(resultWithoutInfo === expected)
-    result.foreach{ case Row(_, _, _, info: String) => assert(info.nonEmpty)}
-  }
-
   test("CreateNameSpace: basic tests") {
     // Session catalog is used.
     withNamespace("ns") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -898,6 +898,15 @@ class DataSourceV2SQLSuite
     }
   }
 
+  test("ShowViews: using v2 catalog, command not supported.") {
+    val exception = intercept[AnalysisException] {
+      sql("SHOW VIEWS FROM testcat")
+    }
+
+    assert(exception.getMessage.contains("Catalog testcat doesn't support SHOW VIEWS," +
+      " only SessionCatalog supports this command."))
+  }
+
   test("ShowTables: change current catalog and namespace with USE statements") {
     sql("CREATE TABLE testcat.ns1.ns2.table (id bigint) USING foo")
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -898,6 +898,14 @@ class DataSourceV2SQLSuite
     }
   }
 
+  test("ShowViews: using v1 catalog, db name with multipartIdentifier ('a.b') is not allowed.") {
+    val exception = intercept[AnalysisException] {
+      sql("SHOW VIEWS FROM a.b")
+    }
+
+    assert(exception.getMessage.contains("The database name is not valid: a.b"))
+  }
+
   test("ShowViews: using v2 catalog, command not supported.") {
     val exception = intercept[AnalysisException] {
       sql("SHOW VIEWS FROM testcat")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesParserSuite.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.command
+
+import org.apache.spark.sql.catalyst.analysis.{AnalysisTest, UnresolvedNamespace}
+import org.apache.spark.sql.catalyst.parser.CatalystSqlParser.parsePlan
+import org.apache.spark.sql.catalyst.plans.logical.{ShowTables, ShowTableStatement}
+import org.apache.spark.sql.test.SharedSparkSession
+
+class ShowTablesParserSuite extends AnalysisTest with SharedSparkSession {
+  private val catalog = "test_catalog"
+
+  test("show tables") {
+    comparePlans(
+      parsePlan("SHOW TABLES"),
+      ShowTables(UnresolvedNamespace(Seq.empty[String]), None))
+    comparePlans(
+      parsePlan("SHOW TABLES '*test*'"),
+      ShowTables(UnresolvedNamespace(Seq.empty[String]), Some("*test*")))
+    comparePlans(
+      parsePlan("SHOW TABLES LIKE '*test*'"),
+      ShowTables(UnresolvedNamespace(Seq.empty[String]), Some("*test*")))
+    comparePlans(
+      parsePlan(s"SHOW TABLES FROM $catalog.ns1.ns2.tbl"),
+      ShowTables(UnresolvedNamespace(Seq(catalog, "ns1", "ns2", "tbl")), None))
+    comparePlans(
+      parsePlan(s"SHOW TABLES IN $catalog.ns1.ns2.tbl"),
+      ShowTables(UnresolvedNamespace(Seq(catalog, "ns1", "ns2", "tbl")), None))
+    comparePlans(
+      parsePlan("SHOW TABLES IN ns1 '*test*'"),
+      ShowTables(UnresolvedNamespace(Seq("ns1")), Some("*test*")))
+    comparePlans(
+      parsePlan("SHOW TABLES IN ns1 LIKE '*test*'"),
+      ShowTables(UnresolvedNamespace(Seq("ns1")), Some("*test*")))
+  }
+
+  test("show table extended") {
+    comparePlans(
+      parsePlan("SHOW TABLE EXTENDED LIKE '*test*'"),
+      ShowTableStatement(None, "*test*", None))
+    comparePlans(
+      parsePlan(s"SHOW TABLE EXTENDED FROM $catalog.ns1.ns2 LIKE '*test*'"),
+      ShowTableStatement(Some(Seq(catalog, "ns1", "ns2")), "*test*", None))
+    comparePlans(
+      parsePlan(s"SHOW TABLE EXTENDED IN $catalog.ns1.ns2 LIKE '*test*'"),
+      ShowTableStatement(Some(Seq(catalog, "ns1", "ns2")), "*test*", None))
+    comparePlans(
+      parsePlan("SHOW TABLE EXTENDED LIKE '*test*' PARTITION(ds='2008-04-09', hr=11)"),
+      ShowTableStatement(None, "*test*", Some(Map("ds" -> "2008-04-09", "hr" -> "11"))))
+    comparePlans(
+      parsePlan(s"SHOW TABLE EXTENDED FROM $catalog.ns1.ns2 LIKE '*test*' " +
+        "PARTITION(ds='2008-04-09')"),
+      ShowTableStatement(Some(Seq(catalog, "ns1", "ns2")), "*test*",
+        Some(Map("ds" -> "2008-04-09"))))
+    comparePlans(
+      parsePlan(s"SHOW TABLE EXTENDED IN $catalog.ns1.ns2 LIKE '*test*' " +
+        "PARTITION(ds='2008-04-09')"),
+      ShowTableStatement(Some(Seq(catalog, "ns1", "ns2")), "*test*",
+        Some(Map("ds" -> "2008-04-09"))))
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
@@ -24,10 +24,6 @@ import org.apache.spark.sql.types.{BooleanType, StringType, StructType}
 trait ShowTablesSuite extends QueryTest with SharedSparkSession {
   protected def catalog: String
   protected def defaultUsing: String
-  protected def namespaceColumn: String = "database"
-  protected def namespace: String = "test"
-  protected def tableColumn: String = "tableName"
-  protected def table: String = "people"
 
   case class ShowRow(namespace: String, table: String, isTemporary: Boolean)
 
@@ -50,20 +46,16 @@ trait ShowTablesSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  protected override def beforeAll(): Unit = {
-    super.beforeAll()
-    sql(s"CREATE DATABASE $catalog.$namespace")
-    sql(s"CREATE TABLE $catalog.$namespace.$table (name STRING, id INT) $defaultUsing")
-  }
-
-  protected override def afterAll(): Unit = {
-    sql(s"DROP TABLE $catalog.$namespace.$table")
-    sql(s"DROP DATABASE $catalog.$namespace")
-    super.afterAll()
-  }
-
   test("show an existing table") {
-    runShowTablesSql(s"SHOW TABLES IN $catalog.test", Seq(ShowRow(namespace, table, false)))
+    val namespace = "test"
+    val table = "people"
+    withDatabase(s"$catalog.$namespace") {
+      sql(s"CREATE DATABASE $catalog.$namespace")
+      withTable(s"$catalog.$namespace.$table") {
+        sql(s"CREATE TABLE $catalog.$namespace.$table (name STRING, id INT) $defaultUsing")
+        runShowTablesSql(s"SHOW TABLES IN $catalog.test", Seq(ShowRow(namespace, table, false)))
+      }
+    }
   }
 
   test("show tables with a pattern") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
@@ -35,16 +35,6 @@ trait ShowTablesSuite extends QueryTest with SharedSparkSession {
     assert(df.collect() === getRows(expected))
   }
 
-  protected def withSourceViews(f: => Unit): Unit = {
-    withTable("source", "source2") {
-      val df = spark.createDataFrame(Seq((1L, "a"), (2L, "b"), (3L, "c"))).toDF("id", "data")
-      df.createOrReplaceTempView("source")
-      val df2 = spark.createDataFrame(Seq((4L, "d"), (5L, "e"), (6L, "f"))).toDF("id", "data")
-      df2.createOrReplaceTempView("source2")
-      f
-    }
-  }
-
   test("show an existing table") {
     val namespace = "test"
     val table = "people"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
@@ -143,6 +143,7 @@ trait ShowTablesSuite extends QueryTest with SharedSparkSession with AnalysisTes
     }
   }
 
+  // TODO(SPARK-33393): Support SHOW TABLE EXTENDED in DSv2
   test("SHOW TABLE EXTENDED for default") {
     withSourceViews {
       val expected = Seq(Row("", "source", true), Row("", "source2", true))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.command
 
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.{BooleanType, StringType, StructType}
+import org.apache.spark.sql.types.StructType
 
 trait ShowTablesSuite extends QueryTest with SharedSparkSession {
   protected def catalog: String

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
@@ -18,13 +18,10 @@
 package org.apache.spark.sql.execution.command
 
 import org.apache.spark.sql.{QueryTest, Row}
-import org.apache.spark.sql.catalyst.analysis.{AnalysisTest, UnresolvedNamespace}
-import org.apache.spark.sql.catalyst.parser.CatalystSqlParser.parsePlan
-import org.apache.spark.sql.catalyst.plans.logical.{ShowTables, ShowTableStatement}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{BooleanType, StringType, StructType}
 
-trait ShowTablesSuite extends QueryTest with SharedSparkSession with AnalysisTest {
+trait ShowTablesSuite extends QueryTest with SharedSparkSession {
   protected def catalog: String
   protected def defaultUsing: String
   case class ShowRow(namespace: String, table: String, isTemporary: Boolean)
@@ -46,55 +43,6 @@ trait ShowTablesSuite extends QueryTest with SharedSparkSession with AnalysisTes
       df2.createOrReplaceTempView("source2")
       f
     }
-  }
-
-  test("show tables") {
-    comparePlans(
-      parsePlan("SHOW TABLES"),
-      ShowTables(UnresolvedNamespace(Seq.empty[String]), None))
-    comparePlans(
-      parsePlan("SHOW TABLES '*test*'"),
-      ShowTables(UnresolvedNamespace(Seq.empty[String]), Some("*test*")))
-    comparePlans(
-      parsePlan("SHOW TABLES LIKE '*test*'"),
-      ShowTables(UnresolvedNamespace(Seq.empty[String]), Some("*test*")))
-    comparePlans(
-      parsePlan(s"SHOW TABLES FROM $catalog.ns1.ns2.tbl"),
-      ShowTables(UnresolvedNamespace(Seq(catalog, "ns1", "ns2", "tbl")), None))
-    comparePlans(
-      parsePlan(s"SHOW TABLES IN $catalog.ns1.ns2.tbl"),
-      ShowTables(UnresolvedNamespace(Seq(catalog, "ns1", "ns2", "tbl")), None))
-    comparePlans(
-      parsePlan("SHOW TABLES IN ns1 '*test*'"),
-      ShowTables(UnresolvedNamespace(Seq("ns1")), Some("*test*")))
-    comparePlans(
-      parsePlan("SHOW TABLES IN ns1 LIKE '*test*'"),
-      ShowTables(UnresolvedNamespace(Seq("ns1")), Some("*test*")))
-  }
-
-  test("show table extended") {
-    comparePlans(
-      parsePlan("SHOW TABLE EXTENDED LIKE '*test*'"),
-      ShowTableStatement(None, "*test*", None))
-    comparePlans(
-      parsePlan(s"SHOW TABLE EXTENDED FROM $catalog.ns1.ns2 LIKE '*test*'"),
-      ShowTableStatement(Some(Seq(catalog, "ns1", "ns2")), "*test*", None))
-    comparePlans(
-      parsePlan(s"SHOW TABLE EXTENDED IN $catalog.ns1.ns2 LIKE '*test*'"),
-      ShowTableStatement(Some(Seq(catalog, "ns1", "ns2")), "*test*", None))
-    comparePlans(
-      parsePlan("SHOW TABLE EXTENDED LIKE '*test*' PARTITION(ds='2008-04-09', hr=11)"),
-      ShowTableStatement(None, "*test*", Some(Map("ds" -> "2008-04-09", "hr" -> "11"))))
-    comparePlans(
-      parsePlan(s"SHOW TABLE EXTENDED FROM $catalog.ns1.ns2 LIKE '*test*' " +
-        "PARTITION(ds='2008-04-09')"),
-      ShowTableStatement(Some(Seq(catalog, "ns1", "ns2")), "*test*",
-        Some(Map("ds" -> "2008-04-09"))))
-    comparePlans(
-      parsePlan(s"SHOW TABLE EXTENDED IN $catalog.ns1.ns2 LIKE '*test*' " +
-        "PARTITION(ds='2008-04-09')"),
-      ShowTableStatement(Some(Seq(catalog, "ns1", "ns2")), "*test*",
-        Some(Map("ds" -> "2008-04-09"))))
   }
 
   test("show an existing table") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution.command
 
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{BooleanType, StringType, StructType}
 
 trait ShowTablesSuite extends QueryTest with SharedSparkSession {
   protected def catalog: String
@@ -26,6 +27,12 @@ trait ShowTablesSuite extends QueryTest with SharedSparkSession {
   protected def namespace: String = "test"
   protected def tableColumn: String = "tableName"
   protected def table: String = "people"
+  protected def showSchema: StructType
+  protected def runShowTablesSql(sqlText: String, expected: Seq[Row]): Unit = {
+    val df = spark.sql(sqlText)
+    assert(df.schema === showSchema)
+    assert(expected === df.collect())
+  }
 
   test("show an existing table") {
     val tables = sql(s"SHOW TABLES IN $catalog.test")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
@@ -90,24 +90,4 @@ trait ShowTablesSuite extends QueryTest with SharedSparkSession {
       }
     }
   }
-
-  // TODO(SPARK-33393): Support SHOW TABLE EXTENDED in DSv2
-  test("SHOW TABLE EXTENDED for default") {
-    withSourceViews {
-      val expected = Seq(Row("", "source", true), Row("", "source2", true))
-      val schema = new StructType()
-        .add("database", StringType, nullable = false)
-        .add("tableName", StringType, nullable = false)
-        .add("isTemporary", BooleanType, nullable = false)
-        .add("information", StringType, nullable = false)
-
-      val df = sql("SHOW TABLE EXTENDED FROM default LIKE '*source*'")
-      val result = df.collect()
-      val resultWithoutInfo = result.map { case Row(db, table, temp, _) => Row(db, table, temp) }
-
-      assert(df.schema === schema)
-      assert(resultWithoutInfo === expected)
-      result.foreach { case Row(_, _, _, info: String) => assert(info.nonEmpty) }
-    }
-  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
@@ -27,16 +27,19 @@ trait ShowTablesSuite extends QueryTest with SharedSparkSession {
   protected def namespace: String = "test"
   protected def tableColumn: String = "tableName"
   protected def table: String = "people"
+
+  case class ShowRow(namespace: String, table: String, isTemporary: Boolean)
+
   protected def showSchema: StructType
-  protected def runShowTablesSql(sqlText: String, expected: Seq[Row]): Unit = {
+  protected def getRows(showRows: Seq[ShowRow]): Seq[Row]
+
+  protected def runShowTablesSql(sqlText: String, expected: Seq[ShowRow]): Unit = {
     val df = spark.sql(sqlText)
     assert(df.schema === showSchema)
-    assert(df.collect() === expected)
+    assert(df.collect() === getRows(expected))
   }
 
   test("show an existing table") {
-    val tables = sql(s"SHOW TABLES IN $catalog.test")
-    checkAnswer(tables.select(namespaceColumn), Row(namespace))
-    checkAnswer(tables.select(tableColumn), Row(table))
+    runShowTablesSql(s"SHOW TABLES IN $catalog.test", Seq(ShowRow(namespace, table, false)))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
@@ -17,6 +17,9 @@
 
 package org.apache.spark.sql.execution.command
 
+import org.scalactic.source.Position
+import org.scalatest.Tag
+
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 import org.apache.spark.sql.internal.SQLConf
@@ -24,6 +27,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
 
 trait ShowTablesSuite extends QueryTest with SharedSparkSession {
+  protected def version: String
   protected def catalog: String
   protected def defaultNamespace: Seq[String]
   protected def defaultUsing: String
@@ -36,6 +40,11 @@ trait ShowTablesSuite extends QueryTest with SharedSparkSession {
     val df = spark.sql(sqlText)
     assert(df.schema === showSchema)
     assert(df.collect() === getRows(expected))
+  }
+
+  override def test(testName: String, testTags: Tag*)(testFun: => Any)
+      (implicit pos: Position): Unit = {
+    super.test(s"SHOW TABLES $version: " + testName, testTags: _*)(testFun)
   }
 
   test("show an existing table") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
 
-trait ShowTablesSuite extends QueryTest with SharedSparkSession {
+trait ShowTablesSuite extends SharedSparkSession {
   protected def version: String
   protected def catalog: String
   protected def defaultNamespace: Seq[String]

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.command
+
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.test.SharedSparkSession
+
+trait ShowTablesSuite extends QueryTest with SharedSparkSession {
+  protected def catalog: String
+  protected def namespaceColumn: String = "database"
+  protected def namespace: String = "test"
+  protected def tableColumn: String = "tableName"
+  protected def table: String = "people"
+
+  test("show an existing table") {
+    val tables = sql(s"SHOW TABLES IN $catalog.test")
+    checkAnswer(tables.select(namespaceColumn), Row(namespace))
+    checkAnswer(tables.select(tableColumn), Row(table))
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
@@ -50,6 +50,18 @@ trait ShowTablesSuite extends QueryTest with SharedSparkSession {
     }
   }
 
+  protected override def beforeAll(): Unit = {
+    super.beforeAll()
+    sql(s"CREATE DATABASE $catalog.$namespace")
+    sql(s"CREATE TABLE $catalog.$namespace.$table (name STRING, id INT) $defaultUsing")
+  }
+
+  protected override def afterAll(): Unit = {
+    sql(s"DROP TABLE $catalog.$namespace.$table")
+    sql(s"DROP DATABASE $catalog.$namespace")
+    super.afterAll()
+  }
+
   test("show an existing table") {
     runShowTablesSql(s"SHOW TABLES IN $catalog.test", Seq(ShowRow(namespace, table, false)))
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.command
 import org.scalactic.source.Position
 import org.scalatest.Tag
 
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
@@ -31,7 +31,7 @@ trait ShowTablesSuite extends QueryTest with SharedSparkSession {
   protected def runShowTablesSql(sqlText: String, expected: Seq[Row]): Unit = {
     val df = spark.sql(sqlText)
     assert(df.schema === showSchema)
-    assert(expected === df.collect())
+    assert(df.collect() === expected)
   }
 
   test("show an existing table") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -49,12 +49,6 @@ class ShowTablesSuite extends CommonShowTablesSuite {
     super.afterAll()
   }
 
-  test("show an existing table in V1 catalog") {
-    val tables = sql(s"SHOW TABLES IN $catalog.test")
-    assert(tables.schema.fieldNames.toSet === Set(namespaceColumn, tableColumn, "isTemporary"))
-    checkAnswer(tables.select("isTemporary"), Row(false))
-  }
-
   // `SHOW TABLES` returns empty result in V2 catalog instead of throwing the exception.
   test("show table in a not existing namespace") {
     val msg = intercept[NoSuchDatabaseException] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -57,9 +57,9 @@ class ShowTablesSuite extends CommonShowTablesSuite {
 
   test("show table in a not existing namespace") {
     val msg = intercept[NoSuchDatabaseException] {
-      checkAnswer(sql(s"SHOW TABLES IN $catalog.bad_test"), Seq())
+      runShowTablesSql(s"SHOW TABLES IN $catalog.unknown", Seq())
     }.getMessage
-    assert(msg.contains("Database 'bad_test' not found"))
+    assert(msg.contains("Database 'unknown' not found"))
   }
 
   private def withSourceViews(f: => Unit): Unit = {
@@ -78,15 +78,6 @@ class ShowTablesSuite extends CommonShowTablesSuite {
         "SHOW TABLES FROM default",
         Seq(ShowRow("", "source", true), ShowRow("", "source2", true)))
     }
-  }
-
-  test("ShowTables: using v1 catalog, db doesn't exist ") {
-    // 'db' below resolves to a database name for v1 catalog because there is no catalog named
-    // 'db' and there is no default catalog set.
-    val exception = intercept[NoSuchDatabaseException] {
-      runShowTablesSql("SHOW TABLES FROM db", Seq())
-    }
-    assert(exception.getMessage.contains("Database 'db' not found"))
   }
 
   test("ShowTables: using v1 catalog, db name with multipartIdentifier ('a.b') is not allowed.") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -62,16 +62,6 @@ class ShowTablesSuite extends CommonShowTablesSuite {
     assert(msg.contains("Database 'unknown' not found"))
   }
 
-  private def withSourceViews(f: => Unit): Unit = {
-    withTable("source", "source2") {
-      val df = spark.createDataFrame(Seq((1L, "a"), (2L, "b"), (3L, "c"))).toDF("id", "data")
-      df.createOrReplaceTempView("source")
-      val df2 = spark.createDataFrame(Seq((4L, "d"), (5L, "e"), (6L, "f"))).toDF("id", "data")
-      df2.createOrReplaceTempView("source2")
-      f
-    }
-  }
-
   test("ShowTables: using v1 catalog") {
     withSourceViews {
       runShowTablesSql(
@@ -103,25 +93,6 @@ class ShowTablesSuite extends CommonShowTablesSuite {
       runShowTablesSql(
         "SHOW TABLES LIKE '*2'",
         Seq(ShowRow("", "source2", true)))
-    }
-  }
-
-  test("SHOW TABLE EXTENDED valid v1") {
-    withSourceViews {
-      val expected = Seq(Row("", "source", true), Row("", "source2", true))
-      val schema = new StructType()
-        .add("database", StringType, nullable = false)
-        .add("tableName", StringType, nullable = false)
-        .add("isTemporary", BooleanType, nullable = false)
-        .add("information", StringType, nullable = false)
-
-      val df = sql("SHOW TABLE EXTENDED FROM default LIKE '*source*'")
-      val result = df.collect()
-      val resultWithoutInfo = result.map { case Row(db, table, temp, _) => Row(db, table, temp) }
-
-      assert(df.schema === schema)
-      assert(resultWithoutInfo === expected)
-      result.foreach { case Row(_, _, _, info: String) => assert(info.nonEmpty) }
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -65,11 +65,8 @@ class ShowTablesSuite extends CommonShowTablesSuite {
     withSourceViews {
       runShowTablesSql(
         "SHOW TABLES",
-        Seq(ShowRow("", "source", true),
-            ShowRow("", "source2", true)))
-      runShowTablesSql(
-        "SHOW TABLES LIKE '*2'",
-        Seq(ShowRow("", "source2", true)))
+        Seq(ShowRow("", "source", true), ShowRow("", "source2", true)))
+      runShowTablesSql("SHOW TABLES LIKE '*2'", Seq(ShowRow("", "source2", true)))
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -27,14 +27,14 @@ class ShowTablesSuite extends CommonShowTablesSuite {
   override def version: String = "V1"
   override def catalog: String = CatalogManager.SESSION_CATALOG_NAME
   override def defaultNamespace: Seq[String] = Seq("default")
-  override protected def defaultUsing: String = "USING parquet"
-  override protected def showSchema: StructType = {
+  override def defaultUsing: String = "USING parquet"
+  override def showSchema: StructType = {
     new StructType()
       .add("database", StringType, nullable = false)
       .add("tableName", StringType, nullable = false)
       .add("isTemporary", BooleanType, nullable = false)
   }
-  override protected def getRows(showRows: Seq[ShowRow]): Seq[Row] = {
+  override def getRows(showRows: Seq[ShowRow]): Seq[Row] = {
     showRows.map {
       case ShowRow(namespace, table, isTemporary) => Row(namespace, table, isTemporary)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -37,18 +37,6 @@ class ShowTablesSuite extends CommonShowTablesSuite {
     }
   }
 
-  protected override def beforeAll(): Unit = {
-    super.beforeAll()
-    sql(s"CREATE DATABASE $namespace")
-    sql(s"CREATE TABLE $namespace.$table (name STRING, id INT) USING PARQUET")
-  }
-
-  protected override def afterAll(): Unit = {
-    sql(s"DROP TABLE $namespace.$table")
-    sql(s"DROP DATABASE $namespace")
-    super.afterAll()
-  }
-
   // `SHOW TABLES` returns empty result in V2 catalog instead of throwing the exception.
   test("show table in a not existing namespace") {
     val msg = intercept[NoSuchDatabaseException] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -57,7 +57,8 @@ class ShowTablesSuite extends CommonShowTablesSuite {
     assert(msg.contains("Database 'unknown' not found"))
   }
 
-  test("ShowTables: using v1 catalog") {
+  // `SHOW TABLES` from v2 catalog returns empty result.
+  test("show views from v1 catalog") {
     withSourceViews {
       runShowTablesSql(
         "SHOW TABLES FROM default",
@@ -65,7 +66,7 @@ class ShowTablesSuite extends CommonShowTablesSuite {
     }
   }
 
-  test("ShowTables: using v1 catalog, db name with multipartIdentifier ('a.b') is not allowed.") {
+  test("using v1 catalog, db name with multipartIdentifier ('a.b') is not allowed.") {
     val exception = intercept[AnalysisException] {
       runShowTablesSql("SHOW TABLES FROM a.b", Seq())
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -55,6 +55,7 @@ class ShowTablesSuite extends CommonShowTablesSuite {
     checkAnswer(tables.select("isTemporary"), Row(false))
   }
 
+  // `SHOW TABLES` returns empty result in V2 catalog instead of throwing the exception.
   test("show table in a not existing namespace") {
     val msg = intercept[NoSuchDatabaseException] {
       runShowTablesSql(s"SHOW TABLES IN $catalog.unknown", Seq())

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -19,11 +19,12 @@ package org.apache.spark.sql.execution.command.v1
 
 import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.analysis.NoSuchDatabaseException
+import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.execution.command.{ShowTablesSuite => CommonShowTablesSuite}
 import org.apache.spark.sql.types.{BooleanType, StringType, StructType}
 
 class ShowTablesSuite extends CommonShowTablesSuite {
-  override def catalog: String = "spark_catalog"
+  override def catalog: String = CatalogManager.SESSION_CATALOG_NAME
   override protected def defaultUsing: String = "USING parquet"
   override protected def showSchema: StructType = {
     new StructType()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.command.v1
+
+import org.apache.spark.sql.execution.command.{ShowTablesSuite => CommonShowTablesSuite}
+
+class ShowTablesSuite extends CommonShowTablesSuite {
+  override def catalog: String = "spark_catalog"
+
+  protected override def beforeAll(): Unit = {
+    super.beforeAll()
+    sql(s"CREATE DATABASE $namespace")
+    sql(s"CREATE TABLE $namespace.$table (name STRING, id INT) USING PARQUET")
+  }
+
+  protected override def afterAll(): Unit = {
+    sql(s"DROP TABLE $namespace.$table")
+    sql(s"DROP DATABASE $namespace")
+    super.afterAll()
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -57,7 +57,7 @@ class ShowTablesSuite extends CommonShowTablesSuite {
   }
 
   // `SHOW TABLES` from v2 catalog returns empty result.
-  test("show views from v1 catalog") {
+  test("v1 SHOW TABLES list the temp views") {
     withSourceViews {
       runShowTablesSql(
         "SHOW TABLES FROM default",

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -30,6 +30,11 @@ class ShowTablesSuite extends CommonShowTablesSuite {
       .add("tableName", StringType, nullable = false)
       .add("isTemporary", BooleanType, nullable = false)
   }
+  override protected def getRows(showRows: Seq[ShowRow]): Seq[Row] = {
+    showRows.map {
+      case ShowRow(namespace, table, isTemporary) => Row(namespace, table, isTemporary)
+    }
+  }
 
   protected override def beforeAll(): Unit = {
     super.beforeAll()
@@ -70,7 +75,7 @@ class ShowTablesSuite extends CommonShowTablesSuite {
     withSourceViews {
       runShowTablesSql(
         "SHOW TABLES FROM default",
-        Seq(Row("", "source", true), Row("", "source2", true)))
+        Seq(ShowRow("", "source", true), ShowRow("", "source2", true)))
     }
   }
 
@@ -99,8 +104,13 @@ class ShowTablesSuite extends CommonShowTablesSuite {
 
   test("ShowTables: namespace not specified and default v2 catalog not set - fallback to v1") {
     withSourceViews {
-      runShowTablesSql("SHOW TABLES", Seq(Row("", "source", true), Row("", "source2", true)))
-      runShowTablesSql("SHOW TABLES LIKE '*2'", Seq(Row("", "source2", true)))
+      runShowTablesSql(
+        "SHOW TABLES",
+        Seq(ShowRow("", "source", true),
+            ShowRow("", "source2", true)))
+      runShowTablesSql(
+        "SHOW TABLES LIKE '*2'",
+        Seq(ShowRow("", "source2", true)))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.analysis.NoSuchDatabaseException
 import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.execution.command.{ShowTablesSuite => CommonShowTablesSuite}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{BooleanType, StringType, StructType}
 
 class ShowTablesSuite extends CommonShowTablesSuite {
@@ -44,6 +45,15 @@ class ShowTablesSuite extends CommonShowTablesSuite {
       runShowTablesSql(s"SHOW TABLES IN $catalog.unknown", Seq())
     }.getMessage
     assert(msg.contains("Database 'unknown' not found"))
+  }
+
+  test("namespace is not specified and the default catalog is set") {
+    withSQLConf(SQLConf.DEFAULT_CATALOG.key -> catalog) {
+      withTable("table") {
+        spark.sql(s"CREATE TABLE table (id bigint, data string) $defaultUsing")
+        runShowTablesSql("SHOW TABLES", Seq(ShowRow("default", "table", false)))
+      }
+    }
   }
 
   // `SHOW TABLES` from v2 catalog returns empty result.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -73,7 +73,7 @@ class ShowTablesSuite extends CommonShowTablesSuite {
     assert(exception.getMessage.contains("The database name is not valid: a.b"))
   }
 
-  test("ShowTables: namespace not specified and default v2 catalog not set - fallback to v1") {
+  test("namespace not specified and default v2 catalog not set - fallback to v1") {
     withSourceViews {
       runShowTablesSql(
         "SHOW TABLES",

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution.command.v1
 
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.analysis.NoSuchDatabaseException
 import org.apache.spark.sql.execution.command.{ShowTablesSuite => CommonShowTablesSuite}
 
@@ -33,6 +34,12 @@ class ShowTablesSuite extends CommonShowTablesSuite {
     sql(s"DROP TABLE $namespace.$table")
     sql(s"DROP DATABASE $namespace")
     super.afterAll()
+  }
+
+  test("show an existing table in V1 catalog") {
+    val tables = sql(s"SHOW TABLES IN $catalog.test")
+    assert(tables.schema.fieldNames.toSet === Set(namespaceColumn, tableColumn, "isTemporary"))
+    checkAnswer(tables.select("isTemporary"), Row(false))
   }
 
   test("show table in a not existing namespace") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -90,4 +90,15 @@ class ShowTablesSuite extends CommonShowTablesSuite {
     }
     assert(exception.getMessage.contains("The database name is not valid: a.b"))
   }
+
+  test("ShowTables: namespace not specified and default v2 catalog not set - fallback to v1") {
+    withTable("source", "source2") {
+      val df = spark.createDataFrame(Seq((1L, "a"), (2L, "b"), (3L, "c"))).toDF("id", "data")
+      df.createOrReplaceTempView("source")
+      val df2 = spark.createDataFrame(Seq((4L, "d"), (5L, "e"), (6L, "f"))).toDF("id", "data")
+      df2.createOrReplaceTempView("source2")
+      runShowTablesSql("SHOW TABLES", Seq(Row("", "source", true), Row("", "source2", true)))
+      runShowTablesSql("SHOW TABLES LIKE '*2'", Seq(Row("", "source2", true)))
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -39,6 +39,16 @@ class ShowTablesSuite extends CommonShowTablesSuite {
     }
   }
 
+  private def withSourceViews(f: => Unit): Unit = {
+    withTable("source", "source2") {
+      val df = spark.createDataFrame(Seq((1L, "a"), (2L, "b"), (3L, "c"))).toDF("id", "data")
+      df.createOrReplaceTempView("source")
+      val df2 = spark.createDataFrame(Seq((4L, "d"), (5L, "e"), (6L, "f"))).toDF("id", "data")
+      df2.createOrReplaceTempView("source2")
+      f
+    }
+  }
+
   // `SHOW TABLES` returns empty result in V2 catalog instead of throwing the exception.
   test("show table in a not existing namespace") {
     val msg = intercept[NoSuchDatabaseException] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -73,13 +73,6 @@ class ShowTablesSuite extends CommonShowTablesSuite {
     assert(exception.getMessage.contains("The database name is not valid: a.b"))
   }
 
-  test("ShowViews: using v1 catalog, db name with multipartIdentifier ('a.b') is not allowed.") {
-    val exception = intercept[AnalysisException] {
-      sql("SHOW TABLES FROM a.b")
-    }
-    assert(exception.getMessage.contains("The database name is not valid: a.b"))
-  }
-
   test("ShowTables: namespace not specified and default v2 catalog not set - fallback to v1") {
     withSourceViews {
       runShowTablesSql(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -70,4 +70,23 @@ class ShowTablesSuite extends CommonShowTablesSuite {
       runShowTablesSql("SHOW TABLES LIKE '*2'", Seq(ShowRow("", "source2", true)))
     }
   }
+
+  test("SHOW TABLE EXTENDED for default") {
+    withSourceViews {
+      val expected = Seq(Row("", "source", true), Row("", "source2", true))
+      val schema = new StructType()
+        .add("database", StringType, nullable = false)
+        .add("tableName", StringType, nullable = false)
+        .add("isTemporary", BooleanType, nullable = false)
+        .add("information", StringType, nullable = false)
+
+      val df = sql("SHOW TABLE EXTENDED FROM default LIKE '*source*'")
+      val result = df.collect()
+      val resultWithoutInfo = result.map { case Row(db, table, temp, _) => Row(db, table, temp) }
+
+      assert(df.schema === schema)
+      assert(resultWithoutInfo === expected)
+      result.foreach { case Row(_, _, _, info: String) => assert(info.nonEmpty) }
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -20,9 +20,16 @@ package org.apache.spark.sql.execution.command.v1
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.analysis.NoSuchDatabaseException
 import org.apache.spark.sql.execution.command.{ShowTablesSuite => CommonShowTablesSuite}
+import org.apache.spark.sql.types.{BooleanType, StringType, StructType}
 
 class ShowTablesSuite extends CommonShowTablesSuite {
   override def catalog: String = "spark_catalog"
+  override protected def showSchema: StructType = {
+    new StructType()
+      .add("database", StringType, nullable = false)
+      .add("tableName", StringType, nullable = false)
+      .add("isTemporary", BooleanType, nullable = false)
+  }
 
   protected override def beforeAll(): Unit = {
     super.beforeAll()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.types.{BooleanType, StringType, StructType}
 
 class ShowTablesSuite extends CommonShowTablesSuite {
   override def catalog: String = "spark_catalog"
+  override protected def defaultUsing: String = "USING parquet"
   override protected def showSchema: StructType = {
     new StructType()
       .add("database", StringType, nullable = false)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.execution.command.{ShowTablesSuite => CommonShowTabl
 import org.apache.spark.sql.types.{BooleanType, StringType, StructType}
 
 class ShowTablesSuite extends CommonShowTablesSuite {
+  override def version: String = "V1"
   override def catalog: String = CatalogManager.SESSION_CATALOG_NAME
   override def defaultNamespace: Seq[String] = Seq("default")
   override protected def defaultUsing: String = "USING parquet"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution.command.v1
 
+import org.apache.spark.sql.catalyst.analysis.NoSuchDatabaseException
 import org.apache.spark.sql.execution.command.{ShowTablesSuite => CommonShowTablesSuite}
 
 class ShowTablesSuite extends CommonShowTablesSuite {
@@ -32,5 +33,12 @@ class ShowTablesSuite extends CommonShowTablesSuite {
     sql(s"DROP TABLE $namespace.$table")
     sql(s"DROP DATABASE $namespace")
     super.afterAll()
+  }
+
+  test("show table in a not existing namespace") {
+    val msg = intercept[NoSuchDatabaseException] {
+      checkAnswer(sql(s"SHOW TABLES IN $catalog.bad_test"), Seq())
+    }.getMessage
+    assert(msg.contains("Database 'bad_test' not found"))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
@@ -46,7 +46,7 @@ class ShowTablesSuite extends QueryTest with SharedSparkSession with CommonShowT
   protected override def beforeAll(): Unit = {
     super.beforeAll()
     sql(s"CREATE DATABASE $catalog.$namespace")
-    sql(s"CREATE TABLE $catalog.$namespace.$table (name STRING, id INT) USING PARQUET")
+    sql(s"CREATE TABLE $catalog.$namespace.$table (name STRING, id INT) $defaultUsing")
   }
 
   protected override def afterAll(): Unit = {
@@ -61,14 +61,14 @@ class ShowTablesSuite extends QueryTest with SharedSparkSession with CommonShowT
 
   test("ShowTables: using v2 catalog") {
     withTable(s"$catalog.db.table_name") {
-      spark.sql(s"CREATE TABLE $catalog.db.table_name (id bigint, data string) USING foo")
+      spark.sql(s"CREATE TABLE $catalog.db.table_name (id bigint, data string) $defaultUsing")
       runShowTablesSql(
         s"SHOW TABLES FROM $catalog.db",
         Seq(ShowRow("db", "table_name", false)))
     }
 
     withTable(s"$catalog.n1.n2.db") {
-      spark.sql(s"CREATE TABLE $catalog.n1.n2.db.table_name (id bigint, data string) USING foo")
+      spark.sql(s"CREATE TABLE $catalog.n1.n2.db.table_name (id bigint, data string) $defaultUsing")
       runShowTablesSql(
         s"SHOW TABLES FROM $catalog.n1.n2.db",
         Seq(ShowRow("n1.n2.db", "table_name", false)))
@@ -85,7 +85,7 @@ class ShowTablesSuite extends QueryTest with SharedSparkSession with CommonShowT
 
   test("ShowTables: using v2 catalog with empty namespace") {
     withTable(s"$catalog.table") {
-      spark.sql(s"CREATE TABLE $catalog.table (id bigint, data string) USING foo")
+      spark.sql(s"CREATE TABLE $catalog.table (id bigint, data string) $defaultUsing")
       runShowTablesSql(s"SHOW TABLES FROM $catalog", Seq(ShowRow("", "table", false)))
     }
   }
@@ -93,7 +93,7 @@ class ShowTablesSuite extends QueryTest with SharedSparkSession with CommonShowT
   test("ShowTables: namespace is not specified and default v2 catalog is set") {
     withSQLConf(SQLConf.DEFAULT_CATALOG.key -> catalog) {
       withTable(s"$catalog.table") {
-        spark.sql(s"CREATE TABLE $catalog.table (id bigint, data string) USING foo")
+        spark.sql(s"CREATE TABLE $catalog.table (id bigint, data string) $defaultUsing")
         // v2 catalog is used where default namespace is empty for TestInMemoryTableCatalog.
         runShowTablesSql("SHOW TABLES", Seq(ShowRow("", "table", false)))
       }
@@ -112,7 +112,7 @@ class ShowTablesSuite extends QueryTest with SharedSparkSession with CommonShowT
     val table = "tbl"
     withTable(s"$namespace.$table") {
       sql(s"CREATE TABLE $namespace.$table (id bigint, data string) " +
-        s"USING foo PARTITIONED BY (id)")
+        s"$defaultUsing PARTITIONED BY (id)")
 
       testV1CommandNamespace(s"SHOW TABLE EXTENDED FROM $namespace LIKE 'tb*'",
         namespace)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
@@ -75,6 +75,7 @@ class ShowTablesSuite extends QueryTest with SharedSparkSession with CommonShowT
     withSQLConf(SQLConf.DEFAULT_CATALOG.key -> catalog) {
       withTable("table") {
         spark.sql(s"CREATE TABLE table (id bigint, data string) $defaultUsing")
+        // TODO(SPARK-33403): DSv2 SHOW TABLES doesn't show `default`
         runShowTablesSql("SHOW TABLES", Seq(ShowRow("", "table", false)))
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
@@ -82,7 +82,10 @@ class ShowTablesSuite extends QueryTest with SharedSparkSession with CommonShowT
     }
   }
 
-  test("ShowTables: namespace is not specified and default v2 catalog is set") {
+  // The test fails for V1 catalog with the error:
+  // org.apache.spark.sql.AnalysisException:
+  //   The namespace in session catalog must have exactly one name part: spark_catalog.table
+  test("namespace is not specified and default v2 catalog is set") {
     withSQLConf(SQLConf.DEFAULT_CATALOG.key -> catalog) {
       withTable(s"$catalog.table") {
         spark.sql(s"CREATE TABLE $catalog.table (id bigint, data string) $defaultUsing")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.command.v2
+
+import org.apache.spark.sql.execution.command.{ShowTablesSuite => CommonShowTablesSuite}
+
+class ShowTablesSuite extends CommonShowTablesSuite {
+  override def catalog: String = "aaa"
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
@@ -43,18 +43,6 @@ class ShowTablesSuite extends QueryTest with SharedSparkSession with CommonShowT
   override def sparkConf: SparkConf = super.sparkConf
     .set(s"spark.sql.catalog.$catalog", classOf[InMemoryTableCatalog].getName)
 
-  protected override def beforeAll(): Unit = {
-    super.beforeAll()
-    sql(s"CREATE DATABASE $catalog.$namespace")
-    sql(s"CREATE TABLE $catalog.$namespace.$table (name STRING, id INT) $defaultUsing")
-  }
-
-  protected override def afterAll(): Unit = {
-    sql(s"DROP TABLE $catalog.$namespace.$table")
-    sql(s"DROP DATABASE $catalog.$namespace")
-    super.afterAll()
-  }
-
   // The test fails with the exception `NoSuchDatabaseException` in V1 catalog.
   test("show table in a not existing namespace") {
     runShowTablesSql(s"SHOW TABLES IN $catalog.unknown", Seq())

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
@@ -28,7 +28,6 @@ import org.apache.spark.sql.types.{StringType, StructType}
 class ShowTablesSuite extends QueryTest with SharedSparkSession with CommonShowTablesSuite {
   override def catalog: String = "test_catalog_v2"
   override protected def defaultUsing: String = "USING _"
-  override protected def namespaceColumn: String = "namespace"
   override protected def showSchema: StructType = {
     new StructType()
       .add("namespace", StringType, nullable = false)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.types.{StringType, StructType}
 
 class ShowTablesSuite extends QueryTest with SharedSparkSession with CommonShowTablesSuite {
   override def catalog: String = "test_catalog_v2"
-  override protected def defaultUsing: String = "USING foo"
+  override protected def defaultUsing: String = "USING _"
   override protected def namespaceColumn: String = "namespace"
   override protected def showSchema: StructType = {
     new StructType()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.execution.command.{ShowTablesSuite => CommonShowTabl
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{StringType, StructType}
 
-class ShowTablesSuite extends QueryTest with SharedSparkSession with CommonShowTablesSuite {
+class ShowTablesSuite extends CommonShowTablesSuite {
   override def version: String = "V2"
   override def catalog: String = "test_catalog"
   override def defaultNamespace: Seq[String] = Nil

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
@@ -95,6 +95,9 @@ class ShowTablesSuite extends QueryTest with SharedSparkSession with CommonShowT
     }
   }
 
+  // The test fails for V1 catalog with the error:
+  // org.apache.spark.sql.AnalysisException:
+  //   The namespace in session catalog must have exactly one name part: spark_catalog.ns1.ns2.tbl
   test("SHOW TABLE EXTENDED not valid v1 database") {
     def testV1CommandNamespace(sqlCommand: String, namespace: String): Unit = {
       val e = intercept[AnalysisException] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
@@ -43,6 +43,7 @@ class ShowTablesSuite extends QueryTest with SharedSparkSession with CommonShowT
     .set(s"spark.sql.catalog.$catalog", classOf[InMemoryTableCatalog].getName)
 
   // The test fails with the exception `NoSuchDatabaseException` in V1 catalog.
+  // TODO(SPARK-33394): Throw `NoSuchDatabaseException` for not existing namespace
   test("show table in a not existing namespace") {
     runShowTablesSql(s"SHOW TABLES IN $catalog.unknown", Seq())
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
@@ -56,7 +56,7 @@ class ShowTablesSuite extends QueryTest with SharedSparkSession with CommonShowT
   }
 
   test("show table in a not existing namespace") {
-    checkAnswer(sql(s"SHOW TABLES IN $catalog.bad_test"), Seq())
+    runShowTablesSql(s"SHOW TABLES IN $catalog.unknown", Seq())
   }
 
   test("ShowTables: using v2 catalog") {
@@ -73,10 +73,6 @@ class ShowTablesSuite extends QueryTest with SharedSparkSession with CommonShowT
         s"SHOW TABLES FROM $catalog.n1.n2.db",
         Seq(ShowRow("n1.n2.db", "table_name", false)))
     }
-  }
-
-  test("ShowTables: using v2 catalog, namespace doesn't exist") {
-    runShowTablesSql(s"SHOW TABLES FROM $catalog.unknown", Seq())
   }
 
   test("ShowViews: using v2 catalog, command not supported.") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
@@ -21,6 +21,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.connector.InMemoryTableCatalog
 import org.apache.spark.sql.execution.command.{ShowTablesSuite => CommonShowTablesSuite}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{StringType, StructType}
 
@@ -110,6 +111,16 @@ class ShowTablesSuite extends QueryTest with SharedSparkSession with CommonShowT
     withTable(s"$catalog.table") {
       spark.sql(s"CREATE TABLE $catalog.table (id bigint, data string) USING foo")
       runShowTablesSql(s"SHOW TABLES FROM $catalog", Seq(Row("", "table")))
+    }
+  }
+
+  test("ShowTables: namespace is not specified and default v2 catalog is set") {
+    withSQLConf(SQLConf.DEFAULT_CATALOG.key -> catalog) {
+      withTable(s"$catalog.table") {
+        spark.sql(s"CREATE TABLE $catalog.table (id bigint, data string) USING foo")
+        // v2 catalog is used where default namespace is empty for TestInMemoryTableCatalog.
+        runShowTablesSql("SHOW TABLES", Seq(Row("", "table")))
+      }
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
@@ -26,7 +26,8 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{StringType, StructType}
 
 class ShowTablesSuite extends QueryTest with SharedSparkSession with CommonShowTablesSuite {
-  override def catalog: String = "test_catalog_v2"
+  override def version: String = "V2"
+  override def catalog: String = "test_catalog"
   override def defaultNamespace: Seq[String] = Nil
   override protected def defaultUsing: String = "USING _"
   override protected def showSchema: StructType = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
@@ -55,6 +55,7 @@ class ShowTablesSuite extends QueryTest with SharedSparkSession with CommonShowT
     super.afterAll()
   }
 
+  // The test fails with the exception `NoSuchDatabaseException` in V1 catalog.
   test("show table in a not existing namespace") {
     runShowTablesSql(s"SHOW TABLES IN $catalog.unknown", Seq())
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
@@ -72,14 +72,6 @@ class ShowTablesSuite extends QueryTest with SharedSparkSession with CommonShowT
     }
   }
 
-  test("ShowViews: using v2 catalog, command not supported.") {
-    val exception = intercept[AnalysisException] {
-      sql(s"SHOW VIEWS FROM $catalog")
-    }
-    assert(exception.getMessage.contains(s"Catalog $catalog doesn't support SHOW VIEWS," +
-      " only SessionCatalog supports this command."))
-  }
-
   test("ShowTables: using v2 catalog with empty namespace") {
     withTable(s"$catalog.table") {
       spark.sql(s"CREATE TABLE $catalog.table (id bigint, data string) $defaultUsing")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
@@ -59,14 +59,10 @@ class ShowTablesSuite extends QueryTest with SharedSparkSession with CommonShowT
     runShowTablesSql(s"SHOW TABLES IN $catalog.unknown", Seq())
   }
 
-  test("ShowTables: using v2 catalog") {
-    withTable(s"$catalog.db.table_name") {
-      spark.sql(s"CREATE TABLE $catalog.db.table_name (id bigint, data string) $defaultUsing")
-      runShowTablesSql(
-        s"SHOW TABLES FROM $catalog.db",
-        Seq(ShowRow("db", "table_name", false)))
-    }
-
+  // The test fails for V1 catalog with the error:
+  // org.apache.spark.sql.AnalysisException:
+  //   The namespace in session catalog must have exactly one name part: spark_catalog.n1.n2.db
+  test("show tables in nested namespaces") {
     withTable(s"$catalog.n1.n2.db") {
       spark.sql(s"CREATE TABLE $catalog.n1.n2.db.table_name (id bigint, data string) $defaultUsing")
       runShowTablesSql(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.types.{StringType, StructType}
 
 class ShowTablesSuite extends QueryTest with SharedSparkSession with CommonShowTablesSuite {
   override def catalog: String = "test_catalog_v2"
+  override protected def defaultUsing: String = "USING foo"
   override protected def namespaceColumn: String = "namespace"
   override protected def showSchema: StructType = {
     new StructType()
@@ -71,36 +72,6 @@ class ShowTablesSuite extends QueryTest with SharedSparkSession with CommonShowT
       runShowTablesSql(
         s"SHOW TABLES FROM $catalog.n1.n2.db",
         Seq(ShowRow("n1.n2.db", "table_name", false)))
-    }
-  }
-
-  test("ShowTables: using v2 catalog with a pattern") {
-    withTable(
-      s"$catalog.db.table",
-      s"$catalog.db.table_name_1",
-      s"$catalog.db.table_name_2",
-      s"$catalog.db2.table_name_2") {
-      spark.sql(s"CREATE TABLE $catalog.db.table (id bigint, data string) USING foo")
-      spark.sql(s"CREATE TABLE $catalog.db.table_name_1 (id bigint, data string) USING foo")
-      spark.sql(s"CREATE TABLE $catalog.db.table_name_2 (id bigint, data string) USING foo")
-      spark.sql(s"CREATE TABLE $catalog.db2.table_name_2 (id bigint, data string) USING foo")
-
-      runShowTablesSql(
-        s"SHOW TABLES FROM $catalog.db",
-        Seq(
-          ShowRow("db", "table", false),
-          ShowRow("db", "table_name_1", false),
-          ShowRow("db", "table_name_2", false)))
-
-      runShowTablesSql(
-        s"SHOW TABLES FROM $catalog.db LIKE '*name*'",
-        Seq(
-          ShowRow("db", "table_name_1", false),
-          ShowRow("db", "table_name_2", false)))
-
-      runShowTablesSql(
-        s"SHOW TABLES FROM $catalog.db LIKE '*2'",
-        Seq(ShowRow("db", "table_name_2", false)))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
@@ -72,7 +72,10 @@ class ShowTablesSuite extends QueryTest with SharedSparkSession with CommonShowT
     }
   }
 
-  test("ShowTables: using v2 catalog with empty namespace") {
+  // The test fails for V1 catalog with the error:
+  // org.apache.spark.sql.AnalysisException:
+  //   The namespace in session catalog must have exactly one name part: spark_catalog.table
+  test("using v2 catalog with empty namespace") {
     withTable(s"$catalog.table") {
       spark.sql(s"CREATE TABLE $catalog.table (id bigint, data string) $defaultUsing")
       runShowTablesSql(s"SHOW TABLES FROM $catalog", Seq(ShowRow("", "table", false)))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
@@ -18,24 +18,23 @@
 package org.apache.spark.sql.execution.command.v2
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.analysis.NoSuchDatabaseException
 import org.apache.spark.sql.connector.InMemoryTableCatalog
 import org.apache.spark.sql.execution.command.{ShowTablesSuite => CommonShowTablesSuite}
-import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{StringType, StructType}
 
 class ShowTablesSuite extends CommonShowTablesSuite {
   override def version: String = "V2"
   override def catalog: String = "test_catalog"
   override def defaultNamespace: Seq[String] = Nil
-  override protected def defaultUsing: String = "USING _"
-  override protected def showSchema: StructType = {
+  override def defaultUsing: String = "USING _"
+  override def showSchema: StructType = {
     new StructType()
       .add("namespace", StringType, nullable = false)
       .add("tableName", StringType, nullable = false)
   }
-  override protected def getRows(showRows: Seq[ShowRow]): Seq[Row] = {
+  override def getRows(showRows: Seq[ShowRow]): Seq[Row] = {
     showRows.map {
       case ShowRow(namespace, table, _) => Row(namespace, table)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
@@ -18,13 +18,13 @@
 package org.apache.spark.sql.execution.command.v2
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.catalyst.analysis.NoSuchDatabaseException
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.catalyst.analysis.NoSuchDatabaseException
 import org.apache.spark.sql.connector.InMemoryTableCatalog
 import org.apache.spark.sql.execution.command.{ShowTablesSuite => CommonShowTablesSuite}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.{BooleanType, StringType, StructType}
+import org.apache.spark.sql.types.{StringType, StructType}
 
 class ShowTablesSuite extends QueryTest with SharedSparkSession with CommonShowTablesSuite {
   override def catalog: String = "test_catalog_v2"
@@ -71,14 +71,10 @@ class ShowTablesSuite extends QueryTest with SharedSparkSession with CommonShowT
     }
   }
 
-  // The test fails for V1 catalog with the error:
-  // org.apache.spark.sql.AnalysisException:
-  //   The namespace in session catalog must have exactly one name part: spark_catalog.table
-  test("namespace is not specified and default v2 catalog is set") {
+  test("namespace is not specified and the default catalog is set") {
     withSQLConf(SQLConf.DEFAULT_CATALOG.key -> catalog) {
-      withTable(s"$catalog.table") {
-        spark.sql(s"CREATE TABLE $catalog.table (id bigint, data string) $defaultUsing")
-        // v2 catalog is used where default namespace is empty for TestInMemoryTableCatalog.
+      withTable("table") {
+        spark.sql(s"CREATE TABLE table (id bigint, data string) $defaultUsing")
         runShowTablesSql("SHOW TABLES", Seq(ShowRow("", "table", false)))
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
@@ -41,4 +41,8 @@ class ShowTablesSuite extends QueryTest with SharedSparkSession with CommonShowT
     sql(s"DROP DATABASE $catalog.$namespace")
     super.afterAll()
   }
+
+  test("show table in a not existing namespace") {
+    checkAnswer(sql(s"SHOW TABLES IN $catalog.bad_test"), Seq())
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to gather common `SHOW TABLES` tests into one trait `org.apache.spark.sql.execution.command.ShowTablesSuite`, and put datasource specific tests to the `v1.ShowTablesSuite` and `v2.ShowTablesSuite`. Also tests for parsing `SHOW TABLES` are extracted to `ShowTablesParserSuite`.

### Why are the changes needed?
- The unification will allow to run common `SHOW TABLES` tests for both DSv1 and DSv2
- We can detect missing features and differences between DSv1 and DSv2 implementations.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
By running new test suites:
- `org.apache.spark.sql.execution.command.v1.ShowTablesSuite`
- `org.apache.spark.sql.execution.command.v2.ShowTablesSuite`
- `ShowTablesParserSuite`