### PR TITLE
[SPARK-33420][SQL] Fix BroadCastJoin failure when keys on join side has cast from DateTyte to String

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -110,6 +110,7 @@ object Cast {
     case (StringType, TimestampType | DateType) => true
     case (TimestampType | DateType, StringType) => true
     case (DateType, TimestampType) => true
+    case (DateType, StringType) => true
     case (TimestampType, DateType) => true
     case (ArrayType(fromType, _), ArrayType(toType, _)) => needsTimeZone(fromType, toType)
     case (MapType(fromKey, fromValue, _), MapType(toKey, toValue, _)) =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
Fix BroadCastJoin failure when keys on join side has cast from DateTyte to String
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?

1.In Expression#canonicalized, Canonicalize.execute method will be called. In it the ignoreTimeZone method will judge CastBase. If it does not need timeZone, timeZone will be forced to be removed。
```
object Canonicalize extends Logging{
    def execute(e: Expression): Expression = {
      expressionReorder(ignoreTimeZone(ignoreNamesTypes(e)))
    }
    private[expressions] def ignoreTimeZone(e: Expression): Expression = e match {
    case c: CastBase if c.timeZoneId.nonEmpty && !c.needsTimeZone =>
      logDebug(s"e:${e} ignoreTimeZone")
      c.withTimeZone(null)
    case _ => e
  }
  }
```
2.The CastBase#needsTimeZone method will call the Cast#needsTimeZone method to judge,
```
  def needsTimeZone(from: DataType, to: DataType): Boolean = (from, to) match {
            case (StringType, TimestampType | DateType) => true
            case (DateType, TimestampType) => true
            case (TimestampType, StringType) => true
            case (TimestampType, DateType) => true
            case (ArrayType(fromType, _), ArrayType(toType, _)) => needsTimeZone(fromType, toType)
            case (MapType(fromKey, fromValue, _), MapType(toKey, toValue, _)) =>
              needsTimeZone(fromKey, toKey) || needsTimeZone(fromValue, toValue)
            case (StructType(fromFields), StructType(toFields)) =>
              fromFields.length == toFields.length &&
                fromFields.zip(toFields).exists {
                  case (fromField, toField) =>
                    needsTimeZone(fromField.dataType, toField.dataType)
                }
            case _ => false
          }
```

It can be seen here that if from DateType to StringType, the judgment result is false, indicating that cast(DateTyte as String) does not require Timezone


3. But the conversion from Datetype to String in Cast requires Timezone, as following:

```
abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression with NullIntolerant {
        private lazy val dateFormatter = DateFormatter(zoneId)

        private[this] def cast(from: DataType, to: DataType): Any => Any = {
            if (DataType.equalsStructurally(from, to)) {
              identity
            } else if (from == NullType) {
              _ => throw new SparkException(s"should not directly cast from NullType to $to.")
            } else {
              to match {
                case dt if dt == from => identity[Any]
                case StringType => castToString(from)
                case BinaryType => castToBinary(from)
                case DateType => castToDate(from)
                case decimal: DecimalType => castToDecimal(from, decimal)
                case TimestampType => castToTimestamp(from)
                case CalendarIntervalType => castToInterval(from)
                case BooleanType => castToBoolean(from)
                case ByteType => castToByte(from)
                case ShortType => castToShort(from)
                case IntegerType => castToInt(from)
                case FloatType => castToFloat(from)
                case LongType => castToLong(from)
                case DoubleType => castToDouble(from)
                case array: ArrayType =>
                  castArray(from.asInstanceOf[ArrayType].elementType, array.elementType)
                case map: MapType => castMap(from.asInstanceOf[MapType], map)
                case struct: StructType => castStruct(from.asInstanceOf[StructType], struct)
                case udt: UserDefinedType[_]
                  if udt.userClass == from.asInstanceOf[UserDefinedType[_]].userClass =>
                  identity[Any]
                case _: UserDefinedType[_] =>
                  throw new SparkException(s"Cannot cast $from to $to.")
              }
            }

            private[this] def castToString(from: DataType): Any => Any = from match {
              case CalendarIntervalType =>
                buildCast[CalendarInterval](_, i => UTF8String.fromString(i.toString))
              case BinaryType => buildCast[Array[Byte]](_, UTF8String.fromBytes)
              case DateType => buildCast[Int](_, d => UTF8String.fromString(dateFormatter.format(d)))
              case TimestampType => buildCast[Long](_,
                t => UTF8String.fromString(DateTimeUtils.timestampToString(timestampFormatter, t)))
            }
        }
 trait TimeZoneAwareExpression extends Expression {
          def timeZoneId: Option[String]
          def withTimeZone(timeZoneId: String): TimeZoneAwareExpression

          @transient lazy val zoneId: ZoneId = DateTimeUtils.getZoneId(timeZoneId.get)
        }
```
4. So we should add judge in Cast#needsTimeZone as following:
```
def needsTimeZone(from: DataType, to: DataType): Boolean = (from, to) match {
            case (StringType, TimestampType | DateType) => true
            case (DateType, TimestampType) => true
            case (DateType, StringType) => true
            case (TimestampType, StringType) => true
            case (TimestampType, DateType) => true
            case (ArrayType(fromType, _), ArrayType(toType, _)) => needsTimeZone(fromType, toType)
            case (MapType(fromKey, fromValue, _), MapType(toKey, toValue, _)) =>
              needsTimeZone(fromKey, toKey) || needsTimeZone(fromValue, toValue)
            case (StructType(fromFields), StructType(toFields)) =>
              fromFields.length == toFields.length &&
                fromFields.zip(toFields).exists {
                  case (fromField, toField) =>
                    needsTimeZone(fromField.dataType, toField.dataType)
                }
            case _ => false
          }
``` 


<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
