### PR TITLE
[SPARK-33128][SQL] Remove EXCEPT, INTERSECT, MINUS, UNION from strictNonReserved

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -1208,18 +1208,14 @@ ansiNonReserved
 strictNonReserved
     : ANTI
     | CROSS
-    | EXCEPT
     | FULL
     | INNER
-    | INTERSECT
     | JOIN
     | LEFT
     | NATURAL
     | ON
     | RIGHT
     | SEMI
-    | SETMINUS
-    | UNION
     | USING
     ;
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -1031,4 +1031,15 @@ class PlanParserSuite extends AnalysisTest {
     assertEqual("select a, b from db.c;;;", table("db", "c").select('a, 'b))
     assertEqual("select a, b from db.c; ;;  ;", table("db", "c").select('a, 'b))
   }
+
+  test("SPARK-33128: Remove EXCEPT, INTERSECT, MINUS, UNION from strictNonReserved") {
+    assertEqual("SELECT 1 EXCEPT SELECT 1",
+      OneRowRelation().select(1).except(OneRowRelation().select(1), false))
+    assertEqual("SELECT 1 INTERSECT SELECT 1",
+      OneRowRelation().select(1).intersect(OneRowRelation().select(1), false))
+    assertEqual("SELECT 1 MINUS SELECT 1",
+      OneRowRelation().select(1).except(OneRowRelation().select(1), false))
+    assertEqual("SELECT 1 UNION SELECT 1",
+      Distinct(OneRowRelation().select(1).union(OneRowRelation().select(1))))
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pr removes `EXCEPT`, `INTERSECT`, `MINUS` and `UNION` from strictNonReserved.


### Why are the changes needed?

1. This is a regression since Spark 3.0.
2. `EXCEPT`, `INTERSECT` and `UNION` are all reserved, Please see https://www.postgresql.org/docs/12/sql-keywords-appendix.html for more details.

### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Unit test.
