### PR TITLE
[SPARK-32240][SQL] Use URL to parse url string

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -1401,13 +1401,7 @@ case class ParseUrl(children: Seq[Expression])
       case QUERY => _.getQuery
       case REF => _.getRef
       case PROTOCOL => _.getProtocol
-      case FILE =>
-        (url: URL) =>
-          if (url.getPath ne null) {
-            url.getPath + "?" + url.getQuery
-          } else {
-            url.getPath
-          }
+      case FILE => _.getFile
       case AUTHORITY => _.getAuthority
       case USERINFO => _.getUserInfo
       case _ => (url: URL) => null

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
@@ -904,6 +904,7 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     }
 
     checkParseUrl("spark.apache.org", "http://spark.apache.org/path?query=1", "HOST")
+    checkParseUrl("a.b.c", "https://a.b.c/index.php?params1=a|b&params2=x", "HOST")
     checkParseUrl("/path", "http://spark.apache.org/path?query=1", "PATH")
     checkParseUrl("query=1", "http://spark.apache.org/path?query=1", "QUERY")
     checkParseUrl("Ref", "http://spark.apache.org/path?query=1#Ref", "REF")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Change `URI` back to `URL`.

The issue JIRA [SPARK-32240](https://issues.apache.org/jira/browse/SPARK-32240).
Some history [#14008](https://github.com/apache/spark/pull/14008) and [#14488](https://github.com/apache/spark/pull/14488).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
```
select parse_url('https://a.b.c/index.php?params1=a|b&params2=x', 'HOST')

-- before this PR
null

-- after this PR
a.b.c
```

Hive also use `URL` to parse url string.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, correct the result.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Add test.