### PR TITLE
[SPARK-33422][DOC] Fix the correct display of left menu item

### DIFF
--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -325,6 +325,7 @@ a.anchorjs-link:hover { text-decoration: none; }
   border-bottom-width: 0px;
   margin-top: 0px;
   width: 210px;
+  height:80%;
   float: left;
   position: fixed;
   overflow-y: scroll;

--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -325,7 +325,7 @@ a.anchorjs-link:hover { text-decoration: none; }
   border-bottom-width: 0px;
   margin-top: 0px;
   width: 210px;
-  height:80%;
+  height: 80%;
   float: left;
   position: fixed;
   overflow-y: scroll;

--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -162,6 +162,7 @@ body .container-wrapper {
   margin-right: auto;
   border-radius: 15px;
   position: relative;
+  min-height: 100vh;
 }
 
 .title {
@@ -264,6 +265,7 @@ a:hover code {
   max-width: 914px;
   line-height: 1.6; /* Inspired by Github's wiki style */
   padding-left: 30px;
+  min-height: 100vh;
 }
 
 .dropdown-menu {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Limit the height of the menu area on the left to display vertical scroll bar


### Why are the changes needed?

The bottom menu item cannot be displayed when the left menu tree is long

### Does this PR introduce any user-facing change?

Yes, if the menu item shows more, you'll see it by pulling down the vertical scroll bar

before:
![image](https://user-images.githubusercontent.com/28332082/98805115-16995d80-2452-11eb-933a-3b72c14bea78.png)

after:
![image](https://user-images.githubusercontent.com/28332082/98805418-7e4fa880-2452-11eb-9a9b-8d265078297c.png)

### How was this patch tested?
NA
