### PR TITLE
[SPARK-33425] Fix https credentials when doing spark-submit

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -747,7 +747,7 @@ private[spark] object Utils extends Logging {
         val uc = url_object.openConnection().asInstanceOf[HttpURLConnection]
         uc.setDoInput(true)
         uc.setRequestMethod("GET")
-        if (!url_object.getUserInfo.isEmpty) {
+        if (url_object.getUserInfo != null) {
           uc.setRequestProperty(
             "Authorization",
             "Basic " + Base64.encodeBase64(url_object.getUserInfo.getBytes))


### PR DESCRIPTION
When using:
```
./bin/spark-submit \
  --class org.apache.spark.examples.SparkPi \
  --master k8s://xx.yy.zz.ww:443 \
  --deploy-mode cluster \
  --executor-memory 20G \
  --num-executors 50 \
  https://user:password@path/to/examples.jar \
  1000
```
I receive an error described in https://issues.apache.org/jira/browse/SPARK-33425

### What changes were proposed in this pull request?
Passing credentials to the request properties so there's no need for a server to challenge the URLConnection for credentials. 


### Why are the changes needed?
Documentations says:
> (Note that credentials for password-protected repositories can be supplied in some cases in the repository URI, such as in https://user:password@host/.... Be careful when supplying credentials this way.)
However, that feature doesn't work.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Not tested yet. Looking for feedback.