### PR TITLE
[SPARK-33426][SQL][TESTS] Unify Hive SHOW TABLES tests

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
@@ -116,6 +116,7 @@ trait ShowTablesSuite extends SharedSparkSession {
         // Update the current namespace to match "ns.tbl".
         sql(s"USE $catalog.ns")
         runShowTablesSql("SHOW TABLES", Seq(ShowRow("ns", "table", false)))
+        sql(s"USE default")
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
@@ -116,7 +116,7 @@ trait ShowTablesSuite extends SharedSparkSession {
         // Update the current namespace to match "ns.tbl".
         sql(s"USE $catalog.ns")
         runShowTablesSql("SHOW TABLES", Seq(ShowRow("ns", "table", false)))
-        sql(s"USE default")
+        defaultNamespace.headOption.foreach(ns => sql(s"USE $ns"))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
@@ -20,13 +20,13 @@ package org.apache.spark.sql.execution.command
 import org.scalactic.source.Position
 import org.scalatest.Tag
 
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
 
-trait ShowTablesSuite extends SharedSparkSession {
+trait ShowTablesSuite extends QueryTest with SharedSparkSession {
   protected def version: String
   protected def catalog: String
   protected def defaultNamespace: Seq[String]
@@ -39,7 +39,7 @@ trait ShowTablesSuite extends SharedSparkSession {
   protected def runShowTablesSql(sqlText: String, expected: Seq[ShowRow]): Unit = {
     val df = spark.sql(sqlText)
     assert(df.schema === showSchema)
-    assert(df.collect().toSet === getRows(expected).toSet)
+    checkAnswer(df, getRows(expected))
   }
 
   override def test(testName: String, testTags: Tag*)(testFun: => Any)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
@@ -23,10 +23,10 @@ import org.scalatest.Tag
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SQLTestUtils
 import org.apache.spark.sql.types.StructType
 
-trait ShowTablesSuite extends QueryTest with SharedSparkSession {
+trait ShowTablesSuite extends QueryTest with SQLTestUtils {
   protected def version: String
   protected def catalog: String
   protected def defaultNamespace: Seq[String]

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
@@ -58,15 +58,18 @@ trait ShowTablesSuite extends SharedSparkSession {
   }
 
   test("show tables with a pattern") {
-    withNamespace(s"$catalog.ns1") {
+    withNamespace(s"$catalog.ns1", s"$catalog.ns2") {
       sql(s"CREATE NAMESPACE $catalog.ns1")
+      sql(s"CREATE NAMESPACE $catalog.ns2")
       withTable(
         s"$catalog.ns1.table",
         s"$catalog.ns1.table_name_1a",
-        s"$catalog.ns1.table_name_2b") {
+        s"$catalog.ns1.table_name_2b",
+        s"$catalog.ns2.table_name_2b") {
         sql(s"CREATE TABLE $catalog.ns1.table (id bigint, data string) $defaultUsing")
         sql(s"CREATE TABLE $catalog.ns1.table_name_1a (id bigint, data string) $defaultUsing")
         sql(s"CREATE TABLE $catalog.ns1.table_name_2b (id bigint, data string) $defaultUsing")
+        sql(s"CREATE TABLE $catalog.ns2.table_name_2b (id bigint, data string) $defaultUsing")
 
         runShowTablesSql(
           s"SHOW TABLES FROM $catalog.ns1",

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuiteBase.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SQLTestUtils
 import org.apache.spark.sql.types.StructType
 
-trait ShowTablesSuite extends QueryTest with SQLTestUtils {
+trait ShowTablesSuiteBase extends QueryTest with SQLTestUtils {
   protected def version: String
   protected def catalog: String
   protected def defaultNamespace: Seq[String]

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -21,9 +21,10 @@ import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.analysis.NoSuchDatabaseException
 import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.execution.command.{ShowTablesSuite => CommonShowTablesSuite}
+import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{BooleanType, StringType, StructType}
 
-class ShowTablesSuite extends CommonShowTablesSuite {
+trait ShowTablesTests extends CommonShowTablesSuite {
   override def version: String = "V1"
   override def catalog: String = CatalogManager.SESSION_CATALOG_NAME
   override def defaultNamespace: Seq[String] = Seq("default")
@@ -93,3 +94,5 @@ class ShowTablesSuite extends CommonShowTablesSuite {
     }
   }
 }
+
+class ShowTablesSuite extends ShowTablesTests with SharedSparkSession

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -20,11 +20,11 @@ package org.apache.spark.sql.execution.command.v1
 import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.analysis.NoSuchDatabaseException
 import org.apache.spark.sql.connector.catalog.CatalogManager
-import org.apache.spark.sql.execution.command.{ShowTablesSuite => CommonShowTablesSuite}
+import org.apache.spark.sql.execution.command
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{BooleanType, StringType, StructType}
 
-trait ShowTablesTests extends CommonShowTablesSuite {
+trait ShowTablesSuiteBase extends command.ShowTablesSuiteBase {
   override def version: String = "V1"
   override def catalog: String = CatalogManager.SESSION_CATALOG_NAME
   override def defaultNamespace: Seq[String] = Seq("default")
@@ -95,4 +95,4 @@ trait ShowTablesTests extends CommonShowTablesSuite {
   }
 }
 
-class ShowTablesSuite extends ShowTablesTests with SharedSparkSession
+class ShowTablesSuite extends ShowTablesSuiteBase with SharedSparkSession

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
@@ -21,11 +21,11 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.analysis.NoSuchDatabaseException
 import org.apache.spark.sql.connector.InMemoryTableCatalog
-import org.apache.spark.sql.execution.command.{ShowTablesSuite => CommonShowTablesSuite}
+import org.apache.spark.sql.execution.command
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{StringType, StructType}
 
-class ShowTablesSuite extends CommonShowTablesSuite with SharedSparkSession {
+class ShowTablesSuite extends command.ShowTablesSuiteBase with SharedSparkSession {
   override def version: String = "V2"
   override def catalog: String = "test_catalog"
   override def defaultNamespace: Seq[String] = Nil

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
@@ -22,9 +22,10 @@ import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.analysis.NoSuchDatabaseException
 import org.apache.spark.sql.connector.InMemoryTableCatalog
 import org.apache.spark.sql.execution.command.{ShowTablesSuite => CommonShowTablesSuite}
+import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{StringType, StructType}
 
-class ShowTablesSuite extends CommonShowTablesSuite {
+class ShowTablesSuite extends CommonShowTablesSuite with SharedSparkSession {
   override def version: String = "V2"
   override def catalog: String = "test_catalog"
   override def defaultNamespace: Seq[String] = Nil

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
@@ -95,28 +95,6 @@ class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
     }
   }
 
-  test("show tables") {
-    withTable("show1a", "show2b") {
-      sql("CREATE TABLE show1a(c1 int)")
-      sql("CREATE TABLE show2b(c2 int)")
-      checkAnswer(
-        sql("SHOW TABLES IN default 'show1*'"),
-        Row("default", "show1a", false) :: Nil)
-      checkAnswer(
-        sql("SHOW TABLES IN default 'show1*|show2*'"),
-        Row("default", "show1a", false) ::
-          Row("default", "show2b", false) :: Nil)
-      checkAnswer(
-        sql("SHOW TABLES 'show1*|show2*'"),
-        Row("default", "show1a", false) ::
-          Row("default", "show2b", false) :: Nil)
-      assert(
-        sql("SHOW TABLES").count() >= 2)
-      assert(
-        sql("SHOW TABLES IN default").count() >= 2)
-    }
-  }
-
   test("show views") {
     withView("show1a", "show2b", "global_temp.temp1", "temp2") {
       sql("CREATE VIEW show1a AS SELECT 1 AS id")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowTablesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowTablesSuite.scala
@@ -26,24 +26,4 @@ class ShowTablesSuite extends v1.ShowTablesSuite {
   override def defaultUsing: String = "USING HIVE"
   override protected val spark: SparkSession = TestHive.sparkSession
   protected override def beforeAll(): Unit = {}
-
-  test("show Hive tables") {
-    withTable("show1a", "show2b") {
-      sql("CREATE TABLE show1a(c1 int)")
-      sql("CREATE TABLE show2b(c2 int)")
-      runShowTablesSql(
-        "SHOW TABLES IN default 'show1*'",
-        ShowRow("default", "show1a", false) :: Nil)
-      runShowTablesSql(
-        "SHOW TABLES IN default 'show1*|show2*'",
-        ShowRow("default", "show1a", false) ::
-          ShowRow("default", "show2b", false) :: Nil)
-      runShowTablesSql(
-        "SHOW TABLES 'show1*|show2*'",
-        ShowRow("default", "show1a", false) ::
-          ShowRow("default", "show2b", false) :: Nil)
-      assert(sql("SHOW TABLES").count() >= 2)
-      assert(sql("SHOW TABLES IN default").count() >= 2)
-    }
-  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowTablesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowTablesSuite.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive.execution.command
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.execution.command.v1
+import org.apache.spark.sql.hive.test.TestHive
+
+class ShowTablesSuite extends v1.ShowTablesSuite {
+  override def version: String = "Hive V1"
+  override def defaultUsing: String = "USING HIVE"
+  override protected val spark: SparkSession = TestHive.sparkSession
+  protected override def beforeAll(): Unit = {}
+
+  test("show Hive tables") {
+    withTable("show1a", "show2b") {
+      sql("CREATE TABLE show1a(c1 int)")
+      sql("CREATE TABLE show2b(c2 int)")
+      runShowTablesSql(
+        "SHOW TABLES IN default 'show1*'",
+        ShowRow("default", "show1a", false) :: Nil)
+      runShowTablesSql(
+        "SHOW TABLES IN default 'show1*|show2*'",
+        ShowRow("default", "show1a", false) ::
+          ShowRow("default", "show2b", false) :: Nil)
+      runShowTablesSql(
+        "SHOW TABLES 'show1*|show2*'",
+        ShowRow("default", "show1a", false) ::
+          ShowRow("default", "show2b", false) :: Nil)
+      assert(sql("SHOW TABLES").count() >= 2)
+      assert(sql("SHOW TABLES IN default").count() >= 2)
+    }
+  }
+}

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowTablesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowTablesSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.hive.execution.command
 import org.apache.spark.sql.execution.command.v1
 import org.apache.spark.sql.hive.test.TestHiveSingleton
 
-class ShowTablesSuite extends v1.ShowTablesTests with TestHiveSingleton {
+class ShowTablesSuite extends v1.ShowTablesSuiteBase with TestHiveSingleton {
   override def version: String = "Hive V1"
   override def defaultUsing: String = "USING HIVE"
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowTablesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowTablesSuite.scala
@@ -17,13 +17,10 @@
 
 package org.apache.spark.sql.hive.execution.command
 
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.command.v1
-import org.apache.spark.sql.hive.test.TestHive
+import org.apache.spark.sql.hive.test.TestHiveSingleton
 
-class ShowTablesSuite extends v1.ShowTablesSuite {
+class ShowTablesSuite extends v1.ShowTablesTests with TestHiveSingleton {
   override def version: String = "Hive V1"
   override def defaultUsing: String = "USING HIVE"
-  override protected val spark: SparkSession = TestHive.sparkSession
-  protected override def beforeAll(): Unit = {}
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Create the separate test suite `org.apache.spark.sql.hive.execution.command.ShowTablesSuite`.
2. Re-use V1 SHOW TABLES tests added by https://github.com/apache/spark/pull/30287 in the Hive test suites.
3. Add new test case for the pattern `'table_name_1*|table_name_2*'` in the common test suite.

### Why are the changes needed?
To test V1 + common  SHOW TABLES tests in Hive.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
By running v1/v2 and Hive v1 `ShowTablesSuite`:
```
$  build/sbt -Phive-2.3 -Phive-thriftserver "test:testOnly *ShowTablesSuite"
```