### PR TITLE
[SPARK-33209][SS] Refactor unit test of stream-stream join in UnsupportedOperationsSuite

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
@@ -293,7 +293,7 @@ object UnsupportedOperationChecker extends Logging {
 
             case LeftAnti =>
               if (right.isStreaming) {
-                throwError("Left anti joins with a streaming DataFrame/Dataset " +
+                throwError(s"$LeftAnti joins with a streaming DataFrame/Dataset " +
                     "on the right are not supported")
               }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
@@ -412,7 +412,7 @@ class UnsupportedOperationsSuite extends SparkFunSuite {
     batchStreamSupported = false,
     streamBatchSupported = false)
 
-  // Left outer, left semi, left anti join: *-stream not allowed
+  // Left outer join, left semi join, left anti join: *-stream not allowed
   Seq((LeftOuter, "LeftOuter join"), (LeftSemi, "LeftSemi join"), (LeftAnti, "Left anti join"))
     .foreach { case (joinType, name) =>
       testBinaryOperationInStreamingPlan(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
@@ -384,239 +384,166 @@ class UnsupportedOperationsSuite extends SparkFunSuite {
     outputMode = Append
   )
 
-  // Inner joins: Multiple stream-stream joins supported only in append mode
-  testBinaryOperationInStreamingPlan(
-    "single inner join in append mode",
-    _.join(_, joinType = Inner),
-    outputMode = Append,
-    streamStreamSupported = true)
+  // stream-stream join
+  {
+    // Inner joins: Multiple stream-stream joins supported only in append mode
+    testBinaryOperationInStreamingPlan(
+      "single inner join in append mode",
+      _.join(_, joinType = Inner),
+      outputMode = Append)
 
-  testBinaryOperationInStreamingPlan(
-    "multiple inner joins in append mode",
-    (x: LogicalPlan, y: LogicalPlan) => {
-      x.join(y, joinType = Inner).join(streamRelation, joinType = Inner)
-    },
-    outputMode = Append,
-    streamStreamSupported = true)
+    testBinaryOperationInStreamingPlan(
+      "multiple inner joins in append mode",
+      (x: LogicalPlan, y: LogicalPlan) => {
+        x.join(y, joinType = Inner).join(streamRelation, joinType = Inner)
+      },
+      outputMode = Append)
 
-  testBinaryOperationInStreamingPlan(
-    "inner join in update mode",
-    _.join(_, joinType = Inner),
-    outputMode = Update,
-    streamStreamSupported = false,
-    expectedMsg = "is not supported in Update output mode")
+    testBinaryOperationInStreamingPlan(
+      "inner join in update mode",
+      _.join(_, joinType = Inner),
+      outputMode = Update,
+      streamStreamSupported = false,
+      expectedMsg = "is not supported in Update output mode")
 
-  // Full outer joins: only batch-batch is allowed
-  testBinaryOperationInStreamingPlan(
-    "full outer join",
-    _.join(_, joinType = FullOuter),
-    streamStreamSupported = false,
-    batchStreamSupported = false,
-    streamBatchSupported = false)
+    // Full outer joins: only batch-batch is allowed
+    testBinaryOperationInStreamingPlan(
+      "full outer join",
+      _.join(_, joinType = FullOuter),
+      streamStreamSupported = false,
+      batchStreamSupported = false,
+      streamBatchSupported = false)
 
-  // Left outer joins: *-stream not allowed
-  testBinaryOperationInStreamingPlan(
-    "left outer join",
-    _.join(_, joinType = LeftOuter),
-    batchStreamSupported = false,
-    streamStreamSupported = false,
-    expectedMsg = "outer join")
+    // Left outer, left semi, left anti join: *-stream not allowed
+    Seq((LeftOuter, "LeftOuter join"), (LeftSemi, "LeftSemi join"), (LeftAnti, "Left anti join"))
+      .foreach { case (joinType, name) =>
+        testBinaryOperationInStreamingPlan(
+          name,
+          _.join(_, joinType = joinType),
+          batchStreamSupported = false,
+          streamStreamSupported = false,
+          expectedMsg = name)
+      }
 
-  // Left outer joins: update and complete mode not allowed
-  assertNotSupportedInStreamingPlan(
-    s"left outer join with stream-stream relations and update mode",
-    streamRelation.join(streamRelation, joinType = LeftOuter,
-      condition = Some(attribute === attribute)),
-    OutputMode.Update(),
-    Seq("is not supported in Update output mode"))
-  assertNotSupportedInStreamingPlan(
-    s"left outer join with stream-stream relations and complete mode",
-    Aggregate(Nil, aggExprs("d"), streamRelation.join(streamRelation, joinType = LeftOuter,
-      condition = Some(attribute === attribute))),
-    OutputMode.Complete(),
-    Seq("is not supported in Complete output mode"))
+    // Right outer joins: stream-* not allowed
+    testBinaryOperationInStreamingPlan(
+      "right outer join",
+      _.join(_, joinType = RightOuter),
+      streamBatchSupported = false,
+      streamStreamSupported = false,
+      expectedMsg = "outer join")
 
-  // Left outer joins: stream-stream allowed with join on watermark attribute
-  // Note that the attribute need not be watermarked on both sides.
-  assertSupportedInStreamingPlan(
-    s"left outer join with stream-stream relations and join on attribute with left watermark",
-    streamRelation.join(streamRelation, joinType = LeftOuter,
-      condition = Some(attributeWithWatermark === attribute)),
-    OutputMode.Append())
-  assertSupportedInStreamingPlan(
-    s"left outer join with stream-stream relations and join on attribute with right watermark",
-    streamRelation.join(streamRelation, joinType = LeftOuter,
-      condition = Some(attribute === attributeWithWatermark)),
-    OutputMode.Append())
-  assertNotSupportedInStreamingPlan(
-    s"left outer join with stream-stream relations and join on non-watermarked attribute",
-    streamRelation.join(streamRelation, joinType = LeftOuter,
-      condition = Some(attribute === attribute)),
-    OutputMode.Append(),
-    Seq("watermark in the join keys"))
+    // Left outer, right outer, left semi joins
+    Seq(LeftOuter, RightOuter, LeftSemi).foreach { joinType =>
+      // Update mode not allowed
+      assertNotSupportedInStreamingPlan(
+        s"$joinType join with stream-stream relations and update mode",
+        streamRelation.join(streamRelation, joinType = joinType,
+          condition = Some(attribute === attribute)),
+        OutputMode.Update(),
+        Seq("is not supported in Update output mode"))
 
-  // Left outer joins: stream-stream allowed with range condition yielding state value watermark
-  assertSupportedInStreamingPlan(
-    s"left outer join with stream-stream relations and state value watermark", {
-      val leftRelation = streamRelation
-      val rightTimeWithWatermark =
+      // Complete mode not allowed
+      assertNotSupportedInStreamingPlan(
+        s"$joinType join with stream-stream relations and complete mode",
+        Aggregate(Nil, aggExprs("d"), streamRelation.join(streamRelation, joinType = joinType,
+          condition = Some(attribute === attribute))),
+        OutputMode.Complete(),
+        Seq("is not supported in Complete output mode"))
+
+      // Stream-stream allowed with join on watermark attribute
+      // Note that the attribute need not be watermarked on both sides.
+      assertSupportedInStreamingPlan(
+        s"$joinType join with stream-stream relations and join on attribute with left watermark",
+        streamRelation.join(streamRelation, joinType = joinType,
+          condition = Some(attributeWithWatermark === attribute)),
+        OutputMode.Append())
+      assertSupportedInStreamingPlan(
+        s"$joinType join with stream-stream relations and join on attribute with right watermark",
+        streamRelation.join(streamRelation, joinType = joinType,
+          condition = Some(attribute === attributeWithWatermark)),
+        OutputMode.Append())
+      assertNotSupportedInStreamingPlan(
+        s"$joinType join with stream-stream relations and join on non-watermarked attribute",
+        streamRelation.join(streamRelation, joinType = joinType,
+          condition = Some(attribute === attribute)),
+        OutputMode.Append(),
+        Seq("without a watermark in the join keys"))
+
+      val timeWithWatermark =
         AttributeReference("b", IntegerType)().withMetadata(watermarkMetadata)
-      val rightRelation = new TestStreamingRelation(rightTimeWithWatermark)
-      leftRelation.join(
-        rightRelation,
-        joinType = LeftOuter,
-        condition = Some(attribute > rightTimeWithWatermark + 10))
-    },
-    OutputMode.Append())
+      val relationWithWatermark = new TestStreamingRelation(timeWithWatermark)
+      val (leftRelation, rightRelation) =
+        if (joinType == RightOuter) {
+          (relationWithWatermark, streamRelation)
+        } else {
+          (streamRelation, relationWithWatermark)
+        }
 
-  // Left outer joins: stream-stream not allowed with insufficient range condition
-  assertNotSupportedInStreamingPlan(
-    s"left outer join with stream-stream relations and state value watermark", {
-      val leftRelation = streamRelation
-      val rightTimeWithWatermark =
-        AttributeReference("b", IntegerType)().withMetadata(watermarkMetadata)
-      val rightRelation = new TestStreamingRelation(rightTimeWithWatermark)
-      leftRelation.join(
-        rightRelation,
-        joinType = LeftOuter,
-        condition = Some(attribute < rightTimeWithWatermark + 10))
-    },
-    OutputMode.Append(),
-    Seq("appropriate range condition"))
+      // stream-stream allowed with range condition yielding state value watermark
+      assertSupportedInStreamingPlan(
+        s"$joinType join with stream-stream relations and state value watermark",
+        leftRelation.join(rightRelation, joinType = joinType,
+          condition = Some(attribute > timeWithWatermark + 10)),
+        OutputMode.Append())
 
-  // Left semi joins: stream-* not allowed
-  testBinaryOperationInStreamingPlan(
-    "left semi join",
-    _.join(_, joinType = LeftSemi),
-    streamStreamSupported = false,
-    batchStreamSupported = false,
-    expectedMsg = "LeftSemi join")
+      // stream-stream not allowed with insufficient range condition
+      assertNotSupportedInStreamingPlan(
+        s"$joinType join with stream-stream relations and state value watermark",
+        leftRelation.join(rightRelation, joinType = joinType,
+          condition = Some(attribute < timeWithWatermark + 10)),
+        OutputMode.Append(),
+        Seq("is not supported without a watermark in the join keys, or a watermark on " +
+          "the nullable side and an appropriate range condition"))
+    }
 
-  // Left semi joins: update and complete mode not allowed
-  assertNotSupportedInStreamingPlan(
-    "left semi join with stream-stream relations and update mode",
-    streamRelation.join(streamRelation, joinType = LeftSemi,
-      condition = Some(attribute === attribute)),
-    OutputMode.Update(),
-    Seq("is not supported in Update output mode"))
-  assertNotSupportedInStreamingPlan(
-    "left semi join with stream-stream relations and complete mode",
-    Aggregate(Nil, aggExprs("d"), streamRelation.join(streamRelation, joinType = LeftSemi,
-      condition = Some(attribute === attribute))),
-    OutputMode.Complete(),
-    Seq("is not supported in Complete output mode"))
+    // stream-stream inner join doesn't emit late rows, whereas outer joins could
+    Seq((Inner, false), (LeftOuter, true), (RightOuter, true)).map {
+      case (joinType, expectFailure) =>
+        assertPassOnGlobalWatermarkLimit(
+          s"single $joinType join in Append mode",
+          streamRelation.join(streamRelation, joinType = RightOuter,
+            condition = Some(attributeWithWatermark === attribute)),
+          OutputMode.Append())
 
-  // Left semi joins: stream-stream allowed with join on watermark attribute
-  // Note that the attribute need not be watermarked on both sides.
-  assertSupportedInStreamingPlan(
-    "left semi join with stream-stream relations and join on attribute with left watermark",
-    streamRelation.join(streamRelation, joinType = LeftSemi,
-      condition = Some(attributeWithWatermark === attribute)),
-    OutputMode.Append())
-  assertSupportedInStreamingPlan(
-    "left semi join with stream-stream relations and join on attribute with right watermark",
-    streamRelation.join(streamRelation, joinType = LeftSemi,
-      condition = Some(attribute === attributeWithWatermark)),
-    OutputMode.Append())
-  assertNotSupportedInStreamingPlan(
-    "left semi join with stream-stream relations and join on non-watermarked attribute",
-    streamRelation.join(streamRelation, joinType = LeftSemi,
-      condition = Some(attribute === attribute)),
-    OutputMode.Append(),
-    Seq("without a watermark in the join keys"))
+        testGlobalWatermarkLimit(
+          s"streaming aggregation after stream-stream $joinType join in Append mode",
+          streamRelation.join(streamRelation, joinType = joinType,
+            condition = Some(attributeWithWatermark === attribute))
+            .groupBy("a")(count("*")),
+          OutputMode.Append(),
+          expectFailure = expectFailure)
 
-  // Left semi joins: stream-stream allowed with range condition yielding state value watermark
-  assertSupportedInStreamingPlan(
-    "left semi join with stream-stream relations and state value watermark", {
-      val leftRelation = streamRelation
-      val rightTimeWithWatermark =
-        AttributeReference("b", IntegerType)().withMetadata(watermarkMetadata)
-      val rightRelation = new TestStreamingRelation(rightTimeWithWatermark)
-      leftRelation.join(
-        rightRelation,
-        joinType = LeftSemi,
-        condition = Some(attribute > rightTimeWithWatermark + 10))
-    },
-    OutputMode.Append())
+        Seq(Inner, LeftOuter, RightOuter).foreach { joinType2 =>
+          testGlobalWatermarkLimit(
+            s"streaming-stream $joinType2 after stream-stream $joinType join in Append mode",
+            streamRelation.join(
+              streamRelation.join(streamRelation, joinType = joinType,
+                condition = Some(attributeWithWatermark === attribute)),
+              joinType = joinType2,
+              condition = Some(attributeWithWatermark === attribute)),
+            OutputMode.Append(),
+            expectFailure = expectFailure)
+        }
 
-  // Left semi joins: stream-stream not allowed with insufficient range condition
-  assertNotSupportedInStreamingPlan(
-    "left semi join with stream-stream relations and state value watermark", {
-      val leftRelation = streamRelation
-      val rightTimeWithWatermark =
-        AttributeReference("b", IntegerType)().withMetadata(watermarkMetadata)
-      val rightRelation = new TestStreamingRelation(rightTimeWithWatermark)
-      leftRelation.join(
-        rightRelation,
-        joinType = LeftSemi,
-        condition = Some(attribute < rightTimeWithWatermark + 10))
-    },
-    OutputMode.Append(),
-    Seq("appropriate range condition"))
+        testGlobalWatermarkLimit(
+          s"FlatMapGroupsWithState after stream-stream $joinType join in Append mode",
+          FlatMapGroupsWithState(
+            null, att, att, Seq(att), Seq(att), att, null, Append,
+            isMapGroupsWithState = false, null,
+            streamRelation.join(streamRelation, joinType = joinType,
+              condition = Some(attributeWithWatermark === attribute))),
+          OutputMode.Append(),
+          expectFailure = expectFailure)
 
-  // Left anti joins: stream-* not allowed
-  testBinaryOperationInStreamingPlan(
-    "left anti join",
-    _.join(_, joinType = LeftAnti),
-    streamStreamSupported = false,
-    batchStreamSupported = false,
-    expectedMsg = "Left anti join")
-
-  // Right outer joins: stream-* not allowed
-  testBinaryOperationInStreamingPlan(
-    "right outer join",
-    _.join(_, joinType = RightOuter),
-    streamBatchSupported = false,
-    streamStreamSupported = false,
-    expectedMsg = "outer join")
-
-  // Right outer joins: stream-stream allowed with join on watermark attribute
-  // Note that the attribute need not be watermarked on both sides.
-  assertSupportedInStreamingPlan(
-    s"right outer join with stream-stream relations and join on attribute with left watermark",
-    streamRelation.join(streamRelation, joinType = RightOuter,
-      condition = Some(attributeWithWatermark === attribute)),
-    OutputMode.Append())
-  assertSupportedInStreamingPlan(
-    s"right outer join with stream-stream relations and join on attribute with right watermark",
-    streamRelation.join(streamRelation, joinType = RightOuter,
-      condition = Some(attribute === attributeWithWatermark)),
-    OutputMode.Append())
-  assertNotSupportedInStreamingPlan(
-    s"right outer join with stream-stream relations and join on non-watermarked attribute",
-    streamRelation.join(streamRelation, joinType = RightOuter,
-      condition = Some(attribute === attribute)),
-    OutputMode.Append(),
-    Seq("watermark in the join keys"))
-
-  // Right outer joins: stream-stream allowed with range condition yielding state value watermark
-  assertSupportedInStreamingPlan(
-    s"right outer join with stream-stream relations and state value watermark", {
-      val leftTimeWithWatermark =
-        AttributeReference("b", IntegerType)().withMetadata(watermarkMetadata)
-      val leftRelation = new TestStreamingRelation(leftTimeWithWatermark)
-      val rightRelation = streamRelation
-      leftRelation.join(
-        rightRelation,
-        joinType = RightOuter,
-        condition = Some(leftTimeWithWatermark + 10 < attribute))
-    },
-    OutputMode.Append())
-
-  // Right outer joins: stream-stream not allowed with insufficient range condition
-  assertNotSupportedInStreamingPlan(
-    s"right outer join with stream-stream relations and state value watermark", {
-      val leftTimeWithWatermark =
-        AttributeReference("b", IntegerType)().withMetadata(watermarkMetadata)
-      val leftRelation = new TestStreamingRelation(leftTimeWithWatermark)
-      val rightRelation = streamRelation
-      leftRelation.join(
-        rightRelation,
-        joinType = RightOuter,
-        condition = Some(leftTimeWithWatermark + 10 > attribute))
-    },
-    OutputMode.Append(),
-    Seq("appropriate range condition"))
+        testGlobalWatermarkLimit(
+          s"deduplicate after stream-stream $joinType join in Append mode",
+          Deduplicate(Seq(attribute), streamRelation.join(streamRelation, joinType = joinType,
+            condition = Some(attributeWithWatermark === attribute))),
+          OutputMode.Append(),
+          expectFailure = expectFailure)
+    }
+  }
 
   // Cogroup: only batch-batch is allowed
   testBinaryOperationInStreamingPlan(
@@ -737,53 +664,6 @@ class UnsupportedOperationsSuite extends SparkFunSuite {
         isMapGroupsWithState = false, null,
         streamRelation.groupBy("a")(count("*"))),
       OutputMode.Append())
-  }
-
-  // stream-stream join
-  // stream-stream inner join doesn't emit late rows, whereas outer joins could
-  Seq((Inner, false), (LeftOuter, true), (RightOuter, true)).map { case (joinType, expectFailure) =>
-    assertPassOnGlobalWatermarkLimit(
-      s"single $joinType join in Append mode",
-      streamRelation.join(streamRelation, joinType = RightOuter,
-        condition = Some(attributeWithWatermark === attribute)),
-      OutputMode.Append())
-
-    testGlobalWatermarkLimit(
-      s"streaming aggregation after stream-stream $joinType join in Append mode",
-      streamRelation.join(streamRelation, joinType = joinType,
-        condition = Some(attributeWithWatermark === attribute))
-        .groupBy("a")(count("*")),
-      OutputMode.Append(),
-      expectFailure = expectFailure)
-
-    Seq(Inner, LeftOuter, RightOuter).map { joinType2 =>
-      testGlobalWatermarkLimit(
-        s"streaming-stream $joinType2 after stream-stream $joinType join in Append mode",
-        streamRelation.join(
-          streamRelation.join(streamRelation, joinType = joinType,
-            condition = Some(attributeWithWatermark === attribute)),
-          joinType = joinType2,
-          condition = Some(attributeWithWatermark === attribute)),
-        OutputMode.Append(),
-        expectFailure = expectFailure)
-    }
-
-    testGlobalWatermarkLimit(
-      s"FlatMapGroupsWithState after stream-stream $joinType join in Append mode",
-      FlatMapGroupsWithState(
-        null, att, att, Seq(att), Seq(att), att, null, Append,
-        isMapGroupsWithState = false, null,
-        streamRelation.join(streamRelation, joinType = joinType,
-          condition = Some(attributeWithWatermark === attribute))),
-      OutputMode.Append(),
-      expectFailure = expectFailure)
-
-    testGlobalWatermarkLimit(
-      s"deduplicate after stream-stream $joinType join in Append mode",
-      Deduplicate(Seq(attribute), streamRelation.join(streamRelation, joinType = joinType,
-        condition = Some(attributeWithWatermark === attribute))),
-      OutputMode.Append(),
-      expectFailure = expectFailure)
   }
 
   // FlatMapGroupsWithState

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
@@ -412,8 +412,8 @@ class UnsupportedOperationsSuite extends SparkFunSuite {
     batchStreamSupported = false,
     streamBatchSupported = false)
 
-  // Left outer join, left semi join, left anti join: *-stream not allowed
-  Seq((LeftOuter, "LeftOuter join"), (LeftSemi, "LeftSemi join"), (LeftAnti, "Left anti join"))
+  // Left outer, left semi, left anti join: *-stream not allowed
+  Seq((LeftOuter, "LeftOuter join"), (LeftSemi, "LeftSemi join"), (LeftAnti, "LeftAnti join"))
     .foreach { case (joinType, name) =>
       testBinaryOperationInStreamingPlan(
         name,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR is a followup from https://github.com/apache/spark/pull/30076 to refactor unit test of stream-stream join in `UnsupportedOperationsSuite`, where we had a lot of duplicated code for stream-stream join unit test, for each join type.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Help reduce duplicated code and make it easier for developers to read and add code in the future.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Existing unit test in `UnsupportedOperationsSuite.scala` (pure refactoring).