### PR TITLE
[SPARK-33413][WEBUI] SparkUI doesn't work when use an external reverse proxy

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
@@ -70,7 +70,7 @@ function stageEndPoint(appId) {
             return newBaseURI + "/api/v1/applications/" + appId + "/" + appAttemptId + "/stages/" + stageId;
         }
     }
-    return location.origin + "/api/v1/applications/" + appId + "/stages/" + stageId;
+    return baseUrl() + "/api/v1/applications/" + appId + "/stages/" + stageId;
 }
 
 function getColumnNameForTaskMetricSummary(columnKey) {

--- a/core/src/main/resources/org/apache/spark/ui/static/utils.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/utils.js
@@ -105,7 +105,7 @@ function getStandAloneAppId(cb) {
   }
   // Looks like Web UI is running in standalone mode
   // Let's get application-id using REST End Point
-  $.getJSON(location.origin + "/api/v1/applications", function(response, status, jqXHR) {
+  $.getJSON(baseUrl() + "/api/v1/applications", function(response, status, jqXHR) {
     if (response && response.length > 0) {
       var appId = response[0].id;
       cb(appId);
@@ -152,7 +152,7 @@ function createTemplateURI(appId, templateName) {
     var baseURI = words.slice(0, ind).join('/') + '/static/' + templateName + '-template.html';
     return baseURI;
   }
-  return location.origin + "/static/" + templateName + "-template.html";
+  return baseUrl() + "/static/" + templateName + "-template.html";
 }
 
 function setDataTableDefaults() {
@@ -190,5 +190,17 @@ function createRESTEndPointForExecutorsPage(appId) {
             return newBaseURI + "/api/v1/applications/" + appId + "/" + attemptId + "/allexecutors";
         }
     }
-    return location.origin + "/api/v1/applications/" + appId + "/allexecutors";
+    return baseUrl() + "/api/v1/applications/" + appId + "/allexecutors";
+}
+
+// This function keep the URL but remove the last part 
+// e.g. https://domain:50509/jobs/ => https://domain:50509
+// e.g. https://acme.corp/sparkui/executors/ => https://acme.corp/sparkui
+function baseUrl() {
+  return location.href
+    .replace(/jobs\/$/, "")
+    .replace(/stages\/$/, "")
+    .replace(/storage\/$/, "")
+    .replace(/environment\/$/, "")
+    .replace(/executors\/$/, "");
 }


### PR DESCRIPTION
[SPARK-33413][WEBUI] SparkUI doesn't work when use an external reverse proxy

### What changes were proposed in this pull request?

This PR aims to fix the compute URL when use an external reverse proxy. SparkUI/Executors make an API call but the URL is wrong and don't use existing (only use the domain).
This PR add a new way to compute this URL using the total URL and removing the last part (eg. "executors/") in order to keep using the full URL.

### Why are the changes needed?

We can use the SparkUI under an external reverse proxy (HTML and other static files already works, just missing API calls)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No tests are made for JS files on this project.