### PR TITLE
[SPARK-33394][SQL][TESTS] Throw `NoSuchNamespaceException` for not existing namespace in `InMemoryTableCatalog.listTables()`

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryTableCatalog.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryTableCatalog.scala
@@ -186,10 +186,11 @@ class InMemoryTableCatalog extends BasicInMemoryTableCatalog with SupportsNamesp
   }
 
   override def listTables(namespace: Array[String]): Array[Identifier] = {
-    if (!namespaceExists(namespace)) {
+    if (namespace.isEmpty || namespaceExists(namespace)) {
+      super.listTables(namespace)
+    } else {
       throw new NoSuchNamespaceException(namespace)
     }
-    super.listTables(namespace)
   }
 }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryTableCatalog.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryTableCatalog.scala
@@ -181,7 +181,11 @@ class InMemoryTableCatalog extends BasicInMemoryTableCatalog with SupportsNamesp
 
   override def dropNamespace(namespace: Array[String]): Boolean = {
     listNamespaces(namespace).foreach(dropNamespace)
-    listTables(namespace).foreach(dropTable)
+    try {
+      listTables(namespace).foreach(dropTable)
+    } catch {
+      case _: NoSuchNamespaceException =>
+    }
     Option(namespaces.remove(namespace.toList)).isDefined
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryTableCatalog.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryTableCatalog.scala
@@ -189,7 +189,7 @@ class InMemoryTableCatalog extends BasicInMemoryTableCatalog with SupportsNamesp
     if (!namespaceExists(namespace)) {
       throw new NoSuchNamespaceException(namespace)
     }
-    tables.keySet.asScala.filter(_.namespace.sameElements(namespace)).toArray
+    super.listTables(namespace)
   }
 }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryTableCatalog.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryTableCatalog.scala
@@ -184,6 +184,13 @@ class InMemoryTableCatalog extends BasicInMemoryTableCatalog with SupportsNamesp
     listTables(namespace).foreach(dropTable)
     Option(namespaces.remove(namespace.toList)).isDefined
   }
+
+  override def listTables(namespace: Array[String]): Array[Identifier] = {
+    if (!namespaceExists(namespace)) {
+      throw new NoSuchNamespaceException(namespace)
+    }
+    tables.keySet.asScala.filter(_.namespace.sameElements(namespace)).toArray
+  }
 }
 
 object InMemoryTableCatalog {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/TableCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/TableCatalogSuite.scala
@@ -64,12 +64,12 @@ class TableCatalogSuite extends SparkFunSuite {
     val ident2 = Identifier.of(Array("ns"), "test_table_2")
     val ident3 = Identifier.of(Array("ns2"), "test_table_1")
 
-    assert(catalog.listTables(Array("ns")).isEmpty)
+    intercept[NoSuchNamespaceException](catalog.listTables(Array("ns")))
 
     catalog.createTable(ident1, schema, Array.empty, emptyProps)
 
     assert(catalog.listTables(Array("ns")).toSet == Set(ident1))
-    assert(catalog.listTables(Array("ns2")).isEmpty)
+    intercept[NoSuchNamespaceException](catalog.listTables(Array("ns2")))
 
     catalog.createTable(ident3, schema, Array.empty, emptyProps)
     catalog.createTable(ident2, schema, Array.empty, emptyProps)
@@ -813,9 +813,10 @@ class TableCatalogSuite extends SparkFunSuite {
 
     assert(catalog.namespaceExists(testNs) === false)
 
-    val ret = catalog.dropNamespace(testNs)
-
-    assert(ret === false)
+    val errMsg = intercept[NoSuchNamespaceException] {
+      catalog.dropNamespace(testNs)
+    }.getMessage
+    assert(errMsg.contains("Namespace '````.`.`' not found"))
   }
 
   test("dropNamespace: drop empty namespace") {
@@ -841,7 +842,7 @@ class TableCatalogSuite extends SparkFunSuite {
     assert(catalog.dropNamespace(testNs))
 
     assert(!catalog.namespaceExists(testNs))
-    assert(catalog.listTables(testNs).isEmpty)
+    intercept[NoSuchNamespaceException](catalog.listTables(testNs))
   }
 
   test("alterNamespace: basic behavior") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/TableCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/TableCatalogSuite.scala
@@ -813,10 +813,9 @@ class TableCatalogSuite extends SparkFunSuite {
 
     assert(catalog.namespaceExists(testNs) === false)
 
-    val errMsg = intercept[NoSuchNamespaceException] {
-      catalog.dropNamespace(testNs)
-    }.getMessage
-    assert(errMsg.contains("Namespace '````.`.`' not found"))
+    val ret = catalog.dropNamespace(testNs)
+
+    assert(ret === false)
   }
 
   test("dropNamespace: drop empty namespace") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
@@ -58,7 +58,6 @@ trait ShowTablesSuite extends SharedSparkSession {
     }
   }
 
-  // `SHOW TABLES` returns empty result in V2 catalog instead of throwing the exception.
   test("show table in a not existing namespace") {
     val msg = intercept[NoSuchNamespaceException] {
       runShowTablesSql(s"SHOW TABLES IN $catalog.unknown", Seq())

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuite.scala
@@ -21,6 +21,7 @@ import org.scalactic.source.Position
 import org.scalatest.Tag
 
 import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
@@ -55,6 +56,14 @@ trait ShowTablesSuite extends SharedSparkSession {
         runShowTablesSql(s"SHOW TABLES IN $catalog.ns", Seq(ShowRow("ns", "table", false)))
       }
     }
+  }
+
+  // `SHOW TABLES` returns empty result in V2 catalog instead of throwing the exception.
+  test("show table in a not existing namespace") {
+    val msg = intercept[NoSuchNamespaceException] {
+      runShowTablesSql(s"SHOW TABLES IN $catalog.unknown", Seq())
+    }.getMessage
+    assert(msg.matches("(Database|Namespace) 'unknown' not found;"))
   }
 
   test("show tables with a pattern") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.execution.command.v1
 
 import org.apache.spark.sql.{AnalysisException, Row}
-import org.apache.spark.sql.catalyst.analysis.NoSuchDatabaseException
 import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.execution.command.{ShowTablesSuite => CommonShowTablesSuite}
 import org.apache.spark.sql.types.{BooleanType, StringType, StructType}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -50,14 +50,6 @@ class ShowTablesSuite extends CommonShowTablesSuite {
     }
   }
 
-  // `SHOW TABLES` returns empty result in V2 catalog instead of throwing the exception.
-  test("show table in a not existing namespace") {
-    val msg = intercept[NoSuchDatabaseException] {
-      runShowTablesSql(s"SHOW TABLES IN $catalog.unknown", Seq())
-    }.getMessage
-    assert(msg.contains("Database 'unknown' not found"))
-  }
-
   // `SHOW TABLES` from v2 catalog returns empty result.
   test("v1 SHOW TABLES list the temp views") {
     withSourceViews {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
@@ -43,12 +43,6 @@ class ShowTablesSuite extends CommonShowTablesSuite {
   override def sparkConf: SparkConf = super.sparkConf
     .set(s"spark.sql.catalog.$catalog", classOf[InMemoryTableCatalog].getName)
 
-  // The test fails with the exception `NoSuchDatabaseException` in V1 catalog.
-  // TODO(SPARK-33394): Throw `NoSuchDatabaseException` for not existing namespace
-  test("show table in a not existing namespace") {
-    runShowTablesSql(s"SHOW TABLES IN $catalog.unknown", Seq())
-  }
-
   // The test fails for V1 catalog with the error:
   // org.apache.spark.sql.AnalysisException:
   //   The namespace in session catalog must have exactly one name part: spark_catalog.n1.n2.db


### PR DESCRIPTION
### What changes were proposed in this pull request?
Throw `NoSuchNamespaceException` in `listTables()` of the custom test catalog `InMemoryTableCatalog` if the passed namespace doesn't exist.

### Why are the changes needed?
1. To align behavior of V2 `InMemoryTableCatalog` to V1 session catalog.
2. To distinguish two situations:
    1. A namespace **does exist** but does not contain any tables. In that case, `listTables()` returns empty result.
    2. A namespace **does not exist**. `listTables()` throws `NoSuchNamespaceException` in this case.

### Does this PR introduce _any_ user-facing change?
Yes. For example, `SHOW TABLES` returns empty result before the changes.

### How was this patch tested?
By running V1/V2 ShowTablesSuites.