### PR TITLE
[SPARK-33139][SQL][FOLLOW-UP] add spark.sql.legacy.allowModifyActiveSession in Exception message

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -775,6 +775,11 @@ class SparkSession private(
 @Stable
 object SparkSession extends Logging {
 
+  private final val activeSessionModifiedErrMsg = "Not allowed to modify active Spark session. " +
+    "`SparkSession.setActiveSession` and `SparkSession.clearActiveSession` are deprecated and " +
+    s"no longer supported. Set ${StaticSQLConf.LEGACY_ALLOW_MODIFY_ACTIVE_SESSION.key} to true " +
+    "could restore legacy behaviors, which is not recommended, please use these API with caution!"
+
   /**
    * Builder for [[SparkSession]].
    */
@@ -988,7 +993,7 @@ object SparkSession extends Logging {
     if (SQLConf.get.legacyAllowModifyActiveSession) {
       setActiveSessionInternal(session)
     } else {
-      throw new UnsupportedOperationException("Not allowed to modify active Spark session.")
+      throw new UnsupportedOperationException(activeSessionModifiedErrMsg)
     }
   }
 
@@ -1007,7 +1012,7 @@ object SparkSession extends Logging {
     if (SQLConf.get.legacyAllowModifyActiveSession) {
       clearActiveSessionInternal()
     } else {
-      throw new UnsupportedOperationException("Not allowed to modify active Spark session.")
+      throw new UnsupportedOperationException(activeSessionModifiedErrMsg)
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

add spark.sql.legacy.allowModifyActiveSession in Exception message, in case user want to restore to the legacy behaviors.

### Why are the changes needed?

nit and code refine.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Existing UT.