### PR TITLE
[SPARK-33440][CORE] Use current timestamp with warning log in HadoopFSDelegationTokenProvider when the issue date for token is not set up properly

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/security/HadoopDelegationTokenManager.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/security/HadoopDelegationTokenManager.scala
@@ -231,7 +231,7 @@ private[spark] class HadoopDelegationTokenManager(
         val ratio = sparkConf.get(CREDENTIALS_RENEWAL_INTERVAL_RATIO)
         val delay = (ratio * (nextRenewal - now)).toLong
         logInfo(s"Calculated delay on renewal is $delay, based on next renewal $nextRenewal " +
-          s"and the ratio $ratio")
+          s"and the ratio $ratio, and current time $now")
         scheduleRenewal(delay)
         creds
       }

--- a/core/src/main/scala/org/apache/spark/deploy/security/HadoopDelegationTokenManager.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/security/HadoopDelegationTokenManager.scala
@@ -178,7 +178,7 @@ private[spark] class HadoopDelegationTokenManager(
 
   private def scheduleRenewal(delay: Long): Unit = {
     val _delay = math.max(0, delay)
-    logInfo(s"Scheduling renewal in ${UIUtils.formatDuration(delay)}.")
+    logInfo(s"Scheduling renewal in ${UIUtils.formatDuration(_delay)}.")
 
     val renewalTask = new Runnable() {
       override def run(): Unit = {
@@ -230,6 +230,8 @@ private[spark] class HadoopDelegationTokenManager(
         val now = System.currentTimeMillis
         val ratio = sparkConf.get(CREDENTIALS_RENEWAL_INTERVAL_RATIO)
         val delay = (ratio * (nextRenewal - now)).toLong
+        logInfo(s"Calculated delay on renewal is $delay, based on next renewal $nextRenewal " +
+          s"and the ratio $ratio")
         scheduleRenewal(delay)
         creds
       }

--- a/core/src/main/scala/org/apache/spark/deploy/security/HadoopFSDelegationTokenProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/security/HadoopFSDelegationTokenProvider.scala
@@ -41,8 +41,6 @@ private[deploy] class HadoopFSDelegationTokenProvider
   // so we cannot get the token renewal interval.
   private var tokenRenewalInterval: Option[Long] = null
 
-  private val tokensWarnedIssueDateProblem = new mutable.HashSet[String]()
-
   override val serviceName: String = "hadoopfs"
 
   override def obtainDelegationTokens(
@@ -140,16 +138,15 @@ private[deploy] class HadoopFSDelegationTokenProvider
   }
 
   private def getIssueDate(kind: String, identifier: AbstractDelegationTokenIdentifier): Long = {
-    if (identifier.getIssueDate > 0L) {
-      identifier.getIssueDate
+    val issueDate = identifier.getIssueDate
+    if (issueDate > 0L) {
+      issueDate
     } else {
-      if (!tokensWarnedIssueDateProblem.contains(kind)) {
-        logWarning(s"Token $kind has not set up issue date properly. Using current timestamp as" +
-          " issue date as a workaround. Consult token implementator to fix the behavior.")
-        tokensWarnedIssueDateProblem.add(kind)
-      }
-
-      System.currentTimeMillis()
+      val now = System.currentTimeMillis()
+      logWarning(s"Token $kind has not set up issue date properly. (provided: $issueDate) " +
+        s"Using current timestamp ($now) as issue date instead. Consult token implementor to fix " +
+        "the behavior.")
+      now
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/deploy/security/HadoopFSDelegationTokenProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/security/HadoopFSDelegationTokenProvider.scala
@@ -23,6 +23,7 @@ import scala.util.control.NonFatal
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.hadoop.io.Text
 import org.apache.hadoop.mapred.Master
 import org.apache.hadoop.security.{Credentials, UserGroupInformation}
 import org.apache.hadoop.security.token.delegation.AbstractDelegationTokenIdentifier
@@ -35,10 +36,10 @@ import org.apache.spark.security.HadoopDelegationTokenProvider
 private[deploy] class HadoopFSDelegationTokenProvider
     extends HadoopDelegationTokenProvider with Logging {
 
-  // This tokenRenewalInterval will be set in the first call to obtainDelegationTokens.
+  // This tokenRenewalIntervals will be set in the first call to obtainDelegationTokens.
   // If None, no token renewer is specified or no token can be renewed,
   // so we cannot get the token renewal interval.
-  private var tokenRenewalInterval: Option[Long] = null
+  private var tokenRenewalIntervals: Map[Text, Long] = null
 
   override val serviceName: String = "hadoopfs"
 
@@ -50,25 +51,34 @@ private[deploy] class HadoopFSDelegationTokenProvider
       val fileSystems = HadoopFSDelegationTokenProvider.hadoopFSsToAccess(sparkConf, hadoopConf)
       val fetchCreds = fetchDelegationTokens(getTokenRenewer(hadoopConf), fileSystems, creds)
 
-      // Get the token renewal interval if it is not set. It will only be called once.
-      if (tokenRenewalInterval == null) {
-        tokenRenewalInterval = getTokenRenewalInterval(hadoopConf, sparkConf, fileSystems)
+      // Get the token renewals interval if it is not set. It will only be called once.
+      if (tokenRenewalIntervals == null) {
+        tokenRenewalIntervals = getTokenRenewalIntervals(hadoopConf, sparkConf, fileSystems)
       }
+
+      // Construct the map for "token kind" to "issue date", so that we can calculate the
+      // next renewal date per token when interval is available.
+      val tokenAndIssueDates = fetchCreds.getAllTokens.asScala
+        .filter(_.decodeIdentifier().isInstanceOf[AbstractDelegationTokenIdentifier])
+        .map { token =>
+          val identifier = token
+            .decodeIdentifier()
+            .asInstanceOf[AbstractDelegationTokenIdentifier]
+          identifier.getKind -> identifier.getIssueDate
+        }.toMap
 
       // Get the time of next renewal.
-      val nextRenewalDate = tokenRenewalInterval.flatMap { interval =>
-        val nextRenewalDates = fetchCreds.getAllTokens.asScala
-          .filter(_.decodeIdentifier().isInstanceOf[AbstractDelegationTokenIdentifier])
-          .map { token =>
-            val identifier = token
-              .decodeIdentifier()
-              .asInstanceOf[AbstractDelegationTokenIdentifier]
-            identifier.getIssueDate + interval
-          }
-        if (nextRenewalDates.isEmpty) None else Some(nextRenewalDates.min)
+      val currentTime = System.currentTimeMillis()
+      logDebug(s"Calculating next renewal date per token. Current timestamp is $currentTime")
+      val nextRenewalDates = tokenRenewalIntervals.flatMap { case (kind, interval) =>
+        tokenAndIssueDates.get(kind).map { issueDate =>
+          val nextRenewalDateForToken = issueDate + interval
+          logDebug(s"Next renewal date is $nextRenewalDateForToken for token ${kind.toString}")
+          nextRenewalDateForToken
+        }.filterNot(_ < currentTime)
       }
 
-      nextRenewalDate
+      if (nextRenewalDates.isEmpty) None else Some(nextRenewalDates.min)
     } catch {
       case NonFatal(e) =>
         logWarning(s"Failed to get token from service $serviceName", e)
@@ -108,10 +118,10 @@ private[deploy] class HadoopFSDelegationTokenProvider
     creds
   }
 
-  private def getTokenRenewalInterval(
+  private def getTokenRenewalIntervals(
       hadoopConf: Configuration,
       sparkConf: SparkConf,
-      filesystems: Set[FileSystem]): Option[Long] = {
+      filesystems: Set[FileSystem]): Map[Text, Long] = {
     // We cannot use the tokens generated with renewer yarn. Trying to renew
     // those will fail with an access control issue. So create new tokens with the logged in
     // user as renewer.
@@ -120,7 +130,7 @@ private[deploy] class HadoopFSDelegationTokenProvider
     val creds = new Credentials()
     fetchDelegationTokens(renewer, filesystems, creds)
 
-    val renewIntervals = creds.getAllTokens.asScala.filter {
+    creds.getAllTokens.asScala.filter {
       _.decodeIdentifier().isInstanceOf[AbstractDelegationTokenIdentifier]
     }.flatMap { token =>
       Try {
@@ -128,10 +138,9 @@ private[deploy] class HadoopFSDelegationTokenProvider
         val identifier = token.decodeIdentifier().asInstanceOf[AbstractDelegationTokenIdentifier]
         val interval = newExpiration - identifier.getIssueDate
         logInfo(s"Renewal interval is $interval for token ${token.getKind.toString}")
-        interval
+        (token.getKind -> interval)
       }.toOption
-    }
-    if (renewIntervals.isEmpty) None else Some(renewIntervals.min)
+    }.toMap
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/deploy/security/HadoopFSDelegationTokenProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/security/HadoopFSDelegationTokenProvider.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.deploy.security
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable
 import scala.util.Try
 import scala.util.control.NonFatal
 

--- a/core/src/main/scala/org/apache/spark/deploy/security/HadoopFSDelegationTokenProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/security/HadoopFSDelegationTokenProvider.scala
@@ -148,7 +148,6 @@ private[deploy] class HadoopFSDelegationTokenProvider
     } else if (issueDate > 0L) {
       issueDate
     } else {
-      val now = System.currentTimeMillis()
       logWarning(s"Token $kind has not set up issue date properly. (provided: $issueDate) " +
         s"Using current timestamp ($now) as issue date instead. Consult token implementor to fix " +
         "the behavior.")

--- a/core/src/main/scala/org/apache/spark/deploy/security/HadoopFSDelegationTokenProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/security/HadoopFSDelegationTokenProvider.scala
@@ -137,8 +137,15 @@ private[deploy] class HadoopFSDelegationTokenProvider
   }
 
   private def getIssueDate(kind: String, identifier: AbstractDelegationTokenIdentifier): Long = {
+    val now = System.currentTimeMillis()
     val issueDate = identifier.getIssueDate
-    if (issueDate > 0L) {
+    if (issueDate > now) {
+      logWarning(s"Token $kind has set up issue date later than current time. (provided: " +
+        s"$issueDate / current timestamp: $now) Please make sure clocks are in sync between " +
+        "machines. If the issue is not a clock mismatch, consult token implementor to check " +
+        "whether issue date is valid.")
+      issueDate
+    } else if (issueDate > 0L) {
       issueDate
     } else {
       val now = System.currentTimeMillis()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to use current timestamp with warning log when the issue date for token is not set up properly. The next section will explain the rationalization with details.

### Why are the changes needed?

Unfortunately not every implementations respect the `issue date` in `AbstractDelegationTokenIdentifier`, which Spark relies on while calculating. The default value of issue date is 0L, which is far from actual issue date, breaking logic on calculating next renewal date under some circumstance, leading to 0 interval (immediate) on rescheduling token renewal.

In HadoopFSDelegationTokenProvider, Spark calculates token renewal interval as below:

https://github.com/apache/spark/blob/2c64b731ae6a976b0d75a95901db849b4a0e2393/core/src/main/scala/org/apache/spark/deploy/security/HadoopFSDelegationTokenProvider.scala#L123-L134

The interval is calculated as `token.renew() - identifier.getIssueDate`, which is providing correct interval assuming both `token.renew()` and `identifier.getIssueDate` produce correct value, but it's going to be weird when `identifier.getIssueDate` provides 0L (default value), like below:

```
20/10/13 06:34:19 INFO security.HadoopFSDelegationTokenProvider: Renewal interval is 1603175657000 for token S3ADelegationToken/IDBroker
20/10/13 06:34:19 INFO security.HadoopFSDelegationTokenProvider: Renewal interval is 86400048 for token HDFS_DELEGATION_TOKEN
```

Hopefully we pick the minimum value as safety guard (so in this case, `86400048` is being picked up), but the safety guard leads unintentional bad impact on this case.

https://github.com/apache/spark/blob/2c64b731ae6a976b0d75a95901db849b4a0e2393/core/src/main/scala/org/apache/spark/deploy/security/HadoopFSDelegationTokenProvider.scala#L58-L71

Spark leverages the interval being calculated in above, "minimum" value of intervals, and blindly adds the value to token's issue date to calculates the next renewal date for the token, and picks "minimum" value again. In problematic case, the value would be `86400048` (86400048 + 0) which is quite smaller than current timestamp.

https://github.com/apache/spark/blob/2c64b731ae6a976b0d75a95901db849b4a0e2393/core/src/main/scala/org/apache/spark/deploy/security/HadoopDelegationTokenManager.scala#L228-L234

The next renewal date is subtracted with current timestamp again to get the interval, and multiplexed by configured ratio to produce the final schedule interval. In problematic case, this value goes to negative.

https://github.com/apache/spark/blob/2c64b731ae6a976b0d75a95901db849b4a0e2393/core/src/main/scala/org/apache/spark/deploy/security/HadoopDelegationTokenManager.scala#L180-L188

There's a safety guard to not allow negative value, but that's simply 0 meaning schedule immediately. This triggers next calculation of next renewal date to calculate the schedule interval, lead to the same behavior, hence updating delegation token immediately and continuously.

As we fetch token just before the calculation happens, the actual issue date is likely slightly before, hence it's not that dangerous to use current timestamp as issue date for the token the issue date has not been set up properly. Still, it's better not to leave the token implementation as it is, so we log warn message to let end users consult with token implementer.

### Does this PR introduce _any_ user-facing change?

Yes. End users won't encounter the tight loop of schedule of token renewal after the PR. In end users' perspective of reflection, there's nothing end users need to change.

### How was this patch tested?

Manually tested with problematic environment.