### PR TITLE
Revert "[SPARK-33139][SQL] protect setActionSession and clearActiveSession"

### DIFF
--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -24,8 +24,6 @@ license: |
 
 ## Upgrading from Spark SQL 3.0 to 3.1
 
-  - In Spark 3.1, `SparkSession.setActiveSession` and `SparkSession.clearActiveSession` are deprecated and unsupported, it will throw `UnsupportedOperationException` if called. To restore the behavior before Spark 3.1, you can set `spark.sql.legacy.allowModifyActiveSession` to true if you really need to use these APIs.
-
   - In Spark 3.1, statistical aggregation function includes `std`, `stddev`, `stddev_samp`, `variance`, `var_samp`, `skewness`, `kurtosis`, `covar_samp`, `corr` will return `NULL` instead of `Double.NaN` when `DivideByZero` occurs during expression evaluation, for example, when `stddev_samp` applied on a single element set. In Spark version 3.0 and earlier, it will return `Double.NaN` in such case. To restore the behavior before Spark 3.1, you can set `spark.sql.legacy.statisticalAggregate` to `true`.
 
   - In Spark 3.1, grouping_id() returns long values. In Spark version 3.0 and earlier, this function returns int values. To restore the behavior before Spark 3.1, you can set `spark.sql.legacy.integerGroupingId` to `true`.

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
@@ -1189,7 +1189,7 @@ class KafkaMicroBatchV2SourceSuite extends KafkaMicroBatchSourceSuiteBase {
         numPartitionsGenerated: Int,
         reusesConsumers: Boolean): Unit = {
 
-      SparkSession.setActiveSessionInternal(spark)
+      SparkSession.setActiveSession(spark)
       withTempDir { dir =>
         val provider = new KafkaSourceProvider()
         val options = Map(

--- a/mllib/src/test/java/org/apache/spark/SharedSparkSession.java
+++ b/mllib/src/test/java/org/apache/spark/SharedSparkSession.java
@@ -20,7 +20,6 @@ package org.apache.spark;
 import java.io.IOException;
 import java.io.Serializable;
 
-import org.apache.spark.sql.SparkSession$;
 import org.junit.After;
 import org.junit.Before;
 
@@ -48,7 +47,7 @@ public abstract class SharedSparkSession implements Serializable {
       spark = null;
     } finally {
       SparkSession.clearDefaultSession();
-      SparkSession$.MODULE$.clearActiveSessionInternal();
+      SparkSession.clearActiveSession();
     }
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/mllib/util/MLlibTestSparkContext.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/util/MLlibTestSparkContext.scala
@@ -48,7 +48,7 @@ trait MLlibTestSparkContext extends TempDirectory { self: Suite =>
   override def afterAll(): Unit = {
     try {
       Utils.deleteRecursively(new File(checkpointDir))
-      SparkSession.clearActiveSessionInternal()
+      SparkSession.clearActiveSession()
       if (spark != null) {
         spark.stop()
       }

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -264,7 +264,9 @@ class SparkSession(SparkConversionMixin):
             SparkSession._instantiatedSession = self
             SparkSession._activeSession = self
             self._jvm.SparkSession.setDefaultSession(self._jsparkSession)
-            getattr(getattr(self._jvm, "SparkSession$"), "MODULE$")\
+            self._jvm.java.lang.Class.forName("org.apache.spark.sql.SparkSession$")\
+                .getDeclaredField("MODULE$")\
+                .get(None)\
                 .setActiveSessionInternal(self._jsparkSession)
 
     def _repr_html_(self):
@@ -650,7 +652,9 @@ class SparkSession(SparkConversionMixin):
         Py4JJavaError: ...
         """
         SparkSession._activeSession = self
-        getattr(getattr(self._jvm, "SparkSession$"), "MODULE$")\
+        self._jvm.java.lang.Class.forName("org.apache.spark.sql.SparkSession$")\
+            .getDeclaredField("MODULE$")\
+            .get(None)\
             .setActiveSessionInternal(self._jsparkSession)
         if isinstance(data, DataFrame):
             raise TypeError("data is already a DataFrame")
@@ -796,7 +800,10 @@ class SparkSession(SparkConversionMixin):
         self._sc.stop()
         # We should clean the default session up. See SPARK-23228.
         self._jvm.SparkSession.clearDefaultSession()
-        getattr(getattr(self._jvm, "SparkSession$"), "MODULE$").clearActiveSessionInternal()
+        self._jvm.java.lang.Class.forName("org.apache.spark.sql.SparkSession$")\
+            .getDeclaredField("MODULE$")\
+            .get(None)\
+            .clearActiveSessionInternal()
         SparkSession._instantiatedSession = None
         SparkSession._activeSession = None
         SQLContext._instantiatedContext = None

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -264,10 +264,7 @@ class SparkSession(SparkConversionMixin):
             SparkSession._instantiatedSession = self
             SparkSession._activeSession = self
             self._jvm.SparkSession.setDefaultSession(self._jsparkSession)
-            self._jvm.java.lang.Class.forName("org.apache.spark.sql.SparkSession$")\
-                .getDeclaredField("MODULE$")\
-                .get(None)\
-                .setActiveSessionInternal(self._jsparkSession)
+            self._jvm.SparkSession.setActiveSession(self._jsparkSession)
 
     def _repr_html_(self):
         return """
@@ -652,10 +649,7 @@ class SparkSession(SparkConversionMixin):
         Py4JJavaError: ...
         """
         SparkSession._activeSession = self
-        self._jvm.java.lang.Class.forName("org.apache.spark.sql.SparkSession$")\
-            .getDeclaredField("MODULE$")\
-            .get(None)\
-            .setActiveSessionInternal(self._jsparkSession)
+        self._jvm.SparkSession.setActiveSession(self._jsparkSession)
         if isinstance(data, DataFrame):
             raise TypeError("data is already a DataFrame")
 
@@ -800,10 +794,7 @@ class SparkSession(SparkConversionMixin):
         self._sc.stop()
         # We should clean the default session up. See SPARK-23228.
         self._jvm.SparkSession.clearDefaultSession()
-        self._jvm.java.lang.Class.forName("org.apache.spark.sql.SparkSession$")\
-            .getDeclaredField("MODULE$")\
-            .get(None)\
-            .clearActiveSessionInternal()
+        self._jvm.SparkSession.clearActiveSession()
         SparkSession._instantiatedSession = None
         SparkSession._activeSession = None
         SQLContext._instantiatedContext = None

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3509,9 +3509,6 @@ class SQLConf extends Serializable with Logging {
 
   def integerGroupingIdEnabled: Boolean = getConf(SQLConf.LEGACY_INTEGER_GROUPING_ID)
 
-  def legacyAllowModifyActiveSession: Boolean =
-    getConf(StaticSQLConf.LEGACY_ALLOW_MODIFY_ACTIVE_SESSION)
-
   def legacyAllowCastNumericToTimestamp: Boolean =
     getConf(SQLConf.LEGACY_ALLOW_CAST_NUMERIC_TO_TIMESTAMP)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -249,13 +249,4 @@ object StaticSQLConf {
     .version("3.1.0")
     .timeConf(TimeUnit.SECONDS)
     .createWithDefault(-1)
-
-  val LEGACY_ALLOW_MODIFY_ACTIVE_SESSION =
-    buildStaticConf("spark.sql.legacy.allowModifyActiveSession")
-      .internal()
-      .doc("When set to true, user is allowed to use setActiveSession or clearActiveSession " +
-        "to modify the current active SparkSession, otherwise an exception will be thrown.")
-      .version("3.1.0")
-      .booleanConf
-      .createWithDefault(false)
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -764,9 +764,9 @@ class SparkSession private(
     // set and not the default session. This to prevent that we promote the default session to the
     // active session once we are done.
     val old = SparkSession.activeThreadSession.get()
-    SparkSession.setActiveSessionInternal(this)
+    SparkSession.setActiveSession(this)
     try block finally {
-      SparkSession.setActiveSessionInternal(old)
+      SparkSession.setActiveSession(old)
     }
   }
 }
@@ -945,7 +945,7 @@ object SparkSession extends Logging {
 
         session = new SparkSession(sparkContext, None, None, extensions, options.toMap)
         setDefaultSession(session)
-        setActiveSessionInternal(session)
+        setActiveSession(session)
         registerContextListener(sparkContext)
       }
 
@@ -983,16 +983,7 @@ object SparkSession extends Logging {
    *
    * @since 2.0.0
    */
-  @deprecated("This method is deprecated and will be removed in future versions.", "3.1.0")
   def setActiveSession(session: SparkSession): Unit = {
-    if (SQLConf.get.legacyAllowModifyActiveSession) {
-      setActiveSessionInternal(session)
-    } else {
-      throw new UnsupportedOperationException("Not allowed to modify active Spark session.")
-    }
-  }
-
-  private[sql] def setActiveSessionInternal(session: SparkSession): Unit = {
     activeThreadSession.set(session)
   }
 
@@ -1002,16 +993,7 @@ object SparkSession extends Logging {
    *
    * @since 2.0.0
    */
-  @deprecated("This method is deprecated and will be removed in future versions.", "3.1.0")
   def clearActiveSession(): Unit = {
-    if (SQLConf.get.legacyAllowModifyActiveSession) {
-      clearActiveSessionInternal()
-    } else {
-      throw new UnsupportedOperationException("Not allowed to modify active Spark session.")
-    }
-  }
-
-  private[spark] def clearActiveSessionInternal(): Unit = {
     activeThreadSession.remove()
   }
 
@@ -1185,7 +1167,7 @@ object SparkSession extends Logging {
            |
          """.stripMargin)
       session.get.stop()
-      SparkSession.clearActiveSessionInternal()
+      SparkSession.clearActiveSession()
       SparkSession.clearDefaultSession()
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
@@ -180,15 +180,15 @@ object SQLExecution {
     exec.submit(() => {
       val originalSession = SparkSession.getActiveSession
       val originalLocalProps = sc.getLocalProperties
-      SparkSession.setActiveSessionInternal(activeSession)
+      SparkSession.setActiveSession(activeSession)
       sc.setLocalProperties(localProps)
       val res = body
       // reset active session and local props.
       sc.setLocalProperties(originalLocalProps)
       if (originalSession.nonEmpty) {
-        SparkSession.setActiveSessionInternal(originalSession.get)
+        SparkSession.setActiveSession(originalSession.get)
       } else {
-        SparkSession.clearActiveSessionInternal()
+        SparkSession.clearActiveSession()
       }
       res
     })

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -82,7 +82,7 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
   /** Overridden make copy also propagates sqlContext to copied plan. */
   override def makeCopy(newArgs: Array[AnyRef]): SparkPlan = {
     if (sqlContext != null) {
-      SparkSession.setActiveSessionInternal(sqlContext.sparkSession)
+      SparkSession.setActiveSession(sqlContext.sparkSession)
     }
     super.makeCopy(newArgs)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -315,7 +315,7 @@ abstract class StreamExecution(
       startLatch.countDown()
 
       // While active, repeatedly attempt to run batches.
-      SparkSession.setActiveSessionInternal(sparkSession)
+      SparkSession.setActiveSession(sparkSession)
 
       updateStatusMessage("Initializing sources")
       // force initialization of the logical plan so that the sources can be created

--- a/sql/core/src/test/scala/org/apache/spark/sql/DeprecatedAPISuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DeprecatedAPISuite.scala
@@ -130,10 +130,10 @@ class DeprecatedAPISuite extends QueryTest with SharedSparkSession {
   test("SQLContext.setActive/clearActive") {
     val sc = spark.sparkContext
     val sqlContext = new SQLContext(sc)
-    intercept[UnsupportedOperationException](SQLContext.setActive(sqlContext))
+    SQLContext.setActive(sqlContext)
     assert(SparkSession.getActiveSession === Some(spark))
-    intercept[UnsupportedOperationException](SQLContext.clearActive())
-    assert(SparkSession.getActiveSession === Some(spark))
+    SQLContext.clearActive()
+    assert(SparkSession.getActiveSession === None)
   }
 
   test("SQLContext.applySchema") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/LocalSparkSession.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/LocalSparkSession.scala
@@ -30,14 +30,14 @@ trait LocalSparkSession extends BeforeAndAfterEach with BeforeAndAfterAll { self
   override def beforeAll(): Unit = {
     super.beforeAll()
     InternalLoggerFactory.setDefaultFactory(Slf4JLoggerFactory.INSTANCE)
-    SparkSession.clearActiveSessionInternal()
+    SparkSession.clearActiveSession()
     SparkSession.clearDefaultSession()
   }
 
   override def afterEach(): Unit = {
     try {
       LocalSparkSession.stop(spark)
-      SparkSession.clearActiveSessionInternal()
+      SparkSession.clearActiveSession()
       SparkSession.clearDefaultSession()
       spark = null
     } finally {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLContextSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLContextSuite.scala
@@ -43,7 +43,7 @@ class SQLContextSuite extends SparkFunSuite with SharedSparkContext {
     val newSession = sqlContext.newSession()
     assert(SQLContext.getOrCreate(sc).eq(sqlContext),
       "SQLContext.getOrCreate after explicitly created SQLContext did not return the context")
-    SparkSession.setActiveSessionInternal(newSession.sparkSession)
+    SparkSession.setActiveSession(newSession.sparkSession)
     assert(SQLContext.getOrCreate(sc).eq(newSession),
       "SQLContext.getOrCreate after explicitly setActive() did not return the active context")
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3468,7 +3468,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     // problem before the fix.
     withSQLConf(SQLConf.CODEGEN_FALLBACK.key -> "true") {
       val cloned = spark.cloneSession()
-      SparkSession.setActiveSessionInternal(cloned)
+      SparkSession.setActiveSession(cloned)
       assert(SQLConf.get.getConf(SQLConf.CODEGEN_FALLBACK) === true)
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SessionStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SessionStateSuite.scala
@@ -48,7 +48,7 @@ class SessionStateSuite extends SparkFunSuite {
       if (activeSession != null) {
         activeSession.stop()
         activeSession = null
-        SparkSession.clearActiveSessionInternal()
+        SparkSession.clearActiveSession()
         SparkSession.clearDefaultSession()
       }
     } finally {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
@@ -22,7 +22,7 @@ import org.scalatest.BeforeAndAfterEach
 import org.apache.spark.{SparkConf, SparkContext, SparkException, SparkFunSuite}
 import org.apache.spark.internal.config.EXECUTOR_ALLOW_SPARK_CONTEXT
 import org.apache.spark.internal.config.UI.UI_ENABLED
-import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.StaticSQLConf._
 
 /**
@@ -33,7 +33,7 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
   override def afterEach(): Unit = {
     // This suite should not interfere with the other test suites.
     SparkSession.getActiveSession.foreach(_.stop())
-    SparkSession.clearActiveSessionInternal()
+    SparkSession.clearActiveSession()
     SparkSession.getDefaultSession.foreach(_.stop())
     SparkSession.clearDefaultSession()
   }
@@ -64,7 +64,7 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
   test("get active or default session") {
     val session = SparkSession.builder().master("local").getOrCreate()
     assert(SparkSession.active == session)
-    SparkSession.clearActiveSessionInternal()
+    SparkSession.clearActiveSession()
     assert(SparkSession.active == session)
     SparkSession.clearDefaultSession()
     intercept[IllegalStateException](SparkSession.active)
@@ -82,7 +82,7 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
   test("use session from active thread session and propagate config options") {
     val defaultSession = SparkSession.builder().master("local").getOrCreate()
     val activeSession = defaultSession.newSession()
-    SparkSession.setActiveSessionInternal(activeSession)
+    SparkSession.setActiveSession(activeSession)
     val session = SparkSession.builder().config("spark-config2", "a").getOrCreate()
 
     assert(activeSession != defaultSession)
@@ -90,7 +90,7 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
     assert(session.conf.get("spark-config2") == "a")
     assert(session.sessionState.conf == SQLConf.get)
     assert(SQLConf.get.getConfString("spark-config2") == "a")
-    SparkSession.clearActiveSessionInternal()
+    SparkSession.clearActiveSession()
 
     assert(SparkSession.builder().getOrCreate() == defaultSession)
   }
@@ -105,7 +105,7 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
 
   test("create a new session if the active thread session has been stopped") {
     val activeSession = SparkSession.builder().master("local").getOrCreate()
-    SparkSession.setActiveSessionInternal(activeSession)
+    SparkSession.setActiveSession(activeSession)
     activeSession.stop()
     val newSession = SparkSession.builder().master("local").getOrCreate()
     assert(newSession != activeSession)
@@ -181,7 +181,7 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
       .master("local")
       .getOrCreate()
     val postFirstCreation = context.listenerBus.listeners.size()
-    SparkSession.clearActiveSessionInternal()
+    SparkSession.clearActiveSession()
     SparkSession.clearDefaultSession()
 
     SparkSession
@@ -190,7 +190,7 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
       .master("local")
       .getOrCreate()
     val postSecondCreation = context.listenerBus.listeners.size()
-    SparkSession.clearActiveSessionInternal()
+    SparkSession.clearActiveSession()
     SparkSession.clearDefaultSession()
     assert(postFirstCreation == postSecondCreation)
   }
@@ -211,7 +211,7 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
     assert(session1.conf.get(GLOBAL_TEMP_DATABASE) === "globaltempdb-spark-31532")
 
     // do not propagate static sql configs to the existing default session
-    SparkSession.clearActiveSessionInternal()
+    SparkSession.clearActiveSession()
     val session2 = SparkSession
       .builder()
       .config(WAREHOUSE_PATH.key, "SPARK-31532-db")
@@ -279,25 +279,6 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
       SparkSession.builder.master("local")
         .config(EXECUTOR_ALLOW_SPARK_CONTEXT.key, true).getOrCreate().stop()
       ()
-    }
-  }
-
-  test("SPARK-33139: Test SparkSession.setActiveSession/clearActiveSession") {
-    Seq(true, false).foreach { allowModifyActiveSession =>
-      val session = SparkSession.builder()
-        .master("local")
-        .config(StaticSQLConf.LEGACY_ALLOW_MODIFY_ACTIVE_SESSION.key, allowModifyActiveSession)
-        .getOrCreate()
-
-      val newSession = session.newSession()
-      if (!allowModifyActiveSession) {
-        intercept[UnsupportedOperationException](SparkSession.setActiveSession(newSession))
-        intercept[UnsupportedOperationException](SparkSession.clearActiveSession())
-      } else {
-        SparkSession.setActiveSession(newSession)
-        SparkSession.clearActiveSession()
-      }
-      session.stop()
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
@@ -51,7 +51,7 @@ class SparkSessionExtensionSuite extends SparkFunSuite {
 
   private def stop(spark: SparkSession): Unit = {
     spark.stop()
-    SparkSession.clearActiveSessionInternal()
+    SparkSession.clearActiveSession()
     SparkSession.clearDefaultSession()
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/V1WriteFallbackSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/V1WriteFallbackSuite.scala
@@ -130,7 +130,7 @@ class V1WriteFallbackSuite extends QueryTest with SharedSparkSession with Before
   }
 
   test("fallback writes should only analyze plan once") {
-    SparkSession.clearActiveSessionInternal()
+    SparkSession.clearActiveSession()
     SparkSession.clearDefaultSession()
     try {
       val session = SparkSession.builder()
@@ -141,7 +141,7 @@ class V1WriteFallbackSuite extends QueryTest with SharedSparkSession with Before
       val df = session.createDataFrame(Seq((1, "x"), (2, "y"), (3, "z")))
       df.write.mode("append").option("name", "t1").format(v2Format).saveAsTable("test")
     } finally {
-      SparkSession.setActiveSessionInternal(spark)
+      SparkSession.setActiveSession(spark)
       SparkSession.setDefaultSession(spark)
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/CoalesceShufflePartitionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/CoalesceShufflePartitionsSuite.scala
@@ -38,14 +38,14 @@ class CoalesceShufflePartitionsSuite extends SparkFunSuite with BeforeAndAfterAl
     originalActiveSparkSession = SparkSession.getActiveSession
     originalInstantiatedSparkSession = SparkSession.getDefaultSession
 
-    SparkSession.clearActiveSessionInternal()
+    SparkSession.clearActiveSession()
     SparkSession.clearDefaultSession()
   }
 
   override protected def afterAll(): Unit = {
     try {
       // Set these states back.
-      originalActiveSparkSession.foreach(ctx => SparkSession.setActiveSessionInternal(ctx))
+      originalActiveSparkSession.foreach(ctx => SparkSession.setActiveSession(ctx))
       originalInstantiatedSparkSession.foreach(ctx => SparkSession.setDefaultSession(ctx))
     } finally {
       super.afterAll()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -999,9 +999,9 @@ class AdaptiveQueryExecSuite
     withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true") {
       val df = spark.range(10).select(sum('id))
       assert(df.queryExecution.executedPlan.isInstanceOf[AdaptiveSparkPlanExec])
-      SparkSession.setActiveSessionInternal(null)
+      SparkSession.setActiveSession(null)
       checkAnswer(df, Seq(Row(45)))
-      SparkSession.setActiveSessionInternal(spark) // recover the active session.
+      SparkSession.setActiveSession(spark) // recover the active session.
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreCoordinatorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreCoordinatorSuite.scala
@@ -121,7 +121,7 @@ class StateStoreCoordinatorSuite extends SparkFunSuite with SharedSparkContext {
     var coordRef: StateStoreCoordinatorRef = null
     try {
       val spark = SparkSession.builder().sparkContext(sc).getOrCreate()
-      SparkSession.setActiveSessionInternal(spark)
+      SparkSession.setActiveSession(spark)
       import spark.implicits._
       coordRef = spark.streams.stateStoreCoordinator
       implicit val sqlContext = spark.sqlContext

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -567,7 +567,7 @@ class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
     try {
       val checkpointLocation = Utils.createTempDir().getAbsoluteFile
       val spark = SparkSession.builder().master("local[2]").getOrCreate()
-      SparkSession.setActiveSessionInternal(spark)
+      SparkSession.setActiveSession(spark)
       implicit val sqlContext = spark.sqlContext
       spark.conf.set(SQLConf.SHUFFLE_PARTITIONS.key, "1")
       import spark.implicits._

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/SymmetricHashJoinStateManagerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/SymmetricHashJoinStateManagerSuite.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.types._
 class SymmetricHashJoinStateManagerSuite extends StreamTest with BeforeAndAfter {
 
   before {
-    SparkSession.setActiveSessionInternal(spark) // set this before force initializing 'joinExec'
+    SparkSession.setActiveSession(spark) // set this before force initializing 'joinExec'
     spark.streams.stateStoreCoordinator // initialize the lazy coordinator
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
@@ -47,8 +47,8 @@ abstract class StreamingJoinSuite
   import testImplicits._
 
   before {
-    SparkSession.setActiveSessionInternal(spark) // set this before force initializing 'joinExec'
-    spark.streams.stateStoreCoordinator // initialize the lazy coordinator
+    SparkSession.setActiveSession(spark)  // set this before force initializing 'joinExec'
+    spark.streams.stateStoreCoordinator   // initialize the lazy coordinator
   }
 
   after {

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
@@ -242,7 +242,7 @@ private[sql] trait SQLTestUtilsBase
   }
 
   protected override def withSQLConf(pairs: (String, String)*)(f: => Unit): Unit = {
-    SparkSession.setActiveSessionInternal(spark)
+    SparkSession.setActiveSession(spark)
     super.withSQLConf(pairs: _*)(f)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SharedSparkSession.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SharedSparkSession.scala
@@ -144,7 +144,7 @@ trait SharedSparkSessionBase
           }
         }
       } finally {
-        SparkSession.clearActiveSessionInternal()
+        SparkSession.clearActiveSession()
         SparkSession.clearDefaultSession()
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/TestSQLContext.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/TestSQLContext.scala
@@ -35,7 +35,7 @@ private[spark] class TestSparkSession(sc: SparkContext) extends SparkSession(sc)
   }
 
   SparkSession.setDefaultSession(this)
-  SparkSession.setActiveSessionInternal(this)
+  SparkSession.setActiveSession(this)
 
   @transient
   override lazy val sessionState: SessionState = {

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkOperation.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkOperation.scala
@@ -65,7 +65,7 @@ private[hive] trait SparkOperation extends Operation with Logging {
 
     try {
       // Set active SparkSession
-      SparkSession.setActiveSessionInternal(sqlContext.sparkSession)
+      SparkSession.setActiveSession(sqlContext.sparkSession)
 
       // Set scheduler pool
       sqlContext.sparkSession.conf.getOption(SQLConf.THRIFTSERVER_POOL.key) match {
@@ -81,8 +81,8 @@ private[hive] trait SparkOperation extends Operation with Logging {
       sqlContext.sparkContext.setLocalProperties(originalProps)
 
       originalSession match {
-        case Some(session) => SparkSession.setActiveSessionInternal(session)
-        case None => SparkSession.clearActiveSessionInternal()
+        case Some(session) => SparkSession.setActiveSession(session)
+        case None => SparkSession.clearActiveSession()
       }
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSharedStateSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSharedStateSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.util.Utils
 class HiveSharedStateSuite extends SparkFunSuite {
 
   override def beforeEach(): Unit = {
-    SparkSession.clearActiveSessionInternal()
+    SparkSession.clearActiveSession()
     SparkSession.clearDefaultSession()
     super.beforeEach()
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
@@ -195,7 +195,7 @@ private[hive] class TestHiveSparkSession(
   }
 
   SparkSession.setDefaultSession(this)
-  SparkSession.setActiveSessionInternal(this)
+  SparkSession.setActiveSession(this)
 
   { // set the metastore temporary configuration
     val metastoreTempConf = HiveUtils.newTemporaryConfiguration(useInMemoryDerby = false) ++ Map(


### PR DESCRIPTION
### What changes were proposed in this pull request?

In [SPARK-33139] we defined `setActionSession` and `clearActiveSession` as deprecated API, it turns out it is widely used, and after discussion, even if without this PR, it should work with unify view feature, it might only be a risk if user really abuse using these two API. So revert the PR is needed.

[SPARK-33139] has two commit, include a follow up. Revert them both.

### Why are the changes needed?

Revert.


### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Existing UT.