### PR TITLE
[SPARK-33446][CORE] Add config spark.executor.coresOverhead

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -600,6 +600,8 @@ private[spark] class SparkSubmit extends Logging {
         confKey = EXECUTOR_INSTANCES.key),
       OptionAssigner(args.executorCores, STANDALONE | YARN | KUBERNETES, ALL_DEPLOY_MODES,
         confKey = EXECUTOR_CORES.key),
+      OptionAssigner(args.executorCoresOverhead, STANDALONE | YARN | KUBERNETES, ALL_DEPLOY_MODES,
+        confKey = "spark.executor.coresOverhead"),
       OptionAssigner(args.executorMemory, STANDALONE | MESOS | YARN | KUBERNETES, ALL_DEPLOY_MODES,
         confKey = EXECUTOR_MEMORY.key),
       OptionAssigner(args.totalExecutorCores, STANDALONE | MESOS | KUBERNETES, ALL_DEPLOY_MODES,

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -45,6 +45,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
   var deployMode: String = null
   var executorMemory: String = null
   var executorCores: String = null
+  var executorCoresOverhead: String = null
   var totalExecutorCores: String = null
   var propertiesFile: String = null
   var driverMemory: String = null
@@ -177,6 +178,10 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
       .orElse(sparkProperties.get(config.EXECUTOR_CORES.key))
       .orElse(env.get("SPARK_EXECUTOR_CORES"))
       .orNull
+    executorCoresOverhead = Option(executorCoresOverhead)
+      .orElse(sparkProperties.get(config.EXECUTOR_CORES_OVERHEAD.key))
+      .orElse(env.get("SPARK_EXECUTOR_CORES_OVERHEAD"))
+      .orNull
     totalExecutorCores = Option(totalExecutorCores)
       .orElse(sparkProperties.get(config.CORES_MAX.key))
       .orNull
@@ -298,6 +303,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
     |  deployMode              $deployMode
     |  executorMemory          $executorMemory
     |  executorCores           $executorCores
+    |  executorCoresOverhead   $executorCoresOverhead
     |  totalExecutorCores      $totalExecutorCores
     |  propertiesFile          $propertiesFile
     |  driverMemory            $driverMemory
@@ -353,6 +359,9 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
 
       case EXECUTOR_CORES =>
         executorCores = value
+
+      case EXECUTOR_CORES_OVERHEAD =>
+        executorCoresOverhead = value
 
       case EXECUTOR_MEMORY =>
         executorMemory = value
@@ -551,6 +560,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
         |  --executor-cores NUM        Number of cores used by each executor. (Default: 1 in
         |                              YARN and K8S modes, or all available cores on the worker
         |                              in standalone mode).
+        |  --executor-coresOverhead NUM Number of overhead cores per executor. (Default: 0).
         |
         | Spark on YARN and Kubernetes only:
         |  --num-executors NUM         Number of executors to launch (Default: 2).

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -295,6 +295,12 @@ package object config {
     .intConf
     .createWithDefault(1)
 
+  private[spark] val EXECUTOR_CORES_OVERHEAD = ConfigBuilder("spark.executor.coresOverhead")
+    .version("3.1.0")
+    .doc("Extra cores allocated per executor.")
+    .intConf
+    .createWithDefault(0)
+
   private[spark] val EXECUTOR_MEMORY = ConfigBuilder(SparkLauncher.EXECUTOR_MEMORY)
     .doc("Amount of memory to use per executor process, in MiB unless otherwise specified.")
     .version("0.7.0")

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -259,6 +259,7 @@ class SparkSubmitSuite
       "--master", "yarn",
       "--executor-memory", "5g",
       "--executor-cores", "5",
+      "--executor-coresOverhead", "3",
       "--class", "org.SomeClass",
       "--jars", "one.jar,two.jar,three.jar",
       "--driver-memory", "4g",
@@ -287,6 +288,7 @@ class SparkSubmitSuite
     conf.get("spark.executor.memory") should be ("5g")
     conf.get("spark.driver.memory") should be ("4g")
     conf.get("spark.executor.cores") should be ("5")
+    conf.get("spark.executor.coresOverhead") should be ("3")
     conf.get("spark.yarn.queue") should be ("thequeue")
     conf.get("spark.yarn.dist.jars") should include regex (".*one.jar,.*two.jar,.*three.jar")
     conf.get("spark.yarn.dist.files") should include regex (".*file1.txt,.*file2.txt")

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitOptionParser.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitOptionParser.java
@@ -71,6 +71,7 @@ class SparkSubmitOptionParser {
   // YARN-only options.
   protected final String ARCHIVES = "--archives";
   protected final String EXECUTOR_CORES = "--executor-cores";
+  protected final String EXECUTOR_CORES_OVERHEAD = "--executor-coresOverhead";
   protected final String KEYTAB = "--keytab";
   protected final String NUM_EXECUTORS = "--num-executors";
   protected final String PRINCIPAL = "--principal";
@@ -97,6 +98,7 @@ class SparkSubmitOptionParser {
     { DRIVER_LIBRARY_PATH },
     { DRIVER_MEMORY },
     { EXECUTOR_CORES },
+    { EXECUTOR_CORES_OVERHEAD },
     { EXECUTOR_MEMORY },
     { FILES },
     { JARS },


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add config spark.executor.coresOverhead

### Why are the changes needed?
This can handle mismatch of memory per core ratio between executor and underlying physical machines or vm. 

### Does this PR introduce _any_ user-facing change?
Yes.

### How was this patch tested?
Covered in UT.
