### PR TITLE
[SPARK-33172][SQL] Adding support for UserDefinedType for Spark SQL Code generator

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -1734,15 +1734,17 @@ object CodeGenerator extends Logging {
    * Returns the specialized code to access a value from a column vector for a given `DataType`.
    */
   def getValueFromVector(vector: String, dataType: DataType, rowId: String): String = {
-    if (dataType.isInstanceOf[StructType]) {
-      // `ColumnVector.getStruct` is different from `InternalRow.getStruct`, it only takes an
-      // `ordinal` parameter.
-      s"$vector.getStruct($rowId)"
-    } else {
-      getValue(vector, dataType, rowId)
+    dataType match {
+      case udt: UserDefinedType[_] => getValueFromVector(vector, udt.sqlType, rowId)
+      case _ => if (dataType.isInstanceOf[StructType]) {
+        // `ColumnVector.getStruct` is different from `InternalRow.getStruct`, it only takes an
+        // `ordinal` parameter.
+        s"$vector.getStruct($rowId)"
+      } else {
+        getValue(vector, dataType, rowId)
+      }
     }
   }
-
   /**
    * This methods returns two values in a Tuple.
    *

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodegenGetValueFromVectorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodegenGetValueFromVectorSuite.scala
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions.codegen
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
+import org.apache.spark.sql.types.{DataTypes, LongType, StructField, StructType, UserDefinedType}
+
+/**
+ * A test suite that makes sure code generation handles expression internally states correctly.
+ */
+class CodegenGetValueFromVectorSuite extends SparkFunSuite {
+
+  test("getValueFromVector should use the primitive value") {
+    val result = CodeGenerator.getValueFromVector("vector", DataTypes.LongType, "0")
+    assert(result == "vector.getLong(0)")
+  }
+
+  test("getValueFromVector should use the StructType") {
+    val structType = StructType(Seq(
+      StructField("str", DataTypes.StringType),
+      StructField("num", DataTypes.LongType)))
+    val result = CodeGenerator.getValueFromVector("vector", structType, "0")
+    assert(result == "vector.getStruct(0)")
+  }
+
+  test("getValueFromVector should use the UDT sqlType") {
+    val udtType = new LongWrapperUDT
+    val result = CodeGenerator.getValueFromVector("vector", udtType, "0")
+    assert(result == "vector.getStruct(0)")
+  }
+
+}
+
+case class LongWrapper(value: Long)
+
+private[spark] class LongWrapperUDT extends UserDefinedType[LongWrapper] {
+
+  override final def sqlType: StructType = _sqlType
+
+  override def serialize(obj: LongWrapper): InternalRow = {
+    val row = new GenericInternalRow(1)
+    row.setLong(0, obj.value)
+    row
+   }
+
+  override def deserialize(datum: Any): LongWrapper = {
+    datum match {
+      case row: InternalRow =>
+        require(row.numFields == 1,
+          s"deserialize given row with length ${row.numFields} but requires length == 1")
+        val tpe = row.getByte(0)
+        LongWrapper(row.getLong(0))
+    }
+  }
+
+  override def pyUDT: String = "should.not.be.used"
+
+  override def userClass: Class[LongWrapper] = classOf[LongWrapper]
+
+  override def equals(o: Any): Boolean = {
+    o match {
+      case lw: LongWrapperUDT => true
+      case _ => false
+    }
+  }
+
+  // see [SPARK-8647], this achieves the needed constant hash code without constant no.
+  override def hashCode(): Int = classOf[LongWrapperUDT].getName.hashCode()
+
+  override def typeName: String = "longWrapper"
+
+  private[spark] override def asNullable: LongWrapperUDT = this
+
+  private[this] val _sqlType = {
+    StructType(Seq(StructField("value", LongType)))
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->
This PR is based on the master branch, replacing PR #30071 

### What changes were proposed in this pull request?
Having `CodeGenerator.getValueFromVector()` to correctly treat `UserDefniedType`s as `CodeGenerator.javaType()` does.

### Why are the changes needed?
Without it the generated java code would not compile, the error was 
```
rg.codehaus.commons.compiler.CompileException: File 'generated.java', Line 153, Column 126: No applicable constructor/method found for actual parameters "int, int"; candidates are: "public org.apache.spark.sql.vectorized.ColumnarRow org.apache.spark.sql.vectorized.ColumnVector.getStruct(int)"
```
The fix makes sure the method call has just one parameter.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
I've added a unit test to verify the proper code is generated: `getStruct(ordinal)`
