### PR TITLE
[WIP][SPARK-33444][ML] Added support for Initial model in Gaussian Mixture Model in ML

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
@@ -421,6 +421,8 @@ class GaussianMixture @Since("2.0.0") (
 
     val (weights, gaussians) = ${initialModel} match {
       case Some(gmm) =>
+        require(gmm.getK == ${k}, "Number of independent Gaussians in the initial model has to be equal to K")
+
         (
           gmm.weights,
           gmm.gaussians.map(gaussian => {

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/GaussianMixture.scala
@@ -65,7 +65,11 @@ private[clustering] trait GaussianMixtureParams extends Params with HasMaxIter w
    *
    * @group param
    */
-  var initialModel = new Param[Option[GaussianMixtureModel]](this, "initialModel", "initial gaussian mixture model")
+  var initialModel = new Param[Option[GaussianMixtureModel]](
+    this,
+    "initialModel",
+    "initial gaussian mixture model"
+  )
 
   /** @group getParam */
   def getInitialModel: Option[GaussianMixtureModel] = $(initialModel)
@@ -238,7 +242,8 @@ object GaussianMixtureModel extends MLReadable[GaussianMixtureModel] {
   override def load(path: String): GaussianMixtureModel = super.load(path)
 
   /** [[MLWriter]] instance for [[GaussianMixtureModel]] */
-  private[GaussianMixtureModel] class GaussianMixtureModelWriter(instance: GaussianMixtureModel) extends MLWriter {
+  private[GaussianMixtureModel] class GaussianMixtureModelWriter(instance: GaussianMixtureModel)
+    extends MLWriter {
 
     private case class Data(weights: Array[Double], mus: Array[OldVector], sigmas: Array[OldMatrix])
 
@@ -380,7 +385,8 @@ class GaussianMixture @Since("2.0.0") (
   def setAggregationDepth(value: Int): this.type = set(aggregationDepth, value)
 
   /** @group initialModel */
-  def setInitialModel(value: GaussianMixtureModel): this.type = set(initialModel, Option[GaussianMixtureModel](value))
+  def setInitialModel(value: GaussianMixtureModel):
+    this.type = set(initialModel, Option[GaussianMixtureModel](value))
 
   /**
    * Number of samples per cluster to use when initializing Gaussians.
@@ -421,7 +427,10 @@ class GaussianMixture @Since("2.0.0") (
 
     val (weights, gaussians) = ${initialModel} match {
       case Some(gmm) =>
-        require(gmm.getK == ${k}, "Number of independent Gaussians in the initial model has to be equal to K")
+        require(
+          gmm.getK == ${k},
+          "Number of independent Gaussians in the initial model has to be equal to K"
+        )
 
         (
           gmm.weights,
@@ -609,16 +618,15 @@ object GaussianMixture extends DefaultParamsReadable[GaussianMixture] {
    *                         (column major).
    * @return A dense matrix which represents the symmetric matrix in column major.
    */
-  private[clustering] def unpackUpperTriangularMatrix(
-                                                       n: Int,
-                                                       triangularValues: Array[Double]): DenseMatrix = {
+  private[clustering] def unpackUpperTriangularMatrix(n: Int,
+         triangularValues: Array[Double]): DenseMatrix = {
     val symmetricValues = unpackUpperTriangular(n, triangularValues)
     new DenseMatrix(n, n, symmetricValues)
   }
 
   private def mergeWeightsMeans(
-                                 a: (DenseVector, DenseVector, Double, Double),
-                                 b: (DenseVector, DenseVector, Double, Double)): (DenseVector, DenseVector, Double, Double) =
+    a: (DenseVector, DenseVector, Double, Double),
+    b: (DenseVector, DenseVector, Double, Double)): (DenseVector, DenseVector, Double, Double) =
   {
     // update the weights, means and covariances for i-th distributions
     BLAS.axpy(1.0, b._1, a._1)
@@ -637,10 +645,10 @@ object GaussianMixture extends DefaultParamsReadable[GaussianMixture] {
    * @return The updated weight, mean and covariance.
    */
   private[clustering] def updateWeightsAndGaussians(
-                                                     mean: DenseVector,
-                                                     cov: DenseVector,
-                                                     weight: Double,
-                                                     sumWeights: Double): (Double, (DenseVector, DenseVector)) = {
+      mean: DenseVector,
+      cov: DenseVector,
+      weight: Double,
+      sumWeights: Double): (Double, (DenseVector, DenseVector)) = {
     BLAS.scal(1.0 / weight, mean)
     BLAS.spr(-weight, mean, cov)
     BLAS.scal(1.0 / weight, cov)
@@ -661,9 +669,9 @@ object GaussianMixture extends DefaultParamsReadable[GaussianMixture] {
  *                    in order to reduce shuffled data size.
  */
 private class ExpectationAggregator(
-                                     numFeatures: Int,
-                                     bcWeights: Broadcast[Array[Double]],
-                                     bcGaussians: Broadcast[Array[(DenseVector, DenseVector)]]) extends Serializable {
+    numFeatures: Int,
+    bcWeights: Broadcast[Array[Double]],
+    bcGaussians: Broadcast[Array[(DenseVector, DenseVector)]]) extends Serializable {
 
   private val k = bcWeights.value.length
   private var totalCnt = 0L

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/GaussianMixtureSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/GaussianMixtureSuite.scala
@@ -75,7 +75,7 @@ class GaussianMixtureSuite extends MLTest with DefaultReadWriteTest {
     assert(gm.getProbabilityCol === "probability")
     assert(gm.getMaxIter === 100)
     assert(gm.getTol === 0.01)
-    assert(gm.getInitialModel === None)
+    assert(gm.getInitialModel === null)
 
     val model = gm.setMaxIter(1).fit(dataset)
 
@@ -119,10 +119,10 @@ class GaussianMixtureSuite extends MLTest with DefaultReadWriteTest {
     assert(gm.getMaxIter === 33)
     assert(gm.getSeed === 123)
     assert(gm.getTol === 1e-3)
-    assert(gm.getInitialModel.get === gmm)
+    assert(gm.getInitialModel === gmm)
   }
 
-  test("Initial model has the same K as the Gaussian Mixture") {
+  test("Initial model doesn't have the same K as the Gaussian Mixture") {
     val gmm = new GaussianMixtureModel(
       "uuid",
       Array(0.5, 0.2, 0.3),
@@ -142,6 +142,28 @@ class GaussianMixtureSuite extends MLTest with DefaultReadWriteTest {
     intercept[IllegalArgumentException] {
       gm.fit(denseDataset);
     }
+  }
+
+  test("Initial model have the same K as the Gaussian Mixture") {
+    val gmm = new GaussianMixtureModel(
+      "uuid",
+      Array(0.5, 0.2, 0.3),
+      Array(
+        new MultivariateGaussian(Vectors.dense(1),
+          Matrices.dense(1, 1, Array.fill[Double](1)(1))),
+        new MultivariateGaussian(Vectors.dense(2),
+          Matrices.dense(1, 1, Array.fill[Double](1)(1))),
+        new MultivariateGaussian(Vectors.dense(3),
+          Matrices.dense(1, 1, Array.fill[Double](1)(1)))
+      ))
+
+    val gm = new GaussianMixture()
+      .setK(3)
+      .setInitialModel(gmm)
+
+    gm.fit(denseDataset);
+
+    assert(gm.getK === gmm.weights.length)
   }
 
   test("parameters validation") {

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/GaussianMixtureSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/GaussianMixtureSuite.scala
@@ -122,7 +122,7 @@ class GaussianMixtureSuite extends MLTest with DefaultReadWriteTest {
     assert(gm.getInitialModel.get === gmm)
   }
 
-  test("Initial model has the same K as the Gaussian Mixture"){
+  test("Initial model has the same K as the Gaussian Mixture") {
     val gmm = new GaussianMixtureModel(
       "uuid",
       Array(0.5, 0.2, 0.3),

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/GaussianMixtureSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/GaussianMixtureSuite.scala
@@ -122,6 +122,28 @@ class GaussianMixtureSuite extends MLTest with DefaultReadWriteTest {
     assert(gm.getInitialModel.get === gmm)
   }
 
+  test("Initial model has the same K as the Gaussian Mixture"){
+    val gmm = new GaussianMixtureModel(
+      "uuid",
+      Array(0.5, 0.2, 0.3),
+      Array(
+        new MultivariateGaussian(Vectors.dense(1),
+          Matrices.dense(1, 1, Array.fill[Double](1)(1))),
+        new MultivariateGaussian(Vectors.dense(2),
+          Matrices.dense(1, 1, Array.fill[Double](1)(1))),
+        new MultivariateGaussian(Vectors.dense(3),
+          Matrices.dense(1, 1, Array.fill[Double](1)(1)))
+      ))
+
+    val gm = new GaussianMixture()
+      .setK(9)
+      .setInitialModel(gmm)
+
+    intercept[IllegalArgumentException] {
+      gm.fit(denseDataset);
+    }
+  }
+
   test("parameters validation") {
     intercept[IllegalArgumentException] {
       new GaussianMixture().setK(1)

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -112,7 +112,8 @@ class _GaussianMixtureParams(HasMaxIter, HasFeaturesCol, HasSeed, HasPredictionC
               "Must be > 1.", typeConverter=TypeConverters.toInt)
 
     initialModel = Param(Params._dummy(), "initialModel",
-                         "The initial Gausssian Mixture Model to use")
+                         "The initial Gausssian Mixture Model to use",
+                         typeConverter=TypeConverters.toString)
 
     def __init__(self, *args):
         super(_GaussianMixtureParams, self).__init__(*args)
@@ -124,6 +125,12 @@ class _GaussianMixtureParams(HasMaxIter, HasFeaturesCol, HasSeed, HasPredictionC
         Gets the value of `k`
         """
         return self.getOrDefault(self.k)
+
+    def getInitialModel(self):
+        """
+        Gets the value of the initial model
+        """
+        return self.getOrDefault(self.initialModel)
 
 
 class GaussianMixtureModel(JavaModel, _GaussianMixtureParams, JavaMLWritable, JavaMLReadable,

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -111,6 +111,9 @@ class _GaussianMixtureParams(HasMaxIter, HasFeaturesCol, HasSeed, HasPredictionC
     k = Param(Params._dummy(), "k", "Number of independent Gaussians in the mixture model. " +
               "Must be > 1.", typeConverter=TypeConverters.toInt)
 
+    initialModel = Param(Params._dummy(), "initialModel",
+                         "The initial Gausssian Mixture Model to use")
+
     def __init__(self, *args):
         super(_GaussianMixtureParams, self).__init__(*args)
         self._setDefault(k=2, tol=0.01, maxIter=100, aggregationDepth=2)
@@ -340,7 +343,7 @@ class GaussianMixture(JavaEstimator, _GaussianMixtureParams, JavaMLWritable, Jav
     @keyword_only
     def __init__(self, *, featuresCol="features", predictionCol="prediction", k=2,
                  probabilityCol="probability", tol=0.01, maxIter=100, seed=None,
-                 aggregationDepth=2, weightCol=None):
+                 aggregationDepth=2, weightCol=None, initialModel=None):
         """
         __init__(self, \\*, featuresCol="features", predictionCol="prediction", k=2, \
                  probabilityCol="probability", tol=0.01, maxIter=100, seed=None, \
@@ -359,7 +362,7 @@ class GaussianMixture(JavaEstimator, _GaussianMixtureParams, JavaMLWritable, Jav
     @since("2.0.0")
     def setParams(self, *, featuresCol="features", predictionCol="prediction", k=2,
                   probabilityCol="probability", tol=0.01, maxIter=100, seed=None,
-                  aggregationDepth=2, weightCol=None):
+                  aggregationDepth=2, weightCol=None, initialModel=None):
         """
         setParams(self, \\*, featuresCol="features", predictionCol="prediction", k=2, \
                   probabilityCol="probability", tol=0.01, maxIter=100, seed=None, \
@@ -376,6 +379,12 @@ class GaussianMixture(JavaEstimator, _GaussianMixtureParams, JavaMLWritable, Jav
         Sets the value of :py:attr:`k`.
         """
         return self._set(k=value)
+
+    def setInitialModel(self, value):
+        """
+        Sets the value of :py:attr:`initialModel`
+        """
+        return self._set(initialModel=value)
 
     @since("2.0.0")
     def setMaxIter(self, value):

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -117,7 +117,7 @@ class _GaussianMixtureParams(HasMaxIter, HasFeaturesCol, HasSeed, HasPredictionC
 
     def __init__(self, *args):
         super(_GaussianMixtureParams, self).__init__(*args)
-        self._setDefault(k=2, tol=0.01, maxIter=100, aggregationDepth=2)
+        self._setDefault(k=2, tol=0.01, maxIter=100, aggregationDepth=2, initialModel=None)
 
     @since("2.0.0")
     def getK(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Added an optional `initialModel` in the GaussianMixture class.

### Why are the changes needed?

To allow for non random initialization in ML's Gaussian Mixture. The algorithm's results can be affected due to the initialization and the existing random initialization may be limiting in some cases. This feature exists in MLLIB. 

### Does this PR introduce _any_ user-facing change?

* A new method: `setInitialModel` in the `GaussianMixture` class


### How was this patch tested?

Yes, tests were added to the `GaussianMixtureSuite.scala` file.
The tests test:
* The ability to add the model
* The fact the GaussianMixture object fit data using the initial parameters
* That the GaussianMixture class validates that `K` is the same to the initial model's `K`

### Why is this WIP?

Not sure if and how to add the `@Since` annotation (even after I've read the _How to contribute_ page). Also, I'm not sure how to add support for Python and R.
