### PR TITLE
[SPARK-32863][SS] Full outer stream-stream join

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
@@ -287,7 +287,7 @@ object UnsupportedOperationChecker extends Logging {
           throwError("dropDuplicates is not supported after aggregation on a " +
             "streaming DataFrame/Dataset")
 
-        case Join(left, right, joinType, condition, _) =>
+        case j @ Join(left, right, joinType, condition, _) =>
           if (left.isStreaming && right.isStreaming && outputMode != InternalOutputModes.Append) {
             throwError("Join between two streaming DataFrames/Datasets is not supported" +
               s" in ${outputMode} output mode, only in Append output mode")
@@ -298,8 +298,14 @@ object UnsupportedOperationChecker extends Logging {
               // no further validations needed
 
             case FullOuter =>
-              if (left.isStreaming || right.isStreaming) {
-                throwError("Full outer joins with streaming DataFrames/Datasets are not supported")
+              if (left.isStreaming && !right.isStreaming) {
+                throwError(s"$FullOuter joins with streaming DataFrames/Datasets on the left " +
+                  "and a static DataFrame/Dataset on the right is not supported")
+              } else if (!left.isStreaming && right.isStreaming) {
+                throwError(s"$FullOuter joins with streaming DataFrames/Datasets on the right " +
+                  "and a static DataFrame/Dataset on the left is not supported")
+              } else if (left.isStreaming && right.isStreaming) {
+                checkForStreamStreamJoinWatermark(j)
               }
 
             case LeftAnti =>
@@ -315,40 +321,17 @@ object UnsupportedOperationChecker extends Logging {
                 throwError(s"$joinType join with a streaming DataFrame/Dataset " +
                   "on the right and a static DataFrame/Dataset on the left is not supported")
               } else if (left.isStreaming && right.isStreaming) {
-                val watermarkInJoinKeys = StreamingJoinHelper.isWatermarkInJoinKeys(subPlan)
-
-                val hasValidWatermarkRange =
-                  StreamingJoinHelper.getStateValueWatermark(
-                    left.outputSet, right.outputSet, condition, Some(1000000)).isDefined
-
-                if (!watermarkInJoinKeys && !hasValidWatermarkRange) {
-                  throwError(
-                    s"Stream-stream $joinType join between two streaming DataFrame/Datasets " +
-                    "is not supported without a watermark in the join keys, or a watermark on " +
-                    "the nullable side and an appropriate range condition")
-                }
+                checkForStreamStreamJoinWatermark(j)
               }
 
             // We support streaming right outer joins with static on the left always, and with
             // stream on both sides under the appropriate conditions.
             case RightOuter =>
               if (left.isStreaming && !right.isStreaming) {
-                throwError("Right outer join with a streaming DataFrame/Dataset on the left and " +
+                throwError(s"$RightOuter join with a streaming DataFrame/Dataset on the left and " +
                     "a static DataFrame/DataSet on the right not supported")
               } else if (left.isStreaming && right.isStreaming) {
-                val isWatermarkInJoinKeys = StreamingJoinHelper.isWatermarkInJoinKeys(subPlan)
-
-                // Check if the nullable side has a watermark, and there's a range condition which
-                // implies a state value watermark on the first side.
-                val hasValidWatermarkRange =
-                    StreamingJoinHelper.getStateValueWatermark(
-                      right.outputSet, left.outputSet, condition, Some(1000000)).isDefined
-
-                if (!isWatermarkInJoinKeys && !hasValidWatermarkRange) {
-                  throwError("Stream-stream outer join between two streaming DataFrame/Datasets " +
-                    "is not supported without a watermark in the join keys, or a watermark on " +
-                    "the nullable side and an appropriate range condition")
-                }
+                checkForStreamStreamJoinWatermark(j)
               }
 
             case NaturalJoin(_) | UsingJoin(_, _) =>
@@ -437,5 +420,30 @@ object UnsupportedOperationChecker extends Logging {
   private def throwError(msg: String)(implicit operator: LogicalPlan): Nothing = {
     throw new AnalysisException(
       msg, operator.origin.line, operator.origin.startPosition, Some(operator))
+  }
+
+  private def checkForStreamStreamJoinWatermark(join: Join): Unit = {
+    val watermarkInJoinKeys = StreamingJoinHelper.isWatermarkInJoinKeys(join)
+
+    val hasValidWatermarkRange = join.joinType match {
+      case LeftOuter | LeftSemi => StreamingJoinHelper.getStateValueWatermark(
+        join.left.outputSet, join.right.outputSet, join.condition, Some(1000000)).isDefined
+      case RightOuter => StreamingJoinHelper.getStateValueWatermark(
+        join.right.outputSet, join.left.outputSet, join.condition, Some(1000000)).isDefined
+      case FullOuter =>
+        Seq((join.left.outputSet, join.right.outputSet),
+          (join.right.outputSet, join.left.outputSet)).exists {
+          case (attributesToFindStateWatermarkFor, attributesWithEventWatermark) =>
+            StreamingJoinHelper.getStateValueWatermark(attributesToFindStateWatermarkFor,
+              attributesWithEventWatermark, join.condition, Some(1000000)).isDefined
+        }
+    }
+
+    if (!watermarkInJoinKeys && !hasValidWatermarkRange) {
+      throwError(
+        s"Stream-stream ${join.joinType} join between two streaming DataFrame/Datasets " +
+          "is not supported without a watermark in the join keys, or a watermark on " +
+          "the nullable side and an appropriate range condition")(join)
+    }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
@@ -437,6 +437,9 @@ object UnsupportedOperationChecker extends Logging {
             StreamingJoinHelper.getStateValueWatermark(attributesToFindStateWatermarkFor,
               attributesWithEventWatermark, join.condition, Some(1000000)).isDefined
         }
+      case _ =>
+        throwError(
+          s"Join type ${join.joinType} is not supported with streaming DataFrame/Dataset")(join)
     }
 
     if (!watermarkInJoinKeys && !hasValidWatermarkRange) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
@@ -299,10 +299,10 @@ object UnsupportedOperationChecker extends Logging {
 
             case FullOuter =>
               if (left.isStreaming && !right.isStreaming) {
-                throwError(s"FullOuter joins with streaming DataFrames/Datasets on the left " +
+                throwError("FullOuter joins with streaming DataFrames/Datasets on the left " +
                   "and a static DataFrame/Dataset on the right is not supported")
               } else if (!left.isStreaming && right.isStreaming) {
-                throwError(s"FullOuter joins with streaming DataFrames/Datasets on the right " +
+                throwError("FullOuter joins with streaming DataFrames/Datasets on the right " +
                   "and a static DataFrame/Dataset on the left is not supported")
               } else if (left.isStreaming && right.isStreaming) {
                 checkForStreamStreamJoinWatermark(j)
@@ -328,7 +328,7 @@ object UnsupportedOperationChecker extends Logging {
             // stream on both sides under the appropriate conditions.
             case RightOuter =>
               if (left.isStreaming && !right.isStreaming) {
-                throwError(s"RightOuter join with a streaming DataFrame/Dataset on the left and " +
+                throwError("RightOuter join with a streaming DataFrame/Dataset on the left and " +
                     "a static DataFrame/DataSet on the right not supported")
               } else if (left.isStreaming && right.isStreaming) {
                 checkForStreamStreamJoinWatermark(j)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
@@ -299,10 +299,10 @@ object UnsupportedOperationChecker extends Logging {
 
             case FullOuter =>
               if (left.isStreaming && !right.isStreaming) {
-                throwError(s"$FullOuter joins with streaming DataFrames/Datasets on the left " +
+                throwError(s"FullOuter joins with streaming DataFrames/Datasets on the left " +
                   "and a static DataFrame/Dataset on the right is not supported")
               } else if (!left.isStreaming && right.isStreaming) {
-                throwError(s"$FullOuter joins with streaming DataFrames/Datasets on the right " +
+                throwError(s"FullOuter joins with streaming DataFrames/Datasets on the right " +
                   "and a static DataFrame/Dataset on the left is not supported")
               } else if (left.isStreaming && right.isStreaming) {
                 checkForStreamStreamJoinWatermark(j)
@@ -328,7 +328,7 @@ object UnsupportedOperationChecker extends Logging {
             // stream on both sides under the appropriate conditions.
             case RightOuter =>
               if (left.isStreaming && !right.isStreaming) {
-                throwError(s"$RightOuter join with a streaming DataFrame/Dataset on the left and " +
+                throwError(s"RightOuter join with a streaming DataFrame/Dataset on the left and " +
                     "a static DataFrame/DataSet on the right not supported")
               } else if (left.isStreaming && right.isStreaming) {
                 checkForStreamStreamJoinWatermark(j)
@@ -425,6 +425,8 @@ object UnsupportedOperationChecker extends Logging {
   private def checkForStreamStreamJoinWatermark(join: Join): Unit = {
     val watermarkInJoinKeys = StreamingJoinHelper.isWatermarkInJoinKeys(join)
 
+    // Check if the nullable side has a watermark, and there's a range condition which
+    // implies a state value watermark on the first side.
     val hasValidWatermarkRange = join.joinType match {
       case LeftOuter | LeftSemi => StreamingJoinHelper.getStateValueWatermark(
         join.left.outputSet, join.right.outputSet, join.condition, Some(1000000)).isDefined

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
@@ -411,11 +411,12 @@ class UnsupportedOperationsSuite extends SparkFunSuite with SQLHelper {
 
   // Full outer joins: only batch-batch is allowed
   testBinaryOperationInStreamingPlan(
-    "full outer join",
+    "FullOuter join",
     _.join(_, joinType = FullOuter),
     streamStreamSupported = false,
     batchStreamSupported = false,
-    streamBatchSupported = false)
+    streamBatchSupported = false,
+    expectedMsg = "FullOuter join")
 
   // Left outer, left semi, left anti join: *-stream not allowed
   Seq((LeftOuter, "LeftOuter join"), (LeftSemi, "LeftSemi join"), (LeftAnti, "LeftAnti join"))
@@ -430,14 +431,14 @@ class UnsupportedOperationsSuite extends SparkFunSuite with SQLHelper {
 
   // Right outer joins: stream-* not allowed
   testBinaryOperationInStreamingPlan(
-    "right outer join",
+    "RightOuter join",
     _.join(_, joinType = RightOuter),
     streamBatchSupported = false,
     streamStreamSupported = false,
-    expectedMsg = "outer join")
+    expectedMsg = "RightOuter join")
 
-  // Left outer, right outer, left semi joins
-  Seq(LeftOuter, RightOuter, LeftSemi).foreach { joinType =>
+  // Left outer, right outer, full outer, left semi joins
+  Seq(LeftOuter, RightOuter, FullOuter, LeftSemi).foreach { joinType =>
     // Update mode not allowed
     assertNotSupportedInStreamingPlan(
       s"$joinType join with stream-stream relations and update mode",

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
@@ -409,7 +409,8 @@ class UnsupportedOperationsSuite extends SparkFunSuite with SQLHelper {
     streamStreamSupported = false,
     expectedMsg = "is not supported in Update output mode")
 
-  // Full outer joins: only batch-batch is allowed
+  // Full outer joins: stream-batch/batch-stream join are not allowed,
+  // and stream-stream join is allowed 'conditionally' - see below check
   testBinaryOperationInStreamingPlan(
     "FullOuter join",
     _.join(_, joinType = FullOuter),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
@@ -165,8 +165,14 @@ case class StreamingSymmetricHashJoinExec(
     throw new IllegalArgumentException(errorMessageForJoinType)
   }
 
+  private def throwBadStateFormatVersionException(): Nothing = {
+    throw new IllegalStateException("Unexpected state format version! " +
+      s"version $stateFormatVersion")
+  }
+
   require(
-    joinType == Inner || joinType == LeftOuter || joinType == RightOuter || joinType == LeftSemi,
+    joinType == Inner || joinType == LeftOuter || joinType == RightOuter || joinType == FullOuter ||
+    joinType == LeftSemi,
     errorMessageForJoinType)
   require(leftKeys.map(_.dataType) == rightKeys.map(_.dataType))
 
@@ -186,6 +192,7 @@ case class StreamingSymmetricHashJoinExec(
     case _: InnerLike => left.output ++ right.output
     case LeftOuter => left.output ++ right.output.map(_.withNullability(true))
     case RightOuter => left.output.map(_.withNullability(true)) ++ right.output
+    case FullOuter => (left.output ++ right.output).map(_.withNullability(true))
     case LeftSemi => left.output
     case _ => throwBadJoinTypeException()
   }
@@ -195,6 +202,7 @@ case class StreamingSymmetricHashJoinExec(
       PartitioningCollection(Seq(left.outputPartitioning, right.outputPartitioning))
     case LeftOuter => left.outputPartitioning
     case RightOuter => right.outputPartitioning
+    case FullOuter => UnknownPartitioning(left.outputPartitioning.numPartitions)
     case LeftSemi => left.outputPartitioning
     case _ => throwBadJoinTypeException()
   }
@@ -250,14 +258,14 @@ case class StreamingSymmetricHashJoinExec(
     //  Join one side input using the other side's buffered/state rows. Here is how it is done.
     //
     //  - `leftSideJoiner.storeAndJoinWithOtherSide(rightSideJoiner)`
-    //    - Inner, Left Outer, Right Outer Join: generates all rows from matching new left input
-    //      with stored right input, and also stores all the left input.
+    //    - Inner, Left Outer, Right Outer, Full Outer Join: generates all rows from matching
+    //      new left input with stored right input, and also stores all the left input.
     //    - Left Semi Join: generates all new left input rows from matching new left input with
     //      stored right input, and also stores all the non-matched left input.
     //
     //  - `rightSideJoiner.storeAndJoinWithOtherSide(leftSideJoiner)`
-    //    - Inner, Left Outer, Right Outer Join: generates all rows from matching new right input
-    //      with stored left input, and also stores all the right input.
+    //    - Inner, Left Outer, Right Outer, Full Outer Join: generates all rows from matching
+    //      new right input with stored left input, and also stores all the right input.
     //      It also generates all rows from matching new left input with new right input, since
     //      the new left input has become stored by that point. This tiny asymmetry is necessary
     //      to avoid duplication.
@@ -314,9 +322,7 @@ case class StreamingSymmetricHashJoinExec(
           stateFormatVersion match {
             case 1 => matchesWithRightSideState(new UnsafeRowPair(kv.key, kv.value))
             case 2 => kv.matched
-            case _ =>
-              throw new IllegalStateException("Unexpected state format version! " +
-                s"version $stateFormatVersion")
+            case _ => throwBadStateFormatVersionException()
           }
         }.map(pair => joinedRow.withLeft(pair.value).withRight(nullRight))
 
@@ -333,13 +339,23 @@ case class StreamingSymmetricHashJoinExec(
           stateFormatVersion match {
             case 1 => matchesWithLeftSideState(new UnsafeRowPair(kv.key, kv.value))
             case 2 => kv.matched
-            case _ =>
-              throw new IllegalStateException("Unexpected state format version! " +
-                s"version $stateFormatVersion")
+            case _ => throwBadStateFormatVersionException()
           }
         }.map(pair => joinedRow.withLeft(nullLeft).withRight(pair.value))
 
         hashJoinOutputIter ++ outerOutputIter
+      case FullOuter =>
+        lazy val isKeyToValuePairMatched = (kv: KeyToValuePair) =>
+          stateFormatVersion match {
+            case 2 => kv.matched
+            case _ => throwBadStateFormatVersionException()
+          }
+        val leftSideOutputIter = leftSideJoiner.removeOldState().filterNot(isKeyToValuePairMatched)
+          .map(pair => joinedRow.withLeft(pair.value).withRight(nullRight))
+        val rightSideOutputIter = rightSideJoiner.removeOldState().filterNot(
+          isKeyToValuePairMatched).map(pair => joinedRow.withLeft(nullLeft).withRight(pair.value))
+
+        hashJoinOutputIter ++ leftSideOutputIter ++ rightSideOutputIter
       case _ => throwBadJoinTypeException()
     }
 
@@ -382,6 +398,7 @@ case class StreamingSymmetricHashJoinExec(
             leftSideJoiner.removeOldState() ++ rightSideJoiner.removeOldState()
           case LeftOuter => rightSideJoiner.removeOldState()
           case RightOuter => leftSideJoiner.removeOldState()
+          case FullOuter => Iterator.empty
           case _ => throwBadJoinTypeException()
         }
         while (cleanupIter.hasNext) {
@@ -491,9 +508,9 @@ case class StreamingSymmetricHashJoinExec(
         }
 
       val generateFilteredJoinedRow: InternalRow => Iterator[InternalRow] = joinSide match {
-        case LeftSide if joinType == LeftOuter =>
+        case LeftSide if joinType == LeftOuter || joinType == FullOuter =>
           (row: InternalRow) => Iterator(generateJoinedRow(row, nullRight))
-        case RightSide if joinType == RightOuter =>
+        case RightSide if joinType == RightOuter || joinType == FullOuter =>
           (row: InternalRow) => Iterator(generateJoinedRow(row, nullLeft))
         case _ => (_: InternalRow) => Iterator.empty
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
@@ -107,7 +107,8 @@ abstract class StreamingJoinSuite
     } else if (joinType == "right_outer") {
       joined.select(right("key"), right("window.end").cast("long"), 'leftValue, 'rightValue)
     } else {
-      joined
+      joined.select(left("key"), left("window.end").cast("long"), 'leftValue,
+        right("key"), right("window.end").cast("long"), 'rightValue)
     }
 
     (leftInput, rightInput, select)
@@ -136,7 +137,8 @@ abstract class StreamingJoinSuite
     } else if (joinType == "right_outer") {
       joined.select(right("key"), right("window.end").cast("long"), 'leftValue, 'rightValue)
     } else {
-      joined
+      joined.select(left("key"), left("window.end").cast("long"), 'leftValue,
+        right("key"), right("window.end").cast("long"), 'rightValue)
     }
 
     (leftInput, rightInput, select)
@@ -1074,6 +1076,209 @@ class StreamingOuterJoinSuite extends StreamingJoinSuite {
     testStream(joined)(
       MultiAddData((input1, inputDataForInput1), (input2, inputDataForInput2)),
       CheckNewAnswer(expectedOutput.head, expectedOutput.tail: _*)
+    )
+  }
+}
+
+class StreamingFullOuterJoinSuite extends StreamingJoinSuite {
+
+  test("windowed full outer join") {
+    val (leftInput, rightInput, joined) = setupWindowedJoin("full_outer")
+
+    testStream(joined)(
+      MultiAddData(leftInput, 1, 2, 3, 4, 5)(rightInput, 3, 4, 5, 6, 7),
+      CheckNewAnswer(Row(3, 10, 6, 9), Row(4, 10, 8, 12), Row(5, 10, 10, 15)),
+      // states
+      // left: 1, 2, 3, 4 ,5
+      // right: 3, 4, 5, 6, 7
+      assertNumStateRows(total = 10, updated = 10),
+      MultiAddData(leftInput, 21)(rightInput, 22),
+      // Watermark = 11, should remove rows having window=[0,10].
+      CheckNewAnswer(Row(1, 10, 2, null), Row(2, 10, 4, null), Row(6, 10, null, 18),
+        Row(7, 10, null, 21)),
+      // states
+      // left: 21
+      // right: 22
+      //
+      // states evicted
+      // left: 1, 2, 3, 4 ,5 (below watermark)
+      // right: 3, 4, 5, 6, 7 (below watermark)
+      assertNumStateRows(total = 2, updated = 2),
+      AddData(leftInput, 22),
+      CheckNewAnswer(Row(22, 30, 44, 66)),
+      // states
+      // left: 21, 22
+      // right: 22
+      assertNumStateRows(total = 3, updated = 1),
+      StopStream,
+      StartStream(),
+
+      AddData(leftInput, 1),
+      // Row not add as 1 < state key watermark = 12.
+      CheckNewAnswer(),
+      // states
+      // left: 21, 22
+      // right: 22
+      assertNumStateRows(total = 3, updated = 0, droppedByWatermark = 1),
+      AddData(rightInput, 5),
+      // Row not add as 5 < state key watermark = 12.
+      CheckNewAnswer(),
+      // states
+      // left: 21, 22
+      // right: 22
+      assertNumStateRows(total = 3, updated = 0, droppedByWatermark = 1)
+    )
+  }
+
+  test("full outer early state exclusion on left") {
+    val (leftInput, rightInput, joined) = setupWindowedJoinWithLeftCondition("full_outer")
+
+    testStream(joined)(
+      MultiAddData(leftInput, 1, 2, 3)(rightInput, 3, 4, 5),
+      // The left rows with leftValue <= 4 should generate their outer join rows now and
+      // not get added to the state.
+      CheckNewAnswer(Row(1, 10, 2, null, null, null), Row(2, 10, 4, null, null, null),
+        Row(3, 10, 6, 3, 10, "9")),
+      // states
+      // left: 3
+      // right: 3, 4, 5
+      assertNumStateRows(total = 4, updated = 4),
+      // Generate outer join result for all non-matched rows when the watermark advances.
+      MultiAddData(leftInput, 20)(rightInput, 21),
+      CheckNewAnswer(Row(null, null, null, 4, 10, "12"), Row(null, null, null, 5, 10, "15")),
+      // states
+      // left: 20
+      // right: 21
+      //
+      // states evicted
+      // left: 3 (below watermark)
+      // right: 3, 4, 5 (below watermark)
+      assertNumStateRows(total = 2, updated = 2),
+      AddData(rightInput, 20),
+      CheckNewAnswer(Row(20, 30, 40, 20, 30, "60")),
+      // states
+      // left: 20
+      // right: 21, 20
+      assertNumStateRows(total = 3, updated = 1)
+    )
+  }
+
+  test("full outer early state exclusion on right") {
+    val (leftInput, rightInput, joined) = setupWindowedJoinWithRightCondition("full_outer")
+
+    testStream(joined)(
+      MultiAddData(leftInput, 3, 4, 5)(rightInput, 1, 2, 3),
+      // The right rows with rightValue <= 7 should generate their outer join rows now,
+      // and never be added to the state.
+      // The right row with rightValue = 9 > 7, hence joined and added to state.
+      CheckNewAnswer(Row(null, null, null, 1, 10, "3"), Row(null, null, null, 2, 10, "6"),
+        Row(3, 10, 6, 3, 10, "9")),
+      // states
+      // left: 3, 4, 5
+      // right: 3
+      assertNumStateRows(total = 4, updated = 4),
+      // Generate outer join result for all non-matched rows when the watermark advances.
+      MultiAddData(leftInput, 20)(rightInput, 21),
+      CheckNewAnswer(Row(4, 10, 8, null, null, null), Row(5, 10, 10, null, null, null)),
+      // states
+      // left: 20
+      // right: 21
+      //
+      // states evicted
+      // left: 3, 4, 5 (below watermark)
+      // right: 3 (below watermark)
+      assertNumStateRows(total = 2, updated = 2),
+      AddData(rightInput, 20),
+      CheckNewAnswer(Row(20, 30, 40, 20, 30, "60")),
+      // states
+      // left: 20
+      // right: 21, 20
+      assertNumStateRows(total = 3, updated = 1)
+    )
+  }
+
+  test("full outer join with watermark range condition") {
+    val (leftInput, rightInput, joined) = setupWindowedJoinWithRangeCondition("full_outer")
+
+    testStream(joined)(
+      AddData(leftInput, (1, 5), (3, 5)),
+      CheckNewAnswer(),
+      // states
+      // left: (1, 5), (3, 5)
+      // right: nothing
+      assertNumStateRows(total = 2, updated = 2),
+      AddData(rightInput, (1, 10), (2, 5)),
+      // Match left row in the state.
+      CheckNewAnswer(Row(1, 1, 5, 10)),
+      // states
+      // left: (1, 5), (3, 5)
+      // right: (1, 10), (2, 5)
+      assertNumStateRows(total = 4, updated = 2),
+      AddData(rightInput, (1, 9)),
+      // Match left row in the state.
+      CheckNewAnswer(Row(1, 1, 5, 9)),
+      // states
+      // left: (1, 5), (3, 5)
+      // right: (1, 10), (2, 5), (1, 9)
+      assertNumStateRows(total = 5, updated = 1),
+      // Increase event time watermark to 20s by adding data with time = 30s on both inputs.
+      AddData(leftInput, (1, 7), (1, 30)),
+      CheckNewAnswer(Row(1, 1, 7, 9), Row(1, 1, 7, 10)),
+      // states
+      // left: (1, 5), (3, 5), (1, 7), (1, 30)
+      // right: (1, 10), (2, 5), (1, 9)
+      assertNumStateRows(total = 7, updated = 2),
+      // Watermark = 30 - 10 = 20, no matched row.
+      // Generate outer join result for all non-matched rows when the watermark advances.
+      AddData(rightInput, (0, 30)),
+      CheckNewAnswer(Row(3, null, 5, null), Row(null, 2, null, 5)),
+      // states
+      // left: (1, 30)
+      // right: (0, 30)
+      //
+      // states evicted
+      // left: (1, 5), (3, 5), (1, 5) (below watermark = 20)
+      // right: (1, 10), (2, 5), (1, 9) (below watermark = 20)
+      assertNumStateRows(total = 2, updated = 1)
+    )
+  }
+
+  test("self full outer join") {
+    val (inputStream, query) = setupWindowedSelfJoin("full_outer")
+
+    testStream(query)(
+      AddData(inputStream, (1, 1L), (2, 2L), (3, 3L), (4, 4L), (5, 5L)),
+      CheckNewAnswer(Row(2, 2L, 2, 2L), Row(4, 4L, 4, 4L)),
+      // batch 1 - global watermark = 0
+      // states
+      // left: (1, 1L), (2, 2L), (3, 3L), (4, 4L), (5, 5L)
+      // right: (2, 2L), (4, 4L)
+      assertNumStateRows(total = 7, updated = 7),
+      AddData(inputStream, (6, 6L), (7, 7L), (8, 8L), (9, 9L), (10, 10L)),
+      CheckNewAnswer(Row(6, 6L, 6, 6L), Row(8, 8L, 8, 8L), Row(10, 10L, 10, 10L)),
+      // batch 2 - global watermark = 5
+      // states
+      // left: (1, 1L), (2, 2L), (3, 3L), (4, 4L), (5, 5L), (6, 6L), (7, 7L), (8, 8L),
+      //       (9, 9L), (10, 10L)
+      // right: (6, 6L), (8, 8L), (10, 10L)
+      //
+      // states evicted
+      // left: nothing (it waits for 5 seconds more than watermark due to join condition)
+      // right: (2, 2L), (4, 4L)
+      assertNumStateRows(total = 13, updated = 8),
+      AddData(inputStream, (11, 11L), (12, 12L), (13, 13L), (14, 14L), (15, 15L)),
+      CheckNewAnswer(Row(12, 12L, 12, 12L), Row(14, 14L, 14, 14L), Row(1, 1L, null, null),
+        Row(3, 3L, null, null)),
+      // batch 3 - global watermark = 9
+      // states
+      // left: (4, 4L), (5, 5L), (6, 6L), (7, 7L), (8, 8L), (9, 9L), (10, 10L), (11, 11L),
+      //       (12, 12L), (13, 13L), (14, 14L), (15, 15L)
+      // right: (10, 10L), (12, 12L), (14, 14L)
+      //
+      // states evicted
+      // left: (1, 1L), (2, 2L), (3, 3L)
+      // right: (6, 6L), (8, 8L)
+      assertNumStateRows(total = 15, updated = 7)
     )
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR is to add full outer stream-stream join, and the implementation of full outer join is:
* For left side input row, check if there's a match on right side state store.
  * if there's a match, output the joined row, o.w. output nothing. Put the row in left side state store.
* For right side input row, check if there's a match on left side state store.
  * if there's a match, output the joined row, o.w. output nothing. Put the row in right side state store.
* State store eviction: evict rows from left/right side state store below watermark, and output rows never matched before (a combination of left outer and right outer join).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Enable more use cases for spark stream-stream join.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added unit tests in `UnsupportedOperationChecker.scala` and `StreamingJoinSuite.scala`.