### PR TITLE
[SPARK-33479][DOC] Make the API Key of DocSearch configurable

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -26,4 +26,15 @@ SCALA_VERSION: "2.12.10"
 MESOS_VERSION: 1.0.0
 SPARK_ISSUE_TRACKER_URL: https://issues.apache.org/jira/browse/SPARK
 SPARK_GITHUB_URL: https://github.com/apache/spark
-DOCSEARCH_API_KEY: b18ca3732c502995563043aa17bc6ecb
+# Before a new release, we should apply a new `apiKey` for the new Spark documentation
+# on https://docsearch.algolia.com/. Otherwise, after release, the search results are always based
+# on the latest documentation(https://spark.apache.org/docs/latest/) even when visiting the
+# documentation of previous releases.
+DOCSEARCH_SCRIPT: |
+  docsearch({
+      apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+      indexName: 'apache_spark',
+      inputSelector: '#docsearch-input',
+      enhancedSearchInput: true,
+      debug: false // Set debug to true if you want to inspect the dropdown
+  });

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -26,3 +26,4 @@ SCALA_VERSION: "2.12.10"
 MESOS_VERSION: 1.0.0
 SPARK_ISSUE_TRACKER_URL: https://issues.apache.org/jira/browse/SPARK
 SPARK_GITHUB_URL: https://github.com/apache/spark
+DOCSEARCH_API_KEY: b18ca3732c502995563043aa17bc6ecb

--- a/docs/_layouts/global.html
+++ b/docs/_layouts/global.html
@@ -187,15 +187,8 @@
             // 2. a JavaScript snippet to be inserted in your website that will bind this Algolia index
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
-            docsearch({
-                apiKey: '{{site.SPARK_VERSION_SHORT}}',
-                indexName: 'apache_spark',
-                inputSelector: '#docsearch-input',
-                enhancedSearchInput: true,
-                debug: false // Set debug to true if you want to inspect the dropdown
-        });
+            {{site.DOCSEARCH_SCRIPT}}
         </script>
-
         <!-- MathJax Section -->
         <script type="text/x-mathjax-config">
             MathJax.Hub.Config({

--- a/docs/_layouts/global.html
+++ b/docs/_layouts/global.html
@@ -188,7 +188,7 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-                apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+                apiKey: '{{site.SPARK_VERSION_SHORT}}',
                 indexName: 'apache_spark',
                 inputSelector: '#docsearch-input',
                 enhancedSearchInput: true,

--- a/docs/_layouts/global.html
+++ b/docs/_layouts/global.html
@@ -189,6 +189,7 @@
             //    details on how works DocSearch, check the docs of DocSearch.
             {{site.DOCSEARCH_SCRIPT}}
         </script>
+
         <!-- MathJax Section -->
         <script type="text/x-mathjax-config">
             MathJax.Hub.Config({


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Make the API key of DocSearch configurable and avoid hardcoding in the HTML template

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

After https://github.com/apache/spark/pull/30292, our Spark documentation site supports searching.
However, the default API key always points to the latest release doc. We have to set different API keys for different releases. Otherwise, the search results are always based on the latest documentation(https://spark.apache.org/docs/latest/) even when visiting the documentation of previous releases.

As per discussion in https://github.com/apache/spark/pull/30292#issuecomment-725613417, we should make the API key configurable and set different values for different releases.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Manual test