### PR TITLE
[SPARK-33478][SQL] Allow overwrite a path that is also being read under dynamic partition overwrite

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
@@ -73,7 +73,7 @@ case class InsertIntoHadoopFsRelationCommand(
     // This config only makes sense when we are overwriting a partitioned dataset with dynamic
     // partition columns.
     enableDynamicOverwrite && mode == SaveMode.Overwrite &&
-      staticPartitions.size < partitionColumns.length
+      staticPartitions.size <= partitionColumns.length
   }
 
   override def run(sparkSession: SparkSession, child: SparkPlan): Seq[Row] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
@@ -72,7 +72,7 @@ case class InsertIntoHadoopFsRelationCommand(
     val enableDynamicOverwrite = partitionOverwriteMode == PartitionOverwriteMode.DYNAMIC
     // This config only makes sense when we are overwriting a partitioned dataset with dynamic
     // partition columns.
-    enableDynamicOverwrite && mode == SaveMode.Overwrite &&
+    enableDynamicOverwrite && mode == SaveMode.Overwrite && partitionColumns.length > 0 &&
       staticPartitions.size <= partitionColumns.length
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
@@ -72,7 +72,7 @@ case class InsertIntoHadoopFsRelationCommand(
     val enableDynamicOverwrite = partitionOverwriteMode == PartitionOverwriteMode.DYNAMIC
     // This config only makes sense when we are overwriting a partitioned dataset with dynamic
     // partition columns.
-    enableDynamicOverwrite && mode == SaveMode.Overwrite && partitionColumns.length > 0 &&
+    enableDynamicOverwrite && mode == SaveMode.Overwrite && partitionColumns.nonEmpty &&
       staticPartitions.size <= partitionColumns.length
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -303,6 +303,14 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
               """.stripMargin)
             checkAnswer(spark.table("insertTable"),
               Row(2, 1, 1) :: Row(3, 1, 2) :: Row(4, 1, 3) :: Nil)
+
+            sql(
+              """
+                |INSERT OVERWRITE TABLE insertTable PARTITION(part1=1, part2=1)
+                |SELECT i + 1 FROM insertTable
+              """.stripMargin)
+            checkAnswer(spark.table("insertTable"),
+              Row(3, 1, 1) :: Row(3, 1, 2) :: Row(4, 1, 1) :: Row(4, 1, 3) :: Row(5, 1, 1) :: Nil)
           } else {
             val message = intercept[AnalysisException] {
               sql(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Insert overwrite same table can overwrite a path that is also being read under dynamic partition overwrite

### Why are the changes needed?

Currently, Insert overwrite cannot overwrite a path that is also being read under dynamic partition overwrite.
In the class DataSourceAnalysis, DDLUtils.verifyNotReadPath is called to determine whether it can be overwrite, but in the InsertIntoHadoopFsRelationCommand.dynamicPartitionOverwrite method, we need to consider the scenario where staticPartitions.size equals partitionColumns.length, which should also be allowed to overwrite path this is also being read.

Consider the following statement:
CREATE TABLE insertTable(i int, part1 int, part2 int) USING PARQUET PARTITIONED BY (part1, part2);
INSERT OVERWRITE TABLE insertTable PARTITION(part1=1, part2=1) SELECT i + 1 FROM insertTable;

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

Add test in InsertSuite, start line:307