### PR TITLE
[SPARK-33728][CORE][K8S] Debug the Jenkins CI K8s failures

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
@@ -254,7 +254,7 @@ private[storage] class BlockManagerDecommissioner(
     shufflesToMigrate.addAll(newShufflesToMigrate.map(x => (x, 0)).asJava)
     migratingShuffles ++= newShufflesToMigrate
     logInfo(s"${newShufflesToMigrate.size} of ${localShuffles.size} local shuffles " +
-      s"are added. In total, ${migratingShuffles.size} shuffles are remained.")
+      s"are added. In total, ${migratingShuffles.size} shuffles remain & migrated ${numMigratedShuffles.get}")
 
     // Update the threads doing migrations
     val livePeerSet = bm.getPeers(false).toSet

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
@@ -254,7 +254,8 @@ private[storage] class BlockManagerDecommissioner(
     shufflesToMigrate.addAll(newShufflesToMigrate.map(x => (x, 0)).asJava)
     migratingShuffles ++= newShufflesToMigrate
     logInfo(s"${newShufflesToMigrate.size} of ${localShuffles.size} local shuffles " +
-      s"are added. In total, ${migratingShuffles.size} shuffles remain & migrated ${numMigratedShuffles.get}")
+      s"are added. In total, ${migratingShuffles.size} shuffles total " +
+      s"migrated so far ${numMigratedShuffles.get}")
 
     // Update the threads doing migrations
     val livePeerSet = bm.getPeers(false).toSet

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DecommissionSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DecommissionSuite.scala
@@ -36,7 +36,7 @@ private[spark] trait DecommissionSuite { k8sSuite: KubernetesSuite =>
       // Ensure we have somewhere to migrate our data too
       .set("spark.executor.instances", "2")
       // The default of 30 seconds is fine, but for testing we just want to get this done fast.
-      .set("spark.storage.decommission.replicationReattemptInterval", "1")
+      .set("spark.storage.decommission.replicationReattemptInterval", "10")
 
     var execLogs = scala.collection.mutable.HashMap[String, String]()
 
@@ -47,8 +47,11 @@ private[spark] trait DecommissionSuite { k8sSuite: KubernetesSuite =>
           .pods()
           .withName(pod.getMetadata.getName)
           .getLog
-        assert(myLog.contains("Exit code"))
         execLogs += ((pod.getMetadata.getName, myLog))
+        assert(
+          myLog.contains("ShutdownHookManager: Shutdown hook called") ||
+          myLog.contains("Executor self-exiting due to")
+        )
       }
     }
 

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DecommissionSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DecommissionSuite.scala
@@ -112,7 +112,7 @@ private[spark] trait DecommissionSuite { k8sSuite: KubernetesSuite =>
           .withName(pod.getMetadata.getName)
           .getLog
         assert(myLog.contains("Exit code"))
-        execLogs += (pod.getMetadata.getName, myLog)
+        execLogs += ((pod.getMetadata.getName, myLog))
       }
     }
 

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DecommissionSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DecommissionSuite.scala
@@ -40,7 +40,7 @@ private[spark] trait DecommissionSuite { k8sSuite: KubernetesSuite =>
 
     var execLogs = scala.collection.mutable.HashMap[String, String]()
 
-    def collectExecLogsPodCheck(pod: Pod) = {
+    def collectExecLogsPodCheck(pod: Pod): Unit = {
       doBasicExecutorPyPodCheck(pod)
       Eventually.eventually(TIMEOUT, INTERVAL) {
         val myLog = kubernetesTestComponents.kubernetesClient
@@ -73,7 +73,7 @@ private[spark] trait DecommissionSuite { k8sSuite: KubernetesSuite =>
         decommissioningTest = true)
     } catch {
       case e: Exception =>
-        println(s"Had an exception, exec logs are ${execLogs.toString}")
+        logError(s"Had an exception, exec logs are ${execLogs.toString}", e)
         throw e
     }
   }

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
@@ -381,8 +381,6 @@ class KubernetesSuite extends SparkFunSuite
       .get(0)
     driverPodChecker(driverPod)
 
-    // If we're testing decommissioning we an executors, but we should have an executor
-    // at some point.
     Eventually.eventually(TIMEOUT, patienceInterval) {
       execPods.values.nonEmpty should be (true)
     }

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
@@ -43,7 +43,7 @@ import org.apache.spark.internal.config._
 class KubernetesSuite extends SparkFunSuite
   with BeforeAndAfterAll with BeforeAndAfter with BasicTestsSuite with SparkConfPropagateSuite
   with SecretsTestsSuite with PythonTestsSuite with ClientModeTestsSuite with PodTemplateSuite
-  with PVTestsSuite with DepsTestsSuite with DecommissionSuite  with RTestsSuite with Logging
+  with PVTestsSuite with DepsTestsSuite with DecommissionSuite with RTestsSuite with Logging
   with Eventually with Matchers {
 
 

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
@@ -43,7 +43,7 @@ import org.apache.spark.internal.config._
 class KubernetesSuite extends SparkFunSuite
   with BeforeAndAfterAll with BeforeAndAfter with BasicTestsSuite with SparkConfPropagateSuite
   with SecretsTestsSuite with PythonTestsSuite with ClientModeTestsSuite with PodTemplateSuite
-  with PVTestsSuite with DepsTestsSuite with DecommissionSuite with RTestsSuite with Logging
+  with PVTestsSuite with DepsTestsSuite with DecommissionSuite  with RTestsSuite with Logging
   with Eventually with Matchers {
 
 
@@ -321,19 +321,19 @@ class KubernetesSuite extends SparkFunSuite
             case Action.MODIFIED =>
               execPods(name) = resource
             case Action.ADDED =>
-              logDebug(s"Add event received for $name.")
+              logInfo(s"Add event received for $name.")
               execPods(name) = resource
               // If testing decommissioning start a thread to simulate
               // decommissioning on the first exec pod.
               if (decommissioningTest && execPods.size == 1) {
                 // Wait for all the containers in the pod to be running
-                logDebug("Waiting for pod to become OK prior to deletion")
+                logInfo("Waiting for pod to become OK prior to deletion")
                 Eventually.eventually(patienceTimeout, patienceInterval) {
                   val result = checkPodReady(namespace, name)
                   result shouldBe (true)
                 }
                 // Look for the string that indicates we're good to trigger decom on the driver
-                logDebug("Waiting for first collect...")
+                logInfo("Waiting for first collect...")
                 Eventually.eventually(TIMEOUT, INTERVAL) {
                   assert(kubernetesTestComponents.kubernetesClient
                     .pods()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Collect executor log info during the decommissioning integration test on Kube.


### Why are the changes needed?

After the Jenkins upgrade the test is failing and there is not enough info in the driver log only to debug this.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

N/A