### PR TITLE
[SPARK-33504][CORE] The application log in the Spark history server contains sensitive attributes should be redacted

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -287,7 +287,7 @@ private[spark] class EventLoggingListener(
     }
     val redactedProperties = new Properties
     // properties may contain some custom local properties such as stage/job description
-    // only properties in sparkConf need to be redacted, 
+    // only properties in sparkConf need to be redacted.
     val (globalProperties, localProperties) = properties.asScala.toSeq.partition {
       case (key, _) => sparkConf.contains(key)
     }
@@ -296,7 +296,7 @@ private[spark] class EventLoggingListener(
     }
     redactedProperties
   }
-      
+
   private[spark] def redactEvent(
       event: SparkListenerEnvironmentUpdate): SparkListenerEnvironmentUpdate = {
     // environmentDetails maps a string descriptor to a set of properties

--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -105,7 +105,7 @@ private[spark] class EventLoggingListener(
 
   // Events that do not trigger a flush
   override def onStageSubmitted(event: SparkListenerStageSubmitted): Unit = {
-    logEvent(SparkListenerStageSubmitted(event.stageInfo, redactProperties(event.properties)))
+    logEvent(event.copy(properties = redactProperties(event.properties)))
     if (shouldLogStageExecutorMetrics) {
       // record the peak metrics for the new stage
       liveStageExecutorMetrics.put((event.stageInfo.stageId, event.stageInfo.attemptNumber()),
@@ -159,8 +159,7 @@ private[spark] class EventLoggingListener(
   }
 
   override def onJobStart(event: SparkListenerJobStart): Unit = {
-    logEvent(SparkListenerJobStart(event.jobId, event.time, event.stageInfos,
-      redactProperties(event.properties)), flushLogger = true)
+    logEvent(event.copy(properties = redactProperties(event.properties)), flushLogger = true)
   }
 
   override def onJobEnd(event: SparkListenerJobEnd): Unit = logEvent(event, flushLogger = true)

--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -281,7 +281,7 @@ private[spark] class EventLoggingListener(
     logWriter.stop()
   }
 
-  private[spark] def redactProperties(properties: Properties): Properties = {
+  private def redactProperties(properties: Properties): Properties = {
     if (properties == null) {
       return properties
     }

--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -296,7 +296,7 @@ private[spark] class EventLoggingListener(
     }
     redactedProperties
   }
- 
+      
   private[spark] def redactEvent(
       event: SparkListenerEnvironmentUpdate): SparkListenerEnvironmentUpdate = {
     // environmentDetails maps a string descriptor to a set of properties

--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -286,17 +286,14 @@ private[spark] class EventLoggingListener(
       return properties
     }
     val redactedProperties = new Properties
-    
     // properties may contain some custom local properties such as stage/job description
     // only properties in sparkConf need to be redacted, 
     val (globalProperties, localProperties) = properties.asScala.toSeq.partition {
       case (key, _) => sparkConf.contains(key)
     }
-    
     (Utils.redact(sparkConf, globalProperties) ++ localProperties).foreach {
       case (key, value) => redactedProperties.setProperty(key, value)
     }
-
     redactedProperties
   }
  

--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -287,7 +287,8 @@ private[spark] class EventLoggingListener(
     }
     val redactedProperties = new Properties
     
-    // only properties in sparkConf need to be redacted.
+    // properties may contain some custom local properties such as stage/job description
+    // only properties in sparkConf need to be redacted, 
     val (globalProperties, localProperties) = properties.asScala.toSeq.partition {
       case (key, _) => sparkConf.contains(key)
     }

--- a/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
@@ -113,8 +113,7 @@ class EventLoggingListenerSuite extends SparkFunSuite with LocalSparkContext wit
     val listenerBus = new LiveListenerBus(conf)
     val stageId = 1
     val jobId = 1
-    val stageInfo = new StageInfo(stageId, 0, stageId.toString, 0,
-      Seq.empty, Seq.empty, "details")
+    val stageInfo = new StageInfo(stageId, 0, stageId.toString, 0, Seq.empty, Seq.empty, "details")
 
     val events = Array(SparkListenerStageSubmitted(stageInfo, properties),
       SparkListenerJobStart(jobId, 0, Seq(stageInfo), properties))

--- a/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
@@ -97,7 +97,7 @@ class EventLoggingListenerSuite extends SparkFunSuite with LocalSparkContext wit
     assert(redactedProps(key) == "*********(redacted)")
   }
 
-  test("Spark-33504 password redaction in properties") {
+  test("Spark-33504 sensitive attributes redaction in properties") {
     val (secretKey, secretPassword) = ("spark.executorEnv.HADOOP_CREDSTORE_PASSWORD",
       "secret_password")
     val (customKey, customValue) = ("parse_token", "secret_password")

--- a/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
@@ -101,15 +101,12 @@ class EventLoggingListenerSuite extends SparkFunSuite with LocalSparkContext wit
     val key = "spark.executorEnv.HADOOP_CREDSTORE_PASSWORD"
     val secretPassword = "secret_password"
     val conf = getLoggingConf(testDirPath, None).set(key, secretPassword)
-
     val properties = new Properties()
     properties.setProperty(key, secretPassword)
-
     val eventLogger = new EventLoggingListener("test", None, testDirPath.toUri(), conf)
     val redactedProperties = eventLogger.redactProperties(properties)
     assert(redactedProperties.getProperty(key) == "*********(redacted)")
   }
-    
   test("Executor metrics update") {
     testStageExecutorMetricsEventLogging()
   }

--- a/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
@@ -132,12 +132,17 @@ class EventLoggingListenerSuite extends SparkFunSuite with LocalSparkContext wit
       fileSystem)
     try {
       val lines = readLines(logData)
-      assert(lines.size === 2)
-      assert(lines(0).contains("SparkListenerStageSubmitted"))
-      assert(lines(1).contains("SparkListenerJobStart"))
+      val logStart = SparkListenerLogStart(SPARK_VERSION)
+      assert(lines.size === 3)
+      assert(lines(0).contains("SparkListenerLogStart"))
+      assert(lines(1).contains("SparkListenerStageSubmitted"))
+      assert(lines(2).contains("SparkListenerJobStart"))
 
       lines.foreach{
         line => JsonProtocol.sparkEventFromJson(parse(line)) match {
+          case logStartEvent: SparkListenerLogStart =>
+            assert(logStartEvent == logStart)
+
           case stageSubmittedEvent: SparkListenerStageSubmitted =>
             assert(stageSubmittedEvent.properties.getProperty(secretKey) == "*********(redacted)")
             assert(stageSubmittedEvent.properties.getProperty(customKey) ==  customValue)

--- a/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
@@ -97,7 +97,7 @@ class EventLoggingListenerSuite extends SparkFunSuite with LocalSparkContext wit
     assert(redactedProps(key) == "*********(redacted)")
   }
 
-  test("Spark-todo password redaction in properties") {
+  test("Spark-33504 password redaction in properties") {
     val key = "spark.executorEnv.HADOOP_CREDSTORE_PASSWORD"
     val secretPassword = "secret_password"
     val conf = getLoggingConf(testDirPath, None).set(key, secretPassword)

--- a/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
@@ -98,14 +98,60 @@ class EventLoggingListenerSuite extends SparkFunSuite with LocalSparkContext wit
   }
 
   test("Spark-33504 password redaction in properties") {
-    val key = "spark.executorEnv.HADOOP_CREDSTORE_PASSWORD"
-    val secretPassword = "secret_password"
-    val conf = getLoggingConf(testDirPath, None).set(key, secretPassword)
+    val (secretKey, secretPassword) = ("spark.executorEnv.HADOOP_CREDSTORE_PASSWORD",
+      "secret_password")
+    val (customKey, customValue) = ("parse token", "secret_password")
+    
+    val conf = getLoggingConf(testDirPath, None).set(secretKey, secretPassword)
+    
     val properties = new Properties()
-    properties.setProperty(key, secretPassword)
-    val eventLogger = new EventLoggingListener("test", None, testDirPath.toUri(), conf)
+    properties.setProperty(secretKey, secretPassword)
+    properties.setProperty(customKey, customValue)
+    
+    val logName = "properties-reaction-test"
+    val eventLogger = new EventLoggingListener(logName, None, testDirPath.toUri(), conf)
     val redactedProperties = eventLogger.redactProperties(properties)
-    assert(redactedProperties.getProperty(key) == "*********(redacted)")
+    val listenerBus = new LiveListenerBus(conf)
+
+    val stageId = 1
+    val jobId = 1
+    val stageInfo = new StageInfo(stageId, 0, stageId.toString, 0,
+      Seq.empty, Seq.empty, "details")
+
+    val events = Array(SparkListenerStageSubmitted(stageInfo, properties),
+      SparkListenerJobStart(jobId, 0, Seq(stageInfo), properties))
+
+    eventLogger.start()
+    listenerBus.start(Mockito.mock(classOf[SparkContext]), Mockito.mock(classOf[MetricsSystem]))
+    listenerBus.addToEventLogQueue(eventLogger)
+    events.foreach(event => listenerBus.post(event))
+    listenerBus.stop()
+    eventLogger.stop()
+    
+    val logData = EventLogFileReader.openEventLog(new Path(eventLogger.logWriter.logPath),
+      fileSystem)
+    try {
+      val lines = readLines(logData)
+      assert(lines.size === 2)
+      assert(lines(0).contains("SparkListenerStageSubmitted"))
+      assert(lines(1).contains("SparkListenerJobStart"))
+      
+      lines.foreach{
+        line => JsonProtocol.sparkEventFromJson(parse(line)) match {
+          case stageSubmittedEvent: SparkListenerStageSubmitted =>
+            assert(stageSubmittedEvent.properties.getProperty(secretKey) == "*********(redacted)")
+            assert(stageSubmittedEvent.properties.getProperty(customKey) ==  customValue)
+            
+          case jobStartEvent : SparkListenerJobStart =>
+            assert(jobStartEvent.properties.getProperty(secretKey) == "*********(redacted)")
+            assert(jobStartEvent.properties.getProperty(customKey) ==  customValue)
+            
+          case _ => assert(false)
+        }
+      }
+    } finally {
+      logData.close()
+    }
   }
 
   test("Executor metrics update") {

--- a/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
@@ -110,7 +110,6 @@ class EventLoggingListenerSuite extends SparkFunSuite with LocalSparkContext wit
     
     val logName = "properties-reaction-test"
     val eventLogger = new EventLoggingListener(logName, None, testDirPath.toUri(), conf)
-    val redactedProperties = eventLogger.redactProperties(properties)
     val listenerBus = new LiveListenerBus(conf)
 
     val stageId = 1

--- a/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
@@ -101,19 +101,22 @@ class EventLoggingListenerSuite extends SparkFunSuite with LocalSparkContext wit
     val (secretKey, secretPassword) = ("spark.executorEnv.HADOOP_CREDSTORE_PASSWORD",
       "secret_password")
     val (customKey, customValue) = ("parse_token", "secret_password")
-
+    
     val conf = getLoggingConf(testDirPath, None).set(secretKey, secretPassword)
-
+    
     val properties = new Properties()
     properties.setProperty(secretKey, secretPassword)
     properties.setProperty(customKey, customValue)
-
+    
     val logName = "properties-reaction-test"
     val eventLogger = new EventLoggingListener(logName, None, testDirPath.toUri(), conf)
     val listenerBus = new LiveListenerBus(conf)
+    
     val stageId = 1
     val jobId = 1
-    val stageInfo = new StageInfo(stageId, 0, stageId.toString, 0, Seq.empty, Seq.empty, "details")
+    val stageInfo = new StageInfo(stageId, 0, stageId.toString, 0,
+      Seq.empty, Seq.empty, "details",
+      resourceProfileId = ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID)
 
     val events = Array(SparkListenerStageSubmitted(stageInfo, properties),
       SparkListenerJobStart(jobId, 0, Seq(stageInfo), properties))
@@ -122,10 +125,9 @@ class EventLoggingListenerSuite extends SparkFunSuite with LocalSparkContext wit
     listenerBus.start(Mockito.mock(classOf[SparkContext]), Mockito.mock(classOf[MetricsSystem]))
     listenerBus.addToEventLogQueue(eventLogger)
     events.foreach(event => listenerBus.post(event))
-
     listenerBus.stop()
     eventLogger.stop()
-
+    
     val logData = EventLogFileReader.openEventLog(new Path(eventLogger.logWriter.logPath),
       fileSystem)
     try {
@@ -133,17 +135,17 @@ class EventLoggingListenerSuite extends SparkFunSuite with LocalSparkContext wit
       assert(lines.size === 2)
       assert(lines(0).contains("SparkListenerStageSubmitted"))
       assert(lines(1).contains("SparkListenerJobStart"))
-
+      
       lines.foreach{
         line => JsonProtocol.sparkEventFromJson(parse(line)) match {
           case stageSubmittedEvent: SparkListenerStageSubmitted =>
             assert(stageSubmittedEvent.properties.getProperty(secretKey) == "*********(redacted)")
             assert(stageSubmittedEvent.properties.getProperty(customKey) ==  customValue)
-
+            
           case jobStartEvent : SparkListenerJobStart =>
             assert(jobStartEvent.properties.getProperty(secretKey) == "*********(redacted)")
             assert(jobStartEvent.properties.getProperty(customKey) ==  customValue)
-
+            
           case _ => assert(false)
         }
       }

--- a/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
@@ -101,17 +101,16 @@ class EventLoggingListenerSuite extends SparkFunSuite with LocalSparkContext wit
     val (secretKey, secretPassword) = ("spark.executorEnv.HADOOP_CREDSTORE_PASSWORD",
       "secret_password")
     val (customKey, customValue) = ("parse_token", "secret_password")
-    
+
     val conf = getLoggingConf(testDirPath, None).set(secretKey, secretPassword)
-    
+
     val properties = new Properties()
     properties.setProperty(secretKey, secretPassword)
     properties.setProperty(customKey, customValue)
-    
+
     val logName = "properties-reaction-test"
     val eventLogger = new EventLoggingListener(logName, None, testDirPath.toUri(), conf)
     val listenerBus = new LiveListenerBus(conf)
-
     val stageId = 1
     val jobId = 1
     val stageInfo = new StageInfo(stageId, 0, stageId.toString, 0,
@@ -124,9 +123,10 @@ class EventLoggingListenerSuite extends SparkFunSuite with LocalSparkContext wit
     listenerBus.start(Mockito.mock(classOf[SparkContext]), Mockito.mock(classOf[MetricsSystem]))
     listenerBus.addToEventLogQueue(eventLogger)
     events.foreach(event => listenerBus.post(event))
+
     listenerBus.stop()
     eventLogger.stop()
-    
+
     val logData = EventLogFileReader.openEventLog(new Path(eventLogger.logWriter.logPath),
       fileSystem)
     try {
@@ -134,17 +134,17 @@ class EventLoggingListenerSuite extends SparkFunSuite with LocalSparkContext wit
       assert(lines.size === 2)
       assert(lines(0).contains("SparkListenerStageSubmitted"))
       assert(lines(1).contains("SparkListenerJobStart"))
-      
+
       lines.foreach{
         line => JsonProtocol.sparkEventFromJson(parse(line)) match {
           case stageSubmittedEvent: SparkListenerStageSubmitted =>
             assert(stageSubmittedEvent.properties.getProperty(secretKey) == "*********(redacted)")
             assert(stageSubmittedEvent.properties.getProperty(customKey) ==  customValue)
-            
+
           case jobStartEvent : SparkListenerJobStart =>
             assert(jobStartEvent.properties.getProperty(secretKey) == "*********(redacted)")
             assert(jobStartEvent.properties.getProperty(customKey) ==  customValue)
-            
+
           case _ => assert(false)
         }
       }

--- a/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
@@ -100,7 +100,7 @@ class EventLoggingListenerSuite extends SparkFunSuite with LocalSparkContext wit
   test("Spark-33504 password redaction in properties") {
     val (secretKey, secretPassword) = ("spark.executorEnv.HADOOP_CREDSTORE_PASSWORD",
       "secret_password")
-    val (customKey, customValue) = ("parse token", "secret_password")
+    val (customKey, customValue) = ("parse_token", "secret_password")
     
     val conf = getLoggingConf(testDirPath, None).set(secretKey, secretPassword)
     

--- a/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.scheduler
 
 import java.io.{File, InputStream}
-import java.util.Arrays
+import java.util.{Arrays, Properties}
 
 import scala.collection.immutable.Map
 import scala.collection.mutable
@@ -97,6 +97,19 @@ class EventLoggingListenerSuite extends SparkFunSuite with LocalSparkContext wit
     assert(redactedProps(key) == "*********(redacted)")
   }
 
+  test("Spark-todo password redaction in properties") {
+    val key = "spark.executorEnv.HADOOP_CREDSTORE_PASSWORD"
+    val secretPassword = "secret_password"
+    val conf = getLoggingConf(testDirPath, None).set(key, secretPassword)
+
+    val properties = new Properties()
+    properties.setProperty(key, secretPassword)
+
+    val eventLogger = new EventLoggingListener("test", None, testDirPath.toUri(), conf)
+    val redactedProperties = eventLogger.redactProperties(properties)
+    assert(redactedProperties.getProperty(key) == "*********(redacted)")
+  }
+    
   test("Executor metrics update") {
     testStageExecutorMetricsEventLogging()
   }

--- a/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
@@ -107,6 +107,7 @@ class EventLoggingListenerSuite extends SparkFunSuite with LocalSparkContext wit
     val redactedProperties = eventLogger.redactProperties(properties)
     assert(redactedProperties.getProperty(key) == "*********(redacted)")
   }
+
   test("Executor metrics update") {
     testStageExecutorMetricsEventLogging()
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
To make sure the sensitive attributes to be redacted in the history server log.

### Why are the changes needed?
We found the secure attributes like password  in SparkListenerJobStart and SparkListenerStageSubmitted events would not been redated, resulting in sensitive attributes can be viewd directly.
The screenshot can be viewed in the attachment of JIRA spark-33504
### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
muntual test works well, I have also added unit testcase.