### PR TITLE
[MINOR][INFRA] Suppress warning in check-license

### DIFF
--- a/dev/check-license
+++ b/dev/check-license
@@ -67,7 +67,7 @@ mkdir -p "$FWDIR"/lib
     exit 1
 }
 
-mkdir target
+mkdir -p target
 $java_cmd -jar "$rat_jar" -E "$FWDIR"/dev/.rat-excludes -d "$FWDIR" > target/rat-results.txt
 
 if [ $? -ne 0 ]; then


### PR DESCRIPTION


### What changes were proposed in this pull request?
This PR aims to suppress the warning `File exists` in check-license 

### Why are the changes needed?

**BEFORE**
```
% dev/check-license
Attempting to fetch rat
RAT checks passed.

% dev/check-license
mkdir: target: File exists
RAT checks passed.
```

**AFTER**
```
% dev/check-license
Attempting to fetch rat
RAT checks passed.

% dev/check-license
RAT checks passed.
```



### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manually do dev/check-license twice. 