### PR TITLE
[SPARK-33423][ML] DoubleParam/FloatParam parse JSON support type conversion

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
@@ -370,6 +370,12 @@ private[param] object DoubleParam {
         Double.PositiveInfinity
       case JDouble(x) =>
         x
+      case JInt(x) =>
+        x.toDouble
+      case JLong(x) =>
+        x.toDouble
+      case JDecimal(x) =>
+        x.doubleValue()
       case _ =>
         throw new IllegalArgumentException(s"Cannot decode $jValue to Double.")
     }
@@ -456,6 +462,12 @@ private object FloatParam {
         Float.PositiveInfinity
       case JDouble(x) =>
         x.toFloat
+      case JInt(x) =>
+        x.toFloat
+      case JLong(x) =>
+        x.toFloat
+      case JDecimal(x) =>
+        x.floatValue()
       case _ =>
         throw new IllegalArgumentException(s"Cannot decode $jValue to Float.")
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
@@ -375,7 +375,7 @@ private[param] object DoubleParam {
       case JLong(x) =>
         x.toDouble
       case JDecimal(x) =>
-        x.doubleValue()
+        x.doubleValue
       case _ =>
         throw new IllegalArgumentException(s"Cannot decode $jValue to Double.")
     }
@@ -467,7 +467,7 @@ private object FloatParam {
       case JLong(x) =>
         x.toFloat
       case JDecimal(x) =>
-        x.floatValue()
+        x.floatValue
       case _ =>
         throw new IllegalArgumentException(s"Cannot decode $jValue to Float.")
     }

--- a/mllib/src/test/scala/org/apache/spark/ml/param/ParamsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/param/ParamsSuite.scala
@@ -19,6 +19,8 @@ package org.apache.spark.ml.param
 
 import java.io.{ByteArrayOutputStream, ObjectOutputStream}
 
+import org.json4s.JsonAST.{JDecimal, JInt, JLong}
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.{Estimator, Transformer}
 import org.apache.spark.ml.linalg.{Vector, Vectors}
@@ -323,6 +325,13 @@ class ParamsSuite extends SparkFunSuite {
     assert(copied.uid === solver.uid)
     assert(copied.getInputCol === solver.getInputCol)
     assert(copied.getMaxIter === 50)
+  }
+
+  test("DoubleParam/FloatParam parse JSON support type conversion") {
+    for (jvalue <- Seq(JInt(10), JLong(10L), JDecimal(BigDecimal("10")))) {
+      assert(DoubleParam.jValueDecode(jvalue) == 10.0d)
+      assert(FloatParam.jValueDecode(jvalue) == 10.0f)
+    }
   }
 
   test("ParamValidate") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make DoubleParam/FloatParam parse JSON support simple type conversion

### Why are the changes needed?
as https://issues.apache.org/jira/browse/SPARK-33423 show,  DoubleParam can't parse a JSON number without decimal places,  we can support it.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added UT