### PR TITLE
[SPARK-33516][BUILD] Upgrade Scala 2.13 version from 2.13.3 to 2.13.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3264,7 +3264,7 @@
     <profile>
       <id>scala-2.13</id>
       <properties>
-        <scala.version>2.13.3</scala.version>
+        <scala.version>2.13.4</scala.version>
         <scala.binary.version>2.13</scala.binary.version>
       </properties>
       <dependencyManagement>


### PR DESCRIPTION
### What changes were proposed in this pull request?
[Scala 2.13.4](https://github.com/scala/scala/releases/tag/v2.13.4) was released on November 19 2020, this pr upgrade the version of Scala 2.13  used by Spark 3.1 from 2.13.3 to 2.13.4.

### Why are the changes needed?
Make the Scala 2.13 version up-to-date for Apache Spark 3.1.0.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass the Jenkins and `Scala 2.13 build with SBT` GitHub Action
