### PR TITLE
[SPARK-33517][SQL][DOCS] Fix the correct menu items and page links in PySpark Usage Guide for Pandas with Apache Arrow

### DIFF
--- a/docs/_data/menu-sql.yaml
+++ b/docs/_data/menu-sql.yaml
@@ -61,8 +61,8 @@
 - text: PySpark Usage Guide for Pandas with Apache Arrow
   url: sql-pyspark-pandas-with-arrow.html
   subitems:
-    - text: Apache Arrow in Spark
-      url: sql-pyspark-pandas-with-arrow.html#apache-arrow-in-spark
+    - text: Apache Arrow in PySpark
+      url: sql-pyspark-pandas-with-arrow.html#apache-arrow-in-pyspark
     - text: "Enabling for Conversion to/from Pandas"
       url: sql-pyspark-pandas-with-arrow.html#enabling-for-conversion-tofrom-pandas
     - text: "Pandas UDFs (a.k.a. Vectorized UDFs)"

--- a/docs/_data/menu-sql.yaml
+++ b/docs/_data/menu-sql.yaml
@@ -58,19 +58,6 @@
       url: sql-distributed-sql-engine.html#running-the-thrift-jdbcodbc-server
     - text: Running the Spark SQL CLI
       url: sql-distributed-sql-engine.html#running-the-spark-sql-cli
-- text: PySpark Usage Guide for Pandas with Apache Arrow
-  url: sql-pyspark-pandas-with-arrow.html
-  subitems:
-    - text: Apache Arrow in PySpark
-      url: sql-pyspark-pandas-with-arrow.html#apache-arrow-in-pyspark
-    - text: "Enabling for Conversion to/from Pandas"
-      url: sql-pyspark-pandas-with-arrow.html#enabling-for-conversion-tofrom-pandas
-    - text: "Pandas UDFs (a.k.a. Vectorized UDFs)"
-      url: sql-pyspark-pandas-with-arrow.html#pandas-udfs-aka-vectorized-udfs
-    - text: "Pandas Function APIs"
-      url: sql-pyspark-pandas-with-arrow.html#pandas-function-apis
-    - text: Usage Notes
-      url: sql-pyspark-pandas-with-arrow.html#usage-notes
 - text: Migration Guide
   url: sql-migration-old.html
 - text: SQL Reference

--- a/docs/_data/menu-sql.yaml
+++ b/docs/_data/menu-sql.yaml
@@ -58,6 +58,8 @@
       url: sql-distributed-sql-engine.html#running-the-thrift-jdbcodbc-server
     - text: Running the Spark SQL CLI
       url: sql-distributed-sql-engine.html#running-the-spark-sql-cli
+- text: PySpark Usage Guide for Pandas with Apache Arrow
+  url: sql-pyspark-pandas-with-arrow.html
 - text: Migration Guide
   url: sql-migration-old.html
 - text: SQL Reference


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change "Apache Arrow in Spark" to "Apache Arrow in PySpark"
and the link to “/sql-pyspark-pandas-with-arrow.html#apache-arrow-in-pyspark”

### Why are the changes needed?
When I click on the menu item it doesn't point to the correct page, and from the parent menu I can infer that the correct menu item name and link should be "Apache Arrow in PySpark".
like this:
 image
![image](https://user-images.githubusercontent.com/28332082/99954725-2b64e200-2dbe-11eb-9576-cf6a3d758980.png)


### Does this PR introduce any user-facing change?
Yes, clicking on the menu item will take you to the correct guide page

### How was this patch tested?
Manually build the doc. This can be verified as below:

cd docs
SKIP_API=1 jekyll build
open _site/sql-pyspark-pandas-with-arrow.html