### PR TITLE
[SPARK-32002][SQL]Support ExtractValue from nested ArrayStruct

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ProjectionOverSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ProjectionOverSchema.scala
@@ -51,6 +51,19 @@ case class ProjectionOverSchema(schema: StructType) {
               s"unmatched child schema for GetArrayStructFields: ${projSchema.toString}"
             )
         }
+      case ExtractNestedArrayField(child, _, _, field, containsNullSeq) =>
+        getProjection(child).map(p => (p, p.dataType)).map {
+          case (projection, ExtractNestedArray(projSchema @ StructType(_), _, _)) =>
+            ExtractNestedArrayField(projection,
+              projSchema.fieldIndex(field.name),
+              projSchema.fields.length,
+              projSchema(field.name),
+              containsNullSeq)
+          case (_, projSchema) =>
+            throw new IllegalStateException(
+              s"unmatched child schema for ExtractNestedArrayField: ${projSchema.toString}"
+            )
+        }
       case MapKeys(child) =>
         getProjection(child).map { projection => MapKeys(projection) }
       case MapValues(child) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ProjectionOverSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ProjectionOverSchema.scala
@@ -53,7 +53,7 @@ case class ProjectionOverSchema(schema: StructType) {
         }
       case ExtractNestedArrayField(child, _, _, field, containsNullSeq) =>
         getProjection(child).map(p => (p, p.dataType)).map {
-          case (projection, ExtractNestedArray(projSchema @ StructType(_), _, _)) =>
+          case (projection, ExtractNestedArrayType(projSchema @ StructType(_), _, _)) =>
             ExtractNestedArrayField(projection,
               projSchema.fieldIndex(field.name),
               projSchema.fields.length,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ProjectionOverSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ProjectionOverSchema.scala
@@ -51,13 +51,14 @@ case class ProjectionOverSchema(schema: StructType) {
               s"unmatched child schema for GetArrayStructFields: ${projSchema.toString}"
             )
         }
-      case ExtractNestedArrayField(child, _, _, field, containsNullSeq) =>
+      case ExtractNestedArrayField(child, _, _, field, containsNull, containsNullSeq) =>
         getProjection(child).map(p => (p, p.dataType)).map {
           case (projection, ExtractNestedArrayType(projSchema @ StructType(_), _, _)) =>
             ExtractNestedArrayField(projection,
               projSchema.fieldIndex(field.name),
               projSchema.fields.length,
               projSchema(field.name),
+              containsNull,
               containsNullSeq)
           case (_, projSchema) =>
             throw new IllegalStateException(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SelectedField.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SelectedField.scala
@@ -92,7 +92,7 @@ object SelectedField {
         }
         val newField = StructField(field.name, newFieldDataType, field.nullable)
         selectField(child, Option(ArrayType(struct(newField), containsNull)))
-      case ExtractNestedArrayField(child, _, _, field @ StructField(_, _, _, _), _) =>
+      case ExtractNestedArrayField(child, _, _, field @ StructField(_, _, _, _), _, _) =>
         val newFieldDataType = dataTypeOpt match {
           case None =>
             // ExtractNestedArrayField is the top level extractor. This means its result is
@@ -104,12 +104,12 @@ object SelectedField {
         val structType = struct(StructField(field.name, newFieldDataType, field.nullable))
 
         val newDataType = child match {
-          case ExtractNestedArrayField(_, _, _, childField, _) =>
+          case ExtractNestedArrayField(_, _, _, childField, containsNull, _) =>
             childField.dataType match {
-              case _: ArrayType => ArrayType(structType)
+              case _: ArrayType => ArrayType(structType, containsNull)
               case _ => structType
             }
-          case _: GetArrayStructFields => ArrayType(structType)
+          case GetArrayStructFields(_, _, _, _, nullable) => ArrayType(structType, nullable)
           case _ => structType
         }
         selectField(child, Some(newDataType), nestArray = true)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
@@ -246,12 +246,12 @@ object ExtractNestedArray {
 }
 
 case class ExtractNestedArrayField(
-  child: Expression,
-  ordinal: Int,
-  numFields: Int,
-  field: StructField,
-  containsNullSeq: Seq[Boolean]) extends UnaryExpression
-  with ExtractValue with NullIntolerant with CodegenFallback {
+    child: Expression,
+    ordinal: Int,
+    numFields: Int,
+    field: StructField,
+    containsNullSeq: Seq[Boolean]) extends UnaryExpression
+    with ExtractValue with NullIntolerant with CodegenFallback {
 
   protected override def nullSafeEval(input: Any): Any = {
     val array = input.asInstanceOf[ArrayData]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
@@ -37,12 +37,13 @@ object ExtractValue {
    * Returns the resolved `ExtractValue`. It will return one kind of concrete `ExtractValue`,
    * depend on the type of `child` and `extraction`.
    *
-   *   `child`      |    `extraction`    |    concrete `ExtractValue`
-   * ----------------------------------------------------------------
-   *    Struct      |   Literal String   |        GetStructField
-   * Array[Struct]  |   Literal String   |     GetArrayStructFields
-   *    Array       |   Integral type    |         GetArrayItem
-   *     Map        |   map key type     |         GetMapValue
+   *            `child`            |    `extraction`    |    concrete `ExtractValue`
+   * --------------------------------------------------------------------------------
+   *            Struct             |   Literal String   |        GetStructField
+   *         Array[Struct]         |   Literal String   |     GetArrayStructFields
+   *  Array[ ...Array[struct] ]    |   Literal String   |    ExtractNestedArrayField
+   *            Array              |   Integral type    |         GetArrayItem
+   *             Map               |   map key type     |         GetMapValue
    */
   def apply(
       child: Expression,
@@ -226,6 +227,13 @@ case class GetArrayStructFields(
   }
 }
 
+/**
+ * ExtractNestedArrayType is used to match consecutive nested array types.
+ *
+ * ReturnType: (DataType: the innermost dataType, Boolean: the outermost array contains null
+ * , Seq[Boolean]: the second outer layer to the innermost layer contains null)
+ *
+ */
 object ExtractNestedArrayType {
   type ReturnType = Option[(DataType, Boolean, Seq[Boolean])]
 
@@ -241,6 +249,10 @@ object ExtractNestedArrayType {
   }
 }
 
+/**
+ * For a child whose data type is a nested array containing struct at the innermost level, extracts
+ * the `ordinal`-th fields of multi-level nested array, and returns them as a new nested array.
+ */
 case class ExtractNestedArrayField(
     child: Expression,
     ordinal: Int,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
@@ -61,7 +61,7 @@ object ExtractValue {
         GetArrayStructFields(child, fields(ordinal).copy(name = fieldName),
           ordinal, fields.length, containsNull || fields(ordinal).nullable)
 
-      case (ExtractNestedArray(StructType(fields), _, containsNullSeq),
+      case (ExtractNestedArrayType(StructType(fields), _, containsNullSeq),
       NonNullLiteral(v, StringType)) if containsNullSeq.nonEmpty =>
         val fieldName = v.toString
         val ordinal = findField(fields, fieldName, resolver)
@@ -226,7 +226,7 @@ case class GetArrayStructFields(
   }
 }
 
-object ExtractNestedArray {
+object ExtractNestedArrayType {
   type ReturnType = Option[(DataType, Boolean, Seq[Boolean])]
 
   def unapply(dataType: DataType): ReturnType = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/ComplexTypesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ComplexTypesSuite.scala
@@ -125,9 +125,4 @@ class ComplexTypesSuite extends QueryTest with SharedSparkSession {
       :: Row(Seq(Seq(Seq(1), Seq(2)))) :: Nil)
   }
 
-  test("SPARK-32003: Support ExtractValue from nested ArrayStruct") {
-    val jsonStr1 = """{"a": [{"b": [{"c": [{"d": [1, 2]}]}]}]}"""
-    val df = spark.read.json(Seq(jsonStr1).toDS())
-    checkAnswer(df.select($"a.b.c.d"), Row(Seq(Seq(Seq(Seq(1))))))
-  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/ComplexTypesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ComplexTypesSuite.scala
@@ -124,6 +124,25 @@ class ComplexTypesSuite extends QueryTest with SharedSparkSession {
     val df = spark.read.json(Seq(jsonStr1, jsonStr2).toDS())
     checkAnswer(df.select($"a.b.c"), Row(Seq(Seq(Seq(1, 2))))
       :: Row(Seq(Seq(Seq(1), Seq(2)))) :: Nil)
+
+    def genJson(start: Char, end: Char, vStr: String): String = {
+      (start to end).map(c => s"""{"$c": [""").mkString +
+        vStr + (start to end).map(_ => "]}").mkString
+    }
+
+    def genResult(start: Char, end: Char, r: Seq[Int]): Any = {
+      (start until end).fold(r) { (z, _) => Seq(z)}
+    }
+
+    val start: Char = 'a'
+    for (i <- 2 to 10) {
+      val end: Char = (start + i).toChar
+      val jsonAToZ = genJson(start, end, "1,2,3")
+      val dfAToZ = spark.read.json(Seq(jsonAToZ).toDS())
+      checkAnswer(dfAToZ.select((start to end).mkString(".")),
+        Row(genResult(start, end, Seq(1, 2, 3))))
+    }
+
   }
 
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/ComplexTypesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ComplexTypesSuite.scala
@@ -137,9 +137,9 @@ class ComplexTypesSuite extends QueryTest with SharedSparkSession {
     val start: Char = 'a'
     for (i <- 2 to 10) {
       val end: Char = (start + i).toChar
-      val jsonAToZ = genJson(start, end, "1,2,3")
-      val dfAToZ = spark.read.json(Seq(jsonAToZ).toDS())
-      checkAnswer(dfAToZ.select((start to end).mkString(".")),
+      val json = genJson(start, end, "1,2,3")
+      val df = spark.read.json(Seq(json).toDS())
+      checkAnswer(df.select((start to end).mkString(".")),
         Row(genResult(start, end, Seq(1, 2, 3))))
     }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/ComplexTypesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ComplexTypesSuite.scala
@@ -18,10 +18,11 @@
 package org.apache.spark.sql
 
 import scala.collection.JavaConverters._
+
 import org.apache.spark.sql.catalyst.expressions.CreateNamedStruct
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.{ArrayType, IntegerType, StructType}
+import org.apache.spark.sql.types.{ArrayType, StructType}
 
 class ComplexTypesSuite extends QueryTest with SharedSparkSession {
   import testImplicits._

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/NestArraySchemaPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/NestArraySchemaPruningSuite.scala
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import java.io.File
+
+import org.scalactic.Equality
+
+import org.apache.spark.sql.{DataFrame, QueryTest, Row}
+import org.apache.spark.sql.catalyst.SchemaPruningTest
+import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
+import org.apache.spark.sql.execution.FileSourceScanExec
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.StructType
+
+
+class NestArraySchemaPruningSuite
+  extends QueryTest
+    with FileBasedDataSourceTest
+    with SchemaPruningTest
+    with SharedSparkSession
+    with AdaptiveSparkPlanHelper {
+  case class AdRecord(positions: Array[Positions])
+  case class Positions(imps: Array[Impression])
+  case class Impression(id: String, ad: Advertising, clicks: Array[Clicks])
+  case class Advertising(index: Int)
+  case class Clicks(fraud_type: Int)
+
+  val adRecords = AdRecord(Array(Positions(Array(Impression("1", Advertising(1),
+    Array(Clicks(0), Clicks(1))))))) :: AdRecord(Array(Positions(Array(
+    Impression("2", Advertising(2), Array(Clicks(1), Clicks(2))))))) :: Nil
+
+  testSchemaPruning("Nested arrays for pruning schema") {
+    val queryIndex = sql("select positions.imps.ad.index from adRecords")
+    checkScan(queryIndex,
+      "struct<positions:array<struct<imps:array<struct<ad:struct<index:int>>>>>>")
+    checkAnswer(queryIndex, Row(Seq(Seq(1))) :: Row(Seq(Seq(2))) :: Nil)
+
+    val queryId = sql("select positions.imps.id from adRecords")
+    checkScan(queryId,
+      "struct<positions:array<struct<imps:array<struct<id:string>>>>>")
+    checkAnswer(queryId, Row(Seq(Seq("1"))) :: Row(Seq(Seq("2"))) :: Nil)
+
+    val queryIndexAndFraud =
+      sql("select positions.imps.ad.index, positions.imps.clicks.fraud_type from adRecords")
+    checkScan(queryIndexAndFraud, "struct<positions:array<struct<imps:array<struct<ad:struct" +
+      "<index:int>, clicks:array<struct<fraud_type:int>>>>>>>")
+    checkAnswer(queryIndexAndFraud, Row(Seq(Seq(1)), Seq(Seq(Seq(0, 1))))
+      :: Row(Seq(Seq(2)), Seq(Seq(Seq(1, 2)))) :: Nil)
+  }
+
+  protected def testSchemaPruning(testName: String)(testThunk: => Unit): Unit = {
+    test(s"$testName") {
+      withSQLConf(vectorizedReaderEnabledKey -> "true") {
+        withData(testThunk)
+      }
+      withSQLConf(vectorizedReaderEnabledKey -> "false") {
+        withData(testThunk)
+      }
+    }
+  }
+
+  private def withData(testThunk: => Unit): Unit = {
+    withTempPath { dir =>
+      val path = dir.getCanonicalPath
+
+      makeDataSourceFile(adRecords, new File(path + "/ad_records/a=1"))
+
+      val schema = "`positions` ARRAY<STRUCT<`imps`: ARRAY<STRUCT<`id`: STRING, " +
+        "`ad`: STRUCT<`index`: INT>, `clicks`: ARRAY<STRUCT<`fraud_type`: INT>>>>>>"
+      spark.read.format(dataSourceName).schema(schema).load(path + "/ad_records")
+        .createOrReplaceTempView("adRecords")
+
+      testThunk
+    }
+  }
+
+  protected val schemaEquality = new Equality[StructType] {
+    override def areEqual(a: StructType, b: Any): Boolean =
+      b match {
+        case otherType: StructType => a.sameType(otherType)
+        case _ => false
+      }
+  }
+
+  protected def checkScan(df: DataFrame, expectedSchemaCatalogStrings: String*): Unit = {
+    checkScanSchemata(df, expectedSchemaCatalogStrings: _*)
+    // We check here that we can execute the query without throwing an exception. The results
+    // themselves are irrelevant, and should be checked elsewhere as needed
+    df.collect()
+  }
+
+  protected def checkScanSchemata(df: DataFrame, expectedSchemaCatalogStrings: String*): Unit = {
+    val fileSourceScanSchemata =
+      collect(df.queryExecution.executedPlan) {
+        case scan: FileSourceScanExec => scan.requiredSchema
+      }
+    assert(fileSourceScanSchemata.size === expectedSchemaCatalogStrings.size,
+      s"Found ${fileSourceScanSchemata.size} file sources in dataframe, " +
+        s"but expected $expectedSchemaCatalogStrings")
+    fileSourceScanSchemata.zip(expectedSchemaCatalogStrings).foreach {
+      case (scanSchema, expectedScanSchemaCatalogString) =>
+        val expectedScanSchema = CatalystSqlParser.parseDataType(expectedScanSchemaCatalogString)
+        implicit val equality = schemaEquality
+        assert(scanSchema === expectedScanSchema)
+    }
+  }
+
+  override protected val dataSourceName: String = "parquet"
+  override protected val vectorizedReaderEnabledKey: String =
+    SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

For data nest.json

```json
{"a": [{"b": [{"c": [1,2]}]}]}
{"a": [{"b": [{"c": [1]}, {"c": [2]}]}]}
```

run with

```scala
val df: DataFrame = spark.read.json(testFile("nest-data.json"))
df.createTempView("nest_table")
sql("select a.b.c from nest_table").show()
```

will got error

```log
org.apache.spark.sql.AnalysisException: cannot resolve 'nest_table.`a`.`b`['c']' due to data type mismatch: argument 2 requires integral type, however, ''c'' is of string type.; line 1 pos 7;
'Project [a#6.b[c] AS c#8|#6.b[c] AS c#8]
+- SubqueryAlias `nest_table`
+- Relationa#6 json
```

Analyse the causes, a.b Expression dataType match extractor for c, but a.b extractor is GetArrayStructFields, ArrayType(ArrayType()) match GetArrayItem, extraction ("c") treat as an ordinal.

### Why are the changes needed?

Spark sql cannot analyse nested arrays, it is very common to analyse this type of data, especially in the field of advertising!

### Does this PR introduce _any_ user-facing change?

Users can query nested arrays directly using sql and pruning is supported.


### How was this patch tested?

Added UT

ComplexTypesSuite 
Added tests show that querying nested arrays is possible.

NestArraySchemaPruningSuite
Test extraction of nested arrays while supporting schema pruning.