### PR TITLE
[SPARK-32221][k8s] Avoid possible errors due to incorrect file size or type supplied in spark conf.

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -28,7 +28,7 @@ private[spark] object Config extends Logging {
   val DECOMMISSION_SCRIPT =
     ConfigBuilder("spark.kubernetes.decommission.script")
       .doc("The location of the script to use for graceful decommissioning")
-      .version("3.2.0")
+      .version("3.1.0")
       .stringConf
       .createWithDefault("/opt/decom.sh")
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -99,6 +99,14 @@ private[spark] object Config extends Logging {
       .toSequence
       .createWithDefault(Nil)
 
+  val CONFIG_MAP_MAXSIZE =
+    ConfigBuilder("spark.kubernetes.configMap.maxsize")
+      .doc("Max size limit for a config map. This is configurable as per" +
+        " https://etcd.io/docs/v3.4.0/dev-guide/limit/ on k8s server end.")
+      .version("3.1.0")
+      .longConf
+      .createWithDefault(1573000) // 1.5 MiB
+
   val KUBERNETES_AUTH_DRIVER_CONF_PREFIX = "spark.kubernetes.authenticate.driver"
   val KUBERNETES_AUTH_EXECUTOR_CONF_PREFIX = "spark.kubernetes.authenticate.executor"
   val KUBERNETES_AUTH_DRIVER_MOUNTED_CONF_PREFIX = "spark.kubernetes.authenticate.driver.mounted"

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -100,10 +100,10 @@ private[spark] object Config extends Logging {
       .createWithDefault(Nil)
 
   val CONFIG_MAP_MAXSIZE =
-    ConfigBuilder("spark.kubernetes.configMap.maxsize")
+    ConfigBuilder("spark.kubernetes.configMap.maxSize")
       .doc("Max size limit for a config map. This is configurable as per" +
         " https://etcd.io/docs/v3.4.0/dev-guide/limit/ on k8s server end.")
-      .version("3.1.0")
+      .version("3.2.0")
       .longConf
       .createWithDefault(1573000) // 1.5 MiB
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -28,7 +28,7 @@ private[spark] object Config extends Logging {
   val DECOMMISSION_SCRIPT =
     ConfigBuilder("spark.kubernetes.decommission.script")
       .doc("The location of the script to use for graceful decommissioning")
-      .version("3.1.0")
+      .version("3.2.0")
       .stringConf
       .createWithDefault("/opt/decom.sh")
 
@@ -103,7 +103,7 @@ private[spark] object Config extends Logging {
     ConfigBuilder("spark.kubernetes.configMap.maxSize")
       .doc("Max size limit for a config map. This is configurable as per" +
         " https://etcd.io/docs/v3.4.0/dev-guide/limit/ on k8s server end.")
-      .version("3.2.0")
+      .version("3.1.0")
       .longConf
       .createWithDefault(1573000) // 1.5 MiB
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -105,7 +105,7 @@ private[spark] object Config extends Logging {
         " https://etcd.io/docs/v3.4.0/dev-guide/limit/ on k8s server end.")
       .version("3.1.0")
       .longConf
-      .createWithDefault(1573000) // 1.5 MiB
+      .createWithDefault(1572864) // 1.5 MiB
 
   val KUBERNETES_AUTH_DRIVER_CONF_PREFIX = "spark.kubernetes.authenticate.driver"
   val KUBERNETES_AUTH_EXECUTOR_CONF_PREFIX = "spark.kubernetes.authenticate.executor"

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
@@ -58,8 +58,12 @@ private[spark] object KubernetesClientUtils extends Logging {
     override def compare(x: (String, String), y: (String, String)): Int = {
       // compare based on file length and break the tie with string comparison of keys
       // (i.e. file names).
-      (x._1.length + x._2.length).compare(y._1.length + y._2.length) * 10 +
+      val lenCompare = (x._1.length + x._2.length) - (y._1.length + y._2.length)
+      if (lenCompare == 0) {
         x._1.compareTo(y._1)
+      } else {
+        lenCompare
+      }
     }
   }
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
@@ -162,8 +162,11 @@ private[spark] object KubernetesClientUtils extends Logging {
     }
     val confFiles: Seq[File] = {
       val dir = new File(confDir)
-      assert(dir.isDirectory, "Spark conf should be a directory.")
-      dir.listFiles.filter(x => fileFilter(x)).toSeq
+      if (dir.isDirectory) {
+        dir.listFiles.filter(x => fileFilter(x)).toSeq
+      } else {
+        Nil
+      }
     }
     confFiles
   }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtilsSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtilsSuite.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.k8s.submit
+
+import org.scalatest.BeforeAndAfter
+
+import org.apache.spark.SparkFunSuite
+
+class KubernetesClientUtilsSuite extends SparkFunSuite with BeforeAndAfter {
+  test("verify truncate to size sorts based on size and then truncates to correct size") {
+    val input = Seq("test" -> "test123", "z12" -> "zZ", "rere" -> "@31")
+    val output = KubernetesClientUtils.truncateToSize(input, 15)
+    val expectedOutput = Map("z12" -> "zZ", "rere" -> "@31")
+    assert(output === expectedOutput)
+  }
+  test("verify truncate to size does not truncate, when the maxsize limit is not exceeded") {
+    val input = Seq("test" -> "test123", "z12" -> "zZ", "rere" -> "@31")
+    val output = KubernetesClientUtils.truncateToSize(input, 35)
+    val expectedOutput = input.toMap
+    assert(output === expectedOutput)
+  }
+  test("verify truncate to size does truncate, when all keys and values are of equal size") {
+    val input = Seq("testConf.5" -> "test123", "testConf.1" -> "test123",
+      "testConf.3" -> "test123", "testConf.2" -> "test123")
+    val output = KubernetesClientUtils.truncateToSize(input, 40)
+    val expectedOutput = Map("testConf.1" -> "test123", "testConf.2" -> "test123")
+    assert(output === expectedOutput)
+  }
+  test("verify truncate to size does truncate, when keys are very large in number.") {
+    val input = for (i <- 10000 to 1 by -1) yield (s"testConf.${i}" -> "test123456")
+    val output = KubernetesClientUtils.truncateToSize(input, 60)
+    val expectedOutput = Map("testConf.1" -> "test123456", "testConf.2" -> "test123456")
+    assert(output === expectedOutput)
+    val output1 = KubernetesClientUtils.truncateToSize(input, 250000)
+    assert(output1 === input.toMap)
+  }
+}

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtilsSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtilsSuite.scala
@@ -17,36 +17,63 @@
 
 package org.apache.spark.deploy.k8s.submit
 
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+
 import org.scalatest.BeforeAndAfter
 
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.deploy.k8s.Config
+import org.apache.spark.util.Utils
 
 class KubernetesClientUtilsSuite extends SparkFunSuite with BeforeAndAfter {
-  test("verify truncate to size sorts based on size and then truncates to correct size") {
-    val input = Seq("test" -> "test123", "z12" -> "zZ", "rere" -> "@31")
-    val output = KubernetesClientUtils.truncateToSize(input, 15)
-    val expectedOutput = Map("z12" -> "zZ", "rere" -> "@31")
+
+  def testSetup(inputFiles: Map[String, Array[Byte]]): SparkConf = {
+    val tempDir = Utils.createTempDir()
+    val sparkConf = new SparkConf(loadDefaults = false)
+      .setSparkHome(tempDir.getAbsolutePath)
+
+    val tempConfDir = new File(s"${tempDir.getAbsolutePath}/conf")
+    tempConfDir.mkdir()
+    for (i <- inputFiles) yield {
+      val file = new File(s"${tempConfDir.getAbsolutePath}/${i._1}")
+      Files.write(file.toPath, i._2)
+      file.getName
+    }
+    sparkConf
+  }
+
+  test("verify load files, loads only allowed files and not the disallowed files.") {
+    val input: Map[String, Array[Byte]] = Map("test.txt" -> "test123", "z12.zip" -> "zZ",
+      "rere.jar" -> "@31", "spark.jar" -> "@31", "_test" -> "", "sample.conf" -> "conf")
+      .map(f => f._1 -> f._2.getBytes(StandardCharsets.UTF_8)) ++
+      Map("binary-file.conf" -> Array[Byte](0x00.toByte, 0xA1.toByte))
+    val sparkConf = testSetup(input)
+    val output = KubernetesClientUtils.loadSparkConfDirFiles(sparkConf)
+    val expectedOutput = Map("test.txt" -> "test123", "sample.conf" -> "conf")
     assert(output === expectedOutput)
   }
-  test("verify truncate to size does not truncate, when the maxsize limit is not exceeded") {
-    val input = Seq("test" -> "test123", "z12" -> "zZ", "rere" -> "@31")
-    val output = KubernetesClientUtils.truncateToSize(input, 35)
-    val expectedOutput = input.toMap
-    assert(output === expectedOutput)
-  }
-  test("verify truncate to size does truncate, when all keys and values are of equal size") {
-    val input = Seq("testConf.5" -> "test123", "testConf.1" -> "test123",
-      "testConf.3" -> "test123", "testConf.2" -> "test123")
-    val output = KubernetesClientUtils.truncateToSize(input, 40)
-    val expectedOutput = Map("testConf.1" -> "test123", "testConf.2" -> "test123")
-    assert(output === expectedOutput)
-  }
-  test("verify truncate to size does truncate, when keys are very large in number.") {
-    val input = for (i <- 10000 to 1 by -1) yield (s"testConf.${i}" -> "test123456")
-    val output = KubernetesClientUtils.truncateToSize(input, 60)
+
+  test("verify load files, truncates the content to maxSize, when keys are very large in number.") {
+    val input = (for (i <- 10000 to 1 by -1) yield (s"testConf.${i}" -> "test123456")).toMap
+    val sparkConf = testSetup(input.map(f => f._1 -> f._2.getBytes(StandardCharsets.UTF_8)))
+      .set(Config.CONFIG_MAP_MAXSIZE.key, "60")
+    val output = KubernetesClientUtils.loadSparkConfDirFiles(sparkConf)
     val expectedOutput = Map("testConf.1" -> "test123456", "testConf.2" -> "test123456")
     assert(output === expectedOutput)
-    val output1 = KubernetesClientUtils.truncateToSize(input, 250000)
-    assert(output1 === input.toMap)
+    val output1 = KubernetesClientUtils.loadSparkConfDirFiles(
+      sparkConf.set(Config.CONFIG_MAP_MAXSIZE.key, "250000"))
+    assert(output1 === input)
+  }
+
+  test("verify load files, truncates the content to maxSize, when keys are equal in length.") {
+    val input = (for (i <- 9 to 1 by -1) yield (s"testConf.${i}" -> "test123456")).toMap
+    val sparkConf = testSetup(input.map(f => f._1 -> f._2.getBytes(StandardCharsets.UTF_8)))
+      .set(Config.CONFIG_MAP_MAXSIZE.key, "80")
+    val output = KubernetesClientUtils.loadSparkConfDirFiles(sparkConf)
+    val expectedOutput = Map("testConf.1" -> "test123456", "testConf.2" -> "test123456",
+      "testConf.3" -> "test123456")
+    assert(output === expectedOutput)
   }
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtilsSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtilsSuite.scala
@@ -51,7 +51,7 @@ class KubernetesClientUtilsSuite extends SparkFunSuite with BeforeAndAfter {
       Map("binary-file.conf" -> Array[Byte](0x00.toByte, 0xA1.toByte))
     val sparkConf = testSetup(input)
     val output = KubernetesClientUtils.loadSparkConfDirFiles(sparkConf)
-    val expectedOutput = Map("test.txt" -> "test123", "sample.conf" -> "conf")
+    val expectedOutput = Map("test.txt" -> "test123", "sample.conf" -> "conf", "_test" -> "")
     assert(output === expectedOutput)
   }
 

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/SparkConfPropagateSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/SparkConfPropagateSuite.scala
@@ -60,4 +60,8 @@ private[spark] trait SparkConfPropagateSuite { k8sSuite: KubernetesSuite =>
       new File(logConfFilePath).delete()
     }
   }
+
+  test("Verify the size limits and file filters are correctly applied.", k8sTestTag) {
+
+  }
 }

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/SparkConfPropagateSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/SparkConfPropagateSuite.scala
@@ -82,12 +82,12 @@ private[spark] trait SparkConfPropagateSuite { k8sSuite: KubernetesSuite =>
         Files.write(new File(s"$sparkConfDirPath/$f").toPath, content.getBytes))
 
       sparkAppConf.set("spark.kubernetes.executor.deleteOnTermination", "false")
-      val expectedLogMessage =
+      val expectedLogMessages =
         Seq(s"Spark configuration files loaded from Some(/opt/spark/conf)") ++ someValidFiles
       runSparkApplicationAndVerifyCompletion(
         appResource = containerLocalSparkDistroExamplesJar,
         mainClass = SPARK_PI_MAIN_CLASS,
-        expectedDriverLogOnCompletion = expectedLogMessage,
+        expectedDriverLogOnCompletion = expectedLogMessages,
         appArgs = Array.empty[String],
         driverPodChecker = doBasicDriverPodCheck,
         executorPodChecker = doBasicExecutorPodCheck,

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/SparkConfPropagateSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/SparkConfPropagateSuite.scala
@@ -61,7 +61,41 @@ private[spark] trait SparkConfPropagateSuite { k8sSuite: KubernetesSuite =>
     }
   }
 
-  test("Verify the size limits and file filters are correctly applied.", k8sTestTag) {
+  test("Verify large files and unsupported binary/non-utf8 encoded files are skipped.",
+    k8sTestTag) {
+    val loggingConfigFileName = "log-config-test-log4j.properties"
+    val loggingConfURL: URL = this.getClass.getClassLoader.getResource(loggingConfigFileName)
+    assert(loggingConfURL != null, "Logging configuration file not available.")
 
+    val content = Source.createBufferedSource(loggingConfURL.openStream()).getLines().mkString("\n")
+    val sparkConfDirPath = s"${sparkHomeDir.toFile}/conf"
+    val filesToGenerateBinary =
+      Seq("test.jar", "non-utf8.txt", "test.zip", "some-random-binary-file")
+    val binaryContent: Array[Byte] = (1 to 10000).map(_.toByte).toArray
+    val someValidFiles = Seq("config.xml", "log4j.properties", "utf8.txt")
+    try {
+
+      filesToGenerateBinary.foreach(f =>
+        Files.write(new File(s"$sparkConfDirPath/$f").toPath, binaryContent))
+
+      someValidFiles.foreach(f =>
+        Files.write(new File(s"$sparkConfDirPath/$f").toPath, content.getBytes))
+
+      sparkAppConf.set("spark.kubernetes.executor.deleteOnTermination", "false")
+      val expectedLogMessage =
+        Seq(s"Spark configuration files loaded from Some(/opt/spark/conf)") ++ someValidFiles
+      runSparkApplicationAndVerifyCompletion(
+        appResource = containerLocalSparkDistroExamplesJar,
+        mainClass = SPARK_PI_MAIN_CLASS,
+        expectedDriverLogOnCompletion = expectedLogMessage,
+        appArgs = Array.empty[String],
+        driverPodChecker = doBasicDriverPodCheck,
+        executorPodChecker = doBasicExecutorPodCheck,
+        appLocator = appLocator,
+        isJVM = true)
+    } finally {
+      (filesToGenerateBinary ++ someValidFiles)
+        .foreach(f => new File(s"$sparkConfDirPath/$f").delete())
+    }
   }
 }

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/SparkConfPropagateSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/SparkConfPropagateSuite.scala
@@ -74,14 +74,12 @@ private[spark] trait SparkConfPropagateSuite { k8sSuite: KubernetesSuite =>
     val binaryContent: Array[Byte] = (1 to 10000).map(_.toByte).toArray
     val someValidFiles = Seq("config.xml", "log4j.properties", "utf8.txt")
     try {
-
       filesToGenerateBinary.foreach(f =>
         Files.write(new File(s"$sparkConfDirPath/$f").toPath, binaryContent))
 
       someValidFiles.foreach(f =>
         Files.write(new File(s"$sparkConfDirPath/$f").toPath, content.getBytes))
 
-      sparkAppConf.set("spark.kubernetes.executor.deleteOnTermination", "false")
       val expectedLogMessages =
         Seq(s"Spark configuration files loaded from Some(/opt/spark/conf)") ++ someValidFiles
       runSparkApplicationAndVerifyCompletion(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Skip files if they are binary or very large to fit the configMap's max size.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Config map cannot hold binary files and there is also a limit on how much data a configMap can hold.
This limit can be configured by the k8s cluster admin. This PR, skips such files (with a warning) instead of failing with weird runtime errors.
If such files are not skipped, then it would result in mount errors or encoding errors (if binary files are submitted). 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
yes, in simple words avoids possible errors due to negligence (for example, placing a large file or a binary file in SPARK_CONF_DIR) and thus improves user experience.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added relevant tests and improved existing tests.