### PR TITLE
[SPARK-33430][SQL] Support namespaces in JDBC v2 Table Catalog

### DIFF
--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresNamespaceSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresNamespaceSuite.scala
@@ -53,9 +53,7 @@ class PostgresNamespaceSuite extends DockerJDBCIntegrationSuite with V2JDBCNames
 
   override def dataPreparation(conn: Connection): Unit = {}
 
-  override def testListNamespaces: Unit = {
-    assert(catalog.listNamespaces() ===
-      Array(Array("foo"), Array("information_schema"), Array("pg_catalog"), Array("public")))
+  override def builtinNamespaces: Array[Array[String]] = {
+    Array(Array("information_schema"), Array("pg_catalog"), Array("public"))
   }
-
 }

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresNamespaceSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresNamespaceSuite.scala
@@ -52,4 +52,10 @@ class PostgresNamespaceSuite extends DockerJDBCIntegrationSuite with V2JDBCNames
   catalog.initialize("postgresql", map)
 
   override def dataPreparation(conn: Connection): Unit = {}
+
+  override def testListNamespaces: Unit = {
+    assert(catalog.listNamespaces() ===
+      Array(Array("foo"), Array("information_schema"), Array("pg_catalog"), Array("public")))
+  }
+
 }

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresNamespaceSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresNamespaceSuite.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.jdbc.v2
+
+import java.sql.Connection
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.jdbc.{DatabaseOnDocker, DockerJDBCIntegrationSuite}
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.tags.DockerTest
+
+/**
+ * To run this test suite for a specific version (e.g., postgres:13.0):
+ * {{{
+ *   POSTGRES_DOCKER_IMAGE_NAME=postgres:13.0
+ *     ./build/sbt -Pdocker-integration-tests "testOnly *v2.PostgresNamespaceSuite"
+ * }}}
+ */
+@DockerTest
+class PostgresNamespaceSuite extends DockerJDBCIntegrationSuite with V2JDBCNamespaceTest {
+  override val db = new DatabaseOnDocker {
+    override val imageName = sys.env.getOrElse("POSTGRES_DOCKER_IMAGE_NAME", "postgres:13.0-alpine")
+    override val env = Map(
+      "POSTGRES_PASSWORD" -> "rootpass"
+    )
+    override val usesIpc = false
+    override val jdbcPort = 5432
+    override def getJdbcUrl(ip: String, port: Int): String =
+      s"jdbc:postgresql://$ip:$port/postgres?user=postgres&password=rootpass"
+  }
+
+  val map = new CaseInsensitiveStringMap(
+    Map("url" -> db.getJdbcUrl(dockerIp, externalPort),
+      "driver" -> "org.postgresql.Driver").asJava)
+
+  catalog.initialize("postgresql", map)
+
+  override def dataPreparation(conn: Connection): Unit = {}
+}

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCNamespaceTest.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCNamespaceTest.scala
@@ -31,11 +31,11 @@ import org.apache.spark.tags.DockerTest
 private[v2] trait V2JDBCNamespaceTest extends SharedSparkSession {
   val catalog = new JDBCTableCatalog()
 
-  def testListNamespaces: Unit
+  def builtinNamespaces: Array[Array[String]]
 
   test("listNamespaces: basic behavior") {
     catalog.createNamespace(Array("foo"), Map("comment" -> "test comment").asJava)
-    testListNamespaces
+    assert(catalog.listNamespaces() === Array(Array("foo")) ++ builtinNamespaces)
     assert(catalog.listNamespaces(Array("foo")) === Array())
     assert(catalog.namespaceExists(Array("foo")) === true)
 
@@ -53,6 +53,7 @@ private[v2] trait V2JDBCNamespaceTest extends SharedSparkSession {
 
     catalog.dropNamespace(Array("foo"))
     assert(catalog.namespaceExists(Array("foo")) === false)
+    assert(catalog.listNamespaces() === builtinNamespaces)
     val msg = intercept[AnalysisException] {
       catalog.listNamespaces(Array("foo"))
     }.getMessage

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCNamespaceTest.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCNamespaceTest.scala
@@ -31,10 +31,11 @@ import org.apache.spark.tags.DockerTest
 private[v2] trait V2JDBCNamespaceTest extends SharedSparkSession {
   val catalog = new JDBCTableCatalog()
 
+  def testListNamespaces: Unit
+
   test("listNamespaces: basic behavior") {
     catalog.createNamespace(Array("foo"), Map("comment" -> "test comment").asJava)
-    assert(catalog.listNamespaces() ===
-      Array(Array("foo"), Array("information_schema"), Array("pg_catalog"), Array("public")))
+    testListNamespaces
     assert(catalog.listNamespaces(Array("foo")) === Array())
     assert(catalog.namespaceExists(Array("foo")) === true)
 
@@ -51,8 +52,6 @@ private[v2] trait V2JDBCNamespaceTest extends SharedSparkSession {
     assert(createCommentWarning === false)
 
     catalog.dropNamespace(Array("foo"))
-    assert(catalog.listNamespaces() ===
-      Array(Array("information_schema"), Array("pg_catalog"), Array("public")))
     assert(catalog.namespaceExists(Array("foo")) === false)
     val msg = intercept[AnalysisException] {
       catalog.listNamespaces(Array("foo"))

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCNamespaceTest.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCNamespaceTest.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.jdbc.v2
+
+import scala.collection.JavaConverters._
+
+import org.apache.log4j.Level
+
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.connector.catalog.NamespaceChange
+import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.tags.DockerTest
+
+@DockerTest
+private[v2] trait V2JDBCNamespaceTest extends SharedSparkSession {
+  val catalog = new JDBCTableCatalog()
+
+  test("listNamespaces: basic behavior") {
+    catalog.createNamespace(Array("foo"), Map("comment" -> "test comment").asJava)
+    assert(catalog.listNamespaces() ===
+      Array(Array("foo"), Array("information_schema"), Array("pg_catalog"), Array("public")))
+    assert(catalog.listNamespaces(Array("foo")) === Array())
+    assert(catalog.namespaceExists(Array("foo")) === true)
+
+    val logAppender = new LogAppender("catalog comment")
+    withLogAppender(logAppender) {
+      catalog.alterNamespace(Array("foo"), NamespaceChange
+        .setProperty("comment", "comment for foo"))
+      catalog.alterNamespace(Array("foo"), NamespaceChange.removeProperty("comment"))
+    }
+    val createCommentWarning = logAppender.loggingEvents
+      .filter(_.getLevel == Level.WARN)
+      .map(_.getRenderedMessage)
+      .exists(_.contains("catalog comment"))
+    assert(createCommentWarning === false)
+
+    catalog.dropNamespace(Array("foo"))
+    assert(catalog.listNamespaces() ===
+      Array(Array("information_schema"), Array("pg_catalog"), Array("public")))
+    assert(catalog.namespaceExists(Array("foo")) === false)
+    val msg = intercept[AnalysisException] {
+      catalog.listNamespaces(Array("foo"))
+    }.getMessage
+    assert(msg.contains("Namespace 'foo' not found"))
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.jdbc
 
-import java.sql.{Connection, Date, SQLFeatureNotSupportedException, Timestamp}
+import java.sql.{Connection, Date, Timestamp}
 
 import scala.collection.mutable.ArrayBuilder
 
@@ -232,7 +232,7 @@ abstract class JdbcDialect extends Serializable with Logging{
           val name = updateNull.fieldNames
           updateClause += getUpdateColumnNullabilityQuery(tableName, name(0), updateNull.nullable())
         case _ =>
-          throw new SQLFeatureNotSupportedException(s"Unsupported TableChange $change")
+          throw new AnalysisException(s"Unsupported TableChange $change in JDBC catalog.")
       }
     }
     updateClause.result()

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -270,6 +270,14 @@ abstract class JdbcDialect extends Serializable with Logging{
     s"COMMENT ON TABLE $table IS '$comment'"
   }
 
+  def getSchemaCommentQuery(schema: String, comment: String): String = {
+    s"COMMENT ON SCHEMA ${quoteIdentifier(schema)} IS '$comment'"
+  }
+
+  def removeSchemaCommentQuery(schema: String): String = {
+    s"COMMENT ON SCHEMA ${quoteIdentifier(schema)} IS NULL"
+  }
+
   /**
    * Gets a dialect exception, classifies it and wraps it by `AnalysisException`.
    * @param message The error message to be placed to the returned exception.


### PR DESCRIPTION

### What changes were proposed in this pull request?
Add namespaces support in JDBC v2 Table Catalog by making ```JDBCTableCatalog``` extends```SupportsNamespaces```



### Why are the changes needed?
make v2 JDBC implementation complete

### Does this PR introduce _any_ user-facing change?
Yes. Add the following to  ```JDBCTableCatalog``` 

- listNamespaces
- listNamespaces(String[] namespace)
- namespaceExists(String[] namespace)
- loadNamespaceMetadata(String[] namespace)
- createNamespace
- alterNamespace
- dropNamespace


### How was this patch tested?
Add new docker tests