### PR TITLE
[SPARK-33521][SQL] Universal type conversion in resolving V2 partition specs 

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolvePartitionSpec.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolvePartitionSpec.scala
@@ -66,7 +66,7 @@ object ResolvePartitionSpec extends Rule[LogicalPlan] {
 
     val partValues = partSchema.map { part =>
       val raw = normalizedSpec.get(part.name).orNull
-      Cast(Literal(raw), part.dataType, Some(conf.sessionLocalTimeZone)).eval()
+      Cast(Literal.create(raw, StringType), part.dataType, Some(conf.sessionLocalTimeZone)).eval()
     }
     InternalRow.fromSeq(partValues)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolvePartitionSpec.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolvePartitionSpec.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
-import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
+import org.apache.spark.sql.catalyst.expressions.{Cast, Literal}
 import org.apache.spark.sql.catalyst.plans.logical.{AlterTableAddPartition, AlterTableDropPartition, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.connector.catalog.SupportsPartitionManagement
@@ -65,31 +65,8 @@ object ResolvePartitionSpec extends Rule[LogicalPlan] {
       conf.resolver)
 
     val partValues = partSchema.map { part =>
-      val partValue = normalizedSpec.get(part.name).orNull
-      if (partValue == null) {
-        null
-      } else {
-        // TODO: Support other datatypes, such as DateType
-        part.dataType match {
-          case _: ByteType =>
-            partValue.toByte
-          case _: ShortType =>
-            partValue.toShort
-          case _: IntegerType =>
-            partValue.toInt
-          case _: LongType =>
-            partValue.toLong
-          case _: FloatType =>
-            partValue.toFloat
-          case _: DoubleType =>
-            partValue.toDouble
-          case _: StringType =>
-            partValue
-          case _ =>
-            throw new AnalysisException(
-              s"Type ${part.dataType.typeName} is not supported for partition.")
-        }
-      }
+      val raw = normalizedSpec.get(part.name).orNull
+      Cast(Literal(raw), part.dataType, Some(conf.sessionLocalTimeZone)).eval()
     }
     InternalRow.fromSeq(partValues)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTablePartitionV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTablePartitionV2SQLSuite.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.catalyst.analysis.{NoSuchPartitionsException, Partit
 import org.apache.spark.sql.connector.catalog.{CatalogV2Implicits, Identifier}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Implicits
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.unsafe.types.UTF8String
 
 class AlterTablePartitionV2SQLSuite extends DatasourceV2SQLBase {
 
@@ -211,14 +212,14 @@ class AlterTablePartitionV2SQLSuite extends DatasourceV2SQLBase {
       val partTable = catalog("testpart").asTableCatalog
         .loadTable(Identifier.of(Array("ns1", "ns2"), "tbl"))
         .asPartitionable
-      val expectedPartition = InternalRow.fromSeq(Seq(
+      val expectedPartition = InternalRow.fromSeq(Seq[Any](
         -1,    // tinyint
         0,     // smallint
         1,     // int
         2,     // bigint
         3.14F, // float
         3.14D, // double
-        "abc"  // string
+        UTF8String.fromString("abc")  // string
       ))
       assert(!partTable.partitionExists(expectedPartition))
       val partSpec = """

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTablePartitionV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTablePartitionV2SQLSuite.scala
@@ -190,7 +190,7 @@ class AlterTablePartitionV2SQLSuite extends DatasourceV2SQLBase {
     }
   }
 
-  test("ALTER TABLE ADD/DROP PARTITIONS: all types") {
+  test("universal type conversions of partition values") {
     val t = "testpart.ns1.ns2.tbl"
     withTable(t) {
       sql(s"""
@@ -206,10 +206,8 @@ class AlterTablePartitionV2SQLSuite extends DatasourceV2SQLBase {
         |  part8 date,
         |  part9 timestamp
         |) USING foo
-        |PARTITIONED BY (
-        |  part0, part1, part2, part3, part4, part5, part6, part7,
-        |  part8, part9
-        |)""".stripMargin)
+        |PARTITIONED BY (part0, part1, part2, part3, part4, part5, part6, part7, part8, part9)
+        |""".stripMargin)
       val partTable = catalog("testpart").asTableCatalog
         .loadTable(Identifier.of(Array("ns1", "ns2"), "tbl"))
         .asPartitionable

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTablePartitionV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTablePartitionV2SQLSuite.scala
@@ -190,7 +190,7 @@ class AlterTablePartitionV2SQLSuite extends DatasourceV2SQLBase {
     }
   }
 
-  test("universal type conversions of partition values") {
+  test("SPARK-33521: universal type conversions of partition values") {
     val t = "testpart.ns1.ns2.tbl"
     withTable(t) {
       sql(s"""

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTablePartitionV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTablePartitionV2SQLSuite.scala
@@ -198,16 +198,11 @@ class AlterTablePartitionV2SQLSuite extends DatasourceV2SQLBase {
         |  part3 bigint,
         |  part4 float,
         |  part5 double,
-        |  part6 string
+        |  part6 string,
+        |  part7 boolean
         |) USING foo
         |PARTITIONED BY (
-        |  part0,
-        |  part1,
-        |  part2,
-        |  part3,
-        |  part4,
-        |  part5,
-        |  part6
+        |  part0, part1, part2, part3, part4, part5, part6, part7
         |)""".stripMargin)
       val partTable = catalog("testpart").asTableCatalog
         .loadTable(Identifier.of(Array("ns1", "ns2"), "tbl"))
@@ -219,7 +214,8 @@ class AlterTablePartitionV2SQLSuite extends DatasourceV2SQLBase {
         2,     // bigint
         3.14F, // float
         3.14D, // double
-        UTF8String.fromString("abc")  // string
+        UTF8String.fromString("abc"), // string
+        true // boolean
       ))
       assert(!partTable.partitionExists(expectedPartition))
       val partSpec = """
@@ -229,7 +225,8 @@ class AlterTablePartitionV2SQLSuite extends DatasourceV2SQLBase {
         |  part3 = 2,
         |  part4 = 3.14,
         |  part5 = 3.14,
-        |  part6 = 'abc'
+        |  part6 = 'abc',
+        |  part7 = true
         |""".stripMargin
       sql(s"ALTER TABLE $t ADD PARTITION ($partSpec) LOCATION 'loc1'")
       assert(partTable.partitionExists(expectedPartition))

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTablePartitionV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTablePartitionV2SQLSuite.scala
@@ -191,25 +191,48 @@ class AlterTablePartitionV2SQLSuite extends DatasourceV2SQLBase {
     withTable(t) {
       sql(s"""
         |CREATE TABLE $t (
-        |  part0 bigint
+        |  part0 tinyint,
+        |  part1 smallint,
+        |  part2 int,
+        |  part3 bigint,
+        |  part4 float,
+        |  part5 double,
+        |  part6 string
         |) USING foo
         |PARTITIONED BY (
-        |  part0
+        |  part0,
+        |  part1,
+        |  part2,
+        |  part3,
+        |  part4,
+        |  part5,
+        |  part6
         |)""".stripMargin)
       val partTable = catalog("testpart").asTableCatalog
         .loadTable(Identifier.of(Array("ns1", "ns2"), "tbl"))
         .asPartitionable
-      val expectedPartition = InternalRow.fromSeq(Seq(123))
+      val expectedPartition = InternalRow.fromSeq(Seq(
+        -1,    // tinyint
+        0,     // smallint
+        1,     // int
+        2,     // bigint
+        3.14F, // float
+        3.14D, // double
+        "abc"  // string
+      ))
       assert(!partTable.partitionExists(expectedPartition))
-      sql(s"""
-        |ALTER TABLE $t ADD PARTITION (
-        |  part0 = 123
-        |) LOCATION 'loc1'""".stripMargin)
+      val partSpec = """
+        |  part0 = -1,
+        |  part1 = 0,
+        |  part2 = 1,
+        |  part3 = 2,
+        |  part4 = 3.14,
+        |  part5 = 3.14,
+        |  part6 = 'abc'
+        |""".stripMargin
+      sql(s"ALTER TABLE $t ADD PARTITION ($partSpec) LOCATION 'loc1'")
       assert(partTable.partitionExists(expectedPartition))
-      sql(s"""
-        |ALTER TABLE $t DROP PARTITION (
-        |  part0 = 123
-        |)""".stripMargin)
+      sql(s" ALTER TABLE $t DROP PARTITION ($partSpec)")
       assert(!partTable.partitionExists(expectedPartition))
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to changes the resolver of partition specs used in V2 `ALTER TABLE .. ADD/DROP PARTITION` (at the moment), and re-use `CAST` in conversion partition values to desired types according to the partition schema.

### Why are the changes needed?
Currently, the resolver of V2 partition specs supports just a few types: https://github.com/apache/spark/blob/23e9920b3910e4f05269853429c7f18888cdc7b5/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolvePartitionSpec.scala#L72, and fails on other types like date/timestamp.

### Does this PR introduce _any_ user-facing change?
Yes

### How was this patch tested?
By running `AlterTablePartitionV2SQLSuite`
