### PR TITLE
[SPARK-33523][SQL][TEST] Add predicate related benchmark to SubExprEliminationBenchmark

### DIFF
--- a/sql/core/benchmarks/SubExprEliminationBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/SubExprEliminationBenchmark-jdk11-results.txt
@@ -5,11 +5,21 @@ Benchmark for performance of subexpression elimination
 Preparing data for benchmarking ...
 OpenJDK 64-Bit Server VM 11.0.9+11 on Mac OS X 10.15.6
 Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
-from_json as subExpr:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+from_json as subExpr in Project:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-subexpressionElimination off, codegen on           25932          26908         916          0.0   259320042.3       1.0X
-subexpressionElimination off, codegen off          26085          26159          65          0.0   260848905.0       1.0X
-subexpressionElimination on, codegen on             2860           2939          72          0.0    28603312.9       9.1X
-subexpressionElimination on, codegen off            2517           2617          93          0.0    25165157.7      10.3X
+subexpressionElimination off, codegen on           24794          25670         804          0.0   247938678.3       1.0X
+subexpressionElimination off, codegen off          23650          23997         416          0.0   236499419.7       1.0X
+subexpressionElimination on, codegen on             2346           2404          52          0.0    23459657.0      10.6X
+subexpressionElimination on, codegen off            2125           2205          71          0.0    21247464.2      11.7X
+
+Preparing data for benchmarking ...
+OpenJDK 64-Bit Server VM 11.0.9+11 on Mac OS X 10.15.6
+Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+from_json as subExpr in Filter:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------
+subexpressionElimination off, codegen on           36434          37385         923          0.0   364342472.7       1.0X
+subexpressionElimination off, codegen off          36329          36802         421          0.0   363285275.9       1.0X
+subexpressionElimination on, codegen on            22556          23355         693          0.0   225558478.3       1.6X
+subexpressionElimination on, codegen off           36034          36620         525          0.0   360342927.5       1.0X
 
 

--- a/sql/core/benchmarks/SubExprEliminationBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/SubExprEliminationBenchmark-jdk11-results.txt
@@ -5,21 +5,21 @@ Benchmark for performance of subexpression elimination
 Preparing data for benchmarking ...
 OpenJDK 64-Bit Server VM 11.0.9+11 on Mac OS X 10.15.6
 Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
-from_json as subExpr in Project:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------
-subexpressionElimination off, codegen on           22605          22935         291          0.0   226047196.5       1.0X
-subexpressionElimination off, codegen off          21811          22151         303          0.0   218105716.6       1.0X
-subexpressionElimination on, codegen on             1353           1385          36          0.0    13531011.3      16.7X
-subexpressionElimination on, codegen off            1237           1260          20          0.0    12368657.3      18.3X
+from_json as subExpr in Project:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+subExprElimination false, codegen: true           26447          27127         605          0.0   264467933.4       1.0X
+subExprElimination false, codegen: false          25673          26035         546          0.0   256732419.1       1.0X
+subExprElimination true, codegen: true             1384           1448         102          0.0    13842910.3      19.1X
+subExprElimination true, codegen: false            1244           1347         123          0.0    12442389.3      21.3X
 
 Preparing data for benchmarking ...
 OpenJDK 64-Bit Server VM 11.0.9+11 on Mac OS X 10.15.6
 Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
-from_json as subExpr in Filter:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------
-subexpressionElimination off, codegen on           32792          33101         282          0.0   327922763.5       1.0X
-subexpressionElimination off, codegen off          32809          33433         550          0.0   328088662.6       1.0X
-subexpressionElimination on, codegen on            18173          18828         869          0.0   181734709.5       1.8X
-subexpressionElimination on, codegen off           33695          33951         287          0.0   336950807.7       1.0X
+from_json as subExpr in Filter:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+subexpressionElimination off, codegen on          34631          35449         833          0.0   346309884.0       1.0X
+subexpressionElimination off, codegen on          34480          34851         353          0.0   344798490.4       1.0X
+subexpressionElimination off, codegen on          16618          16811         291          0.0   166176642.6       2.1X
+subexpressionElimination off, codegen on          34316          34667         310          0.0   343157094.7       1.0X
 
 

--- a/sql/core/benchmarks/SubExprEliminationBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/SubExprEliminationBenchmark-jdk11-results.txt
@@ -7,19 +7,19 @@ OpenJDK 64-Bit Server VM 11.0.9+11 on Mac OS X 10.15.6
 Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 from_json as subExpr in Project:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-subexpressionElimination off, codegen on           24794          25670         804          0.0   247938678.3       1.0X
-subexpressionElimination off, codegen off          23650          23997         416          0.0   236499419.7       1.0X
-subexpressionElimination on, codegen on             2346           2404          52          0.0    23459657.0      10.6X
-subexpressionElimination on, codegen off            2125           2205          71          0.0    21247464.2      11.7X
+subexpressionElimination off, codegen on           22605          22935         291          0.0   226047196.5       1.0X
+subexpressionElimination off, codegen off          21811          22151         303          0.0   218105716.6       1.0X
+subexpressionElimination on, codegen on             1353           1385          36          0.0    13531011.3      16.7X
+subexpressionElimination on, codegen off            1237           1260          20          0.0    12368657.3      18.3X
 
 Preparing data for benchmarking ...
 OpenJDK 64-Bit Server VM 11.0.9+11 on Mac OS X 10.15.6
 Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 from_json as subExpr in Filter:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-subexpressionElimination off, codegen on           36434          37385         923          0.0   364342472.7       1.0X
-subexpressionElimination off, codegen off          36329          36802         421          0.0   363285275.9       1.0X
-subexpressionElimination on, codegen on            22556          23355         693          0.0   225558478.3       1.6X
-subexpressionElimination on, codegen off           36034          36620         525          0.0   360342927.5       1.0X
+subexpressionElimination off, codegen on           32792          33101         282          0.0   327922763.5       1.0X
+subexpressionElimination off, codegen off          32809          33433         550          0.0   328088662.6       1.0X
+subexpressionElimination on, codegen on            18173          18828         869          0.0   181734709.5       1.8X
+subexpressionElimination on, codegen off           33695          33951         287          0.0   336950807.7       1.0X
 
 

--- a/sql/core/benchmarks/SubExprEliminationBenchmark-results.txt
+++ b/sql/core/benchmarks/SubExprEliminationBenchmark-results.txt
@@ -5,21 +5,21 @@ Benchmark for performance of subexpression elimination
 Preparing data for benchmarking ...
 OpenJDK 64-Bit Server VM 1.8.0_265-b01 on Mac OS X 10.15.6
 Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
-from_json as subExpr in Project:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------
-subexpressionElimination off, codegen on           25887          26105         326          0.0   258868246.6       1.0X
-subexpressionElimination off, codegen off          25131          25454         522          0.0   251309329.7       1.0X
-subexpressionElimination on, codegen on             2230           2340         106          0.0    22302959.3      11.6X
-subexpressionElimination on, codegen off            2185           2254          64          0.0    21852694.0      11.8X
+from_json as subExpr in Project:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+subExprElimination false, codegen: true           22767          23240         424          0.0   227665316.7       1.0X
+subExprElimination false, codegen: false          22869          23351         465          0.0   228693464.1       1.0X
+subExprElimination true, codegen: true             1328           1340          10          0.0    13280056.2      17.1X
+subExprElimination true, codegen: false            1248           1276          31          0.0    12476135.1      18.2X
 
 Preparing data for benchmarking ...
 OpenJDK 64-Bit Server VM 1.8.0_265-b01 on Mac OS X 10.15.6
 Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
-from_json as subExpr in Filter:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------
-subexpressionElimination off, codegen on           42687          42805         111          0.0   426873372.5       1.0X
-subexpressionElimination off, codegen off          43606          45108        1613          0.0   436055236.3       1.0X
-subexpressionElimination on, codegen on            29761          30563         704          0.0   297614324.4       1.4X
-subexpressionElimination on, codegen off           41676          42598         955          0.0   416758112.3       1.0X
+from_json as subExpr in Filter:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+subexpressionElimination off, codegen on          37691          38846        1004          0.0   376913767.9       1.0X
+subexpressionElimination off, codegen on          37852          39124        1103          0.0   378517745.5       1.0X
+subexpressionElimination off, codegen on          22900          23085         202          0.0   229000242.5       1.6X
+subexpressionElimination off, codegen on          38298          38598         374          0.0   382978731.3       1.0X
 
 

--- a/sql/core/benchmarks/SubExprEliminationBenchmark-results.txt
+++ b/sql/core/benchmarks/SubExprEliminationBenchmark-results.txt
@@ -5,11 +5,21 @@ Benchmark for performance of subexpression elimination
 Preparing data for benchmarking ...
 OpenJDK 64-Bit Server VM 1.8.0_265-b01 on Mac OS X 10.15.6
 Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
-from_json as subExpr:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+from_json as subExpr in Project:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-subexpressionElimination off, codegen on           26503          27622        1937          0.0   265033362.4       1.0X
-subexpressionElimination off, codegen off          24920          25376         430          0.0   249196978.2       1.1X
-subexpressionElimination on, codegen on             2421           2466          39          0.0    24213606.1      10.9X
-subexpressionElimination on, codegen off            2360           2435          87          0.0    23604320.7      11.2X
+subexpressionElimination off, codegen on           25887          26105         326          0.0   258868246.6       1.0X
+subexpressionElimination off, codegen off          25131          25454         522          0.0   251309329.7       1.0X
+subexpressionElimination on, codegen on             2230           2340         106          0.0    22302959.3      11.6X
+subexpressionElimination on, codegen off            2185           2254          64          0.0    21852694.0      11.8X
+
+Preparing data for benchmarking ...
+OpenJDK 64-Bit Server VM 1.8.0_265-b01 on Mac OS X 10.15.6
+Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+from_json as subExpr in Filter:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------
+subexpressionElimination off, codegen on           42687          42805         111          0.0   426873372.5       1.0X
+subexpressionElimination off, codegen off          43606          45108        1613          0.0   436055236.3       1.0X
+subexpressionElimination on, codegen on            29761          30563         704          0.0   297614324.4       1.4X
+subexpressionElimination on, codegen off           41676          42598         955          0.0   416758112.3       1.0X
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SubExprEliminationBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SubExprEliminationBenchmark.scala
@@ -17,6 +17,8 @@
 package org.apache.spark.sql.execution
 
 import org.apache.spark.benchmark.Benchmark
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, Or}
 import org.apache.spark.sql.execution.benchmark.SqlBasedBenchmark
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
@@ -39,7 +41,7 @@ object SubExprEliminationBenchmark extends SqlBasedBenchmark {
   import spark.implicits._
 
   def withFromJson(rowsNum: Int, numIters: Int): Unit = {
-    val benchmark = new Benchmark("from_json as subExpr", rowsNum, output = output)
+    val benchmark = new Benchmark("from_json as subExpr in Project", rowsNum, output = output)
 
     withTempPath { path =>
       prepareDataInfo(benchmark)
@@ -108,11 +110,81 @@ object SubExprEliminationBenchmark extends SqlBasedBenchmark {
     }
   }
 
+  def withFilter(rowsNum: Int, numIters: Int): Unit = {
+    val benchmark = new Benchmark("from_json as subExpr in Filter", rowsNum, output = output)
+
+    withTempPath { path =>
+      prepareDataInfo(benchmark)
+      val numCols = 1000
+      val schema = writeWideRow(path.getAbsolutePath, rowsNum, numCols)
+
+      val predicate = (0 until numCols).map { idx =>
+        (from_json('value, schema).getField(s"col$idx") >= Literal(100000)).expr
+      }.asInstanceOf[Seq[Expression]].reduce(Or)
+
+      // We only benchmark subexpression performance under codegen/non-codegen, so disabling
+      // json optimization.
+      benchmark.addCase("subexpressionElimination off, codegen on", numIters) { _ =>
+        withSQLConf(
+          SQLConf.SUBEXPRESSION_ELIMINATION_ENABLED.key -> "false",
+          SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "true",
+          SQLConf.CODEGEN_FACTORY_MODE.key -> "CODEGEN_ONLY",
+          SQLConf.JSON_EXPRESSION_OPTIMIZATION.key -> "false") {
+          val df = spark.read
+            .text(path.getAbsolutePath)
+            .where(Column(predicate))
+          df.collect()
+        }
+      }
+
+      benchmark.addCase("subexpressionElimination off, codegen off", numIters) { _ =>
+        withSQLConf(
+          SQLConf.SUBEXPRESSION_ELIMINATION_ENABLED.key -> "false",
+          SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false",
+          SQLConf.CODEGEN_FACTORY_MODE.key -> "NO_CODEGEN",
+          SQLConf.JSON_EXPRESSION_OPTIMIZATION.key -> "false") {
+          val df = spark.read
+            .text(path.getAbsolutePath)
+            .where(Column(predicate))
+          df.collect()
+        }
+      }
+
+      benchmark.addCase("subexpressionElimination on, codegen on", numIters) { _ =>
+        withSQLConf(
+          SQLConf.SUBEXPRESSION_ELIMINATION_ENABLED.key -> "true",
+          SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "true",
+          SQLConf.CODEGEN_FACTORY_MODE.key -> "CODEGEN_ONLY",
+          SQLConf.JSON_EXPRESSION_OPTIMIZATION.key -> "false") {
+          val df = spark.read
+            .text(path.getAbsolutePath)
+            .where(Column(predicate))
+          df.collect()
+        }
+      }
+
+      benchmark.addCase("subexpressionElimination on, codegen off", numIters) { _ =>
+        withSQLConf(
+          SQLConf.SUBEXPRESSION_ELIMINATION_ENABLED.key -> "true",
+          SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false",
+          SQLConf.CODEGEN_FACTORY_MODE.key -> "NO_CODEGEN",
+          SQLConf.JSON_EXPRESSION_OPTIMIZATION.key -> "false") {
+          val df = spark.read
+            .text(path.getAbsolutePath)
+            .where(Column(predicate))
+          df.collect()
+        }
+      }
+
+      benchmark.run()
+    }
+  }
 
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
     val numIters = 3
     runBenchmark("Benchmark for performance of subexpression elimination") {
       withFromJson(100, numIters)
+      withFilter(100, numIters)
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SubExprEliminationBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SubExprEliminationBenchmark.scala
@@ -63,7 +63,7 @@ object SubExprEliminationBenchmark extends SqlBasedBenchmark {
           val df = spark.read
             .text(path.getAbsolutePath)
             .select(cols: _*)
-          df.collect()
+          df.write.mode("overwrite").format("noop").save()
         }
       }
 
@@ -76,7 +76,7 @@ object SubExprEliminationBenchmark extends SqlBasedBenchmark {
           val df = spark.read
             .text(path.getAbsolutePath)
             .select(cols: _*)
-          df.collect()
+          df.write.mode("overwrite").format("noop").save()
         }
       }
 
@@ -89,7 +89,7 @@ object SubExprEliminationBenchmark extends SqlBasedBenchmark {
           val df = spark.read
             .text(path.getAbsolutePath)
             .select(cols: _*)
-          df.collect()
+          df.write.mode("overwrite").format("noop").save()
         }
       }
 
@@ -102,7 +102,7 @@ object SubExprEliminationBenchmark extends SqlBasedBenchmark {
           val df = spark.read
             .text(path.getAbsolutePath)
             .select(cols: _*)
-          df.collect()
+          df.write.mode("overwrite").format("noop").save()
         }
       }
 
@@ -133,7 +133,7 @@ object SubExprEliminationBenchmark extends SqlBasedBenchmark {
           val df = spark.read
             .text(path.getAbsolutePath)
             .where(Column(predicate))
-          df.collect()
+          df.write.mode("overwrite").format("noop").save()
         }
       }
 
@@ -146,7 +146,7 @@ object SubExprEliminationBenchmark extends SqlBasedBenchmark {
           val df = spark.read
             .text(path.getAbsolutePath)
             .where(Column(predicate))
-          df.collect()
+          df.write.mode("overwrite").format("noop").save()
         }
       }
 
@@ -159,7 +159,7 @@ object SubExprEliminationBenchmark extends SqlBasedBenchmark {
           val df = spark.read
             .text(path.getAbsolutePath)
             .where(Column(predicate))
-          df.collect()
+          df.write.mode("overwrite").format("noop").save()
         }
       }
 
@@ -172,7 +172,7 @@ object SubExprEliminationBenchmark extends SqlBasedBenchmark {
           val df = spark.read
             .text(path.getAbsolutePath)
             .where(Column(predicate))
-          df.collect()
+          df.write.mode("overwrite").format("noop").save()
         }
       }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This patch adds predicate related benchmark to `SubExprEliminationBenchmark`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

We should have a benchmark for subexpression elimination of predicate.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No, dev only.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Run benchmark locally.