### PR TITLE
[SPARK-33526][SQL] Add config to control if cancel invoke interrupt task on thriftserver

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -937,6 +937,16 @@ object SQLConf {
       .timeConf(TimeUnit.SECONDS)
       .createWithDefault(0L)
 
+  val THRIFTSERVER_FORCE_CANCEL =
+    buildConf("spark.sql.thriftServer.forceCancel")
+      .doc("When true, all the job of query will be cancelled and running tasks will be" +
+        "interrupted. When false, all the job of query will be cancelled but running task" +
+        "will be remained until finished. Note that, this config must be set before query" +
+        "otherwise it doesn't help.")
+      .version("3.1.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val THRIFTSERVER_UI_STATEMENT_LIMIT =
     buildConf("spark.sql.thriftserver.ui.retainedStatements")
       .doc("The number of SQL statements kept in the JDBC/ODBC web UI history.")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -943,7 +943,7 @@ object SQLConf {
         "interrupted. When false, all the job of query will be cancelled but running task" +
         "will be remained until finished. Note that, this config must be set before query" +
         "otherwise it doesn't help.")
-      .version("3.1.0")
+      .version("3.2.0")
       .booleanConf
       .createWithDefault(false)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -938,9 +938,9 @@ object SQLConf {
       .createWithDefault(0L)
 
   val THRIFTSERVER_FORCE_CANCEL =
-    buildConf("spark.sql.thriftServer.forceCancel")
-      .doc("When true, all the job of query will be cancelled and running tasks will be" +
-        "interrupted. When false, all the job of query will be cancelled but running task" +
+    buildConf("spark.sql.thriftServer.interruptOnCancel")
+      .doc("When true, if a running query has been cancelled then all running tasks will be" +
+        "interrupted. When false, if a running query has been cancelled then all running task " +
         "will be remained until finished.")
       .version("3.2.0")
       .booleanConf

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -932,8 +932,9 @@ object SQLConf {
         "a positive value, a running query will be cancelled automatically when the timeout is " +
         "exceeded, otherwise the query continues to run till completion. If timeout values are " +
         "set for each statement via `java.sql.Statement.setQueryTimeout` and they are smaller " +
-        "than this configuration value, they take precedence. After set this config, you may be " +
-        "interesting in spark.sql.thriftServer.interruptOnCancel which can help interrupt task.")
+        "than this configuration value, they take precedence. If you set this timeout and prefer" +
+        "to cancel the queries right away without waiting task to finish, consider enabling" +
+        s"${THRIFTSERVER_FORCE_CANCEL.key} together.")
       .version("3.1.0")
       .timeConf(TimeUnit.SECONDS)
       .createWithDefault(0L)
@@ -941,7 +942,7 @@ object SQLConf {
   val THRIFTSERVER_FORCE_CANCEL =
     buildConf("spark.sql.thriftServer.interruptOnCancel")
       .doc("When true, all running tasks will be interrupted if one cancels a query. " +
-        "When false, all running tasks will be remained until finished.")
+        "When false, all running tasks will remain until finished.")
       .version("3.2.0")
       .booleanConf
       .createWithDefault(false)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -941,8 +941,7 @@ object SQLConf {
     buildConf("spark.sql.thriftServer.forceCancel")
       .doc("When true, all the job of query will be cancelled and running tasks will be" +
         "interrupted. When false, all the job of query will be cancelled but running task" +
-        "will be remained until finished. Note that, this config must be set before query" +
-        "otherwise it doesn't help.")
+        "will be remained until finished.")
       .version("3.2.0")
       .booleanConf
       .createWithDefault(false)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -932,7 +932,8 @@ object SQLConf {
         "a positive value, a running query will be cancelled automatically when the timeout is " +
         "exceeded, otherwise the query continues to run till completion. If timeout values are " +
         "set for each statement via `java.sql.Statement.setQueryTimeout` and they are smaller " +
-        "than this configuration value, they take precedence.")
+        "than this configuration value, they take precedence. After set this config, you may be " +
+        "interesting in spark.sql.thriftServer.interruptOnCancel which can help interrupt task.")
       .version("3.1.0")
       .timeConf(TimeUnit.SECONDS)
       .createWithDefault(0L)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -939,9 +939,8 @@ object SQLConf {
 
   val THRIFTSERVER_FORCE_CANCEL =
     buildConf("spark.sql.thriftServer.interruptOnCancel")
-      .doc("When true, if a running query has been cancelled then all running tasks will be" +
-        "interrupted. When false, if a running query has been cancelled then all running task " +
-        "will be remained until finished.")
+      .doc("When true, all running tasks will be interrupted if one cancels a query. " +
+        "When false, all running tasks will be remained until finished.")
       .version("3.2.0")
       .booleanConf
       .createWithDefault(false)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -926,6 +926,14 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val THRIFTSERVER_FORCE_CANCEL =
+    buildConf("spark.sql.thriftServer.interruptOnCancel")
+      .doc("When true, all running tasks will be interrupted if one cancels a query. " +
+        "When false, all running tasks will remain until finished.")
+      .version("3.2.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val THRIFTSERVER_QUERY_TIMEOUT =
     buildConf("spark.sql.thriftServer.queryTimeout")
       .doc("Set a query duration timeout in seconds in Thrift Server. If the timeout is set to " +
@@ -938,14 +946,6 @@ object SQLConf {
       .version("3.1.0")
       .timeConf(TimeUnit.SECONDS)
       .createWithDefault(0L)
-
-  val THRIFTSERVER_FORCE_CANCEL =
-    buildConf("spark.sql.thriftServer.interruptOnCancel")
-      .doc("When true, all running tasks will be interrupted if one cancels a query. " +
-        "When false, all running tasks will remain until finished.")
-      .version("3.2.0")
-      .booleanConf
-      .createWithDefault(false)
 
   val THRIFTSERVER_UI_STATEMENT_LIMIT =
     buildConf("spark.sql.thriftserver.ui.retainedStatements")

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
@@ -63,6 +63,8 @@ private[hive] class SparkExecuteStatementOperation(
     }
   }
 
+  private val forceCancel = sqlContext.conf.getConf(SQLConf.THRIFTSERVER_FORCE_CANCEL)
+
   private val substitutorStatement = SQLConf.withExistingConf(sqlContext.conf) {
     new VariableSubstitution().substitute(statement)
   }
@@ -131,7 +133,7 @@ private[hive] class SparkExecuteStatementOperation(
 
   def getNextRowSet(order: FetchOrientation, maxRowsL: Long): RowSet = withLocalProperties {
     try {
-      sqlContext.sparkContext.setJobGroup(statementId, substitutorStatement)
+      sqlContext.sparkContext.setJobGroup(statementId, substitutorStatement, forceCancel)
       getNextRowSetInternal(order, maxRowsL)
     } finally {
       sqlContext.sparkContext.clearJobGroup()
@@ -321,7 +323,7 @@ private[hive] class SparkExecuteStatementOperation(
         parentSession.getSessionState.getConf.setClassLoader(executionHiveClassLoader)
       }
 
-      sqlContext.sparkContext.setJobGroup(statementId, substitutorStatement)
+      sqlContext.sparkContext.setJobGroup(statementId, substitutorStatement, forceCancel)
       result = sqlContext.sql(statement)
       logDebug(result.queryExecution.toString())
       HiveThriftServer2.eventManager.onStatementParsed(statementId,

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerWithSparkContextSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerWithSparkContextSuite.scala
@@ -85,7 +85,7 @@ trait ThriftServerWithSparkContextSuite extends SharedThriftServer {
     }
   }
 
-  test("SPARK-33526: Add config to control if interrupt task on thriftserver") {
+  test("SPARK-33526: Add config to control if cancel invoke interrupt task on thriftserver") {
     withJdbcStatement { statement =>
       val forceCancel = new AtomicBoolean(false)
       val listener = new SparkListener {

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerWithSparkContextSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerWithSparkContextSuite.scala
@@ -18,8 +18,13 @@
 package org.apache.spark.sql.hive.thriftserver
 
 import java.sql.SQLException
+import java.util.concurrent.atomic.AtomicBoolean
 
 import org.apache.hive.service.cli.HiveSQLException
+
+import org.apache.spark.TaskKilled
+import org.apache.spark.scheduler.{SparkListener, SparkListenerTaskEnd}
+import org.apache.spark.sql.internal.SQLConf
 
 trait ThriftServerWithSparkContextSuite extends SharedThriftServer {
 
@@ -77,6 +82,45 @@ trait ThriftServerWithSparkContextSuite extends SharedThriftServer {
         .contains("The second argument of 'date_sub' function needs to be an integer."))
       assert(e.getMessage.contains("" +
         "java.lang.NumberFormatException: invalid input syntax for type numeric: 1.2"))
+    }
+  }
+
+  test("SPARK-33526: Add config to control if interrupt task on thriftserver") {
+    withJdbcStatement { statement =>
+      val forceCancel = new AtomicBoolean(false)
+      val listener = new SparkListener {
+        override def onTaskEnd(taskEnd: SparkListenerTaskEnd): Unit = {
+          taskEnd.reason match {
+            case _: TaskKilled =>
+              if (forceCancel.get()) {
+                assert(System.currentTimeMillis() - taskEnd.taskInfo.launchTime < 1000)
+              } else {
+                assert(System.currentTimeMillis() - taskEnd.taskInfo.launchTime >= 2900)
+              }
+            case _ =>
+          }
+        }
+      }
+
+      spark.sparkContext.addSparkListener(listener)
+      try {
+        statement.execute(s"SET ${SQLConf.THRIFTSERVER_QUERY_TIMEOUT.key}=1")
+        statement.execute(s"SET ${SQLConf.THRIFTSERVER_FORCE_CANCEL.key}=false")
+        forceCancel.set(false)
+        val e1 = intercept[SQLException] {
+          statement.execute("select java_method('java.lang.Thread', 'sleep', 3000L)")
+        }.getMessage
+        assert(e1.contains("Query timed out"))
+
+        statement.execute(s"SET ${SQLConf.THRIFTSERVER_FORCE_CANCEL.key}=true")
+        forceCancel.set(true)
+        val e2 = intercept[SQLException] {
+          statement.execute("select java_method('java.lang.Thread', 'sleep', 3000L)")
+        }.getMessage
+        assert(e2.contains("Query timed out"))
+      } finally {
+        spark.sparkContext.removeSparkListener(listener)
+      }
     }
   }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerWithSparkContextSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerWithSparkContextSuite.scala
@@ -95,7 +95,7 @@ trait ThriftServerWithSparkContextSuite extends SharedThriftServer {
               if (forceCancel.get()) {
                 assert(System.currentTimeMillis() - taskEnd.taskInfo.launchTime < 1000)
               } else {
-                assert(System.currentTimeMillis() - taskEnd.taskInfo.launchTime >= 2900)
+                assert(System.currentTimeMillis() - taskEnd.taskInfo.launchTime >= 2000)
               }
             case _ =>
           }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerWithSparkContextSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerWithSparkContextSuite.scala
@@ -90,14 +90,12 @@ trait ThriftServerWithSparkContextSuite extends SharedThriftServer {
       val forceCancel = new AtomicBoolean(false)
       val listener = new SparkListener {
         override def onTaskEnd(taskEnd: SparkListenerTaskEnd): Unit = {
-          taskEnd.reason match {
-            case _: TaskKilled =>
-              if (forceCancel.get()) {
-                assert(System.currentTimeMillis() - taskEnd.taskInfo.launchTime < 1000)
-              } else {
-                assert(System.currentTimeMillis() - taskEnd.taskInfo.launchTime >= 2000)
-              }
-            case _ =>
+          assert(taskEnd.reason.isInstanceOf[TaskKilled])
+          if (forceCancel.get()) {
+            assert(System.currentTimeMillis() - taskEnd.taskInfo.launchTime < 1000)
+          } else {
+            // avoid accuracy, we check 2s instead of 3s.
+            assert(System.currentTimeMillis() - taskEnd.taskInfo.launchTime >= 2000)
           }
         }
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR add a new config `spark.sql.thriftServer.forceCancel` to give user a way to interrupt task when cancel statement.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
After [#29933](https://github.com/apache/spark/pull/29933), we support cancel query if timeout, but the default behavior of `SparkContext.cancelJobGroups` won't interrupt task and just let task finish by itself. In some case it's dangerous, e.g., data skew or exists a heavily shuffle. A task will hold in a long time after do cancel and the resource will not release.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, a new config.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Add test.