### PR TITLE
[SPARK-33529][SQL] Handle '__HIVE_DEFAULT_PARTITION__' while resolving V2 partition specs

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
-
+import org.apache.spark.sql.util.PartitioningUtils.castPartitionValues
 
 /**
  * A function defined in the catalog.
@@ -149,18 +149,8 @@ case class CatalogTablePartition(
   /**
    * Given the partition schema, returns a row with that schema holding the partition values.
    */
-  def toRow(partitionSchema: StructType, defaultTimeZondId: String): InternalRow = {
-    val caseInsensitiveProperties = CaseInsensitiveMap(storage.properties)
-    val timeZoneId = caseInsensitiveProperties.getOrElse(
-      DateTimeUtils.TIMEZONE_OPTION, defaultTimeZondId)
-    InternalRow.fromSeq(partitionSchema.map { field =>
-      val partValue = if (spec(field.name) == ExternalCatalogUtils.DEFAULT_PARTITION_NAME) {
-        null
-      } else {
-        spec(field.name)
-      }
-      Cast(Literal(partValue), field.dataType, Option(timeZoneId)).eval()
-    })
+  def toRow(partitionSchema: StructType, defaultTimeZoneId: String): InternalRow = {
+    castPartitionValues(spec, partitionSchema, storage.properties, defaultTimeZoneId)
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -30,7 +30,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, InternalRow, SQLConfHelper, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis.MultiInstanceRelation
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, AttributeReference, Cast, ExprId, Literal}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, AttributeReference, ExprId}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.EstimationUtils
 import org.apache.spark.sql.catalyst.util._

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/util/PartitioningUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/util/PartitioningUtils.scala
@@ -58,10 +58,10 @@ object PartitioningUtils {
       spec: TablePartitionSpec,
       partitionSchema: StructType,
       properties: Map[String, String],
-      defaultTimeZondId: String): InternalRow = {
+      defaultTimeZoneId: String): InternalRow = {
     val caseInsensitiveProperties = CaseInsensitiveMap(properties)
     val timeZoneId = caseInsensitiveProperties.getOrElse(
-      DateTimeUtils.TIMEZONE_OPTION, defaultTimeZondId)
+      DateTimeUtils.TIMEZONE_OPTION, defaultTimeZoneId)
     InternalRow.fromSeq(partitionSchema.map { field =>
       val partValue = if (spec(field.name) == ExternalCatalogUtils.DEFAULT_PARTITION_NAME) {
         null

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/util/PartitioningUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/util/PartitioningUtils.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.expressions.{Cast, Literal}
 import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, DateTimeUtils}
 import org.apache.spark.sql.types.StructType
 
-object PartitioningUtils {
+private[sql] object PartitioningUtils {
   /**
    * Normalize the column names in partition specification, w.r.t. the real partition column names
    * and case sensitivity. e.g., if the partition spec has a column named `monTh`, and there is a

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTablePartitionV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTablePartitionV2SQLSuite.scala
@@ -244,7 +244,7 @@ class AlterTablePartitionV2SQLSuite extends DatasourceV2SQLBase {
     }
   }
 
-  test("handle __HIVE_DEFAULT_PARTITION__") {
+  test("SPARK-33529: handle __HIVE_DEFAULT_PARTITION__") {
     val t = "testpart.ns1.ns2.tbl"
     withTable(t) {
       sql(s"CREATE TABLE $t (part0 string) USING foo PARTITIONED BY (part0)")

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTablePartitionV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTablePartitionV2SQLSuite.scala
@@ -255,7 +255,7 @@ class AlterTablePartitionV2SQLSuite extends DatasourceV2SQLBase {
       val expectedPartition = InternalRow.fromSeq(Seq[Any](null))
       assert(!partTable.partitionExists(expectedPartition))
       val partSpec = "PARTITION (part0 = '__HIVE_DEFAULT_PARTITION__')"
-      sql(s"ALTER TABLE $t ADD $partSpec LOCATION 'loc'")
+      sql(s"ALTER TABLE $t ADD $partSpec")
       assert(partTable.partitionExists(expectedPartition))
       spark.sql(s"ALTER TABLE $t DROP $partSpec")
       assert(!partTable.partitionExists(expectedPartition))


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Extract the code for partition values casting from DSv1 to the common place `sql.util.PartitioningUtils` - the method `castPartitionValues()`.
2. Re-use `castPartitionValues()` from DSv2 resolver of partition specs - `ResolvePartitionSpec`.

### Why are the changes needed?
To have the same behavior as DSv1 which interprets `__HIVE_DEFAULT_PARTITION__` as `NULL`:
```sql
spark-sql> CREATE TABLE tbl11 (id int, part0 string) USING parquet PARTITIONED BY (part0);
spark-sql> ALTER TABLE tbl11 ADD PARTITION (part0 = '__HIVE_DEFAULT_PARTITION__');
spark-sql> INSERT INTO tbl11 PARTITION (part0='__HIVE_DEFAULT_PARTITION__') SELECT 1;
spark-sql> SELECT * FROM tbl11;
1	NULL
```

### Does this PR introduce _any_ user-facing change?
Yes

### How was this patch tested?
Add new test to `AlterTablePartitionV2SQLSuite`.