### PR TITLE
[SPARK-33545][CORE] Support Fallback Storage during Worker decommission

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -462,6 +462,47 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-aws</artifactId>
+      <version>${hadoop.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-mapper-asl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-core-asl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+        </exclusion>
+        <!-- Keep old SDK out of the assembly to avoid conflict with Kinesis module -->
+        <exclusion>
+          <groupId>com.amazonaws</groupId>
+          <artifactId>aws-java-sdk</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-crypto</artifactId>
     </dependency>

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -576,6 +576,7 @@ class SparkContext(config: SparkConf) extends Logging {
     }
     _ui.foreach(_.setAppId(_applicationId))
     _env.blockManager.initialize(_applicationId)
+    FallbackStorage.registerBlockManagerIfNeeded(_env.blockManager.master, _conf)
 
     // The metrics system for Driver need to be set spark.app.id to app ID.
     // So it should start after we get app ID from the task scheduler and set spark.app.id.

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -471,6 +471,15 @@ package object config {
         "cache block replication should be positive.")
       .createWithDefaultString("30s")
 
+  private[spark] val STORAGE_DECOMMISSION_FALLBACK_STORAGE_PATH =
+    ConfigBuilder("spark.storage.decommission.fallbackStorage.path")
+      .doc("The location for fallback storage during block manager decommissioning." +
+        "In case of empty, fallback storage is disabled.")
+      .version("3.1.0")
+      .stringConf
+      .checkValue(_.endsWith(java.io.File.separator), "Path should end with separator.")
+      .createOptional
+
   private[spark] val STORAGE_REPLICATION_TOPOLOGY_FILE =
     ConfigBuilder("spark.storage.replication.topologyFile")
       .version("2.1.0")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -473,8 +473,9 @@ package object config {
 
   private[spark] val STORAGE_DECOMMISSION_FALLBACK_STORAGE_PATH =
     ConfigBuilder("spark.storage.decommission.fallbackStorage.path")
-      .doc("The location for fallback storage during block manager decommissioning." +
-        "In case of empty, fallback storage is disabled.")
+      .doc("The location for fallback storage during block manager decommissioning. " +
+        "For example, `s3a://spark-storage/`. In case of empty, fallback storage is disabled. " +
+        "The storage should be managed by TTL because Spark will not clean up it.")
       .version("3.1.0")
       .stringConf
       .checkValue(_.endsWith(java.io.File.separator), "Path should end with separator.")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -475,7 +475,7 @@ package object config {
     ConfigBuilder("spark.storage.decommission.fallbackStorage.path")
       .doc("The location for fallback storage during block manager decommissioning. " +
         "For example, `s3a://spark-storage/`. In case of empty, fallback storage is disabled. " +
-        "The storage should be managed by TTL because Spark will not clean up it.")
+        "The storage should be managed by TTL because Spark will not clean it up.")
       .version("3.1.0")
       .stringConf
       .checkValue(_.endsWith(java.io.File.separator), "Path should end with separator.")

--- a/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
@@ -91,7 +91,7 @@ private[spark] class IndexShuffleBlockResolver(
    * When the dirs parameter is None then use the disk manager's local directories. Otherwise,
    * read from the specified directories.
    */
-  private def getIndexFile(
+  def getIndexFile(
       shuffleId: Int,
       mapId: Long,
       dirs: Option[Array[String]] = None): File = {

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
@@ -39,6 +39,7 @@ private[storage] class BlockManagerDecommissioner(
     conf: SparkConf,
     bm: BlockManager) extends Logging {
 
+  private val fallbackStorage = FallbackStorage.getFallbackStorage(conf)
   private val maxReplicationFailuresForDecommission =
     conf.get(config.STORAGE_DECOMMISSION_MAX_REPLICATION_FAILURE_PER_BLOCK)
 
@@ -114,6 +115,8 @@ private[storage] class BlockManagerDecommissioner(
                       // driver a no longer referenced RDD with shuffle files.
                       if (bm.migratableResolver.getMigrationBlocks(shuffleBlockInfo).isEmpty) {
                         logWarning(s"Skipping block ${shuffleBlockInfo}, block deleted.")
+                      } else if (fallbackStorage.isDefined) {
+                        fallbackStorage.foreach(_.copy(shuffleBlockInfo, bm))
                       } else {
                         throw e
                       }

--- a/core/src/main/scala/org/apache/spark/storage/FallbackStorage.scala
+++ b/core/src/main/scala/org/apache/spark/storage/FallbackStorage.scala
@@ -158,9 +158,9 @@ object FallbackStorage extends Logging {
         val size = nextOffset - 1 - offset
         logDebug(s"To byte array $size")
         val array = new Array[Byte](size.toInt)
+        val startTimeNs = System.nanoTime()
         f.seek(offset)
         f.read(array)
-        val startTimeNs = System.nanoTime()
         logDebug(s"Took ${(System.nanoTime() - startTimeNs) / (1000 * 1000)}ms")
         f.close()
         new NioManagedBuffer(ByteBuffer.wrap(array))
@@ -168,3 +168,4 @@ object FallbackStorage extends Logging {
     }
   }
 }
+

--- a/core/src/main/scala/org/apache/spark/storage/FallbackStorage.scala
+++ b/core/src/main/scala/org/apache/spark/storage/FallbackStorage.scala
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.storage
+
+import java.io.{DataInputStream, InputStream, IOException}
+import java.nio.ByteBuffer
+
+import scala.concurrent.Future
+import scala.reflect.ClassTag
+
+import org.apache.hadoop.fs.{FileSystem, Path}
+
+import org.apache.spark.{SparkConf, SparkEnv}
+import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config.STORAGE_DECOMMISSION_FALLBACK_STORAGE_PATH
+import org.apache.spark.network.buffer.{ManagedBuffer, NioManagedBuffer}
+import org.apache.spark.rpc.{RpcAddress, RpcEndpointRef, RpcTimeout}
+import org.apache.spark.shuffle.{IndexShuffleBlockResolver, ShuffleBlockInfo}
+import org.apache.spark.shuffle.IndexShuffleBlockResolver.NOOP_REDUCE_ID
+import org.apache.spark.util.Utils
+
+/**
+ * A fallback storage used by storage decommissioners.
+ */
+private[storage] class FallbackStorage(conf: SparkConf) extends Logging {
+  require(conf.get(STORAGE_DECOMMISSION_FALLBACK_STORAGE_PATH).isDefined)
+
+  private val fallbackPath = new Path(conf.get(STORAGE_DECOMMISSION_FALLBACK_STORAGE_PATH).get)
+  private val hadoopConf = SparkHadoopUtil.get.newConfiguration(conf)
+  private val fallbackFileSystem = FileSystem.get(fallbackPath.toUri, hadoopConf)
+
+  // Visible for testing
+  def copy(
+      shuffleBlockInfo: ShuffleBlockInfo,
+      bm: BlockManager): Unit = {
+    val shuffleId = shuffleBlockInfo.shuffleId
+    val mapId = shuffleBlockInfo.mapId
+
+    bm.migratableResolver match {
+      case r: IndexShuffleBlockResolver =>
+        val indexFile = r.getIndexFile(shuffleId, mapId)
+
+        if (indexFile.exists()) {
+          fallbackFileSystem.copyFromLocalFile(
+            new Path(indexFile.getAbsolutePath),
+            new Path(fallbackPath, s"$shuffleId/${indexFile.getName}"))
+
+          val dataFile = r.getDataFile(shuffleId, mapId)
+          if (dataFile.exists()) {
+            fallbackFileSystem.copyFromLocalFile(
+              new Path(dataFile.getAbsolutePath),
+              new Path(fallbackPath, s"$shuffleId/${dataFile.getName}"))
+          }
+
+          // Report block statuses
+          val reduceId = NOOP_REDUCE_ID
+          val indexBlockId = ShuffleIndexBlockId(shuffleId, mapId, reduceId)
+          FallbackStorage.reportBlockStatus(bm, indexBlockId, indexFile.length)
+          if (dataFile.exists) {
+            val dataBlockId = ShuffleDataBlockId(shuffleId, mapId, reduceId)
+            FallbackStorage.reportBlockStatus(bm, dataBlockId, dataFile.length)
+          }
+        }
+      case r =>
+        logWarning(s"Unsupported Resolver: ${r.getClass.getName}")
+    }
+  }
+
+  def exists(shuffleId: Int, filename: String): Boolean = {
+    fallbackFileSystem.exists(new Path(fallbackPath, s"$shuffleId/$filename"))
+  }
+}
+
+class NoopRpcEndpointRef(conf: SparkConf) extends RpcEndpointRef(conf) {
+  import scala.concurrent.ExecutionContext.Implicits.global
+  override def address: RpcAddress = null
+  override def name: String = "fallback"
+  override def send(message: Any): Unit = {}
+  override def ask[T: ClassTag](message: Any, timeout: RpcTimeout): Future[T] = {
+    Future{true.asInstanceOf[T]}
+  }
+}
+
+object FallbackStorage extends Logging {
+  /** We use one block manager id as a place holder. */
+  val FALLBACK_BLOCK_MANAGER_ID: BlockManagerId = BlockManagerId("fallback", "remote", 7337)
+
+  def getFallbackStorage(conf: SparkConf): Option[FallbackStorage] = {
+    if (conf.get(STORAGE_DECOMMISSION_FALLBACK_STORAGE_PATH).isDefined) {
+      Some(new FallbackStorage(conf))
+    } else {
+      None
+    }
+  }
+
+  /** Register the fallback block manager and its RPC endpoint. */
+  def registerBlockManagerIfNeeded(master: BlockManagerMaster, conf: SparkConf): Unit = {
+    if (conf.get(STORAGE_DECOMMISSION_FALLBACK_STORAGE_PATH).isDefined) {
+      master.registerBlockManager(
+        FALLBACK_BLOCK_MANAGER_ID, Array.empty[String], 0, 0, new NoopRpcEndpointRef(conf))
+    }
+  }
+
+  /** Report block status to block manager master and map output tracker master. */
+  private def reportBlockStatus(blockManager: BlockManager, blockId: BlockId, dataLength: Long) = {
+    assert(blockManager.master != null)
+    blockManager.master.updateBlockInfo(
+      FALLBACK_BLOCK_MANAGER_ID, blockId, StorageLevel.DISK_ONLY, memSize = 0, dataLength)
+  }
+
+  /**
+   * Read a ManagedBuffer.
+   */
+  def read(conf: SparkConf, blockId: BlockId): ManagedBuffer = {
+    logInfo(s"Read $blockId")
+    val fallbackPath = new Path(conf.get(STORAGE_DECOMMISSION_FALLBACK_STORAGE_PATH).get)
+    val hadoopConf = SparkHadoopUtil.get.newConfiguration(conf)
+    val fallbackFileSystem = FileSystem.get(fallbackPath.toUri, hadoopConf)
+
+    val (shuffleId, mapId, startReduceId, endReduceId) = blockId match {
+      case id: ShuffleBlockId =>
+        (id.shuffleId, id.mapId, id.reduceId, id.reduceId + 1)
+      case batchId: ShuffleBlockBatchId =>
+        (batchId.shuffleId, batchId.mapId, batchId.startReduceId, batchId.endReduceId)
+      case _ =>
+        throw new IllegalArgumentException("unexpected shuffle block id format: " + blockId)
+    }
+
+    val name = ShuffleIndexBlockId(shuffleId, mapId, NOOP_REDUCE_ID).name
+    val indexFile = new Path(fallbackPath, s"$shuffleId/$name")
+    val start = startReduceId * 8L
+    val end = endReduceId * 8L
+    Utils.tryWithResource(fallbackFileSystem.open(indexFile)) { inputStream =>
+      Utils.tryWithResource(new DataInputStream(inputStream)) { index =>
+        index.skip(start)
+        val offset = index.readLong()
+        index.skip(end - (start + 8L))
+        val nextOffset = index.readLong()
+        val name = ShuffleDataBlockId(shuffleId, mapId, NOOP_REDUCE_ID).name
+        val dataFile = new Path(fallbackPath, s"$shuffleId/$name")
+        val f = fallbackFileSystem.open(dataFile)
+        val size = nextOffset - 1 - offset
+        logDebug(s"To byte array $size")
+        val array = new Array[Byte](size.toInt)
+        f.seek(offset)
+        f.read(array)
+        val startTimeNs = System.nanoTime()
+        logDebug(s"Took ${(System.nanoTime() - startTimeNs) / (1000 * 1000)}ms")
+        f.close()
+        new NioManagedBuffer(ByteBuffer.wrap(array))
+      }
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/storage/FallbackStorage.scala
+++ b/core/src/main/scala/org/apache/spark/storage/FallbackStorage.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.storage
 
-import java.io.{DataInputStream, InputStream, IOException}
+import java.io.DataInputStream
 import java.nio.ByteBuffer
 
 import scala.concurrent.Future
@@ -25,7 +25,7 @@ import scala.reflect.ClassTag
 
 import org.apache.hadoop.fs.{FileSystem, Path}
 
-import org.apache.spark.{SparkConf, SparkEnv}
+import org.apache.spark.SparkConf
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.STORAGE_DECOMMISSION_FALLBACK_STORAGE_PATH

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -295,8 +295,9 @@ final class ShuffleBlockFetcherIterator(
     var hostLocalBlockBytes = 0L
     var remoteBlockBytes = 0L
 
+    val fallback = FallbackStorage.FALLBACK_BLOCK_MANAGER_ID.executorId
     for ((address, blockInfos) <- blocksByAddress) {
-      if (Seq(blockManager.blockManagerId.executorId, "fallback").contains(address.executorId)) {
+      if (Seq(blockManager.blockManagerId.executorId, fallback).contains(address.executorId)) {
         checkBlockSizes(blockInfos)
         val mergedBlockInfos = mergeContinuousShuffleBlockIdsIfNeeded(
           blockInfos.map(info => FetchBlockInfo(info._1, info._2, info._3)), doBatchFetch)

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -296,7 +296,7 @@ final class ShuffleBlockFetcherIterator(
     var remoteBlockBytes = 0L
 
     for ((address, blockInfos) <- blocksByAddress) {
-      if (address.executorId == blockManager.blockManagerId.executorId) {
+      if (Seq(blockManager.blockManagerId.executorId, "fallback").contains(address.executorId)) {
         checkBlockSizes(blockInfos)
         val mergedBlockInfos = mergeContinuousShuffleBlockIdsIfNeeded(
           blockInfos.map(info => FetchBlockInfo(info._1, info._2, info._3)), doBatchFetch)

--- a/core/src/test/scala/org/apache/spark/storage/FallbackStorageSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/FallbackStorageSuite.scala
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.storage
+
+import java.io.{DataOutputStream, FileOutputStream, IOException}
+import java.nio.file.Files
+
+import scala.concurrent.duration._
+
+import org.mockito.{ArgumentMatchers => mc}
+import org.mockito.Mockito.{mock, times, verify, when}
+import org.scalatest.concurrent.Eventually.{eventually, interval, timeout}
+
+import org.apache.spark.{LocalSparkContext, SparkConf, SparkContext, SparkFunSuite, TestUtils}
+import org.apache.spark.LocalSparkContext.withSpark
+import org.apache.spark.internal.config._
+import org.apache.spark.launcher.SparkLauncher.{EXECUTOR_MEMORY, SPARK_MASTER}
+import org.apache.spark.network.BlockTransferService
+import org.apache.spark.network.buffer.ManagedBuffer
+import org.apache.spark.scheduler.ExecutorDecommissionInfo
+import org.apache.spark.scheduler.cluster.StandaloneSchedulerBackend
+import org.apache.spark.shuffle.{IndexShuffleBlockResolver, ShuffleBlockInfo}
+import org.apache.spark.shuffle.IndexShuffleBlockResolver.NOOP_REDUCE_ID
+import org.apache.spark.util.Utils.tryWithResource
+
+class FallbackStorageSuite extends SparkFunSuite with LocalSparkContext {
+
+  def getSparkConf(initialExecutor: Int = 1, minExecutor: Int = 1): SparkConf = {
+    new SparkConf(false)
+      .setAppName(getClass.getName)
+      .set(SPARK_MASTER, s"local-cluster[$initialExecutor,1,1024]")
+      .set(EXECUTOR_MEMORY, "1g")
+      .set(UI.UI_ENABLED, false)
+      .set(DYN_ALLOCATION_ENABLED, true)
+      .set(DYN_ALLOCATION_SHUFFLE_TRACKING_ENABLED, true)
+      .set(DYN_ALLOCATION_INITIAL_EXECUTORS, initialExecutor)
+      .set(DYN_ALLOCATION_MIN_EXECUTORS, minExecutor)
+      .set(DECOMMISSION_ENABLED, true)
+      .set(STORAGE_DECOMMISSION_ENABLED, true)
+      .set(STORAGE_DECOMMISSION_SHUFFLE_BLOCKS_ENABLED, true)
+      .set(STORAGE_DECOMMISSION_FALLBACK_STORAGE_PATH,
+         Files.createTempDirectory("tmp").toFile.getAbsolutePath + "/")
+  }
+
+  test("fallback storage APIs - copy/exists") {
+    val conf = new SparkConf(false)
+      .set(STORAGE_DECOMMISSION_SHUFFLE_BLOCKS_ENABLED, true)
+      .set(STORAGE_DECOMMISSION_FALLBACK_STORAGE_PATH,
+        Files.createTempDirectory("tmp").toFile.getAbsolutePath + "/")
+    val fallbackStorage = new FallbackStorage(conf)
+    val bmm = new BlockManagerMaster(new NoopRpcEndpointRef(conf), null, conf, false)
+
+    val bm = mock(classOf[BlockManager])
+    when(bm.diskBlockManager).thenReturn(new DiskBlockManager(conf, false))
+    when(bm.master).thenReturn(bmm)
+
+    val resolver = new IndexShuffleBlockResolver(conf, bm)
+    resolver.getIndexFile(1, 1L).createNewFile()
+    resolver.getDataFile(1, 1L).createNewFile()
+
+    val indexFile = resolver.getIndexFile(1, 2L)
+    tryWithResource(new FileOutputStream(indexFile)) { fos =>
+      tryWithResource(new DataOutputStream(fos)) { dos =>
+        dos.writeLong(0)
+        dos.writeLong(4)
+      }
+    }
+
+    val dataFile = resolver.getDataFile(1, 2L)
+    tryWithResource(new FileOutputStream(dataFile)) { fos =>
+      tryWithResource(new DataOutputStream(fos)) { dos =>
+        dos.writeLong(0)
+      }
+    }
+
+    when(bm.migratableResolver).thenReturn(resolver)
+    fallbackStorage.copy(ShuffleBlockInfo(1, 1L), bm)
+    fallbackStorage.copy(ShuffleBlockInfo(1, 2L), bm)
+
+    assert(fallbackStorage.exists(1, ShuffleIndexBlockId(1, 1L, NOOP_REDUCE_ID).name))
+    assert(fallbackStorage.exists(1, ShuffleDataBlockId(1, 1L, NOOP_REDUCE_ID).name))
+    assert(fallbackStorage.exists(1, ShuffleIndexBlockId(1, 2L, NOOP_REDUCE_ID).name))
+    assert(fallbackStorage.exists(1, ShuffleDataBlockId(1, 2L, NOOP_REDUCE_ID).name))
+
+    // The files for shuffle 1 and map 1 are empty intentionally.
+    intercept[java.io.EOFException] {
+      FallbackStorage.read(conf, ShuffleBlockId(1, 1L, 0))
+    }
+    FallbackStorage.read(conf, ShuffleBlockId(1, 2L, 0))
+  }
+
+  test("migrate shuffle data to fallback storage") {
+    val conf = new SparkConf(false)
+      .set(STORAGE_DECOMMISSION_SHUFFLE_BLOCKS_ENABLED, true)
+      .set(STORAGE_DECOMMISSION_FALLBACK_STORAGE_PATH,
+        Files.createTempDirectory("tmp").toFile.getAbsolutePath + "/")
+
+    val ids = Set((1, 1L, 1))
+    val bmm = new BlockManagerMaster(new NoopRpcEndpointRef(conf), null, conf, false)
+    val bm = mock(classOf[BlockManager])
+    when(bm.diskBlockManager).thenReturn(new DiskBlockManager(conf, false))
+
+    val indexShuffleBlockResolver = new IndexShuffleBlockResolver(conf, bm)
+    val indexFile = indexShuffleBlockResolver.getIndexFile(1, 1L)
+    val dataFile = indexShuffleBlockResolver.getDataFile(1, 1L)
+    indexFile.createNewFile()
+    dataFile.createNewFile()
+
+    val resolver = mock(classOf[IndexShuffleBlockResolver])
+    when(resolver.getStoredShuffles())
+      .thenReturn(ids.map(triple => ShuffleBlockInfo(triple._1, triple._2)).toSeq)
+    ids.foreach { case (shuffleId: Int, mapId: Long, reduceId: Int) =>
+      when(resolver.getMigrationBlocks(mc.any()))
+        .thenReturn(List(
+          (ShuffleIndexBlockId(shuffleId, mapId, reduceId), mock(classOf[ManagedBuffer])),
+          (ShuffleDataBlockId(shuffleId, mapId, reduceId), mock(classOf[ManagedBuffer]))))
+      when(resolver.getIndexFile(shuffleId, mapId)).thenReturn(indexFile)
+      when(resolver.getDataFile(shuffleId, mapId)).thenReturn(dataFile)
+    }
+
+    when(bm.getPeers(mc.any()))
+      .thenReturn(Seq(FallbackStorage.FALLBACK_BLOCK_MANAGER_ID))
+    when(bm.master).thenReturn(bmm)
+    val blockTransferService = mock(classOf[BlockTransferService])
+    when(blockTransferService.uploadBlockSync(mc.any(), mc.any(), mc.any(), mc.any(), mc.any(),
+      mc.any(), mc.any())).thenThrow(new IOException)
+    when(bm.blockTransferService).thenReturn(blockTransferService)
+    when(bm.migratableResolver).thenReturn(resolver)
+    when(bm.getMigratableRDDBlocks()).thenReturn(Seq())
+
+    val decommissioner = new BlockManagerDecommissioner(conf, bm)
+
+    try {
+      decommissioner.start()
+      val fallbackStorage = new FallbackStorage(conf)
+      eventually(timeout(10.second), interval(1.seconds)) {
+        // uploadBlockSync is not used
+        verify(blockTransferService, times(1))
+          .uploadBlockSync(mc.any(), mc.any(), mc.any(), mc.any(), mc.any(), mc.any(), mc.any())
+
+        Seq("shuffle_1_1_0.index", "shuffle_1_1_0.data").foreach { filename =>
+          assert(fallbackStorage.exists(shuffleId = 1, filename))
+        }
+      }
+    } finally {
+      decommissioner.stop()
+    }
+  }
+
+  test("Upload from all decommissioned executors") {
+    sc = new SparkContext(getSparkConf(2, 2))
+    withSpark(sc) { sc =>
+      TestUtils.waitUntilExecutorsUp(sc, 2, 60000)
+      val rdd1 = sc.parallelize(1 to 10, 10)
+      val rdd2 = rdd1.map(x => (x % 2, 1))
+      val rdd3 = rdd2.reduceByKey(_ + _)
+      assert(rdd3.count() === 2)
+
+      // Decommission all
+      val sched = sc.schedulerBackend.asInstanceOf[StandaloneSchedulerBackend]
+      sc.getExecutorIds().foreach {
+        sched.decommissionExecutor(_, ExecutorDecommissionInfo(""), false)
+      }
+
+      val files = Seq("shuffle_0_0_0.index", "shuffle_0_0_0.data")
+      val fallbackStorage = new FallbackStorage(sc.getConf)
+      // Uploading is not started yet.
+      files.foreach { file => assert(!fallbackStorage.exists(0, file)) }
+
+      // Uploading is completed on decommissioned executors
+      eventually(timeout(20.seconds), interval(1.seconds)) {
+        files.foreach { file => assert(fallbackStorage.exists(0, file)) }
+      }
+
+      // All executors are still alive.
+      assert(sc.getExecutorIds().size == 2)
+    }
+  }
+
+  test("Upload multi stages") {
+    sc = new SparkContext(getSparkConf())
+    withSpark(sc) { sc =>
+      TestUtils.waitUntilExecutorsUp(sc, 1, 60000)
+      val rdd1 = sc.parallelize(1 to 10, 2)
+      val rdd2 = rdd1.map(x => (x % 2, 1))
+      val rdd3 = rdd2.reduceByKey(_ + _)
+      val rdd4 = rdd3.sortByKey()
+      assert(rdd4.count() === 2)
+
+      val shuffle0_files = Seq(
+        "shuffle_0_0_0.index", "shuffle_0_0_0.data",
+        "shuffle_0_1_0.index", "shuffle_0_1_0.data")
+      val shuffle1_files = Seq(
+        "shuffle_1_4_0.index", "shuffle_1_4_0.data",
+        "shuffle_1_5_0.index", "shuffle_1_5_0.data")
+      val fallbackStorage = new FallbackStorage(sc.getConf)
+      shuffle0_files.foreach { file => assert(!fallbackStorage.exists(0, file)) }
+      shuffle1_files.foreach { file => assert(!fallbackStorage.exists(1, file)) }
+
+      // Decommission all
+      val sched = sc.schedulerBackend.asInstanceOf[StandaloneSchedulerBackend]
+      sc.getExecutorIds().foreach {
+        sched.decommissionExecutor(_, ExecutorDecommissionInfo(""), false)
+      }
+
+      eventually(timeout(10.seconds), interval(1.seconds)) {
+        shuffle0_files.foreach { file => assert(fallbackStorage.exists(0, file)) }
+        shuffle1_files.foreach { file => assert(fallbackStorage.exists(1, file)) }
+      }
+    }
+  }
+
+  test("Newly added executors should access old data from remote storage") {
+    sc = new SparkContext(getSparkConf(2, 0))
+    withSpark(sc) { sc =>
+      TestUtils.waitUntilExecutorsUp(sc, 2, 60000)
+      val rdd1 = sc.parallelize(1 to 10, 2)
+      val rdd2 = rdd1.map(x => (x % 2, 1))
+      val rdd3 = rdd2.reduceByKey(_ + _)
+      assert(rdd3.collect() === Array((0, 5), (1, 5)))
+
+      // Decommission all
+      val sched = sc.schedulerBackend.asInstanceOf[StandaloneSchedulerBackend]
+      sc.getExecutorIds().foreach {
+        sched.decommissionExecutor(_, ExecutorDecommissionInfo(""), false)
+      }
+
+      // Make it sure that fallback storage are ready
+      val fallbackStorage = new FallbackStorage(sc.getConf)
+      eventually(timeout(10.seconds), interval(1.seconds)) {
+        Seq(
+          "shuffle_0_0_0.index", "shuffle_0_0_0.data",
+          "shuffle_0_1_0.index", "shuffle_0_1_0.data").foreach { file =>
+          assert(fallbackStorage.exists(0, file))
+        }
+      }
+
+      // Since the data is safe, force to shrink down to zero executor
+      sc.getExecutorIds().foreach { id =>
+        sched.killExecutor(id)
+      }
+      eventually(timeout(20.seconds), interval(1.seconds)) {
+        assert(sc.getExecutorIds().isEmpty)
+      }
+
+      // Dynamic allocation will start new executors
+      assert(rdd3.collect() === Array((0, 5), (1, 5)))
+      assert(rdd3.sortByKey().count() == 2)
+      assert(sc.getExecutorIds().nonEmpty)
+    }
+  }
+}

--- a/core/src/test/scala/org/apache/spark/storage/FallbackStorageSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/FallbackStorageSuite.scala
@@ -111,10 +111,10 @@ class FallbackStorageSuite extends SparkFunSuite with LocalSparkContext {
         Files.createTempDirectory("tmp").toFile.getAbsolutePath + "/")
 
     val ids = Set((1, 1L, 1))
-    val bm1 = mock(classOf[BlockManager])
+    val bm = mock(classOf[BlockManager])
     val dbm = new DiskBlockManager(conf, false)
-    when(bm1.diskBlockManager).thenReturn(dbm)
-    val indexShuffleBlockResolver = new IndexShuffleBlockResolver(conf, bm1)
+    when(bm.diskBlockManager).thenReturn(dbm)
+    val indexShuffleBlockResolver = new IndexShuffleBlockResolver(conf, bm)
     val indexFile = indexShuffleBlockResolver.getIndexFile(1, 1L)
     val dataFile = indexShuffleBlockResolver.getDataFile(1, 1L)
     indexFile.createNewFile()
@@ -132,20 +132,18 @@ class FallbackStorageSuite extends SparkFunSuite with LocalSparkContext {
       when(resolver.getDataFile(shuffleId, mapId)).thenReturn(dataFile)
     }
 
-    val bm2 = mock(classOf[BlockManager])
-    when(bm2.diskBlockManager).thenReturn(new DiskBlockManager(conf, false))
-    when(bm2.getPeers(mc.any()))
+    when(bm.getPeers(mc.any()))
       .thenReturn(Seq(FallbackStorage.FALLBACK_BLOCK_MANAGER_ID))
     val bmm = new BlockManagerMaster(new NoopRpcEndpointRef(conf), null, conf, false)
-    when(bm2.master).thenReturn(bmm)
+    when(bm.master).thenReturn(bmm)
     val blockTransferService = mock(classOf[BlockTransferService])
     when(blockTransferService.uploadBlockSync(mc.any(), mc.any(), mc.any(), mc.any(), mc.any(),
       mc.any(), mc.any())).thenThrow(new IOException)
-    when(bm2.blockTransferService).thenReturn(blockTransferService)
-    when(bm2.migratableResolver).thenReturn(resolver)
-    when(bm2.getMigratableRDDBlocks()).thenReturn(Seq())
+    when(bm.blockTransferService).thenReturn(blockTransferService)
+    when(bm.migratableResolver).thenReturn(resolver)
+    when(bm.getMigratableRDDBlocks()).thenReturn(Seq())
 
-    val decommissioner = new BlockManagerDecommissioner(conf, bm2)
+    val decommissioner = new BlockManagerDecommissioner(conf, bm)
 
     try {
       decommissioner.start()

--- a/core/src/test/scala/org/apache/spark/storage/FallbackStorageSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/FallbackStorageSuite.scala
@@ -65,7 +65,8 @@ class FallbackStorageSuite extends SparkFunSuite with LocalSparkContext {
     val bmm = new BlockManagerMaster(new NoopRpcEndpointRef(conf), null, conf, false)
 
     val bm = mock(classOf[BlockManager])
-    when(bm.diskBlockManager).thenReturn(new DiskBlockManager(conf, false))
+    val dbm = new DiskBlockManager(conf, false)
+    when(bm.diskBlockManager).thenReturn(dbm)
     when(bm.master).thenReturn(bmm)
     val resolver = new IndexShuffleBlockResolver(conf, bm)
     when(bm.migratableResolver).thenReturn(resolver)
@@ -111,7 +112,8 @@ class FallbackStorageSuite extends SparkFunSuite with LocalSparkContext {
 
     val ids = Set((1, 1L, 1))
     val bm1 = mock(classOf[BlockManager])
-    when(bm1.diskBlockManager).thenReturn(new DiskBlockManager(conf, false))
+    val dbm = new DiskBlockManager(conf, false)
+    when(bm1.diskBlockManager).thenReturn(dbm)
     val indexShuffleBlockResolver = new IndexShuffleBlockResolver(conf, bm1)
     val indexFile = indexShuffleBlockResolver.getIndexFile(1, 1L)
     val dataFile = indexShuffleBlockResolver.getDataFile(1, 1L)

--- a/core/src/test/scala/org/apache/spark/storage/FallbackStorageSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/FallbackStorageSuite.scala
@@ -58,6 +58,7 @@ class FallbackStorageSuite extends SparkFunSuite with LocalSparkContext {
 
   test("fallback storage APIs - copy/exists") {
     val conf = new SparkConf(false)
+      .set("spark.app.id", "testId")
       .set(STORAGE_DECOMMISSION_SHUFFLE_BLOCKS_ENABLED, true)
       .set(STORAGE_DECOMMISSION_FALLBACK_STORAGE_PATH,
         Files.createTempDirectory("tmp").toFile.getAbsolutePath + "/")
@@ -106,6 +107,7 @@ class FallbackStorageSuite extends SparkFunSuite with LocalSparkContext {
 
   test("migrate shuffle data to fallback storage") {
     val conf = new SparkConf(false)
+      .set("spark.app.id", "testId")
       .set(STORAGE_DECOMMISSION_SHUFFLE_BLOCKS_ENABLED, true)
       .set(STORAGE_DECOMMISSION_FALLBACK_STORAGE_PATH,
         Files.createTempDirectory("tmp").toFile.getAbsolutePath + "/")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support storage migration to the fallback storage like cloud storage (`S3`) during worker decommission for the corner cases where the exceptions occur or there is no live peer left.

Although this PR focuses on cloud storage like `S3` which has a TTL feature in order to simplify Spark's logic, we can use alternative fallback storages like HDFS/NFS(EFS) if the user provides a clean-up mechanism.

### Why are the changes needed?

Currently, storage migration is not possible when there is no available executor. For example, when there is one executor, the executor cannot perform storage migration because it has no peer.

### Does this PR introduce _any_ user-facing change?

Yes. This is a new feature.

### How was this patch tested?

Pass the CIs with newly added test cases.