### PR TITLE
[SPARK-33548][WEBUI] display the jvm peak memory usage on the executor ui

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/executorspage-template.html
+++ b/core/src/main/resources/org/apache/spark/ui/static/executorspage-template.html
@@ -126,6 +126,14 @@ limitations under the License.
             <span data-toggle="tooltip" data-placement="top"
                   title="Bytes and records written to disk in order to be read by a shuffle in a future stage.">
               Shuffle Write</span></th>
+          <th>
+            <span data-toggle="tooltip" data-placement="top"
+                  title="Jvm on heap peak memory usage">
+              JVMHeapMemory</span></th>
+          <th>
+            <span data-toggle="tooltip" data-placement="top"
+                  title="Jvm off heap peak memory usage">
+              JVMOffHeapMemory</span></th>
           <th>Logs</th>
           <th>Thread Dump</th>
         </tr>

--- a/core/src/main/resources/org/apache/spark/ui/static/executorspage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/executorspage.js
@@ -222,7 +222,14 @@ $(document).ready(function () {
                     totalOffHeapStorageMemory: 0
                 };
 
+                var peakMemoryMetrics = {
+                    JVMOffHeapMemory : 0,
+                    JVMHeapMemory : 0
+                };
+
                 exec.memoryMetrics = exec.hasOwnProperty('memoryMetrics') ? exec.memoryMetrics : memoryMetrics;
+                exec.peakMemoryMetrics = exec.hasOwnProperty('peakMemoryMetrics') ? exec.peakMemoryMetrics : peakMemoryMetrics;
+
             });
 
             response.forEach(function (exec) {
@@ -486,6 +493,28 @@ $(document).ready(function () {
                         {data: 'totalInputBytes', render: formatBytes},
                         {data: 'totalShuffleRead', render: formatBytes},
                         {data: 'totalShuffleWrite', render: formatBytes},
+                        {
+                            data: function (row, type) {
+                                if (type !== 'display')
+                                    return row.peakMemoryMetrics.JVMHeapMemory;
+                                else
+                                    return (formatBytes(row.peakMemoryMetrics.JVMHeapMemory, type));
+                            },
+                            "fnCreatedCell": function (nTd, sData, oData, iRow, iCol) {
+                                $(nTd).addClass('jvm_heap_memory')
+                            }
+                        },
+                        {
+                            data: function (row, type) {
+                                if (type !== 'display')
+                                    return row.peakMemoryMetrics.JVMOffHeapMemory;
+                                else
+                                    return (formatBytes(row.peakMemoryMetrics.JVMOffHeapMemory, type));
+                            },
+                            "fnCreatedCell": function (nTd, sData, oData, iRow, iCol) {
+                                $(nTd).addClass('jvm_off_heap_memory')
+                            }
+                        },
                         {name: 'executorLogsCol', data: 'executorLogs', render: formatLogsCells},
                         {
                             name: 'threadDumpCol',


### PR DESCRIPTION
# What changes were proposed in this pull request?
display the jvm peak memory usage on the executors page to help user tune "spark.executor.memory" and "spark.executor.memoryOverhead"

# Why are the changes needed?
Peak Execution Memory can only be obtained through restAPI and cannot be displayed on Spark Executors UI intuitively,
although spark users tune spark executor memory are dependent on the metrics. Therefore, it is very important to display the peak memory usage on the spark UI.


# Does this PR introduce any user-facing change?
NO

# How was this patch tested?
The pr only involves minor changes to the page and does not affect other functions,
The manual test results are as follows.

![image](https://user-images.githubusercontent.com/7624181/100187502-308f7180-2f23-11eb-82a6-9739c555fb80.png)
