### PR TITLE
[SPARK-33547][SQL] Add usage of typed literal in doc

### DIFF
--- a/docs/sql-ref-literals.md
+++ b/docs/sql-ref-literals.md
@@ -21,13 +21,73 @@ license: |
 
 A literal (also known as a constant) represents a fixed data value. Spark SQL supports the following literals:
 
+ * [Typed Literal](#typed-literal)
  * [String Literal](#string-literal)
  * [Binary Literal](#binary-literal)
  * [Null Literal](#null-literal)
  * [Boolean Literal](#boolean-literal)
  * [Numeric Literal](#numeric-literal)
+ * [Timestamp Literal](#timestamp-literal)
  * [Datetime Literal](#datetime-literal)
  * [Interval Literal](#interval-literal)
+
+### Typed Literal
+
+A typed Literal expression parsing string values to typed Literal 
+
+#### Syntax
+
+```sql
+[TYPE] '[VALUE]'
+```
+
+#### Parameters
+
+* **TYPE**
+   
+    `TYPE` parameter shows which type of Literal we will generate. Currently Date, Timestamp, Interval and Binary typed literal are supported.
+     
+      X: Binary Literal
+      DATE: Datetime Literal 
+      TIMESTAMP: Timestamp Literal
+      INTERVAL: Interval Literal
+     
+    
+* **VALUE**
+ 
+    One character from the character set. Use `\` to escape special characters (e.g., `'` or `\`).
+
+#### Example
+
+```sql
+SELECT X'123456' AS col;
++----------+
+|       col|
++----------+
+|[12 34 56]|
++----------+
+
+SELECT DATE '2011-11-11' AS col;
++----------+
+|       col|
++----------+
+|2011-11-11|
++----------+
+
+SELECT TIMESTAMP '1997-01-31 09:26:56.123' AS col;
++-----------------------+
+|                    col|
++-----------------------+
+|1997-01-31 09:26:56.123|
++-----------------------+
+
+SELECT INTERVAL '20 15:40:32.99899999' DAY TO SECOND AS col;
++---------------------------------------------+
+|                                          col|
++---------------------------------------------+
+|20 days 15 hours 40 minutes 32.998999 seconds|
++---------------------------------------------+
+```
 
 ### String Literal
 

--- a/docs/sql-ref-literals.md
+++ b/docs/sql-ref-literals.md
@@ -21,7 +21,7 @@ license: |
 
 A literal (also known as a constant) represents a fixed data value. Spark SQL supports the following literals:
 
- * [Typed Literal](#typed-literal)
+ * [Typed Literal for Binary, Date, Timestamp, and Interval](#typed-literal)
  * [String Literal](#string-literal)
  * [Binary Literal](#binary-literal)
  * [Null Literal](#null-literal)
@@ -31,7 +31,7 @@ A literal (also known as a constant) represents a fixed data value. Spark SQL su
  * [Datetime Literal](#datetime-literal)
  * [Interval Literal](#interval-literal)
 
-### Typed Literal
+### Typed Literal for Binary, Date, Timestamp, and Interval
 
 A typed Literal expression parsing string values to typed Literal 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
According  to https://github.com/apache/spark/pull/30421#discussion_r530024114
Add typed literal in doc


### Why are the changes needed?
Make user clear about usage of typed literal


### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
NOT need
