### PR TITLE
[SPARK-33565][PYTHON][BUILD][3.0] Remove py38 spark3

### DIFF
--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -164,7 +164,7 @@ def run_individual_python_test(target_dir, test_name, pyspark_python):
 
 
 def get_default_python_executables():
-    python_execs = [x for x in ["python3.8", "python2.7", "pypy3", "pypy"] if which(x)]
+    python_execs = [x for x in ["python3.6", "python2.7", "pypy3", "pypy"] if which(x)]
 
     if "python3.6" not in python_execs:
         p = which("python3")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
remove python 3.8 from python/run-tests.py and stop build breaks


### Why are the changes needed?
the python tests are running against the bare-bones system install of python3, rather than an anaconda environment.


### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
jenkins

see also https://github.com/apache/spark/pull/30506
