### PR TITLE
[SPARK-33577][SS] Add support for V1Table in stream writer table API and create table if not exist by default

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
@@ -334,7 +334,7 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) {
         None,
         Map.empty[String, String],
         Some(source),
-        Map("createBy" -> "DataStreamWriterAPI"),
+        Map.empty[String, String],
         extraOptions.get("path"),
         None,
         None,

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
@@ -305,6 +305,9 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) {
    * table as new data arrives. A new table will be created if the table not exists. The returned
    * [[StreamingQuery]] object can be used to interact with the stream.
    *
+   * Note, currently the new table creation by this API doesn't fully cover the V2 table.
+   * TODO (SPARK-33638): Full support of v2 table creation
+   *
    * @since 3.1.0
    */
   @throws[TimeoutException]

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
@@ -302,8 +302,8 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) {
 
   /**
    * Starts the execution of the streaming query, which will continually output results to the given
-   * table as new data arrives. The returned [[StreamingQuery]] object can be used to interact with
-   * the stream.
+   * table as new data arrives. A new table will be created if the table not exists. The returned
+   * [[StreamingQuery]] object can be used to interact with the stream.
    *
    * @since 3.1.0
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
@@ -305,9 +305,6 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) {
    * table as new data arrives. A new table will be created if the table not exists. The returned
    * [[StreamingQuery]] object can be used to interact with the stream.
    *
-   * Note, currently the new table creation by this API doesn't fully cover the V2 table.
-   * TODO (SPARK-33638): Full support of v2 table creation
-   *
    * @since 3.1.0
    */
   @throws[TimeoutException]
@@ -330,6 +327,10 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) {
 
     if (!catalog.asTableCatalog.tableExists(identifier)) {
       import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+      /**
+       * Note, currently the new table creation by this API doesn't fully cover the V2 table.
+       * TODO (SPARK-33638): Full support of v2 table creation
+       */
       val cmd = CreateTableStatement(
         originalMultipartIdentifier,
         df.schema.asNullable,

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala
@@ -280,7 +280,7 @@ class DataStreamTableAPISuite extends StreamTest with BeforeAndAfter {
         Seq(4, 5, 6).toDF("value").write.format("parquet")
           .option("path", dir.getCanonicalPath).saveAsTable(tableName)
 
-        checkForStreamTable(Some(dir), tableName, createByStream = false)
+        checkForStreamTable(Some(dir), tableName)
       }
     }
   }
@@ -293,7 +293,7 @@ class DataStreamTableAPISuite extends StreamTest with BeforeAndAfter {
       // using HDFS API.
       Seq(4, 5, 6).toDF("value").write.format("parquet").saveAsTable(tableName)
 
-      checkForStreamTable(None, tableName, createByStream = false)
+      checkForStreamTable(None, tableName)
     }
   }
 
@@ -312,10 +312,7 @@ class DataStreamTableAPISuite extends StreamTest with BeforeAndAfter {
     }
   }
 
-  private def checkForStreamTable(
-      dir: Option[File],
-      tableName: String,
-      createByStream: Boolean = true): Unit = {
+  private def checkForStreamTable(dir: Option[File], tableName: String): Unit = {
     val memory = MemoryStream[Int]
     val dsw = memory.toDS().writeStream.format("parquet")
     dir.foreach { output =>
@@ -335,9 +332,6 @@ class DataStreamTableAPISuite extends StreamTest with BeforeAndAfter {
       dir.get
     } else {
       new File(catalogTable.location)
-    }
-    if (createByStream) {
-      assert(catalogTable.storage.properties("createBy") === "DataStreamWriterAPI")
     }
     checkDataset(
       spark.read.format("parquet").load(path.getCanonicalPath).as[Int],

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala
@@ -335,7 +335,7 @@ class DataStreamTableAPISuite extends StreamTest with BeforeAndAfter {
     }
     val sq = dsw
       .option("checkpointLocation", Utils.createTempDir().getCanonicalPath)
-      .table(tableName)
+      .toTable(tableName)
     memory.addData(1, 2, 3)
     sq.processAllAvailable()
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala
@@ -26,7 +26,7 @@ import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.catalyst.analysis.{NoSuchTableException, TableAlreadyExistsException}
+import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
 import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType}
 import org.apache.spark.sql.catalyst.streaming.StreamingRelationV2
 import org.apache.spark.sql.connector.{FakeV2Provider, InMemoryTableCatalog, InMemoryTableSessionCatalog}
@@ -39,6 +39,7 @@ import org.apache.spark.sql.streaming.StreamTest
 import org.apache.spark.sql.streaming.sources.FakeScanBuilder
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.util.Utils
 
 class DataStreamTableAPISuite extends StreamTest with BeforeAndAfter {
   import testImplicits._
@@ -175,21 +176,24 @@ class DataStreamTableAPISuite extends StreamTest with BeforeAndAfter {
   test("write: write to table with custom catalog & no namespace") {
     val tableIdentifier = "testcat.table_name"
 
-    spark.sql(s"CREATE TABLE $tableIdentifier (id bigint, data string) USING foo")
-    checkAnswer(spark.table(tableIdentifier), Seq.empty)
+    withTable(tableIdentifier) {
+      spark.sql(s"CREATE TABLE $tableIdentifier (id bigint, data string) USING foo")
+      checkAnswer(spark.table(tableIdentifier), Seq.empty)
 
-    runTestWithStreamAppend(tableIdentifier)
+      runTestWithStreamAppend(tableIdentifier)
+    }
   }
 
   test("write: write to table with custom catalog & namespace") {
     spark.sql("CREATE NAMESPACE testcat.ns")
-
     val tableIdentifier = "testcat.ns.table_name"
 
-    spark.sql(s"CREATE TABLE $tableIdentifier (id bigint, data string) USING foo")
-    checkAnswer(spark.table(tableIdentifier), Seq.empty)
+    withTable(tableIdentifier) {
+      spark.sql(s"CREATE TABLE $tableIdentifier (id bigint, data string) USING foo")
+      checkAnswer(spark.table(tableIdentifier), Seq.empty)
 
-    runTestWithStreamAppend(tableIdentifier)
+      runTestWithStreamAppend(tableIdentifier)
+    }
   }
 
   test("write: write to table with default session catalog") {
@@ -200,35 +204,19 @@ class DataStreamTableAPISuite extends StreamTest with BeforeAndAfter {
     spark.sql("CREATE NAMESPACE ns")
 
     val tableIdentifier = "ns.table_name"
-    spark.sql(s"CREATE TABLE $tableIdentifier (id bigint, data string) USING $v2Source")
-    checkAnswer(spark.table(tableIdentifier), Seq.empty)
+    withTable(tableIdentifier) {
+      spark.sql(s"CREATE TABLE $tableIdentifier (id bigint, data string) USING $v2Source")
+      checkAnswer(spark.table(tableIdentifier), Seq.empty)
 
-    runTestWithStreamAppend(tableIdentifier)
+      runTestWithStreamAppend(tableIdentifier)
+    }
   }
 
   test("write: write to non-exist table with custom catalog") {
     val tableIdentifier = "testcat.nonexisttable"
-    spark.sql("CREATE NAMESPACE testcat.ns")
 
-    withTempDir { checkpointDir =>
-      val exc = intercept[NoSuchTableException] {
-        runStreamQueryAppendMode(tableIdentifier, checkpointDir, Seq.empty, Seq.empty)
-      }
-      assert(exc.getMessage.contains("nonexisttable"))
-    }
-  }
-
-  test("write: write to file provider based table isn't allowed yet") {
-    val tableIdentifier = "table_name"
-
-    spark.sql(s"CREATE TABLE $tableIdentifier (id bigint, data string) USING parquet")
-    checkAnswer(spark.table(tableIdentifier), Seq.empty)
-
-    withTempDir { checkpointDir =>
-      val exc = intercept[AnalysisException] {
-        runStreamQueryAppendMode(tableIdentifier, checkpointDir, Seq.empty, Seq.empty)
-      }
-      assert(exc.getMessage.contains("doesn't support streaming write"))
+    withTable(tableIdentifier) {
+      runTestWithStreamAppend(tableIdentifier)
     }
   }
 
@@ -259,11 +247,101 @@ class DataStreamTableAPISuite extends StreamTest with BeforeAndAfter {
     spark.sql(s"CREATE VIEW $viewIdentifier AS SELECT id, data FROM $tableIdentifier")
 
     withTempDir { checkpointDir =>
-      val exc = intercept[AnalysisException] {
+      val exc = intercept[IllegalArgumentException] {
         runStreamQueryAppendMode(viewIdentifier, checkpointDir, Seq.empty, Seq.empty)
       }
-      assert(exc.getMessage.contains("doesn't support streaming write"))
+      assert(exc.getMessage.contains("Streaming into views is not supported"))
     }
+  }
+
+  test("write: write to an external table") {
+    withTempDir { dir =>
+      val tableName = "stream_test"
+      withTable(tableName) {
+        checkForStreamTable(Some(dir), tableName)
+      }
+    }
+  }
+
+  test("write: write to a managed table") {
+    val tableName = "stream_test"
+    withTable(tableName) {
+      checkForStreamTable(None, tableName)
+    }
+  }
+
+  test("write: write to an external table with existing path") {
+    withTempDir { dir =>
+      val tableName = "stream_test"
+      withTable(tableName) {
+        // The file written by batch will not be seen after the table was written by a streaming
+        // query. This is because we loads files from the metadata log instead of listing them
+        // using HDFS API.
+        Seq(4, 5, 6).toDF("value").write.format("parquet")
+          .option("path", dir.getCanonicalPath).saveAsTable(tableName)
+
+        checkForStreamTable(Some(dir), tableName, createByStream = false)
+      }
+    }
+  }
+
+  test("write: write to a managed table with existing path") {
+    val tableName = "stream_test"
+    withTable(tableName) {
+      // The file written by batch will not be seen after the table was written by a streaming
+      // query. This is because we loads files from the metadata log instead of listing them
+      // using HDFS API.
+      Seq(4, 5, 6).toDF("value").write.format("parquet").saveAsTable(tableName)
+
+      checkForStreamTable(None, tableName, createByStream = false)
+    }
+  }
+
+  test("write: write to an external path and create table") {
+    withTempDir { dir =>
+      val tableName = "stream_test"
+      withTable(tableName) {
+        // The file written by batch will not be seen after the table was written by a streaming
+        // query. This is because we loads files from the metadata log instead of listing them
+        // using HDFS API.
+        Seq(4, 5, 6).toDF("value").write
+          .mode("append").format("parquet").save(dir.getCanonicalPath)
+
+        checkForStreamTable(Some(dir), tableName)
+      }
+    }
+  }
+
+  private def checkForStreamTable(
+      dir: Option[File],
+      tableName: String,
+      createByStream: Boolean = true): Unit = {
+    val memory = MemoryStream[Int]
+    val dsw = memory.toDS().writeStream.format("parquet")
+    dir.foreach { output =>
+      dsw.option("path", output.getCanonicalPath)
+    }
+    val sq = dsw
+      .option("checkpointLocation", Utils.createTempDir().getCanonicalPath)
+      .table(tableName)
+    memory.addData(1, 2, 3)
+    sq.processAllAvailable()
+
+    checkDataset(
+      spark.table(tableName).as[Int],
+      1, 2, 3)
+    val catalogTable = spark.sessionState.catalog.getTableMetadata(TableIdentifier(tableName))
+    val path = if (dir.nonEmpty) {
+      dir.get
+    } else {
+      new File(catalogTable.location)
+    }
+    if (createByStream) {
+      assert(catalogTable.storage.properties("createBy") === "DataStreamWriterAPI")
+    }
+    checkDataset(
+      spark.read.format("parquet").load(path.getCanonicalPath).as[Int],
+      1, 2, 3)
   }
 
   private def runTestWithStreamAppend(tableIdentifier: String) = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
After SPARK-32896, we have table API for stream writer but only support DataSource v2 tables. Here we add the following enhancements:

- Create non-existing tables by default
- Support both managed and external V1Tables

### Why are the changes needed?
Make the API covers more use cases. Especially for the file provider based tables.

### Does this PR introduce _any_ user-facing change?
Yes, new features added.

### How was this patch tested?
Add new UTs.
