### PR TITLE
[SPARK-33578][CORE] enableHiveSupport is invalid after sparkContext t…

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -710,6 +710,11 @@ class SparkContext(config: SparkConf) extends Logging {
     }
   }
 
+  /** Set spark conf */
+  def setSparkConf(sparkConf: SparkConf): Unit = {
+    _conf = sparkConf
+  }
+
   /**
    * Get a local property set in this thread, or null if it is missing. See
    * `org.apache.spark.SparkContext.setLocalProperty`.
@@ -2611,6 +2616,7 @@ object SparkContext extends Logging {
           logWarning("Using an existing SparkContext; some configuration may not take effect.")
         }
       }
+      activeContext.get().setSparkConf(config)
       activeContext.get()
     }
   }


### PR DESCRIPTION

### What changes were proposed in this pull request?

  1. add setSparkConf method in SparkContext
  2.set the newest sparkconf in SparkContext#getOrCreate


### Why are the changes needed?
reproduce as follow code:

        SparkConf sparkConf = new SparkConf().setAppName("hello");
        sparkConf.set("spark.master", "local");
        JavaSparkContext jssc = new JavaSparkContext(sparkConf);
        spark = SparkSession.builder()
                .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
                .config("hive.exec.dynamici.partition", true).config("hive.exec.dynamic.partition.mode", "nonstrict")
                .config("hive.metastore.uris", "thrift://hivemetastore:9083")
                .enableHiveSupport() 
                .master("local")
                .getOrCreate();
       spark.sql("select * from hudi_db.hudi_test_order").show();

  it will produce follow Exception     AssertionError: assertion failed: No plan for HiveTableRelation [`hudi_db`.`hudi_test_order` … (at current master branch)
 org.apache.spark.sql.AnalysisException: Table or view not found: `hudi_db`.`hudi_test_order`;  (at spark v2.4.4)

 The reason is SparkContext#getOrCreate(SparkConf) will return activeContext that include previous spark config if it has
 but the input SparkConf is the newest which include previous spark config and options.

 enableHiveSupport will set options (“spark.sql.catalogImplementation", "hive”) when spark session created it will miss this conf
 SharedState load conf from sparkContext and will miss hive catalog

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?