### PR TITLE
[SPARK-33380] [EXAMPLES] New python example (series-pi.py) to calculate pi via series

### DIFF
--- a/examples/src/main/python/series-pi.py
+++ b/examples/src/main/python/series-pi.py
@@ -1,0 +1,72 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import print_function
+
+import sys
+import time
+from decimal import *
+from operator import add
+
+from pyspark.sql import SparkSession
+
+# To keep the runtime reasonable, process up to 1 billion terms
+minTerms = 10_000_000
+maxTerms = 1_000_000_000
+# Default number of partitions
+defPartitions = 16
+
+def partialSum(k):
+    """Returns the sum S of terms i.e. Sigma(1/i**2) for i in [a..b]
+    where a=k[0] and b=k[1]."""
+
+    partialSum = Decimal(0)
+    for i in range(k[0], k[1] + 1):
+        partialSum += Decimal(1 / i**2)
+    return partialSum
+
+if __name__ == "__main__":
+    """
+        Usage: series-pi {terms} {partitions}
+    """
+
+    # Configure result for a precision of 30 decimal places.
+    getcontext().prec = 30
+
+    n = min(maxTerms, int(sys.argv[1])) if len(sys.argv) > 1 else minTerms
+    p = int(sys.argv[2]) if len(sys.argv) > 2 else defPartitions
+
+    # Partition the 'n' terms into 'p' partitions such that each 
+    # partition contains 'nums' terms 
+
+    nums = n // p
+    l1 = [ (1 + (k - 1) * nums, k * nums) for k in range(1, p + 1) ]
+
+    # If n is not a multiple of p, extend the last
+    # partition to include all the terms.
+    if l1[p - 1][1] < n:
+        l1[p - 1][1] = n
+
+    spark = SparkSession.builder.appName("series-Pi").getOrCreate()
+
+    t1=time.perf_counter()
+    val = spark.sparkContext.parallelize(l1, p).map(partialSum).reduce(add)
+    # pi^2 = 6 * val
+    print(f"Pi is approximately {Decimal(6 * val).sqrt()} using {n} terms of the power series.")
+    print(f"Calculation took {time.perf_counter() - t1:.3f} seconds")
+
+    spark.stop()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
The current example script (pi.py) produces an approximate value for pi based on randomly-chosen points and is neither deterministic nor accurate. A new example is needed to fix this issue. 
https://en.wikipedia.org/wiki/Approximations_of_%CF%80 
http://oeis.org/wiki/Pi#Decimal_expansion_of_.CF.80.E2.80.8A2
https://mathworld.wolfram.com/PiFormulas.html

![image](https://user-images.githubusercontent.com/9453471/100529357-97b75b00-319b-11eb-8e46-78ea845db567.png)

This new example calculates pi using a partial sum of series that implements the formula shown in the attached image.

### Does this PR introduce _any_ user-facing change?
Yes, it provides an additional example python script (series-pi.py) to calculate pi. 

### How was this patch tested?
The script accepts two optional command-line parameters. The first parameter specifies the number of terms to use to approximate pi. The second parameter specifies the number of Spark partitions to use to calculate the result.

The script was run multiple times with 10 million terms, 100 million terms, 500 million terms and 1 billion terms each as the value of the first parameter. The resulting approximate value for pi was verified against the published/known approximation (https://oeis.org/A000796).
Two things were noted and verified:
1. For the same number of terms provided, it was verified that each run of the script produced a deterministic value for pi.
2. Increasing the number of terms (first parameter) produced a more accurate approximation.
