### PR TITLE
[SPARK-33498][SQL][FOLLOW-UP] Deduplicate the unittest by using checkCastWithParseError

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -971,11 +971,7 @@ abstract class AnsiCastSuiteBase extends CastSuiteBase {
         checkCastWithParseError("20150318")
         checkCastWithParseError("2015-031-8")
         checkCastWithParseError("2015-03-18T12:03:17-0:70")
-
-        val input = "abdef"
-        checkExceptionInExpression[DateTimeException](
-          cast(input, TimestampType, Option(zid.getId)),
-          s"Cannot cast $input to TimestampType.")
+        checkCastWithParseError("abdef")
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Dup code removed in SPARK-33498 as follow-up.

### Why are the changes needed?

Nit.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Existing UT.