### PR TITLE
[SPARK-32405][SQL][FOLLOWUP] Throw Exception if provider is specified in JDBCTableCatalog create table

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
@@ -126,7 +126,6 @@ class JDBCTableCatalog extends TableCatalog with Logging {
       properties.asScala.map {
         case (k, v) => k match {
           case "comment" => tableComment = v
-          // ToDo: have a follow up to fail provider once unify create table syntax PR is merged
           case "provider" =>
             throw new AnalysisException("CREATE TABLE ... USING ... is not supported in" +
               " JDBC catalog.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
@@ -128,6 +128,8 @@ class JDBCTableCatalog extends TableCatalog with Logging {
           case "comment" => tableComment = v
           // ToDo: have a follow up to fail provider once unify create table syntax PR is merged
           case "provider" =>
+            throw new AnalysisException("CREATE TABLE ... USING ... is not supported in" +
+              " JDBC catalog.")
           case "owner" => // owner is ignored. It is default to current user name.
           case "location" =>
             throw new AnalysisException("CREATE TABLE ... LOCATION ... is not supported in" +

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
@@ -153,21 +153,20 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
 
   test("create a table") {
     withTable("h2.test.new_table") {
-      // TODO (SPARK-32427): Omit USING in CREATE TABLE
-      sql("CREATE TABLE h2.test.new_table(i INT, j STRING) USING _")
+      sql("CREATE TABLE h2.test.new_table(i INT, j STRING)")
       checkAnswer(
         sql("SHOW TABLES IN h2.test"),
         Seq(Row("test", "people"), Row("test", "new_table")))
     }
     withTable("h2.test.new_table") {
-      sql("CREATE TABLE h2.test.new_table(i INT, j STRING) USING _")
+      sql("CREATE TABLE h2.test.new_table(i INT, j STRING)")
       val msg = intercept[AnalysisException] {
-        sql("CREATE TABLE h2.test.new_table(i INT, j STRING) USING _")
+        sql("CREATE TABLE h2.test.new_table(i INT, j STRING)")
       }.getMessage
       assert(msg.contains("Table test.new_table already exists"))
     }
     val exp = intercept[NoSuchNamespaceException] {
-      sql("CREATE TABLE h2.bad_test.new_table(i INT, j STRING) USING _")
+      sql("CREATE TABLE h2.bad_test.new_table(i INT, j STRING)")
     }
     assert(exp.getMessage.contains("Failed table creation: bad_test.new_table"))
     assert(exp.cause.get.getMessage.contains("Schema \"bad_test\" not found"))
@@ -176,7 +175,7 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
   test("ALTER TABLE ... add column") {
     val tableName = "h2.test.alt_table"
     withTable(tableName) {
-      sql(s"CREATE TABLE $tableName (ID INTEGER) USING _")
+      sql(s"CREATE TABLE $tableName (ID INTEGER)")
       sql(s"ALTER TABLE $tableName ADD COLUMNS (C1 INTEGER, C2 STRING)")
       var t = spark.table(tableName)
       var expectedSchema = new StructType()
@@ -206,7 +205,7 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
   test("ALTER TABLE ... rename column") {
     val tableName = "h2.test.alt_table"
     withTable(tableName) {
-      sql(s"CREATE TABLE $tableName (id INTEGER, C0 INTEGER) USING _")
+      sql(s"CREATE TABLE $tableName (id INTEGER, C0 INTEGER)")
       sql(s"ALTER TABLE $tableName RENAME COLUMN id TO C")
       val t = spark.table(tableName)
       val expectedSchema = new StructType()
@@ -231,7 +230,7 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
   test("ALTER TABLE ... drop column") {
     val tableName = "h2.test.alt_table"
     withTable(tableName) {
-      sql(s"CREATE TABLE $tableName (C1 INTEGER, C2 INTEGER, c3 INTEGER) USING _")
+      sql(s"CREATE TABLE $tableName (C1 INTEGER, C2 INTEGER, c3 INTEGER)")
       sql(s"ALTER TABLE $tableName DROP COLUMN C1")
       sql(s"ALTER TABLE $tableName DROP COLUMN c3")
       val t = spark.table(tableName)
@@ -255,7 +254,7 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
   test("ALTER TABLE ... update column type") {
     val tableName = "h2.test.alt_table"
     withTable(tableName) {
-      sql(s"CREATE TABLE $tableName (ID INTEGER, deptno INTEGER) USING _")
+      sql(s"CREATE TABLE $tableName (ID INTEGER, deptno INTEGER)")
       sql(s"ALTER TABLE $tableName ALTER COLUMN id TYPE DOUBLE")
       sql(s"ALTER TABLE $tableName ALTER COLUMN deptno TYPE DOUBLE")
       val t = spark.table(tableName)
@@ -284,7 +283,7 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
   test("ALTER TABLE ... update column nullability") {
     val tableName = "h2.test.alt_table"
     withTable(tableName) {
-      sql(s"CREATE TABLE $tableName (ID INTEGER NOT NULL, deptno INTEGER NOT NULL) USING _")
+      sql(s"CREATE TABLE $tableName (ID INTEGER NOT NULL, deptno INTEGER NOT NULL)")
       sql(s"ALTER TABLE $tableName ALTER COLUMN ID DROP NOT NULL")
       sql(s"ALTER TABLE $tableName ALTER COLUMN deptno DROP NOT NULL")
       val t = spark.table(tableName)
@@ -309,7 +308,7 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
   test("ALTER TABLE ... update column comment not supported") {
     val tableName = "h2.test.alt_table"
     withTable(tableName) {
-      sql(s"CREATE TABLE $tableName (ID INTEGER) USING _")
+      sql(s"CREATE TABLE $tableName (ID INTEGER)")
       val exp = intercept[AnalysisException] {
         sql(s"ALTER TABLE $tableName ALTER COLUMN ID COMMENT 'test'")
       }
@@ -333,7 +332,7 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
   test("ALTER TABLE case sensitivity") {
     val tableName = "h2.test.alt_table"
     withTable(tableName) {
-      sql(s"CREATE TABLE $tableName (c1 INTEGER NOT NULL, c2 INTEGER) USING _")
+      sql(s"CREATE TABLE $tableName (c1 INTEGER NOT NULL, c2 INTEGER)")
       var t = spark.table(tableName)
       var expectedSchema = new StructType().add("c1", IntegerType).add("c2", IntegerType)
       assert(t.schema === expectedSchema)
@@ -400,7 +399,7 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
     withTable("h2.test.new_table") {
       val logAppender = new LogAppender("table comment")
       withLogAppender(logAppender) {
-        sql("CREATE TABLE h2.test.new_table(i INT, j STRING) USING _ COMMENT 'this is a comment'")
+        sql("CREATE TABLE h2.test.new_table(i INT, j STRING) COMMENT 'this is a comment'")
       }
       val createCommentWarning = logAppender.loggingEvents
         .filter(_.getLevel == Level.WARN)
@@ -413,7 +412,7 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
   test("CREATE TABLE with table property") {
     withTable("h2.test.new_table") {
       val m = intercept[AnalysisException] {
-        sql("CREATE TABLE h2.test.new_table(i INT, j STRING) USING _" +
+        sql("CREATE TABLE h2.test.new_table(i INT, j STRING)" +
           " TBLPROPERTIES('ENGINE'='tableEngineName')")
       }.cause.get.getMessage
       assert(m.contains("\"TABLEENGINENAME\" not found"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -111,7 +111,7 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession {
 
   test("read/write with partition info") {
     withTable("h2.test.abc") {
-      sql("CREATE TABLE h2.test.abc USING _ AS SELECT * FROM h2.test.people")
+      sql("CREATE TABLE h2.test.abc AS SELECT * FROM h2.test.people")
       val df1 = Seq(("evan", 3), ("cathy", 4), ("alex", 5)).toDF("NAME", "ID")
       val e = intercept[IllegalArgumentException] {
         df1.write
@@ -148,11 +148,9 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession {
       Seq(Row("test", "people"), Row("test", "empty_table")))
   }
 
-  // TODO (SPARK-32603): Operation not allowed: CREATE TABLE ... STORED AS ... does not support
-  // multi-part identifiers
   test("SQL API: create table as select") {
     withTable("h2.test.abc") {
-      sql("CREATE TABLE h2.test.abc USING _ AS SELECT * FROM h2.test.people")
+      sql("CREATE TABLE h2.test.abc AS SELECT * FROM h2.test.people")
       checkAnswer(sql("SELECT name, id FROM h2.test.abc"), Seq(Row("fred", 1), Row("mary", 2)))
     }
   }
@@ -164,15 +162,14 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession {
     }
   }
 
-  // TODO (SPARK-32603): ParseException: mismatched input 'AS' expecting {'(', 'USING'}
   test("SQL API: replace table as select") {
     withTable("h2.test.abc") {
       intercept[CannotReplaceMissingTableException] {
-        sql("REPLACE TABLE h2.test.abc USING _ AS SELECT 1 as col")
+        sql("REPLACE TABLE h2.test.abc AS SELECT 1 as col")
       }
-      sql("CREATE OR REPLACE TABLE h2.test.abc USING _ AS SELECT 1 as col")
+      sql("CREATE OR REPLACE TABLE h2.test.abc AS SELECT 1 as col")
       checkAnswer(sql("SELECT col FROM h2.test.abc"), Row(1))
-      sql("REPLACE TABLE h2.test.abc USING _ AS SELECT * FROM h2.test.people")
+      sql("REPLACE TABLE h2.test.abc AS SELECT * FROM h2.test.people")
       checkAnswer(sql("SELECT name, id FROM h2.test.abc"), Seq(Row("fred", 1), Row("mary", 2)))
     }
   }
@@ -189,11 +186,9 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession {
     }
   }
 
-  // TODO (SPARK-32603): Operation not allowed: CREATE TABLE ... STORED AS ... does not support
-  // multi-part identifiers
   test("SQL API: insert and overwrite") {
     withTable("h2.test.abc") {
-      sql("CREATE TABLE h2.test.abc USING _ AS SELECT * FROM h2.test.people")
+      sql("CREATE TABLE h2.test.abc AS SELECT * FROM h2.test.people")
 
       sql("INSERT INTO h2.test.abc SELECT 'lucy', 3")
       checkAnswer(
@@ -205,11 +200,9 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession {
     }
   }
 
-  // TODO (SPARK-32603): Operation not allowed: CREATE TABLE ... STORED AS ... does not support
-  // multi-part identifiers
   test("DataFrameWriterV2: insert and overwrite") {
     withTable("h2.test.abc") {
-      sql("CREATE TABLE h2.test.abc USING _ AS SELECT * FROM h2.test.people")
+      sql("CREATE TABLE h2.test.abc AS SELECT * FROM h2.test.people")
 
       // `DataFrameWriterV2` is by-name.
       sql("SELECT 3 AS ID, 'lucy' AS NAME").writeTo("h2.test.abc").append()


### PR DESCRIPTION


### What changes were proposed in this pull request?
Throw Exception if JDBC Table Catalog has provider in create table.


### Why are the changes needed?
JDBC Table Catalog doesn't support provider and we should throw Exception. Previously CREATE TABLE syntax forces people to specify a provider so we have to add a `USING_`. Now the problem was fix and we will throw Exception for provider.


### Does this PR introduce _any_ user-facing change?
Yes. We throw Exception if a provider is specified in CREATE TABLE for JDBC Table catalog.



### How was this patch tested?
Existing tests (remove `USING _`)

