### PR TITLE
[SPARK-33596][SS] NPE when there is no watermark metrics

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/ui/StreamingQueryStatisticsPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/ui/StreamingQueryStatisticsPage.scala
@@ -152,6 +152,7 @@ private[ui] class StreamingQueryStatisticsPage(parent: StreamingQueryTab)
         val batchTimestamp = parseProgressTimestamp(p.timestamp)
         val watermarkValueOpt = Option(p.eventTime.get("watermark")).map(parseProgressTimestamp)
         if (watermarkValueOpt.nonEmpty && watermarkValueOpt.get > 0L) {
+          // seconds
           watermarkValueOpt.map { e => (batchTimestamp, (batchTimestamp - e) / 1000.0) }
         } else {
           None

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/ui/StreamingQueryStatisticsPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/ui/StreamingQueryStatisticsPage.scala
@@ -150,10 +150,9 @@ private[ui] class StreamingQueryStatisticsPage(parent: StreamingQueryTab)
     if (query.lastProgress.eventTime.containsKey("watermark")) {
       val watermarkData = query.recentProgress.flatMap { p =>
         val batchTimestamp = parseProgressTimestamp(p.timestamp)
-        val watermarkValue = parseProgressTimestamp(p.eventTime.get("watermark"))
-        if (watermarkValue > 0L) {
-          // seconds
-          Some((batchTimestamp, ((batchTimestamp - watermarkValue) / 1000.0)))
+        val watermarkValueOpt = Option(p.eventTime.get("watermark")).map(parseProgressTimestamp)
+        if (watermarkValueOpt.nonEmpty && watermarkValueOpt.get > 0L) {
+          watermarkValueOpt.map { e => (batchTimestamp, (batchTimestamp - e) / 1000.0) }
         } else {
           None
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?
add check if there is watermark metrics or not


### Why are the changes needed?
NPE when there is no watermark metrics, and then make some UT flaky.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing UTs.
