### PR TITLE
[SPARK-33611][UI] Avoid encoding twice on the query parameter of rewritten proxy URL

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -51,8 +51,6 @@ private[spark] object JettyUtils extends Logging {
 
   val SPARK_CONNECTOR_NAME = "Spark"
   val REDIRECT_CONNECTOR_NAME = "HttpsRedirect"
-  // By default decoding the URI as "UTF-8" should be enough for SparkUI
-  val defaultUrlEncoding = "UTF-8"
 
   // Base type for a function that returns something based on an HTTP request. Allows for
   // implicit conversion from many types of functions to jetty Handlers.
@@ -437,7 +435,7 @@ private[spark] object JettyUtils extends Logging {
     handler.addFilter(holder, "/*", EnumSet.allOf(classOf[DispatcherType]))
   }
 
-  private def decodeURL(url: String, encoding: String = defaultUrlEncoding): String = {
+  private def decodeURL(url: String, encoding: String): String = {
     if (url == null) {
       null
     } else {
@@ -457,7 +455,8 @@ private[spark] object JettyUtils extends Logging {
     val queryEncoding = if (request.getQueryEncoding != null) {
       request.getQueryEncoding
     } else {
-      defaultUrlEncoding
+      // By default decoding the URI as "UTF-8" should be enough for SparkUI
+      "UTF-8"
     }
     // The request URL can be raw or encoded here. To avoid the request URL being
     // encoded twice, let's decode it here.

--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -399,7 +399,7 @@ private[spark] object JettyUtils extends Logging {
   }
 
   /**
-   * Check if the input url is percent-encoded twice.
+   * Check if the input url contains reserved characters and it is percent-encoded twice.
    * If yes, decode the url once(assuming handler functions will decode again on parsing it).
    * Otherwise, return the URL as it is.
    */

--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -53,6 +53,16 @@ private[spark] object JettyUtils extends Logging {
   val REDIRECT_CONNECTOR_NAME = "HttpsRedirect"
   // By default decoding the URI as "UTF-8" should be enough for SparkUI
   val defaultUrlEncoding = "UTF-8"
+  // As per https://en.wikipedia.org/wiki/Percent-encoding:
+  // "Percent-encoding a reserved character involves converting the character to its corresponding
+  // byte value in ASCII and then representing that value as a pair of hexadecimal digits.
+  // The digits, preceded by a percent sign (%) which is used as an escape character,
+  // are then used in the URI in place of the reserved character."
+  //
+  // If a URL with a "reserved character" is encoded once, there will be "%[0-9a-fA-F]{2}" in
+  // the encoded result. After encoded again, the character "%" will become "%25", thus, there will
+  // "%25[0-9a-fA-F]{2}" in the second encoded result.
+  val urlWithReservedCharacterEncodedTwicePattern = "%25[0-9a-fA-F]{2}".r
 
   // Base type for a function that returns something based on an HTTP request. Allows for
   // implicit conversion from many types of functions to jetty Handlers.
@@ -388,6 +398,19 @@ private[spark] object JettyUtils extends Logging {
     redirectHandler
   }
 
+  /**
+   * Check if the input url is percent-encoded twice.
+   * If yes, decode the url once(assuming handler functions will decode again on parsing it).
+   * Otherwise, return the URL as it is.
+   */
+  def decodeURLIfEncodedTwice(url: String): String = {
+    if (urlWithReservedCharacterEncodedTwicePattern.findFirstMatchIn(url).isDefined) {
+      decodeURL(url, defaultUrlEncoding)
+    } else {
+      url
+    }
+  }
+
   def createProxyURI(prefix: String, target: String, path: String, query: String): URI = {
     if (!path.startsWith(prefix)) {
       return null
@@ -403,16 +426,22 @@ private[spark] object JettyUtils extends Logging {
       uri.append(rest)
     }
 
-    val rewrittenURI = URI.create(uri.toString()).normalize()
+    // When running Spark behind a reverse proxy(e.g. Nginx, Apache HTTP Server), the request URL
+    // on Spark can be encoded twice: one from the browser and another one from the reverse proxy.
+    // In general, the problem can be resolved by configuring the reverse proxy properly. However,
+    // we can detect whether the URL is percent-encoded twice and decode it if yes. This makes
+    // the setup of reverse proxy easier.
+    val decodedUri = decodeURLIfEncodedTwice(uri.toString())
+    val rewrittenURI = URI.create(decodedUri)
     if (query != null) {
-      val decodedQuery = decodeURL(query, defaultUrlEncoding)
+      val decodedQuery = decodeURLIfEncodedTwice(query)
       return new URI(
           rewrittenURI.getScheme(),
           rewrittenURI.getAuthority(),
           rewrittenURI.getPath(),
           decodedQuery,
           rewrittenURI.getFragment()
-        )
+        ).normalize()
     }
     rewrittenURI.normalize()
   }

--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -399,7 +399,7 @@ private[spark] object JettyUtils extends Logging {
   }
 
   /**
-   * Check if the input url contains reserved characters and it is percent-encoded twice.
+   * Check if the input url is percent-encoded twice.
    * If yes, decode the url once(assuming handler functions will decode again on parsing it).
    * Otherwise, return the URL as it is.
    */

--- a/core/src/test/scala/org/apache/spark/ui/UISuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UISuite.scala
@@ -216,13 +216,21 @@ class UISuite extends SparkFunSuite {
     assert(rewrittenURI === null)
   }
 
-  test("Decode query parameters of proxy rewrittenURI if it is double-encoded") {
+  test("Decode proxy rewrittenURI if it is percent-encoded twice") {
     val prefix = "/worker-id"
     val target = "http://localhost:8081"
     val path = "/worker-id/json"
-    val rewrittenURI =
+    var rewrittenURI =
       JettyUtils.createProxyURI(prefix, target, path, "order%255B0%255D%255Bcolumn%255D=0")
-    assert(rewrittenURI.getQuery() === "order%5B0%5D%5Bcolumn%5D=0")
+    assert(rewrittenURI.getQuery === "order%5B0%5D%5Bcolumn%5D=0")
+    rewrittenURI = JettyUtils.createProxyURI(prefix, target, "/worker-id/test%255B0%255D", null)
+    assert(rewrittenURI.toString() === "http://localhost:8081/test%5B0%5D")
+
+    // If the URL is not percent-encoded twice, return the URL as it is
+    rewrittenURI = JettyUtils.createProxyURI(prefix, target, path, "order%5B0%5D%5Bcolumn%5D=0")
+    assert(rewrittenURI.getQuery === "order%5B0%5D%5Bcolumn%5D=0")
+    rewrittenURI = JettyUtils.createProxyURI(prefix, target, "/worker-id/test%255B0%255D", null)
+    assert(rewrittenURI.toString() === "http://localhost:8081/test%5B0%5D")
   }
 
   test("verify rewriting location header for reverse proxy") {

--- a/core/src/test/scala/org/apache/spark/ui/UISuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UISuite.scala
@@ -216,21 +216,13 @@ class UISuite extends SparkFunSuite {
     assert(rewrittenURI === null)
   }
 
-  test("Decode proxy rewrittenURI if it is percent-encoded twice") {
+  test("Decode query parameters of proxy rewrittenURI if it is double-encoded") {
     val prefix = "/worker-id"
     val target = "http://localhost:8081"
     val path = "/worker-id/json"
-    var rewrittenURI =
+    val rewrittenURI =
       JettyUtils.createProxyURI(prefix, target, path, "order%255B0%255D%255Bcolumn%255D=0")
-    assert(rewrittenURI.getQuery === "order%5B0%5D%5Bcolumn%5D=0")
-    rewrittenURI = JettyUtils.createProxyURI(prefix, target, "/worker-id/test%255B0%255D", null)
-    assert(rewrittenURI.toString() === "http://localhost:8081/test%5B0%5D")
-
-    // If the URL is not percent-encoded twice, return the URL as it is
-    rewrittenURI = JettyUtils.createProxyURI(prefix, target, path, "order%5B0%5D%5Bcolumn%5D=0")
-    assert(rewrittenURI.getQuery === "order%5B0%5D%5Bcolumn%5D=0")
-    rewrittenURI = JettyUtils.createProxyURI(prefix, target, "/worker-id/test%255B0%255D", null)
-    assert(rewrittenURI.toString() === "http://localhost:8081/test%5B0%5D")
+    assert(rewrittenURI.getQuery() === "order%5B0%5D%5Bcolumn%5D=0")
   }
 
   test("verify rewriting location header for reverse proxy") {

--- a/core/src/test/scala/org/apache/spark/ui/UISuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UISuite.scala
@@ -216,6 +216,15 @@ class UISuite extends SparkFunSuite {
     assert(rewrittenURI === null)
   }
 
+  test("Decode query parameters of proxy rewrittenURI if it is double-encoded") {
+    val prefix = "/worker-id"
+    val target = "http://localhost:8081"
+    val path = "/worker-id/json"
+    val rewrittenURI =
+      JettyUtils.createProxyURI(prefix, target, path, "order%255B0%255D%255Bcolumn%255D=0")
+    assert(rewrittenURI.getQuery() === "order%5B0%5D%5Bcolumn%5D=0")
+  }
+
   test("verify rewriting location header for reverse proxy") {
     val clientRequest = mock(classOf[HttpServletRequest])
     var headerValue = "http://localhost:4040/jobs"

--- a/core/src/test/scala/org/apache/spark/ui/UISuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UISuite.scala
@@ -216,13 +216,13 @@ class UISuite extends SparkFunSuite {
     assert(rewrittenURI === null)
   }
 
-  test("Decode query parameters of proxy rewrittenURI if it is double-encoded") {
+  test("SPARK-33611: Avoid encoding twice on the query parameter of proxy rewrittenURI") {
     val prefix = "/worker-id"
     val target = "http://localhost:8081"
     val path = "/worker-id/json"
     val rewrittenURI =
-      JettyUtils.createProxyURI(prefix, target, path, "order%255B0%255D%255Bcolumn%255D=0")
-    assert(rewrittenURI.getQuery() === "order%5B0%5D%5Bcolumn%5D=0")
+      JettyUtils.createProxyURI(prefix, target, path, "order%5B0%5D%5Bcolumn%5D=0")
+    assert(rewrittenURI.toString === "http://localhost:8081/json?order%5B0%5D%5Bcolumn%5D=0")
   }
 
   test("verify rewriting location header for reverse proxy") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

When running Spark behind a reverse proxy(e.g. Nginx, Apache HTTP server), the request URL can be encoded twice if we pass the query string directly to the constructor of `java.net.URI`:
```
> val uri = "http://localhost:8081/test"
> val query = "order%5B0%5D%5Bcolumn%5D=0"  // query string of URL from the reverse proxy
> val rewrittenURI = URI.create(uri.toString())

> new URI(rewrittenURI.getScheme(),
      rewrittenURI.getAuthority(), 
      rewrittenURI.getPath(),
      query, 
      rewrittenURI.getFragment()).toString
result: http://localhost:8081/test?order%255B0%255D%255Bcolumn%255D=0
```

In Spark's stage page, the URL of "/taskTable" contains query parameter order[0][dir]. After encoding twice, the query parameter becomes `order%255B0%255D%255Bdir%255D` and it will be decoded as `order%5B0%5D%5Bdir%5D` instead of `order[0][dir]`. As a result, there will be NullPointerException from https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/status/api/v1/StagesResource.scala#L176
Other than that, the other parameter may not work as expected after encoded twice.

This PR is to fix the bug by calling the method `URI.create(String URL)` directly. This convenience method can avoid encoding twice on the query parameter.
```
> val uri = "http://localhost:8081/test"
> val query = "order%5B0%5D%5Bcolumn%5D=0"
> URI.create(s"$uri?$query").toString
result: http://localhost:8081/test?order%5B0%5D%5Bcolumn%5D=0

> URI.create(s"$uri?$query").getQuery
result: order[0][column]=0
```


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix a potential bug when Spark's reverse proxy is enabled.
The bug itself is similar to https://github.com/apache/spark/pull/29271.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Add a new unit test.
Also, Manual UI testing for master, worker and app UI with an nginx proxy

Spark config:
```
spark.ui.port 8080
spark.ui.reverseProxy=true
spark.ui.reverseProxyUrl=/path/to/spark/
```
nginx config:
```
server {
    listen 9000;
    set $SPARK_MASTER http://127.0.0.1:8080;
    # split spark UI path into prefix and local path within master UI
    location ~ ^(/path/to/spark/) {
        # strip prefix when forwarding request
        rewrite /path/to/spark(/.*) $1  break;
        #rewrite /path/to/spark/ "/" ;
        # forward to spark master UI
        proxy_pass $SPARK_MASTER;
        proxy_intercept_errors on;
        error_page 301 302 307 = @handle_redirects;
    }
    location @handle_redirects {
        set $saved_redirect_location '$upstream_http_location';
        proxy_pass $saved_redirect_location;
    }
}
```
