### PR TITLE
[SPARK-33608][SQL] Handle DELETE/UPDATE/MERGE in PullupCorrelatedPredicates

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
@@ -328,6 +328,8 @@ object PullupCorrelatedPredicates extends Rule[LogicalPlan] with PredicateHelper
     // Only a few unary nodes (Project/Filter/Aggregate) can contain subqueries.
     case q: UnaryNode =>
       rewriteSubQueries(q, q.children)
+    case s: SupportsSubquery =>
+      rewriteSubQueries(s, s.children)
   }
 }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PullupCorrelatedPredicatesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PullupCorrelatedPredicatesSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.PlanTest
-import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical.{Assignment, DeleteAction, DeleteFromTable, InsertAction, LocalRelation, LogicalPlan, MergeIntoTable, UpdateTable}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 
 class PullupCorrelatedPredicatesSuite extends PlanTest {
@@ -97,5 +97,67 @@ class PullupCorrelatedPredicatesSuite extends PlanTest {
     val optimized = Optimize.execute(scalarSubquery)
     val doubleOptimized = Optimize.execute(optimized)
     comparePlans(optimized, doubleOptimized, false)
+  }
+
+  test("PullupCorrelatedPredicates should handle deletes") {
+    val subPlan = testRelation2.where('a === 'c).select('c)
+    val cond = InSubquery(Seq('a), ListQuery(subPlan))
+    val deletePlan = DeleteFromTable(testRelation, Some(cond)).analyze
+    assert(deletePlan.resolved)
+
+    val optimized = Optimize.execute(deletePlan)
+    assert(optimized.resolved)
+
+    optimized match {
+      case DeleteFromTable(_, Some(s: InSubquery)) =>
+        val outerRefs = SubExprUtils.getOuterReferences(s.query.plan)
+        assert(outerRefs.isEmpty, "should be no outer refs")
+      case other =>
+        fail(s"unexpected logical plan: $other")
+    }
+  }
+
+  test("PullupCorrelatedPredicates should handle updates") {
+    val subPlan = testRelation2.where('a === 'c).select('c)
+    val cond = InSubquery(Seq('a), ListQuery(subPlan))
+    val updatePlan = UpdateTable(testRelation, Seq.empty, Some(cond)).analyze
+    assert(updatePlan.resolved)
+
+    val optimized = Optimize.execute(updatePlan)
+    assert(optimized.resolved)
+
+    optimized match {
+      case UpdateTable(_, _, Some(s: InSubquery)) =>
+        val outerRefs = SubExprUtils.getOuterReferences(s.query.plan)
+        assert(outerRefs.isEmpty, "should be no outer refs")
+      case other =>
+        fail(s"unexpected logical plan: $other")
+    }
+  }
+
+  test("PullupCorrelatedPredicates should handle merge") {
+    val testRelation3 = LocalRelation('e.int, 'f.double)
+    val subPlan = testRelation3.where('a === 'e).select('e)
+    val cond = InSubquery(Seq('a), ListQuery(subPlan))
+
+    val mergePlan = MergeIntoTable(
+      testRelation,
+      testRelation2,
+      cond,
+      Seq(DeleteAction(None)),
+      Seq(InsertAction(None, Seq(Assignment('a, 'c), Assignment('b, 'd)))))
+    val analyzedMergePlan = mergePlan.analyze
+    assert(analyzedMergePlan.resolved)
+
+    val optimized = Optimize.execute(analyzedMergePlan)
+    assert(optimized.resolved)
+
+    optimized match {
+      case MergeIntoTable(_, _, s: InSubquery, _, _) =>
+        val outerRefs = SubExprUtils.getOuterReferences(s.query.plan)
+        assert(outerRefs.isEmpty, "should be no outer refs")
+      case other =>
+        fail(s"unexpected logical plan: $other")
+    }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR adds logic to handle DELETE/UPDATE/MERGE plans in `PullupCorrelatedPredicates`.
### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Right now, `PullupCorrelatedPredicates` applies only to filters and unary nodes. As a result, correlated predicates in DELETE/UPDATE/MERGE are not rewritten.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

The PR adds 3 new test cases.