### PR TITLE
[MINOR][SS] Rename auxiliary protected methods in StreamingJoinSuite

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
@@ -76,7 +76,7 @@ abstract class StreamingJoinSuite
     (input1, input2, select)
   }
 
-  protected def setupJoinWithLeftCondition(joinType: String)
+  protected def setupWindowedJoinWithLeftCondition(joinType: String)
     : (MemoryStream[Int], MemoryStream[Int], DataFrame) = {
 
     val (leftInput, df1) = setupStream("left", 2)
@@ -106,7 +106,7 @@ abstract class StreamingJoinSuite
     (leftInput, rightInput, select)
   }
 
-  protected def setupJoinWithRightCondition(joinType: String)
+  protected def setupWindowedJoinWithRightCondition(joinType: String)
     : (MemoryStream[Int], MemoryStream[Int], DataFrame) = {
 
     val (leftInput, df1) = setupStream("left", 2)
@@ -642,7 +642,7 @@ class StreamingOuterJoinSuite extends StreamingJoinSuite {
   import org.apache.spark.sql.functions._
 
   test("left outer early state exclusion on left") {
-    val (leftInput, rightInput, joined) = setupJoinWithLeftCondition("left_outer")
+    val (leftInput, rightInput, joined) = setupWindowedJoinWithLeftCondition("left_outer")
 
     testStream(joined)(
       MultiAddData(leftInput, 1, 2, 3)(rightInput, 3, 4, 5),
@@ -659,7 +659,7 @@ class StreamingOuterJoinSuite extends StreamingJoinSuite {
   }
 
   test("left outer early state exclusion on right") {
-    val (leftInput, rightInput, joined) = setupJoinWithRightCondition("left_outer")
+    val (leftInput, rightInput, joined) = setupWindowedJoinWithRightCondition("left_outer")
 
     testStream(joined)(
       MultiAddData(leftInput, 3, 4, 5)(rightInput, 1, 2, 3),
@@ -676,7 +676,7 @@ class StreamingOuterJoinSuite extends StreamingJoinSuite {
   }
 
   test("right outer early state exclusion on left") {
-    val (leftInput, rightInput, joined) = setupJoinWithLeftCondition("right_outer")
+    val (leftInput, rightInput, joined) = setupWindowedJoinWithLeftCondition("right_outer")
 
     testStream(joined)(
       MultiAddData(leftInput, 1, 2, 3)(rightInput, 3, 4, 5),
@@ -693,7 +693,7 @@ class StreamingOuterJoinSuite extends StreamingJoinSuite {
   }
 
   test("right outer early state exclusion on right") {
-    val (leftInput, rightInput, joined) = setupJoinWithRightCondition("right_outer")
+    val (leftInput, rightInput, joined) = setupWindowedJoinWithRightCondition("right_outer")
 
     testStream(joined)(
       MultiAddData(leftInput, 3, 4, 5)(rightInput, 1, 2, 3),
@@ -1123,7 +1123,7 @@ class StreamingFullOuterJoinSuite extends StreamingJoinSuite {
   }
 
   test("full outer early state exclusion on left") {
-    val (leftInput, rightInput, joined) = setupJoinWithLeftCondition("full_outer")
+    val (leftInput, rightInput, joined) = setupWindowedJoinWithLeftCondition("full_outer")
 
     testStream(joined)(
       MultiAddData(leftInput, 1, 2, 3)(rightInput, 3, 4, 5),
@@ -1156,7 +1156,7 @@ class StreamingFullOuterJoinSuite extends StreamingJoinSuite {
   }
 
   test("full outer early state exclusion on right") {
-    val (leftInput, rightInput, joined) = setupJoinWithRightCondition("full_outer")
+    val (leftInput, rightInput, joined) = setupWindowedJoinWithRightCondition("full_outer")
 
     testStream(joined)(
       MultiAddData(leftInput, 3, 4, 5)(rightInput, 1, 2, 3),
@@ -1330,7 +1330,7 @@ class StreamingLeftSemiJoinSuite extends StreamingJoinSuite {
   }
 
   test("left semi early state exclusion on left") {
-    val (leftInput, rightInput, joined) = setupJoinWithLeftCondition("left_semi")
+    val (leftInput, rightInput, joined) = setupWindowedJoinWithLeftCondition("left_semi")
 
     testStream(joined)(
       MultiAddData(leftInput, 1, 2, 3)(rightInput, 3, 4, 5),
@@ -1362,7 +1362,7 @@ class StreamingLeftSemiJoinSuite extends StreamingJoinSuite {
   }
 
   test("left semi early state exclusion on right") {
-    val (leftInput, rightInput, joined) = setupJoinWithRightCondition("left_semi")
+    val (leftInput, rightInput, joined) = setupWindowedJoinWithRightCondition("left_semi")
 
     testStream(joined)(
       MultiAddData(leftInput, 3, 4, 5)(rightInput, 1, 2, 3),

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
@@ -59,7 +59,7 @@ abstract class StreamingJoinSuite
     (input, df)
   }
 
-  protected def setupWindowedJoin(joinType: String)
+  protected def setupJoin(joinType: String)
     : (MemoryStream[Int], MemoryStream[Int], DataFrame) = {
 
     val (input1, df1) = setupStream("left", 2)
@@ -76,7 +76,7 @@ abstract class StreamingJoinSuite
     (input1, input2, select)
   }
 
-  protected def setupWindowedJoinWithLeftCondition(joinType: String)
+  protected def setupJoinWithLeftCondition(joinType: String)
     : (MemoryStream[Int], MemoryStream[Int], DataFrame) = {
 
     val (leftInput, df1) = setupStream("left", 2)
@@ -106,7 +106,7 @@ abstract class StreamingJoinSuite
     (leftInput, rightInput, select)
   }
 
-  protected def setupWindowedJoinWithRightCondition(joinType: String)
+  protected def setupJoinWithRightCondition(joinType: String)
     : (MemoryStream[Int], MemoryStream[Int], DataFrame) = {
 
     val (leftInput, df1) = setupStream("left", 2)
@@ -136,7 +136,7 @@ abstract class StreamingJoinSuite
     (leftInput, rightInput, select)
   }
 
-  protected def setupWindowedJoinWithRangeCondition(joinType: String)
+  protected def setupJoinWithRangeCondition(joinType: String)
     : (MemoryStream[(Int, Int)], MemoryStream[(Int, Int)], DataFrame) = {
 
     val leftInput = MemoryStream[(Int, Int)]
@@ -167,7 +167,7 @@ abstract class StreamingJoinSuite
     (leftInput, rightInput, select)
   }
 
-  protected def setupWindowedSelfJoin(joinType: String)
+  protected def setupSelfJoin(joinType: String)
     : (MemoryStream[(Int, Long)], DataFrame) = {
 
     val inputStream = MemoryStream[(Int, Long)]
@@ -642,7 +642,7 @@ class StreamingOuterJoinSuite extends StreamingJoinSuite {
   import org.apache.spark.sql.functions._
 
   test("left outer early state exclusion on left") {
-    val (leftInput, rightInput, joined) = setupWindowedJoinWithLeftCondition("left_outer")
+    val (leftInput, rightInput, joined) = setupJoinWithLeftCondition("left_outer")
 
     testStream(joined)(
       MultiAddData(leftInput, 1, 2, 3)(rightInput, 3, 4, 5),
@@ -659,7 +659,7 @@ class StreamingOuterJoinSuite extends StreamingJoinSuite {
   }
 
   test("left outer early state exclusion on right") {
-    val (leftInput, rightInput, joined) = setupWindowedJoinWithRightCondition("left_outer")
+    val (leftInput, rightInput, joined) = setupJoinWithRightCondition("left_outer")
 
     testStream(joined)(
       MultiAddData(leftInput, 3, 4, 5)(rightInput, 1, 2, 3),
@@ -676,7 +676,7 @@ class StreamingOuterJoinSuite extends StreamingJoinSuite {
   }
 
   test("right outer early state exclusion on left") {
-    val (leftInput, rightInput, joined) = setupWindowedJoinWithLeftCondition("right_outer")
+    val (leftInput, rightInput, joined) = setupJoinWithLeftCondition("right_outer")
 
     testStream(joined)(
       MultiAddData(leftInput, 1, 2, 3)(rightInput, 3, 4, 5),
@@ -693,7 +693,7 @@ class StreamingOuterJoinSuite extends StreamingJoinSuite {
   }
 
   test("right outer early state exclusion on right") {
-    val (leftInput, rightInput, joined) = setupWindowedJoinWithRightCondition("right_outer")
+    val (leftInput, rightInput, joined) = setupJoinWithRightCondition("right_outer")
 
     testStream(joined)(
       MultiAddData(leftInput, 3, 4, 5)(rightInput, 1, 2, 3),
@@ -710,7 +710,7 @@ class StreamingOuterJoinSuite extends StreamingJoinSuite {
   }
 
   test("windowed left outer join") {
-    val (leftInput, rightInput, joined) = setupWindowedJoin("left_outer")
+    val (leftInput, rightInput, joined) = setupJoin("left_outer")
 
     testStream(joined)(
       // Test inner part of the join.
@@ -728,7 +728,7 @@ class StreamingOuterJoinSuite extends StreamingJoinSuite {
   }
 
   test("windowed right outer join") {
-    val (leftInput, rightInput, joined) = setupWindowedJoin("right_outer")
+    val (leftInput, rightInput, joined) = setupJoin("right_outer")
 
     testStream(joined)(
       // Test inner part of the join.
@@ -750,7 +750,7 @@ class StreamingOuterJoinSuite extends StreamingJoinSuite {
     ("right_outer", Row(null, 2, null, 5))
   ).foreach { case (joinType: String, outerResult) =>
     test(s"${joinType.replaceAllLiterally("_", " ")} with watermark range condition") {
-      val (leftInput, rightInput, joined) = setupWindowedJoinWithRangeCondition(joinType)
+      val (leftInput, rightInput, joined) = setupJoinWithRangeCondition(joinType)
 
       testStream(joined)(
         AddData(leftInput, (1, 5), (3, 5)),
@@ -830,7 +830,7 @@ class StreamingOuterJoinSuite extends StreamingJoinSuite {
   }
 
   test("SPARK-26187 self left outer join should not return outer nulls for already matched rows") {
-    val (inputStream, query) = setupWindowedSelfJoin("left_outer")
+    val (inputStream, query) = setupSelfJoin("left_outer")
 
     testStream(query)(
       AddData(inputStream, (1, 1L), (2, 2L), (3, 3L), (4, 4L), (5, 5L)),
@@ -1075,7 +1075,7 @@ class StreamingOuterJoinSuite extends StreamingJoinSuite {
 class StreamingFullOuterJoinSuite extends StreamingJoinSuite {
 
   test("windowed full outer join") {
-    val (leftInput, rightInput, joined) = setupWindowedJoin("full_outer")
+    val (leftInput, rightInput, joined) = setupJoin("full_outer")
 
     testStream(joined)(
       MultiAddData(leftInput, 1, 2, 3, 4, 5)(rightInput, 3, 4, 5, 6, 7),
@@ -1123,7 +1123,7 @@ class StreamingFullOuterJoinSuite extends StreamingJoinSuite {
   }
 
   test("full outer early state exclusion on left") {
-    val (leftInput, rightInput, joined) = setupWindowedJoinWithLeftCondition("full_outer")
+    val (leftInput, rightInput, joined) = setupJoinWithLeftCondition("full_outer")
 
     testStream(joined)(
       MultiAddData(leftInput, 1, 2, 3)(rightInput, 3, 4, 5),
@@ -1156,7 +1156,7 @@ class StreamingFullOuterJoinSuite extends StreamingJoinSuite {
   }
 
   test("full outer early state exclusion on right") {
-    val (leftInput, rightInput, joined) = setupWindowedJoinWithRightCondition("full_outer")
+    val (leftInput, rightInput, joined) = setupJoinWithRightCondition("full_outer")
 
     testStream(joined)(
       MultiAddData(leftInput, 3, 4, 5)(rightInput, 1, 2, 3),
@@ -1190,7 +1190,7 @@ class StreamingFullOuterJoinSuite extends StreamingJoinSuite {
   }
 
   test("full outer join with watermark range condition") {
-    val (leftInput, rightInput, joined) = setupWindowedJoinWithRangeCondition("full_outer")
+    val (leftInput, rightInput, joined) = setupJoinWithRangeCondition("full_outer")
 
     testStream(joined)(
       AddData(leftInput, (1, 5), (3, 5)),
@@ -1236,7 +1236,7 @@ class StreamingFullOuterJoinSuite extends StreamingJoinSuite {
   }
 
   test("self full outer join") {
-    val (inputStream, query) = setupWindowedSelfJoin("full_outer")
+    val (inputStream, query) = setupSelfJoin("full_outer")
 
     testStream(query)(
       AddData(inputStream, (1, 1L), (2, 2L), (3, 3L), (4, 4L), (5, 5L)),
@@ -1280,7 +1280,7 @@ class StreamingLeftSemiJoinSuite extends StreamingJoinSuite {
   import testImplicits._
 
   test("windowed left semi join") {
-    val (leftInput, rightInput, joined) = setupWindowedJoin("left_semi")
+    val (leftInput, rightInput, joined) = setupJoin("left_semi")
 
     testStream(joined)(
       MultiAddData(leftInput, 1, 2, 3, 4, 5)(rightInput, 3, 4, 5, 6, 7),
@@ -1330,7 +1330,7 @@ class StreamingLeftSemiJoinSuite extends StreamingJoinSuite {
   }
 
   test("left semi early state exclusion on left") {
-    val (leftInput, rightInput, joined) = setupWindowedJoinWithLeftCondition("left_semi")
+    val (leftInput, rightInput, joined) = setupJoinWithLeftCondition("left_semi")
 
     testStream(joined)(
       MultiAddData(leftInput, 1, 2, 3)(rightInput, 3, 4, 5),
@@ -1362,7 +1362,7 @@ class StreamingLeftSemiJoinSuite extends StreamingJoinSuite {
   }
 
   test("left semi early state exclusion on right") {
-    val (leftInput, rightInput, joined) = setupWindowedJoinWithRightCondition("left_semi")
+    val (leftInput, rightInput, joined) = setupJoinWithRightCondition("left_semi")
 
     testStream(joined)(
       MultiAddData(leftInput, 3, 4, 5)(rightInput, 1, 2, 3),
@@ -1394,7 +1394,7 @@ class StreamingLeftSemiJoinSuite extends StreamingJoinSuite {
   }
 
   test("left semi join with watermark range condition") {
-    val (leftInput, rightInput, joined) = setupWindowedJoinWithRangeCondition("left_semi")
+    val (leftInput, rightInput, joined) = setupJoinWithRangeCondition("left_semi")
 
     testStream(joined)(
       AddData(leftInput, (1, 5), (3, 5)),
@@ -1439,7 +1439,7 @@ class StreamingLeftSemiJoinSuite extends StreamingJoinSuite {
   }
 
   test("self left semi join") {
-    val (inputStream, query) = setupWindowedSelfJoin("left_semi")
+    val (inputStream, query) = setupSelfJoin("left_semi")
 
     testStream(query)(
       AddData(inputStream, (1, 1L), (2, 2L), (3, 3L), (4, 4L), (5, 5L)),

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
@@ -59,7 +59,7 @@ abstract class StreamingJoinSuite
     (input, df)
   }
 
-  protected def setupJoin(joinType: String)
+  protected def setupWindowedJoin(joinType: String)
     : (MemoryStream[Int], MemoryStream[Int], DataFrame) = {
 
     val (input1, df1) = setupStream("left", 2)
@@ -710,7 +710,7 @@ class StreamingOuterJoinSuite extends StreamingJoinSuite {
   }
 
   test("windowed left outer join") {
-    val (leftInput, rightInput, joined) = setupJoin("left_outer")
+    val (leftInput, rightInput, joined) = setupWindowedJoin("left_outer")
 
     testStream(joined)(
       // Test inner part of the join.
@@ -728,7 +728,7 @@ class StreamingOuterJoinSuite extends StreamingJoinSuite {
   }
 
   test("windowed right outer join") {
-    val (leftInput, rightInput, joined) = setupJoin("right_outer")
+    val (leftInput, rightInput, joined) = setupWindowedJoin("right_outer")
 
     testStream(joined)(
       // Test inner part of the join.
@@ -1075,7 +1075,7 @@ class StreamingOuterJoinSuite extends StreamingJoinSuite {
 class StreamingFullOuterJoinSuite extends StreamingJoinSuite {
 
   test("windowed full outer join") {
-    val (leftInput, rightInput, joined) = setupJoin("full_outer")
+    val (leftInput, rightInput, joined) = setupWindowedJoin("full_outer")
 
     testStream(joined)(
       MultiAddData(leftInput, 1, 2, 3, 4, 5)(rightInput, 3, 4, 5, 6, 7),
@@ -1280,7 +1280,7 @@ class StreamingLeftSemiJoinSuite extends StreamingJoinSuite {
   import testImplicits._
 
   test("windowed left semi join") {
-    val (leftInput, rightInput, joined) = setupJoin("left_semi")
+    val (leftInput, rightInput, joined) = setupWindowedJoin("left_semi")
 
     testStream(joined)(
       MultiAddData(leftInput, 1, 2, 3, 4, 5)(rightInput, 3, 4, 5, 6, 7),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Per request from https://github.com/apache/spark/pull/30395#issuecomment-735028698, here we remove `Windowed` from methods names `setupWindowedJoinWithRangeCondition` and `setupWindowedSelfJoin` as they don't join on time window.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
There's no such official name for `windowed join`, so this is to help avoid confusion for future developers.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Existing unit tests.