### PR TITLE
[SPARK-33544][SQL][FOLLOW-UP] Rename NoSideEffect to NoThrow and clarify the documentation more

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -45,7 +45,7 @@ object ConstantFolding extends Rule[LogicalPlan] {
   private def hasNoSideEffect(e: Expression): Boolean = e match {
     case _: Attribute => true
     case _: Literal => true
-    case _: NoSideEffect => e.children.forall(hasNoSideEffect)
+    case _: NoThrow if e.deterministic => e.children.forall(hasNoSideEffect)
     case _ => false
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ConstantFoldingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ConstantFoldingSuite.scala
@@ -264,7 +264,7 @@ class ConstantFoldingSuite extends PlanTest {
     comparePlans(optimized, correctAnswer)
   }
 
-  test("SPARK-33544: Constant folding test with sideaffects") {
+  test("SPARK-33544: Constant folding test with side effects") {
     val originalQuery =
       testRelation
         .select('a)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferFiltersFromGenerateSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferFiltersFromGenerateSuite.scala
@@ -90,13 +90,13 @@ class InferFiltersFromGenerateSuite extends PlanTest {
 
   Seq(Explode(_), PosExplode(_)).foreach { f =>
      val createArrayExplode = f(CreateArray(Seq('c1)))
-     test("Don't infer filters from CreateArray " + createArrayExplode) {
+     test("SPARK-33544: Don't infer filters from CreateArray " + createArrayExplode) {
        val originalQuery = testRelation.generate(createArrayExplode).analyze
        val optimized = OptimizeInferAndConstantFold.execute(originalQuery)
        comparePlans(optimized, originalQuery)
      }
      val createMapExplode = f(CreateMap(Seq('c1, 'c2)))
-     test("Don't infer filters from CreateMap " + createMapExplode) {
+     test("SPARK-33544: Don't infer filters from CreateMap " + createMapExplode) {
        val originalQuery = testRelation.generate(createMapExplode).analyze
        val optimized = OptimizeInferAndConstantFold.execute(originalQuery)
        comparePlans(optimized, originalQuery)
@@ -105,7 +105,7 @@ class InferFiltersFromGenerateSuite extends PlanTest {
 
    Seq(Inline(_)).foreach { f =>
      val createArrayStructExplode = f(CreateArray(Seq(CreateStruct(Seq('c1)))))
-     test("Don't infer filters from CreateArray " + createArrayStructExplode) {
+     test("SPARK-33544: Don't infer filters from CreateArray " + createArrayStructExplode) {
        val originalQuery = testRelation.generate(createArrayStructExplode).analyze
        val optimized = OptimizeInferAndConstantFold.execute(originalQuery)
        comparePlans(optimized, originalQuery)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/30504. It proposes:

- Rename `NoSideEffect` to `NoThrow`, and use `Expression.deterministic` together where it is used.
- Clarify, in the docs in the expressions, that it means they don't throw exceptions

### Why are the changes needed?

`NoSideEffect` virtually means that `Expression.eval` does not throw an exception, and the expressions are deterministic.
It's best to be explicit so `NoThrow` was proposed -  I looked if there's a similar name to represent this concept and borrowed the name of [nothrow](https://clang.llvm.org/docs/AttributeReference.html#nothrow).
For determinism, we already have a way to note it under `Expression.deterministic`. 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Manually ran the existing unittests written.