### PR TITLE
[SPARK-33628][SQL] Use the Hive.getPartitionsByNames method instead of Hive.getPartitions in the HiveClientImpl

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -617,7 +617,7 @@ private[hive] class HiveClientImpl(
         // The provided spec here can be a partial spec, i.e. it will match all partitions
         // whose specs are supersets of this partial spec. E.g. If a table has partitions
         // (b='1', c='1') and (b='1', c='2'), a partial spec of (b='1') will match both.
-        val parts = client.getPartitions(hiveTable, s.asJava).asScala
+        val parts = client.getPartitionsByNames(hiveTable, s.asJava).asScala
         if (parts.isEmpty && !ignoreIfNotExists) {
           throw new AnalysisException(
             s"No partition is dropped. One partition spec '$s' does not exist in table '$table' " +
@@ -726,7 +726,8 @@ private[hive] class HiveClientImpl(
         assert(s.values.forall(_.nonEmpty), s"partition spec '$s' is invalid")
         s
     }
-    val parts = client.getPartitions(hiveTable, partSpec.asJava).asScala.map(fromHivePartition)
+    val parts = client.getPartitionsByNames(hiveTable, partSpec.asJava).asScala
+      .map(fromHivePartition)
     HiveCatalogMetrics.incrementFetchedPartitions(parts.length)
     parts.toSeq
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

When partitions are tracked by the catalog, that will compute all custom partition locations, especially when dynamic partitions, and the field staticPartitions is empty.

The poor performance of the method listPartitions results in a long period of no response at the Driver.

For example in InsertIntoHadoopFsRelationCommand:

```java
if (partitionsTrackedByCatalog) {
  matchingPartitions = sparkSession.sessionState.catalog.listPartitions(
    catalogTable.get.identifier, Some(staticPartitions))
  initialMatchingPartitions = matchingPartitions.map(_.spec)
  customPartitionLocations = getCustomPartitionLocations(
    fs, catalogTable.get, qualifiedOutputPath, matchingPartitions)
}
```

### Why are the changes needed?

1. Improve list metastore partitions performance, 200 times better in our production environment

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

This change is already covered by existing tests