### PR TITLE
Revert "[SPARK-33504][CORE] The application log in the Spark history server contains sensitive attributes should be redacted"

### DIFF
--- a/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.scheduler
 
 import java.io.{File, InputStream}
-import java.util.{Arrays, Properties}
+import java.util.Arrays
 
 import scala.collection.immutable.Map
 import scala.collection.mutable
@@ -94,68 +94,6 @@ class EventLoggingListenerSuite extends SparkFunSuite with LocalSparkContext wit
     val event = SparkListenerEnvironmentUpdate(envDetails)
     val redactedProps = eventLogger.redactEvent(event).environmentDetails("Spark Properties").toMap
     assert(redactedProps(key) == "*********(redacted)")
-  }
-
-  test("Spark-33504 sensitive attributes redaction in properties") {
-    val (secretKey, secretPassword) = ("spark.executorEnv.HADOOP_CREDSTORE_PASSWORD",
-      "secret_password")
-    val (customKey, customValue) = ("parse_token", "secret_password")
-
-    val conf = getLoggingConf(testDirPath, None).set(secretKey, secretPassword)
-
-    val properties = new Properties()
-    properties.setProperty(secretKey, secretPassword)
-    properties.setProperty(customKey, customValue)
-
-    val logName = "properties-reaction-test"
-    val eventLogger = new EventLoggingListener(logName, None, testDirPath.toUri(), conf)
-    val listenerBus = new LiveListenerBus(conf)
-
-    val stageId = 1
-    val jobId = 1
-    val stageInfo = new StageInfo(stageId, 0, stageId.toString, 0,
-      Seq.empty, Seq.empty, "details",
-      resourceProfileId = ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID)
-
-    val events = Array(SparkListenerStageSubmitted(stageInfo, properties),
-      SparkListenerJobStart(jobId, 0, Seq(stageInfo), properties))
-
-    eventLogger.start()
-    listenerBus.start(Mockito.mock(classOf[SparkContext]), Mockito.mock(classOf[MetricsSystem]))
-    listenerBus.addToEventLogQueue(eventLogger)
-    events.foreach(event => listenerBus.post(event))
-    listenerBus.stop()
-    eventLogger.stop()
-
-    val logData = EventLogFileReader.openEventLog(new Path(eventLogger.logWriter.logPath),
-      fileSystem)
-    try {
-      val lines = readLines(logData)
-      val logStart = SparkListenerLogStart(SPARK_VERSION)
-      assert(lines.size === 3)
-      assert(lines(0).contains("SparkListenerLogStart"))
-      assert(lines(1).contains("SparkListenerStageSubmitted"))
-      assert(lines(2).contains("SparkListenerJobStart"))
-
-      lines.foreach{
-        line => JsonProtocol.sparkEventFromJson(parse(line)) match {
-          case logStartEvent: SparkListenerLogStart =>
-            assert(logStartEvent == logStart)
-
-          case stageSubmittedEvent: SparkListenerStageSubmitted =>
-            assert(stageSubmittedEvent.properties.getProperty(secretKey) == "*********(redacted)")
-            assert(stageSubmittedEvent.properties.getProperty(customKey) ==  customValue)
-
-          case jobStartEvent : SparkListenerJobStart =>
-            assert(jobStartEvent.properties.getProperty(secretKey) == "*********(redacted)")
-            assert(jobStartEvent.properties.getProperty(customKey) ==  customValue)
-
-          case _ => assert(false)
-        }
-      }
-    } finally {
-      logData.close()
-    }
   }
 
   test("Executor metrics update") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Revert SPARK-33504 on branch-3.0 compilation error. Original PR https://github.com/apache/spark/pull/30446

This reverts commit e59179b7326112f526e4c000e21146df283d861c.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
