### PR TITLE
[MINOR][INFRA][3.1] Update branch name from master to branch-3.1 GitHub Action

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3,10 +3,10 @@ name: Build and test
 on:
   push:
     branches:
-    - master
+    - branch-3.1
   pull_request:
     branches:
-    - master
+    - branch-3.1
   workflow_dispatch:
     inputs:
       target:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the branch name in `branch-3.1` branch.

### Why are the changes needed?

To start GitHub Action in `branch-3.1`. Currently, it's stopped.

![Screen Shot 2020-12-04 at 9 29 32 AM](https://user-images.githubusercontent.com/9700541/101194754-4122a480-3613-11eb-9284-8c575c70f216.png)


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Check GitHub Action on this PR.