### PR TITLE
[WIP][SPARK-33666][SQL][TEST] Use a dedicate JVM for HiveThriftHttpServerSuite

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -489,6 +489,7 @@ object SparkParallelTestGrouping {
     "org.apache.spark.sql.SQLQueryTestSuite",
     "org.apache.spark.sql.hive.client.HadoopVersionInfoSuite",
     "org.apache.spark.sql.hive.thriftserver.SparkExecuteStatementOperationSuite",
+    "org.apache.spark.sql.hive.thriftserver.HiveThriftHttpServerSuite",
     "org.apache.spark.sql.hive.thriftserver.ThriftServerQueryTestSuite",
     "org.apache.spark.sql.hive.thriftserver.SparkSQLEnvSuite",
     "org.apache.spark.sql.hive.thriftserver.ui.ThriftServerPageSuite",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to isolate `HiveThriftHttpServerSuite` by using a dedicated JVM to mitigate the flakiness in Jenkins and GitHub Action.

### Why are the changes needed?

This is very flaky in Jenkins and recently fail consistently in GitHub Action.

**Jenkins SBT Failure**
![Screen Shot 2020-12-04 at 6 41 44 PM](https://user-images.githubusercontent.com/9700541/101231470-5e319480-3660-11eb-8c4a-31dcf6ebd7b5.png)

![Screen Shot 2020-12-04 at 9 50 51 PM](https://user-images.githubusercontent.com/9700541/101235162-e2911100-367a-11eb-85d1-73f695d40617.png)


**GitHub Action Failure**
![Screen Shot 2020-12-04 at 6 42 59 PM](https://user-images.githubusercontent.com/9700541/101231500-8b7e4280-3660-11eb-8c32-a1f550ef52d7.png)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the GitHub Action CI.
