### PR TITLE
[SPARK-31711][CORE][FOLLOWUP] Move executorSourceLocalModeOnly to sparkEnv

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -639,7 +639,7 @@ class SparkContext(config: SparkConf) extends Logging {
     // Post init
     _taskScheduler.postStartHook()
     if (isLocal) {
-      _env.metricsSystem.registerSource(Executor.executorSourceLocalModeOnly)
+      _env.metricsSystem.registerSource(env.executorSourceLocalModeOnly)
     }
     _env.metricsSystem.registerSource(_dagScheduler.metricsSource)
     _env.metricsSystem.registerSource(new BlockManagerSource(_env.blockManager))

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -32,6 +32,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.api.python.PythonWorkerFactory
 import org.apache.spark.broadcast.BroadcastManager
+import org.apache.spark.executor.ExecutorSource
 import org.apache.spark.internal.{config, Logging}
 import org.apache.spark.internal.config._
 import org.apache.spark.memory.{MemoryManager, UnifiedMemoryManager}
@@ -73,6 +74,9 @@ class SparkEnv (
 
   @volatile private[spark] var isStopped = false
   private val pythonWorkers = mutable.HashMap[(String, Map[String, String]), PythonWorkerFactory]()
+
+  // Used to store executorSource, intended for local mode only
+  private[spark] var executorSourceLocalModeOnly: ExecutorSource = null
 
   // A general, soft-reference map for metadata needed during HadoopRDD split computation
   // (e.g., HadoopFileRDD uses this to cache JobConfs and InputFormats).

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -140,10 +140,10 @@ private[spark] class Executor(
     executorMetricsSource.foreach(_.register(env.metricsSystem))
     env.metricsSystem.registerSource(env.blockManager.shuffleMetricsSource)
   } else {
-    // This enable the registration of the executor source in local mode.
+    // This enables the registration of the executor source in local mode.
     // The actual registration happens in SparkContext,
     // it cannot be done here as the appId is not available yet
-    Executor.executorSourceLocalModeOnly = executorSource
+    env.executorSourceLocalModeOnly = executorSource
   }
 
   // Whether to load classes in user jars before those in Spark jars
@@ -1018,9 +1018,6 @@ private[spark] object Executor {
   // task is fully deserialized. When possible, the TaskContext.getLocalProperty call should be
   // used instead.
   val taskDeserializationProps: ThreadLocal[Properties] = new ThreadLocal[Properties]
-
-  // Used to store executorSource, for local mode only
-  var executorSourceLocalModeOnly: ExecutorSource = null
 
   /**
    * Whether a `Throwable` thrown from a task is a fatal error. We will use this to decide whether


### PR DESCRIPTION
### What changes were proposed in this pull request?

This followup of from SPARK-31711 and a recent review comment in #28528 by @zsxwing :
( `executorSourceLocalModeOnly` ) is never been cleaned. It would be great to avoid using a global executorSourceLocalModeOnly to save a state of a specific executor. Can we move this to SparkEnv so that a state of one test won't be leaked to other tests?

### Why are the changes needed?
This PR moves `executorSourceLocalModeOnly` from Executor to SparkEnv

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
This is covered by existing tests + also manually tested.