### PR TITLE
[SPARK-33675][INFRA][3.0] Add GitHub Action job to publish snapshot

### DIFF
--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -1,0 +1,31 @@
+name: Publish Snapshot
+
+on:
+  push:
+    branches:
+    - branch-3.0
+
+jobs:
+  publish-snapshot:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Spark repository
+      uses: actions/checkout@master
+    - name: Cache Maven local repository
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: snapshot-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          snapshot-maven-
+    - name: Install Java 8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - name: Publish snapshot
+      env:
+        ASF_USERNAME: ${{ secrets.NEXUS_USER }}
+        ASF_PASSWORD: ${{ secrets.NEXUS_PW }}
+        GPG_KEY: "not_used"
+        GPG_PASSPHRASE: "not_used"
+      run: ./dev/create-release/release-build.sh publish-snapshot


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `GitHub Action` job to publish snapshot from `branch-3.0`.

https://repository.apache.org/content/groups/snapshots/org/apache/spark/spark-core_2.12/3.0.2-SNAPSHOT/

### Why are the changes needed?

This will remove our maintenance burden for `branch-3.0` and will stop automatically when we don't have any commit on `branch-3.0`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A