### PR TITLE
[SPARK-33680][SQL][TESTS] Fix PrunePartitionSuiteBase/BucketedReadWithHiveSupportSuite not to depend on the default conf

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/BucketedReadWithHiveSupportSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/BucketedReadWithHiveSupportSuite.scala
@@ -17,19 +17,14 @@
 
 package org.apache.spark.sql.sources
 
+import org.apache.spark.sql.execution.adaptive.DisableAdaptiveExecutionSuite
 import org.apache.spark.sql.hive.test.TestHiveSingleton
-import org.apache.spark.sql.internal.SQLConf.ADAPTIVE_EXECUTION_ENABLED
 import org.apache.spark.sql.internal.StaticSQLConf.CATALOG_IMPLEMENTATION
 
-class BucketedReadWithHiveSupportSuite extends BucketedReadSuite with TestHiveSingleton {
+class BucketedReadWithHiveSupportSuite
+  extends BucketedReadSuite with DisableAdaptiveExecutionSuite with TestHiveSingleton {
   protected override def beforeAll(): Unit = {
     super.beforeAll()
-    spark.sessionState.conf.setConf(ADAPTIVE_EXECUTION_ENABLED, false)
     assert(spark.sparkContext.conf.get(CATALOG_IMPLEMENTATION) == "hive")
-  }
-
-  protected override def afterAll(): Unit = {
-    spark.sessionState.conf.unsetConf(ADAPTIVE_EXECUTION_ENABLED)
-    super.afterAll()
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/BucketedReadWithHiveSupportSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/BucketedReadWithHiveSupportSuite.scala
@@ -18,11 +18,18 @@
 package org.apache.spark.sql.sources
 
 import org.apache.spark.sql.hive.test.TestHiveSingleton
+import org.apache.spark.sql.internal.SQLConf.ADAPTIVE_EXECUTION_ENABLED
 import org.apache.spark.sql.internal.StaticSQLConf.CATALOG_IMPLEMENTATION
 
 class BucketedReadWithHiveSupportSuite extends BucketedReadSuite with TestHiveSingleton {
   protected override def beforeAll(): Unit = {
     super.beforeAll()
+    spark.sessionState.conf.setConf(ADAPTIVE_EXECUTION_ENABLED, false)
     assert(spark.sparkContext.conf.get(CATALOG_IMPLEMENTATION) == "hive")
+  }
+
+  protected override def afterAll(): Unit = {
+    spark.sessionState.conf.unsetConf(ADAPTIVE_EXECUTION_ENABLED)
+    super.afterAll()
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates `PrunePartitionSuiteBase/BucketedReadWithHiveSupportSuite` to have the require conf explicitly.

### Why are the changes needed?

The unit test should not depend on the default configurations.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

According to https://github.com/apache/spark/pull/30628 , this seems to be the only ones.

Pass the CIs.