### PR TITLE
[SPARK-31677][SS] Remove reduplicate cache of stream query progress info in StreamingExecution

### DIFF
--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSinkSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSinkSuite.scala
@@ -314,7 +314,9 @@ class KafkaSinkMicroBatchStreamingSuite extends KafkaSinkStreamingSuiteBase {
     try {
       input.addData("1", "2", "3")
       verifyResult(writer) {
-        assert(writer.recentProgress.exists(_.sink.numOutputRows == 3L))
+        eventually(timeout(10.seconds)) {
+          assert(writer.recentProgress.exists(_.sink.numOutputRows == 3L))
+        }
       }
     } finally {
       writer.stop()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ProgressReporter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ProgressReporter.scala
@@ -32,6 +32,7 @@ import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.connector.read.streaming.{MicroBatchStream, SparkDataStream}
 import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.execution.datasources.v2.{MicroBatchScanExec, StreamingDataSourceV2Relation, StreamWriterCommitProgress}
+import org.apache.spark.sql.execution.ui.StreamingQueryStatusStore
 import org.apache.spark.sql.streaming._
 import org.apache.spark.sql.streaming.StreamingQueryListener.QueryProgressEvent
 import org.apache.spark.util.Clock
@@ -65,6 +66,7 @@ trait ProgressReporter extends Logging {
   protected def currentBatchId: Long
   protected def sparkSession: SparkSession
   protected def postEvent(event: StreamingQueryListener.Event): Unit
+  protected def store: StreamingQueryStatusStore
 
   // Local timestamps and counters.
   private var currentTriggerStartTimestamp = -1L
@@ -78,9 +80,6 @@ trait ProgressReporter extends Logging {
 
   /** Flag that signals whether any error with input metrics have already been logged */
   private var metricWarningLogged: Boolean = false
-
-  /** Holds the most recent query progress updates.  Accesses must lock on the queue itself. */
-  private val progressBuffer = new mutable.Queue[StreamingQueryProgress]()
 
   private val noDataProgressEventInterval =
     sparkSession.sessionState.conf.streamingNoDataProgressEventInterval
@@ -103,13 +102,13 @@ trait ProgressReporter extends Logging {
   def status: StreamingQueryStatus = currentStatus
 
   /** Returns an array containing the most recent query progress updates. */
-  def recentProgress: Array[StreamingQueryProgress] = progressBuffer.synchronized {
-    progressBuffer.toArray
+  def recentProgress: Array[StreamingQueryProgress] = {
+    store.getStreamingQueryProgressData(runId).getOrElse(Array.empty[StreamingQueryProgress])
   }
 
   /** Returns the most recent query progress update or null if there were no progress updates. */
-  def lastProgress: StreamingQueryProgress = progressBuffer.synchronized {
-    progressBuffer.lastOption.orNull
+  def lastProgress: StreamingQueryProgress = {
+    store.getStreamingQueryProgressData(runId).map(_.last).orNull
   }
 
   /** Begins recording statistics about query progress for a given trigger. */
@@ -132,12 +131,6 @@ trait ProgressReporter extends Logging {
   }
 
   private def updateProgress(newProgress: StreamingQueryProgress): Unit = {
-    progressBuffer.synchronized {
-      progressBuffer += newProgress
-      while (progressBuffer.length >= sparkSession.sqlContext.conf.streamingProgressRetention) {
-        progressBuffer.dequeue()
-      }
-    }
     postEvent(new QueryProgressEvent(newProgress))
     logInfo(s"Streaming query made progress: $newProgress")
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ProgressReporter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ProgressReporter.scala
@@ -108,7 +108,11 @@ trait ProgressReporter extends Logging {
 
   /** Returns the most recent query progress update or null if there were no progress updates. */
   def lastProgress: StreamingQueryProgress = {
-    store.getStreamingQueryProgressData(runId).map(_.last).orNull
+    if (recentProgress.isEmpty) {
+      null
+    } else {
+      recentProgress.last
+    }
   }
 
   /** Begins recording statistics about query progress for a given trigger. */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -42,10 +42,12 @@ import org.apache.spark.sql.connector.write.{LogicalWriteInfoImpl, SupportsTrunc
 import org.apache.spark.sql.connector.write.streaming.StreamingWrite
 import org.apache.spark.sql.execution.command.StreamingExplainCommand
 import org.apache.spark.sql.execution.datasources.v2.StreamWriterCommitProgress
+import org.apache.spark.sql.execution.ui.StreamingQueryStatusStore
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.connector.SupportsStreamingUpdateAsAppend
 import org.apache.spark.sql.streaming._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.status.ElementTrackingStore
 import org.apache.spark.util.{Clock, UninterruptibleThread, Utils}
 
 /** States for [[StreamExecution]]'s lifecycle. */
@@ -93,6 +95,9 @@ abstract class StreamExecution(
   private val initializationLatch = new CountDownLatch(1)
   private val startLatch = new CountDownLatch(1)
   private val terminationLatch = new CountDownLatch(1)
+
+  protected val store = new StreamingQueryStatusStore(
+    sparkSession.sparkContext.statusStore.store.asInstanceOf[ElementTrackingStore])
 
   val resolvedCheckpointRoot = {
     val checkpointPath = new Path(checkpointRoot)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use KVStore instead to cache streaming query progress information.

### Why are the changes needed?
Streaming query progress information are cached twice in StreamExecution and StreamingQueryStatusListener. It is memory-wasting. We can make this two memory usage unified.


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
existing ut

cc @xuanyuanking 
