### PR TITLE
[SPARK-33689][SQL] ArrayData specialization

### DIFF
--- a/sql/catalyst/benchmarks/ArrayDataExtractionBenchmark-results.txt
+++ b/sql/catalyst/benchmarks/ArrayDataExtractionBenchmark-results.txt
@@ -1,0 +1,9 @@
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.7
+Intel(R) Core(TM) i7-8850H CPU @ 2.60GHz
+ArrayData - arrays extraction:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------------------
+GenericArrayData (int[] constructor): array() call                2010           2104         133          5.0         201.0       1.0X
+GenericArrayData (int[] constructor): toIntArray() call           2174           2873         989          4.6         217.4       0.9X
+UnsafeArrayData: toIntArray() call                                 347            418          99         28.8          34.7       5.8X
+PrimitiveArrayData: toIntArray() call                               92            119          16        108.7           9.2      21.8X
+

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/RowEncoder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/RowEncoder.scala
@@ -286,10 +286,21 @@ object RowEncoder {
     case StringType => createDeserializerForString(input, returnNullable = false)
 
     case ArrayType(et, nullable) =>
+      def arrayCreationFuncName: String = et match {
+        case _ if nullable => "array"
+        case _: LongType => "toLongArray"
+        case _: IntegerType => "toIntArray"
+        case _: DoubleType => "toDoubleArray"
+        case _: BooleanType => "toBooleanArray"
+        case _: ByteType => "toByteArray"
+        case _: ShortType => "toShortArray"
+        case _: FloatType => "toFloatArray"
+        case _ => "array"
+      }
       val arrayData =
         Invoke(
-          MapObjects(deserializerFor(_), input, et),
-          "array",
+          MapObjects(deserializerFor(_), input, et, nullable),
+          arrayCreationFuncName,
           ObjectType(classOf[Array[_]]), returnNullable = false)
       // TODO should use `scala.collection.immutable.ArrayDeq.unsafeMake` method to create
       //  `immutable.Seq` in Scala 2.13 when Scala version compatibility is no longer required.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -332,7 +332,13 @@ case class Invoke(
       val invokeMethod = if (method.isDefined) {
         method.get
       } else {
-        obj.getClass.getDeclaredMethod(functionName, argClasses: _*)
+        // try to find an appropriate method among ancestors in case of error
+        try {
+          obj.getClass.getDeclaredMethod(functionName, argClasses: _*)
+        } catch {
+          case _: NoSuchMethodException =>
+            obj.getClass.getMethod(functionName, argClasses: _*)
+        }
       }
       invoke(obj, invokeMethod, arguments, input, dataType)
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/GenericArrayData.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/GenericArrayData.scala
@@ -30,15 +30,6 @@ class GenericArrayData(val array: Array[Any]) extends ArrayData {
   def this(seq: scala.collection.Seq[Any]) = this(seq.toArray)
   def this(list: java.util.List[Any]) = this(list.asScala.toSeq)
 
-  // TODO: This is boxing.  We should specialize.
-  def this(primitiveArray: Array[Int]) = this(primitiveArray.toSeq)
-  def this(primitiveArray: Array[Long]) = this(primitiveArray.toSeq)
-  def this(primitiveArray: Array[Float]) = this(primitiveArray.toSeq)
-  def this(primitiveArray: Array[Double]) = this(primitiveArray.toSeq)
-  def this(primitiveArray: Array[Short]) = this(primitiveArray.toSeq)
-  def this(primitiveArray: Array[Byte]) = this(primitiveArray.toSeq)
-  def this(primitiveArray: Array[Boolean]) = this(primitiveArray.toSeq)
-
   def this(seqOrArray: Any) = this(seqOrArray match {
     // Specified this as`scala.collection.Seq` because seqOrArray can be
     // `mutable.ArraySeq` in Scala 2.13

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/PrimitiveArrayData.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/PrimitiveArrayData.scala
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.util
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.types.{DataType, Decimal}
+import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
+
+// scalastyle:off line.size.limit
+object PrimitiveArrayData {
+  def create(input: Any): ArrayData = input match {
+    case a: Array[Boolean] => new BooleanArrayData(a)
+    case a: Array[Byte] => new ByteArrayData(a)
+    case a: Array[Short] => new ShortArrayData(a)
+    case a: Array[Int] => new IntArrayData(a)
+    case a: Array[Long] => new LongArrayData(a)
+    case a: Array[Float] => new FloatArrayData(a)
+    case a: Array[Double] => new DoubleArrayData(a)
+    case _ => throw new IllegalArgumentException(s"PrimitiveArrayData does not support " +
+        s"construction from ${input.getClass} instances.")
+  }
+}
+
+sealed abstract class PrimitiveArrayData[T <: AnyVal](private val arr: Array[T])
+  extends ArrayData {
+
+  override final def numElements(): Int = arr.length
+
+  override final def array: Array[Any] =
+    throw new UnsupportedOperationException(s"Unsupported for $getClass")
+
+  override final def setNullAt(i: Int): Unit =
+    throw new UnsupportedOperationException(s"Unsupported for $getClass")
+
+  override def update(i: Int, value: Any): Unit = arr(i) = value.asInstanceOf[T]
+
+  override def copy(): ArrayData = {
+    val classConstructor = this.getClass.getDeclaredConstructors.head
+    classConstructor.newInstance(arr.clone()).asInstanceOf[PrimitiveArrayData[T]]
+  }
+
+  override final def isNullAt(ordinal: Int): Boolean = false
+
+  override def getBoolean(ordinal: Int): Boolean =
+    throw new UnsupportedOperationException(s"Unsupported for $getClass")
+
+  override def getByte(ordinal: Int): Byte =
+    throw new UnsupportedOperationException(s"Unsupported for $getClass")
+
+  override def getShort(ordinal: Int): Short =
+    throw new UnsupportedOperationException(s"Unsupported for $getClass")
+
+  override def getInt(ordinal: Int): Int =
+    throw new UnsupportedOperationException(s"Unsupported for $getClass")
+
+  override def getLong(ordinal: Int): Long =
+    throw new UnsupportedOperationException(s"Unsupported for $getClass")
+
+  override def getFloat(ordinal: Int): Float =
+    throw new UnsupportedOperationException(s"Unsupported for $getClass")
+
+  override def getDouble(ordinal: Int): Double =
+    throw new UnsupportedOperationException(s"Unsupported for $getClass")
+
+  override def getDecimal(ordinal: Int, precision: Int, scale: Int): Decimal =
+    throw new UnsupportedOperationException(s"Unsupported for $getClass")
+
+  override def getUTF8String(ordinal: Int): UTF8String =
+    throw new UnsupportedOperationException(s"Unsupported for $getClass")
+
+  override def getBinary(ordinal: Int): Array[Byte] =
+    throw new UnsupportedOperationException(s"Unsupported for $getClass")
+
+  override def getInterval(ordinal: Int): CalendarInterval =
+    throw new UnsupportedOperationException(s"Unsupported for $getClass")
+
+  override def getStruct(ordinal: Int, numFields: Int): InternalRow =
+    throw new UnsupportedOperationException(s"Unsupported for $getClass")
+
+  override def getArray(ordinal: Int): ArrayData =
+    throw new UnsupportedOperationException(s"Unsupported for $getClass")
+
+  override def getMap(ordinal: Int): MapData =
+    throw new UnsupportedOperationException(s"Unsupported for $getClass")
+
+  override def get(ordinal: Int, dataType: DataType): AnyRef =
+    throw new UnsupportedOperationException(s"Unsupported for $getClass")
+
+  override def hashCode(): Int = arr.toSeq.hashCode()
+
+  override def equals(obj: Any): Boolean = {
+    if (!obj.isInstanceOf[PrimitiveArrayData[_]]) {
+      false
+    } else {
+      val other = obj.asInstanceOf[PrimitiveArrayData[_]]
+      if (this eq other) {
+        true
+      } else if (this.getClass != other.getClass || this.arr.length != other.arr.length) {
+        false
+      } else {
+        var i = 0
+        while (i < arr.length) {
+          if (this.arr(i) != other.arr(i)) {
+            return false
+          }
+          i += 1
+        }
+        true
+      }
+    }
+  }
+}
+
+private class LongArrayData(longArray: Array[Long]) extends PrimitiveArrayData[Long](longArray) {
+  override def toLongArray(): Array[Long] = longArray.clone()
+  override def getLong(ordinal: Int): Long = longArray(ordinal)
+}
+
+private class IntArrayData(intArray: Array[Int]) extends PrimitiveArrayData[Int](intArray) {
+  override def toIntArray(): Array[Int] = intArray.clone()
+  override def getInt(ordinal: Int): Int = intArray(ordinal)
+}
+
+private class ShortArrayData(shortArray: Array[Short]) extends PrimitiveArrayData[Short](shortArray) {
+  override def toShortArray(): Array[Short] = shortArray.clone()
+  override def getShort(ordinal: Int): Short = shortArray(ordinal)
+}
+
+private class ByteArrayData(byteArray: Array[Byte]) extends PrimitiveArrayData[Byte](byteArray) {
+  override def toByteArray(): Array[Byte] = byteArray.clone()
+  override def getByte(ordinal: Int): Byte = byteArray(ordinal)
+}
+
+private class BooleanArrayData(booleanArray: Array[Boolean]) extends PrimitiveArrayData[Boolean](booleanArray) {
+  override def toBooleanArray(): Array[Boolean] = booleanArray.clone()
+  override def getBoolean(ordinal: Int): Boolean = booleanArray(ordinal)
+}
+
+private class DoubleArrayData(doubleArray: Array[Double]) extends PrimitiveArrayData[Double](doubleArray) {
+  override def toDoubleArray(): Array[Double] = doubleArray.clone()
+  override def getDouble(ordinal: Int): Double = doubleArray(ordinal)
+}
+
+private class FloatArrayData(floatArray: Array[Float]) extends PrimitiveArrayData[Float](floatArray) {
+  override def toFloatArray(): Array[Float] = floatArray.clone()
+  override def getFloat(ordinal: Int): Float = floatArray(ordinal)
+}
+// scalastyle:on line.size.limit

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/ArrayDataExtractionBenchmark.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/ArrayDataExtractionBenchmark.scala
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.util
+
+import scala.util.Random
+
+import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}
+
+/**
+ * Benchmark for [[ArrayData]] array extraction methods.
+ * To run this benchmark:
+ * {{{
+ *   1. without sbt:
+ *      bin/spark-submit --class <this class> --jars <spark core test jar> <spark catalyst test jar>
+ *   2. build/sbt "catalyst/test:runMain <this class>"
+ *   3. generate result:
+ *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "catalyst/test:runMain <this class>"
+ *      Results will be written to "benchmarks/ArrayDataExtractionBenchmark-results.txt".
+ * }}}
+ */
+object ArrayDataExtractionBenchmark extends BenchmarkBase {
+
+  def benchmark(): Unit = {
+    val valuesPerIteration: Long = 1000 * 1000 * 10
+    val arraySize = 25
+    val randomIntArray: Array[Int] = new Array[Int](arraySize).map(_ => Random.nextInt())
+
+    val benchmark = new Benchmark(
+      "ArrayData - arrays extraction",
+      valuesPerIteration, output = output)
+
+    benchmark.addCase("GenericArrayData (int[] constructor): array() call") { _ =>
+      val arr: Array[Int] = randomIntArray
+      var n = 0
+      while (n < valuesPerIteration) {
+        new GenericArrayData(arr).array
+        n += 1
+      }
+    }
+
+    benchmark.addCase("GenericArrayData (int[] constructor): toIntArray() call") { _ =>
+      val arr: Array[Int] = randomIntArray
+      var n = 0
+      while (n < valuesPerIteration) {
+        new GenericArrayData(arr).toIntArray()
+        n += 1
+      }
+    }
+
+    benchmark.addCase("UnsafeArrayData: toIntArray() call") { _ =>
+      val arr: Array[Int] = randomIntArray
+      var n = 0
+      while (n < valuesPerIteration) {
+        ArrayData.toArrayData(arr).toIntArray()
+        n += 1
+      }
+    }
+
+    benchmark.addCase("PrimitiveArrayData: toIntArray() call") { _ =>
+      val arr: Array[Int] = randomIntArray
+      var n = 0
+      while (n < valuesPerIteration) {
+        PrimitiveArrayData.create(arr).toIntArray()
+        n += 1
+      }
+    }
+
+    benchmark.run()
+  }
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    benchmark()
+  }
+}

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaHigherOrderFunctionsSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaHigherOrderFunctionsSuite.java
@@ -35,6 +35,7 @@ import org.apache.spark.sql.RowFactory;
 import static org.apache.spark.sql.functions.*;
 import org.apache.spark.sql.test.TestSparkSession;
 import org.apache.spark.sql.types.*;
+import scala.collection.Seq;
 import scala.reflect.ClassTag;
 
 import static org.apache.spark.sql.types.DataTypes.*;
@@ -55,7 +56,7 @@ public class JavaHigherOrderFunctionsSuite {
                 Object expectedValue = expectedRow.get(j);
                 Object actualValue = actualRow.get(j);
                 if (expectedValue != null && expectedValue.getClass().isArray()) {
-                    actualValue = ((scala.collection.Seq<?>) actualValue).toArray(ClassTag.AnyRef());
+                    actualValue = ((Seq<?>) actualValue).toArray(ClassTag.AnyRef());
                     Assert.assertArrayEquals((Object[]) expectedValue, (Object[]) actualValue);
                 } else {
                     Assert.assertEquals(expectedValue, actualValue);

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaHigherOrderFunctionsSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaHigherOrderFunctionsSuite.java
@@ -35,6 +35,8 @@ import org.apache.spark.sql.RowFactory;
 import static org.apache.spark.sql.functions.*;
 import org.apache.spark.sql.test.TestSparkSession;
 import org.apache.spark.sql.types.*;
+import scala.reflect.ClassTag;
+
 import static org.apache.spark.sql.types.DataTypes.*;
 
 public class JavaHigherOrderFunctionsSuite {
@@ -53,7 +55,7 @@ public class JavaHigherOrderFunctionsSuite {
                 Object expectedValue = expectedRow.get(j);
                 Object actualValue = actualRow.get(j);
                 if (expectedValue != null && expectedValue.getClass().isArray()) {
-                    actualValue = actualValue.getClass().getMethod("array").invoke(actualValue);
+                    actualValue = ((scala.collection.Seq<?>) actualValue).toArray(ClassTag.AnyRef());
                     Assert.assertArrayEquals((Object[]) expectedValue, (Object[]) actualValue);
                 } else {
                     Assert.assertEquals(expectedValue, actualValue);


### PR DESCRIPTION
**What changes were proposed in this pull request?**
This PR introduces a specialized version of ArrayData class backed by primitive arrays. Then it is used for more efficient row decoding in case of non-nullable arrays.

**Why are the changes needed?**
Currently, even non-nullable arrays fields are represented as WrappedArray.ofRef in Row external representation. It leads to memory foorprint, as well as unnecessary cycles in boxing/unboxing operations.

**Does this PR introduce any user-facing change?**
UDFs depending on  WrrappedArray.ofRef/WrappedArray[AnyRef] would stop working in case of non-nullable arrays.

**How was this patch tested?**
Pass the CIs. Also added a benchmark to illustrate the benefits.