### PR TITLE
SPARK-33686: Spark SQL unrecognized `db.tbl`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -1192,7 +1192,13 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
    */
   override def visitTableIdentifier(
       ctx: TableIdentifierContext): TableIdentifier = withOrigin(ctx) {
-    TableIdentifier(ctx.table.getText, Option(ctx.db).map(_.getText))
+    var db = Option(ctx.db).map(_.getText)
+    var tbl = ctx.table.getText
+    if (db.isEmpty && 0 < tbl.indexOf(".") && tbl.indexOf(".") < tbl.length - 1) {
+      db = Option(tbl.substring(0, tbl.indexOf(".")))
+      tbl = tbl.substring(tbl.indexOf(".") + 1)
+    }
+    TableIdentifier(tbl, db)
   }
 
   /**

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/TableIdentifierParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/TableIdentifierParserSuite.scala
@@ -301,7 +301,7 @@ class TableIdentifierParserSuite extends SparkFunSuite with SQLKeywordUtils {
     assert(TableIdentifier("y.z", Some("x")) === parseTableIdentifier("x.`y.z`"))
     assert(TableIdentifier("z", Some("`x.y`")) === parseTableIdentifier("```x.y```.z"))
     assert(TableIdentifier("`y.z`", Some("x")) === parseTableIdentifier("x.```y.z```"))
-    assert(TableIdentifier("x.y.z", None) === parseTableIdentifier("`x.y.z`"))
+    assert(TableIdentifier("y.z", Some("x")) === parseTableIdentifier("`x.y.z`"))
   }
 
   test("table identifier - reserved/non-reserved keywords if ANSI mode enabled") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -2854,4 +2854,11 @@ class HiveDDLSuite
       assert(sql("SELECT * FROM t2 WHERE c = 'A'").collect().isEmpty)
     }
   }
+
+  test("SPARK-33686: Spark SQL unrecognized `db.tbl`") {
+    withTable("t1", "t2") {
+      sql("create table `default.t1` (c1 int);")
+      sql("create table `default`.`t2` (c1 int);")
+    }
+  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -2854,11 +2854,4 @@ class HiveDDLSuite
       assert(sql("SELECT * FROM t2 WHERE c = 'A'").collect().isEmpty)
     }
   }
-
-  test("SPARK-33686: Spark SQL unrecognized `db.tbl`") {
-    withTable("t1", "t2") {
-      sql("create table `default.t1` (c1 int);")
-      sql("create table `default`.`t2` (c1 int);")
-    }
-  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
In this PR, if somebody created table like this:
```
create table `bigdata_db.test_spark_33686` (c1 int);
```
it's mean db name is `bigdata_db`, table name is `test_spark_33686`, but current version don't support it and throws exception like:
```
spark-sql> create table `bigdata_db.test_spark_33686` (c1 int);
Error in query: `bigdata_db.test_spark_33686` is not a valid name for tables/databases. Valid names only contain alphabet characters, numbers and _.;
```
we should support it.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This is more relaxed and friendly syntax support.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
add new tests