### PR TITLE
[SPARK-24818][CORE] Support delay scheduling for barrier execution

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -680,9 +680,9 @@ private[spark] class TaskSchedulerImpl(
               // always reject the offered resources. As a result, the barrier taskset can't get
               // launched. And if we retry the resourceOffer, we'd go through the same path again
               // and get into the endless loop in the end.
-              val errorMsg = s"$msg We highly recommend you to use the new delay scheduling " +
-                s"by setting spark.locality.wait.legacyResetOnTaskLaunch to false to get rid " +
-                s"of this error."
+              val errorMsg = s"$msg We highly recommend you to use the non-legacy" +
+                s" delay scheduling by setting ${LEGACY_LOCALITY_WAIT_RESET.key} " +
+                s"to false to get rid of this error."
               logWarning(errorMsg)
               taskSet.abort(errorMsg)
               throw new SparkException(errorMsg)

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -688,7 +688,6 @@ private[spark] class TaskSchedulerImpl(
               // re-add the task to the schedule pending list
               taskSet.addPendingTask(task.index)
             }
-            taskSet.currentLocalityIndex = 0
           } else {
             // All tasks are able to launch in this barrier task set. Let's do
             // some preparation work before launching them.

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -671,14 +671,14 @@ private[spark] class TaskSchedulerImpl(
           // Check whether the barrier tasks are partially launched.
           if (barrierPendingLaunchTasks.length != taskSet.numTasks) {
             val curTime = clock.getTimeMillis()
-            if (curTime - taskSet.lastResourceOfferFailTime >
+            if (curTime - taskSet.lastResourceOfferFailLogTime >
                 TaskSetManager.BARRIER_LOGGING_INTERVAL) {
               logInfo(s"Fail resource offers for barrier stage ${taskSet.stageId} " +
                 s"because only ${barrierPendingLaunchTasks.length} out of a total number " +
                 s"of ${taskSet.numTasks} tasks got resource offers. Waiting for later round " +
                 s"resource offers.")
+              taskSet.lastResourceOfferFailLogTime = curTime
             }
-            taskSet.lastResourceOfferFailTime = curTime
             barrierPendingLaunchTasks.foreach { task =>
               // revert all assigned resources
               availableCpus(task.assignedOfferIndex) += task.assignedCores

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -669,16 +669,17 @@ private[spark] class TaskSchedulerImpl(
         if (launchedAnyTask && taskSet.isBarrier) {
           val barrierPendingLaunchTasks = taskSet.barrierPendingLaunchTasks.values.toArray
           // Check whether the barrier tasks are partially launched.
-          if (barrierPendingLaunchTasks.size != taskSet.numTasks) {
+          if (barrierPendingLaunchTasks.length != taskSet.numTasks) {
             barrierPendingLaunchTasks.foreach { task =>
               // revert all assigned resources
               availableCpus(task.assignedOfferIndex) += task.assignedCores
               task.assignedResources.foreach { case (rName, rInfo) =>
-                availableResources(task.assignedOfferIndex)(rName).prependAll(rInfo.addresses)
+                availableResources(task.assignedOfferIndex)(rName).appendAll(rInfo.addresses)
               }
               // re-add the task to the schedule pending list
               taskSet.addPendingTask(task.index)
             }
+            taskSet.currentLocalityIndex = 0
           } else {
             // All tasks are able to launch in this barrier task set. Let's do
             // some preparation work before launching them.

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -680,7 +680,7 @@ private[spark] class TaskSchedulerImpl(
               val errorMsg = s"Fail resource offers for barrier stage ${taskSet.stageId} " +
                 s"because only ${barrierPendingLaunchTasks.length} out of a total number " +
                 s"of ${taskSet.numTasks} tasks got resource offers. We highly recommend " +
-                s"you to use the non-legacy delay scheduling by setting " +
+                "you to use the non-legacy delay scheduling by setting " +
                 s"${LEGACY_LOCALITY_WAIT_RESET.key} to false to get rid of this error."
               logWarning(errorMsg)
               taskSet.abort(errorMsg)
@@ -689,8 +689,8 @@ private[spark] class TaskSchedulerImpl(
               val curTime = clock.getTimeMillis()
               if (curTime - taskSet.lastResourceOfferFailLogTime >
                 TaskSetManager.BARRIER_LOGGING_INTERVAL) {
-                logInfo(s"Releasing the assigned resource offers since only partial tasks can " +
-                  s"be launched. Waiting for later round resource offers.")
+                logInfo("Releasing the assigned resource offers since only partial tasks can " +
+                  "be launched. Waiting for later round resource offers.")
                 taskSet.lastResourceOfferFailLogTime = curTime
               }
               barrierPendingLaunchTasks.foreach { task =>

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -364,7 +364,6 @@ private[spark] class TaskSchedulerImpl(
    * @param availableResources remaining resources per offer,
    *                           value at index 'i' corresponds to shuffledOffers[i]
    * @param tasks tasks scheduled per offer, value at index 'i' corresponds to shuffledOffers[i]
-   * @param addressesWithDescs tasks scheduler per host:port, used for barrier tasks
    * @return tuple of (no delay schedule rejects?, option of min locality of launched task)
    */
   private def resourceOfferSingleTaskSet(
@@ -373,8 +372,7 @@ private[spark] class TaskSchedulerImpl(
       shuffledOffers: Seq[WorkerOffer],
       availableCpus: Array[Int],
       availableResources: Array[Map[String, Buffer[String]]],
-      tasks: IndexedSeq[ArrayBuffer[TaskDescription]],
-      addressesWithDescs: ArrayBuffer[(String, TaskDescription)])
+      tasks: IndexedSeq[ArrayBuffer[TaskDescription]])
     : (Boolean, Option[TaskLocality]) = {
     var noDelayScheduleRejects = true
     var minLaunchedLocality: Option[TaskLocality] = None
@@ -393,30 +391,31 @@ private[spark] class TaskSchedulerImpl(
           try {
             val prof = sc.resourceProfileManager.resourceProfileFromId(taskSetRpID)
             val taskCpus = ResourceProfile.getTaskCpusOrDefaultForProfile(prof, conf)
-            val (taskDescOption, didReject) =
+            val (taskDescOption, didReject, index) =
               taskSet.resourceOffer(execId, host, maxLocality, taskResAssignments)
             noDelayScheduleRejects &= !didReject
             for (task <- taskDescOption) {
-              tasks(i) += task
-              val tid = task.taskId
-              val locality = taskSet.taskInfos(task.taskId).taskLocality
+              val (locality, resources) = if (task != null) {
+                tasks(i) += task
+                addRunningTask(task.taskId, execId, taskSet)
+                (taskSet.taskInfos(task.taskId).taskLocality, task.resources)
+              } else {
+                assert(taskSet.isBarrier, "TaskDescription can only be null for barrier task")
+                val barrierTask = taskSet.barrierPendingLaunchTasks(index)
+                barrierTask.assignedOfferIndex = i
+                barrierTask.assignedCores = taskCpus
+                (barrierTask.taskLocality, barrierTask.assignedResources)
+              }
+
               minLaunchedLocality = minTaskLocality(minLaunchedLocality, Some(locality))
-              taskIdToTaskSetManager.put(tid, taskSet)
-              taskIdToExecutorId(tid) = execId
-              executorIdToRunningTaskIds(execId).add(tid)
               availableCpus(i) -= taskCpus
               assert(availableCpus(i) >= 0)
-              task.resources.foreach { case (rName, rInfo) =>
+              resources.foreach { case (rName, rInfo) =>
                 // Remove the first n elements from availableResources addresses, these removed
                 // addresses are the same as that we allocated in taskResourceAssignments since it's
                 // synchronized. We don't remove the exact addresses allocated because the current
                 // approach produces the identical result with less time complexity.
                 availableResources(i)(rName).remove(0, rInfo.addresses.size)
-              }
-              // Only update hosts for a barrier task.
-              if (taskSet.isBarrier) {
-                // The executor address is expected to be non empty.
-                addressesWithDescs += (shuffledOffers(i).address.get -> task)
               }
             }
           } catch {
@@ -430,6 +429,15 @@ private[spark] class TaskSchedulerImpl(
       }
     }
     (noDelayScheduleRejects, minLaunchedLocality)
+  }
+
+  /**
+   * Add the running task to TaskScheduler's related structures
+   */
+  private def addRunningTask(tid: Long, execId: String, taskSet: TaskSetManager): Unit = {
+    taskIdToTaskSetManager.put(tid, taskSet)
+    taskIdToExecutorId(tid) = execId
+    executorIdToRunningTaskIds(execId).add(tid)
   }
 
   /**
@@ -571,14 +579,12 @@ private[spark] class TaskSchedulerImpl(
         var launchedAnyTask = false
         var noDelaySchedulingRejects = true
         var globalMinLocality: Option[TaskLocality] = None
-        // Record all the executor IDs assigned barrier tasks on.
-        val addressesWithDescs = ArrayBuffer[(String, TaskDescription)]()
         for (currentMaxLocality <- taskSet.myLocalityLevels) {
           var launchedTaskAtCurrentMaxLocality = false
           do {
             val (noDelayScheduleReject, minLocality) = resourceOfferSingleTaskSet(
               taskSet, currentMaxLocality, shuffledOffers, availableCpus,
-              availableResources, tasks, addressesWithDescs)
+              availableResources, tasks)
             launchedTaskAtCurrentMaxLocality = minLocality.isDefined
             launchedAnyTask |= launchedTaskAtCurrentMaxLocality
             noDelaySchedulingRejects &= noDelayScheduleReject
@@ -661,35 +667,51 @@ private[spark] class TaskSchedulerImpl(
         }
 
         if (launchedAnyTask && taskSet.isBarrier) {
+          val barrierPendingLaunchTasks = taskSet.barrierPendingLaunchTasks.values.toArray
           // Check whether the barrier tasks are partially launched.
-          // TODO SPARK-24818 handle the assert failure case (that can happen when some locality
-          // requirements are not fulfilled, and we should revert the launched tasks).
-          if (addressesWithDescs.size != taskSet.numTasks) {
-            val errorMsg =
-              s"Fail resource offers for barrier stage ${taskSet.stageId} because only " +
-                s"${addressesWithDescs.size} out of a total number of ${taskSet.numTasks}" +
-                s" tasks got resource offers. This happens because barrier execution currently " +
-                s"does not work gracefully with delay scheduling. We highly recommend you to " +
-                s"disable delay scheduling by setting spark.locality.wait=0 as a workaround if " +
-                s"you see this error frequently."
-            logWarning(errorMsg)
-            taskSet.abort(errorMsg)
-            throw new SparkException(errorMsg)
+          if (barrierPendingLaunchTasks.size != taskSet.numTasks) {
+            barrierPendingLaunchTasks.foreach { task =>
+              // revert all assigned resources
+              availableCpus(task.assignedOfferIndex) += task.assignedCores
+              task.assignedResources.foreach { case (rName, rInfo) =>
+                availableResources(task.assignedOfferIndex)(rName).prependAll(rInfo.addresses)
+              }
+              // re-add the task to the schedule pending list
+              taskSet.addPendingTask(task.index)
+            }
+          } else {
+            // All tasks are able to launch in this barrier task set. Let's do
+            // some preparation work before launching them.
+            val launchTime = clock.getTimeMillis()
+            val addressesWithDescs = barrierPendingLaunchTasks.map { task =>
+              val taskDesc = taskSet.prepareLaunchingTask(
+                task.execId,
+                task.host,
+                task.index,
+                task.taskLocality,
+                false,
+                task.assignedResources,
+                launchTime)
+              addRunningTask(taskDesc.taskId, taskDesc.executorId, taskSet)
+              tasks(task.assignedOfferIndex) += taskDesc
+              shuffledOffers(task.assignedOfferIndex).address.get -> taskDesc
+            }
+
+            // materialize the barrier coordinator.
+            maybeInitBarrierCoordinator()
+
+            // Update the taskInfos into all the barrier task properties.
+            val addressesStr = addressesWithDescs
+              // Addresses ordered by partitionId
+              .sortBy(_._2.partitionId)
+              .map(_._1)
+              .mkString(",")
+            addressesWithDescs.foreach(_._2.properties.setProperty("addresses", addressesStr))
+
+            logInfo(s"Successfully scheduled all the ${addressesWithDescs.size} tasks for " +
+              s"barrier stage ${taskSet.stageId}.")
           }
-
-          // materialize the barrier coordinator.
-          maybeInitBarrierCoordinator()
-
-          // Update the taskInfos into all the barrier task properties.
-          val addressesStr = addressesWithDescs
-            // Addresses ordered by partitionId
-            .sortBy(_._2.partitionId)
-            .map(_._1)
-            .mkString(",")
-          addressesWithDescs.foreach(_._2.properties.setProperty("addresses", addressesStr))
-
-          logInfo(s"Successfully scheduled all the ${addressesWithDescs.size} tasks for barrier " +
-            s"stage ${taskSet.stageId}.")
+          taskSet.barrierPendingLaunchTasks.clear()
         }
       }
     }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -162,8 +162,8 @@ private[spark] class TaskSetManager(
   // revert everything we did during task scheduling.
   private[scheduler] val barrierPendingLaunchTasks = new HashMap[Int, BarrierPendingLaunchTask]()
 
-  // Record the last time of the barrier TaskSetManager that failed to get all tasks launched.
-  private[scheduler] var lastResourceOfferFailTime = clock.getTimeMillis()
+  // Record the last log time of the barrier TaskSetManager that failed to get all tasks launched.
+  private[scheduler] var lastResourceOfferFailLogTime = clock.getTimeMillis()
 
   // Store tasks waiting to be scheduled by locality preferences
   private[scheduler] val pendingTasks = new PendingTasksByLocality()

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -157,6 +157,11 @@ private[spark] class TaskSetManager(
   // same time for a barrier stage.
   private[scheduler] def isBarrier = taskSet.tasks.nonEmpty && taskSet.tasks(0).isBarrier
 
+  // Barrier tasks that are pending to launch in a single resourceOffers round. Tasks will only get
+  // launched when all tasks are added to this pending list in a single round. Otherwise, we'll
+  // revert everything we did during task scheduling.
+  private[scheduler] val barrierPendingLaunchTasks = new HashMap[Int, BarrierPendingLaunchTask]()
+
   // Store tasks waiting to be scheduled by locality preferences
   private[scheduler] val pendingTasks = new PendingTasksByLocality()
 
@@ -302,7 +307,7 @@ private[spark] class TaskSetManager(
         // Speculatable task should only be launched when at most one copy of the
         // original task is running
         if (!successful(index)) {
-          if (copiesRunning(index) == 0) {
+          if (copiesRunning(index) == 0 && !barrierPendingLaunchTasks.contains(index)) {
             return Some(index)
           } else if (speculative && copiesRunning(index) == 1) {
             return Some(index)
@@ -411,8 +416,10 @@ private[spark] class TaskSetManager(
    * @param host  the host Id of the offered resource
    * @param maxLocality the maximum locality we want to schedule the tasks at
    *
-   * @return Tuple containing:
-   *         (TaskDescription of launched task if any, rejected resource due to delay scheduling?)
+   * @return Triple containing:
+   *         (TaskDescription of launched task if any,
+   *         rejected resource due to delay scheduling?,
+   *         dequeued task index)
    */
   @throws[TaskNotSerializableException]
   def resourceOffer(
@@ -420,7 +427,7 @@ private[spark] class TaskSetManager(
       host: String,
       maxLocality: TaskLocality.TaskLocality,
       taskResourceAssignments: Map[String, ResourceInformation] = Map.empty)
-    : (Option[TaskDescription], Boolean) =
+    : (Option[TaskDescription], Boolean, Int) =
   {
     val offerExcluded = taskSetExcludelistHelperOpt.exists { excludeList =>
       excludeList.isNodeExcludedForTaskSet(host) ||
@@ -439,75 +446,107 @@ private[spark] class TaskSetManager(
         }
       }
 
+      var dequeuedTaskIndex: Option[Int] = None
       val taskDescription =
         dequeueTask(execId, host, allowedLocality)
           .map { case (index, taskLocality, speculative) =>
-        // Found a task; do some bookkeeping and return a task description
-        val task = tasks(index)
-        val taskId = sched.newTaskId()
-        // Do various bookkeeping
-        copiesRunning(index) += 1
-        val attemptNum = taskAttempts(index).size
-        val info = new TaskInfo(taskId, index, attemptNum, curTime,
-          execId, host, taskLocality, speculative)
-        taskInfos(taskId) = info
-        taskAttempts(index) = info :: taskAttempts(index)
-        if (legacyLocalityWaitReset && maxLocality != TaskLocality.NO_PREF) {
-          resetDelayScheduleTimer(Some(taskLocality))
-        }
-        // Serialize and return the task
-        val serializedTask: ByteBuffer = try {
-          ser.serialize(task)
-        } catch {
-          // If the task cannot be serialized, then there's no point to re-attempt the task,
-          // as it will always fail. So just abort the whole task-set.
-          case NonFatal(e) =>
-            val msg = s"Failed to serialize task $taskId, not attempting to retry it."
-            logError(msg, e)
-            abort(s"$msg Exception during serialization: $e")
-            throw new TaskNotSerializableException(e)
-        }
-        if (serializedTask.limit() > TaskSetManager.TASK_SIZE_TO_WARN_KIB * 1024 &&
-          !emittedTaskSizeWarning) {
-          emittedTaskSizeWarning = true
-          logWarning(s"Stage ${task.stageId} contains a task of very large size " +
-            s"(${serializedTask.limit() / 1024} KiB). The maximum recommended task size is " +
-            s"${TaskSetManager.TASK_SIZE_TO_WARN_KIB} KiB.")
-        }
-        addRunningTask(taskId)
-
-        // We used to log the time it takes to serialize the task, but task size is already
-        // a good proxy to task serialization time.
-        // val timeTaken = clock.getTime() - startTime
-        val tName = taskName(taskId)
-        logInfo(s"Starting $tName ($host, executor ${info.executorId}, " +
-          s"partition ${task.partitionId}, $taskLocality, ${serializedTask.limit()} bytes) " +
-          s"taskResourceAssignments ${taskResourceAssignments}")
-
-        sched.dagScheduler.taskStarted(task, info)
-        new TaskDescription(
-          taskId,
-          attemptNum,
-          execId,
-          tName,
-          index,
-          task.partitionId,
-          addedFiles,
-          addedJars,
-          addedArchives,
-          task.localProperties,
-          taskResourceAssignments,
-          serializedTask)
-      }
+            dequeuedTaskIndex = Some(index)
+            if (legacyLocalityWaitReset && maxLocality != TaskLocality.NO_PREF) {
+              resetDelayScheduleTimer(Some(taskLocality))
+            }
+            if (isBarrier) {
+              barrierPendingLaunchTasks(index) =
+                BarrierPendingLaunchTask(
+                  execId,
+                  host,
+                  index,
+                  taskLocality,
+                  taskResourceAssignments)
+              // return null since the TaskDescription for the barrier task is not ready yet
+              null
+            } else {
+              prepareLaunchingTask(
+                execId,
+                host,
+                index,
+                taskLocality,
+                speculative,
+                taskResourceAssignments,
+                curTime)
+            }
+          }
       val hasPendingTasks = pendingTasks.all.nonEmpty || pendingSpeculatableTasks.all.nonEmpty
       val hasScheduleDelayReject =
         taskDescription.isEmpty &&
           maxLocality == TaskLocality.ANY &&
           hasPendingTasks
-      (taskDescription, hasScheduleDelayReject)
+      (taskDescription, hasScheduleDelayReject, dequeuedTaskIndex.getOrElse(-1))
     } else {
-      (None, false)
+      (None, false, -1)
     }
+  }
+
+  def prepareLaunchingTask(
+      execId: String,
+      host: String,
+      index: Int,
+      taskLocality: TaskLocality.Value,
+      speculative: Boolean,
+      taskResourceAssignments: Map[String, ResourceInformation],
+      launchTime: Long): TaskDescription = {
+    // Found a task; do some bookkeeping and return a task description
+    val task = tasks(index)
+    val taskId = sched.newTaskId()
+    // Do various bookkeeping
+    copiesRunning(index) += 1
+    val attemptNum = taskAttempts(index).size
+    val info = new TaskInfo(taskId, index, attemptNum, launchTime,
+      execId, host, taskLocality, speculative)
+    taskInfos(taskId) = info
+    taskAttempts(index) = info :: taskAttempts(index)
+    // Serialize and return the task
+    val serializedTask: ByteBuffer = try {
+      ser.serialize(task)
+    } catch {
+      // If the task cannot be serialized, then there's no point to re-attempt the task,
+      // as it will always fail. So just abort the whole task-set.
+      case NonFatal(e) =>
+        val msg = s"Failed to serialize task $taskId, not attempting to retry it."
+        logError(msg, e)
+        abort(s"$msg Exception during serialization: $e")
+        throw new TaskNotSerializableException(e)
+    }
+    if (serializedTask.limit() > TaskSetManager.TASK_SIZE_TO_WARN_KIB * 1024 &&
+      !emittedTaskSizeWarning) {
+      emittedTaskSizeWarning = true
+      logWarning(s"Stage ${task.stageId} contains a task of very large size " +
+        s"(${serializedTask.limit() / 1024} KiB). The maximum recommended task size is " +
+        s"${TaskSetManager.TASK_SIZE_TO_WARN_KIB} KiB.")
+    }
+    addRunningTask(taskId)
+
+    // We used to log the time it takes to serialize the task, but task size is already
+    // a good proxy to task serialization time.
+    // val timeTaken = clock.getTime() - startTime
+    val tName = taskName(taskId)
+    logInfo(s"Starting $tName ($host, executor ${info.executorId}, " +
+      s"partition ${task.partitionId}, $taskLocality, ${serializedTask.limit()} bytes) " +
+      s"taskResourceAssignments ${taskResourceAssignments}")
+
+    sched.dagScheduler.taskStarted(task, info)
+    new TaskDescription(
+      taskId,
+      attemptNum,
+      execId,
+      tName,
+      index,
+      task.partitionId,
+      addedFiles,
+      addedJars,
+      addedArchives,
+      task.localProperties,
+      taskResourceAssignments,
+      serializedTask)
   }
 
   def taskName(tid: Long): String = {
@@ -1191,4 +1230,17 @@ private[scheduler] class PendingTasksByLocality {
   val forRack = new HashMap[String, ArrayBuffer[Int]]
   // Set containing all pending tasks (also used as a stack, as above).
   val all = new ArrayBuffer[Int]
+}
+
+private[scheduler] case class BarrierPendingLaunchTask(
+    execId: String,
+    host: String,
+    index: Int,
+    taskLocality: TaskLocality.TaskLocality,
+    assignedResources: Map[String, ResourceInformation]) {
+  // Stored the corresponding index of the WorkerOffer which is responsible to launch the task.
+  // Used to revert the assigned resources (e.g., cores, custome resources) when the barrier
+  // task set doesn't launch successfully in a single resourceOffers round.
+  var assignedOfferIndex: Int = _
+  var assignedCores: Int = 0
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -237,7 +237,7 @@ private[spark] class TaskSetManager(
   // last reset the locality wait timer, and move up a level when localityWaits[curLevel] expires.
   // We then move down if we manage to launch a "more local" task when resetting the timer
   private val legacyLocalityWaitReset = conf.get(LEGACY_LOCALITY_WAIT_RESET)
-  private var currentLocalityIndex = 0   // Index of our current locality level in validLocalityLevels
+  private var currentLocalityIndex = 0 // Index of our current locality level in validLocalityLevels
   private var lastLocalityWaitResetTime = clock.getTimeMillis()  // Time we last reset locality wait
 
   override def schedulableQueue: ConcurrentLinkedQueue[Schedulable] = null

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -234,7 +234,8 @@ private[spark] class TaskSetManager(
   // last reset the locality wait timer, and move up a level when localityWaits[curLevel] expires.
   // We then move down if we manage to launch a "more local" task when resetting the timer
   private val legacyLocalityWaitReset = conf.get(LEGACY_LOCALITY_WAIT_RESET)
-  private var currentLocalityIndex = 0 // Index of our current locality level in validLocalityLevels
+  // Index of our current locality level in validLocalityLevels
+  private[scheduler] var currentLocalityIndex = 0
   private var lastLocalityWaitResetTime = clock.getTimeMillis()  // Time we last reset locality wait
 
   override def schedulableQueue: ConcurrentLinkedQueue[Schedulable] = null

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -162,6 +162,9 @@ private[spark] class TaskSetManager(
   // revert everything we did during task scheduling.
   private[scheduler] val barrierPendingLaunchTasks = new HashMap[Int, BarrierPendingLaunchTask]()
 
+  // Record the last time of the barrier TaskSetManager that failed to get all tasks launched.
+  private[scheduler] var lastResourceOfferFailTime = clock.getTimeMillis()
+
   // Store tasks waiting to be scheduled by locality preferences
   private[scheduler] val pendingTasks = new PendingTasksByLocality()
 
@@ -1202,6 +1205,9 @@ private[spark] object TaskSetManager {
   // The user will be warned if any stages contain a task that has a serialized size greater than
   // this.
   val TASK_SIZE_TO_WARN_KIB = 1000
+
+  // 1 minute
+  val BARRIER_LOGGING_INTERVAL = 60000
 }
 
 /**

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -237,8 +237,7 @@ private[spark] class TaskSetManager(
   // last reset the locality wait timer, and move up a level when localityWaits[curLevel] expires.
   // We then move down if we manage to launch a "more local" task when resetting the timer
   private val legacyLocalityWaitReset = conf.get(LEGACY_LOCALITY_WAIT_RESET)
-  // Index of our current locality level in validLocalityLevels
-  private[scheduler] var currentLocalityIndex = 0
+  private var currentLocalityIndex = 0   // Index of our current locality level in validLocalityLevels
   private var lastLocalityWaitResetTime = clock.getTimeMillis()  // Time we last reset locality wait
 
   override def schedulableQueue: ConcurrentLinkedQueue[Schedulable] = null

--- a/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
@@ -275,15 +275,10 @@ class BarrierTaskContextSuite extends SparkFunSuite with LocalSparkContext with 
     testBarrierTaskKilled(interruptOnKill = true)
   }
 
-<<<<<<< HEAD
-  test("SPARK-31485: barrier stage should fail if only partial tasks are launched") {
-    initLocalClusterSparkContext(2)
-=======
   test("SPARK-31485: barrier stage should fail if only partial tasks are launched " +
     "under legacy delay scheduling") {
     val conf = new SparkConf().set(LEGACY_LOCALITY_WAIT_RESET, true)
     initLocalClusterSparkContext(2, conf)
->>>>>>> add back SPARK-31485 for legacy delay scheduling
     val id = sc.getExecutorIds().head
     val rdd0 = sc.parallelize(Seq(0, 1, 2, 3), 2)
     val dep = new OneToOneDependency[Int](rdd0)
@@ -298,7 +293,6 @@ class BarrierTaskContextSuite extends SparkFunSuite with LocalSparkContext with 
     }.getMessage
     assert(errorMsg.contains("Fail resource offers for barrier stage"))
   }
-<<<<<<< HEAD
 
   test("SPARK-34069: Kill barrier tasks should respect SPARK_JOB_INTERRUPT_ON_CANCEL") {
     sc = new SparkContext(new SparkConf().setAppName("test").setMaster("local[2]"))
@@ -342,6 +336,4 @@ class BarrierTaskContextSuite extends SparkFunSuite with LocalSparkContext with 
     // double check we kill task success
     assert(System.currentTimeMillis() - startTime < 5000)
   }
-=======
->>>>>>> add back SPARK-31485 for legacy delay scheduling
 }

--- a/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BarrierTaskContextSuite.scala
@@ -38,7 +38,6 @@ class BarrierTaskContextSuite extends SparkFunSuite with LocalSparkContext with 
       .setMaster(s"local-cluster[$numWorker, 1, 1024]")
       .setAppName("test-cluster")
       .set(TEST_NO_STAGE_RETRY, true)
-      .set(LEGACY_LOCALITY_WAIT_RESET, true)
     sc = new SparkContext(conf)
     TestUtils.waitUntilExecutorsUp(sc, numWorker, 60000)
   }

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -223,8 +223,9 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     assert(!failedTaskSet)
   }
 
-  private def setupTaskSchedulerForLocalityTests(clock: ManualClock): TaskSchedulerImpl = {
-    val conf = new SparkConf()
+  private def setupTaskSchedulerForLocalityTests(
+      clock: ManualClock,
+      conf: SparkConf = new SparkConf()): TaskSchedulerImpl = {
     sc = new SparkContext("local", "TaskSchedulerImplSuite", conf)
     val taskScheduler = new TaskSchedulerImpl(sc,
       sc.conf.get(config.TASK_MAX_FAILURES),
@@ -1921,7 +1922,8 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
 
   test("SPARK-24818: test delay scheduling for barrier TaskSetManager") {
     val clock = new ManualClock()
-    val sched = setupTaskSchedulerForLocalityTests(clock)
+    val conf = new SparkConf().set(config.LEGACY_LOCALITY_WAIT_RESET, false)
+    val sched = setupTaskSchedulerForLocalityTests(clock, conf)
 
     // Call resourceOffers() first, so executor-0 can be used
     // to calculate the locality levels of the TaskSetManager later
@@ -1948,7 +1950,8 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
 
   test("SPARK-24818: test resource revert of barrier TaskSetManager") {
     val clock = new ManualClock()
-    val sched = setupTaskSchedulerForLocalityTests(clock)
+    val conf = new SparkConf().set(config.LEGACY_LOCALITY_WAIT_RESET, false)
+    val sched = setupTaskSchedulerForLocalityTests(clock, conf)
 
     // Call resourceOffers() first, so executors can be used
     // to calculate the locality levels of the TaskSetManager later

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -1919,6 +1919,79 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     assert(manager.copiesRunning.take(2) === Array(1, 1))
   }
 
+  test("test delay scheduling for barrier TaskSetManager") {
+    val clock = new ManualClock()
+    val sched = setupTaskSchedulerForLocalityTests(clock)
+
+    // Call resourceOffers() first, so executor-0 can be used
+    // to calculate the locality levels of the TaskSetManager later
+    sched.resourceOffers(Seq(WorkerOffer("executor-0", "host1", 1, Some("host1"))).toIndexedSeq)
+
+    val prefLocs = Seq(TaskLocation("host1", "executor-0"))
+    val barrierTaskSet = FakeTask.createBarrierTaskSet(1, prefLocs)
+    sched.submitTasks(barrierTaskSet)
+
+    val tsm = sched.taskSetManagerForAttempt(0, 0).get
+    assert(tsm.myLocalityLevels ===
+      Array(TaskLocality.PROCESS_LOCAL, TaskLocality.NODE_LOCAL, TaskLocality.ANY))
+    val offers = Seq(WorkerOffer("executor-1", "host1", 1, Some("host1"))).toIndexedSeq
+    var tasks = sched.resourceOffers(offers).flatten
+    // The TaskSetManager prefers executor-0 for the PROCESS_LOCAL location but there's no
+    // available offer of executor-0 in this round, so task scheduling will be delayed first.
+    assert(tasks.length === 0)
+    // Advance the clock so the TaskSetManager can move to next locality level(NODE_LOCAL)
+    clock.advance(4000)
+    tasks = sched.resourceOffers(offers).flatten
+    assert(tasks.length === 1)
+    assert(tsm.taskInfos(tasks.head.taskId).taskLocality === TaskLocality.NODE_LOCAL)
+  }
+
+  test("test resource revert of barrier TaskSetManager") {
+    val clock = new ManualClock()
+    val sched = setupTaskSchedulerForLocalityTests(clock)
+
+    // Call resourceOffers() first, so executors can be used
+    // to calculate the locality levels of the TaskSetManager later
+    sched.resourceOffers(Seq(WorkerOffer("executor-0", "host1", 1, Some("host1"))).toIndexedSeq)
+
+    val barrierTaskSet =
+      FakeTask.createBarrierTaskSet(2, 0, 0, 0, 0,
+        Seq(TaskLocation("host1", "executor-0")), Seq(TaskLocation("host1", "executor-1")))
+    val normalTaskSet = FakeTask.createTaskSet(2, 1, 0, 0, 0)
+
+    // Submit barrier task set first, so we can schedule it before the normal task set in order to
+    // test the resource revert behaviour of the barrier TaskSetManager
+    sched.submitTasks(barrierTaskSet)
+    sched.submitTasks(normalTaskSet)
+
+    val barrierTSM = sched.taskSetManagerForAttempt(0, 0).get
+    val normalTSM = sched.taskSetManagerForAttempt(1, 0).get
+    assert(barrierTSM.myLocalityLevels ===
+      Array(TaskLocality.PROCESS_LOCAL, TaskLocality.NODE_LOCAL, TaskLocality.ANY))
+    assert(normalTSM.myLocalityLevels ===  Array(TaskLocality.NO_PREF, TaskLocality.ANY))
+
+    // The barrier TaskSetManager can not launch all tasks because of delay scheduling.
+    // So it will revert assigned resources and let the normal TaskSetManager to schedule first.
+    var tasks = sched.resourceOffers(
+      Seq(WorkerOffer("executor-0", "host1", 1, Some("host1")),
+        WorkerOffer("executor-2", "host1", 1, Some("host1"))).toIndexedSeq).flatten
+    assert(tasks.length === 2)
+    var taskId = tasks.head.taskId
+    assert(!barrierTSM.runningTasksSet.contains(taskId))
+    assert(normalTSM.runningTasksSet.contains(taskId))
+
+    // Advance the clock so the TaskSetManager can move to next locality level(NODE_LOCAL)
+    // and launch all tasks.
+    clock.advance(4000)
+    tasks = sched.resourceOffers(
+      Seq(WorkerOffer("executor-0", "host1", 1, Some("host1")),
+        WorkerOffer("executor-2", "host1", 1, Some("host1"))).toIndexedSeq).flatten
+    assert(tasks.length === 2)
+    taskId = tasks.head.taskId
+    assert(barrierTSM.runningTasksSet.contains(taskId))
+    assert(!normalTSM.runningTasksSet.contains(taskId))
+  }
+
   /**
    * Used by tests to simulate a task failure. This calls the failure handler explicitly, to ensure
    * that all the state is updated when this method returns. Otherwise, there's no way to know when

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -1919,7 +1919,7 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     assert(manager.copiesRunning.take(2) === Array(1, 1))
   }
 
-  test("test delay scheduling for barrier TaskSetManager") {
+  test("SPARK-24818: test delay scheduling for barrier TaskSetManager") {
     val clock = new ManualClock()
     val sched = setupTaskSchedulerForLocalityTests(clock)
 
@@ -1946,7 +1946,7 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
     assert(tsm.taskInfos(tasks.head.taskId).taskLocality === TaskLocality.NODE_LOCAL)
   }
 
-  test("test resource revert of barrier TaskSetManager") {
+  test("SPARK-24818: test resource revert of barrier TaskSetManager") {
     val clock = new ManualClock()
     val sched = setupTaskSchedulerForLocalityTests(clock)
 

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -377,7 +377,7 @@ class TaskSetManagerSuite
 
     // offers not accepted due to task set zombies are not delay schedule rejects
     manager.isZombie = true
-    val (taskDescription, delayReject) = manager.resourceOffer("exec2", "host2", ANY)
+    val (taskDescription, delayReject, _) = manager.resourceOffer("exec2", "host2", ANY)
     assert(taskDescription.isEmpty)
     assert(delayReject === false)
     manager.isZombie = false
@@ -387,7 +387,7 @@ class TaskSetManagerSuite
     val excludelist = mock(classOf[TaskSetExcludelist])
     when(tsmSpy.taskSetExcludelistHelperOpt).thenReturn(Some(excludelist))
     when(excludelist.isNodeExcludedForTaskSet(any())).thenReturn(true)
-    val (task, taskReject) = tsmSpy.resourceOffer("exec2", "host2", ANY)
+    val (task, taskReject, _) = tsmSpy.resourceOffer("exec2", "host2", ANY)
     assert(task.isEmpty)
     assert(taskReject === false)
 
@@ -395,7 +395,7 @@ class TaskSetManagerSuite
     assert(manager.resourceOffer("exec2", "host2", ANY)._1.get.index === 3)
 
     // offers not accepted due to no pending tasks are not delay schedule rejects
-    val (noPendingTask, noPendingReject) = manager.resourceOffer("exec2", "host2", ANY)
+    val (noPendingTask, noPendingReject, _) = manager.resourceOffer("exec2", "host2", ANY)
     assert(noPendingTask.isEmpty)
     assert(noPendingReject === false)
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR tries to support the (non-legacy) delay scheduling for the barrier execution. 

The idea is, adding a pending launch tasks list(`barrierPendingLaunchTasks`) in the barrier `TaskSetManager`. And we don't really add those pending launch tasks to the running list and post task start event to the listeners and so on until all tasks in the barrier `TaskSetManager` has been added to `barrierPendingLaunchTasks` after a single round `resourceOffers()`. If there're only partial tasks that are able to launch after a single `rousourceOffers()` round, we'll revert all the assigned resources to those tasks which were added in `barrierPendingLaunchTasks` and clear `barrierPendingLaunchTasks` and wait for the next `resourceOffers()` round. The barrier `TaskSetManager` should be launched finally since we've ensured enough slots before the scheduling.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Currently, with delay scheduling enabled for the barrier execution, the application can abort immediately when there're only partial tasks can be launched. This is really bad, especially when the application already completed many stages before the barrier stage. For example, the application may do some ETL jobs before the barrier job(for ML).

After this PR, this scenario  should no longer happen.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, users will no longer face the `Fail resource offers for barrier stage...` error.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Added/updated unit tests.
