### PR TITLE
[SPARK-33480][SQL][FOLLOWUP] do not expose user data in error message

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/CharVarcharUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/CharVarcharUtils.scala
@@ -183,9 +183,9 @@ object CharVarcharUtils extends Logging {
 
   private def raiseError(expr: Expression, typeName: String, length: Int): Expression = {
     val errorMsg = Concat(Seq(
-      Literal("input string '"),
-      expr,
-      Literal(s"' exceeds $typeName type length limitation: $length")))
+      Literal("input string of length "),
+      Cast(Length(expr), StringType),
+      Literal(s" exceeds $typeName type length limitation: $length")))
     Cast(RaiseError(errorMsg), StringType)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -190,7 +190,7 @@ trait CharVarcharTestSuite extends QueryTest with SQLTestUtils {
       checkAnswer(spark.table("t"), Row(null))
       val e = intercept[SparkException](sql("INSERT INTO t VALUES ('123456')"))
       assert(e.getCause.getMessage.contains(
-        s"input string '123456' exceeds $typeName type length limitation: 5"))
+        s"input string of length 6 exceeds $typeName type length limitation: 5"))
     }
   }
 
@@ -203,7 +203,7 @@ trait CharVarcharTestSuite extends QueryTest with SQLTestUtils {
         checkAnswer(spark.table("t"), Row(1, null))
         val e = intercept[SparkException](sql("INSERT INTO t VALUES (1, '123456')"))
         assert(e.getCause.getMessage.contains(
-          s"input string '123456' exceeds $typeName type length limitation: 5"))
+          s"input string of length 6 exceeds $typeName type length limitation: 5"))
       }
     }
   }
@@ -215,7 +215,7 @@ trait CharVarcharTestSuite extends QueryTest with SQLTestUtils {
       checkAnswer(spark.table("t"), Row(Row(null)))
       val e = intercept[SparkException](sql("INSERT INTO t SELECT struct('123456')"))
       assert(e.getCause.getMessage.contains(
-        s"input string '123456' exceeds $typeName type length limitation: 5"))
+        s"input string of length 6 exceeds $typeName type length limitation: 5"))
     }
   }
 
@@ -226,7 +226,7 @@ trait CharVarcharTestSuite extends QueryTest with SQLTestUtils {
       checkAnswer(spark.table("t"), Row(Seq(null)))
       val e = intercept[SparkException](sql("INSERT INTO t VALUES (array('a', '123456'))"))
       assert(e.getCause.getMessage.contains(
-        s"input string '123456' exceeds $typeName type length limitation: 5"))
+        s"input string of length 6 exceeds $typeName type length limitation: 5"))
     }
   }
 
@@ -235,7 +235,7 @@ trait CharVarcharTestSuite extends QueryTest with SQLTestUtils {
       sql(s"CREATE TABLE t(c MAP<$typeName(5), STRING>) USING $format")
       val e = intercept[SparkException](sql("INSERT INTO t VALUES (map('123456', 'a'))"))
       assert(e.getCause.getMessage.contains(
-        s"input string '123456' exceeds $typeName type length limitation: 5"))
+        s"input string of length 6 exceeds $typeName type length limitation: 5"))
     }
   }
 
@@ -246,7 +246,7 @@ trait CharVarcharTestSuite extends QueryTest with SQLTestUtils {
       checkAnswer(spark.table("t"), Row(Map("a" -> null)))
       val e = intercept[SparkException](sql("INSERT INTO t VALUES (map('a', '123456'))"))
       assert(e.getCause.getMessage.contains(
-        s"input string '123456' exceeds $typeName type length limitation: 5"))
+        s"input string of length 6 exceeds $typeName type length limitation: 5"))
     }
   }
 
@@ -255,10 +255,10 @@ trait CharVarcharTestSuite extends QueryTest with SQLTestUtils {
       sql(s"CREATE TABLE t(c MAP<$typeName(5), $typeName(5)>) USING $format")
       val e1 = intercept[SparkException](sql("INSERT INTO t VALUES (map('123456', 'a'))"))
       assert(e1.getCause.getMessage.contains(
-        s"input string '123456' exceeds $typeName type length limitation: 5"))
+        s"input string of length 6 exceeds $typeName type length limitation: 5"))
       val e2 = intercept[SparkException](sql("INSERT INTO t VALUES (map('a', '123456'))"))
       assert(e2.getCause.getMessage.contains(
-        s"input string '123456' exceeds $typeName type length limitation: 5"))
+        s"input string of length 6 exceeds $typeName type length limitation: 5"))
     }
   }
 
@@ -269,7 +269,7 @@ trait CharVarcharTestSuite extends QueryTest with SQLTestUtils {
       checkAnswer(spark.table("t"), Row(Row(Seq(null))))
       val e = intercept[SparkException](sql("INSERT INTO t SELECT struct(array('123456'))"))
       assert(e.getCause.getMessage.contains(
-        s"input string '123456' exceeds $typeName type length limitation: 5"))
+        s"input string of length 6 exceeds $typeName type length limitation: 5"))
     }
   }
 
@@ -280,7 +280,7 @@ trait CharVarcharTestSuite extends QueryTest with SQLTestUtils {
       checkAnswer(spark.table("t"), Row(Seq(Row(null))))
       val e = intercept[SparkException](sql("INSERT INTO t VALUES (array(struct('123456')))"))
       assert(e.getCause.getMessage.contains(
-        s"input string '123456' exceeds $typeName type length limitation: 5"))
+        s"input string of length 6 exceeds $typeName type length limitation: 5"))
     }
   }
 
@@ -291,7 +291,7 @@ trait CharVarcharTestSuite extends QueryTest with SQLTestUtils {
       checkAnswer(spark.table("t"), Row(Seq(Seq(null))))
       val e = intercept[SparkException](sql("INSERT INTO t VALUES (array(array('123456')))"))
       assert(e.getCause.getMessage.contains(
-        s"input string '123456' exceeds $typeName type length limitation: 5"))
+        s"input string of length 6 exceeds $typeName type length limitation: 5"))
     }
   }
 
@@ -313,10 +313,10 @@ trait CharVarcharTestSuite extends QueryTest with SQLTestUtils {
       checkAnswer(spark.table("t"), Row("1234 ", "1234"))
       val e1 = intercept[SparkException](sql("INSERT INTO t VALUES (123456, 1)"))
       assert(e1.getCause.getMessage.contains(
-        "input string '123456' exceeds char type length limitation: 5"))
+        "input string of length 6 exceeds char type length limitation: 5"))
       val e2 = intercept[SparkException](sql("INSERT INTO t VALUES (1, 123456)"))
       assert(e2.getCause.getMessage.contains(
-        "input string '123456' exceeds varchar type length limitation: 5"))
+        "input string of length 6 exceeds varchar type length limitation: 5"))
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This is a followup of https://github.com/apache/spark/pull/30412. This PR updates the error message of char/varchar table insertion length check, to not expose user data.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This is risky to expose user data in the error message, especially the string data, as it may contain sensitive data.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
updated tests