### PR TITLE
Update ExternalShuffleBlockResolver.java

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
@@ -120,7 +120,7 @@ public class ExternalShuffleBlockResolver {
       .maximumWeight(JavaUtils.byteStringAsBytes(indexCacheSize))
       .weigher(new Weigher<File, ShuffleIndexInformation>() {
         public int weigh(File file, ShuffleIndexInformation indexInfo) {
-          return indexInfo.getSize();
+          return file.getAbsolutePath().length() + indexInfo.getSize();
         }
       })
       .build(indexCacheLoader);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Guava cache capacity limit join key size statistics

### Why are the changes needed?
When using guava cache, the key size is not counted, resulting in memory overflow. If the value is infinitely small, then the heap memory can store countless File type keys. I think this is a defect

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
No

![Cache OutOfMemory](https://upload-images.jianshu.io/upload_images/18249296-ed0cfee76b6f6bf2.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240)
![Many Paths](https://upload-images.jianshu.io/upload_images/18249296-f85e27a501605260.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240)

[ISSUE SPARK-33710](https://issues.apache.org/jira/browse/SPARK-33710)
[YARN GC ALARM](https://www.jianshu.com/writer#/notebooks/37701793/notes/80461429/preview)