### PR TITLE
[SPARK-33675][INFRA][FOLLOWUP] Schedule branch-3.1 snapshot at master branch

### DIFF
--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -7,9 +7,17 @@ on:
 jobs:
   publish-snapshot:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        branch:
+          - master
+          - branch-3.1
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@master
+      with:
+        ref: ${{ matrix.branch }}
     - name: Cache Maven local repository
       uses: actions/cache@v2
       with:
@@ -27,4 +35,5 @@ jobs:
         ASF_PASSWORD: ${{ secrets.NEXUS_PW }}
         GPG_KEY: "not_used"
         GPG_PASSPHRASE: "not_used"
+        GIT_REF: ${{ matrix.branch }}
       run: ./dev/create-release/release-build.sh publish-snapshot


### PR DESCRIPTION
### What changes were proposed in this pull request?

Currently, `master`/`branch-3.0`/`branch-2.4` snapshot publishing is successfully migrated from Jenkins to `GitHub Action`.

- https://github.com/apache/spark/actions?query=workflow%3A%22Publish+Snapshot%22

This PR aims to schedule `branch-3.1` snapshot at `master` branch. 

### Why are the changes needed?

This is because it turns out that `GitHub Action Schedule` works only at `master` branch. (the default branch).
- https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#scheduled-events

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The matrix triggering is tested at the forked branch.
- https://github.com/dongjoon-hyun/spark/runs/1519015974