### PR TITLE
[MINOR][SQL] Spelling: binaries - readBinarys

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReader.java
@@ -615,7 +615,7 @@ public class VectorizedColumnReader {
     VectorizedValuesReader data = (VectorizedValuesReader) dataColumn;
     if (column.dataType() == DataTypes.StringType || column.dataType() == DataTypes.BinaryType
             || DecimalType.isByteArrayDecimalType(column.dataType())) {
-      defColumn.readBinarys(num, column, rowId, maxDefLevel, data);
+      defColumn.readBinaries(num, column, rowId, maxDefLevel, data);
     } else if (column.dataType() == DataTypes.TimestampType) {
       final boolean failIfRebase = "EXCEPTION".equals(int96RebaseMode);
       if (!shouldConvertTimestamps()) {

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReader.java
@@ -486,7 +486,7 @@ public final class VectorizedRleValuesReader extends ValuesReader
     }
   }
 
-  public void readBinarys(
+  public void readBinaries(
       int total,
       WritableColumnVector c,
       int rowId,


### PR DESCRIPTION
### What changes were proposed in this pull request?
Replacing `readBinarys` with `readBinaries`

### Why are the changes needed?
per @srowen https://github.com/apache/spark/pull/30323#discussion_r521458926

### Does this PR introduce _any_ user-facing change?
I suspect this is technically a public API. GitHub doesn't appear to show any instances beyond copies of the source code.

### How was this patch tested?
This was covered by CI at one point.