### PR TITLE
[Spark-33657][SQL]After spark sql is executed to generate hdfs data, the relevant status information is printed

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -817,6 +817,18 @@ package object config {
       .booleanConf
       .createWithDefault(false)
 
+  private[spark] val FILE_INSERT_STATUS_LOG_FLAG =
+    ConfigBuilder("spark.file.insert.status.log.flag")
+      .internal()
+      .doc("When hive sql executes to generate HDFS data, " +
+        "it will print status information, which is more friendly to user interaction. " +
+        "Spark sql is compatible with this. If the configuration is true, " +
+        "related status information will also be printed. " +
+        "If it is false, it will not print.")
+      .booleanConf
+      .createWithDefault(true);
+
+
   private[spark] val UNREGISTER_OUTPUT_ON_HOST_ON_FETCH_FAILURE =
     ConfigBuilder("spark.files.fetchFailure.unRegisterOutputOnHost")
       .doc("Whether to un-register all the outputs on the host in condition that we receive " +


### PR DESCRIPTION
### What changes were proposed in this pull request?

The main modification of this pull request is the write method of FileFormatWriter. This method prints out the relevant information of generating hdfs. Through configuration, you can flexibly determine whether you need to play.



### Why are the changes needed?

Such changes can help users or produce detailed information about HDFS.
This change is very user friendly

### Does this PR introduce _any_ user-facing change?

For the user, this change user does not need to make any changes.



### How was this patch tested?

**Results before modification**

[guihuawen@bigdata-nmg-client01.nmg01 ~/sparkdir/test_client]$ spark-sql -e "insert overwrite table bigdata_qa.external_table_hive partition (par_dt = '20201010') select consume_stability, consume_stability from bigdata_qa.travel_feature_hive limit 20;" 
 
Application Id: application_1606795588298_74026, Tracking URL: http://xxxx.xxxx.xxxx:8088/proxy/application_1606795588298_74026/
DriverContainer URL:  http://xxxx.xxxx.xxxx:8042/node/containerlogs/container_e15_1606795588298_74026_01_000001/prod_bigdata_qa

**Modified result**

[guihuawen@bigdata-nmg-client01.nmg01 ~/sparkdir/test_client]$ spark-sql -e "insert overwrite table bigdata_qa.external_table_hive partition (par_dt = '20201010') select consume_stability, consume_stability from bigdata_qa.travel_feature_hive limit 20;" 
 
 
Application Id: application_1606795588298_74026, Tracking URL: http://xxxx.xxxx.xxxx:8088/proxy/application_1606795588298_74026/
DriverContainer URL:  http://xxxx.xxxx.xxxx:8042/node/containerlogs/container_e15_1606795588298_74026_01_000001/prod_bigdata_qa
File stats [ numFiles=1; numOutputBytes=738; numOutputRows=20; numParts=0 
