### PR TITLE
[SPARK-33721][SQL] Support to use Hive build-in functions by configuration

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2973,6 +2973,24 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val USE_HIVE_BUILD_IN_FUNCTIONS_ENABLED =
+    buildConf("spark.sql.hive.buildin.functions.enabled")
+    .internal()
+    .doc("When true, Spark will register hive build-in functions like unix_timestamp,to_date," +
+      " datediff,collect_set instead of self build-in functions.")
+    .booleanConf
+    .createWithDefault(false)
+
+  val HIVE_BUILD_IN_FUNCTIONS_LIST =
+    buildConf("spark.sql.hive.buildin.functions.list")
+    .internal()
+    .doc("Configures a list of hive build-in functions, here is an example for the format: " +
+      " org.apache.hadoop.hive.ql.udf.generic.GenericUDFUnixTimeStamp:unix_timestamp;" +
+      " org.apache.hadoop.hive.ql.udf.generic.GenericUDFDate:to_date. This configuration only " +
+      s" has an effect when '${USE_HIVE_BUILD_IN_FUNCTIONS_ENABLED.key}' is set to true.")
+    .stringConf
+    .createWithDefault("")
+
   /**
    * Holds information about keys that have been deprecated.
    *
@@ -3626,6 +3644,10 @@ class SQLConf extends Serializable with Logging {
   def disabledJdbcConnectionProviders: String = getConf(SQLConf.DISABLED_JDBC_CONN_PROVIDER_LIST)
 
   def charVarcharAsString: Boolean = getConf(SQLConf.LEGACY_CHAR_VARCHAR_AS_STRING)
+
+  def useHiveBuildInFunctionsEnabled: Boolean = getConf(SQLConf.USE_HIVE_BUILD_IN_FUNCTIONS_ENABLED)
+
+  def hiveBuildINFunctionsList: String = getConf(SQLConf.HIVE_BUILD_IN_FUNCTIONS_LIST)
 
   /** ********************** SQLConf functionality methods ************ */
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
Hive and Spark SQL engines have many differences in built-in functions.The differences between several functions are shown below：

build-in functions | SQL | result of Hive SQL | result of Spark SQL
-- | -- | -- | --
unix_timestamp | select unix_timestamp(concat('2020-06-01',  ' 24:00:00')); | 1591027200 | NULL
to_date | select to_date('0000-00-00'); | 0002-11-30 | NULL
datediff | select datediff(CURRENT_DATE, '0000-00-00'); | 737986 | NULL
collect_set | selectc1,c2,concat_ws('##', collect_set(c3)) c3_set from bigdata_offline.test_collect_set group by c1, c2; bigdata_offline.test_collect_set contains data:(1, 1, '1')，(1, 1, '2'),(1, 1, '3'),(1, 1, '4'),(1, 1, '5') | c1  c2  c3_set1   1   2##3##4##5##1 | c1  c2      c3_set1   1   3##1##2##5##4

Notice: Hive version is 1.2.1

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
There is no conclusion on which engine is more accurate. Users prefer to be able to make choices according to their real production environment.

I think we should do some improvement for this.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
manual