### PR TITLE
[SPARK-33707][SQL] Support multiple types of function partition pruning on hive metastore

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -832,6 +832,14 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val HIVE_METASTORE_PREDICATE_CONCAT_FILTER =
+    buildConf("spark.sql.hive.metastore.concat.PartitionPruning")
+      .doc("When true, some predicates of which contains concat or concat_ws can be filter " +
+        "throught hive metstore's getPartitionsByExpr function,thereby reducing the pressure " +
+        "of metastore's sql query ")
+      .booleanConf
+      .createWithDefault(false)
+
   val HIVE_METASTORE_PARTITION_PRUNING_INSET_THRESHOLD =
     buildConf("spark.sql.hive.metastorePartitionPruningInSetThreshold")
       .doc("The threshold of set size for InSet predicate when pruning partitions through Hive " +
@@ -3231,6 +3239,8 @@ class SQLConf extends Serializable with Logging {
   def verifyPartitionPath: Boolean = getConf(HIVE_VERIFY_PARTITION_PATH)
 
   def metastorePartitionPruning: Boolean = getConf(HIVE_METASTORE_PARTITION_PRUNING)
+
+  def metastorePredicateConcatFilter: Boolean = getConf(HIVE_METASTORE_PREDICATE_CONCAT_FILTER)
 
   def metastorePartitionPruningInSetThreshold: Int =
     getConf(HIVE_METASTORE_PARTITION_PRUNING_INSET_THRESHOLD)


### PR DESCRIPTION
### What changes were proposed in this pull request?
For the current version, partition pruning support is limited to the scene.

Let's look at the implementation of the source code:
https://github.com/apache/spark/blob/031c5ef280e0cba8c4718a6457a44b6cccb17f46/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala#L840

Hive getPartitionsByFilter() takes a string that represents partition predicates like "str_key=\"value\" and int_key=1 ...", but for normal functions like concat/concat_ws/substr,it  does not support.

This PR  supports  `concat/concat_ws`  to prune partitions, and  this framework is extensible，I'll add more  functions like `substring` and combinations of different functions.

### Why are the changes needed?
The defect can cause a large number of partitions to be scanned which will increase the amount of data involved in the calculation and increase the pressure of service of metastore.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
manual
