### PR TITLE
[SPARK-33741][CORE] Add min threshold time speculation config

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1889,6 +1889,12 @@ package object config {
       .doubleConf
       .createWithDefault(0.75)
 
+  private[spark] val SPECULATION_MIN_THRESHOLD =
+    ConfigBuilder("spark.speculation.min.threshold")
+      .version("3.2.0")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefault(100)
+
   private[spark] val SPECULATION_TASK_DURATION_THRESHOLD =
     ConfigBuilder("spark.speculation.task.duration.threshold")
       .doc("Task duration after which scheduler would try to speculative run the task. If " +

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1892,6 +1892,7 @@ package object config {
   private[spark] val SPECULATION_MIN_THRESHOLD =
     ConfigBuilder("spark.speculation.min.threshold")
       .version("3.2.0")
+      .doc("Minimum amount of time a task runs before being considered for speculation.s")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefault(100)
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1891,8 +1891,8 @@ package object config {
 
   private[spark] val SPECULATION_MIN_THRESHOLD =
     ConfigBuilder("spark.speculation.min.threshold")
+      .doc("Minimum amount of time a task runs before being considered for speculation.")
       .version("3.2.0")
-      .doc("Minimum amount of time a task runs before being considered for speculation.s")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefault(100)
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1891,7 +1891,8 @@ package object config {
 
   private[spark] val SPECULATION_MIN_THRESHOLD =
     ConfigBuilder("spark.speculation.min.threshold")
-      .doc("Minimum amount of time a task runs before being considered for speculation.")
+      .doc("Minimum amount of time a task runs before being considered for speculation. " +
+        "This can be used to avoid launching speculative copies of tasks that are very short.")
       .version("3.2.0")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefault(100)

--- a/core/src/main/scala/org/apache/spark/scheduler/Pool.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Pool.scala
@@ -94,7 +94,7 @@ private[spark] class Pool(
     schedulableQueue.asScala.foreach(_.executorDecommission(executorId))
   }
 
-  override def checkSpeculatableTasks(minTimeToSpeculation: Int): Boolean = {
+  override def checkSpeculatableTasks(minTimeToSpeculation: Long): Boolean = {
     var shouldRevive = false
     for (schedulable <- schedulableQueue.asScala) {
       shouldRevive |= schedulable.checkSpeculatableTasks(minTimeToSpeculation)

--- a/core/src/main/scala/org/apache/spark/scheduler/Schedulable.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Schedulable.scala
@@ -45,6 +45,6 @@ private[spark] trait Schedulable {
   def getSchedulableByName(name: String): Schedulable
   def executorLost(executorId: String, host: String, reason: ExecutorLossReason): Unit
   def executorDecommission(executorId: String): Unit
-  def checkSpeculatableTasks(minTimeToSpeculation: Int): Boolean
+  def checkSpeculatableTasks(minTimeToSpeculation: Long): Boolean
   def getSortedTaskSetQueue: ArrayBuffer[TaskSetManager]
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -100,7 +100,7 @@ private[spark] class TaskSchedulerImpl(
   // Duplicate copies of a task will only be launched if the original copy has been running for
   // at least this amount of time. This is to avoid the overhead of launching speculative copies
   // of tasks that are very short.
-  val MIN_TIME_TO_SPECULATION = conf.getTimeAsMs("spark.speculation.min.threshold", "100ms")
+  val MIN_TIME_TO_SPECULATION = conf.get(SPECULATION_MIN_THRESHOLD)
 
   private val speculationScheduler =
     ThreadUtils.newDaemonSingleThreadScheduledExecutor("task-scheduler-speculation")

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -100,7 +100,7 @@ private[spark] class TaskSchedulerImpl(
   // Duplicate copies of a task will only be launched if the original copy has been running for
   // at least this amount of time. This is to avoid the overhead of launching speculative copies
   // of tasks that are very short.
-  val MIN_TIME_TO_SPECULATION = 100
+  val MIN_TIME_TO_SPECULATION = conf.getTimeAsMs("spark.speculation.min.threshold", "100ms")
 
   private val speculationScheduler =
     ThreadUtils.newDaemonSingleThreadScheduledExecutor("task-scheduler-speculation")

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -1035,7 +1035,7 @@ private[spark] class TaskSetManager(
    * by the TaskScheduler.
    *
    */
-  override def checkSpeculatableTasks(minTimeToSpeculation: Int): Boolean = {
+  override def checkSpeculatableTasks(minTimeToSpeculation: Long): Boolean = {
     // No need to speculate if the task set is zombie or is from a barrier stage. If there is only
     // one task we don't speculate since we don't have metrics to decide whether it's taking too
     // long or not, unless a task duration threshold is explicitly provided.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2314,6 +2314,7 @@ Apart from these, the following properties are also available, and may be useful
   <td>100ms</td>
   <td>
     Minimum amount of time a task runs before being considered for speculation.
+    This can be used to avoid launching speculative copies of tasks that are very short.
   </td>
   <td>3.2.0</td>
 </tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2310,6 +2310,16 @@ Apart from these, the following properties are also available, and may be useful
   <td>0.6.0</td>
 </tr>
 <tr>
+  <td><code>spark.speculation.min.threshold</code></td>
+  <td>100ms</td>
+  <td>
+    Duplicate copies of a task will only be launched if the original copy has been running for
+    at least this amount of time. This is to avoid the overhead of launching speculative copies
+    of tasks that are very short.
+  </td>
+  <td>3.2.0</td>
+</tr>
+<tr>
   <td><code>spark.speculation.task.duration.threshold</code></td>
   <td>None</td>
   <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2313,9 +2313,7 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.speculation.min.threshold</code></td>
   <td>100ms</td>
   <td>
-    Duplicate copies of a task will only be launched if the original copy has been running for
-    at least this amount of time. This is to avoid the overhead of launching speculative copies
-    of tasks that are very short.
+    Minimum amount of time a task runs before being considered for speculation.
   </td>
   <td>3.2.0</td>
 </tr>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add min threshold time speculation config

### Why are the changes needed?
When we turn on speculation with default configs we have the last 10% of the tasks subject to speculation. There are a lot of stages where the stage runs for few seconds to minutes. Also in general we don't want to speculate tasks that run within a minimum threshold. By setting a minimum threshold for speculation config gives us better control for speculative tasks


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit test