### PR TITLE
[SPARK-33747][CORE] Avoid calling unregisterMapOutput when the map stage is being rerunning.

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskScheduler.scala
@@ -125,4 +125,8 @@ private[spark] trait TaskScheduler {
    */
   def applicationAttemptId(): Option[String]
 
+  /**
+   * Returns the TaskSetManager corresponding to the given stage and attempt id.
+   */
+  def taskSetManagerForAttempt(stageId: Int, stageAttemptId: Int): Option[TaskSetManager]
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -1106,7 +1106,7 @@ private[spark] class TaskSchedulerImpl(
   override def applicationAttemptId(): Option[String] = backend.applicationAttemptId()
 
   // exposed for testing
-  private[scheduler] def taskSetManagerForAttempt(
+  override def taskSetManagerForAttempt(
       stageId: Int,
       stageAttemptId: Int): Option[TaskSetManager] = synchronized {
     for {

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -797,6 +797,10 @@ private[spark] class TaskSetManager(
     }
   }
 
+  private[scheduler] def hasPartitionId(partitionId: Int): Boolean = {
+    partitionToIndex.contains(partitionId)
+  }
+
   /**
    * Marks the task as failed, re-adds it to the list of pending tasks, and notifies the
    * DAG Scheduler.

--- a/core/src/test/scala/org/apache/spark/scheduler/ExternalClusterManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/ExternalClusterManagerSuite.scala
@@ -93,6 +93,8 @@ private class DummyTaskScheduler extends TaskScheduler {
   override def executorLost(executorId: String, reason: ExecutorLossReason): Unit = {}
   override def workerRemoved(workerId: String, host: String, message: String): Unit = {}
   override def applicationAttemptId(): Option[String] = None
+  override def taskSetManagerForAttempt(
+    stageId: Int, stageAttemptId: Int): Option[TaskSetManager] = None
   def executorHeartbeatReceived(
       execId: String,
       accumUpdates: Array[(Long, Seq[AccumulatorV2[_, _]])],


### PR DESCRIPTION
### What changes were proposed in this pull request?
 Avoid calling unregisterMapOutput when the map stage is being rerunning.

### Why are the changes needed?

When a fetch failure happened, DAGScheduler will try to unregister the corresponding map output. The current logic has a race condition that the new map stage attempt is running while the current reduce stage attempt returns another fetch failure (note: the current reduce stage firstly returns a fetch failure to make the maps stage is rerunning, and then the rerunning map stage may return some mapstatus of the failed MapId before the current reduce stage returns another fetch failure at the same MapId, the current reduce is last attempt due to the new map stage is not yet completed). In this case, if the map output is always unregistered, it may actually unregister the map output from the new map stage attempt.
### Does this PR introduce _any_ user-facing change?
No. It is a bug fix.

### How was this patch tested?
Add new uts
