### PR TITLE
[SPAKRK-33639][SQL]The external table does not specify a location

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1597,6 +1597,15 @@ object SQLConf {
        .doc("When true, use legacy MySqlServer SMALLINT and REAL type mapping.")
        .booleanConf
        .createWithDefault(false)
+
+  val CREATE_EXTERNAL_STATEMENT_LOCATION = buildConf("spark.sql.create.external.statement.location")
+    .doc("In is a statement about whether to specify location when creating an external table. " +
+      "If it is not declared, the default value is false. " +
+      "If you do not specify a location when creating an external table, you can create it successfully; " +
+      "if you declare it as true, you must specify a location when creating an external table.")
+    .booleanConf
+    .createWithDefault(false)
+
 }
 
 /**
@@ -2009,6 +2018,8 @@ class SQLConf extends Serializable with Logging {
 
   def legacyMsSqlServerNumericMappingEnabled: Boolean =
     getConf(LEGACY_MSSQLSERVER_NUMERIC_MAPPING_ENABLED)
+
+  def createExternalStatementLocation: Boolean = getConf(CREATE_EXTERNAL_STATEMENT_LOCATION)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -1149,7 +1149,7 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder(conf) {
       .getOrElse(CatalogStorageFormat.empty)
     val location = ctx.locationSpec.asScala.headOption.map(visitLocationSpec)
     // If we are creating an EXTERNAL table, then the LOCATION field is required
-    if (external && location.isEmpty) {
+    if (conf.createExternalStatementLocation && external && location.isEmpty) {
       operationNotAllowed("CREATE EXTERNAL TABLE must be accompanied by LOCATION", ctx)
     }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -250,7 +250,8 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     // specify location for managed table. And in [[CreateDataSourceTableAsSelectCommand]] we have
     // to create the table directory and write out data before we create this table, to avoid
     // exposing a partial written table.
-    val needDefaultTableLocation = tableDefinition.tableType == MANAGED &&
+    val needDefaultTableLocation = (tableDefinition.tableType == MANAGED
+      || tableDefinition.tableType == EXTERNAL) &&
       tableDefinition.storage.locationUri.isEmpty
 
     val tableLocation = if (needDefaultTableLocation) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

When creating an external table, if the external path is not declared, an error will be reported, so the sense of interaction is not very user-friendly. 
When creating an internal table, a path is initialized, which is the default path. 
If this path is also set to the path of the external table, user interaction will become more friendly.

### Why are the changes needed?

Increase the friendly experience of user interaction.


### Does this PR introduce any user-facing change?

The user does not need to make any modification. If the user does not want such a configuration to take effect, he can close this modification.

### How was this patch tested?

**State before modification：**

spark-sql> create external table if not exists `external_table_spark_2`(`last_update` STRING, `col_a` STRING)
         > PARTITIONED BY (`par_dt` STRING)
         > ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.orc.OrcSerde'
         > WITH SERDEPROPERTIES (
         >   'field.delim' = ',',
         >   'serialization.format' = ','
         > )
         > STORED AS
         >   INPUTFORMAT 'org.apache.hadoop.hive.ql.io.orc.OrcInputFormat'
         >   OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat'
         > ;
Error in query:
Operation not allowed: CREATE EXTERNAL TABLE must be accompanied by LOCATION(line 1, pos 0)

== SQL ==
create external table if not exists `external_table_spark_2`(`last_update` STRING, `col_a` STRING)
^^^
PARTITIONED BY (`par_dt` STRING)
ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.orc.OrcSerde'
WITH SERDEPROPERTIES (
  'field.delim' = ',',
  'serialization.format' = ','
)
STORED AS
  INPUTFORMAT 'org.apache.hadoop.hive.ql.io.orc.OrcInputFormat'
  OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat'

**Modified state：**

spark-sql> CREATE EXTERNAL TABLE `external_table_spark_10`(`last_update` STRING, `col_a` STRING)
         > PARTITIONED BY (`par_dt` STRING)
         > ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.orc.OrcSerde'
         > WITH SERDEPROPERTIES (
         >   'field.delim' = ',',
         >   'serialization.format' = ','
         > )
         > STORED AS
         >   INPUTFORMAT 'org.apache.hadoop.hive.ql.io.orc.OrcInputFormat'
         >   OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat';
20/11/02 11:26:59 DEBUG log: DDL: struct external_table_spark_10 { string last_update, string col_a}
Response code
Time taken: 1.024 seconds
spark-sql>

**After modification, the table creation statement will add the table creation path by default.**

spark-sql> show create table external_table_spark_10;
createtab_stmt
CREATE EXTERNAL TABLE `external_table_spark_10`(`last_update` STRING, `col_a` STRING)
PARTITIONED BY (`par_dt` STRING)
ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.orc.OrcSerde'
WITH SERDEPROPERTIES (
  'field.delim' = ',',
  'serialization.format' = ','
)
STORED AS
  INPUTFORMAT 'org.apache.hadoop.hive.ql.io.orc.OrcInputFormat'
  OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat'
LOCATION 'hdfs://xxxx/xxxx/xxxx/xxxx/xxxx/xxxx/external_table_spark_10'
TBLPROPERTIES (
  'transient_lastDdlTime' = '1604287619',
  'PART_LIMIT' = '10000',
  'LEVEL' = '0',
  'TTL' = '60'
)

**If you don't want this modification to take effect, you can set spark.sql.create.external.statement.location to true.**

spark.sql.create.external.statement.location=true

