### PR TITLE
SPARK-33691: Support partition filters in ALTER TABLE DROP PARTITION

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -120,8 +120,8 @@ statement
         partitionSpec+                                                 #addTablePartition
     | ALTER TABLE tableIdentifier
         from=partitionSpec RENAME TO to=partitionSpec                  #renameTablePartition
-    | ALTER TABLE tableIdentifier
-        DROP (IF EXISTS)? partitionSpec (',' partitionSpec)* PURGE?    #dropTablePartitions
+    | ALTER TABLE tableIdentifier DROP (IF EXISTS)?
+        dropPartitionSpec (',' dropPartitionSpec)* PURGE?              #dropTablePartitions
     | ALTER VIEW tableIdentifier
         DROP (IF EXISTS)? partitionSpec (',' partitionSpec)*           #dropTablePartitions
     | ALTER TABLE tableIdentifier partitionSpec? SET locationSpec      #setTableLocation
@@ -265,6 +265,22 @@ partitionSpec
 
 partitionVal
     : identifier (EQ constant)?
+    ;
+
+dropPartitionSpec
+    : PARTITION '(' dropPartitionVal (',' dropPartitionVal)* ')'
+    ;
+
+dropPartitionVal
+    : left=identifier dropPartitionOperator right=constant  #dropPartLExpr
+    | left=constant dropPartitionOperator right=identifier  #dropPartRExpr
+    ;
+
+/**
+ * we should not support NSEQ <=>
+ */
+dropPartitionOperator
+    : EQ  | NEQ | NEQJ | LT | LTE | GT | GTE
     ;
 
 describeFuncName

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1591,6 +1591,21 @@ object SQLConf {
        .doc("When true, use legacy MySqlServer SMALLINT and REAL type mapping.")
        .booleanConf
        .createWithDefault(false)
+
+  val BATCH_DROP_PARTITIONS_ENABLE =
+    buildConf("spark.sql.batch.drop.partitions.enable")
+      .internal()
+      .doc("Whether support partition filter in ALTER TABLE DROP PARTITION.")
+      .booleanConf
+      .createWithDefault(false)
+
+  val BATCH_DROP_PARTITIONS_LIMIT =
+    buildConf("spark.sql.batch.drop.partitions.limit")
+      .internal()
+      .doc("The max partition's number which is allowed to be deleted.")
+      .intConf
+      .checkValue(bit => bit >= -1 && bit <= 1000, "The bit value must be in [-1, 1000].")
+      .createWithDefault(1000)
 }
 
 /**
@@ -2003,6 +2018,10 @@ class SQLConf extends Serializable with Logging {
 
   def legacyMsSqlServerNumericMappingEnabled: Boolean =
     getConf(LEGACY_MSSQLSERVER_NUMERIC_MAPPING_ENABLED)
+
+  def batchDropPartitionsEnable: Boolean = getConf(SQLConf.BATCH_DROP_PARTITIONS_ENABLE)
+
+  def batchDropPartitionsLimit: Int = getConf(SQLConf.BATCH_DROP_PARTITIONS_LIMIT)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -927,7 +927,8 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder(conf) {
     }
     AlterTableDropPartitionCommand(
       visitTableIdentifier(ctx.tableIdentifier),
-      ctx.partitionSpec.asScala.map(visitNonOptionalPartitionSpec),
+      ctx.dropPartitionSpec().asScala.map(visitDropPartitionSpec),
+      Seq(),
       ifExists = ctx.EXISTS != null,
       purge = ctx.PURGE != null,
       retainData = false)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
@@ -147,7 +147,7 @@ case class InsertIntoHadoopFsRelationCommand(
             val deletedPartitions = initialMatchingPartitions.toSet -- updatedPartitions
             if (deletedPartitions.nonEmpty) {
               AlterTableDropPartitionCommand(
-                catalogTable.get.identifier, deletedPartitions.toSeq,
+                catalogTable.get.identifier, Seq(), deletedPartitions.toSeq,
                 ifExists = true, purge = false,
                 retainData = true /* already deleted */).run(sparkSession)
             }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
@@ -863,6 +863,7 @@ class DDLParserSuite extends PlanTest with SharedSQLContext {
     val tableIdent = TableIdentifier("table_name", None)
     val expected1_table = AlterTableDropPartitionCommand(
       tableIdent,
+      Seq(),
       Seq(
         Map("dt" -> "2008-08-08", "country" -> "us"),
         Map("dt" -> "2009-09-09", "country" -> "uk")),

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDropPartsWithFilterSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDropPartsWithFilterSuite.scala
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive.execution
+
+import org.scalatest.BeforeAndAfterEach
+
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.hive.test.TestHiveSingleton
+import org.apache.spark.sql.test.SQLTestUtils
+
+class HiveDropPartsWithFilterSuite
+  extends QueryTest with SQLTestUtils with TestHiveSingleton with BeforeAndAfterEach {
+  protected override def beforeAll(): Unit = {
+    super.beforeAll()
+    sql("create table test_drop_part(c1 int) partitioned by(year string, month string, day string)")
+  }
+
+  override protected def afterAll(): Unit = {
+    try {
+      sql("DROP TABLE IF EXISTS test_drop_part")
+    } finally {
+      super.afterAll()
+    }
+  }
+
+  protected def addParts(): Unit = {
+    sql("alter table test_drop_part add if not exists partition(year='2020', month='08', day='01')")
+    sql("alter table test_drop_part add if not exists partition(year='2020', month='08', day='02')")
+    sql("alter table test_drop_part add if not exists partition(year='2020', month='08', day='03')")
+    sql("alter table test_drop_part add if not exists partition(year='2020', month='08', day='04')")
+    sql("alter table test_drop_part add if not exists partition(year='2020', month='08', day='05')")
+    sql("alter table test_drop_part add if not exists partition(year='2020', month='08', day='06')")
+    sql("alter table test_drop_part add if not exists partition(year='2020', month='08', day='07')")
+    sql("alter table test_drop_part add if not exists partition(year='2020', month='08', day='08')")
+    sql("alter table test_drop_part add if not exists partition(year='2020', month='08', day='09')")
+    sql("alter table test_drop_part add if not exists partition(year='2020', month='08', day='10')")
+
+  }
+
+  test("Case 1: The part column on the left and the value on the right like year > 2020") {
+    addParts()
+    sql("set spark.sql.batch.drop.partitions.enable = true;")
+
+    // delete year=2020/month=08/day=10
+    sql("alter table test_drop_part drop if exists partition (year='2020', month='08', day=='10')")
+    checkAnswer(
+      sql("SHOW PARTITIONS test_drop_part"),
+      Row("year=2020/month=08/day=01") ::
+      Row("year=2020/month=08/day=02") ::
+      Row("year=2020/month=08/day=03") ::
+      Row("year=2020/month=08/day=04") ::
+      Row("year=2020/month=08/day=05") ::
+      Row("year=2020/month=08/day=06") ::
+      Row("year=2020/month=08/day=07") ::
+      Row("year=2020/month=08/day=08") ::
+      Row("year=2020/month=08/day=09") :: Nil)
+
+    // delete year=2020/month=08/day=01
+    sql("alter table test_drop_part drop if exists partition(year='2020', month='08', day < '02')")
+    checkAnswer(
+      sql("SHOW PARTITIONS test_drop_part"),
+        Row("year=2020/month=08/day=02") ::
+        Row("year=2020/month=08/day=03") ::
+        Row("year=2020/month=08/day=04") ::
+        Row("year=2020/month=08/day=05") ::
+        Row("year=2020/month=08/day=06") ::
+        Row("year=2020/month=08/day=07") ::
+        Row("year=2020/month=08/day=08") ::
+        Row("year=2020/month=08/day=09") :: Nil)
+
+    // delete year=2020/month=08/day=02 year=2020/month=08/day=03
+    sql("alter table test_drop_part drop if exists partition(year='2020', month='08', day<='03')")
+    checkAnswer(
+      sql("SHOW PARTITIONS test_drop_part"),
+      Row("year=2020/month=08/day=04") ::
+        Row("year=2020/month=08/day=05") ::
+        Row("year=2020/month=08/day=06") ::
+        Row("year=2020/month=08/day=07") ::
+        Row("year=2020/month=08/day=08") ::
+        Row("year=2020/month=08/day=09") :: Nil)
+
+    // delete year=2020/month=08/day=04 year=2020/month=08/day=05
+    sql("alter table test_drop_part drop if exists partition(year='2020', month='08', day !>'05')")
+    checkAnswer(
+      sql("SHOW PARTITIONS test_drop_part"),
+      Row("year=2020/month=08/day=06") ::
+        Row("year=2020/month=08/day=07") ::
+        Row("year=2020/month=08/day=08") ::
+        Row("year=2020/month=08/day=09") :: Nil)
+
+    // delete year=2020/month=08/day=09
+    sql("alter table test_drop_part drop if exists partition(year='2020', month='08', day > '08')")
+    checkAnswer(
+      sql("SHOW PARTITIONS test_drop_part"),
+      Row("year=2020/month=08/day=06") ::
+        Row("year=2020/month=08/day=07") ::
+        Row("year=2020/month=08/day=08") :: Nil)
+
+    // delete year=2020/month=08/day=07 year=2020/month=08/day=08
+    sql("alter table test_drop_part drop if exists partition(year='2020', month='08', day >= '07')")
+    checkAnswer(
+      sql("SHOW PARTITIONS test_drop_part"),
+      Row("year=2020/month=08/day=06") :: Nil)
+
+    // delete year=2020/month=08/day=06
+    sql("alter table test_drop_part drop if exists partition(year='2020', month='08', day !< '06')")
+    checkAnswer(
+      sql("SHOW PARTITIONS test_drop_part"), Nil)
+  }
+
+  test("Case 2: The part column on the right and the value on the left like 2020 > year") {
+    addParts()
+    sql("set spark.sql.batch.drop.partitions.enable = true;")
+
+    // delete year=2020/month=08/day=10
+    sql("alter table test_drop_part drop if exists partition (year='2020', month='08', '10'==day)")
+    checkAnswer(
+      sql("SHOW PARTITIONS test_drop_part"),
+      Row("year=2020/month=08/day=01") ::
+        Row("year=2020/month=08/day=02") ::
+        Row("year=2020/month=08/day=03") ::
+        Row("year=2020/month=08/day=04") ::
+        Row("year=2020/month=08/day=05") ::
+        Row("year=2020/month=08/day=06") ::
+        Row("year=2020/month=08/day=07") ::
+        Row("year=2020/month=08/day=08") ::
+        Row("year=2020/month=08/day=09") :: Nil)
+
+    // delete year=2020/month=08/day=01
+    sql("alter table test_drop_part drop if exists partition(year='2020', month='08', '02' > day)")
+    checkAnswer(
+      sql("SHOW PARTITIONS test_drop_part"),
+      Row("year=2020/month=08/day=02") ::
+        Row("year=2020/month=08/day=03") ::
+        Row("year=2020/month=08/day=04") ::
+        Row("year=2020/month=08/day=05") ::
+        Row("year=2020/month=08/day=06") ::
+        Row("year=2020/month=08/day=07") ::
+        Row("year=2020/month=08/day=08") ::
+        Row("year=2020/month=08/day=09") :: Nil)
+
+    // delete year=2020/month=08/day=02 year=2020/month=08/day=03
+    sql("alter table test_drop_part drop if exists partition(year='2020', month='08', '03' >= day)")
+    checkAnswer(
+      sql("SHOW PARTITIONS test_drop_part"),
+      Row("year=2020/month=08/day=04") ::
+        Row("year=2020/month=08/day=05") ::
+        Row("year=2020/month=08/day=06") ::
+        Row("year=2020/month=08/day=07") ::
+        Row("year=2020/month=08/day=08") ::
+        Row("year=2020/month=08/day=09") :: Nil)
+
+    // delete year=2020/month=08/day=04 year=2020/month=08/day=05
+    sql("alter table test_drop_part drop if exists partition(year='2020', month='08', '05' !< day)")
+    checkAnswer(
+      sql("SHOW PARTITIONS test_drop_part"),
+      Row("year=2020/month=08/day=06") ::
+        Row("year=2020/month=08/day=07") ::
+        Row("year=2020/month=08/day=08") ::
+        Row("year=2020/month=08/day=09") :: Nil)
+
+    // delete year=2020/month=08/day=09
+    sql("alter table test_drop_part drop if exists partition(year='2020', month='08', '08' < day)")
+    checkAnswer(
+      sql("SHOW PARTITIONS test_drop_part"),
+      Row("year=2020/month=08/day=06") ::
+        Row("year=2020/month=08/day=07") ::
+        Row("year=2020/month=08/day=08") :: Nil)
+
+    // delete year=2020/month=08/day=07 year=2020/month=08/day=08
+    sql("alter table test_drop_part drop if exists partition(year='2020', month='08', '07' <= day)")
+    checkAnswer(
+      sql("SHOW PARTITIONS test_drop_part"),
+      Row("year=2020/month=08/day=06") :: Nil)
+
+    // delete year=2020/month=08/day=06
+    sql("alter table test_drop_part drop if exists partition(year='2020', month='08', '06' !> day)")
+    checkAnswer(
+      sql("SHOW PARTITIONS test_drop_part"), Nil)
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->
For instance, Spark doesn't support:

`alter table test drop partition(pt > '2020-1211')`

The PR adds the support to this syntax too.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->



<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
UTs to be added
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
