### PR TITLE
[SPARK-33759][K8S] docker entrypoint should using `spark-class` for spark executor

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
@@ -80,7 +80,7 @@ case "$1" in
   executor)
     shift 1
     CMD=(
-      ${JAVA_HOME}/bin/java
+      "$SPARK_HOME/bin/spark-class"
       "${SPARK_EXECUTOR_JAVA_OPTS[@]}"
       -Xms$SPARK_EXECUTOR_MEMORY
       -Xmx$SPARK_EXECUTOR_MEMORY


### PR DESCRIPTION
Signed-off-by: Đặng Minh Dũng <dungdm93@live.com>

### What changes were proposed in this pull request?
In docker entrypoint.sh, spark executor should using `spark-class` instead of pure `java` command.
https://github.com/apache/spark/blob/8b97b19ffad7ec78e4b1f05cb1168ef79dc647b2/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh#L70-L102

### Why are the changes needed?
In docker `entrypoint.sh`, spark driver using `spark-submit` command but spark executor using pure `java` command which don't load `spark-env.sh` in `$SPARK_HOME/conf` directory.
This can lead configuration mismatch between driver and executors in the cases `spark-env.sh` contains something like custom envvars or pre-start hooks

### Does this PR introduce _any_ user-facing change?
N/A


### How was this patch tested?
