### PR TITLE
[SPARK-33783][SS] Unload State Store Provider after configured keep alive time

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1391,6 +1391,7 @@ object SQLConf {
 
   val STATE_STORE_PROVIDER_KEEP_ALIVE_TIME =
     buildConf("spark.sql.streaming.stateStore.keepAliveTime")
+      .internal()
       .doc("The time in milliseconds that a loaded store provider will be kept alive " +
         "as inactive instance in an executor. Spark runs a maintenance task and periodically " +
         "checks inactive instances. Once a loaded store provider is inactive over this " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1389,6 +1389,16 @@ object SQLConf {
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefault(TimeUnit.MINUTES.toMillis(1)) // 1 minute
 
+  val STATE_STORE_PROVIDER_KEEP_ALIVE_TIME =
+    buildConf("spark.sql.streaming.stateStore.keepAliveTime")
+      .doc("The time in milliseconds that a loaded store provider will be kept alive " +
+        "as inactive instance in an executor. Spark runs a maintenance task and periodically " +
+        "checks inactive instances. Once a loaded store provider is inactive over this " +
+        "configured time, Spark will unload it to release resources such as memory.")
+      .version("3.2.0")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefault(TimeUnit.MINUTES.toMillis(1)) // 1 minute
+
   val STATE_STORE_COMPRESSION_CODEC =
     buildConf("spark.sql.streaming.stateStore.compression.codec")
       .internal()
@@ -3230,6 +3240,8 @@ class SQLConf extends Serializable with Logging {
   def maxBatchesToRetainInMemory: Int = getConf(MAX_BATCHES_TO_RETAIN_IN_MEMORY)
 
   def streamingMaintenanceInterval: Long = getConf(STREAMING_MAINTENANCE_INTERVAL)
+
+  def stateStoreKeepAliveTime: Long = getConf(STATE_STORE_PROVIDER_KEEP_ALIVE_TIME)
 
   def stateStoreCompressionCodec: String = getConf(STATE_STORE_COMPRESSION_CODEC)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -563,10 +563,8 @@ object StateStore extends Logging {
           lastAliveTime(id) = System.currentTimeMillis()
           provider.doMaintenance()
         } else {
-          if (System.currentTimeMillis() - lastAliveTime(id) > storeConf.stateStoreKeepAliveTime) {
-            unload(id)
-            logInfo(s"Unloaded $provider")
-          }
+          unload(id)
+          logInfo(s"Unloaded $provider")
         }
       } catch {
         case NonFatal(e) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -563,8 +563,10 @@ object StateStore extends Logging {
           lastAliveTime(id) = System.currentTimeMillis()
           provider.doMaintenance()
         } else {
-          unload(id)
-          logInfo(s"Unloaded $provider")
+          if (System.currentTimeMillis() - lastAliveTime(id) > storeConf.stateStoreKeepAliveTime) {
+            unload(id)
+            logInfo(s"Unloaded $provider")
+          }
         }
       } catch {
         case NonFatal(e) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -393,6 +393,9 @@ object StateStore extends Logging {
   @GuardedBy("loadedProviders")
   private val schemaValidated = new mutable.HashMap[StateStoreProviderId, Option[Throwable]]()
 
+  @GuardedBy("loadedProviders")
+  private val lastAliveTime = new mutable.HashMap[StateStoreProviderId, Long]()
+
   /**
    * Runs the `task` periodically and automatically cancels it if there is an exception. `onError`
    * will be called when an exception happens.
@@ -494,6 +497,7 @@ object StateStore extends Logging {
         StateStoreProvider.createAndInit(
           storeProviderId, keySchema, valueSchema, indexOrdinal, storeConf, hadoopConf)
       )
+      lastAliveTime(storeProviderId) = System.currentTimeMillis()
       reportActiveStoreInstance(storeProviderId)
       provider
     }
@@ -537,7 +541,7 @@ object StateStore extends Logging {
       if (SparkEnv.get != null && !isMaintenanceRunning) {
         maintenanceTask = new MaintenanceTask(
           storeConf.maintenanceInterval,
-          task = { doMaintenance() },
+          task = { doMaintenance(storeConf) },
           onError = { loadedProviders.synchronized { loadedProviders.clear() } }
         )
         logInfo("State Store maintenance task started")
@@ -548,7 +552,7 @@ object StateStore extends Logging {
    * Execute background maintenance task in all the loaded store providers if they are still
    * the active instances according to the coordinator.
    */
-  private def doMaintenance(): Unit = {
+  private def doMaintenance(storeConf: StateStoreConf): Unit = {
     logDebug("Doing maintenance")
     if (SparkEnv.get == null) {
       throw new IllegalStateException("SparkEnv not active, cannot do maintenance on StateStores")
@@ -556,10 +560,13 @@ object StateStore extends Logging {
     loadedProviders.synchronized { loadedProviders.toSeq }.foreach { case (id, provider) =>
       try {
         if (verifyIfStoreInstanceActive(id)) {
+          lastAliveTime(id) = System.currentTimeMillis()
           provider.doMaintenance()
         } else {
-          unload(id)
-          logInfo(s"Unloaded $provider")
+          if (System.currentTimeMillis() - lastAliveTime(id) > storeConf.stateStoreKeepAliveTime) {
+            unload(id)
+            logInfo(s"Unloaded $provider")
+          }
         }
       } catch {
         case NonFatal(e) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreConf.scala
@@ -61,6 +61,9 @@ class StateStoreConf(
   /** The interval of maintenance tasks. */
   val maintenanceInterval = sqlConf.streamingMaintenanceInterval
 
+  /** The time a inactive statestore provider can keep alive. */
+  val stateStoreKeepAliveTime = sqlConf.stateStoreKeepAliveTime
+
   /**
    * Additional configurations related to state store. This will capture all configs in
    * SQLConf that start with `spark.sql.streaming.stateStore.` and extraOptions for a specific

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -387,14 +387,14 @@ class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
   }
 
   test("maintenance") {
-    runMainTenanceTest()
+    runMaintenanceTest()
   }
 
   test("maintenance: configured keep alive time") {
-    runMainTenanceTest(30L, 3000L)
+    runMaintenanceTest(30L, 3000L)
   }
 
-  private def runMainTenanceTest(
+  private def runMaintenanceTest(
       maintenanceInterval: Long = 10L,
       keepAliveTime: Long = 30000L): Unit = {
     val conf = new SparkConf()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -396,7 +396,7 @@ class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
 
   private def runMainTenanceTest(
       maintenanceInterval: Long = 10L,
-      keepAliveTime: Long = 60000L): Unit = {
+      keepAliveTime: Long = 30000L): Unit = {
     val conf = new SparkConf()
       .setMaster("local")
       .setAppName("test")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This patch proposes to enable users to control state store provider in more detailed way. A configuration is added for keeping inactive state store provider alive in executors.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Currently Spark unloads an inactive state store provider in an maintenance task which is run periodically. So it is said one state store provider might be unloaded immediately after it becomes inactive because the maintenance task is asynchronous. 

So it is possible some stores are unloaded earilier and others are later. The inconsistent unloading behavior makes harder to estimate query behavior.

It is also inefficient as the state store provider could be reused in next batches and we should be able to have more control of unloading behavior.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, users can use the added configuration to change the time an inactive state store provider can keep alive.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Unit test.