### PR TITLE
[SPARK-22748][SQL] Analyze grouping__id bug when grouping__id is used as a column reference of subquery

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -1006,4 +1006,72 @@ class AnalysisSuite extends AnalysisTest with Matchers {
       checkAnalysis(plan, expect)
     }
   }
+
+  test("SPARK-22748: Analyze bug when grouping__id is used as a colref of subquery") {
+    assertAnalysisSuccess(parsePlan(
+      """
+        |SELECT grouping__id FROM (
+        |  SELECT grouping__id FROM (
+        |    SELECT a, b, count(1), grouping__id FROM TaBlE2
+        |      GROUP BY a, b WITH ROLLUP
+        |  )
+        |)
+      """.stripMargin), false)
+
+
+    assertAnalysisSuccess(parsePlan(
+      """
+        |SELECT grouping__id FROM (
+        |  SELECT a, b, count(1), grouping__id FROM TaBlE2
+        |   GROUP BY a, b WITH CUBE
+        |)
+      """.stripMargin), false)
+
+    assertAnalysisSuccess(parsePlan(
+      """
+        |SELECT grouping__id FROM (
+        |  SELECT a, b, count(1), grouping__id FROM TaBlE2
+        |    GROUP BY a, b GROUPING SETS ((a, b), ())
+        |)
+      """.stripMargin), false)
+
+    assertAnalysisSuccess(parsePlan(
+      """
+        |SELECT a, b, count(1) FROM TaBlE2
+        |  GROUP BY CUBE(a, b) HAVING grouping__id > 0
+      """.stripMargin), false)
+
+    assertAnalysisSuccess(parsePlan(
+      """
+        |SELECT * FROM (
+        |  SELECT a, b, count(1) FROM TaBlE2
+        |    GROUP BY a, b GROUPING SETS ((a, b), ())
+        |) WHERE grouping__id > 0
+      """.stripMargin), false)
+
+    assertAnalysisSuccess(parsePlan(
+      """
+        |SELECT * FROM (
+        |  SELECT a, b, count(1) FROM TaBlE2
+        |    GROUP BY a, b GROUPING SETS ((a, b), ())
+        |) ORDER BY grouping__id > 0
+      """.stripMargin), false)
+
+    assertAnalysisSuccess(parsePlan(
+      """
+        |SELECT a, b, count(1) FROM TaBlE2
+        |  GROUP BY a, b GROUPING SETS ((a, b), ())
+        |    ORDER BY grouping__id > 0
+      """.stripMargin), false)
+
+    assertAnalysisError(parsePlan(
+      """
+        |SELECT grouping__id FROM (
+        |  SELECT a, b, count(1), grouping__id FROM TaBlE2
+        |    GROUP BY a, b
+        |)
+      """.stripMargin),
+      Seq("grouping_id() can only be used with GroupingSets/Cube/Rollup"),
+      false)
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
See SPARK-22748,  sql like:
```
create table temp.test_grouping_replace(a int, b int);
select grouping__id from (select a, b, count(1) , grouping__id from temp.test_grouping_replace group by a, b grouping sets(a, b))
```
will raise an error like

> Error in query: grouping_id() can only be used with GroupingSets/Cube/Rollup;;

This is because Spark translate grouping__id to grouping_id() every when it occurs, actually the 'grouping__id' in outer query is only a attribute reference to inner query, not a new function.


### Why are the changes needed?
Although user can add alias to avoid this problem, but since fix this problem is not difficult, I guess we should fix it to make user use spark easier.


### How was this patch tested?
New Test added in AnalysisSuite
