### PR TITLE
SPARK-33755: Allow creating orc table when row format separator is defined

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -521,9 +521,9 @@ object SQLConf {
     .doc("Whether to support row format delimited when creating orc table. If true  SparkSQL will catch " +
       "exception when creating table like " +
       "\"create table test(c1 int) row format delimited fields terminated by '002';\"" +
-      ", default is true.")
+      ", default is false.")
     .booleanConf
-    .createWithDefault(true)
+    .createWithDefault(false)
 
   val HIVE_VERIFY_PARTITION_PATH = buildConf("spark.sql.hive.verifyPartitionPath")
     .doc("When true, check all the partition paths under the table\'s root directory " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -517,6 +517,14 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
+  val ORC_SKIP_ROW_FORMAT_DELIMITED_ERROR = buildConf("spark.sql.orc.skipRowFormatDelimitedError")
+    .doc("Whether to support row format delimited when creating orc table. If true  SparkSQL will catch " +
+      "exception when creating table like " +
+      "\"create table test(c1 int) row format delimited fields terminated by '002';\"" +
+      ", default is true.")
+    .booleanConf
+    .createWithDefault(true)
+
   val HIVE_VERIFY_PARTITION_PATH = buildConf("spark.sql.hive.verifyPartitionPath")
     .doc("When true, check all the partition paths under the table\'s root directory " +
          "when reading data stored in HDFS. This configuration will be deprecated in the future " +
@@ -1712,6 +1720,8 @@ class SQLConf extends Serializable with Logging {
     getConf(PARQUET_FILTER_PUSHDOWN_INFILTERTHRESHOLD)
 
   def orcFilterPushDown: Boolean = getConf(ORC_FILTER_PUSHDOWN_ENABLED)
+
+  def orcSkipRowFormatDelimitedError: Boolean = getConf(ORC_SKIP_ROW_FORMAT_DELIMITED_ERROR)
 
   def verifyPartitionPath: Boolean = getConf(HIVE_VERIFY_PARTITION_PATH)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -1374,6 +1374,11 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder(conf) {
       case (rfDelimited: RowFormatDelimitedContext, ffGeneric: GenericFileFormatContext) =>
         ffGeneric.identifier.getText.toLowerCase(Locale.ROOT) match {
           case "textfile" => // OK
+          case ("orcfile" | "orc") => if (!SQLConf.get.orcSkipRowFormatDelimitedError) {
+            operationNotAllowed(
+              s"ROW FORMAT DELIMITED is only compatible with 'textfile', not 'orcfile/orc'",
+              parentCtx)
+          }
           case fmt => operationNotAllowed(
             s"ROW FORMAT DELIMITED is only compatible with 'textfile', not '$fmt'", parentCtx)
         }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcSourceSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcSourceSuite.scala
@@ -153,4 +153,18 @@ class HiveOrcSourceSuite extends OrcSuite with TestHiveSingleton {
       }
     }
   }
+
+  test("SPARK-33755: Allow creating orc table when row format separator is defined") {
+    withTable("row_format_orc") {
+      sql(
+        s"""CREATE TABLE row_format_orc(
+           |  intField INT,
+           |  stringField STRING
+           |)
+           |ROW FORMAT DELIMITED FIELDS TERMINATED BY '002'
+           |STORED AS ORC
+           |LOCATION '${orcTableAsDir.toURI}'
+       """.stripMargin)
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
When creating table like this:
`create table test_orc(c1 string) row format delimited fields terminated by '002' stored as orcfile;`
spark throws exception like :
`Operation not allowed: ROW FORMAT DELIMITED is only compatible with 'textfile', not 'orcfile'(line 2, pos 0)`

In this pr, we support non-strict rules when creating orc table with row format delimited.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
I found this problem when migrating task from hive to spark. Hive is supported (It's not good, but it's not a problem, we can ignore it). So I fixed it in version Spark 2.4. Although Orc doesn't need this delimiter, but I don't think we need to be so strict in syntax. It is more convenient to migrate tasks from hive to spark.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
UTs to be added