### PR TITLE
[SPARK-33799][CORE] Handle excluded executors/nodes in ExecutorMonitor

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/dynalloc/ExecutorMonitor.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/dynalloc/ExecutorMonitor.scala
@@ -360,7 +360,7 @@ private[spark] class ExecutorMonitor(
     execResourceProfileCount.remove(rpId, 0)
   }
 
-  private def increaseExecResourceProfileCount(rpId: Int): Unit = {
+  private def incrementExecResourceProfileCount(rpId: Int): Unit = {
     val count = execResourceProfileCount.computeIfAbsent(rpId, _ => 0)
     execResourceProfileCount.replace(rpId, count, count + 1)
   }
@@ -448,7 +448,7 @@ private[spark] class ExecutorMonitor(
   override def onExecutorUnexcluded(executorUnexcluded: SparkListenerExecutorUnexcluded): Unit = {
     val exec = executors.get(executorUnexcluded.executorId)
     exec.excluded = false
-    increaseExecResourceProfileCount(exec.resourceProfileId)
+    incrementExecResourceProfileCount(exec.resourceProfileId)
   }
 
   override def onNodeExcluded(nodeExcluded: SparkListenerNodeExcluded): Unit = {
@@ -463,7 +463,7 @@ private[spark] class ExecutorMonitor(
   override def onNodeUnexcluded(nodeUnexcluded: SparkListenerNodeUnexcluded): Unit = {
     executors.values().asScala.filter(_.host == nodeUnexcluded.hostId).foreach { exec =>
       exec.excluded = false
-      increaseExecResourceProfileCount(exec.resourceProfileId)
+      incrementExecResourceProfileCount(exec.resourceProfileId)
     }
   }
 
@@ -518,7 +518,7 @@ private[spark] class ExecutorMonitor(
    */
   private def ensureExecutorIsTracked(id: String, host: String, resourceProfileId: Int): Tracker = {
     val execTracker = executors.computeIfAbsent(id, _ => {
-      increaseExecResourceProfileCount(resourceProfileId)
+      incrementExecResourceProfileCount(resourceProfileId)
       logDebug(s"Executor added with ResourceProfile id: $resourceProfileId " +
         s"count is now ${execResourceProfileCount.get(resourceProfileId)}")
       new Tracker(resourceProfileId, host)
@@ -530,7 +530,7 @@ private[spark] class ExecutorMonitor(
         s"it to $resourceProfileId")
       execTracker.resourceProfileId = resourceProfileId
       // fix up the counts for each resource profile id
-      increaseExecResourceProfileCount(resourceProfileId)
+      incrementExecResourceProfileCount(resourceProfileId)
       decrementExecResourceProfileCount(UNKNOWN_RESOURCE_PROFILE_ID)
     }
     execTracker

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -1648,7 +1648,7 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
     assert(numExecutorsTargetForDefaultProfileId(manager) === 1)
   }
 
-  test("excluded executors should not be considered as available executors") {
+  test("SPARK-33799: excluded executors should not be considered as available executors") {
     val manager = createManager(createConf(1, 4, 1,
       exclusionEnabled = true))
     post(SparkListenerStageSubmitted(createStageInfo(0, 1000)))

--- a/core/src/test/scala/org/apache/spark/scheduler/dynalloc/ExecutorMonitorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/dynalloc/ExecutorMonitorSuite.scala
@@ -433,7 +433,7 @@ class ExecutorMonitorSuite extends SparkFunSuite {
     assert(monitor.timedOutExecutors(idleDeadline).isEmpty)
   }
 
-  test("ExecutorMonitor should handle " +
+  test("SPARK-33799: ExecutorMonitor should handle " +
     "SparkListenerExecutorExcluded/SparkListenerExecutorUnexcluded") {
     monitor = new ExecutorMonitor(conf, client, null, clock)
     monitor.onExecutorAdded(SparkListenerExecutorAdded(clock.getTimeMillis(), "1", execInfo))
@@ -448,7 +448,7 @@ class ExecutorMonitorSuite extends SparkFunSuite {
     assert(monitor.executorCountWithResourceProfile(execInfo.resourceProfileId) === 1)
   }
 
-  test("ExecutorMonitor should handle " +
+  test("SPARK-33799: ExecutorMonitor should handle " +
     "SparkListenerNodeExcluded/SparkListenerNodeUnexcluded") {
     monitor = new ExecutorMonitor(conf, client, null, clock)
     monitor.onExecutorAdded(SparkListenerExecutorAdded(clock.getTimeMillis(), "1", execInfo))
@@ -467,7 +467,7 @@ class ExecutorMonitorSuite extends SparkFunSuite {
     assert(monitor.executorCount === 2)
   }
 
-  test("Excluded executor can still be timedout") {
+  test("SPARK-33799: Excluded executor can still be timedout") {
     monitor = new ExecutorMonitor(conf, client, null, clock)
     monitor.onExecutorAdded(SparkListenerExecutorAdded(clock.getTimeMillis(), "1", execInfo))
     assert(monitor.executorCount === 1)

--- a/core/src/test/scala/org/apache/spark/scheduler/dynalloc/ExecutorMonitorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/dynalloc/ExecutorMonitorSuite.scala
@@ -435,6 +435,8 @@ class ExecutorMonitorSuite extends SparkFunSuite {
 
   test("SPARK-33799: ExecutorMonitor should handle " +
     "SparkListenerExecutorExcluded/SparkListenerExecutorUnexcluded") {
+    conf.set(EXCLUDE_ON_FAILURE_ENABLED, true)
+      .set(EXCLUDE_ON_FAILURE_KILL_ENABLED, false)
     monitor = new ExecutorMonitor(conf, client, null, clock)
     monitor.onExecutorAdded(SparkListenerExecutorAdded(clock.getTimeMillis(), "1", execInfo))
     assert(monitor.executorCountWithResourceProfile(execInfo.resourceProfileId) === 1)
@@ -450,6 +452,8 @@ class ExecutorMonitorSuite extends SparkFunSuite {
 
   test("SPARK-33799: ExecutorMonitor should handle " +
     "SparkListenerNodeExcluded/SparkListenerNodeUnexcluded") {
+    conf.set(EXCLUDE_ON_FAILURE_ENABLED, true)
+      .set(EXCLUDE_ON_FAILURE_KILL_ENABLED, false)
     monitor = new ExecutorMonitor(conf, client, null, clock)
     monitor.onExecutorAdded(SparkListenerExecutorAdded(clock.getTimeMillis(), "1", execInfo))
     monitor.onExecutorAdded(SparkListenerExecutorAdded(clock.getTimeMillis(), "2", execInfo))
@@ -468,6 +472,8 @@ class ExecutorMonitorSuite extends SparkFunSuite {
   }
 
   test("SPARK-33799: Excluded executor can still be timedout") {
+    conf.set(EXCLUDE_ON_FAILURE_ENABLED, true)
+      .set(EXCLUDE_ON_FAILURE_KILL_ENABLED, false)
     monitor = new ExecutorMonitor(conf, client, null, clock)
     monitor.onExecutorAdded(SparkListenerExecutorAdded(clock.getTimeMillis(), "1", execInfo))
     assert(monitor.executorCount === 1)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR proposes to handle exclusion events in `ExecutorMonitor` so it doesn't count excluded executors as available executors for running tasks.

The main change includes:
* implement `onExecutorExcluded`/`onExecutorUnexcluded`/`onNodeExcluded`/`onNodeUnexcluded` insides `ExecutorMonitor`.
* Allow the `ExecutorAllocationManager` to request at most (`maxNumExecutors` + `excludeExecutors`)

Note that this improvement only tasks effects when both dynamic allocation and exclusion features are enabled but with  `spark.excludeOnFailure.killExcludedExecutors=false`. We don't want to handle the exclude executors specifically when we do kill excluded executors. Because in that case, we assume that there would be new executors launched later to replace those killed executors.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Currently, the excluded executors are counted as available executors for running tasks. But that's not correct since the `TaskScheduler` never schedules tasks on those excluded executors. As a result, it can lower the scheduling efficiency of the `TaskScheduler`. In the worst case, the TaskSet can not be scheduled anywhere and it then has to go through `getCompletelyExcludedTaskIfAny(...)` path which is inefficient. 

This PR makes the Spark be aware of the lack of executors at dynamic allocation level. So we can launch the new executors early before the `TaskScheduler` realizes the problem, which could ease the worst case and improve scheduling efficiency.

Besides, this also prevents the `ExecutorAllocationManager` from going into the fake `minExecutor` status when removing idle executors. For example, when we have 5 executors (2 excluded) and minExecutor=3, and we need to remove 2 idle but not exluded executors. Then, we'd have 3 executors with 2 excluded executor at the end and only one executor can launch tasks indeed.  (this worths a followup to kill the idle-exclude-executor first if this PR gets approved). And this PR could avoid the problem since we'd remove the excluded executors in first place.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Added unit tests.
