### PR TITLE
[SPARK-33809][SQL] Support `all_columns_except` complex column expression

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/QueryCompilationErrors.scala
@@ -326,4 +326,11 @@ object QueryCompilationErrors {
       "of rows, therefore they are currently not supported.", t.origin.line, t.origin.startPosition)
   }
 
+  def complexColumnExpressionsNotSupportOutsideOfProject(
+      method: String,
+      t: TreeNode[_]): Throwable = {
+    new AnalysisException(s"Complex column expressions `${method}`" +
+      s" not supported outside of Project's projection list.",
+      t.origin.line, t.origin.startPosition)
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -986,8 +986,6 @@ class Analyzer(override val catalogManager: CatalogManager)
         val newProjectList = p.projectList.flatMap {
           case UnresolvedAlias(child: AllColumnsExcept, _) =>
             p.child.output.filter(!child.children.contains(_))
-          case UnresolvedAlias(child: AllColumnsExcept, _) =>
-            p.child.output.filter(!child.children.contains(_))
           case Alias(child: AllColumnsExcept, _) =>
             p.child.output.filter(!child.children.contains(_))
           case MultiAlias(child: AllColumnsExcept, _) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -978,29 +978,29 @@ class Analyzer(override val catalogManager: CatalogManager)
   object ResolveColumnsExpression extends Rule[LogicalPlan] {
 
     def containsColumnsExpression(expr: Expression): Boolean = expr.collect {
-      case a: AllColumnExcept => a
+      case a: AllColumnsExcept => a
     }.nonEmpty
 
     def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperatorsUp {
       case p: Project =>
         val newProjectList = p.projectList.flatMap {
-          case UnresolvedAlias(child: AllColumnExcept, _) =>
+          case UnresolvedAlias(child: AllColumnsExcept, _) =>
             p.child.output.filter(!child.children.contains(_))
-          case UnresolvedAlias(child: AllColumnExcept, _) =>
+          case UnresolvedAlias(child: AllColumnsExcept, _) =>
             p.child.output.filter(!child.children.contains(_))
-          case Alias(child: AllColumnExcept, _) =>
+          case Alias(child: AllColumnsExcept, _) =>
             p.child.output.filter(!child.children.contains(_))
-          case MultiAlias(child: AllColumnExcept, _) =>
+          case MultiAlias(child: AllColumnsExcept, _) =>
             p.child.output.filter(!child.children.contains(_))
           case e if containsColumnsExpression(e) =>
             throw QueryCompilationErrors
-              .complexColumnExpressionsNotSupportOutsideOfProject("all_column_except", p)
+              .complexColumnExpressionsNotSupportOutsideOfProject("all_columns_except", p)
           case e => Seq(e)
         }
         p.copy(projectList = newProjectList)
       case p if p.expressions.exists(containsColumnsExpression) =>
         throw QueryCompilationErrors
-          .complexColumnExpressionsNotSupportOutsideOfProject("all_column_except", p)
+          .complexColumnExpressionsNotSupportOutsideOfProject("all_columns_except", p)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -578,7 +578,7 @@ object FunctionRegistry {
     expression[StructsToCsv]("to_csv"),
 
     // column
-    expression[AllColumnExcept]("all_column_except")
+    expression[AllColumnsExcept]("all_columns_except")
   )
 
   val builtin: SimpleFunctionRegistry = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -575,7 +575,10 @@ object FunctionRegistry {
     // csv
     expression[CsvToStructs]("from_csv"),
     expression[SchemaOfCsv]("schema_of_csv"),
-    expression[StructsToCsv]("to_csv")
+    expression[StructsToCsv]("to_csv"),
+
+    // column
+    expression[AllColumnExcept]("all_column_except")
   )
 
   val builtin: SimpleFunctionRegistry = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/columnExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/columnExpression.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.types.DataType
   """,
   since = "1.5.0")
 // scalastyle:on line.size.limit
-case class AllColumnExcept(exclude: Expression*) extends Expression with CodegenFallback {
+case class AllColumnsExcept(exclude: Expression*) extends Expression with CodegenFallback {
 
   override def children: Seq[Expression] = exclude
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/columnExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/columnExpression.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.expressions
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.types.DataType
+
+/**
+ * A function that returns the columns except columns given in function parameters.
+ */
+// scalastyle:off line.size.limit
+@ExpressionDescription(
+  usage = """
+    _FUNC_(expr*) - Returns the columns except columns given in function parameters.
+  """,
+  examples = """
+    Examples:
+      > select * FROM TBL;
+       A B C
+       1 2 3
+      > SELECT _FUNC_(a, b) FROM TBL;
+       C
+       3
+  """,
+  since = "1.5.0")
+// scalastyle:on line.size.limit
+case class AllColumnExcept(exclude: Expression*) extends Expression with CodegenFallback {
+
+  override def children: Seq[Expression] = exclude
+
+  // this should be replaced first
+  override lazy val resolved: Boolean = false
+
+  override def dataType: DataType = throw new UnsupportedOperationException
+  override def foldable: Boolean = false
+  override def nullable: Boolean = true
+  override def eval(input: InternalRow): Any = throw new UnsupportedOperationException
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3733,22 +3733,22 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     }
   }
 
-  test("SPARK: column_exclude") {
+  test("SPARK-33809: Support `all_columns_except` complex column expression") {
     withTempView("src") {
       val df = Seq((1, 2)).toDF("key", "value")
       df.createOrReplaceTempView("src")
-      checkAnswer(sql("SELECT all_column_except(key) FROM src"), Row(2))
-      checkAnswer(sql("SELECT key, all_column_except(key) FROM src"), Row(1, 2))
-      checkAnswer(sql("SELECT key, all_column_except(value) FROM src"), Row(1, 1))
+      checkAnswer(sql("SELECT all_columns_except(key) FROM src"), Row(2))
+      checkAnswer(sql("SELECT key, all_columns_except(key) FROM src"), Row(1, 2))
+      checkAnswer(sql("SELECT key, all_columns_except(value) FROM src"), Row(1, 1))
       val e1 = intercept[AnalysisException] {
-        sql("SELECT key, all_column_except(value, invalid_column) FROM src")
+        sql("SELECT key, all_columns_except(value, invalid_column) FROM src")
       }.getMessage
       assert(e1.contains("cannot resolve '`invalid_column`' given input columns:" +
         " [src.key, src.value]"))
       val e2 = intercept[AnalysisException] {
-        sql("SELECT all_column_except(value), count(value) FROM src GROUP BY key")
+        sql("SELECT all_columns_except(value), count(value) FROM src GROUP BY key")
       }.getMessage
-      assert(e2.contains("Complex column expressions `all_column_except` not supported" +
+      assert(e2.contains("Complex column expressions `all_columns_except` not supported" +
         " outside of Project's projection list."))
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
We are easy to drop some column when use DF/DS api `drop` but difficult when use SQL when there are so many columns.
Add a function to support this:


```
 usage = """
    _FUNC_(expr*) - Returns the columns except columns given in function parameters.
  """,
  examples = """
    Examples:
      > select * FROM TBL;
       A B C
       1 2 3
      > SELECT _FUNC_(a, b) FROM TBL;
       C
       3
```
Idea from a Chinese blog
https://mp.weixin.qq.com/s?src=11&timestamp=1608729276&ver=2784&signature=IMj38*tURJObyQv8z84ELR-Vfkw2becwRfzQ5*9p0X7ilIp-AJVmIFUGOHOr6DcEF5syqfEhiQHa87ZAdzQJHWmy7FjjvTYdEldLkc9GsqrOELpLQrQ5CVG2KdK0ZCgP&new=1
### Why are the changes needed?
Provide a way to handle  drop column in SQL


### Does this PR introduce _any_ user-facing change?
Yes, user can use `all_columns_except` func in projection list to handle complex drop column  scenario


### How was this patch tested?
Added UT
