### PR TITLE
[SPARK-33814][SS] Provide preferred locations for stateful operations without reported state store locations

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinHelper.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinHelper.scala
@@ -245,7 +245,13 @@ object StreamingSymmetricHashJoinHelper extends Logging {
       if (stateStoreLocs.isEmpty) {
         defaultPreferredLocations
       } else {
-        stateStoreLocs.foreach(executorMap(_) += 1)
+        stateStoreLocs.foreach { executorId =>
+          if (executorMap.contains(executorId)) {
+            executorMap(executorId) += 1
+          } else {
+            executorMap.put(executorId, 1)
+          }
+        }
         stateStoreLocs
       }
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinHelper.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinHelper.scala
@@ -245,6 +245,7 @@ object StreamingSymmetricHashJoinHelper extends Logging {
       if (stateStoreLocs.isEmpty) {
         defaultPreferredLocations
       } else {
+        stateStoreLocs.foreach(executorMap(_) += 1)
         stateStoreLocs
       }
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRDD.scala
@@ -73,6 +73,13 @@ abstract class BaseStateStoreRDD[T: ClassTag, U: ClassTag](
     if (stateStoreLocs.isEmpty) {
       defaultPreferredLocations
     } else {
+      stateStoreLocs.foreach { executorId =>
+        if (executorMap.contains(executorId)) {
+          executorMap(executorId) += 1
+        } else {
+          executorMap.put(executorId, 1)
+        }
+      }
       stateStoreLocs
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This proposes to provide preferred locations for stateful operations even there is no reported state store locations.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Stateful operators in SS provides preferred locations on the previous batches if any. However, if there is no previous batch to follow, Spark possibly schedules stateful tasks in inefficient distribution. In local test, Spark has scheduled stateful tasks to a few ones among all executors.

This is because when the first batch takes payload from latest offsets, this batch possibly finishes very quick. An executor might be assigned more than one task because the executor finishes previous task very quickly and becomes available again.

Generally this is not a problem. It doesn't mater these tasks are evenly distributed or not, because the tasks are finished very quickly. But for SS stateful tasks, next batches will choose task locations of previous batch. So this is why this is an issue only for SS.

As stateful operations probably need to maintain large state stores, it means large memory usage. A skew state store distribution possibly causes one or few executors to have memory usage times more than others. So it means the streaming query could be OOM on these executors, even there are other executors are still available for state stores.

It is better we distribute stateful tasks across all executors evenly. This patch proposes to provide preferred locations for stateful operations even there is no reported state store locations.

Summary:

1. This proposes to leverage existing preferred locations to have evenly initial state store locations. We already leverage it to have state store on same locations in existing implementation.
2. It is required to avoid uneven resource (memory, disk) requirement on executors.
3. It is also required to have stable state store locations across executors with locality setting.
4. Looks no other feasible approaches without making major change. Any major change can also possibly be regression for non-streaming jobs.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Unit test. Manual test on testing cluster.
