### PR TITLE
[SPARK-33787][SQL][3.1] Add the `purge` parameter to `dropPartition()` of `SupportsPartitionManagement`

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsAtomicPartitionManagement.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsAtomicPartitionManagement.java
@@ -86,7 +86,7 @@ public interface SupportsAtomicPartitionManagement extends SupportsPartitionMana
   /**
    * Drop an array of partitions atomically from table.
    * <p>
-   * If any partition doesn't exists,
+   * If any partition doesn't exist,
    * the operation of dropPartitions need to be safely rolled back.
    *
    * If the catalog supports the option to purge a table, this method must be overridden. The

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsAtomicPartitionManagement.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsAtomicPartitionManagement.java
@@ -82,4 +82,27 @@ public interface SupportsAtomicPartitionManagement extends SupportsPartitionMana
    * @return true if partitions were deleted, false if any partition not exists
    */
   boolean dropPartitions(InternalRow[] idents);
+
+  /**
+   * Drop an array of partitions atomically from table.
+   * <p>
+   * If any partition doesn't exists,
+   * the operation of dropPartitions need to be safely rolled back.
+   *
+   * If the catalog supports the option to purge a table, this method must be overridden. The
+   * default implementation falls back to {@link #dropPartitions(InternalRow[])} dropPartitions} if
+   * the purge option is set to false. Otherwise, it throws {@link UnsupportedOperationException}.
+   *
+   * @param idents an array of partition identifiers
+   * @param purge whether a partition should be purged
+   * @return true if partitions were deleted, false if any partition not exists
+   *
+   * @since 3.2.0
+   */
+  default boolean dropPartitions(InternalRow[] idents, boolean purge) {
+    if (purge) {
+      throw new UnsupportedOperationException("Purge option is not supported.");
+    }
+    return dropPartitions(idents);
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsAtomicPartitionManagement.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsAtomicPartitionManagement.java
@@ -97,7 +97,7 @@ public interface SupportsAtomicPartitionManagement extends SupportsPartitionMana
    * @param purge whether a partition should be purged
    * @return true if partitions were deleted, false if any partition not exists
    *
-   * @since 3.2.0
+   * @since 3.1.0
    */
   default boolean dropPartitions(InternalRow[] idents, boolean purge) {
     if (purge) {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsAtomicPartitionManagement.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsAtomicPartitionManagement.java
@@ -75,8 +75,8 @@ public interface SupportsAtomicPartitionManagement extends SupportsPartitionMana
   /**
    * Drop an array of partitions atomically from table.
    * <p>
-   * If any partition doesn't exists,
-   * the operation of dropPartitions need to be safely rolled back.
+   * If any partition doesn't exist,
+   * the operation of dropPartitions needs to be safely rolled back.
    *
    * @param idents an array of partition identifiers
    * @return true if partitions were deleted, false if any partition not exists

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsAtomicPartitionManagement.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsAtomicPartitionManagement.java
@@ -52,8 +52,8 @@ public interface SupportsAtomicPartitionManagement extends SupportsPartitionMana
   }
 
   @Override
-  default boolean dropPartition(InternalRow ident) {
-    return dropPartitions(new InternalRow[]{ident});
+  default boolean dropPartition(InternalRow ident, boolean purge) {
+    return dropPartitions(new InternalRow[]{ident}, purge);
   }
 
   /**
@@ -79,30 +79,14 @@ public interface SupportsAtomicPartitionManagement extends SupportsPartitionMana
    * the operation of dropPartitions needs to be safely rolled back.
    *
    * @param idents an array of partition identifiers
+   * @param purge whether partitions should be purged. If the purge parameter is set to true,
+   *              the information about the partitions in the catalog as well as partitions data
+   *              shall be deleted. If this is set to false, the catalog shall not delete
+   *              the data which belongs to the partitions.
    * @return true if partitions were deleted, false if any partition not exists
-   */
-  boolean dropPartitions(InternalRow[] idents);
-
-  /**
-   * Drop an array of partitions atomically from table.
-   * <p>
-   * If any partition doesn't exist,
-   * the operation of dropPartitions needs to be safely rolled back.
-   *
-   * If the catalog supports the option to purge a table, this method must be overridden. The
-   * default implementation falls back to {@link #dropPartitions(InternalRow[])} dropPartitions} if
-   * the purge option is set to false. Otherwise, it throws {@link UnsupportedOperationException}.
-   *
-   * @param idents an array of partition identifiers
-   * @param purge whether a partition should be purged
-   * @return true if partitions were deleted, false if any partition not exists
+   * @throws UnsupportedOperationException if the option purge is not supported
    *
    * @since 3.1.0
    */
-  default boolean dropPartitions(InternalRow[] idents, boolean purge) {
-    if (purge) {
-      throw new UnsupportedOperationException("Purge option is not supported.");
-    }
-    return dropPartitions(idents);
-  }
+  boolean dropPartitions(InternalRow[] idents, boolean purge);
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsAtomicPartitionManagement.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsAtomicPartitionManagement.java
@@ -87,7 +87,7 @@ public interface SupportsAtomicPartitionManagement extends SupportsPartitionMana
    * Drop an array of partitions atomically from table.
    * <p>
    * If any partition doesn't exist,
-   * the operation of dropPartitions need to be safely rolled back.
+   * the operation of dropPartitions needs to be safely rolled back.
    *
    * If the catalog supports the option to purge a table, this method must be overridden. The
    * default implementation falls back to {@link #dropPartitions(InternalRow[])} dropPartitions} if

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsPartitionManagement.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsPartitionManagement.java
@@ -68,29 +68,15 @@ public interface SupportsPartitionManagement extends Table {
      * Drop a partition from table.
      *
      * @param ident a partition identifier
+     * @param purge whether a partition should be purged. If the purge parameter is set to true,
+     *              the information about the partition in the catalog as well as partition data
+     *              shall be deleted. If this is set to false, the catalog shall not delete
+     *              the data which belongs to the partition.
      * @return true if a partition was deleted, false if no partition exists for the identifier
-     */
-    boolean dropPartition(InternalRow ident);
-
-    /**
-     * Drop a partition from table.
-     *
-     * If the catalog supports the option to purge a partition, this method must be overridden. The
-     * default implementation falls back to {@link #dropPartition(InternalRow)} dropPartition} if
-     * the purge option is set to false. Otherwise, it throws {@link UnsupportedOperationException}.
-     *
-     * @param ident a partition identifier
-     * @param purge whether a partition should be purged
-     * @return true if a partition was deleted, false if no partition exists for the identifier
-     *
+     * @throws UnsupportedOperationException if the option purge is not supported
      * @since 3.1.0
      */
-    default boolean dropPartition(InternalRow ident, boolean purge) {
-      if (purge) {
-        throw new UnsupportedOperationException("Purge option is not supported.");
-      }
-      return dropPartition(ident);
-    }
+    boolean dropPartition(InternalRow ident, boolean purge);
 
     /**
      * Test whether a partition exists using an {@link InternalRow ident} from the table.

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsPartitionManagement.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsPartitionManagement.java
@@ -73,6 +73,26 @@ public interface SupportsPartitionManagement extends Table {
     boolean dropPartition(InternalRow ident);
 
     /**
+     * Drop a partition from table.
+     *
+     * If the catalog supports the option to purge a partition, this method must be overridden. The
+     * default implementation falls back to {@link #dropPartition(InternalRow)} dropPartition} if
+     * the purge option is set to false. Otherwise, it throws {@link UnsupportedOperationException}.
+     *
+     * @param ident a partition identifier
+     * @param purge whether a partition should be purged
+     * @return true if a partition was deleted, false if no partition exists for the identifier
+     *
+     * @since 3.2.0
+     */
+    default boolean dropPartition(InternalRow ident, boolean purge) {
+      if (purge) {
+        throw new UnsupportedOperationException("Purge option is not supported.");
+      }
+      return dropPartition(ident);
+    }
+
+    /**
      * Test whether a partition exists using an {@link InternalRow ident} from the table.
      *
      * @param ident a partition identifier which must contain all partition fields in order

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsPartitionManagement.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsPartitionManagement.java
@@ -83,7 +83,7 @@ public interface SupportsPartitionManagement extends Table {
      * @param purge whether a partition should be purged
      * @return true if a partition was deleted, false if no partition exists for the identifier
      *
-     * @since 3.2.0
+     * @since 3.1.0
      */
     default boolean dropPartition(InternalRow ident, boolean purge) {
       if (purge) {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableCatalog.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableCatalog.java
@@ -183,8 +183,12 @@ public interface TableCatalog extends CatalogPlugin {
    * purge option is set to false. Otherwise, it throws {@link UnsupportedOperationException}.
    *
    * @param ident a table identifier
-   * @param purge whether a table should be purged
+   * @param purge whether a table should be purged. If the purge parameter is set to true,
+   *              the information about the table in the catalog as well as table data
+   *              shall be deleted. If this is set to false, the catalog shall not delete
+   *              the data which belongs to the table.
    * @return true if a table was deleted, false if no table exists for the identifier
+   * @throws UnsupportedOperationException if the option purge is not supported
    *
    * @since 3.1.0
    */

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryAtomicPartitionTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryAtomicPartitionTable.scala
@@ -46,8 +46,10 @@ class InMemoryAtomicPartitionTable (
     }
   }
 
-  override def dropPartition(ident: InternalRow): Boolean = {
-    if (memoryTablePartitions.containsKey(ident)) {
+  override def dropPartition(ident: InternalRow, purge: Boolean): Boolean = {
+    if (purge) {
+      throw new UnsupportedOperationException("Purge option is not supported.")
+    } else if (memoryTablePartitions.containsKey(ident)) {
       memoryTablePartitions.remove(ident)
       true
     } else {
@@ -67,10 +69,10 @@ class InMemoryAtomicPartitionTable (
     }
   }
 
-  override def dropPartitions(idents: Array[InternalRow]): Boolean = {
+  override def dropPartitions(idents: Array[InternalRow], purge: Boolean): Boolean = {
     if (!idents.forall(partitionExists)) {
       return false;
     }
-    idents.forall(dropPartition)
+    idents.forall(dropPartition(_, purge))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryPartitionTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryPartitionTable.scala
@@ -58,8 +58,10 @@ class InMemoryPartitionTable(
     }
   }
 
-  def dropPartition(ident: InternalRow): Boolean = {
-    if (memoryTablePartitions.containsKey(ident)) {
+  def dropPartition(ident: InternalRow, purge: Boolean): Boolean = {
+    if (purge) {
+      throw new UnsupportedOperationException("Purge option is not supported.")
+    } else if (memoryTablePartitions.containsKey(ident)) {
       memoryTablePartitions.remove(ident)
       true
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AlterTableDropPartitionExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AlterTableDropPartitionExec.scala
@@ -28,7 +28,8 @@ import org.apache.spark.sql.connector.catalog.{SupportsAtomicPartitionManagement
 case class AlterTableDropPartitionExec(
     table: SupportsPartitionManagement,
     partSpecs: Seq[ResolvedPartitionSpec],
-    ignoreIfNotExists: Boolean) extends V2CommandExec {
+    ignoreIfNotExists: Boolean,
+    purge: Boolean) extends V2CommandExec {
   import DataSourceV2Implicits._
 
   override def output: Seq[Attribute] = Seq.empty
@@ -45,9 +46,9 @@ case class AlterTableDropPartitionExec(
     existsPartIdents match {
       case Seq() => // Nothing will be done
       case Seq(partIdent) =>
-        table.dropPartition(partIdent)
+        table.dropPartition(partIdent, purge)
       case _ if table.isInstanceOf[SupportsAtomicPartitionManagement] =>
-        table.asAtomicPartitionable.dropPartitions(existsPartIdents.toArray)
+        table.asAtomicPartitionable.dropPartitions(existsPartIdents.toArray, purge)
       case _ =>
         throw new UnsupportedOperationException(
           s"Nonatomic partition table ${table.name()} can not drop multiple partitions.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -319,9 +319,13 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
         table, parts.asResolvedPartitionSpecs, ignoreIfExists) :: Nil
 
     case AlterTableDropPartition(
-        ResolvedTable(_, _, table: SupportsPartitionManagement), parts, ignoreIfNotExists, _, _) =>
+        ResolvedTable(_, _, table: SupportsPartitionManagement),
+        parts,
+        ignoreIfNotExists,
+        purge,
+        _) =>
       AlterTableDropPartitionExec(
-        table, parts.asResolvedPartitionSpecs, ignoreIfNotExists) :: Nil
+        table, parts.asResolvedPartitionSpecs, ignoreIfNotExists, purge) :: Nil
 
     case LoadData(_: ResolvedTable, _, _, _, _) =>
       throw new AnalysisException("LOAD DATA is not supported for v2 tables.")

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTablePartitionV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTablePartitionV2SQLSuite.scala
@@ -281,4 +281,20 @@ class AlterTablePartitionV2SQLSuite extends DatasourceV2SQLBase {
       }
     }
   }
+
+  test("SPARK-33787: purge partition data") {
+    val t = "testpart.ns1.ns2.tbl"
+    withTable(t) {
+      sql(s"CREATE TABLE $t (id bigint, data string) USING foo PARTITIONED BY (id)")
+      sql(s"ALTER TABLE $t ADD PARTITION (id=1)")
+      try {
+        val errMsg = intercept[UnsupportedOperationException] {
+          sql(s"ALTER TABLE $t DROP PARTITION (id=1) PURGE")
+        }.getMessage
+        assert(errMsg.contains("Purge option is not supported"))
+      } finally {
+        sql(s"ALTER TABLE $t DROP PARTITION (id=1)")
+      }
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Add the boolean flag `purge` to `dropPartition()` in `SupportsPartitionManagement` and `dropPartitions()` in `SupportsAtomicPartitionManagement`.
2. Propagate the parameter from the logical `command` to V2 exec node and further to catalog implementations.
3. Remove the default implementations of dropping partitions from the `SupportsPartitionManagement` and `SupportsAtomicPartitionManagement` interfaces.
4. Update Java docs for `dropTable`.

### Why are the changes needed?
The sql statement `ALTER TABLE .. DROP PARTITION` allows to specify the `PURGE` flag but it is ignored by v2 implementation. We should propagate it at least to `SupportsPartitionManagement` and to `SupportsAtomicPartitionManagement`, and let to implementations of those interface decide how to support it.

### Does this PR introduce _any_ user-facing change?
Should not.

### How was this patch tested?
By running new UT:
```
$ build/sbt -Phive-2.3 -Phive-thriftserver "test:testOnly *AlterTablePartitionV2SQLSuite"
```