### PR TITLE
[SPARK-33830][SQL][DOCS] Describe the `PURGE` option of `ALTER TABLE .. DROP PARTITION`

### DIFF
--- a/docs/sql-ref-syntax-ddl-alter-table.md
+++ b/docs/sql-ref-syntax-ddl-alter-table.md
@@ -147,6 +147,10 @@ ALTER TABLE table_identifier DROP [ IF EXISTS ] partition_spec [PURGE]
     Partition to be dropped.
 
     **Syntax:** `PARTITION ( partition_col_name  = partition_col_val [ , ... ] )`
+
+* **PURGE**
+
+    The option turns on removing of partition data. It is applicable only for managed tables, and ignored for external tables. For V1 In-Memory catalog, Spark always removes data belongs to dropped partitions, but it takes this option into account for V1 Hive and V2 catalogs. If this option is not specified, Spark removes partitions only from a catalog otherwise when PURGE is set Spark also removes partition data.  
      
 ### SET AND UNSET
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
Update the SQL docs about the `ALTER TABLE .. DROP PARTITION` command, and describe the `PURGE` option.

<img width="1031" alt="Screenshot 2020-12-17 at 22 16 48" src="https://user-images.githubusercontent.com/1580697/102533418-7240b180-40b6-11eb-9dcf-651799d334f4.png">

### Why are the changes needed?
To improve UX with Spark SQL.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
By regenerating the SQL docs, and checking by eyes.