### PR TITLE
[SPARK-33827][SS] Unload inactive state store as soon as possible

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreCoordinator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreCoordinator.scala
@@ -34,7 +34,8 @@ private sealed trait StateStoreCoordinatorMessage extends Serializable
 private case class ReportActiveInstance(
     storeId: StateStoreProviderId,
     host: String,
-    executorId: String)
+    executorId: String,
+    otherProviderIds: Seq[StateStoreProviderId])
   extends StateStoreCoordinatorMessage
 
 private case class VerifyIfInstanceActive(storeId: StateStoreProviderId, executorId: String)
@@ -87,8 +88,10 @@ class StateStoreCoordinatorRef private(rpcEndpointRef: RpcEndpointRef) {
   private[sql] def reportActiveInstance(
       stateStoreProviderId: StateStoreProviderId,
       host: String,
-      executorId: String): Unit = {
-    rpcEndpointRef.send(ReportActiveInstance(stateStoreProviderId, host, executorId))
+      executorId: String,
+      otherProviderIds: Seq[StateStoreProviderId]): Seq[StateStoreProviderId] = {
+    rpcEndpointRef.askSync[Seq[StateStoreProviderId]](
+      ReportActiveInstance(stateStoreProviderId, host, executorId, otherProviderIds))
   }
 
   /** Verify whether the given executor has the active instance of a state store */
@@ -122,13 +125,20 @@ private class StateStoreCoordinator(override val rpcEnv: RpcEnv)
     extends ThreadSafeRpcEndpoint with Logging {
   private val instances = new mutable.HashMap[StateStoreProviderId, ExecutorCacheTaskLocation]
 
-  override def receive: PartialFunction[Any, Unit] = {
-    case ReportActiveInstance(id, host, executorId) =>
-      logDebug(s"Reported state store $id is active at $executorId")
-      instances.put(id, ExecutorCacheTaskLocation(host, executorId))
-  }
-
   override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {
+    case ReportActiveInstance(id, host, executorId, otherProviderIds) =>
+      logDebug(s"Reported state store $id is active at $executorId")
+      val taskLocation = ExecutorCacheTaskLocation(host, executorId)
+      instances.put(id, taskLocation)
+
+      // Check if any loaded provider id is already loaded in other executor.
+      val providerIdsToUnload = otherProviderIds.filter { providerId =>
+        val providerLoc = instances.get(providerId)
+        // This provider is is already loaded in other executor. Marked it to unload.
+        providerLoc.map(_ != taskLocation).getOrElse(false)
+      }
+      context.reply(providerIdsToUnload)
+
     case VerifyIfInstanceActive(id, execId) =>
       val response = instances.get(id) match {
         case Some(location) => location.executorId == execId

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreCoordinatorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreCoordinatorSuite.scala
@@ -41,7 +41,7 @@ class StateStoreCoordinatorSuite extends SparkFunSuite with SharedSparkContext {
       assert(coordinatorRef.verifyIfInstanceActive(id, "exec1") === false)
       assert(coordinatorRef.getLocation(id) === None)
 
-      coordinatorRef.reportActiveInstance(id, "hostX", "exec1")
+      coordinatorRef.reportActiveInstance(id, "hostX", "exec1", Seq.empty)
       eventually(timeout(5.seconds)) {
         assert(coordinatorRef.verifyIfInstanceActive(id, "exec1"))
         assert(
@@ -49,7 +49,7 @@ class StateStoreCoordinatorSuite extends SparkFunSuite with SharedSparkContext {
             Some(ExecutorCacheTaskLocation("hostX", "exec1").toString))
       }
 
-      coordinatorRef.reportActiveInstance(id, "hostX", "exec2")
+      coordinatorRef.reportActiveInstance(id, "hostX", "exec2", Seq.empty)
 
       eventually(timeout(5.seconds)) {
         assert(coordinatorRef.verifyIfInstanceActive(id, "exec1") === false)
@@ -72,9 +72,9 @@ class StateStoreCoordinatorSuite extends SparkFunSuite with SharedSparkContext {
       val host = "hostX"
       val exec = "exec1"
 
-      coordinatorRef.reportActiveInstance(id1, host, exec)
-      coordinatorRef.reportActiveInstance(id2, host, exec)
-      coordinatorRef.reportActiveInstance(id3, host, exec)
+      coordinatorRef.reportActiveInstance(id1, host, exec, Seq.empty)
+      coordinatorRef.reportActiveInstance(id2, host, exec, Seq.empty)
+      coordinatorRef.reportActiveInstance(id3, host, exec, Seq.empty)
 
       eventually(timeout(5.seconds)) {
         assert(coordinatorRef.verifyIfInstanceActive(id1, exec))
@@ -106,7 +106,7 @@ class StateStoreCoordinatorSuite extends SparkFunSuite with SharedSparkContext {
 
       val id = StateStoreProviderId(StateStoreId("x", 0, 0), UUID.randomUUID)
 
-      coordRef1.reportActiveInstance(id, "hostX", "exec1")
+      coordRef1.reportActiveInstance(id, "hostX", "exec1", Seq.empty)
 
       eventually(timeout(5.seconds)) {
         assert(coordRef2.verifyIfInstanceActive(id, "exec1"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRDDSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRDDSuite.scala
@@ -159,8 +159,8 @@ class StateStoreRDDSuite extends SparkFunSuite with BeforeAndAfter with BeforeAn
         val coordinatorRef = sqlContext.streams.stateStoreCoordinator
         val storeProviderId1 = StateStoreProviderId(StateStoreId(path, opId, 0), queryRunId)
         val storeProviderId2 = StateStoreProviderId(StateStoreId(path, opId, 1), queryRunId)
-        coordinatorRef.reportActiveInstance(storeProviderId1, "host1", "exec1")
-        coordinatorRef.reportActiveInstance(storeProviderId2, "host2", "exec2")
+        coordinatorRef.reportActiveInstance(storeProviderId1, "host1", "exec1", Seq.empty)
+        coordinatorRef.reportActiveInstance(storeProviderId2, "host2", "exec2", Seq.empty)
 
         require(
           coordinatorRef.getLocation(storeProviderId1) ===

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
@@ -523,7 +523,7 @@ class StreamingInnerJoinSuite extends StreamingJoinSuite {
       }.toMap
       partitionAndStoreNameToLocation.foreach { case ((partIndex, storeName), hostName) =>
         val providerId = StateStoreProviderId(stateInfo, partIndex, storeName)
-        coordinatorRef.reportActiveInstance(providerId, hostName, s"exec-$hostName")
+        coordinatorRef.reportActiveInstance(providerId, hostName, s"exec-$hostName", Seq.empty)
         require(
           coordinatorRef.getLocation(providerId) ===
             Some(ExecutorCacheTaskLocation(hostName, s"exec-$hostName").toString))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This patch proposes to unload inactive state store as soon as possible. The timing of unload inactive state stores, happens when we get to load active state store provider at executors. At the time, state store coordinator will return back the state store provider list including loaded stores that are already loaded by other executors in new batch. Each state store provider in the list will go to unload.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Per the discussion at #30770, it makes sense to me we should unload inactive state store asap. Now we run a maintenance task periodically to unload inactive state stores. So there will be some delays between a state store becomes inactive and it is unloaded.

However, we can force Spark to always allocate a state store to same executor, by using task locality configuration. This can reduce the possibility to have inactive state store.

Normally, with locality configuration, we might not able to see inactive state store generally. There is still chance an executor can be failed and reallocated, but in this case, inactive state store is also lost too. So it is not an issue.

Making driver-executor bi-directional for unloading inactive state store looks non-trivial, and seems to me, it is not worth, after considering what we can do with locality.

This proposes a simpler but effective approach. We can check if loaded state store is already loaded at other executor during reporting active state store to the coordinator. If so, it means the loaded store is inactive now, and it is going to be unload by the next maintenance task. Then we unload that store immediately.

How do we make sure the loaded state store in previous batch is loaded at other executor in this batch before reporting in this executor? With task locality and preferred location, once an executor is ready to be scheduled, Spark should assign the state store provider previously loaded at the executor. So when this executor gets a new assignment other than previously loaded state store, it means the previously loaded one is already assigned to other executor.

There is still a delay between the state store is loaded at other executor, and unloading it when reporting active state store at this executor. But it should be minimized now. And there won't be multiple state store belonging to same operator are loaded at the same time at one single executor, because once the executor reports any active store, it will unload all inactive stores. This should not be an issue IMHO.

This is a minimal change to unload inactive state store asap without significant change.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Unit test.