### PR TITLE
[SPARK-33832][SQL] Add an option in AQE to mitigate skew even if it c…

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -425,7 +425,7 @@ object SQLConf {
 
   val ADAPTIVE_FORCE_IF_SHUFFLE = buildConf("spark.sql.adaptive.force.if.shuffle")
     .doc("Make OptimizeSkewJoin choose skew mitigation even if it causes an extra shuffle")
-    .version("3.0.0")
+    .version("3.2.0")
     .booleanConf
     .createWithDefault(false)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -423,6 +423,12 @@ object SQLConf {
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("64MB")
 
+  val ADAPTIVE_FORCE_IF_SHUFFLE = buildConf("spark.sql.adaptive.force.if.shuffle")
+    .doc("Make OptimizeSkewJoin choose skew mitigation even if it causes an extra shuffle")
+    .version("3.0.0")
+    .booleanConf
+    .createWithDefault(false)
+
   val ADAPTIVE_EXECUTION_ENABLED = buildConf("spark.sql.adaptive.enabled")
     .doc("When true, enable adaptive query execution, which re-optimizes the query plan in the " +
       "middle of query execution, based on accurate runtime statistics.")
@@ -3259,6 +3265,8 @@ class SQLConf extends Serializable with Logging {
   def adaptiveExecutionEnabled: Boolean = getConf(ADAPTIVE_EXECUTION_ENABLED)
 
   def adaptiveExecutionLogLevel: String = getConf(ADAPTIVE_EXECUTION_LOG_LEVEL)
+
+  def adaptiveForceIfShuffle: Boolean = getConf(ADAPTIVE_FORCE_IF_SHUFFLE)
 
   def fetchShuffleBlocksInBatch: Boolean = getConf(FETCH_SHUFFLE_BLOCKS_IN_BATCH)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -348,7 +348,6 @@ case class AdaptiveSparkPlanExec(
     }
     val newShuffle = newShuffles.head
     val parentOfNewShuffle = optimizedPlan.find(_.containsChild(newShuffle)).get
-    // todo: is this the right tag to use?  Maybe AdaptiveSparkPlanExec.TEMP_LOGICAL_PLAN_TAG?
     val t = parentOfNewShuffle.getTagValue(SparkPlan.LOGICAL_PLAN_TAG)
     // find corresponding node in the original plan
     val origPlanParent = originalPlan

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CustomShuffleReaderExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CustomShuffleReaderExec.scala
@@ -91,6 +91,7 @@ case class CustomShuffleReaderExec private(
       UnknownPartitioning(partitionSpecs.length)
     }
   }
+
   override def stringArgs: Iterator[Any] = {
     val desc = if (isLocalReader) {
       "local"

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CustomShuffleReaderExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CustomShuffleReaderExec.scala
@@ -91,9 +91,6 @@ case class CustomShuffleReaderExec private(
       UnknownPartitioning(partitionSpecs.length)
     }
   }
-  /**
-   * include id so that it is visible in the plan text
-   */
   override def stringArgs: Iterator[Any] = {
     val desc = if (isLocalReader) {
       "local"
@@ -106,7 +103,7 @@ case class CustomShuffleReaderExec private(
     } else {
       ""
     }
-    Iterator(id, desc) // todo: or should this be QueryPlan.OP_ID_TAG?
+    Iterator(desc)
   }
 
   def hasCoalescedPartition: Boolean =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeLocalShuffleReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeLocalShuffleReader.scala
@@ -50,8 +50,11 @@ object OptimizeLocalShuffleReader extends CustomShuffleReaderRule {
         val localReader = createLocalReader(shuffleStage)
         join.asInstanceOf[BroadcastHashJoinExec].copy(right = localReader)
     }
-
-    val numShuffles = ensureRequirements.apply(optimizedPlan).collect {
+    if(optimizedPlan eq plan) {
+      return plan
+    }
+    val executedPlan = ensureRequirements.apply(optimizedPlan)
+    val numShuffles = executedPlan.collect {
       case e: ShuffleExchangeExec => e
     }.length
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptivePreferShuffleSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptivePreferShuffleSuite.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.adaptive
+
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * This tests SQLConf.ADAPTIVE_FORCE_IF_SHUFFLE = true
+ * By default SQLConf.ADAPTIVE_FORCE_IF_SHUFFLE = false.
+ * New tests should be added in AdaptiveQueryExecSuite so that they get
+ * tested with the option both on and off.
+ *
+ *
+ * 3. test where new shuffle doesn't get a CSRE - coalesceShufflePartitionsEnabled?
+ */
+class AdaptivePreferShuffleSuite extends AdaptiveQueryExecSuite {
+  var initVal = false
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    initVal = SQLConf.get.getConf(SQLConf.ADAPTIVE_FORCE_IF_SHUFFLE)
+    SQLConf.get.setConf(SQLConf.ADAPTIVE_FORCE_IF_SHUFFLE, true)
+  }
+  override protected def afterAll(): Unit = {
+    super.afterAll()
+    SQLConf.get.setConf(SQLConf.ADAPTIVE_FORCE_IF_SHUFFLE, initVal)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptivePreferShuffleSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptivePreferShuffleSuite.scala
@@ -16,7 +16,6 @@
  */
 package org.apache.spark.sql.execution.adaptive
 
-import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.internal.SQLConf
 
 /**
@@ -24,9 +23,6 @@ import org.apache.spark.sql.internal.SQLConf
  * By default SQLConf.ADAPTIVE_FORCE_IF_SHUFFLE = false.
  * New tests should be added in AdaptiveQueryExecSuite so that they get
  * tested with the option both on and off.
- *
- *
- * 3. test where new shuffle doesn't get a CSRE - coalesceShufflePartitionsEnabled?
  */
 class AdaptivePreferShuffleSuite extends AdaptiveQueryExecSuite {
   var initVal = false

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -236,9 +236,6 @@ class AdaptiveQueryExecSuite
       val df1 = spark.range(10).withColumn("a", 'id)
       val df2 = spark.range(10).withColumn("b", 'id)
       withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
-        //        val testDf = df1.where('a > 5).join(df2.where('b > 5), Seq("id"), "inner")
-        //          .groupBy('id).count()
-        //        checkAnswer(testDf, Seq(Row(6, 1), Row(7, 1), Row(8, 1), Row(9, 1)))
         val testDf = df1.where('a > 10).join(df2.where('b > 10), Seq("id"), "left_outer")
           .groupBy('a).count()
         checkAnswer(testDf, Seq())
@@ -746,7 +743,6 @@ class AdaptiveQueryExecSuite
           assert(innerSmj.last.isSkewJoin, s"actual plan=$innerAdaptivePlan")
           assert(csre.length == 5, s"actual plan=$innerAdaptivePlan")
         }
-        innerAdaptivePlan
       }
     }
   }


### PR DESCRIPTION
…auses an new shuffle

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds `spark.sql.adaptive.force.if.shuffle` config option which, if set to true, causes `OptimizeSkewedJoin` to perform skew mitigation even if it requires a new shuffle to be performed.
For example, current behavior is not perform skew mitigation in the following query
```
Project
|-Group By key1
  |-SMJ on key1 = key2
```
With `spark.sql.adaptive.force.if.shuffle=true`, the SMJ will become `skew=true` and a new shuffle will be added for the Aggregate.  New shuffle itself will be processed by AQE and coalesced, etc if needed.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
It enables AQE to apply in cases where the cost of extra shuffle is less than the cost of unmitigated skew.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, with `spark.sql.adaptive.force.if.shuffle=false`, which is the default

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
New UTs + enhancements of existing ones