### PR TITLE
[SPARK-33835][CORE] Refector AbstractCommandBuilder.buildJavaCommand: use firstNonEmpty

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -96,6 +96,7 @@ abstract class AbstractCommandBuilder {
       childEnv.get("JAVA_HOME"),
       System.getenv("JAVA_HOME"),
       System.getProperty("java.home"));
+
     if (firstJavaHome != null) {
       cmd.add(join(File.separator, firstJavaHome, "bin", "java"));
     }

--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -96,8 +96,9 @@ abstract class AbstractCommandBuilder {
       childEnv.get("JAVA_HOME"),
       System.getenv("JAVA_HOME"),
       System.getProperty("java.home"));
+
     if (firstJavaHome != null) {
-        cmd.add(join(File.separator, firstJavaHome, "bin", "java"));
+      cmd.add(join(File.separator, firstJavaHome, "bin", "java"));
     }
 
     // Load extra JAVA_OPTS from conf/java-opts, if it exists.

--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -96,7 +96,6 @@ abstract class AbstractCommandBuilder {
       childEnv.get("JAVA_HOME"),
       System.getenv("JAVA_HOME"),
       System.getProperty("java.home"));
-
     if (firstJavaHome != null) {
       cmd.add(join(File.separator, firstJavaHome, "bin", "java"));
     }

--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -92,18 +92,11 @@ abstract class AbstractCommandBuilder {
   List<String> buildJavaCommand(String extraClassPath) throws IOException {
     List<String> cmd = new ArrayList<>();
 
-    String[] candidateJavaHomes = new String[] {
-      javaHome,
+    String firstJavaHome = firstNonEmpty(javaHome,
       childEnv.get("JAVA_HOME"),
       System.getenv("JAVA_HOME"),
-      System.getProperty("java.home")
-    };
-    for (String javaHome : candidateJavaHomes) {
-      if (javaHome != null) {
-        cmd.add(join(File.separator, javaHome, "bin", "java"));
-        break;
-      }
-    }
+      System.getProperty("java.home"));
+    cmd.add(join(File.separator, firstJavaHome, "bin", "java"));
 
     // Load extra JAVA_OPTS from conf/java-opts, if it exists.
     File javaOpts = new File(join(File.separator, getConfDir(), "java-opts"));

--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -96,7 +96,9 @@ abstract class AbstractCommandBuilder {
       childEnv.get("JAVA_HOME"),
       System.getenv("JAVA_HOME"),
       System.getProperty("java.home"));
-    cmd.add(join(File.separator, firstJavaHome, "bin", "java"));
+    if (firstJavaHome != null) {
+        cmd.add(join(File.separator, firstJavaHome, "bin", "java"));
+    }
 
     // Load extra JAVA_OPTS from conf/java-opts, if it exists.
     File javaOpts = new File(join(File.separator, getConfDir(), "java-opts"));


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
refector AbstractCommandBuilder.buildJavaCommand: use firstNonEmpty 


### Why are the changes needed?
For better code understanding, and firstNonEmpty can detect javaHome = "   ", an empty string.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
End to End.
