### PR TITLE
[SPARK-33838][SQL][DOCS] Comment the `PURGE` option in the DropTable and in AlterTableDropPartition commands

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -657,9 +657,15 @@ case class AlterTableAddPartition(
  * The logical plan of the ALTER TABLE DROP PARTITION command.
  * This may remove the data and metadata for this partition.
  *
+ * The `PURGE` option turns on removing of partition data. It is applicable only for managed tables,
+ * and ignored for external tables. For V1 In-Memory catalog, Spark always removes data belongs to
+ * dropped partitions, but it takes this option into account for V1 Hive external catalog. If this
+ * option is not specified, Spark removes partitions only from a catalog otherwise when `PURGE` is
+ * set Spark also removes partition data.
+ *
  * The syntax of this command is:
  * {{{
- *     ALTER TABLE table DROP [IF EXISTS] PARTITION spec1[, PARTITION spec2, ...];
+ *     ALTER TABLE table DROP [IF EXISTS] PARTITION spec1[, PARTITION spec2, ...] [PURGE];
  * }}}
  */
 case class AlterTableDropPartition(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -411,11 +411,8 @@ case class Assignment(key: Expression, value: Expression) extends Expression wit
 /**
  * The logical plan of the DROP TABLE command.
  *
- * The `PURGE` option turns on removing of table data. It is applicable only for managed tables,
- * and ignored for external tables. For V1 In-Memory catalog, Spark always removes data belongs to
- * dropped tables, but it takes this option into account for V1 Hive external catalog. If this
- * option is not specified, Spark removes tables only from a catalog otherwise when `PURGE` is
- * set Spark also removes table data.
+ * If the `PURGE` option is set, the table catalog must remove table data by skipping the trash
+ * even when the catalog has configured one. The option is applicable only for managed tables.
  *
  * The syntax of this command is:
  * {{{
@@ -668,11 +665,8 @@ case class AlterTableAddPartition(
  * The logical plan of the ALTER TABLE DROP PARTITION command.
  * This may remove the data and metadata for this partition.
  *
- * The `PURGE` option turns on removing of partition data. It is applicable only for managed tables,
- * and ignored for external tables. For V1 In-Memory catalog, Spark always removes data belongs to
- * dropped partitions, but it takes this option into account for V1 Hive external catalog. If this
- * option is not specified, Spark removes partitions only from a catalog otherwise when `PURGE` is
- * set Spark also removes partition data.
+ * If the `PURGE` option is set, the table catalog must remove partition data by skipping the trash
+ * even when the catalog has configured one. The option is applicable only for managed tables.
  *
  * The syntax of this command is:
  * {{{

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -410,6 +410,17 @@ case class Assignment(key: Expression, value: Expression) extends Expression wit
 
 /**
  * The logical plan of the DROP TABLE command.
+ *
+ * The `PURGE` option turns on removing of table data. It is applicable only for managed tables,
+ * and ignored for external tables. For V1 In-Memory catalog, Spark always removes data belongs to
+ * dropped tables, but it takes this option into account for V1 Hive external catalog. If this
+ * option is not specified, Spark removes tables only from a catalog otherwise when `PURGE` is
+ * set Spark also removes table data.
+ *
+ * The syntax of this command is:
+ * {{{
+ *     DROP TABLE [IF EXISTS] table [PURGE];
+ * }}}
  */
 case class DropTable(
     child: LogicalPlan,


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add comments for the `PURGE` option to the logical nodes `DropTable` and `AlterTableDropPartition`.

### Why are the changes needed?
To improve code maintenance. 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
By running `./dev/scalastyle`