### PR TITLE
[SPARK-33842][Core][Shuffle] Add spark.shuffle.io.sessionTimeout to check an established connection for being idled or dead

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
@@ -192,7 +192,7 @@ public class TransportContext implements Closeable {
         .addLast(TransportFrameDecoder.HANDLER_NAME, NettyUtils.createFrameDecoder())
         .addLast("decoder", DECODER)
         .addLast("idleStateHandler",
-          new IdleStateHandler(0, 0, conf.connectionTimeoutMs() / 1000))
+          new IdleStateHandler(0, 0, conf.sessionTimeoutMs() / 1000))
         // NOTE: Chunks are currently guaranteed to be returned in the order of request, but this
         // would require more logic to guarantee if this were not part of the same event loop.
         .addLast("handler", channelHandler);
@@ -228,7 +228,7 @@ public class TransportContext implements Closeable {
     TransportRequestHandler requestHandler = new TransportRequestHandler(channel, client,
       rpcHandler, conf.maxChunksBeingTransferred(), chunkFetchRequestHandler);
     return new TransportChannelHandler(client, responseHandler, requestHandler,
-      conf.connectionTimeoutMs(), separateChunkFetchRequest, closeIdleConnections, this);
+      conf.sessionTimeoutMs(), separateChunkFetchRequest, closeIdleConnections, this);
   }
 
   public TransportConf getConf() { return conf; }

--- a/common/network-common/src/main/java/org/apache/spark/network/server/TransportChannelHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/TransportChannelHandler.java
@@ -165,8 +165,8 @@ public class TransportChannelHandler extends SimpleChannelInboundHandler<Message
           if (hasInFlightRequests) {
             String address = getRemoteAddress(ctx.channel());
             logger.error("Connection to {} has been quiet for {} ms while there are outstanding " +
-              "requests. Assuming connection is dead; please adjust spark.{}.io.sessionTimeout if " +
-              "this is wrong.", address, requestTimeoutNs / 1000 / 1000,
+              "requests. Assuming connection is dead; please adjust spark.{}.io.sessionTimeout " +
+              "if this is wrong.", address, requestTimeoutNs / 1000 / 1000,
                transportContext.getConf().getModuleName());
             client.timeOut();
             ctx.close();

--- a/common/network-common/src/main/java/org/apache/spark/network/server/TransportChannelHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/TransportChannelHandler.java
@@ -165,8 +165,9 @@ public class TransportChannelHandler extends SimpleChannelInboundHandler<Message
           if (hasInFlightRequests) {
             String address = getRemoteAddress(ctx.channel());
             logger.error("Connection to {} has been quiet for {} ms while there are outstanding " +
-              "requests. Assuming connection is dead; please adjust spark.network.timeout if " +
-              "this is wrong.", address, requestTimeoutNs / 1000 / 1000);
+              "requests. Assuming connection is dead; please adjust spark.{}.io.sessionTimeout if " +
+              "this is wrong.", address, requestTimeoutNs / 1000 / 1000,
+               transportContext.getConf().getModuleName());
             client.timeOut();
             ctx.close();
           } else if (closeIdleConnections) {

--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -31,6 +31,7 @@ public class TransportConf {
   private final String SPARK_NETWORK_IO_MODE_KEY;
   private final String SPARK_NETWORK_IO_PREFERDIRECTBUFS_KEY;
   private final String SPARK_NETWORK_IO_CONNECTIONTIMEOUT_KEY;
+  private final String SPARK_NETWORK_IO_SESSIONTIMEOUT_KEY;
   private final String SPARK_NETWORK_IO_BACKLOG_KEY;
   private final String SPARK_NETWORK_IO_NUMCONNECTIONSPERPEER_KEY;
   private final String SPARK_NETWORK_IO_SERVERTHREADS_KEY;
@@ -54,6 +55,7 @@ public class TransportConf {
     SPARK_NETWORK_IO_MODE_KEY = getConfKey("io.mode");
     SPARK_NETWORK_IO_PREFERDIRECTBUFS_KEY = getConfKey("io.preferDirectBufs");
     SPARK_NETWORK_IO_CONNECTIONTIMEOUT_KEY = getConfKey("io.connectionTimeout");
+    SPARK_NETWORK_IO_SESSIONTIMEOUT_KEY = getConfKey("io.sessionTimeout");
     SPARK_NETWORK_IO_BACKLOG_KEY = getConfKey("io.backLog");
     SPARK_NETWORK_IO_NUMCONNECTIONSPERPEER_KEY =  getConfKey("io.numConnectionsPerPeer");
     SPARK_NETWORK_IO_SERVERTHREADS_KEY = getConfKey("io.serverThreads");
@@ -100,6 +102,13 @@ public class TransportConf {
       conf.get("spark.network.timeout", "120s"));
     long defaultTimeoutMs = JavaUtils.timeStringAsSec(
       conf.get(SPARK_NETWORK_IO_CONNECTIONTIMEOUT_KEY, defaultNetworkTimeoutS + "s")) * 1000;
+    return (int) defaultTimeoutMs;
+  }
+
+  /** Session timeout in milliseconds. Default {@link TransportConf#connectionTimeoutMs}. */
+  public int sessionTimeoutMs() {
+    long defaultTimeoutMs = JavaUtils.timeStringAsMs(
+      conf.get(SPARK_NETWORK_IO_SESSIONTIMEOUT_KEY, connectionTimeoutMs() + "ms"));
     return (int) defaultTimeoutMs;
   }
 

--- a/common/network-common/src/test/java/org/apache/spark/network/RequestTimeoutIntegrationSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/RequestTimeoutIntegrationSuite.java
@@ -61,7 +61,8 @@ public class RequestTimeoutIntegrationSuite {
   @Before
   public void setUp() throws Exception {
     Map<String, String> configMap = new HashMap<>();
-    configMap.put("spark.shuffle.io.connectionTimeout", "10s");
+    configMap.put("spark.shuffle.io.sessionTimeout", "10s");
+    configMap.put("spark.shuffle.io.connectionTimeout", "600s");
     conf = new TransportConf("shuffle", new MapConfigProvider(configMap));
 
     defaultManager = new StreamManager() {

--- a/common/network-common/src/test/java/org/apache/spark/network/client/TransportClientFactorySuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/client/TransportClientFactorySuite.java
@@ -192,7 +192,7 @@ public class TransportClientFactorySuite {
 
       @Override
       public String get(String name) {
-        if ("spark.shuffle.io.connectionTimeout".equals(name)) {
+        if ("spark.shuffle.io.sessionTimeout".equals(name)) {
           // We should make sure there is enough time for us to observe the channel is active
           return "1s";
         }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -940,7 +940,7 @@ Apart from these, the following properties are also available, and may be useful
   <td>
     (Netty only) Timeout for the established connections between shuffle servers and clients
     to be marked as idled. The connection will be closed for it is quiet or may be dead whether
-    there are still outstanding request or not.
+    there are still outstanding requests or not.
   </td>
   <td>3.2.0</td>
 </tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -924,6 +924,27 @@ Apart from these, the following properties are also available, and may be useful
   <td>1.1.1</td>
 </tr>
 <tr>
+  <td><code>spark.shuffle.io.connectionTimeout</code></td>
+  <td>value of <code>spark.network.timeout</code></td>
+  <td>
+    (Netty only) Timeout for a shuffle clients to establish the connection with shuffle server. If
+    time exceeds this setting, the current handshake will be aborted and retry within
+    <code>spark.shuffle.io.maxRetries</code> in shuffle transportation or
+    <code>spark.shuffle.registration.maxAttempts</code> in registration with external shuffle service.
+  </td>
+  <td>1.2.0</td>
+</tr>
+<tr>
+  <td><code>spark.shuffle.io.sessionTimeout</code></td>
+  <td>value of <code>spark.shuffle.io.connectionTimeout</code></td>
+  <td>
+    (Netty only) Timeout for the established connections between shuffle servers and clients
+    to be marked as idled. The connection will be closed for it is quiet or may be dead whether
+    there are still outstanding request or not.
+  </td>
+  <td>3.2.0</td>
+</tr>
+<tr>
   <td><code>spark.shuffle.service.enabled</code></td>
   <td>false</td>
   <td>
@@ -1920,7 +1941,8 @@ Apart from these, the following properties are also available, and may be useful
   <td>
     Default timeout for all network interactions. This config will be used in place of
     <code>spark.storage.blockManagerHeartbeatTimeoutMs</code>,
-    <code>spark.shuffle.io.connectionTimeout</code>, <code>spark.rpc.askTimeout</code> or
+    <code>spark.shuffle.io.connectionTimeout</code>, <code>spark.shuffle.io.sessionTimeout</code>,
+    <code>spark.rpc.askTimeout</code> or
     <code>spark.rpc.lookupTimeout</code> if they are not configured.
   </td>
   <td>1.3.0</td>


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

We have `spark.shuffle.io.connectionTimeout` for timeout checking when shuffle clients establish connections with shuffle servers. We also use it to check the established connection is idled or dead too. If we want a connection that can keep alive for a long time, we may increase the blocking time to create a shuffle client if the server is busy at that time.

In practice, we always use connection timeout and session timeout to control these two different phases.
This PR adds `spark.shuffle.io.sessionTimeout `to check an established connection for being idled or dead
### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

yes, w/ new conf spark.shuffle.io.sessionTimeout ` to check an established connection for being idled or dead
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
modified tests