### PR TITLE
[SPARK-33124][SQL] Fills missing group tags and re-categorizes all the group tags for built-in functions

### DIFF
--- a/docs/sql-ref-functions-builtin.md
+++ b/docs/sql-ref-functions-builtin.md
@@ -31,6 +31,8 @@ license: |
     {% if static_file.name == 'generated-window-funcs-table.html' %}
 ### Window Functions
 {% include_relative generated-window-funcs-table.html %}
+#### Examples
+{% include_relative generated-window-funcs-examples.html %}
         {% break %}
     {% endif %}
 {% endfor %}

--- a/docs/sql-ref-functions-builtin.md
+++ b/docs/sql-ref-functions-builtin.md
@@ -31,8 +31,6 @@ license: |
     {% if static_file.name == 'generated-window-funcs-table.html' %}
 ### Window Functions
 {% include_relative generated-window-funcs-table.html %}
-#### Examples
-{% include_relative generated-window-funcs-examples.html %}
         {% break %}
     {% endif %}
 {% endfor %}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionInfo.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionInfo.java
@@ -40,8 +40,11 @@ public class ExpressionInfo {
     private String deprecated;
 
     private static final Set<String> validGroups =
-        new HashSet<>(Arrays.asList("agg_funcs", "array_funcs", "datetime_funcs",
-            "json_funcs", "map_funcs", "window_funcs"));
+        new HashSet<>(Arrays.asList("agg_funcs", "array_funcs", "binary_funcs", "bitwise_funcs",
+            "comparison_funcs", "conditional_funcs", "conversion_funcs", "csv_funcs",
+            "datetime_funcs", "generator_funcs", "grouping_funcs", "json_funcs", "logical_funcs",
+            "map_funcs", "math_funcs", "misc_funcs", "regex_funcs", "string_funcs", "struct_funcs",
+            "window_funcs", "xml_funcs"));
 
     public String getClassName() {
         return className;

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionInfo.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionInfo.java
@@ -41,8 +41,8 @@ public class ExpressionInfo {
 
     private static final Set<String> validGroups =
         new HashSet<>(Arrays.asList("agg_funcs", "array_funcs", "binary_funcs", "bitwise_funcs",
-            "comparison_funcs", "conditional_funcs", "conversion_funcs", "csv_funcs",
-            "datetime_funcs", "generator_funcs", "grouping_funcs", "json_funcs", "logical_funcs",
+            "collection_funcs", "comparison_funcs", "condition_funcs", "conversion_funcs",
+            "csv_funcs", "datetime_funcs", "generator_funcs", "json_funcs", "logical_funcs",
             "map_funcs", "math_funcs", "misc_funcs", "regex_funcs", "string_funcs", "struct_funcs",
             "window_funcs", "xml_funcs"));
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionInfo.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionInfo.java
@@ -41,9 +41,9 @@ public class ExpressionInfo {
 
     private static final Set<String> validGroups =
         new HashSet<>(Arrays.asList("agg_funcs", "array_funcs", "binary_funcs", "bitwise_funcs",
-            "collection_funcs", "comparison_funcs", "condition_funcs", "conversion_funcs",
-            "csv_funcs", "datetime_funcs", "generator_funcs", "json_funcs", "logical_funcs",
-            "map_funcs", "math_funcs", "misc_funcs", "regex_funcs", "string_funcs", "struct_funcs",
+            "collection_funcs", "predicate_funcs", "conditional_funcs", "conversion_funcs",
+            "csv_funcs", "datetime_funcs", "generator_funcs", "hash_funcs", "json_funcs",
+            "lambda_funcs", "map_funcs", "math_funcs", "misc_funcs", "string_funcs", "struct_funcs",
             "window_funcs", "xml_funcs"));
 
     public String getClassName() {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -660,7 +660,8 @@ object FunctionRegistry {
     val clazz = scala.reflect.classTag[Cast].runtimeClass
     val usage = "_FUNC_(expr) - Casts the value `expr` to the target data type `_FUNC_`."
     val expressionInfo =
-      new ExpressionInfo(clazz.getCanonicalName, null, name, usage, "", "", "", "", "2.0.1", "")
+      new ExpressionInfo(clazz.getCanonicalName, null, name, usage, "", "", "",
+        "conversion_funcs", "2.0.1", "")
     (name, (expressionInfo, builder))
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/CallMethodViaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/CallMethodViaReflection.scala
@@ -52,7 +52,8 @@ import org.apache.spark.util.Utils
       > SELECT _FUNC_('java.util.UUID', 'fromString', 'a5cf6c42-0c85-418f-af6c-3e4e5b1328f2');
        a5cf6c42-0c85-418f-af6c-3e4e5b1328f2
   """,
-  since = "2.0.0")
+  since = "2.0.0",
+  group = "misc_funcs")
 case class CallMethodViaReflection(children: Seq[Expression])
   extends Nondeterministic with CodegenFallback {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -1755,7 +1755,8 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
       > SELECT _FUNC_('10' as int);
        10
   """,
-  since = "1.0.0")
+  since = "1.0.0",
+  group = "conversion_funcs")
 case class Cast(child: Expression, dataType: DataType, timeZoneId: Option[String] = None)
   extends CastBase {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/MonotonicallyIncreasingID.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/MonotonicallyIncreasingID.scala
@@ -46,7 +46,8 @@ import org.apache.spark.sql.types.{DataType, LongType}
       > SELECT _FUNC_();
        0
   """,
-  since = "1.4.0")
+  since = "1.4.0",
+  group = "misc_funcs")
 case class MonotonicallyIncreasingID() extends LeafExpression with Stateful {
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SparkPartitionID.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SparkPartitionID.scala
@@ -32,7 +32,8 @@ import org.apache.spark.sql.types.{DataType, IntegerType}
       > SELECT _FUNC_();
        0
   """,
-  since = "1.4.0")
+  since = "1.4.0",
+  group = "misc_funcs")
 case class SparkPartitionID() extends LeafExpression with Nondeterministic {
 
   override def nullable: Boolean = false

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -33,7 +33,8 @@ import org.apache.spark.unsafe.types.CalendarInterval
       > SELECT _FUNC_(1);
        -1
   """,
-  since = "1.0.0")
+  since = "1.0.0",
+  group = "math_funcs")
 case class UnaryMinus(
     child: Expression,
     failOnError: Boolean = SQLConf.get.ansiEnabled)
@@ -105,7 +106,8 @@ case class UnaryMinus(
       > SELECT _FUNC_(1);
        1
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "math_funcs")
 case class UnaryPositive(child: Expression)
   extends UnaryExpression with ExpectsInputTypes with NullIntolerant {
 
@@ -133,7 +135,8 @@ case class UnaryPositive(child: Expression)
       > SELECT _FUNC_(-1);
        1
   """,
-  since = "1.2.0")
+  since = "1.2.0",
+  group = "math_funcs")
 case class Abs(child: Expression)
   extends UnaryExpression with ExpectsInputTypes with NullIntolerant {
 
@@ -236,7 +239,8 @@ object BinaryArithmetic {
       > SELECT 1 _FUNC_ 2;
        3
   """,
-  since = "1.0.0")
+  since = "1.0.0",
+  group = "math_funcs")
 case class Add(
     left: Expression,
     right: Expression,
@@ -274,7 +278,8 @@ case class Add(
       > SELECT 2 _FUNC_ 1;
        1
   """,
-  since = "1.0.0")
+  since = "1.0.0",
+  group = "math_funcs")
 case class Subtract(
     left: Expression,
     right: Expression,
@@ -312,7 +317,8 @@ case class Subtract(
       > SELECT 2 _FUNC_ 3;
        6
   """,
-  since = "1.0.0")
+  since = "1.0.0",
+  group = "math_funcs")
 case class Multiply(
     left: Expression,
     right: Expression,
@@ -436,7 +442,8 @@ trait DivModLike extends BinaryArithmetic {
       > SELECT 2L _FUNC_ 2L;
        1.0
   """,
-  since = "1.0.0")
+  since = "1.0.0",
+  group = "math_funcs")
 // scalastyle:on line.size.limit
 case class Divide(
     left: Expression,
@@ -465,7 +472,8 @@ case class Divide(
       > SELECT 3 _FUNC_ 2;
        1
   """,
-  since = "3.0.0")
+  since = "3.0.0",
+  group = "math_funcs")
 // scalastyle:on line.size.limit
 case class IntegralDivide(
     left: Expression,
@@ -512,7 +520,8 @@ case class IntegralDivide(
       > SELECT MOD(2, 1.8);
        0.2
   """,
-  since = "1.0.0")
+  since = "1.0.0",
+  group = "math_funcs")
 case class Remainder(
     left: Expression,
     right: Expression,
@@ -565,7 +574,8 @@ case class Remainder(
       > SELECT _FUNC_(-10, 3);
        2
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "math_funcs")
 case class Pmod(
     left: Expression,
     right: Expression,
@@ -750,7 +760,8 @@ case class Pmod(
       > SELECT _FUNC_(10, 9, 2, 4, 3);
        2
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "comparison_funcs")
 case class Least(children: Seq[Expression]) extends ComplexTypeMergingExpression {
 
   override def nullable: Boolean = children.forall(_.nullable)
@@ -824,7 +835,8 @@ case class Least(children: Seq[Expression]) extends ComplexTypeMergingExpression
       > SELECT _FUNC_(10, 9, 2, 4, 3);
        10
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "comparison_funcs")
 case class Greatest(children: Seq[Expression]) extends ComplexTypeMergingExpression {
 
   override def nullable: Boolean = children.forall(_.nullable)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -761,7 +761,7 @@ case class Pmod(
        2
   """,
   since = "1.5.0",
-  group = "comparison_funcs")
+  group = "math_funcs")
 case class Least(children: Seq[Expression]) extends ComplexTypeMergingExpression {
 
   override def nullable: Boolean = children.forall(_.nullable)
@@ -836,7 +836,7 @@ case class Least(children: Seq[Expression]) extends ComplexTypeMergingExpression
        10
   """,
   since = "1.5.0",
-  group = "comparison_funcs")
+  group = "math_funcs")
 case class Greatest(children: Seq[Expression]) extends ComplexTypeMergingExpression {
 
   override def nullable: Boolean = children.forall(_.nullable)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/bitwiseExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/bitwiseExpressions.scala
@@ -33,7 +33,8 @@ import org.apache.spark.sql.types._
       > SELECT 3 _FUNC_ 5;
        1
   """,
-  since = "1.4.0")
+  since = "1.4.0",
+  group = "bitwise_funcs")
 case class BitwiseAnd(left: Expression, right: Expression) extends BinaryArithmetic {
 
   protected override val failOnError: Boolean = false
@@ -68,7 +69,8 @@ case class BitwiseAnd(left: Expression, right: Expression) extends BinaryArithme
       > SELECT 3 _FUNC_ 5;
        7
   """,
-  since = "1.4.0")
+  since = "1.4.0",
+  group = "bitwise_funcs")
 case class BitwiseOr(left: Expression, right: Expression) extends BinaryArithmetic {
 
   protected override val failOnError: Boolean = false
@@ -103,7 +105,8 @@ case class BitwiseOr(left: Expression, right: Expression) extends BinaryArithmet
       > SELECT 3 _FUNC_ 5;
        6
   """,
-  since = "1.4.0")
+  since = "1.4.0",
+  group = "bitwise_funcs")
 case class BitwiseXor(left: Expression, right: Expression) extends BinaryArithmetic {
 
   protected override val failOnError: Boolean = false
@@ -136,7 +139,8 @@ case class BitwiseXor(left: Expression, right: Expression) extends BinaryArithme
       > SELECT _FUNC_ 0;
        -1
   """,
-  since = "1.4.0")
+  since = "1.4.0",
+  group = "bitwise_funcs")
 case class BitwiseNot(child: Expression)
   extends UnaryExpression with ExpectsInputTypes with NullIntolerant {
 
@@ -174,7 +178,8 @@ case class BitwiseNot(child: Expression)
       > SELECT _FUNC_(0);
        0
   """,
-  since = "3.0.0")
+  since = "3.0.0",
+  group = "bitwise_funcs")
 case class BitwiseCount(child: Expression)
   extends UnaryExpression with ExpectsInputTypes with NullIntolerant {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -90,7 +90,8 @@ trait BinaryArrayExpressionWithImplicitCast extends BinaryExpression
       > SELECT _FUNC_(NULL);
        -1
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "array_funcs")
 case class Size(child: Expression, legacySizeOfNull: Boolean)
   extends UnaryExpression with ExpectsInputTypes {
 
@@ -1922,7 +1923,8 @@ case class ArrayPosition(left: Expression, right: Expression)
       > SELECT _FUNC_(map(1, 'a', 2, 'b'), 2);
        b
   """,
-  since = "2.4.0")
+  since = "2.4.0",
+  group = "map_funcs")
 case class ElementAt(
     left: Expression,
     right: Expression,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -91,7 +91,7 @@ trait BinaryArrayExpressionWithImplicitCast extends BinaryExpression
        -1
   """,
   since = "1.5.0",
-  group = "array_funcs")
+  group = "collection_funcs")
 case class Size(child: Expression, legacySizeOfNull: Boolean)
   extends UnaryExpression with ExpectsInputTypes {
 
@@ -1019,7 +1019,7 @@ case class Shuffle(child: Expression, randomSeed: Option[Long] = None)
       > SELECT _FUNC_(array(2, 1, 4, 3));
        [3,4,1,2]
   """,
-  group = "array_funcs",
+  group = "collection_funcs",
   since = "1.5.0",
   note = """
     Reverse logic for arrays is available since 2.4.0.
@@ -2099,7 +2099,7 @@ case class ElementAt(
   note = """
     Concat logic for arrays is available since 2.4.0.
   """,
-  group = "array_funcs",
+  group = "collection_funcs",
   since = "1.5.0")
 case class Concat(children: Seq[Expression]) extends ComplexTypeMergingExpression {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
@@ -52,7 +52,8 @@ trait NoThrow
       > SELECT _FUNC_(1, 2, 3);
        [1,2,3]
   """,
-  since = "1.1.0")
+  since = "1.1.0",
+  group = "array_funcs")
 case class CreateArray(children: Seq[Expression], useStringTypeWhenEmpty: Boolean)
   extends Expression with NoThrow {
 
@@ -170,7 +171,8 @@ private [sql] object GenArrayData {
       > SELECT _FUNC_(1.0, '2', 3.0, '4');
        {1.0:"2",3.0:"4"}
   """,
-  since = "2.0.0")
+  since = "2.0.0",
+  group = "map_funcs")
 case class CreateMap(children: Seq[Expression], useStringTypeWhenEmpty: Boolean)
   extends Expression with NoThrow {
 
@@ -271,7 +273,8 @@ object CreateMap {
       > SELECT _FUNC_(array(1.0, 3.0), array('2', '4'));
        {1.0:"2",3.0:"4"}
   """,
-  since = "2.4.0")
+  since = "2.4.0",
+  group = "map_funcs")
 case class MapFromArrays(left: Expression, right: Expression)
   extends BinaryExpression with ExpectsInputTypes with NullIntolerant {
 
@@ -369,7 +372,7 @@ object CreateStruct {
         |       {"col1":1,"col2":2,"col3":3}
         |  """.stripMargin,
       "",
-      "",
+      "struct_funcs",
       "1.4.0",
       "")
     ("struct", (info, this.create))
@@ -389,7 +392,8 @@ object CreateStruct {
       > SELECT _FUNC_("a", 1, "b", 2, "c", 3);
        {"a":1,"b":2,"c":3}
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "struct_funcs")
 // scalastyle:on line.size.limit
 case class CreateNamedStruct(children: Seq[Expression]) extends Expression with NoThrow {
   lazy val (nameExprs, valExprs) = children.grouped(2).map {
@@ -495,7 +499,8 @@ case class CreateNamedStruct(children: Seq[Expression]) extends Expression with 
       > SELECT _FUNC_('a');
        {"a":null}
   """,
-  since = "2.0.1")
+  since = "2.0.1",
+  group = "map_funcs")
 // scalastyle:on line.size.limit
 case class StringToMap(text: Expression, pairDelim: Expression, keyValueDelim: Expression)
   extends TernaryExpression with ExpectsInputTypes with NullIntolerant {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
@@ -31,7 +31,8 @@ import org.apache.spark.sql.types._
       > SELECT _FUNC_(1 < 2, 'a', 'b');
        a
   """,
-  since = "1.0.0")
+  since = "1.0.0",
+  group = "conditional_funcs")
 // scalastyle:on line.size.limit
 case class If(predicate: Expression, trueValue: Expression, falseValue: Expression)
   extends ComplexTypeMergingExpression {
@@ -118,7 +119,8 @@ case class If(predicate: Expression, trueValue: Expression, falseValue: Expressi
       > SELECT CASE WHEN 1 < 0 THEN 1 WHEN 2 < 0 THEN 2.0 END;
        NULL
   """,
-  since = "1.0.1")
+  since = "1.0.1",
+  group = "conditional_funcs")
 // scalastyle:on line.size.limit
 case class CaseWhen(
     branches: Seq[(Expression, Expression)],

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.types._
        a
   """,
   since = "1.0.0",
-  group = "condition_funcs")
+  group = "conditional_funcs")
 // scalastyle:on line.size.limit
 case class If(predicate: Expression, trueValue: Expression, falseValue: Expression)
   extends ComplexTypeMergingExpression {
@@ -120,7 +120,7 @@ case class If(predicate: Expression, trueValue: Expression, falseValue: Expressi
        NULL
   """,
   since = "1.0.1",
-  group = "condition_funcs")
+  group = "conditional_funcs")
 // scalastyle:on line.size.limit
 case class CaseWhen(
     branches: Seq[(Expression, Expression)],

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.types._
        a
   """,
   since = "1.0.0",
-  group = "conditional_funcs")
+  group = "condition_funcs")
 // scalastyle:on line.size.limit
 case class If(predicate: Expression, trueValue: Expression, falseValue: Expression)
   extends ComplexTypeMergingExpression {
@@ -120,7 +120,7 @@ case class If(predicate: Expression, trueValue: Expression, falseValue: Expressi
        NULL
   """,
   since = "1.0.1",
-  group = "conditional_funcs")
+  group = "condition_funcs")
 // scalastyle:on line.size.limit
 case class CaseWhen(
     branches: Seq[(Expression, Expression)],

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/csvExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/csvExpressions.scala
@@ -44,7 +44,8 @@ import org.apache.spark.unsafe.types.UTF8String
       > SELECT _FUNC_('26/08/2015', 'time Timestamp', map('timestampFormat', 'dd/MM/yyyy'));
        {"time":2015-08-26 00:00:00}
   """,
-  since = "3.0.0")
+  since = "3.0.0",
+  group = "csv_funcs")
 // scalastyle:on line.size.limit
 case class CsvToStructs(
     schema: StructType,
@@ -146,7 +147,8 @@ case class CsvToStructs(
       > SELECT _FUNC_('1,abc');
        STRUCT<`_c0`: INT, `_c1`: STRING>
   """,
-  since = "3.0.0")
+  since = "3.0.0",
+  group = "csv_funcs")
 case class SchemaOfCsv(
     child: Expression,
     options: Map[String, String])
@@ -205,7 +207,8 @@ case class SchemaOfCsv(
       > SELECT _FUNC_(named_struct('time', to_timestamp('2015-08-26', 'yyyy-MM-dd')), map('timestampFormat', 'dd/MM/yyyy'));
        26/08/2015
   """,
-  since = "3.0.0")
+  since = "3.0.0",
+  group = "csv_funcs")
 // scalastyle:on line.size.limit
 case class StructsToCsv(
      options: Map[String, String],

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -697,6 +697,7 @@ case class Month(child: Expression) extends GetDateField {
       > SELECT _FUNC_('2009-07-30');
        30
   """,
+  group = "datetime_funcs",
   since = "1.5.0")
 case class DayOfMonth(child: Expression) extends GetDateField {
   override val func = DateTimeUtils.getDayOfMonth
@@ -2247,6 +2248,7 @@ case class DatePart(field: Expression, source: Expression, child: Expression)
   note = """
     The _FUNC_ function is equivalent to `date_part(field, source)`.
   """,
+  group = "datetime_funcs",
   since = "3.0.0")
 // scalastyle:on line.size.limit
 case class Extract(field: Expression, source: Expression, child: Expression)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/generators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/generators.scala
@@ -136,7 +136,8 @@ case class UserDefinedGenerator(
        1	2
        3	NULL
   """,
-  since = "2.0.0")
+  since = "2.0.0",
+  group = "generator_funcs")
 // scalastyle:on line.size.limit line.contains.tab
 case class Stack(children: Seq[Expression]) extends Generator {
 
@@ -362,7 +363,8 @@ abstract class ExplodeBase extends UnaryExpression with CollectionGenerator with
        10
        20
   """,
-  since = "1.0.0")
+  since = "1.0.0",
+  group = "generator_funcs")
 // scalastyle:on line.size.limit
 case class Explode(child: Expression) extends ExplodeBase {
   override val position: Boolean = false
@@ -386,7 +388,8 @@ case class Explode(child: Expression) extends ExplodeBase {
        0	10
        1	20
   """,
-  since = "2.0.0")
+  since = "2.0.0",
+  group = "generator_funcs")
 // scalastyle:on line.size.limit line.contains.tab
 case class PosExplode(child: Expression) extends ExplodeBase {
   override val position = true
@@ -404,7 +407,8 @@ case class PosExplode(child: Expression) extends ExplodeBase {
        1	a
        2	b
   """,
-  since = "2.0.0")
+  since = "2.0.0",
+  group = "generator_funcs")
 // scalastyle:on line.size.limit line.contains.tab
 case class Inline(child: Expression) extends UnaryExpression with CollectionGenerator {
   override val inline: Boolean = true

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/grouping.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/grouping.scala
@@ -56,7 +56,8 @@ trait GroupingSet extends Expression with CodegenFallback {
         Bob	NULL	1
         NULL	5	1
   """,
-  since = "2.0.0")
+  since = "2.0.0",
+  group = "grouping_funcs")
 // scalastyle:on line.size.limit line.contains.tab
 case class Cube(groupByExprs: Seq[Expression]) extends GroupingSet {}
 
@@ -75,7 +76,8 @@ case class Cube(groupByExprs: Seq[Expression]) extends GroupingSet {}
         NULL	NULL	2
         Bob	NULL	1
   """,
-  since = "2.0.0")
+  since = "2.0.0",
+  group = "grouping_funcs")
 // scalastyle:on line.size.limit line.contains.tab
 case class Rollup(groupByExprs: Seq[Expression]) extends GroupingSet {}
 
@@ -96,7 +98,8 @@ case class Rollup(groupByExprs: Seq[Expression]) extends GroupingSet {}
         Bob	0	5
         NULL	1	7
   """,
-  since = "2.0.0")
+  since = "2.0.0",
+  group = "grouping_funcs")
 // scalastyle:on line.size.limit line.contains.tab
 case class Grouping(child: Expression) extends Expression with Unevaluable {
   @transient
@@ -133,7 +136,8 @@ case class Grouping(child: Expression) extends Expression with Unevaluable {
     Input columns should match with grouping columns exactly, or empty (means all the grouping
     columns).
   """,
-  since = "2.0.0")
+  since = "2.0.0",
+  group = "grouping_funcs")
 // scalastyle:on line.size.limit line.contains.tab
 case class GroupingID(groupByExprs: Seq[Expression]) extends Expression with Unevaluable {
   @transient

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/grouping.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/grouping.scala
@@ -57,7 +57,7 @@ trait GroupingSet extends Expression with CodegenFallback {
         NULL	5	1
   """,
   since = "2.0.0",
-  group = "grouping_funcs")
+  group = "agg_funcs")
 // scalastyle:on line.size.limit line.contains.tab
 case class Cube(groupByExprs: Seq[Expression]) extends GroupingSet {}
 
@@ -77,7 +77,7 @@ case class Cube(groupByExprs: Seq[Expression]) extends GroupingSet {}
         Bob	NULL	1
   """,
   since = "2.0.0",
-  group = "grouping_funcs")
+  group = "agg_funcs")
 // scalastyle:on line.size.limit line.contains.tab
 case class Rollup(groupByExprs: Seq[Expression]) extends GroupingSet {}
 
@@ -99,7 +99,7 @@ case class Rollup(groupByExprs: Seq[Expression]) extends GroupingSet {}
         NULL	1	7
   """,
   since = "2.0.0",
-  group = "grouping_funcs")
+  group = "agg_funcs")
 // scalastyle:on line.size.limit line.contains.tab
 case class Grouping(child: Expression) extends Expression with Unevaluable {
   @transient
@@ -137,7 +137,7 @@ case class Grouping(child: Expression) extends Expression with Unevaluable {
     columns).
   """,
   since = "2.0.0",
-  group = "grouping_funcs")
+  group = "agg_funcs")
 // scalastyle:on line.size.limit line.contains.tab
 case class GroupingID(groupByExprs: Seq[Expression]) extends Expression with Unevaluable {
   @transient

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
@@ -53,7 +53,8 @@ import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
       > SELECT _FUNC_('Spark');
        8cde774d6f7333752ed72cacddb05126
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "binary_funcs")
 case class Md5(child: Expression)
   extends UnaryExpression with ImplicitCastInputTypes with NullIntolerant {
 
@@ -89,7 +90,8 @@ case class Md5(child: Expression)
       > SELECT _FUNC_('Spark', 256);
        529bc3b07127ecb7e53a4dcf1991d9152c24537d919178022b2c42657f79a26b
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "binary_funcs")
 // scalastyle:on line.size.limit
 case class Sha2(left: Expression, right: Expression)
   extends BinaryExpression with ImplicitCastInputTypes with NullIntolerant with Serializable {
@@ -163,7 +165,8 @@ case class Sha2(left: Expression, right: Expression)
       > SELECT _FUNC_('Spark');
        85f5955f4b27a9a4c2aab6ffe5d7189fc298b92c
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "binary_funcs")
 case class Sha1(child: Expression)
   extends UnaryExpression with ImplicitCastInputTypes with NullIntolerant {
 
@@ -192,7 +195,8 @@ case class Sha1(child: Expression)
       > SELECT _FUNC_('Spark');
        1557323817
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "binary_funcs")
 case class Crc32(child: Expression)
   extends UnaryExpression with ImplicitCastInputTypes with NullIntolerant {
 
@@ -580,7 +584,8 @@ abstract class InterpretedHashFunction {
       > SELECT _FUNC_('Spark', array(123), 2);
        -1321691492
   """,
-  since = "2.0.0")
+  since = "2.0.0",
+  group = "binary_funcs")
 case class Murmur3Hash(children: Seq[Expression], seed: Int) extends HashExpression[Int] {
   def this(arguments: Seq[Expression]) = this(arguments, 42)
 
@@ -619,7 +624,8 @@ object Murmur3HashFunction extends InterpretedHashFunction {
       > SELECT _FUNC_('Spark', array(123), 2);
        5602566077635097486
   """,
-  since = "3.0.0")
+  since = "3.0.0",
+  group = "binary_funcs")
 case class XxHash64(children: Seq[Expression], seed: Long) extends HashExpression[Long] {
   def this(arguments: Seq[Expression]) = this(arguments, 42L)
 
@@ -653,7 +659,8 @@ object XxHash64Function extends InterpretedHashFunction {
  */
 @ExpressionDescription(
   usage = "_FUNC_(expr1, expr2, ...) - Returns a hash value of the arguments.",
-  since = "2.2.0")
+  since = "2.2.0",
+  group = "binary_funcs")
 case class HiveHash(children: Seq[Expression]) extends HashExpression[Int] {
   override val seed = 0
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
@@ -54,7 +54,7 @@ import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
        8cde774d6f7333752ed72cacddb05126
   """,
   since = "1.5.0",
-  group = "misc_funcs")
+  group = "hash_funcs")
 case class Md5(child: Expression)
   extends UnaryExpression with ImplicitCastInputTypes with NullIntolerant {
 
@@ -91,7 +91,7 @@ case class Md5(child: Expression)
        529bc3b07127ecb7e53a4dcf1991d9152c24537d919178022b2c42657f79a26b
   """,
   since = "1.5.0",
-  group = "misc_funcs")
+  group = "hash_funcs")
 // scalastyle:on line.size.limit
 case class Sha2(left: Expression, right: Expression)
   extends BinaryExpression with ImplicitCastInputTypes with NullIntolerant with Serializable {
@@ -166,7 +166,7 @@ case class Sha2(left: Expression, right: Expression)
        85f5955f4b27a9a4c2aab6ffe5d7189fc298b92c
   """,
   since = "1.5.0",
-  group = "misc_funcs")
+  group = "hash_funcs")
 case class Sha1(child: Expression)
   extends UnaryExpression with ImplicitCastInputTypes with NullIntolerant {
 
@@ -196,7 +196,7 @@ case class Sha1(child: Expression)
        1557323817
   """,
   since = "1.5.0",
-  group = "misc_funcs")
+  group = "hash_funcs")
 case class Crc32(child: Expression)
   extends UnaryExpression with ImplicitCastInputTypes with NullIntolerant {
 
@@ -585,7 +585,7 @@ abstract class InterpretedHashFunction {
        -1321691492
   """,
   since = "2.0.0",
-  group = "misc_funcs")
+  group = "hash_funcs")
 case class Murmur3Hash(children: Seq[Expression], seed: Int) extends HashExpression[Int] {
   def this(arguments: Seq[Expression]) = this(arguments, 42)
 
@@ -625,7 +625,7 @@ object Murmur3HashFunction extends InterpretedHashFunction {
        5602566077635097486
   """,
   since = "3.0.0",
-  group = "misc_funcs")
+  group = "hash_funcs")
 case class XxHash64(children: Seq[Expression], seed: Long) extends HashExpression[Long] {
   def this(arguments: Seq[Expression]) = this(arguments, 42L)
 
@@ -660,7 +660,7 @@ object XxHash64Function extends InterpretedHashFunction {
 @ExpressionDescription(
   usage = "_FUNC_(expr1, expr2, ...) - Returns a hash value of the arguments.",
   since = "2.2.0",
-  group = "misc_funcs")
+  group = "hash_funcs")
 case class HiveHash(children: Seq[Expression]) extends HashExpression[Int] {
   override val seed = 0
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
@@ -54,7 +54,7 @@ import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
        8cde774d6f7333752ed72cacddb05126
   """,
   since = "1.5.0",
-  group = "binary_funcs")
+  group = "misc_funcs")
 case class Md5(child: Expression)
   extends UnaryExpression with ImplicitCastInputTypes with NullIntolerant {
 
@@ -91,7 +91,7 @@ case class Md5(child: Expression)
        529bc3b07127ecb7e53a4dcf1991d9152c24537d919178022b2c42657f79a26b
   """,
   since = "1.5.0",
-  group = "binary_funcs")
+  group = "misc_funcs")
 // scalastyle:on line.size.limit
 case class Sha2(left: Expression, right: Expression)
   extends BinaryExpression with ImplicitCastInputTypes with NullIntolerant with Serializable {
@@ -166,7 +166,7 @@ case class Sha2(left: Expression, right: Expression)
        85f5955f4b27a9a4c2aab6ffe5d7189fc298b92c
   """,
   since = "1.5.0",
-  group = "binary_funcs")
+  group = "misc_funcs")
 case class Sha1(child: Expression)
   extends UnaryExpression with ImplicitCastInputTypes with NullIntolerant {
 
@@ -196,7 +196,7 @@ case class Sha1(child: Expression)
        1557323817
   """,
   since = "1.5.0",
-  group = "binary_funcs")
+  group = "misc_funcs")
 case class Crc32(child: Expression)
   extends UnaryExpression with ImplicitCastInputTypes with NullIntolerant {
 
@@ -585,7 +585,7 @@ abstract class InterpretedHashFunction {
        -1321691492
   """,
   since = "2.0.0",
-  group = "binary_funcs")
+  group = "misc_funcs")
 case class Murmur3Hash(children: Seq[Expression], seed: Int) extends HashExpression[Int] {
   def this(arguments: Seq[Expression]) = this(arguments, 42)
 
@@ -625,7 +625,7 @@ object Murmur3HashFunction extends InterpretedHashFunction {
        5602566077635097486
   """,
   since = "3.0.0",
-  group = "binary_funcs")
+  group = "misc_funcs")
 case class XxHash64(children: Seq[Expression], seed: Long) extends HashExpression[Long] {
   def this(arguments: Seq[Expression]) = this(arguments, 42L)
 
@@ -660,7 +660,7 @@ object XxHash64Function extends InterpretedHashFunction {
 @ExpressionDescription(
   usage = "_FUNC_(expr1, expr2, ...) - Returns a hash value of the arguments.",
   since = "2.2.0",
-  group = "binary_funcs")
+  group = "misc_funcs")
 case class HiveHash(children: Seq[Expression]) extends HashExpression[Int] {
   override val seed = 0
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
@@ -239,7 +239,8 @@ trait MapBasedSimpleHigherOrderFunction extends SimpleHigherOrderFunction {
       > SELECT _FUNC_(array(1, 2, 3), (x, i) -> x + i);
        [1,3,5]
   """,
-  since = "2.4.0")
+  since = "2.4.0",
+  group = "array_funcs")
 case class ArrayTransform(
     argument: Expression,
     function: Expression)
@@ -309,7 +310,8 @@ case class ArrayTransform(
       > SELECT _FUNC_(array('b', 'd', null, 'c', 'a'));
        ["a","b","c","d",null]
   """,
-  since = "2.4.0")
+  since = "2.4.0",
+  group = "array_funcs")
 // scalastyle:on line.size.limit
 case class ArraySort(
     argument: Expression,
@@ -403,7 +405,8 @@ object ArraySort {
       > SELECT _FUNC_(map(1, 0, 2, 2, 3, -1), (k, v) -> k > v);
        {1:0,3:-1}
   """,
-  since = "3.0.0")
+  since = "3.0.0",
+  group = "map_funcs")
 case class MapFilter(
     argument: Expression,
     function: Expression)
@@ -458,6 +461,7 @@ case class MapFilter(
        [0,2,3]
   """,
   since = "2.4.0",
+  group = "array_funcs",
   note = """
     The inner function may use the index argument since 3.0.0.
   """)
@@ -525,7 +529,8 @@ case class ArrayFilter(
       > SELECT _FUNC_(array(1, 2, 3), x -> x IS NULL);
        false
   """,
-  since = "2.4.0")
+  since = "2.4.0",
+  group = "array_funcs")
 case class ArrayExists(
     argument: Expression,
     function: Expression,
@@ -609,7 +614,8 @@ object ArrayExists {
       > SELECT _FUNC_(array(2, null, 8), x -> x % 2 == 0);
        NULL
   """,
-  since = "3.0.0")
+  since = "3.0.0",
+  group = "array_funcs")
 case class ArrayForAll(
     argument: Expression,
     function: Expression)
@@ -679,7 +685,8 @@ case class ArrayForAll(
       > SELECT _FUNC_(array(1, 2, 3), 0, (acc, x) -> acc + x, acc -> acc * 10);
        60
   """,
-  since = "2.4.0")
+  since = "2.4.0",
+  group = "array_funcs")
 case class ArrayAggregate(
     argument: Expression,
     zero: Expression,
@@ -766,7 +773,8 @@ case class ArrayAggregate(
       > SELECT _FUNC_(map_from_arrays(array(1, 2, 3), array(1, 2, 3)), (k, v) -> k + v);
        {2:1,4:2,6:3}
   """,
-  since = "3.0.0")
+  since = "3.0.0",
+  group = "map_funcs")
 case class TransformKeys(
     argument: Expression,
     function: Expression)
@@ -818,7 +826,8 @@ case class TransformKeys(
       > SELECT _FUNC_(map_from_arrays(array(1, 2, 3), array(1, 2, 3)), (k, v) -> k + v);
        {1:2,2:4,3:6}
   """,
-  since = "3.0.0")
+  since = "3.0.0",
+  group = "map_funcs")
 case class TransformValues(
     argument: Expression,
     function: Expression)
@@ -869,7 +878,8 @@ case class TransformValues(
       > SELECT _FUNC_(map(1, 'a', 2, 'b'), map(1, 'x', 2, 'y'), (k, v1, v2) -> concat(v1, v2));
        {1:"ax",2:"by"}
   """,
-  since = "3.0.0")
+  since = "3.0.0",
+  group = "map_funcs")
 case class MapZipWith(left: Expression, right: Expression, function: Expression)
   extends HigherOrderFunction with CodegenFallback {
 
@@ -1047,7 +1057,8 @@ case class MapZipWith(left: Expression, right: Expression, function: Expression)
       > SELECT _FUNC_(array('a', 'b', 'c'), array('d', 'e', 'f'), (x, y) -> concat(x, y));
        ["ad","be","cf"]
   """,
-  since = "2.4.0")
+  since = "2.4.0",
+  group = "array_funcs")
 // scalastyle:on line.size.limit
 case class ZipWith(left: Expression, right: Expression, function: Expression)
   extends HigherOrderFunction with CodegenFallback {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
@@ -240,7 +240,7 @@ trait MapBasedSimpleHigherOrderFunction extends SimpleHigherOrderFunction {
        [1,3,5]
   """,
   since = "2.4.0",
-  group = "array_funcs")
+  group = "lambda_funcs")
 case class ArrayTransform(
     argument: Expression,
     function: Expression)
@@ -311,7 +311,7 @@ case class ArrayTransform(
        ["a","b","c","d",null]
   """,
   since = "2.4.0",
-  group = "array_funcs")
+  group = "lambda_funcs")
 // scalastyle:on line.size.limit
 case class ArraySort(
     argument: Expression,
@@ -406,7 +406,7 @@ object ArraySort {
        {1:0,3:-1}
   """,
   since = "3.0.0",
-  group = "map_funcs")
+  group = "lambda_funcs")
 case class MapFilter(
     argument: Expression,
     function: Expression)
@@ -461,7 +461,7 @@ case class MapFilter(
        [0,2,3]
   """,
   since = "2.4.0",
-  group = "array_funcs",
+  group = "lambda_funcs",
   note = """
     The inner function may use the index argument since 3.0.0.
   """)
@@ -530,7 +530,7 @@ case class ArrayFilter(
        false
   """,
   since = "2.4.0",
-  group = "array_funcs")
+  group = "lambda_funcs")
 case class ArrayExists(
     argument: Expression,
     function: Expression,
@@ -615,7 +615,7 @@ object ArrayExists {
        NULL
   """,
   since = "3.0.0",
-  group = "array_funcs")
+  group = "lambda_funcs")
 case class ArrayForAll(
     argument: Expression,
     function: Expression)
@@ -686,7 +686,7 @@ case class ArrayForAll(
        60
   """,
   since = "2.4.0",
-  group = "array_funcs")
+  group = "lambda_funcs")
 case class ArrayAggregate(
     argument: Expression,
     zero: Expression,
@@ -774,7 +774,7 @@ case class ArrayAggregate(
        {2:1,4:2,6:3}
   """,
   since = "3.0.0",
-  group = "map_funcs")
+  group = "lambda_funcs")
 case class TransformKeys(
     argument: Expression,
     function: Expression)
@@ -827,7 +827,7 @@ case class TransformKeys(
        {1:2,2:4,3:6}
   """,
   since = "3.0.0",
-  group = "map_funcs")
+  group = "lambda_funcs")
 case class TransformValues(
     argument: Expression,
     function: Expression)
@@ -879,7 +879,7 @@ case class TransformValues(
        {1:"ax",2:"by"}
   """,
   since = "3.0.0",
-  group = "map_funcs")
+  group = "lambda_funcs")
 case class MapZipWith(left: Expression, right: Expression, function: Expression)
   extends HigherOrderFunction with CodegenFallback {
 
@@ -1058,7 +1058,7 @@ case class MapZipWith(left: Expression, right: Expression, function: Expression)
        ["ad","be","cf"]
   """,
   since = "2.4.0",
-  group = "array_funcs")
+  group = "lambda_funcs")
 // scalastyle:on line.size.limit
 case class ZipWith(left: Expression, right: Expression, function: Expression)
   extends HigherOrderFunction with CodegenFallback {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/inputFileBlock.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/inputFileBlock.scala
@@ -32,7 +32,8 @@ import org.apache.spark.unsafe.types.UTF8String
       > SELECT _FUNC_();
 
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "misc_funcs")
 // scalastyle:on whitespace.end.of.line
 case class InputFileName() extends LeafExpression with Nondeterministic {
 
@@ -64,7 +65,8 @@ case class InputFileName() extends LeafExpression with Nondeterministic {
       > SELECT _FUNC_();
        -1
   """,
-  since = "2.2.0")
+  since = "2.2.0",
+  group = "misc_funcs")
 case class InputFileBlockStart() extends LeafExpression with Nondeterministic {
   override def nullable: Boolean = false
 
@@ -93,7 +95,8 @@ case class InputFileBlockStart() extends LeafExpression with Nondeterministic {
       > SELECT _FUNC_();
        -1
   """,
-  since = "2.2.0")
+  since = "2.2.0",
+  group = "misc_funcs")
 case class InputFileBlockLength() extends LeafExpression with Nondeterministic {
   override def nullable: Boolean = false
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
@@ -152,7 +152,8 @@ case class DivideInterval(
       > SELECT _FUNC_(0, 1, 0, 1, 0, 0, 100.000001);
        1 months 1 days 1 minutes 40.000001 seconds
   """,
-  since = "3.0.0")
+  since = "3.0.0",
+  group = "datetime_funcs")
 // scalastyle:on line.size.limit
 case class MakeInterval(
     years: Expression,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
@@ -148,7 +148,8 @@ abstract class BinaryMathExpression(f: (Double, Double) => Double, name: String)
       > SELECT _FUNC_();
        2.718281828459045
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "math_funcs")
 case class EulerNumber() extends LeafMathExpression(math.E, "E")
 
 /**
@@ -162,7 +163,8 @@ case class EulerNumber() extends LeafMathExpression(math.E, "E")
       > SELECT _FUNC_();
        3.141592653589793
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "math_funcs")
 case class Pi() extends LeafMathExpression(math.Pi, "PI")
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -183,7 +185,8 @@ case class Pi() extends LeafMathExpression(math.Pi, "PI")
       > SELECT _FUNC_(2);
        NaN
   """,
-  since = "1.4.0")
+  since = "1.4.0",
+  group = "math_funcs")
 case class Acos(child: Expression) extends UnaryMathExpression(math.acos, "ACOS")
 
 @ExpressionDescription(
@@ -198,7 +201,8 @@ case class Acos(child: Expression) extends UnaryMathExpression(math.acos, "ACOS"
       > SELECT _FUNC_(2);
        NaN
   """,
-  since = "1.4.0")
+  since = "1.4.0",
+  group = "math_funcs")
 case class Asin(child: Expression) extends UnaryMathExpression(math.asin, "ASIN")
 
 @ExpressionDescription(
@@ -211,7 +215,8 @@ case class Asin(child: Expression) extends UnaryMathExpression(math.asin, "ASIN"
       > SELECT _FUNC_(0);
        0.0
   """,
-  since = "1.4.0")
+  since = "1.4.0",
+  group = "math_funcs")
 case class Atan(child: Expression) extends UnaryMathExpression(math.atan, "ATAN")
 
 @ExpressionDescription(
@@ -221,7 +226,8 @@ case class Atan(child: Expression) extends UnaryMathExpression(math.atan, "ATAN"
       > SELECT _FUNC_(27.0);
        3.0
   """,
-  since = "1.4.0")
+  since = "1.4.0",
+  group = "math_funcs")
 case class Cbrt(child: Expression) extends UnaryMathExpression(math.cbrt, "CBRT")
 
 @ExpressionDescription(
@@ -233,7 +239,8 @@ case class Cbrt(child: Expression) extends UnaryMathExpression(math.cbrt, "CBRT"
       > SELECT _FUNC_(5);
        5
   """,
-  since = "1.4.0")
+  since = "1.4.0",
+  group = "math_funcs")
 case class Ceil(child: Expression) extends UnaryMathExpression(math.ceil, "CEIL") {
   override def dataType: DataType = child.dataType match {
     case dt @ DecimalType.Fixed(_, 0) => dt
@@ -276,7 +283,8 @@ case class Ceil(child: Expression) extends UnaryMathExpression(math.ceil, "CEIL"
       > SELECT _FUNC_(0);
        1.0
   """,
-  since = "1.4.0")
+  since = "1.4.0",
+  group = "math_funcs")
 case class Cos(child: Expression) extends UnaryMathExpression(math.cos, "COS")
 
 @ExpressionDescription(
@@ -293,7 +301,8 @@ case class Cos(child: Expression) extends UnaryMathExpression(math.cos, "COS")
       > SELECT _FUNC_(0);
        1.0
   """,
-  since = "1.4.0")
+  since = "1.4.0",
+  group = "math_funcs")
 case class Cosh(child: Expression) extends UnaryMathExpression(math.cosh, "COSH")
 
 @ExpressionDescription(
@@ -307,7 +316,8 @@ case class Cosh(child: Expression) extends UnaryMathExpression(math.cosh, "COSH"
       > SELECT _FUNC_(0);
        NaN
   """,
-  since = "3.0.0")
+  since = "3.0.0",
+  group = "math_funcs")
 case class Acosh(child: Expression)
   extends UnaryMathExpression((x: Double) => StrictMath.log(x + math.sqrt(x * x - 1.0)), "ACOSH") {
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
@@ -332,7 +342,8 @@ case class Acosh(child: Expression)
       > SELECT _FUNC_(-10, 16, -10);
        -16
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "math_funcs")
 case class Conv(numExpr: Expression, fromBaseExpr: Expression, toBaseExpr: Expression)
   extends TernaryExpression with ImplicitCastInputTypes with NullIntolerant {
 
@@ -368,7 +379,8 @@ case class Conv(numExpr: Expression, fromBaseExpr: Expression, toBaseExpr: Expre
       > SELECT _FUNC_(0);
        1.0
   """,
-  since = "1.4.0")
+  since = "1.4.0",
+  group = "math_funcs")
 case class Exp(child: Expression) extends UnaryMathExpression(StrictMath.exp, "EXP") {
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     defineCodeGen(ctx, ev, c => s"java.lang.StrictMath.exp($c)")
@@ -382,7 +394,8 @@ case class Exp(child: Expression) extends UnaryMathExpression(StrictMath.exp, "E
       > SELECT _FUNC_(0);
        0.0
   """,
-  since = "1.4.0")
+  since = "1.4.0",
+  group = "math_funcs")
 case class Expm1(child: Expression) extends UnaryMathExpression(StrictMath.expm1, "EXPM1") {
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     defineCodeGen(ctx, ev, c => s"java.lang.StrictMath.expm1($c)")
@@ -398,7 +411,8 @@ case class Expm1(child: Expression) extends UnaryMathExpression(StrictMath.expm1
       > SELECT _FUNC_(5);
        5
   """,
-  since = "1.4.0")
+  since = "1.4.0",
+  group = "math_funcs")
 case class Floor(child: Expression) extends UnaryMathExpression(math.floor, "FLOOR") {
   override def dataType: DataType = child.dataType match {
     case dt @ DecimalType.Fixed(_, 0) => dt
@@ -465,7 +479,8 @@ object Factorial {
       > SELECT _FUNC_(5);
        120
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "math_funcs")
 case class Factorial(child: Expression)
   extends UnaryExpression with ImplicitCastInputTypes with NullIntolerant {
 
@@ -506,7 +521,8 @@ case class Factorial(child: Expression)
       > SELECT _FUNC_(1);
        0.0
   """,
-  since = "1.4.0")
+  since = "1.4.0",
+  group = "math_funcs")
 case class Log(child: Expression) extends UnaryLogExpression(StrictMath.log, "LOG") {
   override def prettyName: String = getTagValue(FunctionRegistry.FUNC_ALIAS).getOrElse("ln")
 }
@@ -518,7 +534,8 @@ case class Log(child: Expression) extends UnaryLogExpression(StrictMath.log, "LO
       > SELECT _FUNC_(2);
        1.0
   """,
-  since = "1.4.0")
+  since = "1.4.0",
+  group = "math_funcs")
 case class Log2(child: Expression)
   extends UnaryLogExpression((x: Double) => StrictMath.log(x) / StrictMath.log(2), "LOG2") {
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
@@ -541,7 +558,8 @@ case class Log2(child: Expression)
       > SELECT _FUNC_(10);
        1.0
   """,
-  since = "1.4.0")
+  since = "1.4.0",
+  group = "math_funcs")
 case class Log10(child: Expression) extends UnaryLogExpression(StrictMath.log10, "LOG10")
 
 @ExpressionDescription(
@@ -551,7 +569,8 @@ case class Log10(child: Expression) extends UnaryLogExpression(StrictMath.log10,
       > SELECT _FUNC_(0);
        0.0
   """,
-  since = "1.4.0")
+  since = "1.4.0",
+  group = "math_funcs")
 case class Log1p(child: Expression) extends UnaryLogExpression(StrictMath.log1p, "LOG1P") {
   protected override val yAsymptote: Double = -1.0
 }
@@ -564,7 +583,8 @@ case class Log1p(child: Expression) extends UnaryLogExpression(StrictMath.log1p,
       > SELECT _FUNC_(12.3456);
        12.0
   """,
-  since = "1.4.0")
+  since = "1.4.0",
+  group = "math_funcs")
 // scalastyle:on line.size.limit
 case class Rint(child: Expression) extends UnaryMathExpression(math.rint, "ROUND") {
   override def funcName: String = "rint"
@@ -578,7 +598,8 @@ case class Rint(child: Expression) extends UnaryMathExpression(math.rint, "ROUND
       > SELECT _FUNC_(40);
        1.0
   """,
-  since = "1.4.0")
+  since = "1.4.0",
+  group = "math_funcs")
 case class Signum(child: Expression) extends UnaryMathExpression(math.signum, "SIGNUM")
 
 @ExpressionDescription(
@@ -592,7 +613,8 @@ case class Signum(child: Expression) extends UnaryMathExpression(math.signum, "S
       > SELECT _FUNC_(0);
        0.0
   """,
-  since = "1.4.0")
+  since = "1.4.0",
+  group = "math_funcs")
 case class Sin(child: Expression) extends UnaryMathExpression(math.sin, "SIN")
 
 @ExpressionDescription(
@@ -608,7 +630,8 @@ case class Sin(child: Expression) extends UnaryMathExpression(math.sin, "SIN")
       > SELECT _FUNC_(0);
        0.0
   """,
-  since = "1.4.0")
+  since = "1.4.0",
+  group = "math_funcs")
 case class Sinh(child: Expression) extends UnaryMathExpression(math.sinh, "SINH")
 
 @ExpressionDescription(
@@ -620,7 +643,8 @@ case class Sinh(child: Expression) extends UnaryMathExpression(math.sinh, "SINH"
       > SELECT _FUNC_(0);
        0.0
   """,
-  since = "3.0.0")
+  since = "3.0.0",
+  group = "math_funcs")
 case class Asinh(child: Expression)
   extends UnaryMathExpression((x: Double) => x match {
     case Double.NegativeInfinity => Double.NegativeInfinity
@@ -639,7 +663,8 @@ case class Asinh(child: Expression)
       > SELECT _FUNC_(4);
        2.0
   """,
-  since = "1.1.1")
+  since = "1.1.1",
+  group = "math_funcs")
 case class Sqrt(child: Expression) extends UnaryMathExpression(math.sqrt, "SQRT")
 
 @ExpressionDescription(
@@ -655,7 +680,8 @@ case class Sqrt(child: Expression) extends UnaryMathExpression(math.sqrt, "SQRT"
       > SELECT _FUNC_(0);
        0.0
   """,
-  since = "1.4.0")
+  since = "1.4.0",
+  group = "math_funcs")
 case class Tan(child: Expression) extends UnaryMathExpression(math.tan, "TAN")
 
 @ExpressionDescription(
@@ -671,7 +697,8 @@ case class Tan(child: Expression) extends UnaryMathExpression(math.tan, "TAN")
       > SELECT _FUNC_(1);
        0.6420926159343306
   """,
-  since = "2.3.0")
+  since = "2.3.0",
+  group = "math_funcs")
 case class Cot(child: Expression)
   extends UnaryMathExpression((x: Double) => 1 / math.tan(x), "COT") {
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
@@ -693,7 +720,8 @@ case class Cot(child: Expression)
       > SELECT _FUNC_(0);
        0.0
   """,
-  since = "1.4.0")
+  since = "1.4.0",
+  group = "math_funcs")
 case class Tanh(child: Expression) extends UnaryMathExpression(math.tanh, "TANH")
 
 @ExpressionDescription(
@@ -707,7 +735,8 @@ case class Tanh(child: Expression) extends UnaryMathExpression(math.tanh, "TANH"
       > SELECT _FUNC_(2);
        NaN
   """,
-  since = "3.0.0")
+  since = "3.0.0",
+  group = "math_funcs")
 case class Atanh(child: Expression)
   // SPARK-28519: more accurate express for 1/2 * ln((1 + x) / (1 - x))
   extends UnaryMathExpression((x: Double) =>
@@ -729,7 +758,8 @@ case class Atanh(child: Expression)
       > SELECT _FUNC_(3.141592653589793);
        180.0
   """,
-  since = "1.4.0")
+  since = "1.4.0",
+  group = "math_funcs")
 case class ToDegrees(child: Expression) extends UnaryMathExpression(math.toDegrees, "DEGREES") {
   override def funcName: String = "toDegrees"
 }
@@ -745,7 +775,8 @@ case class ToDegrees(child: Expression) extends UnaryMathExpression(math.toDegre
       > SELECT _FUNC_(180);
        3.141592653589793
   """,
-  since = "1.4.0")
+  since = "1.4.0",
+  group = "math_funcs")
 case class ToRadians(child: Expression) extends UnaryMathExpression(math.toRadians, "RADIANS") {
   override def funcName: String = "toRadians"
 }
@@ -762,7 +793,8 @@ case class ToRadians(child: Expression) extends UnaryMathExpression(math.toRadia
       > SELECT _FUNC_(13.3);
        1101
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "math_funcs")
 // scalastyle:on line.size.limit
 case class Bin(child: Expression)
   extends UnaryExpression with ImplicitCastInputTypes with NullIntolerant with Serializable {
@@ -864,7 +896,8 @@ object Hex {
       > SELECT _FUNC_('Spark SQL');
        537061726B2053514C
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "math_funcs")
 case class Hex(child: Expression)
   extends UnaryExpression with ImplicitCastInputTypes with NullIntolerant {
 
@@ -901,7 +934,8 @@ case class Hex(child: Expression)
       > SELECT decode(_FUNC_('537061726B2053514C'), 'UTF-8');
        Spark SQL
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "math_funcs")
 case class Unhex(child: Expression)
   extends UnaryExpression with ImplicitCastInputTypes with NullIntolerant {
 
@@ -947,7 +981,8 @@ case class Unhex(child: Expression)
       > SELECT _FUNC_(0, 0);
        0.0
   """,
-  since = "1.4.0")
+  since = "1.4.0",
+  group = "math_funcs")
 case class Atan2(left: Expression, right: Expression)
   extends BinaryMathExpression(math.atan2, "ATAN2") {
 
@@ -968,7 +1003,8 @@ case class Atan2(left: Expression, right: Expression)
       > SELECT _FUNC_(2, 3);
        8.0
   """,
-  since = "1.4.0")
+  since = "1.4.0",
+  group = "math_funcs")
 case class Pow(left: Expression, right: Expression)
   extends BinaryMathExpression(StrictMath.pow, "POWER") {
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
@@ -990,7 +1026,8 @@ case class Pow(left: Expression, right: Expression)
       > SELECT _FUNC_(2, 1);
        4
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "math_funcs")
 case class ShiftLeft(left: Expression, right: Expression)
   extends BinaryExpression with ImplicitCastInputTypes with NullIntolerant {
 
@@ -1025,7 +1062,8 @@ case class ShiftLeft(left: Expression, right: Expression)
       > SELECT _FUNC_(4, 1);
        2
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "bitwise_funcs")
 case class ShiftRight(left: Expression, right: Expression)
   extends BinaryExpression with ImplicitCastInputTypes with NullIntolerant {
 
@@ -1060,7 +1098,8 @@ case class ShiftRight(left: Expression, right: Expression)
       > SELECT _FUNC_(4, 1);
        2
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "bitwise_funcs")
 case class ShiftRightUnsigned(left: Expression, right: Expression)
   extends BinaryExpression with ImplicitCastInputTypes with NullIntolerant {
 
@@ -1088,7 +1127,8 @@ case class ShiftRightUnsigned(left: Expression, right: Expression)
       > SELECT _FUNC_(3, 4);
        5.0
   """,
-  since = "1.4.0")
+  since = "1.4.0",
+  group = "math_funcs")
 case class Hypot(left: Expression, right: Expression)
   extends BinaryMathExpression(math.hypot, "HYPOT")
 
@@ -1106,7 +1146,8 @@ case class Hypot(left: Expression, right: Expression)
       > SELECT _FUNC_(10, 100);
        2.0
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "math_funcs")
 case class Logarithm(left: Expression, right: Expression)
   extends BinaryMathExpression((c1, c2) => StrictMath.log(c2) / StrictMath.log(c1), "LOG") {
 
@@ -1337,7 +1378,8 @@ abstract class RoundBase(child: Expression, scale: Expression,
       > SELECT _FUNC_(2.5, 0);
        3
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "math_funcs")
 // scalastyle:on line.size.limit
 case class Round(child: Expression, scale: Expression)
   extends RoundBase(child, scale, BigDecimal.RoundingMode.HALF_UP, "ROUND_HALF_UP")
@@ -1358,7 +1400,8 @@ case class Round(child: Expression, scale: Expression)
       > SELECT _FUNC_(2.5, 0);
        2
   """,
-  since = "2.0.0")
+  since = "2.0.0",
+  group = "math_funcs")
 // scalastyle:on line.size.limit
 case class BRound(child: Expression, scale: Expression)
   extends RoundBase(child, scale, BigDecimal.RoundingMode.HALF_EVEN, "ROUND_HALF_EVEN")
@@ -1434,7 +1477,8 @@ object WidthBucket {
       > SELECT _FUNC_(-0.9, 5.2, 0.5, 2);
        3
   """,
-  since = "3.1.0")
+  since = "3.1.0",
+  group = "math_funcs")
 case class WidthBucket(
     value: Expression,
     minValue: Expression,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -63,7 +63,8 @@ case class PrintToStderr(child: Expression) extends UnaryExpression {
        java.lang.RuntimeException
        custom error message
   """,
-  since = "3.1.0")
+  since = "3.1.0",
+  group = "misc_funcs")
 case class RaiseError(child: Expression) extends UnaryExpression with ImplicitCastInputTypes {
 
   override def foldable: Boolean = false
@@ -108,7 +109,8 @@ case class RaiseError(child: Expression) extends UnaryExpression with ImplicitCa
       > SELECT _FUNC_(0 < 1);
        NULL
   """,
-  since = "2.0.0")
+  since = "2.0.0",
+  group = "misc_funcs")
 case class AssertTrue(left: Expression, right: Expression, child: Expression)
   extends RuntimeReplaceable {
 
@@ -140,7 +142,8 @@ object AssertTrue {
       > SELECT _FUNC_();
        default
   """,
-  since = "1.6.0")
+  since = "1.6.0",
+  group = "misc_funcs")
 case class CurrentDatabase() extends LeafExpression with Unevaluable {
   override def dataType: DataType = StringType
   override def nullable: Boolean = false
@@ -157,7 +160,8 @@ case class CurrentDatabase() extends LeafExpression with Unevaluable {
       > SELECT _FUNC_();
        spark_catalog
   """,
-  since = "3.1.0")
+  since = "3.1.0",
+  group = "misc_funcs")
 case class CurrentCatalog() extends LeafExpression with Unevaluable {
   override def dataType: DataType = StringType
   override def nullable: Boolean = false
@@ -175,7 +179,8 @@ case class CurrentCatalog() extends LeafExpression with Unevaluable {
   note = """
     The function is non-deterministic.
   """,
-  since = "2.3.0")
+  since = "2.3.0",
+  group = "misc_funcs")
 // scalastyle:on line.size.limit
 case class Uuid(randomSeed: Option[Long] = None) extends LeafExpression with Stateful
     with ExpressionWithRandomSeed {
@@ -221,7 +226,8 @@ case class Uuid(randomSeed: Option[Long] = None) extends LeafExpression with Sta
       > SELECT _FUNC_();
        3.1.0 a6d6ea3efedbad14d99c24143834cd4e2e52fb40
   """,
-  since = "3.0.0")
+  since = "3.0.0",
+  group = "misc_funcs")
 // scalastyle:on line.size.limit
 case class SparkVersion() extends LeafExpression with CodegenFallback {
   override def nullable: Boolean = false
@@ -242,7 +248,8 @@ case class SparkVersion() extends LeafExpression with CodegenFallback {
       > SELECT _FUNC_(array(1));
        array<int>
   """,
-  since = "3.0.0")
+  since = "3.0.0",
+  group = "conversion_funcs")
 case class TypeOf(child: Expression) extends UnaryExpression {
   override def nullable: Boolean = false
   override def foldable: Boolean = true

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -249,7 +249,7 @@ case class SparkVersion() extends LeafExpression with CodegenFallback {
        array<int>
   """,
   since = "3.0.0",
-  group = "conversion_funcs")
+  group = "misc_funcs")
 case class TypeOf(child: Expression) extends UnaryExpression {
   override def nullable: Boolean = false
   override def foldable: Boolean = true

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
@@ -43,7 +43,8 @@ import org.apache.spark.sql.types._
       > SELECT _FUNC_(NULL, 1, NULL);
        1
   """,
-  since = "1.0.0")
+  since = "1.0.0",
+  group = "conditional_funcs")
 // scalastyle:on line.size.limit
 case class Coalesce(children: Seq[Expression]) extends ComplexTypeMergingExpression {
 
@@ -129,7 +130,8 @@ case class Coalesce(children: Seq[Expression]) extends ComplexTypeMergingExpress
       > SELECT _FUNC_(NULL, array('2'));
        ["2"]
   """,
-  since = "2.0.0")
+  since = "2.0.0",
+  group = "conditional_funcs")
 case class IfNull(left: Expression, right: Expression, child: Expression)
   extends RuntimeReplaceable {
 
@@ -149,7 +151,8 @@ case class IfNull(left: Expression, right: Expression, child: Expression)
       > SELECT _FUNC_(2, 2);
        NULL
   """,
-  since = "2.0.0")
+  since = "2.0.0",
+  group = "conditional_funcs")
 case class NullIf(left: Expression, right: Expression, child: Expression)
   extends RuntimeReplaceable {
 
@@ -169,7 +172,8 @@ case class NullIf(left: Expression, right: Expression, child: Expression)
       > SELECT _FUNC_(NULL, array('2'));
        ["2"]
   """,
-  since = "2.0.0")
+  since = "2.0.0",
+  group = "conditional_funcs")
 case class Nvl(left: Expression, right: Expression, child: Expression) extends RuntimeReplaceable {
 
   def this(left: Expression, right: Expression) = {
@@ -189,7 +193,8 @@ case class Nvl(left: Expression, right: Expression, child: Expression) extends R
       > SELECT _FUNC_(NULL, 2, 1);
        1
   """,
-  since = "2.0.0")
+  since = "2.0.0",
+  group = "conditional_funcs")
 // scalastyle:on line.size.limit
 case class Nvl2(expr1: Expression, expr2: Expression, expr3: Expression, child: Expression)
   extends RuntimeReplaceable {
@@ -213,7 +218,8 @@ case class Nvl2(expr1: Expression, expr2: Expression, expr3: Expression, child: 
       > SELECT _FUNC_(cast('NaN' as double));
        true
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "comparison_funcs")
 case class IsNaN(child: Expression) extends UnaryExpression
   with Predicate with ImplicitCastInputTypes {
 
@@ -256,7 +262,8 @@ case class IsNaN(child: Expression) extends UnaryExpression
       > SELECT _FUNC_(cast('NaN' as double), 123);
        123.0
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "conditional_funcs")
 case class NaNvl(left: Expression, right: Expression)
     extends BinaryExpression with ImplicitCastInputTypes {
 
@@ -317,7 +324,8 @@ case class NaNvl(left: Expression, right: Expression)
       > SELECT _FUNC_(1);
        false
   """,
-  since = "1.0.0")
+  since = "1.0.0",
+  group = "comparison_funcs")
 case class IsNull(child: Expression) extends UnaryExpression with Predicate {
   override def nullable: Boolean = false
 
@@ -344,7 +352,8 @@ case class IsNull(child: Expression) extends UnaryExpression with Predicate {
       > SELECT _FUNC_(1);
        true
   """,
-  since = "1.0.0")
+  since = "1.0.0",
+  group = "comparison_funcs")
 case class IsNotNull(child: Expression) extends UnaryExpression with Predicate {
   override def nullable: Boolean = false
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
@@ -44,7 +44,7 @@ import org.apache.spark.sql.types._
        1
   """,
   since = "1.0.0",
-  group = "conditional_funcs")
+  group = "condition_funcs")
 // scalastyle:on line.size.limit
 case class Coalesce(children: Seq[Expression]) extends ComplexTypeMergingExpression {
 
@@ -131,7 +131,7 @@ case class Coalesce(children: Seq[Expression]) extends ComplexTypeMergingExpress
        ["2"]
   """,
   since = "2.0.0",
-  group = "conditional_funcs")
+  group = "condition_funcs")
 case class IfNull(left: Expression, right: Expression, child: Expression)
   extends RuntimeReplaceable {
 
@@ -152,7 +152,7 @@ case class IfNull(left: Expression, right: Expression, child: Expression)
        NULL
   """,
   since = "2.0.0",
-  group = "conditional_funcs")
+  group = "condition_funcs")
 case class NullIf(left: Expression, right: Expression, child: Expression)
   extends RuntimeReplaceable {
 
@@ -173,7 +173,7 @@ case class NullIf(left: Expression, right: Expression, child: Expression)
        ["2"]
   """,
   since = "2.0.0",
-  group = "conditional_funcs")
+  group = "condition_funcs")
 case class Nvl(left: Expression, right: Expression, child: Expression) extends RuntimeReplaceable {
 
   def this(left: Expression, right: Expression) = {
@@ -194,7 +194,7 @@ case class Nvl(left: Expression, right: Expression, child: Expression) extends R
        1
   """,
   since = "2.0.0",
-  group = "conditional_funcs")
+  group = "condition_funcs")
 // scalastyle:on line.size.limit
 case class Nvl2(expr1: Expression, expr2: Expression, expr3: Expression, child: Expression)
   extends RuntimeReplaceable {
@@ -263,7 +263,7 @@ case class IsNaN(child: Expression) extends UnaryExpression
        123.0
   """,
   since = "1.5.0",
-  group = "conditional_funcs")
+  group = "condition_funcs")
 case class NaNvl(left: Expression, right: Expression)
     extends BinaryExpression with ImplicitCastInputTypes {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
@@ -44,7 +44,7 @@ import org.apache.spark.sql.types._
        1
   """,
   since = "1.0.0",
-  group = "condition_funcs")
+  group = "conditional_funcs")
 // scalastyle:on line.size.limit
 case class Coalesce(children: Seq[Expression]) extends ComplexTypeMergingExpression {
 
@@ -131,7 +131,7 @@ case class Coalesce(children: Seq[Expression]) extends ComplexTypeMergingExpress
        ["2"]
   """,
   since = "2.0.0",
-  group = "condition_funcs")
+  group = "conditional_funcs")
 case class IfNull(left: Expression, right: Expression, child: Expression)
   extends RuntimeReplaceable {
 
@@ -152,7 +152,7 @@ case class IfNull(left: Expression, right: Expression, child: Expression)
        NULL
   """,
   since = "2.0.0",
-  group = "condition_funcs")
+  group = "conditional_funcs")
 case class NullIf(left: Expression, right: Expression, child: Expression)
   extends RuntimeReplaceable {
 
@@ -173,7 +173,7 @@ case class NullIf(left: Expression, right: Expression, child: Expression)
        ["2"]
   """,
   since = "2.0.0",
-  group = "condition_funcs")
+  group = "conditional_funcs")
 case class Nvl(left: Expression, right: Expression, child: Expression) extends RuntimeReplaceable {
 
   def this(left: Expression, right: Expression) = {
@@ -194,7 +194,7 @@ case class Nvl(left: Expression, right: Expression, child: Expression) extends R
        1
   """,
   since = "2.0.0",
-  group = "condition_funcs")
+  group = "conditional_funcs")
 // scalastyle:on line.size.limit
 case class Nvl2(expr1: Expression, expr2: Expression, expr3: Expression, child: Expression)
   extends RuntimeReplaceable {
@@ -219,7 +219,7 @@ case class Nvl2(expr1: Expression, expr2: Expression, expr3: Expression, child: 
        true
   """,
   since = "1.5.0",
-  group = "comparison_funcs")
+  group = "predicate_funcs")
 case class IsNaN(child: Expression) extends UnaryExpression
   with Predicate with ImplicitCastInputTypes {
 
@@ -263,7 +263,7 @@ case class IsNaN(child: Expression) extends UnaryExpression
        123.0
   """,
   since = "1.5.0",
-  group = "condition_funcs")
+  group = "conditional_funcs")
 case class NaNvl(left: Expression, right: Expression)
     extends BinaryExpression with ImplicitCastInputTypes {
 
@@ -325,7 +325,7 @@ case class NaNvl(left: Expression, right: Expression)
        false
   """,
   since = "1.0.0",
-  group = "comparison_funcs")
+  group = "predicate_funcs")
 case class IsNull(child: Expression) extends UnaryExpression with Predicate {
   override def nullable: Boolean = false
 
@@ -353,7 +353,7 @@ case class IsNull(child: Expression) extends UnaryExpression with Predicate {
        true
   """,
   since = "1.0.0",
-  group = "comparison_funcs")
+  group = "predicate_funcs")
 case class IsNotNull(child: Expression) extends UnaryExpression with Predicate {
   override def nullable: Boolean = false
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -255,7 +255,8 @@ trait PredicateHelper extends AliasHelper with Logging {
       > SELECT _FUNC_ NULL;
        NULL
   """,
-  since = "1.0.0")
+  since = "1.0.0",
+  group = "logical_funcs")
 case class Not(child: Expression)
   extends UnaryExpression with Predicate with ImplicitCastInputTypes with NullIntolerant {
 
@@ -358,7 +359,8 @@ case class InSubquery(values: Seq[Expression], query: ListQuery)
       > SELECT named_struct('a', 1, 'b', 2) _FUNC_(named_struct('a', 1, 'b', 2), named_struct('a', 1, 'b', 3));
        true
   """,
-  since = "1.0.0")
+  since = "1.0.0",
+  group = "comparison_funcs")
 // scalastyle:on line.size.limit
 case class In(value: Expression, list: Seq[Expression]) extends Predicate {
 
@@ -594,7 +596,8 @@ case class InSet(child: Expression, hset: Set[Any]) extends UnaryExpression with
       > SELECT false _FUNC_ NULL;
        false
   """,
-  since = "1.0.0")
+  since = "1.0.0",
+  group = "logical_funcs")
 case class And(left: Expression, right: Expression) extends BinaryOperator with Predicate {
 
   override def inputType: AbstractDataType = BooleanType
@@ -676,7 +679,8 @@ case class And(left: Expression, right: Expression) extends BinaryOperator with 
       > SELECT false _FUNC_ NULL;
        NULL
   """,
-  since = "1.0.0")
+  since = "1.0.0",
+  group = "logical_funcs")
 case class Or(left: Expression, right: Expression) extends BinaryOperator with Predicate {
 
   override def inputType: AbstractDataType = BooleanType
@@ -810,7 +814,8 @@ object Equality {
       > SELECT NULL _FUNC_ NULL;
        NULL
   """,
-  since = "1.0.0")
+  since = "1.0.0",
+  group = "comparison_funcs")
 case class EqualTo(left: Expression, right: Expression)
     extends BinaryComparison with NullIntolerant {
 
@@ -854,7 +859,8 @@ case class EqualTo(left: Expression, right: Expression)
       > SELECT NULL _FUNC_ NULL;
        true
   """,
-  since = "1.1.0")
+  since = "1.1.0",
+  group = "comparison_funcs")
 case class EqualNullSafe(left: Expression, right: Expression) extends BinaryComparison {
 
   override def symbol: String = "<=>"
@@ -912,7 +918,8 @@ case class EqualNullSafe(left: Expression, right: Expression) extends BinaryComp
       > SELECT 1 _FUNC_ NULL;
        NULL
   """,
-  since = "1.0.0")
+  since = "1.0.0",
+  group = "comparison_funcs")
 case class LessThan(left: Expression, right: Expression)
     extends BinaryComparison with NullIntolerant {
 
@@ -943,7 +950,8 @@ case class LessThan(left: Expression, right: Expression)
       > SELECT 1 _FUNC_ NULL;
        NULL
   """,
-  since = "1.0.0")
+  since = "1.0.0",
+  group = "comparison_funcs")
 case class LessThanOrEqual(left: Expression, right: Expression)
     extends BinaryComparison with NullIntolerant {
 
@@ -974,7 +982,8 @@ case class LessThanOrEqual(left: Expression, right: Expression)
       > SELECT 1 _FUNC_ NULL;
        NULL
   """,
-  since = "1.0.0")
+  since = "1.0.0",
+  group = "comparison_funcs")
 case class GreaterThan(left: Expression, right: Expression)
     extends BinaryComparison with NullIntolerant {
 
@@ -1005,7 +1014,8 @@ case class GreaterThan(left: Expression, right: Expression)
       > SELECT 1 _FUNC_ NULL;
        NULL
   """,
-  since = "1.0.0")
+  since = "1.0.0",
+  group = "comparison_funcs")
 case class GreaterThanOrEqual(left: Expression, right: Expression)
     extends BinaryComparison with NullIntolerant {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -256,7 +256,7 @@ trait PredicateHelper extends AliasHelper with Logging {
        NULL
   """,
   since = "1.0.0",
-  group = "logical_funcs")
+  group = "predicate_funcs")
 case class Not(child: Expression)
   extends UnaryExpression with Predicate with ImplicitCastInputTypes with NullIntolerant {
 
@@ -360,7 +360,7 @@ case class InSubquery(values: Seq[Expression], query: ListQuery)
        true
   """,
   since = "1.0.0",
-  group = "comparison_funcs")
+  group = "predicate_funcs")
 // scalastyle:on line.size.limit
 case class In(value: Expression, list: Seq[Expression]) extends Predicate {
 
@@ -597,7 +597,7 @@ case class InSet(child: Expression, hset: Set[Any]) extends UnaryExpression with
        false
   """,
   since = "1.0.0",
-  group = "logical_funcs")
+  group = "predicate_funcs")
 case class And(left: Expression, right: Expression) extends BinaryOperator with Predicate {
 
   override def inputType: AbstractDataType = BooleanType
@@ -680,7 +680,7 @@ case class And(left: Expression, right: Expression) extends BinaryOperator with 
        NULL
   """,
   since = "1.0.0",
-  group = "logical_funcs")
+  group = "predicate_funcs")
 case class Or(left: Expression, right: Expression) extends BinaryOperator with Predicate {
 
   override def inputType: AbstractDataType = BooleanType
@@ -815,7 +815,7 @@ object Equality {
        NULL
   """,
   since = "1.0.0",
-  group = "comparison_funcs")
+  group = "predicate_funcs")
 case class EqualTo(left: Expression, right: Expression)
     extends BinaryComparison with NullIntolerant {
 
@@ -860,7 +860,7 @@ case class EqualTo(left: Expression, right: Expression)
        true
   """,
   since = "1.1.0",
-  group = "comparison_funcs")
+  group = "predicate_funcs")
 case class EqualNullSafe(left: Expression, right: Expression) extends BinaryComparison {
 
   override def symbol: String = "<=>"
@@ -919,7 +919,7 @@ case class EqualNullSafe(left: Expression, right: Expression) extends BinaryComp
        NULL
   """,
   since = "1.0.0",
-  group = "comparison_funcs")
+  group = "predicate_funcs")
 case class LessThan(left: Expression, right: Expression)
     extends BinaryComparison with NullIntolerant {
 
@@ -951,7 +951,7 @@ case class LessThan(left: Expression, right: Expression)
        NULL
   """,
   since = "1.0.0",
-  group = "comparison_funcs")
+  group = "predicate_funcs")
 case class LessThanOrEqual(left: Expression, right: Expression)
     extends BinaryComparison with NullIntolerant {
 
@@ -983,7 +983,7 @@ case class LessThanOrEqual(left: Expression, right: Expression)
        NULL
   """,
   since = "1.0.0",
-  group = "comparison_funcs")
+  group = "predicate_funcs")
 case class GreaterThan(left: Expression, right: Expression)
     extends BinaryComparison with NullIntolerant {
 
@@ -1015,7 +1015,7 @@ case class GreaterThan(left: Expression, right: Expression)
        NULL
   """,
   since = "1.0.0",
-  group = "comparison_funcs")
+  group = "predicate_funcs")
 case class GreaterThanOrEqual(left: Expression, right: Expression)
     extends BinaryComparison with NullIntolerant {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/randomExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/randomExpressions.scala
@@ -81,7 +81,8 @@ trait ExpressionWithRandomSeed {
   note = """
     The function is non-deterministic in general case.
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "math_funcs")
 // scalastyle:on line.size.limit
 case class Rand(child: Expression, hideSeed: Boolean = false)
   extends RDG with ExpressionWithRandomSeed {
@@ -132,7 +133,8 @@ object Rand {
   note = """
     The function is non-deterministic in general case.
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "math_funcs")
 // scalastyle:on line.size.limit
 case class Randn(child: Expression, hideSeed: Boolean = false)
   extends RDG with ExpressionWithRandomSeed {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
@@ -116,7 +116,8 @@ abstract class StringRegexExpression extends BinaryExpression
   note = """
     Use RLIKE to match with standard regular expressions.
   """,
-  since = "1.0.0")
+  since = "1.0.0",
+  group = "comparison_funcs")
 // scalastyle:on line.contains.tab
 case class Like(left: Expression, right: Expression, escapeChar: Char)
   extends StringRegexExpression {
@@ -358,7 +359,8 @@ case class NotLikeAny(child: Expression, patterns: Seq[UTF8String]) extends Like
   note = """
     Use LIKE to match with simple string pattern.
   """,
-  since = "1.0.0")
+  since = "1.0.0",
+  group = "regex_funcs")
 // scalastyle:on line.contains.tab
 case class RLike(left: Expression, right: Expression) extends StringRegexExpression {
 
@@ -436,7 +438,8 @@ case class RLike(left: Expression, right: Expression) extends StringRegexExpress
       > SELECT _FUNC_('oneAtwoBthreeC', '[ABC]', 2);
        ["one","twoBthreeC"]
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "regex_funcs")
 case class StringSplit(str: Expression, regex: Expression, limit: Expression)
   extends TernaryExpression with ImplicitCastInputTypes with NullIntolerant {
 
@@ -494,7 +497,8 @@ case class StringSplit(str: Expression, regex: Expression, limit: Expression)
       > SELECT _FUNC_('100-200', '(\\d+)', 'num');
        num-num
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "regex_funcs")
 // scalastyle:on line.size.limit
 case class RegExpReplace(subject: Expression, regexp: Expression, rep: Expression, pos: Expression)
   extends QuaternaryExpression with ImplicitCastInputTypes with NullIntolerant {
@@ -687,7 +691,8 @@ abstract class RegExpExtractBase
       > SELECT _FUNC_('100-200', '(\\d+)-(\\d+)', 1);
        100
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "regex_funcs")
 case class RegExpExtract(subject: Expression, regexp: Expression, idx: Expression)
   extends RegExpExtractBase {
   def this(s: Expression, r: Expression) = this(s, r, Literal(1))
@@ -787,7 +792,8 @@ case class RegExpExtract(subject: Expression, regexp: Expression, idx: Expressio
       > SELECT _FUNC_('100-200, 300-400', '(\\d+)-(\\d+)', 1);
        ["100","300"]
   """,
-  since = "3.1.0")
+  since = "3.1.0",
+  group = "regex_funcs")
 case class RegExpExtractAll(subject: Expression, regexp: Expression, idx: Expression)
   extends RegExpExtractBase {
   def this(s: Expression, r: Expression) = this(s, r, Literal(1))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
@@ -117,7 +117,7 @@ abstract class StringRegexExpression extends BinaryExpression
     Use RLIKE to match with standard regular expressions.
   """,
   since = "1.0.0",
-  group = "comparison_funcs")
+  group = "predicate_funcs")
 // scalastyle:on line.contains.tab
 case class Like(left: Expression, right: Expression, escapeChar: Char)
   extends StringRegexExpression {
@@ -360,7 +360,7 @@ case class NotLikeAny(child: Expression, patterns: Seq[UTF8String]) extends Like
     Use LIKE to match with simple string pattern.
   """,
   since = "1.0.0",
-  group = "regex_funcs")
+  group = "predicate_funcs")
 // scalastyle:on line.contains.tab
 case class RLike(left: Expression, right: Expression) extends StringRegexExpression {
 
@@ -439,7 +439,7 @@ case class RLike(left: Expression, right: Expression) extends StringRegexExpress
        ["one","twoBthreeC"]
   """,
   since = "1.5.0",
-  group = "regex_funcs")
+  group = "string_funcs")
 case class StringSplit(str: Expression, regex: Expression, limit: Expression)
   extends TernaryExpression with ImplicitCastInputTypes with NullIntolerant {
 
@@ -498,7 +498,7 @@ case class StringSplit(str: Expression, regex: Expression, limit: Expression)
        num-num
   """,
   since = "1.5.0",
-  group = "regex_funcs")
+  group = "string_funcs")
 // scalastyle:on line.size.limit
 case class RegExpReplace(subject: Expression, regexp: Expression, rep: Expression, pos: Expression)
   extends QuaternaryExpression with ImplicitCastInputTypes with NullIntolerant {
@@ -692,7 +692,7 @@ abstract class RegExpExtractBase
        100
   """,
   since = "1.5.0",
-  group = "regex_funcs")
+  group = "string_funcs")
 case class RegExpExtract(subject: Expression, regexp: Expression, idx: Expression)
   extends RegExpExtractBase {
   def this(s: Expression, r: Expression) = this(s, r, Literal(1))
@@ -793,7 +793,7 @@ case class RegExpExtract(subject: Expression, regexp: Expression, idx: Expressio
        ["100","300"]
   """,
   since = "3.1.0",
-  group = "regex_funcs")
+  group = "string_funcs")
 case class RegExpExtractAll(subject: Expression, regexp: Expression, idx: Expression)
   extends RegExpExtractBase {
   def this(s: Expression, r: Expression) = this(s, r, Literal(1))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -56,7 +56,8 @@ import org.apache.spark.unsafe.types.{ByteArray, UTF8String}
       > SELECT _FUNC_(' ', 'Spark', 'SQL');
         Spark SQL
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "string_funcs")
 // scalastyle:on line.size.limit
 case class ConcatWs(children: Seq[Expression])
   extends Expression with ImplicitCastInputTypes {
@@ -244,7 +245,8 @@ case class ConcatWs(children: Seq[Expression])
       > SELECT _FUNC_(1, 'scala', 'java');
        scala
   """,
-  since = "2.0.0")
+  since = "2.0.0",
+  group = "conditional_funcs")
 // scalastyle:on line.size.limit
 case class Elt(
     children: Seq[Expression],
@@ -389,7 +391,8 @@ trait String2StringExpression extends ImplicitCastInputTypes {
       > SELECT _FUNC_('SparkSql');
        SPARKSQL
   """,
-  since = "1.0.1")
+  since = "1.0.1",
+  group = "string_funcs")
 case class Upper(child: Expression)
   extends UnaryExpression with String2StringExpression with NullIntolerant {
 
@@ -412,7 +415,8 @@ case class Upper(child: Expression)
       > SELECT _FUNC_('SparkSql');
        sparksql
   """,
-  since = "1.0.1")
+  since = "1.0.1",
+  group = "string_funcs")
 case class Lower(child: Expression)
   extends UnaryExpression with String2StringExpression with NullIntolerant {
 
@@ -490,7 +494,8 @@ case class EndsWith(left: Expression, right: Expression) extends StringPredicate
       > SELECT _FUNC_('ABCabc', 'abc', 'DEF');
        ABCDEF
   """,
-  since = "2.3.0")
+  since = "2.3.0",
+  group = "string_funcs")
 // scalastyle:on line.size.limit
 case class StringReplace(srcExpr: Expression, searchExpr: Expression, replaceExpr: Expression)
   extends TernaryExpression with ImplicitCastInputTypes with NullIntolerant {
@@ -570,7 +575,8 @@ object Overlay {
       > SELECT _FUNC_(encode('Spark SQL', 'utf-8') PLACING encode('tructured', 'utf-8') FROM 2 FOR 4);
        Structured SQL
   """,
-  since = "3.0.0")
+  since = "3.0.0",
+  group = "string_funcs")
 // scalastyle:on line.size.limit
 case class Overlay(input: Expression, replace: Expression, pos: Expression, len: Expression)
   extends QuaternaryExpression with ImplicitCastInputTypes with NullIntolerant {
@@ -657,7 +663,8 @@ object StringTranslate {
       > SELECT _FUNC_('AaBbCc', 'abc', '123');
        A1B2C3
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "string_funcs")
 // scalastyle:on line.size.limit
 case class StringTranslate(srcExpr: Expression, matchingExpr: Expression, replaceExpr: Expression)
   extends TernaryExpression with ImplicitCastInputTypes with NullIntolerant {
@@ -722,7 +729,8 @@ case class StringTranslate(srcExpr: Expression, matchingExpr: Expression, replac
       > SELECT _FUNC_('ab','abc,b,ab,c,def');
        3
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "string_funcs")
 // scalastyle:on line.size.limit
 case class FindInSet(left: Expression, right: Expression) extends BinaryExpression
     with ImplicitCastInputTypes with NullIntolerant {
@@ -830,7 +838,8 @@ object StringTrim {
       > SELECT _FUNC_(TRAILING 'SL' FROM 'SSparkSQLS');
        SSparkSQ
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "string_funcs")
 case class StringTrim(
     srcStr: Expression,
     trimStr: Option[Expression] = None)
@@ -923,7 +932,8 @@ object StringTrimLeft {
       > SELECT _FUNC_('    SparkSQL   ');
        SparkSQL
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "string_funcs")
 case class StringTrimLeft(
     srcStr: Expression,
     trimStr: Option[Expression] = None)
@@ -1017,7 +1027,8 @@ object StringTrimRight {
       > SELECT _FUNC_('    SparkSQL   ');
        SparkSQL
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "string_funcs")
 // scalastyle:on line.size.limit
 case class StringTrimRight(
     srcStr: Expression,
@@ -1094,7 +1105,8 @@ case class StringTrimRight(
       > SELECT _FUNC_('SparkSQL', 'SQL');
        6
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "string_funcs")
 // scalastyle:on line.size.limit
 case class StringInstr(str: Expression, substr: Expression)
   extends BinaryExpression with ImplicitCastInputTypes with NullIntolerant {
@@ -1136,7 +1148,8 @@ case class StringInstr(str: Expression, substr: Expression)
       > SELECT _FUNC_('www.apache.org', '.', 2);
        www.apache
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "string_funcs")
 // scalastyle:on line.size.limit
 case class SubstringIndex(strExpr: Expression, delimExpr: Expression, countExpr: Expression)
  extends TernaryExpression with ImplicitCastInputTypes with NullIntolerant {
@@ -1176,7 +1189,8 @@ case class SubstringIndex(strExpr: Expression, delimExpr: Expression, countExpr:
       > SELECT POSITION('bar' IN 'foobarbar');
        4
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "string_funcs")
 // scalastyle:on line.size.limit
 case class StringLocate(substr: Expression, str: Expression, start: Expression)
   extends TernaryExpression with ImplicitCastInputTypes {
@@ -1266,7 +1280,8 @@ case class StringLocate(substr: Expression, str: Expression, start: Expression)
       > SELECT _FUNC_('hi', 5);
           hi
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "string_funcs")
 case class StringLPad(str: Expression, len: Expression, pad: Expression = Literal(" "))
   extends TernaryExpression with ImplicitCastInputTypes with NullIntolerant {
 
@@ -1307,7 +1322,8 @@ case class StringLPad(str: Expression, len: Expression, pad: Expression = Litera
       > SELECT _FUNC_('hi', 5);
        hi
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "string_funcs")
 case class StringRPad(str: Expression, len: Expression, pad: Expression = Literal(" "))
   extends TernaryExpression with ImplicitCastInputTypes with NullIntolerant {
 
@@ -1357,7 +1373,8 @@ object ParseUrl {
       > SELECT _FUNC_('http://spark.apache.org/path?query=1', 'QUERY', 'query');
        1
   """,
-  since = "2.0.0")
+  since = "2.0.0",
+  group = "string_funcs")
 case class ParseUrl(children: Seq[Expression], failOnError: Boolean = SQLConf.get.ansiEnabled)
   extends Expression with ExpectsInputTypes with CodegenFallback {
   def this(children: Seq[Expression]) = this(children, SQLConf.get.ansiEnabled)
@@ -1512,7 +1529,8 @@ case class ParseUrl(children: Seq[Expression], failOnError: Boolean = SQLConf.ge
       > SELECT _FUNC_("Hello World %d %s", 100, "days");
        Hello World 100 days
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "string_funcs")
 // scalastyle:on line.size.limit
 case class FormatString(children: Expression*) extends Expression with ImplicitCastInputTypes {
 
@@ -1601,7 +1619,8 @@ case class FormatString(children: Expression*) extends Expression with ImplicitC
       > SELECT _FUNC_('sPark sql');
        Spark Sql
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "string_funcs")
 case class InitCap(child: Expression)
   extends UnaryExpression with ImplicitCastInputTypes with NullIntolerant {
 
@@ -1628,7 +1647,8 @@ case class InitCap(child: Expression)
       > SELECT _FUNC_('123', 2);
        123123
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "string_funcs")
 case class StringRepeat(str: Expression, times: Expression)
   extends BinaryExpression with ImplicitCastInputTypes with NullIntolerant {
 
@@ -1658,7 +1678,8 @@ case class StringRepeat(str: Expression, times: Expression)
       > SELECT concat(_FUNC_(2), '1');
          1
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "string_funcs")
 case class StringSpace(child: Expression)
   extends UnaryExpression with ImplicitCastInputTypes with NullIntolerant {
 
@@ -1706,7 +1727,8 @@ case class StringSpace(child: Expression)
       > SELECT _FUNC_('Spark SQL' FROM 5 FOR 1);
        k
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "string_funcs")
 // scalastyle:on line.size.limit
 case class Substring(str: Expression, pos: Expression, len: Expression)
   extends TernaryExpression with ImplicitCastInputTypes with NullIntolerant {
@@ -1753,7 +1775,8 @@ case class Substring(str: Expression, pos: Expression, len: Expression)
       > SELECT _FUNC_('Spark SQL', 3);
        SQL
   """,
-  since = "2.3.0")
+  since = "2.3.0",
+  group = "string_funcs")
 // scalastyle:on line.size.limit
 case class Right(str: Expression, len: Expression, child: Expression) extends RuntimeReplaceable {
   def this(str: Expression, len: Expression) = {
@@ -1776,7 +1799,8 @@ case class Right(str: Expression, len: Expression, child: Expression) extends Ru
       > SELECT _FUNC_('Spark SQL', 3);
        Spa
   """,
-  since = "2.3.0")
+  since = "2.3.0",
+  group = "string_funcs")
 // scalastyle:on line.size.limit
 case class Left(str: Expression, len: Expression, child: Expression) extends RuntimeReplaceable {
   def this(str: Expression, len: Expression) = {
@@ -1803,7 +1827,8 @@ case class Left(str: Expression, len: Expression, child: Expression) extends Run
       > SELECT CHARACTER_LENGTH('Spark SQL ');
        10
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "string_funcs")
 // scalastyle:on line.size.limit
 case class Length(child: Expression)
   extends UnaryExpression with ImplicitCastInputTypes with NullIntolerant {
@@ -1833,7 +1858,8 @@ case class Length(child: Expression)
       > SELECT _FUNC_('Spark SQL');
        72
   """,
-  since = "2.3.0")
+  since = "2.3.0",
+  group = "string_funcs")
 case class BitLength(child: Expression)
   extends UnaryExpression with ImplicitCastInputTypes with NullIntolerant {
   override def dataType: DataType = IntegerType
@@ -1865,7 +1891,8 @@ case class BitLength(child: Expression)
       > SELECT _FUNC_('Spark SQL');
        9
   """,
-  since = "2.3.0")
+  since = "2.3.0",
+  group = "string_funcs")
 case class OctetLength(child: Expression)
   extends UnaryExpression with ImplicitCastInputTypes with NullIntolerant {
   override def dataType: DataType = IntegerType
@@ -1896,7 +1923,8 @@ case class OctetLength(child: Expression)
       > SELECT _FUNC_('kitten', 'sitting');
        3
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "string_funcs")
 case class Levenshtein(left: Expression, right: Expression) extends BinaryExpression
     with ImplicitCastInputTypes with NullIntolerant {
 
@@ -1922,7 +1950,8 @@ case class Levenshtein(left: Expression, right: Expression) extends BinaryExpres
       > SELECT _FUNC_('Miller');
        M460
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "string_funcs")
 case class SoundEx(child: Expression)
   extends UnaryExpression with ExpectsInputTypes with NullIntolerant {
 
@@ -1949,7 +1978,8 @@ case class SoundEx(child: Expression)
       > SELECT _FUNC_(2);
        50
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "string_funcs")
 case class Ascii(child: Expression)
   extends UnaryExpression with ImplicitCastInputTypes with NullIntolerant {
 
@@ -1991,7 +2021,8 @@ case class Ascii(child: Expression)
       > SELECT _FUNC_(65);
        A
   """,
-  since = "2.3.0")
+  since = "2.3.0",
+  group = "string_funcs")
 // scalastyle:on line.size.limit
 case class Chr(child: Expression)
   extends UnaryExpression with ImplicitCastInputTypes with NullIntolerant {
@@ -2036,7 +2067,8 @@ case class Chr(child: Expression)
       > SELECT _FUNC_('Spark SQL');
        U3BhcmsgU1FM
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "string_funcs")
 case class Base64(child: Expression)
   extends UnaryExpression with ImplicitCastInputTypes with NullIntolerant {
 
@@ -2065,7 +2097,8 @@ case class Base64(child: Expression)
       > SELECT _FUNC_('U3BhcmsgU1FM');
        Spark SQL
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "string_funcs")
 case class UnBase64(child: Expression)
   extends UnaryExpression with ImplicitCastInputTypes with NullIntolerant {
 
@@ -2155,7 +2188,8 @@ case class Decode(params: Seq[Expression], child: Expression) extends RuntimeRep
       > SELECT _FUNC_(encode('abc', 'utf-8'), 'utf-8');
        abc
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "string_funcs")
 // scalastyle:on line.size.limit
 case class StringDecode(bin: Expression, charset: Expression)
   extends BinaryExpression with ImplicitCastInputTypes with NullIntolerant {
@@ -2195,7 +2229,8 @@ case class StringDecode(bin: Expression, charset: Expression)
       > SELECT _FUNC_('abc', 'utf-8');
        abc
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "string_funcs")
 // scalastyle:on line.size.limit
 case class Encode(value: Expression, charset: Expression)
   extends BinaryExpression with ImplicitCastInputTypes with NullIntolerant {
@@ -2240,7 +2275,8 @@ case class Encode(value: Expression, charset: Expression)
       > SELECT _FUNC_(12332.123456, '##################.###');
        12332.123
   """,
-  since = "1.5.0")
+  since = "1.5.0",
+  group = "string_funcs")
 case class FormatNumber(x: Expression, d: Expression)
   extends BinaryExpression with ExpectsInputTypes with NullIntolerant {
 
@@ -2411,7 +2447,8 @@ case class FormatNumber(x: Expression, d: Expression)
       > SELECT _FUNC_('Hi there! Good morning.');
        [["Hi","there"],["Good","morning"]]
   """,
-  since = "2.0.0")
+  since = "2.0.0",
+  group = "string_funcs")
 case class Sentences(
     str: Expression,
     language: Expression = Literal(""),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -246,7 +246,7 @@ case class ConcatWs(children: Seq[Expression])
        scala
   """,
   since = "2.0.0",
-  group = "conditional_funcs")
+  group = "string_funcs")
 // scalastyle:on line.size.limit
 case class Elt(
     children: Seq[Expression],
@@ -2163,7 +2163,8 @@ object Decode {
       > SELECT _FUNC_(6, 1, 'Southlake', 2, 'San Francisco', 3, 'New Jersey', 4, 'Seattle');
        NULL
   """,
-  since = "3.2.0")
+  since = "3.2.0",
+  group = "string_funcs")
 // scalastyle:on line.size.limit
 case class Decode(params: Seq[Expression], child: Expression) extends RuntimeReplaceable {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/xml/xpath.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/xml/xpath.scala
@@ -64,7 +64,8 @@ abstract class XPathExtract
       > SELECT _FUNC_('<a><b>1</b></a>','a/b');
        true
   """,
-  since = "2.0.0")
+  since = "2.0.0",
+  group = "xml_funcs")
 // scalastyle:on line.size.limit
 case class XPathBoolean(xml: Expression, path: Expression) extends XPathExtract {
 
@@ -84,7 +85,8 @@ case class XPathBoolean(xml: Expression, path: Expression) extends XPathExtract 
       > SELECT _FUNC_('<a><b>1</b><b>2</b></a>', 'sum(a/b)');
        3
   """,
-  since = "2.0.0")
+  since = "2.0.0",
+  group = "xml_funcs")
 // scalastyle:on line.size.limit
 case class XPathShort(xml: Expression, path: Expression) extends XPathExtract {
   override def prettyName: String = "xpath_short"
@@ -104,7 +106,8 @@ case class XPathShort(xml: Expression, path: Expression) extends XPathExtract {
       > SELECT _FUNC_('<a><b>1</b><b>2</b></a>', 'sum(a/b)');
        3
   """,
-  since = "2.0.0")
+  since = "2.0.0",
+  group = "xml_funcs")
 // scalastyle:on line.size.limit
 case class XPathInt(xml: Expression, path: Expression) extends XPathExtract {
   override def prettyName: String = "xpath_int"
@@ -124,7 +127,8 @@ case class XPathInt(xml: Expression, path: Expression) extends XPathExtract {
       > SELECT _FUNC_('<a><b>1</b><b>2</b></a>', 'sum(a/b)');
        3
   """,
-  since = "2.0.0")
+  since = "2.0.0",
+  group = "xml_funcs")
 // scalastyle:on line.size.limit
 case class XPathLong(xml: Expression, path: Expression) extends XPathExtract {
   override def prettyName: String = "xpath_long"
@@ -144,7 +148,8 @@ case class XPathLong(xml: Expression, path: Expression) extends XPathExtract {
       > SELECT _FUNC_('<a><b>1</b><b>2</b></a>', 'sum(a/b)');
        3.0
   """,
-  since = "2.0.0")
+  since = "2.0.0",
+  group = "xml_funcs")
 // scalastyle:on line.size.limit
 case class XPathFloat(xml: Expression, path: Expression) extends XPathExtract {
   override def prettyName: String = "xpath_float"
@@ -164,7 +169,8 @@ case class XPathFloat(xml: Expression, path: Expression) extends XPathExtract {
       > SELECT _FUNC_('<a><b>1</b><b>2</b></a>', 'sum(a/b)');
        3.0
   """,
-  since = "2.0.0")
+  since = "2.0.0",
+  group = "xml_funcs")
 // scalastyle:on line.size.limit
 case class XPathDouble(xml: Expression, path: Expression) extends XPathExtract {
   override def prettyName: String =
@@ -185,7 +191,8 @@ case class XPathDouble(xml: Expression, path: Expression) extends XPathExtract {
       > SELECT _FUNC_('<a><b>b</b><c>cc</c></a>','a/c');
        cc
   """,
-  since = "2.0.0")
+  since = "2.0.0",
+  group = "xml_funcs")
 // scalastyle:on line.size.limit
 case class XPathString(xml: Expression, path: Expression) extends XPathExtract {
   override def prettyName: String = "xpath_string"
@@ -205,7 +212,8 @@ case class XPathString(xml: Expression, path: Expression) extends XPathExtract {
       > SELECT _FUNC_('<a><b>b1</b><b>b2</b><b>b3</b><c>c1</c><c>c2</c></a>','a/b/text()');
        ["b1","b2","b3"]
   """,
-  since = "2.0.0")
+  since = "2.0.0",
+  group = "xml_funcs")
 // scalastyle:on line.size.limit
 case class XPathList(xml: Expression, path: Expression) extends XPathExtract {
   override def prettyName: String = "xpath"

--- a/sql/core/src/test/scala/org/apache/spark/sql/expressions/ExpressionInfoSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/expressions/ExpressionInfoSuite.scala
@@ -121,6 +121,7 @@ class ExpressionInfoSuite extends SparkFunSuite with SharedSparkSession {
           assert(info.getExamples.startsWith("\n    Examples:\n"))
           assert(info.getExamples.endsWith("\n  "))
           assert(info.getSince.matches("[0-9]+\\.[0-9]+\\.[0-9]+"))
+          assert(info.getGroup.nonEmpty)
 
           if (info.getArguments.nonEmpty) {
             assert(info.getArguments.startsWith("\n    Arguments:\n"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/expressions/ExpressionInfoSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/expressions/ExpressionInfoSuite.scala
@@ -43,6 +43,10 @@ class ExpressionInfoSuite extends SparkFunSuite with SharedSparkSession {
   test("group info in ExpressionInfo") {
     val info = spark.sessionState.catalog.lookupFunctionInfo(FunctionIdentifier("sum"))
     assert(info.getGroup === "agg_funcs")
+    Seq("agg_funcs", "array_funcs", "binary_funcs", "bitwise_funcs", "collection_funcs",
+      "predicate_funcs", "conditional_funcs", "conversion_funcs", "csv_funcs", "datetime_funcs",
+      "generator_funcs", "hash_funcs", "json_funcs", "lambda_funcs", "map_funcs", "math_funcs",
+      "misc_funcs", "string_funcs", "struct_funcs", "window_funcs", "xml_funcs")
 
     Seq("agg_funcs", "array_funcs", "datetime_funcs", "json_funcs", "map_funcs", "window_funcs")
         .foreach { groupName =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/expressions/ExpressionInfoSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/expressions/ExpressionInfoSuite.scala
@@ -106,7 +106,7 @@ class ExpressionInfoSuite extends SparkFunSuite with SharedSparkSession {
   }
 
   test("SPARK-32870: Default expressions in FunctionRegistry should have their " +
-    "usage, examples and since filled") {
+    "usage, examples, since, and group filled") {
     val ignoreSet = Set(
       // Explicitly inherits NonSQLExpression, and has no ExpressionDescription
       "org.apache.spark.sql.catalyst.expressions.TimeWindow",

--- a/sql/gen-sql-functions-docs.py
+++ b/sql/gen-sql-functions-docs.py
@@ -29,8 +29,11 @@ from pyspark.java_gateway import launch_gateway
 ExpressionInfo = namedtuple("ExpressionInfo", "name usage examples group")
 
 groups = {
-    "agg_funcs", "array_funcs", "datetime_funcs",
-    "json_funcs", "map_funcs", "window_funcs",
+    "agg_funcs", "array_funcs", "binary_funcs", "bitwise_funcs",
+    "comparison_funcs", "conditional_funcs", "conversion_funcs", "csv_funcs",
+    "datetime_funcs", "generator_funcs", "grouping_funcs", "json_funcs", "logical_funcs",
+    "map_funcs", "math_funcs", "misc_funcs", "regex_funcs", "string_funcs", "struct_funcs",
+    "window_funcs", "xml_funcs"
 }
 
 
@@ -108,7 +111,7 @@ def _make_pretty_usage(infos):
         # Expected formats are as follows;
         #  - `_FUNC_(...) - description`, or
         #  - `_FUNC_ - description`
-        usages = iter(re.split(r"(%s.*) - " % info.name, info.usage.strip())[1:])
+        usages = iter(re.split(r"(%s.*) - " % re.escape(info.name), info.usage.strip())[1:])
         for (sig, description) in zip(usages, usages):
             result.append("    <tr>")
             result.append("      <td>%s</td>" % sig)
@@ -145,12 +148,16 @@ def _make_pretty_examples(jspark, infos):
 
     pretty_output = ""
     for info in infos:
+        if info.name == 'raise_error':
+            # TODO: how to handle this
+            continue
+
         if info.examples.startswith("\n    Examples:"):
             output = []
             output.append("-- %s" % info.name)
             query_examples = filter(lambda x: x.startswith("      > "), info.examples.split("\n"))
             for query_example in query_examples:
-                query = query_example.lstrip("      > ")
+                query = query_example.lstrip("      > ").rstrip(';')
                 print("    %s" % query)
                 query_output = jspark.sql(query).showString(20, 20, False)
                 output.append(query)

--- a/sql/gen-sql-functions-docs.py
+++ b/sql/gen-sql-functions-docs.py
@@ -29,11 +29,8 @@ from pyspark.java_gateway import launch_gateway
 ExpressionInfo = namedtuple("ExpressionInfo", "name usage examples group")
 
 groups = {
-    "agg_funcs", "array_funcs", "binary_funcs", "bitwise_funcs",
-    "comparison_funcs", "conditional_funcs", "conversion_funcs", "csv_funcs",
-    "datetime_funcs", "generator_funcs", "grouping_funcs", "json_funcs", "logical_funcs",
-    "map_funcs", "math_funcs", "misc_funcs", "regex_funcs", "string_funcs", "struct_funcs",
-    "window_funcs", "xml_funcs"
+    "agg_funcs", "array_funcs", "datetime_funcs",
+    "json_funcs", "map_funcs", "window_funcs",
 }
 
 
@@ -111,7 +108,7 @@ def _make_pretty_usage(infos):
         # Expected formats are as follows;
         #  - `_FUNC_(...) - description`, or
         #  - `_FUNC_ - description`
-        usages = iter(re.split(r"(%s.*) - " % re.escape(info.name), info.usage.strip())[1:])
+        usages = iter(re.split(r"(%s.*) - " % info.name, info.usage.strip())[1:])
         for (sig, description) in zip(usages, usages):
             result.append("    <tr>")
             result.append("      <td>%s</td>" % sig)
@@ -148,16 +145,12 @@ def _make_pretty_examples(jspark, infos):
 
     pretty_output = ""
     for info in infos:
-        if info.name == 'raise_error':
-            # TODO: how to handle this
-            continue
-
         if info.examples.startswith("\n    Examples:"):
             output = []
             output.append("-- %s" % info.name)
             query_examples = filter(lambda x: x.startswith("      > "), info.examples.split("\n"))
             for query_example in query_examples:
-                query = query_example.lstrip("      > ").rstrip(';')
+                query = query_example.lstrip("      > ")
                 print("    %s" % query)
                 query_output = jspark.sql(query).showString(20, 20, False)
                 output.append(query)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR proposes to fill missing group tags and re-categorize all the group tags for built-in functions.
New groups below are added in this PR:
 - binary_funcs
 - bitwise_funcs
 - collection_funcs
 - predicate_funcs
 - conditional_funcs
 - conversion_funcs
 - csv_funcs
 - generator_funcs
 - hash_funcs
 - lambda_funcs
 - math_funcs
 - misc_funcs
 - string_funcs
 - struct_funcs
 - xml_funcs

A basic policy to re-categorize functions is that functions in the same file are categorized into the same group. For example, all the functions in `hash.scala` are categorized into `hash_funcs`. But, there are some exceptional/ambiguous cases when categorizing them. Here are some special notes:
 - All the aggregate functions are categorized into `agg_funcs`.
 - `array_funcs` and `map_funcs` are  sub-groups of `collection_funcs`. For example, `array_contains` is used only for arrays, so it is assigned to `array_funcs`. On the other hand, `reverse` is used for both arrays and strings, so it is assigned to `collection_funcs`.
 - Some functions logically belong to multiple groups. In this case, these functions are categorized based on the file that they belong to. For example, `schema_of_csv` can be grouped into both `csv_funcs` and `struct_funcs` in terms of input types, but it is assigned to `csv_funcs` because it belongs to the `csvExpressions.scala` file that holds the other CSV-related functions.
 - Functions in `nullExpressions.scala`, `complexTypeCreator.scala`, `randomExpressions.scala`, and `regexExpressions.scala` are categorized based on their functionalities. For example:
   - `isnull` in `nullExpressions`  is assigned to `predicate_funcs` because this is a predicate function.
   - `array` in `complexTypeCreator.scala` is assigned to `array_funcs`based on its output type (The other functions in `array_funcs` are categorized based on their input types though).

A category list (after this PR) is as follows (the list below includes the exprs that already have a group tag in the current master):
|group|name|class|
|-----|----|-----|
|agg_funcs|any|org.apache.spark.sql.catalyst.expressions.aggregate.BoolOr|
|agg_funcs|approx_count_distinct|org.apache.spark.sql.catalyst.expressions.aggregate.HyperLogLogPlusPlus|
|agg_funcs|approx_percentile|org.apache.spark.sql.catalyst.expressions.aggregate.ApproximatePercentile|
|agg_funcs|avg|org.apache.spark.sql.catalyst.expressions.aggregate.Average|
|agg_funcs|bit_and|org.apache.spark.sql.catalyst.expressions.aggregate.BitAndAgg|
|agg_funcs|bit_or|org.apache.spark.sql.catalyst.expressions.aggregate.BitOrAgg|
|agg_funcs|bit_xor|org.apache.spark.sql.catalyst.expressions.aggregate.BitXorAgg|
|agg_funcs|bool_and|org.apache.spark.sql.catalyst.expressions.aggregate.BoolAnd|
|agg_funcs|bool_or|org.apache.spark.sql.catalyst.expressions.aggregate.BoolOr|
|agg_funcs|collect_list|org.apache.spark.sql.catalyst.expressions.aggregate.CollectList|
|agg_funcs|collect_set|org.apache.spark.sql.catalyst.expressions.aggregate.CollectSet|
|agg_funcs|corr|org.apache.spark.sql.catalyst.expressions.aggregate.Corr|
|agg_funcs|count_if|org.apache.spark.sql.catalyst.expressions.aggregate.CountIf|
|agg_funcs|count_min_sketch|org.apache.spark.sql.catalyst.expressions.aggregate.CountMinSketchAgg|
|agg_funcs|count|org.apache.spark.sql.catalyst.expressions.aggregate.Count|
|agg_funcs|covar_pop|org.apache.spark.sql.catalyst.expressions.aggregate.CovPopulation|
|agg_funcs|covar_samp|org.apache.spark.sql.catalyst.expressions.aggregate.CovSample|
|agg_funcs|cube|org.apache.spark.sql.catalyst.expressions.Cube|
|agg_funcs|every|org.apache.spark.sql.catalyst.expressions.aggregate.BoolAnd|
|agg_funcs|first_value|org.apache.spark.sql.catalyst.expressions.aggregate.First|
|agg_funcs|first|org.apache.spark.sql.catalyst.expressions.aggregate.First|
|agg_funcs|grouping_id|org.apache.spark.sql.catalyst.expressions.GroupingID|
|agg_funcs|grouping|org.apache.spark.sql.catalyst.expressions.Grouping|
|agg_funcs|kurtosis|org.apache.spark.sql.catalyst.expressions.aggregate.Kurtosis|
|agg_funcs|last_value|org.apache.spark.sql.catalyst.expressions.aggregate.Last|
|agg_funcs|last|org.apache.spark.sql.catalyst.expressions.aggregate.Last|
|agg_funcs|max_by|org.apache.spark.sql.catalyst.expressions.aggregate.MaxBy|
|agg_funcs|max|org.apache.spark.sql.catalyst.expressions.aggregate.Max|
|agg_funcs|mean|org.apache.spark.sql.catalyst.expressions.aggregate.Average|
|agg_funcs|min_by|org.apache.spark.sql.catalyst.expressions.aggregate.MinBy|
|agg_funcs|min|org.apache.spark.sql.catalyst.expressions.aggregate.Min|
|agg_funcs|percentile_approx|org.apache.spark.sql.catalyst.expressions.aggregate.ApproximatePercentile|
|agg_funcs|percentile|org.apache.spark.sql.catalyst.expressions.aggregate.Percentile|
|agg_funcs|rollup|org.apache.spark.sql.catalyst.expressions.Rollup|
|agg_funcs|skewness|org.apache.spark.sql.catalyst.expressions.aggregate.Skewness|
|agg_funcs|some|org.apache.spark.sql.catalyst.expressions.aggregate.BoolOr|
|agg_funcs|stddev_pop|org.apache.spark.sql.catalyst.expressions.aggregate.StddevPop|
|agg_funcs|stddev_samp|org.apache.spark.sql.catalyst.expressions.aggregate.StddevSamp|
|agg_funcs|stddev|org.apache.spark.sql.catalyst.expressions.aggregate.StddevSamp|
|agg_funcs|std|org.apache.spark.sql.catalyst.expressions.aggregate.StddevSamp|
|agg_funcs|sum|org.apache.spark.sql.catalyst.expressions.aggregate.Sum|
|agg_funcs|var_pop|org.apache.spark.sql.catalyst.expressions.aggregate.VariancePop|
|agg_funcs|var_samp|org.apache.spark.sql.catalyst.expressions.aggregate.VarianceSamp|
|agg_funcs|variance|org.apache.spark.sql.catalyst.expressions.aggregate.VarianceSamp|
|array_funcs|array_contains|org.apache.spark.sql.catalyst.expressions.ArrayContains|
|array_funcs|array_distinct|org.apache.spark.sql.catalyst.expressions.ArrayDistinct|
|array_funcs|array_except|org.apache.spark.sql.catalyst.expressions.ArrayExcept|
|array_funcs|array_intersect|org.apache.spark.sql.catalyst.expressions.ArrayIntersect|
|array_funcs|array_join|org.apache.spark.sql.catalyst.expressions.ArrayJoin|
|array_funcs|array_max|org.apache.spark.sql.catalyst.expressions.ArrayMax|
|array_funcs|array_min|org.apache.spark.sql.catalyst.expressions.ArrayMin|
|array_funcs|array_position|org.apache.spark.sql.catalyst.expressions.ArrayPosition|
|array_funcs|array_remove|org.apache.spark.sql.catalyst.expressions.ArrayRemove|
|array_funcs|array_repeat|org.apache.spark.sql.catalyst.expressions.ArrayRepeat|
|array_funcs|array_union|org.apache.spark.sql.catalyst.expressions.ArrayUnion|
|array_funcs|arrays_overlap|org.apache.spark.sql.catalyst.expressions.ArraysOverlap|
|array_funcs|arrays_zip|org.apache.spark.sql.catalyst.expressions.ArraysZip|
|array_funcs|array|org.apache.spark.sql.catalyst.expressions.CreateArray|
|array_funcs|flatten|org.apache.spark.sql.catalyst.expressions.Flatten|
|array_funcs|sequence|org.apache.spark.sql.catalyst.expressions.Sequence|
|array_funcs|shuffle|org.apache.spark.sql.catalyst.expressions.Shuffle|
|array_funcs|slice|org.apache.spark.sql.catalyst.expressions.Slice|
|array_funcs|sort_array|org.apache.spark.sql.catalyst.expressions.SortArray|
|bitwise_funcs|&|org.apache.spark.sql.catalyst.expressions.BitwiseAnd|
|bitwise_funcs|^|org.apache.spark.sql.catalyst.expressions.BitwiseXor|
|bitwise_funcs|bit_count|org.apache.spark.sql.catalyst.expressions.BitwiseCount|
|bitwise_funcs|shiftrightunsigned|org.apache.spark.sql.catalyst.expressions.ShiftRightUnsigned|
|bitwise_funcs|shiftright|org.apache.spark.sql.catalyst.expressions.ShiftRight|
|bitwise_funcs|~|org.apache.spark.sql.catalyst.expressions.BitwiseNot|
|collection_funcs|cardinality|org.apache.spark.sql.catalyst.expressions.Size|
|collection_funcs|concat|org.apache.spark.sql.catalyst.expressions.Concat|
|collection_funcs|reverse|org.apache.spark.sql.catalyst.expressions.Reverse|
|collection_funcs|size|org.apache.spark.sql.catalyst.expressions.Size|
|conditional_funcs|coalesce|org.apache.spark.sql.catalyst.expressions.Coalesce|
|conditional_funcs|ifnull|org.apache.spark.sql.catalyst.expressions.IfNull|
|conditional_funcs|if|org.apache.spark.sql.catalyst.expressions.If|
|conditional_funcs|nanvl|org.apache.spark.sql.catalyst.expressions.NaNvl|
|conditional_funcs|nullif|org.apache.spark.sql.catalyst.expressions.NullIf|
|conditional_funcs|nvl2|org.apache.spark.sql.catalyst.expressions.Nvl2|
|conditional_funcs|nvl|org.apache.spark.sql.catalyst.expressions.Nvl|
|conditional_funcs|when|org.apache.spark.sql.catalyst.expressions.CaseWhen|
|conversion_funcs|bigint|org.apache.spark.sql.catalyst.expressions.Cast|
|conversion_funcs|binary|org.apache.spark.sql.catalyst.expressions.Cast|
|conversion_funcs|boolean|org.apache.spark.sql.catalyst.expressions.Cast|
|conversion_funcs|cast|org.apache.spark.sql.catalyst.expressions.Cast|
|conversion_funcs|date|org.apache.spark.sql.catalyst.expressions.Cast|
|conversion_funcs|decimal|org.apache.spark.sql.catalyst.expressions.Cast|
|conversion_funcs|double|org.apache.spark.sql.catalyst.expressions.Cast|
|conversion_funcs|float|org.apache.spark.sql.catalyst.expressions.Cast|
|conversion_funcs|int|org.apache.spark.sql.catalyst.expressions.Cast|
|conversion_funcs|smallint|org.apache.spark.sql.catalyst.expressions.Cast|
|conversion_funcs|string|org.apache.spark.sql.catalyst.expressions.Cast|
|conversion_funcs|timestamp|org.apache.spark.sql.catalyst.expressions.Cast|
|conversion_funcs|tinyint|org.apache.spark.sql.catalyst.expressions.Cast|
|csv_funcs|from_csv|org.apache.spark.sql.catalyst.expressions.CsvToStructs|
|csv_funcs|schema_of_csv|org.apache.spark.sql.catalyst.expressions.SchemaOfCsv|
|csv_funcs|to_csv|org.apache.spark.sql.catalyst.expressions.StructsToCsv|
|datetime_funcs|add_months|org.apache.spark.sql.catalyst.expressions.AddMonths|
|datetime_funcs|current_date|org.apache.spark.sql.catalyst.expressions.CurrentDate|
|datetime_funcs|current_timestamp|org.apache.spark.sql.catalyst.expressions.CurrentTimestamp|
|datetime_funcs|current_timezone|org.apache.spark.sql.catalyst.expressions.CurrentTimeZone|
|datetime_funcs|date_add|org.apache.spark.sql.catalyst.expressions.DateAdd|
|datetime_funcs|date_format|org.apache.spark.sql.catalyst.expressions.DateFormatClass|
|datetime_funcs|date_from_unix_date|org.apache.spark.sql.catalyst.expressions.DateFromUnixDate|
|datetime_funcs|date_part|org.apache.spark.sql.catalyst.expressions.DatePart|
|datetime_funcs|date_sub|org.apache.spark.sql.catalyst.expressions.DateSub|
|datetime_funcs|date_trunc|org.apache.spark.sql.catalyst.expressions.TruncTimestamp|
|datetime_funcs|datediff|org.apache.spark.sql.catalyst.expressions.DateDiff|
|datetime_funcs|dayofmonth|org.apache.spark.sql.catalyst.expressions.DayOfMonth|
|datetime_funcs|dayofweek|org.apache.spark.sql.catalyst.expressions.DayOfWeek|
|datetime_funcs|dayofyear|org.apache.spark.sql.catalyst.expressions.DayOfYear|
|datetime_funcs|day|org.apache.spark.sql.catalyst.expressions.DayOfMonth|
|datetime_funcs|extract|org.apache.spark.sql.catalyst.expressions.Extract|
|datetime_funcs|from_unixtime|org.apache.spark.sql.catalyst.expressions.FromUnixTime|
|datetime_funcs|from_utc_timestamp|org.apache.spark.sql.catalyst.expressions.FromUTCTimestamp|
|datetime_funcs|hour|org.apache.spark.sql.catalyst.expressions.Hour|
|datetime_funcs|last_day|org.apache.spark.sql.catalyst.expressions.LastDay|
|datetime_funcs|make_date|org.apache.spark.sql.catalyst.expressions.MakeDate|
|datetime_funcs|make_interval|org.apache.spark.sql.catalyst.expressions.MakeInterval|
|datetime_funcs|make_timestamp|org.apache.spark.sql.catalyst.expressions.MakeTimestamp|
|datetime_funcs|minute|org.apache.spark.sql.catalyst.expressions.Minute|
|datetime_funcs|months_between|org.apache.spark.sql.catalyst.expressions.MonthsBetween|
|datetime_funcs|month|org.apache.spark.sql.catalyst.expressions.Month|
|datetime_funcs|next_day|org.apache.spark.sql.catalyst.expressions.NextDay|
|datetime_funcs|now|org.apache.spark.sql.catalyst.expressions.Now|
|datetime_funcs|quarter|org.apache.spark.sql.catalyst.expressions.Quarter|
|datetime_funcs|second|org.apache.spark.sql.catalyst.expressions.Second|
|datetime_funcs|timestamp_micros|org.apache.spark.sql.catalyst.expressions.MicrosToTimestamp|
|datetime_funcs|timestamp_millis|org.apache.spark.sql.catalyst.expressions.MillisToTimestamp|
|datetime_funcs|timestamp_seconds|org.apache.spark.sql.catalyst.expressions.SecondsToTimestamp|
|datetime_funcs|to_date|org.apache.spark.sql.catalyst.expressions.ParseToDate|
|datetime_funcs|to_timestamp|org.apache.spark.sql.catalyst.expressions.ParseToTimestamp|
|datetime_funcs|to_unix_timestamp|org.apache.spark.sql.catalyst.expressions.ToUnixTimestamp|
|datetime_funcs|to_utc_timestamp|org.apache.spark.sql.catalyst.expressions.ToUTCTimestamp|
|datetime_funcs|trunc|org.apache.spark.sql.catalyst.expressions.TruncDate|
|datetime_funcs|unix_date|org.apache.spark.sql.catalyst.expressions.UnixDate|
|datetime_funcs|unix_micros|org.apache.spark.sql.catalyst.expressions.UnixMicros|
|datetime_funcs|unix_millis|org.apache.spark.sql.catalyst.expressions.UnixMillis|
|datetime_funcs|unix_seconds|org.apache.spark.sql.catalyst.expressions.UnixSeconds|
|datetime_funcs|unix_timestamp|org.apache.spark.sql.catalyst.expressions.UnixTimestamp|
|datetime_funcs|weekday|org.apache.spark.sql.catalyst.expressions.WeekDay|
|datetime_funcs|weekofyear|org.apache.spark.sql.catalyst.expressions.WeekOfYear|
|datetime_funcs|year|org.apache.spark.sql.catalyst.expressions.Year|
|generator_funcs|explode_outer|org.apache.spark.sql.catalyst.expressions.Explode|
|generator_funcs|explode|org.apache.spark.sql.catalyst.expressions.Explode|
|generator_funcs|inline_outer|org.apache.spark.sql.catalyst.expressions.Inline|
|generator_funcs|inline|org.apache.spark.sql.catalyst.expressions.Inline|
|generator_funcs|posexplode_outer|org.apache.spark.sql.catalyst.expressions.PosExplode|
|generator_funcs|posexplode|org.apache.spark.sql.catalyst.expressions.PosExplode|
|generator_funcs|stack|org.apache.spark.sql.catalyst.expressions.Stack|
|hash_funcs|crc32|org.apache.spark.sql.catalyst.expressions.Crc32|
|hash_funcs|hash|org.apache.spark.sql.catalyst.expressions.Murmur3Hash|
|hash_funcs|md5|org.apache.spark.sql.catalyst.expressions.Md5|
|hash_funcs|sha1|org.apache.spark.sql.catalyst.expressions.Sha1|
|hash_funcs|sha2|org.apache.spark.sql.catalyst.expressions.Sha2|
|hash_funcs|sha|org.apache.spark.sql.catalyst.expressions.Sha1|
|hash_funcs|xxhash64|org.apache.spark.sql.catalyst.expressions.XxHash64|
|json_funcs|from_json|org.apache.spark.sql.catalyst.expressions.JsonToStructs|
|json_funcs|get_json_object|org.apache.spark.sql.catalyst.expressions.GetJsonObject|
|json_funcs|json_array_length|org.apache.spark.sql.catalyst.expressions.LengthOfJsonArray|
|json_funcs|json_object_keys|org.apache.spark.sql.catalyst.expressions.JsonObjectKeys|
|json_funcs|json_tuple|org.apache.spark.sql.catalyst.expressions.JsonTuple|
|json_funcs|schema_of_json|org.apache.spark.sql.catalyst.expressions.SchemaOfJson|
|json_funcs|to_json|org.apache.spark.sql.catalyst.expressions.StructsToJson|
|lambda_funcs|aggregate|org.apache.spark.sql.catalyst.expressions.ArrayAggregate|
|lambda_funcs|array_sort|org.apache.spark.sql.catalyst.expressions.ArraySort|
|lambda_funcs|exists|org.apache.spark.sql.catalyst.expressions.ArrayExists|
|lambda_funcs|filter|org.apache.spark.sql.catalyst.expressions.ArrayFilter|
|lambda_funcs|forall|org.apache.spark.sql.catalyst.expressions.ArrayForAll|
|lambda_funcs|map_filter|org.apache.spark.sql.catalyst.expressions.MapFilter|
|lambda_funcs|map_zip_with|org.apache.spark.sql.catalyst.expressions.MapZipWith|
|lambda_funcs|transform_keys|org.apache.spark.sql.catalyst.expressions.TransformKeys|
|lambda_funcs|transform_values|org.apache.spark.sql.catalyst.expressions.TransformValues|
|lambda_funcs|transform|org.apache.spark.sql.catalyst.expressions.ArrayTransform|
|lambda_funcs|zip_with|org.apache.spark.sql.catalyst.expressions.ZipWith|
|map_funcs|element_at|org.apache.spark.sql.catalyst.expressions.ElementAt|
|map_funcs|map_concat|org.apache.spark.sql.catalyst.expressions.MapConcat|
|map_funcs|map_entries|org.apache.spark.sql.catalyst.expressions.MapEntries|
|map_funcs|map_from_arrays|org.apache.spark.sql.catalyst.expressions.MapFromArrays|
|map_funcs|map_from_entries|org.apache.spark.sql.catalyst.expressions.MapFromEntries|
|map_funcs|map_keys|org.apache.spark.sql.catalyst.expressions.MapKeys|
|map_funcs|map_values|org.apache.spark.sql.catalyst.expressions.MapValues|
|map_funcs|map|org.apache.spark.sql.catalyst.expressions.CreateMap|
|map_funcs|str_to_map|org.apache.spark.sql.catalyst.expressions.StringToMap|
|math_funcs|%|org.apache.spark.sql.catalyst.expressions.Remainder|
|math_funcs|*|org.apache.spark.sql.catalyst.expressions.Multiply|
|math_funcs|+|org.apache.spark.sql.catalyst.expressions.Add|
|math_funcs|-|org.apache.spark.sql.catalyst.expressions.Subtract|
|math_funcs|/|org.apache.spark.sql.catalyst.expressions.Divide|
|math_funcs|abs|org.apache.spark.sql.catalyst.expressions.Abs|
|math_funcs|acosh|org.apache.spark.sql.catalyst.expressions.Acosh|
|math_funcs|acos|org.apache.spark.sql.catalyst.expressions.Acos|
|math_funcs|asinh|org.apache.spark.sql.catalyst.expressions.Asinh|
|math_funcs|asin|org.apache.spark.sql.catalyst.expressions.Asin|
|math_funcs|atan2|org.apache.spark.sql.catalyst.expressions.Atan2|
|math_funcs|atanh|org.apache.spark.sql.catalyst.expressions.Atanh|
|math_funcs|atan|org.apache.spark.sql.catalyst.expressions.Atan|
|math_funcs|bin|org.apache.spark.sql.catalyst.expressions.Bin|
|math_funcs|bround|org.apache.spark.sql.catalyst.expressions.BRound|
|math_funcs|cbrt|org.apache.spark.sql.catalyst.expressions.Cbrt|
|math_funcs|ceiling|org.apache.spark.sql.catalyst.expressions.Ceil|
|math_funcs|ceil|org.apache.spark.sql.catalyst.expressions.Ceil|
|math_funcs|conv|org.apache.spark.sql.catalyst.expressions.Conv|
|math_funcs|cosh|org.apache.spark.sql.catalyst.expressions.Cosh|
|math_funcs|cos|org.apache.spark.sql.catalyst.expressions.Cos|
|math_funcs|cot|org.apache.spark.sql.catalyst.expressions.Cot|
|math_funcs|degrees|org.apache.spark.sql.catalyst.expressions.ToDegrees|
|math_funcs|div|org.apache.spark.sql.catalyst.expressions.IntegralDivide|
|math_funcs|expm1|org.apache.spark.sql.catalyst.expressions.Expm1|
|math_funcs|exp|org.apache.spark.sql.catalyst.expressions.Exp|
|math_funcs|e|org.apache.spark.sql.catalyst.expressions.EulerNumber|
|math_funcs|factorial|org.apache.spark.sql.catalyst.expressions.Factorial|
|math_funcs|floor|org.apache.spark.sql.catalyst.expressions.Floor|
|math_funcs|greatest|org.apache.spark.sql.catalyst.expressions.Greatest|
|math_funcs|hex|org.apache.spark.sql.catalyst.expressions.Hex|
|math_funcs|hypot|org.apache.spark.sql.catalyst.expressions.Hypot|
|math_funcs|least|org.apache.spark.sql.catalyst.expressions.Least|
|math_funcs|ln|org.apache.spark.sql.catalyst.expressions.Log|
|math_funcs|log10|org.apache.spark.sql.catalyst.expressions.Log10|
|math_funcs|log1p|org.apache.spark.sql.catalyst.expressions.Log1p|
|math_funcs|log2|org.apache.spark.sql.catalyst.expressions.Log2|
|math_funcs|log|org.apache.spark.sql.catalyst.expressions.Logarithm|
|math_funcs|mod|org.apache.spark.sql.catalyst.expressions.Remainder|
|math_funcs|negative|org.apache.spark.sql.catalyst.expressions.UnaryMinus|
|math_funcs|pi|org.apache.spark.sql.catalyst.expressions.Pi|
|math_funcs|pmod|org.apache.spark.sql.catalyst.expressions.Pmod|
|math_funcs|positive|org.apache.spark.sql.catalyst.expressions.UnaryPositive|
|math_funcs|power|org.apache.spark.sql.catalyst.expressions.Pow|
|math_funcs|pow|org.apache.spark.sql.catalyst.expressions.Pow|
|math_funcs|radians|org.apache.spark.sql.catalyst.expressions.ToRadians|
|math_funcs|randn|org.apache.spark.sql.catalyst.expressions.Randn|
|math_funcs|random|org.apache.spark.sql.catalyst.expressions.Rand|
|math_funcs|rand|org.apache.spark.sql.catalyst.expressions.Rand|
|math_funcs|rint|org.apache.spark.sql.catalyst.expressions.Rint|
|math_funcs|round|org.apache.spark.sql.catalyst.expressions.Round|
|math_funcs|shiftleft|org.apache.spark.sql.catalyst.expressions.ShiftLeft|
|math_funcs|signum|org.apache.spark.sql.catalyst.expressions.Signum|
|math_funcs|sign|org.apache.spark.sql.catalyst.expressions.Signum|
|math_funcs|sinh|org.apache.spark.sql.catalyst.expressions.Sinh|
|math_funcs|sin|org.apache.spark.sql.catalyst.expressions.Sin|
|math_funcs|sqrt|org.apache.spark.sql.catalyst.expressions.Sqrt|
|math_funcs|tanh|org.apache.spark.sql.catalyst.expressions.Tanh|
|math_funcs|tan|org.apache.spark.sql.catalyst.expressions.Tan|
|math_funcs|unhex|org.apache.spark.sql.catalyst.expressions.Unhex|
|math_funcs|width_bucket|org.apache.spark.sql.catalyst.expressions.WidthBucket|
|misc_funcs|assert_true|org.apache.spark.sql.catalyst.expressions.AssertTrue|
|misc_funcs|current_catalog|org.apache.spark.sql.catalyst.expressions.CurrentCatalog|
|misc_funcs|current_database|org.apache.spark.sql.catalyst.expressions.CurrentDatabase|
|misc_funcs|input_file_block_length|org.apache.spark.sql.catalyst.expressions.InputFileBlockLength|
|misc_funcs|input_file_block_start|org.apache.spark.sql.catalyst.expressions.InputFileBlockStart|
|misc_funcs|input_file_name|org.apache.spark.sql.catalyst.expressions.InputFileName|
|misc_funcs|java_method|org.apache.spark.sql.catalyst.expressions.CallMethodViaReflection|
|misc_funcs|monotonically_increasing_id|org.apache.spark.sql.catalyst.expressions.MonotonicallyIncreasingID|
|misc_funcs|raise_error|org.apache.spark.sql.catalyst.expressions.RaiseError|
|misc_funcs|reflect|org.apache.spark.sql.catalyst.expressions.CallMethodViaReflection|
|misc_funcs|spark_partition_id|org.apache.spark.sql.catalyst.expressions.SparkPartitionID|
|misc_funcs|typeof|org.apache.spark.sql.catalyst.expressions.TypeOf|
|misc_funcs|uuid|org.apache.spark.sql.catalyst.expressions.Uuid|
|misc_funcs|version|org.apache.spark.sql.catalyst.expressions.SparkVersion|
|predicate_funcs|!|org.apache.spark.sql.catalyst.expressions.Not|
|predicate_funcs|<=>|org.apache.spark.sql.catalyst.expressions.EqualNullSafe|
|predicate_funcs|<=|org.apache.spark.sql.catalyst.expressions.LessThanOrEqual|
|predicate_funcs|<|org.apache.spark.sql.catalyst.expressions.LessThan|
|predicate_funcs|==|org.apache.spark.sql.catalyst.expressions.EqualTo|
|predicate_funcs|=|org.apache.spark.sql.catalyst.expressions.EqualTo|
|predicate_funcs|>=|org.apache.spark.sql.catalyst.expressions.GreaterThanOrEqual|
|predicate_funcs|>|org.apache.spark.sql.catalyst.expressions.GreaterThan|
|predicate_funcs|and|org.apache.spark.sql.catalyst.expressions.And|
|predicate_funcs|in|org.apache.spark.sql.catalyst.expressions.In|
|predicate_funcs|isnan|org.apache.spark.sql.catalyst.expressions.IsNaN|
|predicate_funcs|isnotnull|org.apache.spark.sql.catalyst.expressions.IsNotNull|
|predicate_funcs|isnull|org.apache.spark.sql.catalyst.expressions.IsNull|
|predicate_funcs|like|org.apache.spark.sql.catalyst.expressions.Like|
|predicate_funcs|not|org.apache.spark.sql.catalyst.expressions.Not|
|predicate_funcs|or|org.apache.spark.sql.catalyst.expressions.Or|
|predicate_funcs|regexp_like|org.apache.spark.sql.catalyst.expressions.RLike|
|predicate_funcs|rlike|org.apache.spark.sql.catalyst.expressions.RLike|
|string_funcs|ascii|org.apache.spark.sql.catalyst.expressions.Ascii|
|string_funcs|base64|org.apache.spark.sql.catalyst.expressions.Base64|
|string_funcs|bit_length|org.apache.spark.sql.catalyst.expressions.BitLength|
|string_funcs|char_length|org.apache.spark.sql.catalyst.expressions.Length|
|string_funcs|character_length|org.apache.spark.sql.catalyst.expressions.Length|
|string_funcs|char|org.apache.spark.sql.catalyst.expressions.Chr|
|string_funcs|chr|org.apache.spark.sql.catalyst.expressions.Chr|
|string_funcs|concat_ws|org.apache.spark.sql.catalyst.expressions.ConcatWs|
|string_funcs|decode|org.apache.spark.sql.catalyst.expressions.Decode|
|string_funcs|elt|org.apache.spark.sql.catalyst.expressions.Elt|
|string_funcs|encode|org.apache.spark.sql.catalyst.expressions.Encode|
|string_funcs|find_in_set|org.apache.spark.sql.catalyst.expressions.FindInSet|
|string_funcs|format_number|org.apache.spark.sql.catalyst.expressions.FormatNumber|
|string_funcs|format_string|org.apache.spark.sql.catalyst.expressions.FormatString|
|string_funcs|initcap|org.apache.spark.sql.catalyst.expressions.InitCap|
|string_funcs|instr|org.apache.spark.sql.catalyst.expressions.StringInstr|
|string_funcs|lcase|org.apache.spark.sql.catalyst.expressions.Lower|
|string_funcs|left|org.apache.spark.sql.catalyst.expressions.Left|
|string_funcs|length|org.apache.spark.sql.catalyst.expressions.Length|
|string_funcs|levenshtein|org.apache.spark.sql.catalyst.expressions.Levenshtein|
|string_funcs|locate|org.apache.spark.sql.catalyst.expressions.StringLocate|
|string_funcs|lower|org.apache.spark.sql.catalyst.expressions.Lower|
|string_funcs|lpad|org.apache.spark.sql.catalyst.expressions.StringLPad|
|string_funcs|ltrim|org.apache.spark.sql.catalyst.expressions.StringTrimLeft|
|string_funcs|octet_length|org.apache.spark.sql.catalyst.expressions.OctetLength|
|string_funcs|overlay|org.apache.spark.sql.catalyst.expressions.Overlay|
|string_funcs|parse_url|org.apache.spark.sql.catalyst.expressions.ParseUrl|
|string_funcs|position|org.apache.spark.sql.catalyst.expressions.StringLocate|
|string_funcs|printf|org.apache.spark.sql.catalyst.expressions.FormatString|
|string_funcs|regexp_extract_all|org.apache.spark.sql.catalyst.expressions.RegExpExtractAll|
|string_funcs|regexp_extract|org.apache.spark.sql.catalyst.expressions.RegExpExtract|
|string_funcs|regexp_replace|org.apache.spark.sql.catalyst.expressions.RegExpReplace|
|string_funcs|repeat|org.apache.spark.sql.catalyst.expressions.StringRepeat|
|string_funcs|replace|org.apache.spark.sql.catalyst.expressions.StringReplace|
|string_funcs|right|org.apache.spark.sql.catalyst.expressions.Right|
|string_funcs|rpad|org.apache.spark.sql.catalyst.expressions.StringRPad|
|string_funcs|rtrim|org.apache.spark.sql.catalyst.expressions.StringTrimRight|
|string_funcs|sentences|org.apache.spark.sql.catalyst.expressions.Sentences|
|string_funcs|soundex|org.apache.spark.sql.catalyst.expressions.SoundEx|
|string_funcs|space|org.apache.spark.sql.catalyst.expressions.StringSpace|
|string_funcs|split|org.apache.spark.sql.catalyst.expressions.StringSplit|
|string_funcs|substring_index|org.apache.spark.sql.catalyst.expressions.SubstringIndex|
|string_funcs|substring|org.apache.spark.sql.catalyst.expressions.Substring|
|string_funcs|substr|org.apache.spark.sql.catalyst.expressions.Substring|
|string_funcs|translate|org.apache.spark.sql.catalyst.expressions.StringTranslate|
|string_funcs|trim|org.apache.spark.sql.catalyst.expressions.StringTrim|
|string_funcs|ucase|org.apache.spark.sql.catalyst.expressions.Upper|
|string_funcs|unbase64|org.apache.spark.sql.catalyst.expressions.UnBase64|
|string_funcs|upper|org.apache.spark.sql.catalyst.expressions.Upper|
|struct_funcs|named_struct|org.apache.spark.sql.catalyst.expressions.CreateNamedStruct|
|struct_funcs|struct|org.apache.spark.sql.catalyst.expressions.CreateNamedStruct|
|window_funcs|cume_dist|org.apache.spark.sql.catalyst.expressions.CumeDist|
|window_funcs|dense_rank|org.apache.spark.sql.catalyst.expressions.DenseRank|
|window_funcs|lag|org.apache.spark.sql.catalyst.expressions.Lag|
|window_funcs|lead|org.apache.spark.sql.catalyst.expressions.Lead|
|window_funcs|nth_value|org.apache.spark.sql.catalyst.expressions.NthValue|
|window_funcs|ntile|org.apache.spark.sql.catalyst.expressions.NTile|
|window_funcs|percent_rank|org.apache.spark.sql.catalyst.expressions.PercentRank|
|window_funcs|rank|org.apache.spark.sql.catalyst.expressions.Rank|
|window_funcs|row_number|org.apache.spark.sql.catalyst.expressions.RowNumber|
|xml_funcs|xpath_boolean|org.apache.spark.sql.catalyst.expressions.xml.XPathBoolean|
|xml_funcs|xpath_double|org.apache.spark.sql.catalyst.expressions.xml.XPathDouble|
|xml_funcs|xpath_float|org.apache.spark.sql.catalyst.expressions.xml.XPathFloat|
|xml_funcs|xpath_int|org.apache.spark.sql.catalyst.expressions.xml.XPathInt|
|xml_funcs|xpath_long|org.apache.spark.sql.catalyst.expressions.xml.XPathLong|
|xml_funcs|xpath_number|org.apache.spark.sql.catalyst.expressions.xml.XPathDouble|
|xml_funcs|xpath_short|org.apache.spark.sql.catalyst.expressions.xml.XPathShort|
|xml_funcs|xpath_string|org.apache.spark.sql.catalyst.expressions.xml.XPathString|
|xml_funcs|xpath|org.apache.spark.sql.catalyst.expressions.xml.XPathList|

Closes #30040

NOTE: An original author of this PR is @tanelk, so the credit should be given to @tanelk.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
For better documents.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Add a test to check if exprs have a group tag in `ExpressionInfoSuite`.