### PR TITLE
[SPARK-33873][CORE][TESTS] Test all compression codecs with encrypted spilling

### DIFF
--- a/core/src/test/scala/org/apache/spark/util/collection/ExternalAppendOnlyMapSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/ExternalAppendOnlyMapSuite.scala
@@ -220,13 +220,13 @@ class ExternalAppendOnlyMapSuite extends SparkFunSuite
     testSimpleSpilling()
   }
 
-  test("spilling with compression") {
+  private def testSimpleSpillingForAllCodecs(encrypt: Boolean) {
     // Keep track of which compression codec we're using to report in test failure messages
     var lastCompressionCodec: Option[String] = None
     try {
       allCompressionCodecs.foreach { c =>
         lastCompressionCodec = Some(c)
-        testSimpleSpilling(Some(c))
+        testSimpleSpilling(Some(c), encrypt)
       }
     } catch {
       // Include compression codec used in test failure message
@@ -241,8 +241,12 @@ class ExternalAppendOnlyMapSuite extends SparkFunSuite
     }
   }
 
+  test("spilling with compression") {
+    testSimpleSpillingForAllCodecs(encrypt = false)
+  }
+
   test("spilling with compression and encryption") {
-    testSimpleSpilling(Some(CompressionCodec.DEFAULT_COMPRESSION_CODEC), encrypt = true)
+    testSimpleSpillingForAllCodecs(encrypt = true)
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to test all compression codecs for encrypted spilling.

### Why are the changes needed?

To improve test coverage. Currently, only `CompressionCodec.DEFAULT_COMPRESSION_CODEC` is under testing.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with the updated test cases.