### PR TITLE
[SPARK-33878][SQL][TESTS] Fix resolving of `spark_catalog` in v1 Hive catalog tests

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DropTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DropTableSuiteBase.scala
@@ -96,4 +96,26 @@ trait DropTableSuiteBase extends QueryTest with DDLCommandTestUtils {
       }
     }
   }
+
+  test("SPARK-33305: DROP TABLE should also invalidate cache") {
+    val t = s"$catalog.ns.tbl"
+    val view = "view"
+    withNamespace(s"$catalog.ns") {
+      sql(s"CREATE NAMESPACE $catalog.ns")
+      withTempView(view, "source") {
+        val df = spark.createDataFrame(Seq((1L, "a"), (2L, "b"), (3L, "c"))).toDF("id", "data")
+        df.createOrReplaceTempView("source")
+        sql(s"CREATE TABLE $t $defaultUsing AS SELECT id, data FROM source")
+        sql(s"CACHE TABLE $view AS SELECT id FROM $t")
+        checkAnswer(sql(s"SELECT * FROM $t"), spark.table("source").collect())
+        checkAnswer(
+          sql(s"SELECT * FROM $view"),
+          spark.table("source").select("id").collect())
+
+        assert(!spark.sharedState.cacheManager.lookupCachedData(spark.table(view)).isEmpty)
+        sql(s"DROP TABLE $t")
+        assert(spark.sharedState.cacheManager.lookupCachedData(spark.table(view)).isEmpty)
+      }
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DropTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DropTableSuite.scala
@@ -31,28 +31,6 @@ trait DropTableSuiteBase extends command.DropTableSuiteBase {
       checkTables("ns") // no tables
     }
   }
-
-  test("SPARK-33305: DROP TABLE should also invalidate cache") {
-    val t = s"$catalog.ns.tbl"
-    val view = "view"
-    withNamespace(s"$catalog.ns") {
-      sql(s"CREATE NAMESPACE $catalog.ns")
-      withTempView(view, "source") {
-        val df = spark.createDataFrame(Seq((1L, "a"), (2L, "b"), (3L, "c"))).toDF("id", "data")
-        df.createOrReplaceTempView("source")
-        sql(s"CREATE TABLE $t $defaultUsing AS SELECT id, data FROM source")
-        sql(s"CACHE TABLE $view AS SELECT id FROM $t")
-        checkAnswer(sql(s"SELECT * FROM $t"), spark.table("source").collect())
-        checkAnswer(
-          sql(s"SELECT * FROM $view"),
-          spark.table("source").select("id").collect())
-
-        assert(!spark.sharedState.cacheManager.lookupCachedData(spark.table(view)).isEmpty)
-        sql(s"DROP TABLE $t")
-        assert(spark.sharedState.cacheManager.lookupCachedData(spark.table(view)).isEmpty)
-      }
-    }
-  }
 }
 
 class DropTableSuite extends DropTableSuiteBase with CommandSuiteBase

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DropTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DropTableSuite.scala
@@ -31,12 +31,7 @@ trait DropTableSuiteBase extends command.DropTableSuiteBase {
       checkTables("ns") // no tables
     }
   }
-}
 
-class DropTableSuite extends DropTableSuiteBase with CommandSuiteBase {
-  // The test fails in Hive External catalog with:
-  // org.apache.spark.sql.AnalysisException:
-  //   spark_catalog.ns.tbl is not a valid TableIdentifier as it has more than 2 name parts.
   test("SPARK-33305: DROP TABLE should also invalidate cache") {
     val t = s"$catalog.ns.tbl"
     val view = "view"
@@ -59,4 +54,6 @@ class DropTableSuite extends DropTableSuiteBase with CommandSuiteBase {
     }
   }
 }
+
+class DropTableSuite extends DropTableSuiteBase with CommandSuiteBase
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
@@ -40,6 +40,7 @@ import org.apache.spark.sql.catalyst.catalog.ExternalCatalogWithListener
 import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode
 import org.apache.spark.sql.catalyst.optimizer.ConvertToLocalRelation
 import org.apache.spark.sql.catalyst.plans.logical.{CacheTable, LogicalPlan, OneRowRelation}
+import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 import org.apache.spark.sql.execution.{QueryExecution, SQLExecution}
 import org.apache.spark.sql.hive._
@@ -601,9 +602,12 @@ private[hive] class TestHiveQueryExecution(
     }
 
     // Make sure any test tables referenced are loaded.
-    val referencedTables =
-      describedTables ++
-        logical.collect { case UnresolvedRelation(ident, _, _) => ident.asTableIdentifier }
+    val referencedTables = describedTables ++ logical.collect {
+      case UnresolvedRelation(ident, _, _) =>
+        if (!ident.isEmpty && ident.head.equalsIgnoreCase(CatalogManager.SESSION_CATALOG_NAME)) {
+          ident.tail.asTableIdentifier
+        } else ident.asTableIdentifier
+    }
     val resolver = sparkSession.sessionState.conf.resolver
     val referencedTestTables = referencedTables.flatMap { tbl =>
       val testTableOpt = sparkSession.testTables.keys.find(resolver(_, tbl.table))

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
@@ -604,7 +604,7 @@ private[hive] class TestHiveQueryExecution(
     // Make sure any test tables referenced are loaded.
     val referencedTables = describedTables ++ logical.collect {
       case UnresolvedRelation(ident, _, _) =>
-        if (!ident.isEmpty && ident.head.equalsIgnoreCase(CatalogManager.SESSION_CATALOG_NAME)) {
+        if (ident.length > 1 && ident.head.equalsIgnoreCase(CatalogManager.SESSION_CATALOG_NAME)) {
           ident.tail.asTableIdentifier
         } else ident.asTableIdentifier
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Recognize `spark_catalog` as the default session catalog in the checks of `TestHiveQueryExecution`.
2. Move v2 and v1 in-memory catalog test `"SPARK-33305: DROP TABLE should also invalidate cache"` to the common trait `command/DropTableSuiteBase`, and run it with v1 Hive external catalog.

### Why are the changes needed?
To run In-memory catalog tests in Hive catalog.

### Does this PR introduce _any_ user-facing change?
No, the changes influence only on tests.

### How was this patch tested?
By running the affected test suites for `DROP TABLE`:
```
$ build/sbt -Phive-2.3 -Phive-thriftserver "test:testOnly *DropTableSuite"
```