### PR TITLE
[SPARK-33659][SS] Document the current behavior for DataStreamWriter.toTable API

### DIFF
--- a/python/pyspark/sql/streaming.py
+++ b/python/pyspark/sql/streaming.py
@@ -1498,18 +1498,7 @@ class DataStreamWriter(object):
         Starts the execution of the streaming query, which will continually output results to the
         given table as new data arrives.
 
-        A new table will be created if the table not exists. The returned
-        :class:`StreamingQuery` object can be used to interact with the stream.
-
-        Note, if the table does not exist, both V1 and V2 tables will respect the
-        partitioningColumns provided by ``partitionBy``. However, when the table exists, only V1
-        table will pass the partitioning info to the sink, V2 table will ignore the provided
-        partitioning info.
-
-        Similar to the above issue of partitioning, the new table created by this API lacks
-        functionality (e.g., customized properties, options, and serde info) on creating V2 tables.
-        Please create a table manually before the execution to avoid creating a table with
-        incomplete information.
+        The returned :class:`StreamingQuery` object can be used to interact with the stream.
 
         .. versionadded:: 3.1.0
 
@@ -1540,6 +1529,15 @@ class DataStreamWriter(object):
         Notes
         -----
         This API is evolving.
+
+        For v1 table, partitioning columns provided by `partitionBy` will be respected no matter
+        the table exists or not. A new table will be created if the table not exists.
+
+        For v2 table, `partitionBy` will be ignored if the table already exists. `partitionBy` will
+        be respected only if the v2 table does not exist. Besides, the v2 table created by this API
+        lacks some functionalities (e.g., customized properties, options, and serde info). If you
+        need them, please create the v2 table manually before the execution to avoid creating a
+        table with incomplete information.
 
         Examples
         --------

--- a/python/pyspark/sql/streaming.py
+++ b/python/pyspark/sql/streaming.py
@@ -1501,6 +1501,16 @@ class DataStreamWriter(object):
         A new table will be created if the table not exists. The returned
         :class:`StreamingQuery` object can be used to interact with the stream.
 
+        Note, if the table does not exist, both V1 and V2 tables will respect the
+        partitioningColumns provided by ``partitionBy``. However, when the table exists, only V1
+        table will pass the partitioning info to the sink, V2 table will ignore the provided
+        partitioning info.
+
+        Similar to the above issue of partitioning, the new table created by this API lacks
+        functionality (e.g., customized properties, options, and serde info) on creating V2 tables.
+        Please create a table manually before the execution to avoid creating a table with
+        incomplete information.
+
         .. versionadded:: 3.1.0
 
         Parameters
@@ -1543,7 +1553,6 @@ class DataStreamWriter(object):
         ...     format='parquet',
         ...     checkpointLocation='/tmp/checkpoint') # doctest: +SKIP
         """
-        # TODO(SPARK-33659): document the current behavior for DataStreamWriter.toTable API
         self.options(**options)
         if outputMode is not None:
             self.outputMode(outputMode)

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
@@ -304,17 +304,17 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) {
    * :: Experimental ::
    *
    * Starts the execution of the streaming query, which will continually output results to the given
-   * table as new data arrives. A new table will be created if the table not exists. The returned
-   * [[StreamingQuery]] object can be used to interact with the stream.
+   * table as new data arrives. The returned [[StreamingQuery]] object can be used to interact with
+   * the stream.
    *
-   * Note, if the table does not exist, both V1 and V2 tables will respect the partitioningColumns
-   * provided by `partitionBy`. However, when the table exists, only V1 table will pass the
-   * partitioning info to the sink, V2 table will ignore the provided partitioning info.
+   * For v1 table, partitioning columns provided by `partitionBy` will be respected no matter the
+   * table exists or not. A new table will be created if the table not exists.
    *
-   * Similar to the above issue of partitioning, the new table created by this API lacks
-   * functionality (e.g., customized properties, options, and serde info) on creating V2 tables.
-   * Please create a table manually before the execution to avoid creating a table with incomplete
-   * information.
+   * For v2 table, `partitionBy` will be ignored if the table already exists. `partitionBy` will be
+   * respected only if the v2 table does not exist. Besides, the v2 table created by this API lacks
+   * some functionalities (e.g., customized properties, options, and serde info). If you need them,
+   * please create the v2 table manually before the execution to avoid creating a table with
+   * incomplete information.
    *
    * @since 3.1.0
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
@@ -301,12 +301,24 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) {
   def start(): StreamingQuery = startInternal(None)
 
   /**
+   * :: Experimental ::
+   *
    * Starts the execution of the streaming query, which will continually output results to the given
    * table as new data arrives. A new table will be created if the table not exists. The returned
    * [[StreamingQuery]] object can be used to interact with the stream.
    *
+   * Note, if the table does not exist, both V1 and V2 tables will respect the partitioningColumns
+   * provided by `partitionBy`. However, when the table exists, only V1 table will pass the
+   * partitioning info to the sink, V2 table will ignore the provided partitioning info.
+   *
+   * Similar to the above issue of partitioning, the new table created by this API lacks
+   * functionality (e.g., customized properties, options, and serde info) on creating V2 tables.
+   * Please create a table manually before the execution to avoid creating a table with incomplete
+   * information.
+   *
    * @since 3.1.0
    */
+  @Evolving
   @throws[TimeoutException]
   def toTable(tableName: String): StreamingQuery = {
     this.tableName = tableName

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
@@ -301,8 +301,6 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) {
   def start(): StreamingQuery = startInternal(None)
 
   /**
-   * :: Experimental ::
-   *
    * Starts the execution of the streaming query, which will continually output results to the given
    * table as new data arrives. The returned [[StreamingQuery]] object can be used to interact with
    * the stream.

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala
@@ -275,7 +275,7 @@ class DataStreamTableAPISuite extends StreamTest with BeforeAndAfter {
       val tableName = "stream_test"
       withTable(tableName) {
         // The file written by batch will not be seen after the table was written by a streaming
-        // query. This is because we loads files from the metadata log instead of listing them
+        // query. This is because we load files from the metadata log instead of listing them
         // using HDFS API.
         Seq(4, 5, 6).toDF("value").write.format("parquet")
           .option("path", dir.getCanonicalPath).saveAsTable(tableName)
@@ -289,7 +289,7 @@ class DataStreamTableAPISuite extends StreamTest with BeforeAndAfter {
     val tableName = "stream_test"
     withTable(tableName) {
       // The file written by batch will not be seen after the table was written by a streaming
-      // query. This is because we loads files from the metadata log instead of listing them
+      // query. This is because we load files from the metadata log instead of listing them
       // using HDFS API.
       Seq(4, 5, 6).toDF("value").write.format("parquet").saveAsTable(tableName)
 
@@ -302,7 +302,7 @@ class DataStreamTableAPISuite extends StreamTest with BeforeAndAfter {
       val tableName = "stream_test"
       withTable(tableName) {
         // The file written by batch will not be seen after the table was written by a streaming
-        // query. This is because we loads files from the metadata log instead of listing them
+        // query. This is because we load files from the metadata log instead of listing them
         // using HDFS API.
         Seq(4, 5, 6).toDF("value").write
           .mode("append").format("parquet").save(dir.getCanonicalPath)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Follow up work for #30521, document the following behaviors in the API doc:

- Figure out the effects when configurations are (provider/partitionBy) conflicting with the existing table.
- Document the lack of functionality on creating a v2 table, and guide that the users should ensure a table is created in prior to avoid the behavior unintended/insufficient table is being created.

### Why are the changes needed?
We didn't have full support for the V2 table created in the API now. (TODO SPARK-33638)


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Document only.