### PR TITLE
[SPARK-33874][K8S] Handle long lived sidecars

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsSnapshot.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsSnapshot.scala
@@ -86,13 +86,12 @@ object ExecutorPodsSnapshot extends Logging {
             sparkContainerStatusOpt match {
               case Some(sparkContainerStatus) =>
                 sparkContainerStatus.getState.getTerminated match {
-                  case null => PodRunning(pod)
-                  case t =>
-                    if (t.getExitCode == 0) {
-                      PodSucceeded(pod)
-                    } else {
-                      PodFailed(pod)
-                    }
+                  case t if t.getExitCode != 0 =>
+                    PodFailed(pod)
+                  case t if t.getExitCode == 0 =>
+                    PodSucceeded(pod)
+                  case _ =>
+                    PodRunning(pod)
                 }
               // If we can't find the Spark container status, fall back to the pod status
               case _ => PodRunning(pod)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsSnapshot.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsSnapshot.scala
@@ -91,6 +91,8 @@ object ExecutorPodsSnapshot extends Logging {
                   case t if t.getExitCode == 0 =>
                     PodSucceeded(pod)
                   case _ =>
+                    logWarning(s"Unable to find container ${sparkContainerName} in pod ${pod} " +
+                      "defaulting to entire pod status (running).")
                     PodRunning(pod)
                 }
               // If we can't find the Spark container status, fall back to the pod status

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsSnapshot.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsSnapshot.scala
@@ -91,14 +91,12 @@ object ExecutorPodsSnapshot extends Logging {
                   case t if t.getExitCode == 0 =>
                     PodSucceeded(pod)
                   case _ =>
-                    logWarning(s"Unable to find container ${sparkContainerName} in pod ${pod} " +
-                      "defaulting to entire pod status (running).")
                     PodRunning(pod)
                 }
               // If we can't find the Spark container status, fall back to the pod status
               case _ =>
                 logWarning(s"Unable to find container ${sparkContainerName} in pod ${pod} " +
-                           "defaulting to entire pod status (running).")
+                  "defaulting to entire pod status (running).")
                 PodRunning(pod)
             }
           }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsSnapshot.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsSnapshot.scala
@@ -18,6 +18,8 @@ package org.apache.spark.scheduler.cluster.k8s
 
 import java.util.Locale
 
+import scala.collection.JavaConverters._
+
 import io.fabric8.kubernetes.api.model.ContainerStateTerminated
 import io.fabric8.kubernetes.api.model.Pod
 
@@ -39,6 +41,7 @@ private[spark] case class ExecutorPodsSnapshot(executorPods: Map[Long, ExecutorP
 
 object ExecutorPodsSnapshot extends Logging {
   private var shouldCheckAllContainers: Boolean = _
+  private var sparkContainerName: String = _
 
   def apply(executorPods: Seq[Pod]): ExecutorPodsSnapshot = {
     ExecutorPodsSnapshot(toStatesByExecutorId(executorPods))
@@ -65,6 +68,7 @@ object ExecutorPodsSnapshot extends Logging {
         case "pending" =>
           PodPending(pod)
         case "running" =>
+          // If we're checking all containers look for any non-zero exits
           if (shouldCheckAllContainers &&
             "Never" == pod.getSpec.getRestartPolicy &&
             pod.getStatus.getContainerStatuses.stream
@@ -72,7 +76,23 @@ object ExecutorPodsSnapshot extends Logging {
               .anyMatch(t => t != null && t.getExitCode != 0)) {
             PodFailed(pod)
           } else {
-            PodRunning(pod)
+            // Otherwise look for the Spark container
+            val sparkContainerStatusOpt = pod.getStatus.getContainerStatuses.asScala
+              .find(_.getName() == sparkContainerName)
+            sparkContainerStatusOpt match {
+              case Some(sparkContainerStatus) =>
+                sparkContainerStatus.getState.getTerminated match {
+                  case null => PodRunning(pod)
+                  case t =>
+                    if (t.getExitCode != 0) {
+                      PodSucceeded(pod)
+                    } else {
+                      PodFailed(pod)
+                    }
+                }
+              // If we can't find the Spark container status, fall back to the pod status
+              case _ => PodRunning(pod)
+            }
           }
         case "failed" =>
           PodFailed(pod)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsSnapshot.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsSnapshot.scala
@@ -53,6 +53,10 @@ object ExecutorPodsSnapshot extends Logging {
     shouldCheckAllContainers = watchAllContainers
   }
 
+  def setSparkContainerName(containerName: String): Unit = {
+    sparkContainerName = containerName
+  }
+
   private def toStatesByExecutorId(executorPods: Seq[Pod]): Map[Long, ExecutorPodState] = {
     executorPods.map { pod =>
       (pod.getMetadata.getLabels.get(SPARK_EXECUTOR_ID_LABEL).toLong, toState(pod))
@@ -84,7 +88,7 @@ object ExecutorPodsSnapshot extends Logging {
                 sparkContainerStatus.getState.getTerminated match {
                   case null => PodRunning(pod)
                   case t =>
-                    if (t.getExitCode != 0) {
+                    if (t.getExitCode == 0) {
                       PodSucceeded(pod)
                     } else {
                       PodFailed(pod)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsSnapshot.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsSnapshot.scala
@@ -94,7 +94,10 @@ object ExecutorPodsSnapshot extends Logging {
                     PodRunning(pod)
                 }
               // If we can't find the Spark container status, fall back to the pod status
-              case _ => PodRunning(pod)
+              case _ =>
+                logWarning(s"Unable to find container ${sparkContainerName} in pod ${pod} " +
+                           "defaulting to entire pod status (running).")
+                PodRunning(pod)
             }
           }
         case "failed" =>

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
@@ -25,6 +25,7 @@ import io.fabric8.kubernetes.client.Config
 import org.apache.spark.SparkContext
 import org.apache.spark.deploy.k8s.{KubernetesConf, KubernetesUtils, SparkKubernetesClientFactory}
 import org.apache.spark.deploy.k8s.Config._
+import org.apache.spark.deploy.k8s.Constants.DEFAULT_EXECUTOR_CONTAINER_NAME
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.{ExternalClusterManager, SchedulerBackend, TaskScheduler, TaskSchedulerImpl}
 import org.apache.spark.util.{SystemClock, ThreadUtils}
@@ -96,6 +97,11 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
 
     ExecutorPodsSnapshot.setShouldCheckAllContainers(
       sc.conf.get(KUBERNETES_EXECUTOR_CHECK_ALL_CONTAINERS))
+    val sparkContainerName = sc.conf.get(KUBERNETES_EXECUTOR_PODTEMPLATE_CONTAINER_NAME).getOrElse(
+      DEFAULT_EXECUTOR_CONTAINER_NAME)
+    ExecutorPodsSnapshot.setSparkContainerName(
+      sparkContainerName
+    )
     val subscribersExecutor = ThreadUtils
       .newDaemonThreadPoolScheduledExecutor(
         "kubernetes-executor-snapshots-subscribers", 2)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
@@ -97,11 +97,9 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
 
     ExecutorPodsSnapshot.setShouldCheckAllContainers(
       sc.conf.get(KUBERNETES_EXECUTOR_CHECK_ALL_CONTAINERS))
-    val sparkContainerName = sc.conf.get(KUBERNETES_EXECUTOR_PODTEMPLATE_CONTAINER_NAME).getOrElse(
-      DEFAULT_EXECUTOR_CONTAINER_NAME)
-    ExecutorPodsSnapshot.setSparkContainerName(
-      sparkContainerName
-    )
+    val sparkContainerName = sc.conf.get(KUBERNETES_EXECUTOR_PODTEMPLATE_CONTAINER_NAME)
+      .getOrElse(DEFAULT_EXECUTOR_CONTAINER_NAME)
+    ExecutorPodsSnapshot.setSparkContainerName(sparkContainerName)
     val subscribersExecutor = ThreadUtils
       .newDaemonThreadPoolScheduledExecutor(
         "kubernetes-executor-snapshots-subscribers", 2)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/DeterministicExecutorPodsSnapshotsStore.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/DeterministicExecutorPodsSnapshotsStore.scala
@@ -19,9 +19,13 @@ package org.apache.spark.scheduler.cluster.k8s
 import io.fabric8.kubernetes.api.model.Pod
 import scala.collection.mutable
 
+import org.apache.spark.deploy.k8s.Constants.DEFAULT_EXECUTOR_CONTAINER_NAME
+
+
 class DeterministicExecutorPodsSnapshotsStore extends ExecutorPodsSnapshotsStore {
 
   ExecutorPodsSnapshot.setShouldCheckAllContainers(false)
+  ExecutorPodsSnapshot.setSparkContainerName(DEFAULT_EXECUTOR_CONTAINER_NAME)
 
   private val snapshotsBuffer = mutable.Buffer.empty[ExecutorPodsSnapshot]
   private val subscribers = mutable.Buffer.empty[Seq[ExecutorPodsSnapshot] => Unit]

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorLifecycleTestUtils.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorLifecycleTestUtils.scala
@@ -106,6 +106,31 @@ object ExecutorLifecycleTestUtils {
       .build()
   }
 
+  /**
+   * This creates a pod with a finished executor and running sidecar
+   */
+  def finishedExecutorWithRunningSidecar(
+      executorId: Long, exitCode: Int, rpId: Int = DEFAULT_RESOURCE_PROFILE_ID): Pod = {
+    new PodBuilder(podWithAttachedContainerForId(executorId, rpId))
+      .editOrNewStatus()
+        .withPhase("running")
+        .addNewContainerStatus()
+          .withNewState()
+              .withNewTerminated()
+              .withExitCode(exitCode)
+            .endTerminated()
+          .endState()
+        .endContainerStatus()
+        .addNewContainerStatus()
+          .withNewState()
+            .withNewRunning()
+            .endRunning()
+          .endState()
+        .endContainerStatus()
+      .endStatus()
+      .build()
+  }
+
   def succeededExecutor(executorId: Long, rpId: Int = DEFAULT_RESOURCE_PROFILE_ID): Pod = {
     new PodBuilder(podWithAttachedContainerForId(executorId, rpId))
       .editOrNewStatus()

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorLifecycleTestUtils.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorLifecycleTestUtils.scala
@@ -110,13 +110,13 @@ object ExecutorLifecycleTestUtils {
    * This creates a pod with a finished executor and running sidecar
    */
   def finishedExecutorWithRunningSidecar(
-      executorId: Long, exitCode: Int, rpId: Int = DEFAULT_RESOURCE_PROFILE_ID): Pod = {
-    new PodBuilder(podWithAttachedContainerForId(executorId, rpId))
+      executorId: Long, exitCode: Int): Pod = {
+    new PodBuilder(podWithAttachedContainerForId(executorId, DEFAULT_RESOURCE_PROFILE_ID))
       .editOrNewStatus()
         .withPhase("running")
         .addNewContainerStatus()
           .withNewState()
-              .withNewTerminated()
+            .withNewTerminated()
               .withExitCode(exitCode)
             .endTerminated()
           .endState()

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsSnapshotSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsSnapshotSuite.scala
@@ -43,7 +43,9 @@ class ExecutorPodsSnapshotSuite extends SparkFunSuite {
       testCase(succeededExecutor(2), PodSucceeded),
       testCase(failedExecutorWithoutDeletion(3), PodFailed),
       testCase(deletedExecutor(4), PodDeleted),
-      testCase(unknownExecutor(5), PodUnknown)
+      testCase(unknownExecutor(5), PodUnknown),
+      testCase(finishedExecutorWithRunningSidecar(6, 0), PodSucceeded),
+      testCase(finishedExecutorWithRunningSidecar(7, 1), PodFailed)
     )
     doTest(testCases)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

For liveness check when checkAllContainers is not set, we check the liveness status of the Spark container if we can find it.

### Why are the changes needed?

Some environments may deploy long lived logs collecting side cars which outlive the Spark application. Just because they remain alive does not mean the Spark executor should keep running.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Extended the existing pod status tests.