### PR TITLE
[SPARK-33887][SQL] Allow insert overwrite same table with static partition if using dynamic partition overwrite mode

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
@@ -70,10 +70,7 @@ case class InsertIntoHadoopFsRelationCommand(
       // scalastyle:on caselocale
       .getOrElse(SQLConf.get.partitionOverwriteMode)
     val enableDynamicOverwrite = partitionOverwriteMode == PartitionOverwriteMode.DYNAMIC
-    // This config only makes sense when we are overwriting a partitioned dataset with dynamic
-    // partition columns.
-    enableDynamicOverwrite && mode == SaveMode.Overwrite &&
-      staticPartitions.size < partitionColumns.length
+    enableDynamicOverwrite && mode == SaveMode.Overwrite
   }
 
   override def run(sparkSession: SparkSession, child: SparkPlan): Seq[Row] = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -954,6 +954,48 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
       assert(msg.contains("cannot resolve '`c3`' given input columns"))
     }
   }
+
+  test("it is allowed to write to static partition while querying it in dynamic" +
+      "partition overwrite mode.") {
+    Seq(PartitionOverwriteMode.DYNAMIC.toString,
+      PartitionOverwriteMode.STATIC.toString).foreach( mode => {
+      withSQLConf(SQLConf.PARTITION_OVERWRITE_MODE.key -> mode) {
+        withTable("insertTable") {
+          sql(
+            """
+              |CREATE TABLE insertTable(i int, part int) USING PARQUET
+              |PARTITIONED BY (part)
+            """.stripMargin)
+
+          sql("INSERT INTO TABLE insertTable PARTITION(part=1) SELECT 1")
+          checkAnswer(spark.table("insertTable"), Row(1, 1))
+
+          sql("INSERT INTO TABLE insertTable PARTITION(part=2) SELECT 2")
+          checkAnswer(spark.table("insertTable"), Row(1, 1) :: Row(2, 2) :: Nil)
+
+          if (mode == PartitionOverwriteMode.DYNAMIC.toString) {
+            sql(
+              """
+                |INSERT OVERWRITE TABLE insertTable PARTITION(part=1)
+                |SELECT i + 1 FROM insertTable WHERE part = 1
+              """.stripMargin)
+            checkAnswer(spark.table("insertTable"), Row(2, 1) :: Row(2, 2) :: Nil)
+          } else {
+            val message = intercept[AnalysisException] {
+              sql(
+                """
+                  |INSERT OVERWRITE TABLE insertTable PARTITION(part=1)
+                  |SELECT i + 1 FROM insertTable WHERE part = 1
+                """.stripMargin)
+            }.getMessage
+            assert(
+              message.contains("Cannot overwrite a path that is also being read from."),
+              "INSERT OVERWRITE to a table while querying it should not be allowed.")
+          }
+        }
+      }
+    })
+  }
 }
 
 class FileExistingTestFileSystem extends RawLocalFileSystem {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
```sql

CREATE TABLE insertTable(i int, part int) USING PARQUET PARTITIONED BY (part);

INSERT INTO TABLE insertTable PARTITION(part=1) SELECT 1;

SET spark.sql.sources.partitionOverwriteMode=DYNAMIC;

INSERT OVERWRITE TABLE insertTable PARTITION(part=1)
SELECT i + 1 FROM insertTable WHERE part = 1;
```
The SQL will fail because Spark complains  "Cannot overwrite a path that is also being read from."


### Why are the changes needed?
Allow users to insert overwrite the same table with static partition if `spark.sql.sources.partitionOverwriteMode` is set to `DYNAMIC`.

### Does this PR introduce _any_ user-facing change?
Yes, with this PR, use can overwrite the same table with static partition.

### How was this patch tested?
New UT.
