### PR TITLE
[SPARK-33889][SQL] Fix NPE from `SHOW PARTITIONS` on V2 tables

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowPartitionsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowPartitionsExec.scala
@@ -53,9 +53,12 @@ case class ShowPartitionsExec(
       var i = 0
       while (i < len) {
         val dataType = schema(i).dataType
-        val partValue = row.get(i, dataType)
-        val partValueStr = Cast(Literal(partValue, dataType), StringType, Some(timeZoneId))
-          .eval().toString
+        val partValueStr = if (row.isNullAt(i)) {
+          "null"
+        } else {
+          Cast(Literal(row.get(i, dataType), dataType), StringType, Some(timeZoneId))
+            .eval().toString
+        }
         partitions(i) = escapePathName(schema(i).name) + "=" + escapePathName(partValueStr)
         i += 1
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowPartitionsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowPartitionsExec.scala
@@ -53,12 +53,9 @@ case class ShowPartitionsExec(
       var i = 0
       while (i < len) {
         val dataType = schema(i).dataType
-        val partValueStr = if (row.isNullAt(i)) {
-          "null"
-        } else {
-          Cast(Literal(row.get(i, dataType), dataType), StringType, Some(timeZoneId))
-            .eval().toString
-        }
+        val partValueUTF8String =
+          Cast(Literal(row.get(i, dataType), dataType), StringType, Some(timeZoneId)).eval()
+        val partValueStr = if (partValueUTF8String == null) "null" else partValueUTF8String.toString
         partitions(i) = escapePathName(schema(i).name) + "=" + escapePathName(partValueStr)
         i += 1
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowPartitionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowPartitionsSuite.scala
@@ -35,7 +35,7 @@ class ShowPartitionsSuite extends command.ShowPartitionsSuiteBase with CommandSu
     }
   }
 
-  test("null and empty string as partition values") {
+  test("SPARK-33889: null and empty string as partition values") {
     import testImplicits._
     withNamespaceAndTable("ns", "tbl") { t =>
       val df = Seq((0, ""), (1, null)).toDF("a", "part")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowPartitionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowPartitionsSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.command.v2
 
-import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.{AnalysisException, Row, SaveMode}
 import org.apache.spark.sql.execution.command
 
 class ShowPartitionsSuite extends command.ShowPartitionsSuiteBase with CommandSuiteBase {
@@ -32,6 +32,20 @@ class ShowPartitionsSuite extends command.ShowPartitionsSuiteBase with CommandSu
       }.getMessage
       assert(errMsg.contains(
         "SHOW PARTITIONS cannot run for a table which does not support partitioning"))
+    }
+  }
+
+  test("null and empty string as partition values") {
+    import testImplicits._
+    withNamespaceAndTable("ns", "tbl") { t =>
+      val df = Seq((0, ""), (1, null)).toDF("a", "part")
+      df.write
+        .partitionBy("part")
+        .format("parquet")
+        .mode(SaveMode.Overwrite)
+        .saveAsTable(t)
+
+      runShowPartitionsSql(s"SHOW PARTITIONS $t", Row("part=") :: Row("part=null") :: Nil)
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
At `ShowPartitionsExec.run()`, check that a row returned by `listPartitionIdentifiers()` contains a `null` field, and convert it to `"null"`. 

### Why are the changes needed?
Because `SHOW PARTITIONS` throws NPE on V2 table with `null` partition values.

### Does this PR introduce _any_ user-facing change?
Yes

### How was this patch tested?
Added new UT to `v2.ShowPartitionsSuite`.
