### PR TITLE
[WIP] [SPARK-33837] Correlated subquery field resolve bug when inner table has a field with the same name with outer table

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
@@ -351,6 +351,29 @@ case class AttributeReference(
   }
 }
 
+case class OuterAttribute(attr: Attribute) extends Attribute with Unevaluable {
+  override def name: String = attr.name
+  override def dataType: DataType = attr.dataType
+
+  override def toString: String = name
+  override def sql: String = toString
+
+  override def withNullability(newNullability: Boolean): Attribute =
+    throw new UnsupportedOperationException
+  override def newInstance(): Attribute = throw new UnsupportedOperationException
+  override def withQualifier(newQualifier: Seq[String]): Attribute =
+    throw new UnsupportedOperationException
+  override def withName(newName: String): Attribute = throw new UnsupportedOperationException
+  override def withMetadata(newMetadata: Metadata): Attribute =
+    throw new UnsupportedOperationException
+  override def qualifier: Seq[String] = throw new UnsupportedOperationException
+  override def exprId: ExprId = throw new UnsupportedOperationException
+  override def withExprId(newExprId: ExprId): Attribute =
+    throw new UnsupportedOperationException
+  override def nullable: Boolean = true
+
+}
+
 /**
  * A place holder used when printing expressions without debugging information such as the
  * expression id or the unresolved indicator.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
@@ -101,8 +101,9 @@ abstract class LogicalPlan
    */
   def resolveChildren(
       nameParts: Seq[String],
-      resolver: Resolver): Option[NamedExpression] =
-    childAttributes.resolve(nameParts, resolver)
+      resolver: Resolver,
+      outerPlans: Seq[LogicalPlan] = Seq.empty): Option[NamedExpression] =
+    childAttributes.resolve(nameParts, resolver, outerPlans.flatMap(_.output))
 
   /**
    * Optionally resolves the given strings to a [[NamedExpression]] based on the output of this
@@ -111,8 +112,9 @@ abstract class LogicalPlan
    */
   def resolve(
       nameParts: Seq[String],
-      resolver: Resolver): Option[NamedExpression] =
-    outputAttributes.resolve(nameParts, resolver)
+      resolver: Resolver,
+      outerPlans: Seq[LogicalPlan] = Seq.empty): Option[NamedExpression] =
+    outputAttributes.resolve(nameParts, resolver, outerPlans.flatMap(_.output))
 
   /**
    * Given an attribute name, split it to name parts by dot, but
@@ -121,8 +123,13 @@ abstract class LogicalPlan
    */
   def resolveQuoted(
       name: String,
-      resolver: Resolver): Option[NamedExpression] = {
-    outputAttributes.resolve(UnresolvedAttribute.parseAttributeName(name), resolver)
+      resolver: Resolver,
+      outerPlans: Seq[LogicalPlan] = Seq.empty): Option[NamedExpression] = {
+    outputAttributes.resolve(
+      UnresolvedAttribute.parseAttributeName(name),
+      resolver,
+      outerPlans.flatMap(_.output)
+    )
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -57,6 +57,11 @@ object Subquery {
     Subquery(s.plan, SubqueryExpression.hasCorrelatedSubquery(s))
 }
 
+case class SubqueryWrapper(child: LogicalPlan, outerPlans: Seq[LogicalPlan])
+  extends OrderPreservingUnaryNode {
+  override def output: Seq[Attribute] = child.output
+}
+
 case class Project(projectList: Seq[NamedExpression], child: LogicalPlan)
     extends OrderPreservingUnaryNode {
   override def output: Seq[Attribute] = projectList.map(_.toAttribute)


### PR DESCRIPTION
### What changes were proposed in this pull request?
See SPARK-33837, In ResolveSubquery rule, we first try to resolve subquery independently, and only when there're unresolved attribute in subquery, we try resolveOuterReferences.

So For the following statements:

```
create table t1(id int, name string)
create table id(key int, name string);

select * from id where name in (select name from t1 where t1.id = id.key)
```
This query is supported by spark, but since table t1 also has an attribute named id, spark will raise an error like:

> Can't extract value from id#83: need struct type but got int;

This change add outer plan info into resolving subquery to make this reference resolving with outer plan possible


### Does this PR introduce _any_ user-facing change?
Yes

### How was this patch tested?
Unit tests needs to be added
