### PR TITLE
[SPARK-33899][SQL] Fix assert failure in v1 SHOW TABLES/VIEWS on `spark_catalog`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -363,7 +363,6 @@ class ResolveSessionCatalog(
       DropDatabaseCommand(ns.head, d.ifExists, d.cascade)
 
     case ShowTables(SessionCatalogAndNamespace(_, ns), pattern) =>
-      assert(ns.nonEmpty)
       if (ns.length != 1) {
           throw QueryCompilationErrors.invalidDatabaseNameError(ns.quoted)
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -372,7 +372,6 @@ class ResolveSessionCatalog(
         SessionCatalogAndNamespace(_, ns),
         pattern,
         partitionSpec @ (None | Some(UnresolvedPartitionSpec(_, _)))) =>
-      assert(ns.nonEmpty)
       if (ns.length != 1) {
         throw QueryCompilationErrors.invalidDatabaseNameError(ns.quoted)
       }
@@ -502,7 +501,6 @@ class ResolveSessionCatalog(
       resolved match {
         case SessionCatalogAndNamespace(_, ns) =>
           // Fallback to v1 ShowViewsCommand since there is no view API in v2 catalog
-          assert(ns.nonEmpty)
           if (ns.length != 1) {
             throw QueryCompilationErrors.invalidDatabaseNameError(ns.quoted)
           }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -100,6 +100,13 @@ trait ShowTablesSuiteBase extends command.ShowTablesSuiteBase {
       }
     }
   }
+
+  test("no database specified") {
+    val errMsg = intercept[AnalysisException] {
+      sql(s"SHOW TABLES IN $catalog")
+    }.getMessage
+    assert(errMsg.contains("multi-part identifier cannot be empty"))
+  }
 }
 
 class ShowTablesSuite extends ShowTablesSuiteBase with CommandSuiteBase {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -102,10 +102,14 @@ trait ShowTablesSuiteBase extends command.ShowTablesSuiteBase {
   }
 
   test("no database specified") {
-    val errMsg = intercept[AnalysisException] {
-      sql(s"SHOW TABLES IN $catalog")
-    }.getMessage
-    assert(errMsg.contains("multi-part identifier cannot be empty"))
+    Seq(
+      s"SHOW TABLES IN $catalog",
+      s"SHOW TABLE EXTENDED IN $catalog LIKE '*tbl'").foreach { showTableCmd =>
+      val errMsg = intercept[AnalysisException] {
+        sql(showTableCmd)
+      }.getMessage
+      assert(errMsg.contains("multi-part identifier cannot be empty"))
+    }
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove `assert(ns.nonEmpty)` in `ResolveSessionCatalog` for:
- `SHOW TABLES`
- `SHOW TABLE EXTENDED`
- `SHOW VIEWS`

### Why are the changes needed?
Spark SQL shouldn't fail with internal assert failures even for invalid user inputs. For instance:
```sql
spark-sql> show tables in spark_catalog;
20/12/24 11:19:46 ERROR SparkSQLDriver: Failed in [show tables in spark_catalog]
java.lang.AssertionError: assertion failed
	at scala.Predef$.assert(Predef.scala:208)
	at org.apache.spark.sql.catalyst.analysis.ResolveSessionCatalog$$anonfun$apply$1.applyOrElse(ResolveSessionCatalog.scala:366)
	at org.apache.spark.sql.catalyst.analysis.ResolveSessionCatalog$$anonfun$apply$1.applyOrElse(ResolveSessionCatalog.scala:49)
	at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.$anonfun$resolveOperatorsUp$3(AnalysisHelper.scala:90)
	at org.apache.spark.sql.catalyst.trees.CurrentOrigin$.withOrigin(TreeNode.scala:73)
```

### Does this PR introduce _any_ user-facing change?
Yes. After the changes, for the example above:
```sql
spark-sql> show tables in spark_catalog;
Error in query: multi-part identifier cannot be empty.
```

### How was this patch tested?
Added new UT to `v1/ShowTablesSuite`.
