### PR TITLE
[SPARK-33906][WEBUI] Fix the bug of UI Executor page stuck due to undefined peakMemoryMetrics

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/executorspage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/executorspage.js
@@ -425,7 +425,7 @@ $(document).ready(function () {
                                     if (type !== 'display') {
                                         return 0;
                                     } else {
-                                        return 'N/A';
+                                        return '0.0 B / 0.0 B';
                                     }
                                 }
                             }
@@ -443,7 +443,7 @@ $(document).ready(function () {
                                     if (type !== 'display') {
                                         return 0;
                                     } else {
-                                        return 'N/A';
+                                        return '0.0 B / 0.0 B';
                                     }
                                 }
                             }
@@ -461,7 +461,7 @@ $(document).ready(function () {
                                     if (type !== 'display') {
                                         return 0;
                                     } else {
-                                        return 'N/A';
+                                        return '0.0 B / 0.0 B';
                                     }
                                 }
                             }
@@ -479,7 +479,7 @@ $(document).ready(function () {
                                     if (type !== 'display') {
                                         return 0;
                                     } else {
-                                        return 'N/A';
+                                        return '0.0 B / 0.0 B';
                                     }
                                 }
                             }

--- a/core/src/main/resources/org/apache/spark/ui/static/executorspage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/executorspage.js
@@ -414,6 +414,9 @@ $(document).ready(function () {
                         },
                         {
                             data: function (row, type) {
+                                if (typeof row.peakMemoryMetrics == "undefined") {
+                                    return "";
+                                }
                                 if (type !== 'display')
                                     return row.peakMemoryMetrics.JVMHeapMemory;
                                 else
@@ -423,6 +426,9 @@ $(document).ready(function () {
                         },
                         {
                             data: function (row, type) {
+                                if (typeof row.peakMemoryMetrics == "undefined") {
+                                    return "";
+                                }
                                 if (type !== 'display')
                                     return row.peakMemoryMetrics.OnHeapExecutionMemory;
                                 else
@@ -432,6 +438,9 @@ $(document).ready(function () {
                         },
                         {
                             data: function (row, type) {
+                                if (typeof row.peakMemoryMetrics == "undefined") {
+                                    return "";
+                                }
                                 if (type !== 'display')
                                     return row.peakMemoryMetrics.OnHeapStorageMemory;
                                 else
@@ -441,6 +450,9 @@ $(document).ready(function () {
                         },
                         {
                             data: function (row, type) {
+                                if (typeof row.peakMemoryMetrics == "undefined") {
+                                    return "";
+                                }
                                 if (type !== 'display')
                                     return row.peakMemoryMetrics.DirectPoolMemory;
                                 else

--- a/core/src/main/resources/org/apache/spark/ui/static/executorspage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/executorspage.js
@@ -414,50 +414,74 @@ $(document).ready(function () {
                         },
                         {
                             data: function (row, type) {
-                                if (typeof row.peakMemoryMetrics == "undefined") {
-                                    return "";
+                                var peakMemoryMetrics = row.peakMemoryMetrics;
+                                if (typeof peakMemoryMetrics !== 'undefined') {
+                                    if (type !== 'display')
+                                        return peakMemoryMetrics.JVMHeapMemory;
+                                    else
+                                        return (formatBytes(peakMemoryMetrics.JVMHeapMemory, type) + ' / ' +
+                                            formatBytes(peakMemoryMetrics.JVMOffHeapMemory, type));
+                                } else {
+                                    if (type !== 'display') {
+                                        return 0;
+                                    } else {
+                                        return 'N/A';
+                                    }
                                 }
-                                if (type !== 'display')
-                                    return row.peakMemoryMetrics.JVMHeapMemory;
-                                else
-                                    return (formatBytes(row.peakMemoryMetrics.JVMHeapMemory, type) + ' / ' +
-                                        formatBytes(row.peakMemoryMetrics.JVMOffHeapMemory, type));
                             }
                         },
                         {
                             data: function (row, type) {
-                                if (typeof row.peakMemoryMetrics == "undefined") {
-                                    return "";
+                                var peakMemoryMetrics = row.peakMemoryMetrics;
+                                if (typeof peakMemoryMetrics !== 'undefined') {
+                                    if (type !== 'display')
+                                        return peakMemoryMetrics.OnHeapExecutionMemory;
+                                    else
+                                        return (formatBytes(peakMemoryMetrics.OnHeapExecutionMemory, type) + ' / ' +
+                                            formatBytes(peakMemoryMetrics.OffHeapExecutionMemory, type));
+                                } else {
+                                    if (type !== 'display') {
+                                        return 0;
+                                    } else {
+                                        return 'N/A';
+                                    }
                                 }
-                                if (type !== 'display')
-                                    return row.peakMemoryMetrics.OnHeapExecutionMemory;
-                                else
-                                    return (formatBytes(row.peakMemoryMetrics.OnHeapExecutionMemory, type) + ' / ' +
-                                        formatBytes(row.peakMemoryMetrics.OffHeapExecutionMemory, type));
                             }
                         },
                         {
                             data: function (row, type) {
-                                if (typeof row.peakMemoryMetrics == "undefined") {
-                                    return "";
+                                var peakMemoryMetrics = row.peakMemoryMetrics;
+                                if (typeof peakMemoryMetrics !== 'undefined') {
+                                    if (type !== 'display')
+                                        return peakMemoryMetrics.OnHeapStorageMemory;
+                                    else
+                                        return (formatBytes(peakMemoryMetrics.OnHeapStorageMemory, type) + ' / ' +
+                                            formatBytes(peakMemoryMetrics.OffHeapStorageMemory, type));
+                                } else {
+                                    if (type !== 'display') {
+                                        return 0;
+                                    } else {
+                                        return 'N/A';
+                                    }
                                 }
-                                if (type !== 'display')
-                                    return row.peakMemoryMetrics.OnHeapStorageMemory;
-                                else
-                                    return (formatBytes(row.peakMemoryMetrics.OnHeapStorageMemory, type) + ' / ' +
-                                        formatBytes(row.peakMemoryMetrics.OffHeapStorageMemory, type));
                             }
                         },
                         {
                             data: function (row, type) {
-                                if (typeof row.peakMemoryMetrics == "undefined") {
-                                    return "";
+                                var peakMemoryMetrics = row.peakMemoryMetrics;
+                                if (typeof peakMemoryMetrics !== 'undefined') {
+                                    if (type !== 'display')
+                                        return peakMemoryMetrics.DirectPoolMemory;
+                                    else
+                                        return (formatBytes(peakMemoryMetrics.DirectPoolMemory, type) + ' / ' +
+                                            formatBytes(peakMemoryMetrics.MappedPoolMemory, type));
+                                } else {
+                                    if (type !== 'display') {
+                                        return 0;
+                                    } else {
+                                        return 'N/A';
+                                    }
                                 }
-                                if (type !== 'display')
-                                    return row.peakMemoryMetrics.DirectPoolMemory;
-                                else
-                                    return (formatBytes(row.peakMemoryMetrics.DirectPoolMemory, type) + ' / ' +
-                                        formatBytes(row.peakMemoryMetrics.MappedPoolMemory, type));
                             }
                         },
                         {data: 'diskUsed', render: formatBytes},


### PR DESCRIPTION
### What changes were proposed in this pull request?
Check if the executorSummary.peakMemoryMetrics is defined before accessing it. Without checking, the UI has risked being stuck at the Executors page.

### Why are the changes needed?
App live UI may stuck at Executors page without this fix.
Steps to reproduce (with master branch):
In mac OS standalone mode, open a spark-shell
$SPARK_HOME/bin/spark-shell --master spark://localhost:7077

val x = sc.makeRDD(1 to 100000, 5)
x.count()

Then open the app UI in the browser, and click the Executors page, will get stuck at this page:
![image](https://user-images.githubusercontent.com/26694233/103105677-ca1a7380-45f4-11eb-9245-c69f4a4e816b.png)

Also, the return JSON from API endpoint http://localhost:4040/api/v1/applications/app-20201224134418-0003/executors miss "peakMemoryMetrics" for executor objects. I attached the full json text in https://issues.apache.org/jira/browse/SPARK-33906.

I debugged it and observed that ExecutorMetricsPoller
.getExecutorUpdates returns an empty map, which causes peakExecutorMetrics to None in https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/status/LiveEntity.scala#L345. The possible reason for returning the empty map is that the stage completion time is shorter than the heartbeat interval, so the stage entry in stageTCMP has already been removed before the reportHeartbeat is called.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manual test, rerun the steps of bug reproduce and see the bug is gone.