### PR TITLE
[SPARK-33804][CORE] Fix compilation warnings about 'view bounds are deprecated'

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/SequenceFileRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/SequenceFileRDDFunctions.scala
@@ -32,15 +32,13 @@ import org.apache.spark.internal.Logging
  * @note This can't be part of PairRDDFunctions because we need more implicit parameters to
  * convert our keys and values to Writable.
  */
-class SequenceFileRDDFunctions[K <% Writable: ClassTag, V <% Writable : ClassTag](
+class SequenceFileRDDFunctions[K: ClassTag, V: ClassTag](
     self: RDD[(K, V)],
     _keyWritableClass: Class[_ <: Writable],
     _valueWritableClass: Class[_ <: Writable])
+    (implicit kToWritable: K => Writable, vToWritable: V => Writable)
   extends Logging
   with Serializable {
-
-  // TODO the context bound (<%) above should be replaced with simple type bound and implicit
-  // conversion but is a breaking change. This should be fixed in Spark 3.x.
 
   /**
    * Output the RDD as a Hadoop SequenceFile using the Writable types we infer from the RDD's key
@@ -52,7 +50,7 @@ class SequenceFileRDDFunctions[K <% Writable: ClassTag, V <% Writable : ClassTag
   def saveAsSequenceFile(
       path: String,
       codec: Option[Class[_ <: CompressionCodec]] = None): Unit = self.withScope {
-    def anyToWritable[U <% Writable](u: U): Writable = u
+    def anyToWritable[U](u: U)(implicit ev: U => Writable): Writable = u
 
     // TODO We cannot force the return type of `anyToWritable` be same as keyWritableClass and
     // valueWritableClass at the compile time. To implement that, we need to add type parameters to

--- a/core/src/main/scala/org/apache/spark/rdd/SequenceFileRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/SequenceFileRDDFunctions.scala
@@ -32,11 +32,10 @@ import org.apache.spark.internal.Logging
  * @note This can't be part of PairRDDFunctions because we need more implicit parameters to
  * convert our keys and values to Writable.
  */
-class SequenceFileRDDFunctions[K, V](
+class SequenceFileRDDFunctions[K: IsWritable: ClassTag, V: IsWritable: ClassTag](
     self: RDD[(K, V)],
     _keyWritableClass: Class[_ <: Writable],
     _valueWritableClass: Class[_ <: Writable])
-    (implicit ev$1: K => Writable, ev$2: V => Writable, ev$3: ClassTag[K], ev$4: ClassTag[V])
   extends Logging
   with Serializable {
 
@@ -50,7 +49,7 @@ class SequenceFileRDDFunctions[K, V](
   def saveAsSequenceFile(
       path: String,
       codec: Option[Class[_ <: CompressionCodec]] = None): Unit = self.withScope {
-    def anyToWritable[U](u: U)(implicit ev: U => Writable): Writable = u
+    def anyToWritable[U: IsWritable](u: U): Writable = u
 
     // TODO We cannot force the return type of `anyToWritable` be same as keyWritableClass and
     // valueWritableClass at the compile time. To implement that, we need to add type parameters to

--- a/core/src/main/scala/org/apache/spark/rdd/SequenceFileRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/SequenceFileRDDFunctions.scala
@@ -32,11 +32,10 @@ import org.apache.spark.internal.Logging
  * @note This can't be part of PairRDDFunctions because we need more implicit parameters to
  * convert our keys and values to Writable.
  */
-class SequenceFileRDDFunctions[K: ClassTag, V: ClassTag](
+class SequenceFileRDDFunctions[K: IsWritable: ClassTag, V: IsWritable: ClassTag](
     self: RDD[(K, V)],
     _keyWritableClass: Class[_ <: Writable],
     _valueWritableClass: Class[_ <: Writable])
-    (implicit kToWritable: K => Writable, vToWritable: V => Writable)
   extends Logging
   with Serializable {
 
@@ -50,7 +49,7 @@ class SequenceFileRDDFunctions[K: ClassTag, V: ClassTag](
   def saveAsSequenceFile(
       path: String,
       codec: Option[Class[_ <: CompressionCodec]] = None): Unit = self.withScope {
-    def anyToWritable[U](u: U)(implicit ev: U => Writable): Writable = u
+    def anyToWritable[U: IsWritable](u: U): Writable = u
 
     // TODO We cannot force the return type of `anyToWritable` be same as keyWritableClass and
     // valueWritableClass at the compile time. To implement that, we need to add type parameters to

--- a/core/src/main/scala/org/apache/spark/rdd/SequenceFileRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/SequenceFileRDDFunctions.scala
@@ -40,9 +40,6 @@ class SequenceFileRDDFunctions[K, V](
   extends Logging
   with Serializable {
 
-  // TODO the context bound (<%) above should be replaced with simple type bound and implicit
-  // conversion but is a breaking change. This should be fixed in Spark 3.x.
-
   /**
    * Output the RDD as a Hadoop SequenceFile using the Writable types we infer from the RDD's key
    * and value types. If the key or value are Writable, then we use their classes directly;

--- a/core/src/main/scala/org/apache/spark/rdd/SequenceFileRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/SequenceFileRDDFunctions.scala
@@ -32,12 +32,16 @@ import org.apache.spark.internal.Logging
  * @note This can't be part of PairRDDFunctions because we need more implicit parameters to
  * convert our keys and values to Writable.
  */
-class SequenceFileRDDFunctions[K: IsWritable: ClassTag, V: IsWritable: ClassTag](
+class SequenceFileRDDFunctions[K, V](
     self: RDD[(K, V)],
     _keyWritableClass: Class[_ <: Writable],
     _valueWritableClass: Class[_ <: Writable])
+    (implicit ev$1: K => Writable, ev$2: V => Writable, ev$3: ClassTag[K], ev$4: ClassTag[V])
   extends Logging
   with Serializable {
+
+  // TODO the context bound (<%) above should be replaced with simple type bound and implicit
+  // conversion but is a breaking change. This should be fixed in Spark 3.x.
 
   /**
    * Output the RDD as a Hadoop SequenceFile using the Writable types we infer from the RDD's key
@@ -49,7 +53,7 @@ class SequenceFileRDDFunctions[K: IsWritable: ClassTag, V: IsWritable: ClassTag]
   def saveAsSequenceFile(
       path: String,
       codec: Option[Class[_ <: CompressionCodec]] = None): Unit = self.withScope {
-    def anyToWritable[U: IsWritable](u: U): Writable = u
+    def anyToWritable[U](u: U)(implicit ev: U => Writable): Writable = u
 
     // TODO We cannot force the return type of `anyToWritable` be same as keyWritableClass and
     // valueWritableClass at the compile time. To implement that, we need to add type parameters to

--- a/core/src/main/scala/org/apache/spark/rdd/package.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/package.scala
@@ -17,7 +17,11 @@
 
 package org.apache.spark
 
+import org.apache.hadoop.io.Writable
+
 /**
  * Provides several RDD implementations. See [[org.apache.spark.rdd.RDD]].
  */
-package object rdd
+package object rdd {
+  type IsWritable[A] = A => Writable
+}

--- a/core/src/main/scala/org/apache/spark/rdd/package.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/package.scala
@@ -17,11 +17,7 @@
 
 package org.apache.spark
 
-import org.apache.hadoop.io.Writable
-
 /**
  * Provides several RDD implementations. See [[org.apache.spark.rdd.RDD]].
  */
-package object rdd {
-  type IsWritable[A] = A => Writable
-}
+package object rdd


### PR DESCRIPTION
### What changes were proposed in this pull request?

There are only 3 compilation warnings related to `view bounds are deprecated` in Spark Code:
```
[WARNING] /spark-source/core/src/main/scala/org/apache/spark/rdd/SequenceFileRDDFunctions.scala:35: view bounds are deprecated; use an implicit parameter instead.
[WARNING] /spark-source/core/src/main/scala/org/apache/spark/rdd/SequenceFileRDDFunctions.scala:35: view bounds are deprecated; use an implicit parameter instead.
[WARNING] /spark-source/core/src/main/scala/org/apache/spark/rdd/SequenceFileRDDFunctions.scala:55: view bounds are deprecated; use an implicit parameter instead.
```

This pr try to fix these compilation warnings.

### Why are the changes needed?
Fix compilation warnings about ` view bounds are deprecated`


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass the Jenkins or GitHub Action
