### PR TITLE
[SPARK-32684][SQL][TESTS] Add a test case to check if null value is same as Hive's '\\N' in script transformation

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -505,8 +505,7 @@ class SparkSqlAstBuilder extends AstBuilder {
           } else {
             None
           }
-          val finalProps = props ++ Seq("field.delim" -> props.getOrElse("field.delim", "\t"),
-            "serialization.null.format" -> props.getOrElse("serialization.null.format", "\\N"))
+          val finalProps = props ++ Seq("field.delim" -> props.getOrElse("field.delim", "\t"))
           (Seq.empty, Option(name), finalProps.toSeq, recordHandler)
 
         case null =>
@@ -515,7 +514,6 @@ class SparkSqlAstBuilder extends AstBuilder {
             "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe")
           val props = Seq(
             "field.delim" -> "\t",
-            "serialization.null.format" -> "\\N",
             "serialization.last.column.takes.rest" -> "true")
           val recordHandler = Option(conf.getConfString(configKey, defaultConfigValue))
           (Nil, Option(name), props, recordHandler)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -505,7 +505,8 @@ class SparkSqlAstBuilder extends AstBuilder {
           } else {
             None
           }
-          val finalProps = props ++ Seq("field.delim" -> props.getOrElse("field.delim", "\t"))
+          val finalProps = props ++ Seq("field.delim" -> props.getOrElse("field.delim", "\t"),
+            "serialization.null.format" -> props.getOrElse("serialization.null.format", "\\N"))
           (Seq.empty, Option(name), finalProps.toSeq, recordHandler)
 
         case null =>
@@ -514,6 +515,7 @@ class SparkSqlAstBuilder extends AstBuilder {
             "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe")
           val props = Seq(
             "field.delim" -> "\t",
+            "serialization.null.format" -> "\\N",
             "serialization.last.column.takes.rest" -> "true")
           val recordHandler = Option(conf.getConfString(configKey, defaultConfigValue))
           (Nil, Option(name), props, recordHandler)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveScriptTransformationSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveScriptTransformationSuite.scala
@@ -507,7 +507,7 @@ class HiveScriptTransformationSuite extends BaseScriptTransformationSuite with T
       """
         |SELECT TRANSFORM(null, null, null)
         |USING 'cat'
-        |FROM (SELECT 1 AS a, 2 AS b, 3 AS c) t
+        |FROM (SELECT 1 AS a) t
       """.stripMargin)
     checkAnswer(query1, identity, Row(null, "\\N\t\\N") :: Nil)
 
@@ -515,14 +515,17 @@ class HiveScriptTransformationSuite extends BaseScriptTransformationSuite with T
       """
         |SELECT TRANSFORM(null, null, null)
         |  ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'
-        |USING 'cat'
+        |  WITH SERDEPROPERTIES (
+        |   'field.delim' = ','
+        |  )
+        |USING 'cat' AS (a)
         |  ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'
         |  WITH SERDEPROPERTIES (
-        |   'serialization.last.column.takes.rest' = 'true'
+        |   'field.delim' = '&'
         |  )
-        |FROM (SELECT 1 AS a, 2 AS b, 3 AS c) t
+        |FROM (SELECT 1 AS a) t
       """.stripMargin)
-    checkAnswer(query2, identity, Row(null, "\\N\t\\N") :: Nil)
+    checkAnswer(query2, identity, Row("\\N,\\N,\\N") :: Nil)
 
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveScriptTransformationSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveScriptTransformationSuite.scala
@@ -502,7 +502,7 @@ class HiveScriptTransformationSuite extends BaseScriptTransformationSuite with T
     checkAnswer(query4, identity, Row(null) :: Nil)
   }
 
-  test("SPARK-32684: Script transform hive serde mode null value keep same with hive as '\\N'") {
+  test("SPARK-32684: Script transform hive serde mode null format is same with hive as '\\N'") {
     val query1 = sql(
       """
         |SELECT TRANSFORM(null, null, null)


### PR DESCRIPTION
### What changes were proposed in this pull request?
In hive script transform serde mode, NULL format default is `\\N`
```
String nullString = tbl.getProperty(
    serdeConstants.SERIALIZATION_NULL_FORMAT, "\\N");
nullSequence = new Text(nullString);
```

I make a mistake that in Spark's code we need to fix and keep same with hive too.  So add some test case to show this issue.

### Why are the changes needed?
add UT


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added UT
