### PR TITLE
[SPARK-33926][SQL] Improve the error message in resolving of DSv1 multi-part identifiers

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Implicits.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Implicits.scala
@@ -118,7 +118,7 @@ private[sql] object CatalogV2Implicits {
 
   implicit class MultipartIdentifierHelper(parts: Seq[String]) {
     if (parts.isEmpty) {
-      throw new AnalysisException("multi-part identifier cannot be empty.")
+      throw new AnalysisException("Namespaces in V1 catalog can have only a single name part.")
     }
 
     def asIdentifier: Identifier = Identifier.of(parts.init.toArray, parts.last)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -116,7 +116,7 @@ trait ShowTablesSuiteBase extends command.ShowTablesSuiteBase {
       val errMsg = intercept[AnalysisException] {
         sql(showTableCmd)
       }.getMessage
-      assert(errMsg.contains("multi-part identifier cannot be empty"))
+      assert(errMsg.contains("Namespaces in V1 catalog can have only a single name part"))
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Replace the error message `multi-part identifier cannot be empty` by `Namespaces in V1 catalog can have only a single name part` in resolving of multi-part namespace identifiers. For V1 datasource, the namespace can have only one part - a database.

### Why are the changes needed?
To improve user experience with Spark SQL, and make the error message more clear.

### Does this PR introduce _any_ user-facing change?
Yes

### How was this patch tested?
By running unified tests for `SHOW TABLES` and Jenkins build.