### PR TITLE
[SPARK-33637][SQL] alter table drop partition equals alter table drop if ex…

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1597,6 +1597,19 @@ object SQLConf {
        .doc("When true, use legacy MySqlServer SMALLINT and REAL type mapping.")
        .booleanConf
        .createWithDefault(false)
+
+  val DROP_EXIST_PARTITION = buildConf("spark.sql.drop.exist.partition")
+    .internal()
+    .doc("This is a switch for drop partition.This is a configuration for " +
+      "deleting a partition. The current method is that if you do not add if exist, " +
+      "it will not judge whether it exists. If it does not exist, " +
+      "an error will be reported directly. For hive SQL migration, " +
+      "the syntax of hive SQL should be consistent with that of hive SQL. " +
+      "When deleting a partition, if the configuration is true, its effect " +
+      "is the same as adding if exist.")
+    .booleanConf
+    .createWithDefault(true)
+
 }
 
 /**
@@ -1775,6 +1788,9 @@ class SQLConf extends Serializable with Logging {
   def topKSortFallbackThreshold: Int = getConf(TOP_K_SORT_FALLBACK_THRESHOLD)
 
   def fastHashAggregateRowMaxCapacityBit: Int = getConf(FAST_HASH_AGGREGATE_MAX_ROWS_CAPACITY_BIT)
+
+  def dropExistPartition: Boolean = getConf(DROP_EXIST_PARTITION)
+
 
   /**
    * Returns the [[Resolver]] for the current configuration, which can be used to determine if two

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -544,8 +544,9 @@ case class AlterTableDropPartitionCommand(
     }
 
     catalog.dropPartitions(
-      table.identifier, normalizedSpecs, ignoreIfNotExists = ifExists, purge = purge,
-      retainData = retainData)
+      table.identifier, normalizedSpecs,
+      ignoreIfNotExists = conf.dropExistPartition || ifExists,
+      purge = purge, retainData = retainData)
 
     CommandUtils.updateTableStats(sparkSession, table)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?



### Why are the changes needed?
Spark SQL reports an error when the partition does not exist. This is not user-friendly



### Does this PR introduce _any_ user-facing change?
For users, no modification is required. If the user wants this configuration not to take effect, configure: spark.sql.drop.exist.partition=true.



### How was this patch tested?

before：
spark-sql> alter table bigdata_qa.test_part_gui drop partition (dt='2019-11-25');
Error in query: No partition is dropped. One partition spec 'Map(dt -> 2019-11-25)' does not exist in table 'test_part_gui' database 'bigdata_qa';

after：
spark-sql> alter table bigdata_qa.test_part_gui drop partition (dt='2019-11-25');
Response code
Time taken: 0.141 seconds

If you don’t want the configuration to take effect, you can configure it like this：
spark-sql> alter table bigdata_qa.test_part_gui drop partition (dt='2019-11-25');
Error in query: No partition is dropped. One partition spec 'Map(dt -> 2019-11-25)' does not exist in table 'test_part_gui' database 'bigdata_qa';
spark-sql> set spark.sql.drop.partition.switch=false；
spark-sql> alter table bigdata_qa.test_part_gui drop partition (dt='2019-11-25');
Response code
Time taken: 0.141 seconds