### PR TITLE
[SPARK-33899][SQL][3.1] Fix assert failure in v1 SHOW TABLES/VIEWS on `spark_catalog`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -377,7 +377,6 @@ class ResolveSessionCatalog(
       DropDatabaseCommand(ns.head, d.ifExists, d.cascade)
 
     case ShowTables(SessionCatalogAndNamespace(_, ns), pattern) =>
-      assert(ns.nonEmpty)
       if (ns.length != 1) {
           throw new AnalysisException(
             s"The database name is not valid: ${ns.quoted}")
@@ -517,7 +516,6 @@ class ResolveSessionCatalog(
       resolved match {
         case SessionCatalogAndNamespace(_, ns) =>
           // Fallback to v1 ShowViewsCommand since there is no view API in v2 catalog
-          assert(ns.nonEmpty)
           if (ns.length != 1) {
             throw new AnalysisException(s"The database name is not valid: ${ns.quoted}")
           }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -3119,6 +3119,19 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
       assert(spark.sessionState.catalog.isRegisteredFunction(rand))
     }
   }
+
+  test("SPARK-33899: invalid multi-part identifier of namespaces") {
+    Seq(
+      "SHOW TABLES IN spark_catalog" -> "multi-part identifier cannot be empty",
+      "SHOW VIEWS IN spark_catalog" -> "multi-part identifier cannot be empty",
+      "SHOW TABLE EXTENDED IN spark_catalog LIKE '*tbl'" -> "Database 'spark_catalog' not found"
+    ).foreach { case (sqlCmd, expectedError) =>
+      val errMsg = intercept[AnalysisException] {
+        sql(sqlCmd)
+      }.getMessage
+      assert(errMsg.contains(expectedError))
+    }
+  }
 }
 
 object FakeLocalFsFileSystem {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove `assert(ns.nonEmpty)` in `ResolveSessionCatalog` for:
- `SHOW TABLES`
- `SHOW TABLE EXTENDED`
- `SHOW VIEWS`

### Why are the changes needed?
Spark SQL shouldn't fail with internal assert failures even for invalid user inputs. For instance:
```sql
spark-sql> show tables in spark_catalog;
20/12/24 11:19:46 ERROR SparkSQLDriver: Failed in [show tables in spark_catalog]
java.lang.AssertionError: assertion failed
	at scala.Predef$.assert(Predef.scala:208)
	at org.apache.spark.sql.catalyst.analysis.ResolveSessionCatalog$$anonfun$apply$1.applyOrElse(ResolveSessionCatalog.scala:366)
	at org.apache.spark.sql.catalyst.analysis.ResolveSessionCatalog$$anonfun$apply$1.applyOrElse(ResolveSessionCatalog.scala:49)
	at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.$anonfun$resolveOperatorsUp$3(AnalysisHelper.scala:90)
	at org.apache.spark.sql.catalyst.trees.CurrentOrigin$.withOrigin(TreeNode.scala:73)
```

### Does this PR introduce _any_ user-facing change?
Yes. After the changes, for the example above:
```sql
spark-sql> show tables in spark_catalog;
Error in query: multi-part identifier cannot be empty.
```

### How was this patch tested?
Added new UT to `DDLSuite`:
```
$ build/sbt -Phive-2.3 -Phive-thriftserver "test:testOnly *CatalogedDDLSuite"
```
