### PR TITLE
[SPARK-33924][SQL][TESTS] Preserve partition metadata by INSERT INTO in v2 table catalog

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryPartitionTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryPartitionTable.scala
@@ -84,7 +84,7 @@ class InMemoryPartitionTable(
   }
 
   override protected def addPartitionKey(key: Seq[Any]): Unit = {
-    memoryTablePartitions.put(InternalRow.fromSeq(key), Map.empty[String, String].asJava)
+    memoryTablePartitions.putIfAbsent(InternalRow.fromSeq(key), Map.empty[String, String].asJava)
   }
 
   override def listPartitionIdentifiers(


### PR DESCRIPTION
### What changes were proposed in this pull request?
For `InMemoryPartitionTable` used in tests, set empty partition metadata only when a partition doesn't exists.

### Why are the changes needed?
This bug fix is needed to use `INSERT INTO .. PARTITION` in other tests.

### Does this PR introduce _any_ user-facing change?
No. It affects only the v2 table catalog used in tests.

### How was this patch tested?
Added new UT to `DataSourceV2SQLSuite`, and run the affected test suite by:
```
$ build/sbt -Phive -Phive-thriftserver "test:testOnly org.apache.spark.sql.connector.DataSourceV2SQLSuite"
```