### PR TITLE
[SPARK-33932][SS] Clean up KafkaOffsetReader API document

### DIFF
--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReaderAdmin.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReaderAdmin.scala
@@ -108,17 +108,10 @@ private[kafka010] class KafkaOffsetReaderAdmin(
 
   override def toString(): String = consumerStrategy.toString
 
-  /**
-   * Closes the connection to Kafka, and cleans up state.
-   */
   override def close(): Unit = {
     stopAdmin()
   }
 
-  /**
-   * Fetch the partition offsets for the topic partitions that are indicated
-   * in the [[ConsumerStrategy]] and [[KafkaOffsetRangeLimit]].
-   */
   override def fetchPartitionOffsets(
       offsetRangeLimit: KafkaOffsetRangeLimit,
       isStartingOffsets: Boolean): Map[TopicPartition, Long] = {
@@ -148,14 +141,6 @@ private[kafka010] class KafkaOffsetReaderAdmin(
     }
   }
 
-  /**
-   * Resolves the specific offsets based on Kafka seek positions.
-   * This method resolves offset value -1 to the latest and -2 to the
-   * earliest Kafka seek position.
-   *
-   * @param partitionOffsets the specific offsets to resolve
-   * @param reportDataLoss callback to either report or log data loss depending on setting
-   */
   override def fetchSpecificOffsets(
       partitionOffsets: Map[TopicPartition, Long],
       reportDataLoss: String => Unit): KafkaSourceOffset = {
@@ -246,10 +231,6 @@ private[kafka010] class KafkaOffsetReaderAdmin(
     KafkaSourceOffset(fetched)
   }
 
-  /**
-   * Fetch the earliest offsets for the topic partitions that are indicated
-   * in the [[ConsumerStrategy]].
-   */
   override def fetchEarliestOffsets(): Map[TopicPartition, Long] = partitionsAssignedToAdmin(
     partitions => {
       val listOffsetsParams = partitions.asScala.map(p => p -> OffsetSpec.earliest()).toMap.asJava
@@ -258,17 +239,6 @@ private[kafka010] class KafkaOffsetReaderAdmin(
       partitionOffsets
     })
 
-  /**
-   * Fetch the latest offsets for the topic partitions that are indicated
-   * in the [[ConsumerStrategy]].
-   *
-   * In order to avoid unknown issues, we use the given `knownOffsets` to audit the
-   * latest offsets returned by Kafka. If we find some incorrect offsets (a latest offset is less
-   * than an offset in `knownOffsets`), we will retry at most `maxOffsetFetchAttempts` times. When
-   * a topic is recreated, the latest offsets may be less than offsets in `knownOffsets`. We cannot
-   * distinguish this with issues like KAFKA-7703, so we just return whatever we get from Kafka
-   * after retrying.
-   */
   override def fetchLatestOffsets(
       knownOffsets: Option[PartitionOffsetMap]): PartitionOffsetMap =
     partitionsAssignedToAdmin { partitions => {
@@ -326,10 +296,6 @@ private[kafka010] class KafkaOffsetReaderAdmin(
     }
   }
 
-  /**
-   * Fetch the earliest offsets for specific topic partitions.
-   * The return result may not contain some partitions if they are deleted.
-   */
   override def fetchEarliestOffsets(
       newPartitions: Seq[TopicPartition]): Map[TopicPartition, Long] = {
     if (newPartitions.isEmpty) {
@@ -349,14 +315,6 @@ private[kafka010] class KafkaOffsetReaderAdmin(
     }
   }
 
-  /**
-   * Return the offset ranges for a Kafka batch query. If `minPartitions` is set, this method may
-   * split partitions to respect it. Since offsets can be early and late binding which are evaluated
-   * on the executors, in order to divvy up the partitions we need to perform some substitutions. We
-   * don't want to send exact offsets to the executors, because data may age out before we can
-   * consume the data. This method makes some approximate splitting, and replaces the special offset
-   * values in the final output.
-   */
   override def getOffsetRangesFromUnresolvedOffsets(
       startingOffsets: KafkaOffsetRangeLimit,
       endingOffsets: KafkaOffsetRangeLimit): Seq[KafkaOffsetRange] = {
@@ -429,11 +387,6 @@ private[kafka010] class KafkaOffsetReaderAdmin(
       .map(_.toString)
   }
 
-  /**
-   * Return the offset ranges for a Kafka streaming batch. If `minPartitions` is set, this method
-   * may split partitions to respect it. If any data lost issue is detected, `reportDataLoss` will
-   * be called.
-   */
   override def getOffsetRangesFromResolvedOffsets(
       fromPartitionOffsets: PartitionOffsetMap,
       untilPartitionOffsets: PartitionOffsetMap,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This patch cleans up KafkaOffsetReader API document.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

KafkaOffsetReader API documents are duplicated among KafkaOffsetReaderConsumer and KafkaOffsetReaderAdmin. It seems to be good if the doc is centralized.

This also adds missing API doc too.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No, dev only.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Doc only.