### PR TITLE
[SPARK-33859][SQL][FOLLOWUP] Add version to `SupportsPartitionManagement.renamePartition()`

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsPartitionManagement.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsPartitionManagement.java
@@ -149,6 +149,8 @@ public interface SupportsPartitionManagement extends Table {
      * @throws UnsupportedOperationException If partition renaming is not supported
      * @throws PartitionAlreadyExistsException If the `to` partition exists already
      * @throws NoSuchPartitionException If the `from` partition does not exist
+     *
+     * @since 3.2.0
      */
     default boolean renamePartition(InternalRow from, InternalRow to)
         throws UnsupportedOperationException,


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add the version 3.2.0 to new method `renamePartition()` in the `SupportsPartitionManagement` interface.

### Why are the changes needed?
To inform Spark devs when the method appears in the interface.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
`./dev/scalastyle`
