### PR TITLE
[SPARK-33936][SQL][3.1] Add the version when connector's interfaces were added

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/MetadataColumn.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/MetadataColumn.java
@@ -33,6 +33,8 @@ import org.apache.spark.sql.types.DataType;
  * example, a partition value produced by bucket(id, 16) could be exposed by a metadata column. In
  * this case, {@link #transform()} should return a non-null {@link Transform} that produced the
  * metadata column's values.
+ *
+ * @since 3.1.0
  */
 @Evolving
 public interface MetadataColumn {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsDelete.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsDelete.java
@@ -44,6 +44,8 @@ public interface SupportsDelete {
    *
    * @param filters filter expressions, used to select rows to delete when all expressions match
    * @return true if the delete operation can be performed
+   *
+   * @since 3.1.0
    */
   default boolean canDeleteWhere(Filter[] filters) {
     return true;

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsMetadataColumns.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsMetadataColumns.java
@@ -37,6 +37,8 @@ import org.apache.spark.sql.types.StructType;
  * If a table column and a metadata column have the same name, the metadata column will never be
  * requested. It is recommended that Table implementations reject data column name that conflict
  * with metadata column names.
+ *
+ * @since 3.1.0
  */
 @Evolving
 public interface SupportsMetadataColumns extends Table {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/Expressions.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/Expressions.java
@@ -163,4 +163,5 @@ public class Expressions {
   public static Transform hours(String column) {
     return LogicalExpressions.hours(Expressions.column(column));
   }
+
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/Expressions.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/Expressions.java
@@ -163,5 +163,4 @@ public class Expressions {
   public static Transform hours(String column) {
     return LogicalExpressions.hours(Expressions.column(column));
   }
-
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add the `@since` tag to the interfaces added recently in version 3.1.0.

### Why are the changes needed?
1. To follow the existing convention for Spark API.
2. To inform devs when Spark API was changed.

### Does this PR introduce _any_ user-facing change?
Should not.

### How was this patch tested?
`dev/scalastyle`