### PR TITLE
[SPARK-33940][SQL] allow configuring the max column name length in csv writer

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -21,6 +21,7 @@ import java.nio.charset.StandardCharsets
 import java.time.ZoneId
 import java.util.Locale
 
+import com.univocity.parsers.common.NormalizedString
 import com.univocity.parsers.csv.{CsvParserSettings, CsvWriterSettings, UnescapedQuoteHandling}
 
 import org.apache.spark.internal.Logging
@@ -135,7 +136,6 @@ class CSVOptions(
   val positiveInf = parameters.getOrElse("positiveInf", "Inf")
   val negativeInf = parameters.getOrElse("negativeInf", "-Inf")
 
-
   val compressionCodec: Option[String] = {
     val name = parameters.get("compression").orElse(parameters.get("codec"))
     name.map(CompressionCodecs.getCodecClassName)
@@ -161,6 +161,9 @@ class CSVOptions(
   val maxColumns = getInt("maxColumns", 20480)
 
   val maxCharsPerColumn = getInt("maxCharsPerColumn", -1)
+
+  val maxColumnNameLength = getInt("maxColumnNameLength",
+    NormalizedString.getCache.getMaxStringLength)
 
   val escapeQuotes = getBool("escapeQuotes", true)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -2448,8 +2448,27 @@ abstract class CSVSuite
         .option("header", "true")
         .option("unescapedQuoteHandling", "STOP_AT_CLOSING_QUOTE")
         .csv(dataPath).collect()
-      val exceptResults = Array(row1, row2)
-      assert(result.sameElements(exceptResults))
+      val expectedResults = Array(row1, row2)
+      assert(result.sameElements(expectedResults))
+    }
+  }
+
+  test("write csv data correctly with the configurable max column name length") {
+    withTempPath { path =>
+      val dataPath = path.getCanonicalPath
+      val row1 = Row("a")
+      val superLongHeader = (0 until 1025).map(_ => "c").mkString("")
+      val df = Seq(s"${row1.getString(0)}").toDF(superLongHeader)
+      df.repartition(1)
+        .write
+        .option("header", "true")
+        .option("maxColumnNameLength", 1025)
+        .csv(dataPath)
+      val result = spark.read
+        .option("header", "true")
+        .csv(dataPath)
+        .collect()
+      assert(result.sameElements(Array(row1)))
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -2453,7 +2453,7 @@ abstract class CSVSuite
     }
   }
 
-  test("write csv data correctly with the configurable max column name length") {
+  test("SPARK-33940: write csv data correctly with the configurable max column name length") {
     withTempPath { path =>
       val dataPath = path.getCanonicalPath
       val row1 = Row("a")


### PR DESCRIPTION
### What changes were proposed in this pull request?

exposed an option maxColumnNameLength to users to define max length of column name in csv writer

### Why are the changes needed?

csv writer actually has an implicit limit on column name length due to univocity-parser, 

 

when we initialize a writer https://github.com/uniVocity/univocity-parsers/blob/e09114c6879fa6c2c15e7365abc02cda3e193ff7/src/main/java/com/univocity/parsers/common/AbstractWriter.java#L211, it calls toIdentifierGroupArray which calls valueOf in NormalizedString.java eventually (https://github.com/uniVocity/univocity-parsers/blob/e09114c6879fa6c2c15e7365abc02cda3e193ff7/src/main/java/com/univocity/parsers/common/NormalizedString.java#L205-L209)

 

in that stringCache.get, it has a maxStringLength cap https://github.com/uniVocity/univocity-parsers/blob/e09114c6879fa6c2c15e7365abc02cda3e193ff7/src/main/java/com/univocity/parsers/common/StringCache.java#L104 which is 1024 by default

 

we do not expose this as a configurable option, leading to NPE when we have a column name larger than 1024, 

 

```

[info]   Cause: java.lang.NullPointerException:

[info]   at com.univocity.parsers.common.AbstractWriter.submitRow(AbstractWriter.java:349)

[info]   at com.univocity.parsers.common.AbstractWriter.writeHeaders(AbstractWriter.java:444)

[info]   at com.univocity.parsers.common.AbstractWriter.writeHeaders(AbstractWriter.java:410)

[info]   at org.apache.spark.sql.catalyst.csv.UnivocityGenerator.writeHeaders(UnivocityGenerator.scala:87)

[info]   at org.apache.spark.sql.execution.datasources.csv.CsvOutputWriter$.writeHeaders(CsvOutputWriter.scala:58)

[info]   at org.apache.spark.sql.execution.datasources.csv.CsvOutputWriter.<init>(CsvOutputWriter.scala:44)

[info]   at org.apache.spark.sql.execution.datasources.csv.CSVFileFormat$$anon$1.newInstance(CSVFileFormat.scala:86)

[info]   at org.apache.spark.sql.execution.datasources.SingleDirectoryDataWriter.newOutputWriter(FileFormatDataWriter.scala:126)

[info]   at org.apache.spark.sql.execution.datasources.SingleDirectoryDataWriter.<init>(FileFormatDataWriter.scala:111)

[info]   at org.apache.spark.sql.execution.datasources.FileFormatWriter$.executeTask(FileFormatWriter.scala:269)

[info]   at org.apache.spark.sql.execution.datasources.FileFormatWriter$.$anonfun$write$15(FileFormatWriter.scala:210)

```

 

it could be reproduced by a simple unit test

 

```

val row1 = Row("a")
val superLongHeader = (0 until 1025).map(_ => "c").mkString("")
val df = Seq(s"${row1.getString(0)}").toDF(superLongHeader)
df.repartition(1)
.write
.option("header", "true")
.option("maxColumnNameLength", 1025)
.csv(dataPath)

```

it will lead to NPE unexpectedly

### Does this PR introduce _any_ user-facing change?

yes

### How was this patch tested?

UT