### PR TITLE
[SPARK-33945][SQL][3.1] Handles a random seed consisting of an expr tree

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/randomExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/randomExpressions.scala
@@ -47,7 +47,7 @@ abstract class RDG extends UnaryExpression with ExpectsInputTypes with Stateful 
     case e if child.foldable && e.dataType == IntegerType => e.eval().asInstanceOf[Int]
     case e if child.foldable && e.dataType == LongType => e.eval().asInstanceOf[Long]
     case _ => throw new AnalysisException(
-      s"Input argument to $prettyName must be an integer, long or null literal.")
+      s"Input argument to $prettyName must be an integer or long constant.")
   }
 
   override def nullable: Boolean = false

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/randomExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/randomExpressions.scala
@@ -44,8 +44,8 @@ abstract class RDG extends UnaryExpression with ExpectsInputTypes with Stateful 
   }
 
   @transient protected lazy val seed: Long = child match {
-    case Literal(s, IntegerType) => s.asInstanceOf[Int]
-    case Literal(s, LongType) => s.asInstanceOf[Long]
+    case e if e.dataType == IntegerType => e.eval().asInstanceOf[Int]
+    case e if e.dataType == LongType => e.eval().asInstanceOf[Long]
     case _ => throw new AnalysisException(
       s"Input argument to $prettyName must be an integer, long or null literal.")
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/randomExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/randomExpressions.scala
@@ -44,8 +44,8 @@ abstract class RDG extends UnaryExpression with ExpectsInputTypes with Stateful 
   }
 
   @transient protected lazy val seed: Long = child match {
-    case e if e.dataType == IntegerType => e.eval().asInstanceOf[Int]
-    case e if e.dataType == LongType => e.eval().asInstanceOf[Long]
+    case e if child.foldable && e.dataType == IntegerType => e.eval().asInstanceOf[Int]
+    case e if child.foldable && e.dataType == LongType => e.eval().asInstanceOf[Long]
     case _ => throw new AnalysisException(
       s"Input argument to $prettyName must be an integer, long or null literal.")
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/randomExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/randomExpressions.scala
@@ -47,7 +47,7 @@ abstract class RDG extends UnaryExpression with ExpectsInputTypes with Stateful 
     case e if child.foldable && e.dataType == IntegerType => e.eval().asInstanceOf[Int]
     case e if child.foldable && e.dataType == LongType => e.eval().asInstanceOf[Long]
     case _ => throw new AnalysisException(
-      s"Input argument to $prettyName must be an integer or long constant.")
+      s"Input argument to $prettyName must be an integer, long, or null constant.")
   }
 
   override def nullable: Boolean = false

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3769,7 +3769,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
         val msg = intercept[AnalysisException] {
           sql(s"SELECT $f(id + 1) FROM range(0, 3)").collect()
         }.getMessage
-        assert(msg.contains("must be an integer, long or null literal"))
+        assert(msg.contains("must be an integer or long constant"))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3769,7 +3769,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
         val msg = intercept[AnalysisException] {
           sql(s"SELECT $f(id + 1) FROM range(0, 3)").collect()
         }.getMessage
-        assert(msg.contains("must be an integer or long constant"))
+        assert(msg.contains("must be an integer, long, or null constant"))
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR intends to fix the minor bug that throws an analysis exception when a seed param in `rand`/`randn` having a expr tree (e.g., `rand(1 + 1)`) with constant folding (`ConstantFolding` and `ReorderAssociativeOperator`) disabled. A query to reproduce this issue is as follows;
```
// v3.1.0, v3.0.2, and v2.4.8
$./bin/spark-shell 
scala> sql("select rand(1 + 2)").show()
+-------------------+
|      rand((1 + 2))|
+-------------------+
|0.25738143505962285|
+-------------------+

$./bin/spark-shell --conf spark.sql.optimizer.excludedRules=org.apache.spark.sql.catalyst.optimizer.ConstantFolding,org.apache.spark.sql.catalyst.optimizer.ReorderAssociativeOperator
scala> sql("select rand(1 + 2)").show()
org.apache.spark.sql.AnalysisException: Input argument to rand must be an integer, long or null literal.;
  at org.apache.spark.sql.catalyst.expressions.RDG.seed$lzycompute(randomExpressions.scala:49)
  at org.apache.spark.sql.catalyst.expressions.RDG.seed(randomExpressions.scala:46)
  at org.apache.spark.sql.catalyst.expressions.Rand.doGenCode(randomExpressions.scala:98)
  at org.apache.spark.sql.catalyst.expressions.Expression.$anonfun$genCode$3(Expression.scala:146)
  at scala.Option.getOrElse(Option.scala:189)
  ...
```

A root cause is that the match-case code below cannot handle the case described above:
https://github.com/apache/spark/blob/42f5e62403469cec6da680b9fbedd0aa508dcbe5/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/randomExpressions.scala#L46-L51

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Bugfix.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Checking if GA/Jenkins can pass