### PR TITLE
[SPARK-33944][SQL] Incorrect logging for warehouse keys in SharedState options

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -276,6 +276,5 @@ object SharedState extends Logging {
     }
     logInfo(s"Warehouse path is '$warehousePath'.")
     initialConfigs -- Seq(WAREHOUSE_PATH.key, hiveWarehouseKey)
-
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
@@ -388,7 +388,7 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
   }
 
 
-  test("SPARK-33944: can not set hive.metastore.warehouse.dir using session options") {
+  test("SPARK-33944: warning setting hive.metastore.warehouse.dir using session options") {
     val msg = "Not allowing to set hive.metastore.warehouse.dir in SparkSession's options"
     val logAppender = new LogAppender(msg)
     withLogAppender(logAppender) {
@@ -399,5 +399,19 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
         .sharedState
     }
     assert(logAppender.loggingEvents.exists(_.getRenderedMessage.contains(msg)))
+  }
+
+
+  test("SPARK-33944: no warning setting spark.sql.warehouse.dir using session options") {
+    val msg = "Not allowing to set hive.metastore.warehouse.dir in SparkSession's options"
+    val logAppender = new LogAppender(msg)
+    withLogAppender(logAppender) {
+      SparkSession.builder()
+        .master("local")
+        .config("spark.sql.warehouse.dir", "any")
+        .getOrCreate()
+        .sharedState
+    }
+    assert(!logAppender.loggingEvents.exists(_.getRenderedMessage.contains(msg)))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
@@ -386,4 +386,19 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
     assert(spark2.conf.get(custom) === "c2")
 
   }
+
+  private val msg = "Not allowing to set hive.metastore.warehouse.dir in SparkSession's options"
+
+  test(msg) {
+    val logAppender = new LogAppender(msg)
+
+    withLogAppender(logAppender) {
+      SparkSession.builder()
+        .master("local")
+        .config("hive.metastore.warehouse.dir", "any")
+        .getOrCreate()
+        .sharedState
+    }
+    assert(logAppender.loggingEvents.exists(_.getRenderedMessage.contains(msg)))
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
@@ -387,11 +387,10 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
 
   }
 
-  private val msg = "Not allowing to set hive.metastore.warehouse.dir in SparkSession's options"
 
-  test(msg) {
+  test("SPARK-33944: can not set hive.metastore.warehouse.dir using session options") {
+    val msg = "Not allowing to set hive.metastore.warehouse.dir in SparkSession's options"
     val logAppender = new LogAppender(msg)
-
     withLogAppender(logAppender) {
       SparkSession.builder()
         .master("local")

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
@@ -399,7 +399,7 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
     }
     assert(logAppender.loggingEvents.exists(_.getRenderedMessage.contains(msg)))
   }
-  
+
   test("SPARK-33944: no warning setting spark.sql.warehouse.dir using session options") {
     val msg = "Not allowing to set hive.metastore.warehouse.dir in SparkSession's options"
     val logAppender = new LogAppender(msg)

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
@@ -387,7 +387,6 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
 
   }
 
-
   test("SPARK-33944: warning setting hive.metastore.warehouse.dir using session options") {
     val msg = "Not allowing to set hive.metastore.warehouse.dir in SparkSession's options"
     val logAppender = new LogAppender(msg)
@@ -400,8 +399,7 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
     }
     assert(logAppender.loggingEvents.exists(_.getRenderedMessage.contains(msg)))
   }
-
-
+  
   test("SPARK-33944: no warning setting spark.sql.warehouse.dir using session options") {
     val msg = "Not allowing to set hive.metastore.warehouse.dir in SparkSession's options"
     val logAppender = new LogAppender(msg)


### PR DESCRIPTION

### What changes were proposed in this pull request?

While using SparkSession's initial options to generate the sharable Spark conf and Hadoop conf in ShardState, we shall put the log in the codeblock that the warehouse keys being handled.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

bugfix, rm ambiguous log when setting spark.sql.warehouse.dir in SparkSession.builder.config, but only warn setting hive.metastore.warehouse.dir 
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

no
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
 new tests