### PR TITLE
[WIP][SPARK-33941][SQL] Refresh cache after partitions dropping from v1 table

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -581,6 +581,7 @@ case class AlterTableDropPartitionCommand(
       table.identifier, normalizedSpecs, ignoreIfNotExists = ifExists, purge = purge,
       retainData = retainData)
 
+    sparkSession.catalog.refreshTable(table.identifier.quotedString)
     CommandUtils.updateTableStats(sparkSession, table)
 
     Seq.empty[Row]

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableDropPartitionSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableDropPartitionSuiteBase.scala
@@ -144,4 +144,16 @@ trait AlterTableDropPartitionSuiteBase extends QueryTest with DDLCommandTestUtil
       checkPartitions(t)
     }
   }
+
+  test("SPARK-33941: invalidate cache") {
+    withNamespaceAndTable("ns", "tbl") { t =>
+      sql(s"CREATE TABLE $t (id int, part int) $defaultUsing PARTITIONED BY (part)")
+      sql(s"INSERT INTO $t PARTITION (part=0) SELECT 0")
+      val df = spark.table(t)
+      df.cache()
+      assert(!df.isEmpty)
+      sql(s"ALTER TABLE $t DROP PARTITION (part=0)")
+      assert(df.isEmpty)
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableDropPartitionSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableDropPartitionSuiteBase.scala
@@ -144,16 +144,4 @@ trait AlterTableDropPartitionSuiteBase extends QueryTest with DDLCommandTestUtil
       checkPartitions(t)
     }
   }
-
-  test("SPARK-33941: invalidate cache") {
-    withNamespaceAndTable("ns", "tbl") { t =>
-      sql(s"CREATE TABLE $t (id int, part int) $defaultUsing PARTITIONED BY (part)")
-      sql(s"INSERT INTO $t PARTITION (part=0) SELECT 0")
-      val df = spark.table(t)
-      df.cache()
-      assert(!df.isEmpty)
-      sql(s"ALTER TABLE $t DROP PARTITION (part=0)")
-      assert(df.isEmpty)
-    }
-  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/AlterTableDropPartitionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/AlterTableDropPartitionSuite.scala
@@ -43,7 +43,7 @@ trait AlterTableDropPartitionSuiteBase extends command.AlterTableDropPartitionSu
     }
   }
 
-  test("SPARK-33941: invalidate cache after partition dropping") {
+  test("SPARK-33941: refresh cache after partition dropping") {
     withNamespaceAndTable("ns", "tbl") { t =>
       sql(s"CREATE TABLE $t (id int, part int) $defaultUsing PARTITIONED BY (part)")
       sql(s"INSERT INTO $t PARTITION (part=0) SELECT 0")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/AlterTableDropPartitionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/AlterTableDropPartitionSuite.scala
@@ -51,6 +51,7 @@ trait AlterTableDropPartitionSuiteBase extends command.AlterTableDropPartitionSu
       df.cache()
       assert(!df.isEmpty)
       sql(s"ALTER TABLE $t DROP PARTITION (part=0)")
+      assert(spark.sharedState.cacheManager.lookupCachedData(df).isDefined)
       assert(df.isEmpty)
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Invoke `refreshTable()` from `AlterTableDropPartitionCommand.run()` after partitions dropping. In particular, this invalidates the cache associated with the modified table.

### Why are the changes needed?
While querying the table, to not return data from the dropped partitions. See the example in SPARK-33941.

### Does this PR introduce _any_ user-facing change?
Yes. After the changes, Spark doesn't return the dropped partition data:
```scala
scala> sql("CREATE TABLE tbl2 (id int, part int) USING parquet PARTITIONED BY (part)")
res1: org.apache.spark.sql.DataFrame = []
scala> sql("INSERT INTO tbl2 PARTITION (part=0) SELECT 0")
res2: org.apache.spark.sql.DataFrame = []
scala> sql("INSERT INTO tbl2 PARTITION (part=1) SELECT 1")

scala> val df1 = spark.table("tbl2")
df1: org.apache.spark.sql.DataFrame = [id: int, part: int]
scala> val df2 = spark.table("tbl2")
df2: org.apache.spark.sql.DataFrame = [id: int, part: int]

scala> df2.cache
res4: df2.type = [id: int, part: int]
scala> df1.show(false)
+---+----+
|id |part|
+---+----+
|0  |0   |
|1  |1   |
+---+----+
scala> df2.show(false)
+---+----+
|id |part|
+---+----+
|0  |0   |
|1  |1   |
+---+----+


scala> sql("ALTER TABLE tbl2 DROP PARTITION(part=0)")
res7: org.apache.spark.sql.DataFrame = []
scala> df1.show(false)
+---+----+
|id |part|
+---+----+
|1  |1   |
+---+----+
scala> df2.show(false)
+---+----+
|id |part|
+---+----+
|1  |1   |
+---+----+
```

### How was this patch tested?
By running the test suites `AlterTableDropPartitionSuite`