### PR TITLE
[SPARK-33915][SQL] Allow json expression to be pushable column

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -139,7 +139,7 @@ case class GetJsonObject(json: Expression, path: Expression)
 
   @transient private lazy val parsedPath = parsePath(path.eval().asInstanceOf[UTF8String])
 
-  override def eval(input: InternalRow): Any = {
+  override def eval(input: InternalRow): UTF8String = {
     val jsonStr = json.eval(input).asInstanceOf[UTF8String]
     if (jsonStr == null) {
       return null

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -737,6 +737,8 @@ abstract class PushableColumnBase {
         }
       case s: GetStructField if nestedPredicatePushdownEnabled =>
         helper(s.child).map(_ :+ s.childSchema(s.ordinal).name)
+      case GetJsonObject(col, field) if nestedPredicatePushdownEnabled =>
+        Some(Seq("GetJsonObject(" + col + "," + field + ")"))
       case _ => None
     }
     helper(e).map(_.quoted)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds support for json / jsonb expression as PushableColumnBase.

With this change, SupportsPushDownFilters implementation would be able to push Filter down to DB.

The activation of this enhancement is controlled by nestedPredicatePushdownEnabled flag.

### Why are the changes needed?
Currently implementation of SupportsPushDownFilters doesn't have a chance to perform pushdown even if third party DB engine supports json expression pushdown.

This poses challenge when table schema uses json / jsonb to encode large amount of data.

Here is some background on how I came about the current approach.

Canonical json expression is something like: phone->code or phone->>code where phone is the json(b) column and code is the field.
However, the json expression is rejected by:
```
org.apache.spark.sql.catalyst.analysis.UnresolvedException: Invalid call to toAttribute on unresolved object, tree: unresolvedalias(lambdafunction(code, lambda 'phone, false), None)
    at org.apache.spark.sql.catalyst.analysis.UnresolvedAlias.toAttribute(unresolved.scala:463)
    at org.apache.spark.sql.catalyst.plans.logical.Project.$anonfun$output$1(basicLogicalOperators.scala:63)
    at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:238)
    at scala.collection.immutable.List.foreach(List.scala:392)
    at scala.collection.TraversableLike.map(TraversableLike.scala:238)
    at scala.collection.TraversableLike.map$(TraversableLike.scala:231)
    at scala.collection.immutable.List.map(List.scala:298)
    at org.apache.spark.sql.catalyst.plans.logical.Project.output(basicLogicalOperators.scala:63)
    at org.apache.spark.sql.catalyst.plans.QueryPlan.$anonfun$inputSet$1(QueryPlan.scala:57)
```
### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
With this change, plus corresponding changes in spark-cassandra-connector, Filter involving json expression can be pushed down.

Here is the plan prior to predicate pushdown:
```
2020-12-26 03:28:59,926 (Time-limited test) [DEBUG - org.apache.spark.internal.Logging.logDebug(Logging.scala:61)] Adaptive execution enabled for plan: Sort [id#34 ASC NULLS FIRST], true, 0
+- Project [id#34, address#35, phone#37, get_json_object(phone#37, $.code) AS phone#33]
   +- Filter (get_json_object(phone#37, $.code) = 1200)
      +- BatchScan[id#34, address#35, phone#37] Cassandra Scan: test.person
 - Cassandra Filters: []
 - Requested Columns: [id,address,phone]
Here is the plan with pushdown:
```
```
2020-12-28 01:40:08,150 (Time-limited test) [DEBUG - org.apache.spark.internal.Logging.logDebug(Logging.scala:61)] Adaptive execution enabled for plan: Sort [id#34 ASC NULLS FIRST], true, 0
    +- Project [id#34, address#35, phone#37, get_json_object(phone#37, $.code) AS phone#33]
       +- BatchScan[id#34, address#35, phone#37] Cassandra Scan: test.person
     - Cassandra Filters: [[phone->'code' = ?, 1200]]
     - Requested Columns: [id,address,phone]
```