### PR TITLE
[SPARK-33960][SQL] Push down Limit through Sort

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -551,6 +551,9 @@ object LimitPushDown extends Rule[LogicalPlan] {
         case _ => join
       }
       LocalLimit(exp, newJoin)
+
+    case LocalLimit(exp, s: Sort) =>
+      LocalLimit(exp, s.copy(child = LocalLimit(exp, stripGlobalLimitIfPresent(s.child))))
   }
 }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LimitPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LimitPushdownSuite.scala
@@ -194,4 +194,11 @@ class LimitPushdownSuite extends PlanTest {
       LocalLimit(1, y.groupBy(Symbol("b"))(count(1))))).analyze
     comparePlans(expected2, optimized2)
   }
+
+  test("SPARK-33960: Limit push down support Sort") {
+    val originalQuery = x.sortBy($"x.a".asc).limit(2)
+    val optimized = Optimize.execute(originalQuery.analyze)
+    val correctAnswer = LocalLimit(2, x).sortBy($"x.a".asc).limit(2).analyze
+    comparePlans(optimized, correctAnswer)
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pr add support push down Limit through Sort.

### Why are the changes needed?

Improve query performance.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test and benchmark test:

```scala
 spark.range(500000000).write.saveAsTable("t1")
 spark.sql("select * from t1 order by  id limit 2").show
```

Before this pr | After this pr
-- | --
![image](https://user-images.githubusercontent.com/5399861/103461507-da9bbe00-4d59-11eb-8131-d1c393771ff6.png) | ![image](https://user-images.githubusercontent.com/5399861/103461511-df607200-4d59-11eb-910f-b0851616bf22.png)




