### PR TITLE
[SPARK-33964][SQL] Combine distinct unions in more cases

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RemoveNoopOperatorsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RemoveNoopOperatorsSuite.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+
+class RemoveNoopOperatorsSuite extends PlanTest {
+
+  object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches =
+      Batch("RemoveNoopOperators", Once,
+        RemoveNoopOperators) :: Nil
+  }
+
+  val testRelation = LocalRelation('a.int, 'b.int, 'c.int)
+
+  test("Remove all redundant projections in one iteration") {
+    val originalQuery = testRelation
+      .select('a, 'b, 'c)
+      .select('a, 'b, 'c)
+      .analyze
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+
+    comparePlans(optimized, testRelation)
+  }
+
+  test("Remove all redundant windows in one iteration") {
+    val originalQuery = testRelation
+      .window(Nil, Nil, Nil)
+      .window(Nil, Nil, Nil)
+      .analyze
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+
+    comparePlans(optimized, testRelation)
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SetOperationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SetOperationSuite.scala
@@ -240,23 +240,4 @@ class SetOperationSuite extends PlanTest {
       Union(testRelation :: testRelation :: testRelation :: testRelation :: Nil, true, false)
     comparePlans(unionOptimized2, unionCorrectAnswer2, false)
   }
-
-  test("SPARK-xxxxx: Combine distinct unions that have noop project between them") {
-    val query1 = Distinct(Union(
-      Distinct(Union(testRelation, testRelation2)).select('a, 'b, 'c),
-      testRelation3
-    ))
-    val query2 = Distinct(Union(
-      testRelation,
-      Distinct(Union(testRelation2, testRelation3)).select('d, 'e, 'f)
-    ))
-
-    val optimized1 = Optimize.execute(query1.analyze)
-    val optimized2 = Optimize.execute(query2.analyze)
-
-    val expected = Distinct(Union(testRelation :: testRelation2 :: testRelation3 :: Nil))
-
-    comparePlans(optimized1, expected)
-    comparePlans(optimized2, expected)
-  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SetOperationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SetOperationSuite.scala
@@ -240,4 +240,23 @@ class SetOperationSuite extends PlanTest {
       Union(testRelation :: testRelation :: testRelation :: testRelation :: Nil, true, false)
     comparePlans(unionOptimized2, unionCorrectAnswer2, false)
   }
+
+  test("SPARK-xxxxx: Combine distinct unions that have noop project between them") {
+    val query1 = Distinct(Union(
+      Distinct(Union(testRelation, testRelation2)).select('a, 'b, 'c),
+      testRelation3
+    ))
+    val query2 = Distinct(Union(
+      testRelation,
+      Distinct(Union(testRelation2, testRelation3)).select('d, 'e, 'f)
+    ))
+
+    val optimized1 = Optimize.execute(query1.analyze)
+    val optimized2 = Optimize.execute(query2.analyze)
+
+    val expected = Distinct(Union(testRelation :: testRelation2 :: testRelation3 :: Nil))
+
+    comparePlans(optimized1, expected)
+    comparePlans(optimized2, expected)
+  }
 }

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q75.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q75.sf100/explain.txt
@@ -1,142 +1,134 @@
 == Physical Plan ==
-TakeOrderedAndProject (138)
-+- * Project (137)
-   +- * SortMergeJoin Inner (136)
-      :- * Sort (74)
-      :  +- Exchange (73)
-      :     +- * HashAggregate (72)
-      :        +- Exchange (71)
-      :           +- * HashAggregate (70)
-      :              +- * HashAggregate (69)
-      :                 +- Exchange (68)
-      :                    +- * HashAggregate (67)
-      :                       +- Union (66)
-      :                          :- * HashAggregate (47)
-      :                          :  +- Exchange (46)
-      :                          :     +- * HashAggregate (45)
-      :                          :        +- Union (44)
-      :                          :           :- * Project (25)
-      :                          :           :  +- SortMergeJoin LeftOuter (24)
-      :                          :           :     :- * Sort (18)
-      :                          :           :     :  +- Exchange (17)
-      :                          :           :     :     +- * Project (16)
-      :                          :           :     :        +- * BroadcastHashJoin Inner BuildRight (15)
-      :                          :           :     :           :- * Project (10)
-      :                          :           :     :           :  +- * BroadcastHashJoin Inner BuildRight (9)
-      :                          :           :     :           :     :- * Filter (3)
-      :                          :           :     :           :     :  +- * ColumnarToRow (2)
-      :                          :           :     :           :     :     +- Scan parquet default.catalog_sales (1)
-      :                          :           :     :           :     +- BroadcastExchange (8)
-      :                          :           :     :           :        +- * Project (7)
-      :                          :           :     :           :           +- * Filter (6)
-      :                          :           :     :           :              +- * ColumnarToRow (5)
-      :                          :           :     :           :                 +- Scan parquet default.item (4)
-      :                          :           :     :           +- BroadcastExchange (14)
-      :                          :           :     :              +- * Filter (13)
-      :                          :           :     :                 +- * ColumnarToRow (12)
-      :                          :           :     :                    +- Scan parquet default.date_dim (11)
-      :                          :           :     +- * Sort (23)
-      :                          :           :        +- Exchange (22)
-      :                          :           :           +- * Filter (21)
-      :                          :           :              +- * ColumnarToRow (20)
-      :                          :           :                 +- Scan parquet default.catalog_returns (19)
-      :                          :           +- * Project (43)
-      :                          :              +- SortMergeJoin LeftOuter (42)
-      :                          :                 :- * Sort (36)
-      :                          :                 :  +- Exchange (35)
-      :                          :                 :     +- * Project (34)
-      :                          :                 :        +- * BroadcastHashJoin Inner BuildRight (33)
-      :                          :                 :           :- * Project (31)
-      :                          :                 :           :  +- * BroadcastHashJoin Inner BuildRight (30)
-      :                          :                 :           :     :- * Filter (28)
-      :                          :                 :           :     :  +- * ColumnarToRow (27)
-      :                          :                 :           :     :     +- Scan parquet default.store_sales (26)
-      :                          :                 :           :     +- ReusedExchange (29)
-      :                          :                 :           +- ReusedExchange (32)
-      :                          :                 +- * Sort (41)
-      :                          :                    +- Exchange (40)
-      :                          :                       +- * Filter (39)
-      :                          :                          +- * ColumnarToRow (38)
-      :                          :                             +- Scan parquet default.store_returns (37)
-      :                          +- * Project (65)
-      :                             +- SortMergeJoin LeftOuter (64)
-      :                                :- * Sort (58)
-      :                                :  +- Exchange (57)
-      :                                :     +- * Project (56)
-      :                                :        +- * BroadcastHashJoin Inner BuildRight (55)
-      :                                :           :- * Project (53)
-      :                                :           :  +- * BroadcastHashJoin Inner BuildRight (52)
-      :                                :           :     :- * Filter (50)
-      :                                :           :     :  +- * ColumnarToRow (49)
-      :                                :           :     :     +- Scan parquet default.web_sales (48)
-      :                                :           :     +- ReusedExchange (51)
-      :                                :           +- ReusedExchange (54)
-      :                                +- * Sort (63)
-      :                                   +- Exchange (62)
-      :                                      +- * Filter (61)
-      :                                         +- * ColumnarToRow (60)
-      :                                            +- Scan parquet default.web_returns (59)
-      +- * Sort (135)
-         +- Exchange (134)
-            +- * HashAggregate (133)
-               +- Exchange (132)
-                  +- * HashAggregate (131)
-                     +- * HashAggregate (130)
-                        +- Exchange (129)
-                           +- * HashAggregate (128)
-                              +- Union (127)
-                                 :- * HashAggregate (111)
-                                 :  +- Exchange (110)
-                                 :     +- * HashAggregate (109)
-                                 :        +- Union (108)
-                                 :           :- * Project (92)
-                                 :           :  +- SortMergeJoin LeftOuter (91)
-                                 :           :     :- * Sort (88)
-                                 :           :     :  +- Exchange (87)
-                                 :           :     :     +- * Project (86)
-                                 :           :     :        +- * BroadcastHashJoin Inner BuildRight (85)
-                                 :           :     :           :- * Project (80)
-                                 :           :     :           :  +- * BroadcastHashJoin Inner BuildRight (79)
-                                 :           :     :           :     :- * Filter (77)
-                                 :           :     :           :     :  +- * ColumnarToRow (76)
-                                 :           :     :           :     :     +- Scan parquet default.catalog_sales (75)
-                                 :           :     :           :     +- ReusedExchange (78)
-                                 :           :     :           +- BroadcastExchange (84)
-                                 :           :     :              +- * Filter (83)
-                                 :           :     :                 +- * ColumnarToRow (82)
-                                 :           :     :                    +- Scan parquet default.date_dim (81)
-                                 :           :     +- * Sort (90)
-                                 :           :        +- ReusedExchange (89)
-                                 :           +- * Project (107)
-                                 :              +- SortMergeJoin LeftOuter (106)
-                                 :                 :- * Sort (103)
-                                 :                 :  +- Exchange (102)
-                                 :                 :     +- * Project (101)
-                                 :                 :        +- * BroadcastHashJoin Inner BuildRight (100)
-                                 :                 :           :- * Project (98)
-                                 :                 :           :  +- * BroadcastHashJoin Inner BuildRight (97)
-                                 :                 :           :     :- * Filter (95)
-                                 :                 :           :     :  +- * ColumnarToRow (94)
-                                 :                 :           :     :     +- Scan parquet default.store_sales (93)
-                                 :                 :           :     +- ReusedExchange (96)
-                                 :                 :           +- ReusedExchange (99)
-                                 :                 +- * Sort (105)
-                                 :                    +- ReusedExchange (104)
-                                 +- * Project (126)
-                                    +- SortMergeJoin LeftOuter (125)
-                                       :- * Sort (122)
-                                       :  +- Exchange (121)
-                                       :     +- * Project (120)
-                                       :        +- * BroadcastHashJoin Inner BuildRight (119)
-                                       :           :- * Project (117)
-                                       :           :  +- * BroadcastHashJoin Inner BuildRight (116)
-                                       :           :     :- * Filter (114)
-                                       :           :     :  +- * ColumnarToRow (113)
-                                       :           :     :     +- Scan parquet default.web_sales (112)
-                                       :           :     +- ReusedExchange (115)
-                                       :           +- ReusedExchange (118)
-                                       +- * Sort (124)
-                                          +- ReusedExchange (123)
+TakeOrderedAndProject (130)
++- * Project (129)
+   +- * SortMergeJoin Inner (128)
+      :- * Sort (70)
+      :  +- Exchange (69)
+      :     +- * HashAggregate (68)
+      :        +- Exchange (67)
+      :           +- * HashAggregate (66)
+      :              +- * HashAggregate (65)
+      :                 +- Exchange (64)
+      :                    +- * HashAggregate (63)
+      :                       +- Union (62)
+      :                          :- * Project (25)
+      :                          :  +- SortMergeJoin LeftOuter (24)
+      :                          :     :- * Sort (18)
+      :                          :     :  +- Exchange (17)
+      :                          :     :     +- * Project (16)
+      :                          :     :        +- * BroadcastHashJoin Inner BuildRight (15)
+      :                          :     :           :- * Project (10)
+      :                          :     :           :  +- * BroadcastHashJoin Inner BuildRight (9)
+      :                          :     :           :     :- * Filter (3)
+      :                          :     :           :     :  +- * ColumnarToRow (2)
+      :                          :     :           :     :     +- Scan parquet default.catalog_sales (1)
+      :                          :     :           :     +- BroadcastExchange (8)
+      :                          :     :           :        +- * Project (7)
+      :                          :     :           :           +- * Filter (6)
+      :                          :     :           :              +- * ColumnarToRow (5)
+      :                          :     :           :                 +- Scan parquet default.item (4)
+      :                          :     :           +- BroadcastExchange (14)
+      :                          :     :              +- * Filter (13)
+      :                          :     :                 +- * ColumnarToRow (12)
+      :                          :     :                    +- Scan parquet default.date_dim (11)
+      :                          :     +- * Sort (23)
+      :                          :        +- Exchange (22)
+      :                          :           +- * Filter (21)
+      :                          :              +- * ColumnarToRow (20)
+      :                          :                 +- Scan parquet default.catalog_returns (19)
+      :                          :- * Project (43)
+      :                          :  +- SortMergeJoin LeftOuter (42)
+      :                          :     :- * Sort (36)
+      :                          :     :  +- Exchange (35)
+      :                          :     :     +- * Project (34)
+      :                          :     :        +- * BroadcastHashJoin Inner BuildRight (33)
+      :                          :     :           :- * Project (31)
+      :                          :     :           :  +- * BroadcastHashJoin Inner BuildRight (30)
+      :                          :     :           :     :- * Filter (28)
+      :                          :     :           :     :  +- * ColumnarToRow (27)
+      :                          :     :           :     :     +- Scan parquet default.store_sales (26)
+      :                          :     :           :     +- ReusedExchange (29)
+      :                          :     :           +- ReusedExchange (32)
+      :                          :     +- * Sort (41)
+      :                          :        +- Exchange (40)
+      :                          :           +- * Filter (39)
+      :                          :              +- * ColumnarToRow (38)
+      :                          :                 +- Scan parquet default.store_returns (37)
+      :                          +- * Project (61)
+      :                             +- SortMergeJoin LeftOuter (60)
+      :                                :- * Sort (54)
+      :                                :  +- Exchange (53)
+      :                                :     +- * Project (52)
+      :                                :        +- * BroadcastHashJoin Inner BuildRight (51)
+      :                                :           :- * Project (49)
+      :                                :           :  +- * BroadcastHashJoin Inner BuildRight (48)
+      :                                :           :     :- * Filter (46)
+      :                                :           :     :  +- * ColumnarToRow (45)
+      :                                :           :     :     +- Scan parquet default.web_sales (44)
+      :                                :           :     +- ReusedExchange (47)
+      :                                :           +- ReusedExchange (50)
+      :                                +- * Sort (59)
+      :                                   +- Exchange (58)
+      :                                      +- * Filter (57)
+      :                                         +- * ColumnarToRow (56)
+      :                                            +- Scan parquet default.web_returns (55)
+      +- * Sort (127)
+         +- Exchange (126)
+            +- * HashAggregate (125)
+               +- Exchange (124)
+                  +- * HashAggregate (123)
+                     +- * HashAggregate (122)
+                        +- Exchange (121)
+                           +- * HashAggregate (120)
+                              +- Union (119)
+                                 :- * Project (88)
+                                 :  +- SortMergeJoin LeftOuter (87)
+                                 :     :- * Sort (84)
+                                 :     :  +- Exchange (83)
+                                 :     :     +- * Project (82)
+                                 :     :        +- * BroadcastHashJoin Inner BuildRight (81)
+                                 :     :           :- * Project (76)
+                                 :     :           :  +- * BroadcastHashJoin Inner BuildRight (75)
+                                 :     :           :     :- * Filter (73)
+                                 :     :           :     :  +- * ColumnarToRow (72)
+                                 :     :           :     :     +- Scan parquet default.catalog_sales (71)
+                                 :     :           :     +- ReusedExchange (74)
+                                 :     :           +- BroadcastExchange (80)
+                                 :     :              +- * Filter (79)
+                                 :     :                 +- * ColumnarToRow (78)
+                                 :     :                    +- Scan parquet default.date_dim (77)
+                                 :     +- * Sort (86)
+                                 :        +- ReusedExchange (85)
+                                 :- * Project (103)
+                                 :  +- SortMergeJoin LeftOuter (102)
+                                 :     :- * Sort (99)
+                                 :     :  +- Exchange (98)
+                                 :     :     +- * Project (97)
+                                 :     :        +- * BroadcastHashJoin Inner BuildRight (96)
+                                 :     :           :- * Project (94)
+                                 :     :           :  +- * BroadcastHashJoin Inner BuildRight (93)
+                                 :     :           :     :- * Filter (91)
+                                 :     :           :     :  +- * ColumnarToRow (90)
+                                 :     :           :     :     +- Scan parquet default.store_sales (89)
+                                 :     :           :     +- ReusedExchange (92)
+                                 :     :           +- ReusedExchange (95)
+                                 :     +- * Sort (101)
+                                 :        +- ReusedExchange (100)
+                                 +- * Project (118)
+                                    +- SortMergeJoin LeftOuter (117)
+                                       :- * Sort (114)
+                                       :  +- Exchange (113)
+                                       :     +- * Project (112)
+                                       :        +- * BroadcastHashJoin Inner BuildRight (111)
+                                       :           :- * Project (109)
+                                       :           :  +- * BroadcastHashJoin Inner BuildRight (108)
+                                       :           :     :- * Filter (106)
+                                       :           :     :  +- * ColumnarToRow (105)
+                                       :           :     :     +- Scan parquet default.web_sales (104)
+                                       :           :     +- ReusedExchange (107)
+                                       :           +- ReusedExchange (110)
+                                       +- * Sort (116)
+                                          +- ReusedExchange (115)
 
 
 (1) Scan parquet default.catalog_sales
@@ -213,7 +205,7 @@ Input [11]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, 
 
 (17) Exchange
 Input [9]: [cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14]
-Arguments: hashpartitioning(cs_order_number#3, cs_item_sk#2, 5), true, [id=#16]
+Arguments: hashpartitioning(cs_order_number#3, cs_item_sk#2, 5), ENSURE_REQUIREMENTS, [id=#16]
 
 (18) Sort [codegen id : 4]
 Input [9]: [cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14]
@@ -235,7 +227,7 @@ Condition : (isnotnull(cr_order_number#18) AND isnotnull(cr_item_sk#17))
 
 (22) Exchange
 Input [4]: [cr_item_sk#17, cr_order_number#18, cr_return_quantity#19, cr_return_amount#20]
-Arguments: hashpartitioning(cr_order_number#18, cr_item_sk#17, 5), true, [id=#21]
+Arguments: hashpartitioning(cr_order_number#18, cr_item_sk#17, 5), ENSURE_REQUIREMENTS, [id=#21]
 
 (23) Sort [codegen id : 6]
 Input [4]: [cr_item_sk#17, cr_order_number#18, cr_return_quantity#19, cr_return_amount#20]
@@ -290,7 +282,7 @@ Input [11]: [ss_sold_date_sk#24, ss_item_sk#25, ss_ticket_number#26, ss_quantity
 
 (35) Exchange
 Input [9]: [ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14]
-Arguments: hashpartitioning(cast(ss_ticket_number#26 as bigint), cast(ss_item_sk#25 as bigint), 5), true, [id=#29]
+Arguments: hashpartitioning(cast(ss_ticket_number#26 as bigint), cast(ss_item_sk#25 as bigint), 5), ENSURE_REQUIREMENTS, [id=#29]
 
 (36) Sort [codegen id : 11]
 Input [9]: [ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14]
@@ -312,7 +304,7 @@ Condition : (isnotnull(sr_ticket_number#31) AND isnotnull(sr_item_sk#30))
 
 (40) Exchange
 Input [4]: [sr_item_sk#30, sr_ticket_number#31, sr_return_quantity#32, sr_return_amt#33]
-Arguments: hashpartitioning(sr_ticket_number#31, sr_item_sk#30, 5), true, [id=#34]
+Arguments: hashpartitioning(sr_ticket_number#31, sr_item_sk#30, 5), ENSURE_REQUIREMENTS, [id=#34]
 
 (41) Sort [codegen id : 13]
 Input [4]: [sr_item_sk#30, sr_ticket_number#31, sr_return_quantity#32, sr_return_amt#33]
@@ -327,426 +319,386 @@ Join condition: None
 Output [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, (ss_quantity#27 - coalesce(sr_return_quantity#32, 0)) AS sales_cnt#35, CheckOverflow((promote_precision(cast(ss_ext_sales_price#28 as decimal(8,2))) - promote_precision(cast(coalesce(sr_return_amt#33, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#36]
 Input [13]: [ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14, sr_item_sk#30, sr_ticket_number#31, sr_return_quantity#32, sr_return_amt#33]
 
-(44) Union
-
-(45) HashAggregate [codegen id : 15]
-Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23]
-Keys [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23]
-Functions: []
-Aggregate Attributes: []
-Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23]
-
-(46) Exchange
-Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23]
-Arguments: hashpartitioning(d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23, 5), true, [id=#37]
-
-(47) HashAggregate [codegen id : 16]
-Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23]
-Keys [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23]
-Functions: []
-Aggregate Attributes: []
-Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23]
-
-(48) Scan parquet default.web_sales
-Output [5]: [ws_sold_date_sk#38, ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42]
+(44) Scan parquet default.web_sales
+Output [5]: [ws_sold_date_sk#37, ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_sales]
 PushedFilters: [IsNotNull(ws_item_sk), IsNotNull(ws_sold_date_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_item_sk:int,ws_order_number:int,ws_quantity:int,ws_ext_sales_price:decimal(7,2)>
 
-(49) ColumnarToRow [codegen id : 19]
-Input [5]: [ws_sold_date_sk#38, ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42]
+(45) ColumnarToRow [codegen id : 17]
+Input [5]: [ws_sold_date_sk#37, ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41]
 
-(50) Filter [codegen id : 19]
-Input [5]: [ws_sold_date_sk#38, ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42]
-Condition : (isnotnull(ws_item_sk#39) AND isnotnull(ws_sold_date_sk#38))
+(46) Filter [codegen id : 17]
+Input [5]: [ws_sold_date_sk#37, ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41]
+Condition : (isnotnull(ws_item_sk#38) AND isnotnull(ws_sold_date_sk#37))
 
-(51) ReusedExchange [Reuses operator id: 8]
+(47) ReusedExchange [Reuses operator id: 8]
 Output [5]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
 
-(52) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [ws_item_sk#39]
+(48) BroadcastHashJoin [codegen id : 17]
+Left keys [1]: [ws_item_sk#38]
 Right keys [1]: [i_item_sk#6]
 Join condition: None
 
-(53) Project [codegen id : 19]
-Output [9]: [ws_sold_date_sk#38, ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
-Input [10]: [ws_sold_date_sk#38, ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42, i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
+(49) Project [codegen id : 17]
+Output [9]: [ws_sold_date_sk#37, ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
+Input [10]: [ws_sold_date_sk#37, ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41, i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
 
-(54) ReusedExchange [Reuses operator id: 14]
+(50) ReusedExchange [Reuses operator id: 14]
 Output [2]: [d_date_sk#13, d_year#14]
 
-(55) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [ws_sold_date_sk#38]
+(51) BroadcastHashJoin [codegen id : 17]
+Left keys [1]: [ws_sold_date_sk#37]
 Right keys [1]: [d_date_sk#13]
 Join condition: None
 
-(56) Project [codegen id : 19]
-Output [9]: [ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14]
-Input [11]: [ws_sold_date_sk#38, ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_date_sk#13, d_year#14]
+(52) Project [codegen id : 17]
+Output [9]: [ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14]
+Input [11]: [ws_sold_date_sk#37, ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_date_sk#13, d_year#14]
 
-(57) Exchange
-Input [9]: [ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14]
-Arguments: hashpartitioning(cast(ws_order_number#40 as bigint), cast(ws_item_sk#39 as bigint), 5), true, [id=#43]
+(53) Exchange
+Input [9]: [ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14]
+Arguments: hashpartitioning(cast(ws_order_number#39 as bigint), cast(ws_item_sk#38 as bigint), 5), ENSURE_REQUIREMENTS, [id=#42]
 
-(58) Sort [codegen id : 20]
-Input [9]: [ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14]
-Arguments: [cast(ws_order_number#40 as bigint) ASC NULLS FIRST, cast(ws_item_sk#39 as bigint) ASC NULLS FIRST], false, 0
+(54) Sort [codegen id : 18]
+Input [9]: [ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14]
+Arguments: [cast(ws_order_number#39 as bigint) ASC NULLS FIRST, cast(ws_item_sk#38 as bigint) ASC NULLS FIRST], false, 0
 
-(59) Scan parquet default.web_returns
-Output [4]: [wr_item_sk#44, wr_order_number#45, wr_return_quantity#46, wr_return_amt#47]
+(55) Scan parquet default.web_returns
+Output [4]: [wr_item_sk#43, wr_order_number#44, wr_return_quantity#45, wr_return_amt#46]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_returns]
 PushedFilters: [IsNotNull(wr_order_number), IsNotNull(wr_item_sk)]
 ReadSchema: struct<wr_item_sk:bigint,wr_order_number:bigint,wr_return_quantity:int,wr_return_amt:decimal(7,2)>
 
-(60) ColumnarToRow [codegen id : 21]
-Input [4]: [wr_item_sk#44, wr_order_number#45, wr_return_quantity#46, wr_return_amt#47]
+(56) ColumnarToRow [codegen id : 19]
+Input [4]: [wr_item_sk#43, wr_order_number#44, wr_return_quantity#45, wr_return_amt#46]
 
-(61) Filter [codegen id : 21]
-Input [4]: [wr_item_sk#44, wr_order_number#45, wr_return_quantity#46, wr_return_amt#47]
-Condition : (isnotnull(wr_order_number#45) AND isnotnull(wr_item_sk#44))
+(57) Filter [codegen id : 19]
+Input [4]: [wr_item_sk#43, wr_order_number#44, wr_return_quantity#45, wr_return_amt#46]
+Condition : (isnotnull(wr_order_number#44) AND isnotnull(wr_item_sk#43))
 
-(62) Exchange
-Input [4]: [wr_item_sk#44, wr_order_number#45, wr_return_quantity#46, wr_return_amt#47]
-Arguments: hashpartitioning(wr_order_number#45, wr_item_sk#44, 5), true, [id=#48]
+(58) Exchange
+Input [4]: [wr_item_sk#43, wr_order_number#44, wr_return_quantity#45, wr_return_amt#46]
+Arguments: hashpartitioning(wr_order_number#44, wr_item_sk#43, 5), ENSURE_REQUIREMENTS, [id=#47]
 
-(63) Sort [codegen id : 22]
-Input [4]: [wr_item_sk#44, wr_order_number#45, wr_return_quantity#46, wr_return_amt#47]
-Arguments: [wr_order_number#45 ASC NULLS FIRST, wr_item_sk#44 ASC NULLS FIRST], false, 0
+(59) Sort [codegen id : 20]
+Input [4]: [wr_item_sk#43, wr_order_number#44, wr_return_quantity#45, wr_return_amt#46]
+Arguments: [wr_order_number#44 ASC NULLS FIRST, wr_item_sk#43 ASC NULLS FIRST], false, 0
 
-(64) SortMergeJoin
-Left keys [2]: [cast(ws_order_number#40 as bigint), cast(ws_item_sk#39 as bigint)]
-Right keys [2]: [wr_order_number#45, wr_item_sk#44]
+(60) SortMergeJoin
+Left keys [2]: [cast(ws_order_number#39 as bigint), cast(ws_item_sk#38 as bigint)]
+Right keys [2]: [wr_order_number#44, wr_item_sk#43]
 Join condition: None
 
-(65) Project [codegen id : 23]
-Output [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, (ws_quantity#41 - coalesce(wr_return_quantity#46, 0)) AS sales_cnt#49, CheckOverflow((promote_precision(cast(ws_ext_sales_price#42 as decimal(8,2))) - promote_precision(cast(coalesce(wr_return_amt#47, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#50]
-Input [13]: [ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14, wr_item_sk#44, wr_order_number#45, wr_return_quantity#46, wr_return_amt#47]
+(61) Project [codegen id : 21]
+Output [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, (ws_quantity#40 - coalesce(wr_return_quantity#45, 0)) AS sales_cnt#48, CheckOverflow((promote_precision(cast(ws_ext_sales_price#41 as decimal(8,2))) - promote_precision(cast(coalesce(wr_return_amt#46, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#49]
+Input [13]: [ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14, wr_item_sk#43, wr_order_number#44, wr_return_quantity#45, wr_return_amt#46]
 
-(66) Union
+(62) Union
 
-(67) HashAggregate [codegen id : 24]
+(63) HashAggregate [codegen id : 22]
 Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23]
 Keys [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23]
 Functions: []
 Aggregate Attributes: []
 Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23]
 
-(68) Exchange
+(64) Exchange
 Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23]
-Arguments: hashpartitioning(d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23, 5), true, [id=#51]
+Arguments: hashpartitioning(d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23, 5), ENSURE_REQUIREMENTS, [id=#50]
 
-(69) HashAggregate [codegen id : 25]
+(65) HashAggregate [codegen id : 23]
 Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23]
 Keys [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23]
 Functions: []
 Aggregate Attributes: []
 Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23]
 
-(70) HashAggregate [codegen id : 25]
+(66) HashAggregate [codegen id : 23]
 Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23]
 Keys [5]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
 Functions [2]: [partial_sum(cast(sales_cnt#22 as bigint)), partial_sum(UnscaledValue(sales_amt#23))]
-Aggregate Attributes [2]: [sum#52, sum#53]
-Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum#54, sum#55]
+Aggregate Attributes [2]: [sum#51, sum#52]
+Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum#53, sum#54]
 
-(71) Exchange
-Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum#54, sum#55]
-Arguments: hashpartitioning(d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, 5), true, [id=#56]
+(67) Exchange
+Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum#53, sum#54]
+Arguments: hashpartitioning(d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, 5), ENSURE_REQUIREMENTS, [id=#55]
 
-(72) HashAggregate [codegen id : 26]
-Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum#54, sum#55]
+(68) HashAggregate [codegen id : 24]
+Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum#53, sum#54]
 Keys [5]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
 Functions [2]: [sum(cast(sales_cnt#22 as bigint)), sum(UnscaledValue(sales_amt#23))]
-Aggregate Attributes [2]: [sum(cast(sales_cnt#22 as bigint))#57, sum(UnscaledValue(sales_amt#23))#58]
-Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum(cast(sales_cnt#22 as bigint))#57 AS sales_cnt#59, MakeDecimal(sum(UnscaledValue(sales_amt#23))#58,18,2) AS sales_amt#60]
+Aggregate Attributes [2]: [sum(cast(sales_cnt#22 as bigint))#56, sum(UnscaledValue(sales_amt#23))#57]
+Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum(cast(sales_cnt#22 as bigint))#56 AS sales_cnt#58, MakeDecimal(sum(UnscaledValue(sales_amt#23))#57,18,2) AS sales_amt#59]
 
-(73) Exchange
-Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#59, sales_amt#60]
-Arguments: hashpartitioning(i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, 5), true, [id=#61]
+(69) Exchange
+Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#58, sales_amt#59]
+Arguments: hashpartitioning(i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, 5), ENSURE_REQUIREMENTS, [id=#60]
 
-(74) Sort [codegen id : 27]
-Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#59, sales_amt#60]
+(70) Sort [codegen id : 25]
+Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#58, sales_amt#59]
 Arguments: [i_brand_id#7 ASC NULLS FIRST, i_class_id#8 ASC NULLS FIRST, i_category_id#9 ASC NULLS FIRST, i_manufact_id#11 ASC NULLS FIRST], false, 0
 
-(75) Scan parquet default.catalog_sales
+(71) Scan parquet default.catalog_sales
 Output [5]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_sales]
 PushedFilters: [IsNotNull(cs_item_sk), IsNotNull(cs_sold_date_sk)]
 ReadSchema: struct<cs_sold_date_sk:int,cs_item_sk:int,cs_order_number:int,cs_quantity:int,cs_ext_sales_price:decimal(7,2)>
 
-(76) ColumnarToRow [codegen id : 30]
+(72) ColumnarToRow [codegen id : 28]
 Input [5]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5]
 
-(77) Filter [codegen id : 30]
+(73) Filter [codegen id : 28]
 Input [5]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5]
 Condition : (isnotnull(cs_item_sk#2) AND isnotnull(cs_sold_date_sk#1))
 
-(78) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#62, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66]
+(74) ReusedExchange [Reuses operator id: 8]
+Output [5]: [i_item_sk#61, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65]
 
-(79) BroadcastHashJoin [codegen id : 30]
+(75) BroadcastHashJoin [codegen id : 28]
 Left keys [1]: [cs_item_sk#2]
-Right keys [1]: [i_item_sk#62]
+Right keys [1]: [i_item_sk#61]
 Join condition: None
 
-(80) Project [codegen id : 30]
-Output [9]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66]
-Input [10]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_item_sk#62, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66]
+(76) Project [codegen id : 28]
+Output [9]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65]
+Input [10]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_item_sk#61, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65]
 
-(81) Scan parquet default.date_dim
-Output [2]: [d_date_sk#67, d_year#68]
+(77) Scan parquet default.date_dim
+Output [2]: [d_date_sk#66, d_year#67]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(82) ColumnarToRow [codegen id : 29]
-Input [2]: [d_date_sk#67, d_year#68]
+(78) ColumnarToRow [codegen id : 27]
+Input [2]: [d_date_sk#66, d_year#67]
 
-(83) Filter [codegen id : 29]
-Input [2]: [d_date_sk#67, d_year#68]
-Condition : ((isnotnull(d_year#68) AND (d_year#68 = 2001)) AND isnotnull(d_date_sk#67))
+(79) Filter [codegen id : 27]
+Input [2]: [d_date_sk#66, d_year#67]
+Condition : ((isnotnull(d_year#67) AND (d_year#67 = 2001)) AND isnotnull(d_date_sk#66))
 
-(84) BroadcastExchange
-Input [2]: [d_date_sk#67, d_year#68]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#69]
+(80) BroadcastExchange
+Input [2]: [d_date_sk#66, d_year#67]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#68]
 
-(85) BroadcastHashJoin [codegen id : 30]
+(81) BroadcastHashJoin [codegen id : 28]
 Left keys [1]: [cs_sold_date_sk#1]
-Right keys [1]: [d_date_sk#67]
+Right keys [1]: [d_date_sk#66]
 Join condition: None
 
-(86) Project [codegen id : 30]
-Output [9]: [cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, d_year#68]
-Input [11]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, d_date_sk#67, d_year#68]
+(82) Project [codegen id : 28]
+Output [9]: [cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, d_year#67]
+Input [11]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, d_date_sk#66, d_year#67]
 
-(87) Exchange
-Input [9]: [cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, d_year#68]
-Arguments: hashpartitioning(cs_order_number#3, cs_item_sk#2, 5), true, [id=#70]
+(83) Exchange
+Input [9]: [cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, d_year#67]
+Arguments: hashpartitioning(cs_order_number#3, cs_item_sk#2, 5), ENSURE_REQUIREMENTS, [id=#69]
 
-(88) Sort [codegen id : 31]
-Input [9]: [cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, d_year#68]
+(84) Sort [codegen id : 29]
+Input [9]: [cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, d_year#67]
 Arguments: [cs_order_number#3 ASC NULLS FIRST, cs_item_sk#2 ASC NULLS FIRST], false, 0
 
-(89) ReusedExchange [Reuses operator id: 22]
+(85) ReusedExchange [Reuses operator id: 22]
 Output [4]: [cr_item_sk#17, cr_order_number#18, cr_return_quantity#19, cr_return_amount#20]
 
-(90) Sort [codegen id : 33]
+(86) Sort [codegen id : 31]
 Input [4]: [cr_item_sk#17, cr_order_number#18, cr_return_quantity#19, cr_return_amount#20]
 Arguments: [cr_order_number#18 ASC NULLS FIRST, cr_item_sk#17 ASC NULLS FIRST], false, 0
 
-(91) SortMergeJoin
+(87) SortMergeJoin
 Left keys [2]: [cs_order_number#3, cs_item_sk#2]
 Right keys [2]: [cr_order_number#18, cr_item_sk#17]
 Join condition: None
 
-(92) Project [codegen id : 34]
-Output [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, (cs_quantity#4 - coalesce(cr_return_quantity#19, 0)) AS sales_cnt#22, CheckOverflow((promote_precision(cast(cs_ext_sales_price#5 as decimal(8,2))) - promote_precision(cast(coalesce(cr_return_amount#20, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#23]
-Input [13]: [cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, d_year#68, cr_item_sk#17, cr_order_number#18, cr_return_quantity#19, cr_return_amount#20]
+(88) Project [codegen id : 32]
+Output [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, (cs_quantity#4 - coalesce(cr_return_quantity#19, 0)) AS sales_cnt#22, CheckOverflow((promote_precision(cast(cs_ext_sales_price#5 as decimal(8,2))) - promote_precision(cast(coalesce(cr_return_amount#20, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#23]
+Input [13]: [cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, d_year#67, cr_item_sk#17, cr_order_number#18, cr_return_quantity#19, cr_return_amount#20]
 
-(93) Scan parquet default.store_sales
+(89) Scan parquet default.store_sales
 Output [5]: [ss_sold_date_sk#24, ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_sold_date_sk)]
 ReadSchema: struct<ss_sold_date_sk:int,ss_item_sk:int,ss_ticket_number:int,ss_quantity:int,ss_ext_sales_price:decimal(7,2)>
 
-(94) ColumnarToRow [codegen id : 37]
+(90) ColumnarToRow [codegen id : 35]
 Input [5]: [ss_sold_date_sk#24, ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28]
 
-(95) Filter [codegen id : 37]
+(91) Filter [codegen id : 35]
 Input [5]: [ss_sold_date_sk#24, ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28]
 Condition : (isnotnull(ss_item_sk#25) AND isnotnull(ss_sold_date_sk#24))
 
-(96) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#62, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66]
+(92) ReusedExchange [Reuses operator id: 8]
+Output [5]: [i_item_sk#61, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65]
 
-(97) BroadcastHashJoin [codegen id : 37]
+(93) BroadcastHashJoin [codegen id : 35]
 Left keys [1]: [ss_item_sk#25]
-Right keys [1]: [i_item_sk#62]
+Right keys [1]: [i_item_sk#61]
 Join condition: None
 
-(98) Project [codegen id : 37]
-Output [9]: [ss_sold_date_sk#24, ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66]
-Input [10]: [ss_sold_date_sk#24, ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_item_sk#62, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66]
+(94) Project [codegen id : 35]
+Output [9]: [ss_sold_date_sk#24, ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65]
+Input [10]: [ss_sold_date_sk#24, ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_item_sk#61, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65]
 
-(99) ReusedExchange [Reuses operator id: 84]
-Output [2]: [d_date_sk#67, d_year#68]
+(95) ReusedExchange [Reuses operator id: 80]
+Output [2]: [d_date_sk#66, d_year#67]
 
-(100) BroadcastHashJoin [codegen id : 37]
+(96) BroadcastHashJoin [codegen id : 35]
 Left keys [1]: [ss_sold_date_sk#24]
-Right keys [1]: [d_date_sk#67]
+Right keys [1]: [d_date_sk#66]
 Join condition: None
 
-(101) Project [codegen id : 37]
-Output [9]: [ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, d_year#68]
-Input [11]: [ss_sold_date_sk#24, ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, d_date_sk#67, d_year#68]
+(97) Project [codegen id : 35]
+Output [9]: [ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, d_year#67]
+Input [11]: [ss_sold_date_sk#24, ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, d_date_sk#66, d_year#67]
 
-(102) Exchange
-Input [9]: [ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, d_year#68]
-Arguments: hashpartitioning(cast(ss_ticket_number#26 as bigint), cast(ss_item_sk#25 as bigint), 5), true, [id=#71]
+(98) Exchange
+Input [9]: [ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, d_year#67]
+Arguments: hashpartitioning(cast(ss_ticket_number#26 as bigint), cast(ss_item_sk#25 as bigint), 5), ENSURE_REQUIREMENTS, [id=#70]
 
-(103) Sort [codegen id : 38]
-Input [9]: [ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, d_year#68]
+(99) Sort [codegen id : 36]
+Input [9]: [ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, d_year#67]
 Arguments: [cast(ss_ticket_number#26 as bigint) ASC NULLS FIRST, cast(ss_item_sk#25 as bigint) ASC NULLS FIRST], false, 0
 
-(104) ReusedExchange [Reuses operator id: 40]
+(100) ReusedExchange [Reuses operator id: 40]
 Output [4]: [sr_item_sk#30, sr_ticket_number#31, sr_return_quantity#32, sr_return_amt#33]
 
-(105) Sort [codegen id : 40]
+(101) Sort [codegen id : 38]
 Input [4]: [sr_item_sk#30, sr_ticket_number#31, sr_return_quantity#32, sr_return_amt#33]
 Arguments: [sr_ticket_number#31 ASC NULLS FIRST, sr_item_sk#30 ASC NULLS FIRST], false, 0
 
-(106) SortMergeJoin
+(102) SortMergeJoin
 Left keys [2]: [cast(ss_ticket_number#26 as bigint), cast(ss_item_sk#25 as bigint)]
 Right keys [2]: [sr_ticket_number#31, sr_item_sk#30]
 Join condition: None
 
-(107) Project [codegen id : 41]
-Output [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, (ss_quantity#27 - coalesce(sr_return_quantity#32, 0)) AS sales_cnt#72, CheckOverflow((promote_precision(cast(ss_ext_sales_price#28 as decimal(8,2))) - promote_precision(cast(coalesce(sr_return_amt#33, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#73]
-Input [13]: [ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, d_year#68, sr_item_sk#30, sr_ticket_number#31, sr_return_quantity#32, sr_return_amt#33]
+(103) Project [codegen id : 39]
+Output [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, (ss_quantity#27 - coalesce(sr_return_quantity#32, 0)) AS sales_cnt#71, CheckOverflow((promote_precision(cast(ss_ext_sales_price#28 as decimal(8,2))) - promote_precision(cast(coalesce(sr_return_amt#33, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#72]
+Input [13]: [ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, d_year#67, sr_item_sk#30, sr_ticket_number#31, sr_return_quantity#32, sr_return_amt#33]
 
-(108) Union
-
-(109) HashAggregate [codegen id : 42]
-Input [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23]
-Keys [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23]
-Functions: []
-Aggregate Attributes: []
-Results [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23]
-
-(110) Exchange
-Input [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23]
-Arguments: hashpartitioning(d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23, 5), true, [id=#74]
-
-(111) HashAggregate [codegen id : 43]
-Input [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23]
-Keys [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23]
-Functions: []
-Aggregate Attributes: []
-Results [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23]
-
-(112) Scan parquet default.web_sales
-Output [5]: [ws_sold_date_sk#38, ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42]
+(104) Scan parquet default.web_sales
+Output [5]: [ws_sold_date_sk#37, ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_sales]
 PushedFilters: [IsNotNull(ws_item_sk), IsNotNull(ws_sold_date_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_item_sk:int,ws_order_number:int,ws_quantity:int,ws_ext_sales_price:decimal(7,2)>
 
-(113) ColumnarToRow [codegen id : 46]
-Input [5]: [ws_sold_date_sk#38, ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42]
+(105) ColumnarToRow [codegen id : 42]
+Input [5]: [ws_sold_date_sk#37, ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41]
 
-(114) Filter [codegen id : 46]
-Input [5]: [ws_sold_date_sk#38, ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42]
-Condition : (isnotnull(ws_item_sk#39) AND isnotnull(ws_sold_date_sk#38))
+(106) Filter [codegen id : 42]
+Input [5]: [ws_sold_date_sk#37, ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41]
+Condition : (isnotnull(ws_item_sk#38) AND isnotnull(ws_sold_date_sk#37))
 
-(115) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#62, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66]
+(107) ReusedExchange [Reuses operator id: 8]
+Output [5]: [i_item_sk#61, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65]
 
-(116) BroadcastHashJoin [codegen id : 46]
-Left keys [1]: [ws_item_sk#39]
-Right keys [1]: [i_item_sk#62]
+(108) BroadcastHashJoin [codegen id : 42]
+Left keys [1]: [ws_item_sk#38]
+Right keys [1]: [i_item_sk#61]
 Join condition: None
 
-(117) Project [codegen id : 46]
-Output [9]: [ws_sold_date_sk#38, ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66]
-Input [10]: [ws_sold_date_sk#38, ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42, i_item_sk#62, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66]
+(109) Project [codegen id : 42]
+Output [9]: [ws_sold_date_sk#37, ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65]
+Input [10]: [ws_sold_date_sk#37, ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41, i_item_sk#61, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65]
 
-(118) ReusedExchange [Reuses operator id: 84]
-Output [2]: [d_date_sk#67, d_year#68]
+(110) ReusedExchange [Reuses operator id: 80]
+Output [2]: [d_date_sk#66, d_year#67]
 
-(119) BroadcastHashJoin [codegen id : 46]
-Left keys [1]: [ws_sold_date_sk#38]
-Right keys [1]: [d_date_sk#67]
+(111) BroadcastHashJoin [codegen id : 42]
+Left keys [1]: [ws_sold_date_sk#37]
+Right keys [1]: [d_date_sk#66]
 Join condition: None
 
-(120) Project [codegen id : 46]
-Output [9]: [ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, d_year#68]
-Input [11]: [ws_sold_date_sk#38, ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, d_date_sk#67, d_year#68]
+(112) Project [codegen id : 42]
+Output [9]: [ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, d_year#67]
+Input [11]: [ws_sold_date_sk#37, ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, d_date_sk#66, d_year#67]
+
+(113) Exchange
+Input [9]: [ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, d_year#67]
+Arguments: hashpartitioning(cast(ws_order_number#39 as bigint), cast(ws_item_sk#38 as bigint), 5), ENSURE_REQUIREMENTS, [id=#73]
+
+(114) Sort [codegen id : 43]
+Input [9]: [ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, d_year#67]
+Arguments: [cast(ws_order_number#39 as bigint) ASC NULLS FIRST, cast(ws_item_sk#38 as bigint) ASC NULLS FIRST], false, 0
+
+(115) ReusedExchange [Reuses operator id: 58]
+Output [4]: [wr_item_sk#43, wr_order_number#44, wr_return_quantity#45, wr_return_amt#46]
+
+(116) Sort [codegen id : 45]
+Input [4]: [wr_item_sk#43, wr_order_number#44, wr_return_quantity#45, wr_return_amt#46]
+Arguments: [wr_order_number#44 ASC NULLS FIRST, wr_item_sk#43 ASC NULLS FIRST], false, 0
+
+(117) SortMergeJoin
+Left keys [2]: [cast(ws_order_number#39 as bigint), cast(ws_item_sk#38 as bigint)]
+Right keys [2]: [wr_order_number#44, wr_item_sk#43]
+Join condition: None
+
+(118) Project [codegen id : 46]
+Output [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, (ws_quantity#40 - coalesce(wr_return_quantity#45, 0)) AS sales_cnt#74, CheckOverflow((promote_precision(cast(ws_ext_sales_price#41 as decimal(8,2))) - promote_precision(cast(coalesce(wr_return_amt#46, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#75]
+Input [13]: [ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, d_year#67, wr_item_sk#43, wr_order_number#44, wr_return_quantity#45, wr_return_amt#46]
+
+(119) Union
+
+(120) HashAggregate [codegen id : 47]
+Input [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sales_cnt#22, sales_amt#23]
+Keys [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sales_cnt#22, sales_amt#23]
+Functions: []
+Aggregate Attributes: []
+Results [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sales_cnt#22, sales_amt#23]
 
 (121) Exchange
-Input [9]: [ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, d_year#68]
-Arguments: hashpartitioning(cast(ws_order_number#40 as bigint), cast(ws_item_sk#39 as bigint), 5), true, [id=#75]
+Input [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sales_cnt#22, sales_amt#23]
+Arguments: hashpartitioning(d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sales_cnt#22, sales_amt#23, 5), ENSURE_REQUIREMENTS, [id=#76]
 
-(122) Sort [codegen id : 47]
-Input [9]: [ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, d_year#68]
-Arguments: [cast(ws_order_number#40 as bigint) ASC NULLS FIRST, cast(ws_item_sk#39 as bigint) ASC NULLS FIRST], false, 0
-
-(123) ReusedExchange [Reuses operator id: 62]
-Output [4]: [wr_item_sk#44, wr_order_number#45, wr_return_quantity#46, wr_return_amt#47]
-
-(124) Sort [codegen id : 49]
-Input [4]: [wr_item_sk#44, wr_order_number#45, wr_return_quantity#46, wr_return_amt#47]
-Arguments: [wr_order_number#45 ASC NULLS FIRST, wr_item_sk#44 ASC NULLS FIRST], false, 0
-
-(125) SortMergeJoin
-Left keys [2]: [cast(ws_order_number#40 as bigint), cast(ws_item_sk#39 as bigint)]
-Right keys [2]: [wr_order_number#45, wr_item_sk#44]
-Join condition: None
-
-(126) Project [codegen id : 50]
-Output [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, (ws_quantity#41 - coalesce(wr_return_quantity#46, 0)) AS sales_cnt#76, CheckOverflow((promote_precision(cast(ws_ext_sales_price#42 as decimal(8,2))) - promote_precision(cast(coalesce(wr_return_amt#47, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#77]
-Input [13]: [ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, d_year#68, wr_item_sk#44, wr_order_number#45, wr_return_quantity#46, wr_return_amt#47]
-
-(127) Union
-
-(128) HashAggregate [codegen id : 51]
-Input [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23]
-Keys [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23]
+(122) HashAggregate [codegen id : 48]
+Input [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sales_cnt#22, sales_amt#23]
+Keys [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sales_cnt#22, sales_amt#23]
 Functions: []
 Aggregate Attributes: []
-Results [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23]
+Results [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sales_cnt#22, sales_amt#23]
 
-(129) Exchange
-Input [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23]
-Arguments: hashpartitioning(d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23, 5), true, [id=#78]
-
-(130) HashAggregate [codegen id : 52]
-Input [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23]
-Keys [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23]
-Functions: []
-Aggregate Attributes: []
-Results [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23]
-
-(131) HashAggregate [codegen id : 52]
-Input [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23]
-Keys [5]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66]
+(123) HashAggregate [codegen id : 48]
+Input [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sales_cnt#22, sales_amt#23]
+Keys [5]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65]
 Functions [2]: [partial_sum(cast(sales_cnt#22 as bigint)), partial_sum(UnscaledValue(sales_amt#23))]
-Aggregate Attributes [2]: [sum#79, sum#80]
-Results [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sum#81, sum#82]
+Aggregate Attributes [2]: [sum#77, sum#78]
+Results [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sum#79, sum#80]
 
-(132) Exchange
-Input [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sum#81, sum#82]
-Arguments: hashpartitioning(d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, 5), true, [id=#83]
+(124) Exchange
+Input [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sum#79, sum#80]
+Arguments: hashpartitioning(d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, 5), ENSURE_REQUIREMENTS, [id=#81]
 
-(133) HashAggregate [codegen id : 53]
-Input [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sum#81, sum#82]
-Keys [5]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66]
+(125) HashAggregate [codegen id : 49]
+Input [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sum#79, sum#80]
+Keys [5]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65]
 Functions [2]: [sum(cast(sales_cnt#22 as bigint)), sum(UnscaledValue(sales_amt#23))]
-Aggregate Attributes [2]: [sum(cast(sales_cnt#22 as bigint))#84, sum(UnscaledValue(sales_amt#23))#85]
-Results [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sum(cast(sales_cnt#22 as bigint))#84 AS sales_cnt#86, MakeDecimal(sum(UnscaledValue(sales_amt#23))#85,18,2) AS sales_amt#87]
+Aggregate Attributes [2]: [sum(cast(sales_cnt#22 as bigint))#82, sum(UnscaledValue(sales_amt#23))#83]
+Results [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sum(cast(sales_cnt#22 as bigint))#82 AS sales_cnt#84, MakeDecimal(sum(UnscaledValue(sales_amt#23))#83,18,2) AS sales_amt#85]
 
-(134) Exchange
-Input [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#86, sales_amt#87]
-Arguments: hashpartitioning(i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, 5), true, [id=#88]
+(126) Exchange
+Input [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sales_cnt#84, sales_amt#85]
+Arguments: hashpartitioning(i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, 5), ENSURE_REQUIREMENTS, [id=#86]
 
-(135) Sort [codegen id : 54]
-Input [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#86, sales_amt#87]
-Arguments: [i_brand_id#63 ASC NULLS FIRST, i_class_id#64 ASC NULLS FIRST, i_category_id#65 ASC NULLS FIRST, i_manufact_id#66 ASC NULLS FIRST], false, 0
+(127) Sort [codegen id : 50]
+Input [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sales_cnt#84, sales_amt#85]
+Arguments: [i_brand_id#62 ASC NULLS FIRST, i_class_id#63 ASC NULLS FIRST, i_category_id#64 ASC NULLS FIRST, i_manufact_id#65 ASC NULLS FIRST], false, 0
 
-(136) SortMergeJoin [codegen id : 55]
+(128) SortMergeJoin [codegen id : 51]
 Left keys [4]: [i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
-Right keys [4]: [i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66]
-Join condition: (CheckOverflow((promote_precision(cast(sales_cnt#59 as decimal(17,2))) / promote_precision(cast(sales_cnt#86 as decimal(17,2)))), DecimalType(37,20), true) < 0.90000000000000000000)
+Right keys [4]: [i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65]
+Join condition: (CheckOverflow((promote_precision(cast(sales_cnt#58 as decimal(17,2))) / promote_precision(cast(sales_cnt#84 as decimal(17,2)))), DecimalType(37,20), true) < 0.90000000000000000000)
 
-(137) Project [codegen id : 55]
-Output [10]: [d_year#68 AS prev_year#89, d_year#14 AS year#90, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#86 AS prev_yr_cnt#91, sales_cnt#59 AS curr_yr_cnt#92, (sales_cnt#59 - sales_cnt#86) AS sales_cnt_diff#93, CheckOverflow((promote_precision(cast(sales_amt#60 as decimal(19,2))) - promote_precision(cast(sales_amt#87 as decimal(19,2)))), DecimalType(19,2), true) AS sales_amt_diff#94]
-Input [14]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#59, sales_amt#60, d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#86, sales_amt#87]
+(129) Project [codegen id : 51]
+Output [10]: [d_year#67 AS prev_year#87, d_year#14 AS year#88, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#84 AS prev_yr_cnt#89, sales_cnt#58 AS curr_yr_cnt#90, (sales_cnt#58 - sales_cnt#84) AS sales_cnt_diff#91, CheckOverflow((promote_precision(cast(sales_amt#59 as decimal(19,2))) - promote_precision(cast(sales_amt#85 as decimal(19,2)))), DecimalType(19,2), true) AS sales_amt_diff#92]
+Input [14]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#58, sales_amt#59, d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sales_cnt#84, sales_amt#85]
 
-(138) TakeOrderedAndProject
-Input [10]: [prev_year#89, year#90, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, prev_yr_cnt#91, curr_yr_cnt#92, sales_cnt_diff#93, sales_amt_diff#94]
-Arguments: 100, [sales_cnt_diff#93 ASC NULLS FIRST], [prev_year#89, year#90, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, prev_yr_cnt#91, curr_yr_cnt#92, sales_cnt_diff#93, sales_amt_diff#94]
+(130) TakeOrderedAndProject
+Input [10]: [prev_year#87, year#88, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, prev_yr_cnt#89, curr_yr_cnt#90, sales_cnt_diff#91, sales_amt_diff#92]
+Arguments: 100, [sales_cnt_diff#91 ASC NULLS FIRST], [prev_year#87, year#88, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, prev_yr_cnt#89, curr_yr_cnt#90, sales_cnt_diff#91, sales_amt_diff#92]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q75.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q75.sf100/simplified.txt
@@ -1,113 +1,105 @@
 TakeOrderedAndProject [sales_cnt_diff,prev_year,year,i_brand_id,i_class_id,i_category_id,i_manufact_id,prev_yr_cnt,curr_yr_cnt,sales_amt_diff]
-  WholeStageCodegen (55)
+  WholeStageCodegen (51)
     Project [d_year,d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_cnt,sales_amt,sales_amt]
       SortMergeJoin [i_brand_id,i_class_id,i_category_id,i_manufact_id,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_cnt]
         InputAdapter
-          WholeStageCodegen (27)
+          WholeStageCodegen (25)
             Sort [i_brand_id,i_class_id,i_category_id,i_manufact_id]
               InputAdapter
                 Exchange [i_brand_id,i_class_id,i_category_id,i_manufact_id] #1
-                  WholeStageCodegen (26)
+                  WholeStageCodegen (24)
                     HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sum,sum] [sum(cast(sales_cnt as bigint)),sum(UnscaledValue(sales_amt)),sales_cnt,sales_amt,sum,sum]
                       InputAdapter
                         Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id] #2
-                          WholeStageCodegen (25)
+                          WholeStageCodegen (23)
                             HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] [sum,sum,sum,sum]
                               HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
                                 InputAdapter
                                   Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #3
-                                    WholeStageCodegen (24)
+                                    WholeStageCodegen (22)
                                       HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
                                         InputAdapter
                                           Union
-                                            WholeStageCodegen (16)
-                                              HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
+                                            WholeStageCodegen (7)
+                                              Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,cs_quantity,cr_return_quantity,cs_ext_sales_price,cr_return_amount]
                                                 InputAdapter
-                                                  Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #4
-                                                    WholeStageCodegen (15)
-                                                      HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
+                                                  SortMergeJoin [cs_order_number,cs_item_sk,cr_order_number,cr_item_sk]
+                                                    WholeStageCodegen (4)
+                                                      Sort [cs_order_number,cs_item_sk]
                                                         InputAdapter
-                                                          Union
-                                                            WholeStageCodegen (7)
-                                                              Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,cs_quantity,cr_return_quantity,cs_ext_sales_price,cr_return_amount]
-                                                                InputAdapter
-                                                                  SortMergeJoin [cs_order_number,cs_item_sk,cr_order_number,cr_item_sk]
-                                                                    WholeStageCodegen (4)
-                                                                      Sort [cs_order_number,cs_item_sk]
-                                                                        InputAdapter
-                                                                          Exchange [cs_order_number,cs_item_sk] #5
-                                                                            WholeStageCodegen (3)
-                                                                              Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                                                BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                                  Project [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                                    BroadcastHashJoin [cs_item_sk,i_item_sk]
-                                                                                      Filter [cs_item_sk,cs_sold_date_sk]
-                                                                                        ColumnarToRow
-                                                                                          InputAdapter
-                                                                                            Scan parquet default.catalog_sales [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price]
-                                                                                      InputAdapter
-                                                                                        BroadcastExchange #6
-                                                                                          WholeStageCodegen (1)
-                                                                                            Project [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                                              Filter [i_category,i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                                                ColumnarToRow
-                                                                                                  InputAdapter
-                                                                                                    Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id,i_category,i_manufact_id]
-                                                                                  InputAdapter
-                                                                                    BroadcastExchange #7
-                                                                                      WholeStageCodegen (2)
-                                                                                        Filter [d_year,d_date_sk]
-                                                                                          ColumnarToRow
-                                                                                            InputAdapter
-                                                                                              Scan parquet default.date_dim [d_date_sk,d_year]
-                                                                    WholeStageCodegen (6)
-                                                                      Sort [cr_order_number,cr_item_sk]
-                                                                        InputAdapter
-                                                                          Exchange [cr_order_number,cr_item_sk] #8
-                                                                            WholeStageCodegen (5)
-                                                                              Filter [cr_order_number,cr_item_sk]
+                                                          Exchange [cs_order_number,cs_item_sk] #4
+                                                            WholeStageCodegen (3)
+                                                              Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
+                                                                BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                                  Project [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                                    BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                                      Filter [cs_item_sk,cs_sold_date_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet default.catalog_sales [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price]
+                                                                      InputAdapter
+                                                                        BroadcastExchange #5
+                                                                          WholeStageCodegen (1)
+                                                                            Project [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                                              Filter [i_category,i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
                                                                                 ColumnarToRow
                                                                                   InputAdapter
-                                                                                    Scan parquet default.catalog_returns [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount]
-                                                            WholeStageCodegen (14)
-                                                              Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ss_quantity,sr_return_quantity,ss_ext_sales_price,sr_return_amt]
-                                                                InputAdapter
-                                                                  SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
-                                                                    WholeStageCodegen (11)
-                                                                      Sort [ss_ticket_number,ss_item_sk]
-                                                                        InputAdapter
-                                                                          Exchange [ss_ticket_number,ss_item_sk] #9
-                                                                            WholeStageCodegen (10)
-                                                                              Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                                                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                                  Project [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                                    BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                                                      Filter [ss_item_sk,ss_sold_date_sk]
-                                                                                        ColumnarToRow
-                                                                                          InputAdapter
-                                                                                            Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price]
-                                                                                      InputAdapter
-                                                                                        ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
-                                                                                  InputAdapter
-                                                                                    ReusedExchange [d_date_sk,d_year] #7
-                                                                    WholeStageCodegen (13)
-                                                                      Sort [sr_ticket_number,sr_item_sk]
-                                                                        InputAdapter
-                                                                          Exchange [sr_ticket_number,sr_item_sk] #10
-                                                                            WholeStageCodegen (12)
-                                                                              Filter [sr_ticket_number,sr_item_sk]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet default.store_returns [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt]
-                                            WholeStageCodegen (23)
+                                                                                    Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id,i_category,i_manufact_id]
+                                                                  InputAdapter
+                                                                    BroadcastExchange #6
+                                                                      WholeStageCodegen (2)
+                                                                        Filter [d_year,d_date_sk]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet default.date_dim [d_date_sk,d_year]
+                                                    WholeStageCodegen (6)
+                                                      Sort [cr_order_number,cr_item_sk]
+                                                        InputAdapter
+                                                          Exchange [cr_order_number,cr_item_sk] #7
+                                                            WholeStageCodegen (5)
+                                                              Filter [cr_order_number,cr_item_sk]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet default.catalog_returns [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount]
+                                            WholeStageCodegen (14)
+                                              Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ss_quantity,sr_return_quantity,ss_ext_sales_price,sr_return_amt]
+                                                InputAdapter
+                                                  SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
+                                                    WholeStageCodegen (11)
+                                                      Sort [ss_ticket_number,ss_item_sk]
+                                                        InputAdapter
+                                                          Exchange [ss_ticket_number,ss_item_sk] #8
+                                                            WholeStageCodegen (10)
+                                                              Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
+                                                                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                                  Project [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                                    BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                                      Filter [ss_item_sk,ss_sold_date_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price]
+                                                                      InputAdapter
+                                                                        ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #5
+                                                                  InputAdapter
+                                                                    ReusedExchange [d_date_sk,d_year] #6
+                                                    WholeStageCodegen (13)
+                                                      Sort [sr_ticket_number,sr_item_sk]
+                                                        InputAdapter
+                                                          Exchange [sr_ticket_number,sr_item_sk] #9
+                                                            WholeStageCodegen (12)
+                                                              Filter [sr_ticket_number,sr_item_sk]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet default.store_returns [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt]
+                                            WholeStageCodegen (21)
                                               Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ws_quantity,wr_return_quantity,ws_ext_sales_price,wr_return_amt]
                                                 InputAdapter
                                                   SortMergeJoin [ws_order_number,ws_item_sk,wr_order_number,wr_item_sk]
-                                                    WholeStageCodegen (20)
+                                                    WholeStageCodegen (18)
                                                       Sort [ws_order_number,ws_item_sk]
                                                         InputAdapter
-                                                          Exchange [ws_order_number,ws_item_sk] #11
-                                                            WholeStageCodegen (19)
+                                                          Exchange [ws_order_number,ws_item_sk] #10
+                                                            WholeStageCodegen (17)
                                                               Project [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
                                                                 BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                                   Project [ws_sold_date_sk,ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
@@ -117,108 +109,100 @@ TakeOrderedAndProject [sales_cnt_diff,prev_year,year,i_brand_id,i_class_id,i_cat
                                                                           InputAdapter
                                                                             Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price]
                                                                       InputAdapter
-                                                                        ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
+                                                                        ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #5
                                                                   InputAdapter
-                                                                    ReusedExchange [d_date_sk,d_year] #7
-                                                    WholeStageCodegen (22)
+                                                                    ReusedExchange [d_date_sk,d_year] #6
+                                                    WholeStageCodegen (20)
                                                       Sort [wr_order_number,wr_item_sk]
                                                         InputAdapter
-                                                          Exchange [wr_order_number,wr_item_sk] #12
-                                                            WholeStageCodegen (21)
+                                                          Exchange [wr_order_number,wr_item_sk] #11
+                                                            WholeStageCodegen (19)
                                                               Filter [wr_order_number,wr_item_sk]
                                                                 ColumnarToRow
                                                                   InputAdapter
                                                                     Scan parquet default.web_returns [wr_item_sk,wr_order_number,wr_return_quantity,wr_return_amt]
         InputAdapter
-          WholeStageCodegen (54)
+          WholeStageCodegen (50)
             Sort [i_brand_id,i_class_id,i_category_id,i_manufact_id]
               InputAdapter
-                Exchange [i_brand_id,i_class_id,i_category_id,i_manufact_id] #13
-                  WholeStageCodegen (53)
+                Exchange [i_brand_id,i_class_id,i_category_id,i_manufact_id] #12
+                  WholeStageCodegen (49)
                     HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sum,sum] [sum(cast(sales_cnt as bigint)),sum(UnscaledValue(sales_amt)),sales_cnt,sales_amt,sum,sum]
                       InputAdapter
-                        Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id] #14
-                          WholeStageCodegen (52)
+                        Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id] #13
+                          WholeStageCodegen (48)
                             HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] [sum,sum,sum,sum]
                               HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
                                 InputAdapter
-                                  Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #15
-                                    WholeStageCodegen (51)
+                                  Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #14
+                                    WholeStageCodegen (47)
                                       HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
                                         InputAdapter
                                           Union
-                                            WholeStageCodegen (43)
-                                              HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
+                                            WholeStageCodegen (32)
+                                              Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,cs_quantity,cr_return_quantity,cs_ext_sales_price,cr_return_amount]
                                                 InputAdapter
-                                                  Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #16
-                                                    WholeStageCodegen (42)
-                                                      HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
+                                                  SortMergeJoin [cs_order_number,cs_item_sk,cr_order_number,cr_item_sk]
+                                                    WholeStageCodegen (29)
+                                                      Sort [cs_order_number,cs_item_sk]
                                                         InputAdapter
-                                                          Union
-                                                            WholeStageCodegen (34)
-                                                              Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,cs_quantity,cr_return_quantity,cs_ext_sales_price,cr_return_amount]
-                                                                InputAdapter
-                                                                  SortMergeJoin [cs_order_number,cs_item_sk,cr_order_number,cr_item_sk]
-                                                                    WholeStageCodegen (31)
-                                                                      Sort [cs_order_number,cs_item_sk]
-                                                                        InputAdapter
-                                                                          Exchange [cs_order_number,cs_item_sk] #17
-                                                                            WholeStageCodegen (30)
-                                                                              Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                                                BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                                  Project [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                                    BroadcastHashJoin [cs_item_sk,i_item_sk]
-                                                                                      Filter [cs_item_sk,cs_sold_date_sk]
-                                                                                        ColumnarToRow
-                                                                                          InputAdapter
-                                                                                            Scan parquet default.catalog_sales [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price]
-                                                                                      InputAdapter
-                                                                                        ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
-                                                                                  InputAdapter
-                                                                                    BroadcastExchange #18
-                                                                                      WholeStageCodegen (29)
-                                                                                        Filter [d_year,d_date_sk]
-                                                                                          ColumnarToRow
-                                                                                            InputAdapter
-                                                                                              Scan parquet default.date_dim [d_date_sk,d_year]
-                                                                    WholeStageCodegen (33)
-                                                                      Sort [cr_order_number,cr_item_sk]
-                                                                        InputAdapter
-                                                                          ReusedExchange [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount] #8
-                                                            WholeStageCodegen (41)
-                                                              Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ss_quantity,sr_return_quantity,ss_ext_sales_price,sr_return_amt]
-                                                                InputAdapter
-                                                                  SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
-                                                                    WholeStageCodegen (38)
-                                                                      Sort [ss_ticket_number,ss_item_sk]
-                                                                        InputAdapter
-                                                                          Exchange [ss_ticket_number,ss_item_sk] #19
-                                                                            WholeStageCodegen (37)
-                                                                              Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                                                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                                  Project [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                                    BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                                                      Filter [ss_item_sk,ss_sold_date_sk]
-                                                                                        ColumnarToRow
-                                                                                          InputAdapter
-                                                                                            Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price]
-                                                                                      InputAdapter
-                                                                                        ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
-                                                                                  InputAdapter
-                                                                                    ReusedExchange [d_date_sk,d_year] #18
-                                                                    WholeStageCodegen (40)
-                                                                      Sort [sr_ticket_number,sr_item_sk]
-                                                                        InputAdapter
-                                                                          ReusedExchange [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt] #10
-                                            WholeStageCodegen (50)
+                                                          Exchange [cs_order_number,cs_item_sk] #15
+                                                            WholeStageCodegen (28)
+                                                              Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
+                                                                BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                                  Project [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                                    BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                                      Filter [cs_item_sk,cs_sold_date_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet default.catalog_sales [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price]
+                                                                      InputAdapter
+                                                                        ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #5
+                                                                  InputAdapter
+                                                                    BroadcastExchange #16
+                                                                      WholeStageCodegen (27)
+                                                                        Filter [d_year,d_date_sk]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet default.date_dim [d_date_sk,d_year]
+                                                    WholeStageCodegen (31)
+                                                      Sort [cr_order_number,cr_item_sk]
+                                                        InputAdapter
+                                                          ReusedExchange [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount] #7
+                                            WholeStageCodegen (39)
+                                              Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ss_quantity,sr_return_quantity,ss_ext_sales_price,sr_return_amt]
+                                                InputAdapter
+                                                  SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
+                                                    WholeStageCodegen (36)
+                                                      Sort [ss_ticket_number,ss_item_sk]
+                                                        InputAdapter
+                                                          Exchange [ss_ticket_number,ss_item_sk] #17
+                                                            WholeStageCodegen (35)
+                                                              Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
+                                                                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                                  Project [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                                    BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                                      Filter [ss_item_sk,ss_sold_date_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price]
+                                                                      InputAdapter
+                                                                        ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #5
+                                                                  InputAdapter
+                                                                    ReusedExchange [d_date_sk,d_year] #16
+                                                    WholeStageCodegen (38)
+                                                      Sort [sr_ticket_number,sr_item_sk]
+                                                        InputAdapter
+                                                          ReusedExchange [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt] #9
+                                            WholeStageCodegen (46)
                                               Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ws_quantity,wr_return_quantity,ws_ext_sales_price,wr_return_amt]
                                                 InputAdapter
                                                   SortMergeJoin [ws_order_number,ws_item_sk,wr_order_number,wr_item_sk]
-                                                    WholeStageCodegen (47)
+                                                    WholeStageCodegen (43)
                                                       Sort [ws_order_number,ws_item_sk]
                                                         InputAdapter
-                                                          Exchange [ws_order_number,ws_item_sk] #20
-                                                            WholeStageCodegen (46)
+                                                          Exchange [ws_order_number,ws_item_sk] #18
+                                                            WholeStageCodegen (42)
                                                               Project [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
                                                                 BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                                   Project [ws_sold_date_sk,ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
@@ -228,10 +212,10 @@ TakeOrderedAndProject [sales_cnt_diff,prev_year,year,i_brand_id,i_class_id,i_cat
                                                                           InputAdapter
                                                                             Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price]
                                                                       InputAdapter
-                                                                        ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
+                                                                        ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #5
                                                                   InputAdapter
-                                                                    ReusedExchange [d_date_sk,d_year] #18
-                                                    WholeStageCodegen (49)
+                                                                    ReusedExchange [d_date_sk,d_year] #16
+                                                    WholeStageCodegen (45)
                                                       Sort [wr_order_number,wr_item_sk]
                                                         InputAdapter
-                                                          ReusedExchange [wr_item_sk,wr_order_number,wr_return_quantity,wr_return_amt] #12
+                                                          ReusedExchange [wr_item_sk,wr_order_number,wr_return_quantity,wr_return_amt] #11

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q75/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q75/explain.txt
@@ -1,121 +1,113 @@
 == Physical Plan ==
-TakeOrderedAndProject (117)
-+- * Project (116)
-   +- * BroadcastHashJoin Inner BuildRight (115)
-      :- * HashAggregate (63)
-      :  +- Exchange (62)
-      :     +- * HashAggregate (61)
-      :        +- * HashAggregate (60)
-      :           +- Exchange (59)
-      :              +- * HashAggregate (58)
-      :                 +- Union (57)
-      :                    :- * HashAggregate (41)
-      :                    :  +- Exchange (40)
-      :                    :     +- * HashAggregate (39)
-      :                    :        +- Union (38)
-      :                    :           :- * Project (22)
-      :                    :           :  +- * BroadcastHashJoin LeftOuter BuildRight (21)
-      :                    :           :     :- * Project (16)
-      :                    :           :     :  +- * BroadcastHashJoin Inner BuildRight (15)
-      :                    :           :     :     :- * Project (10)
-      :                    :           :     :     :  +- * BroadcastHashJoin Inner BuildRight (9)
-      :                    :           :     :     :     :- * Filter (3)
-      :                    :           :     :     :     :  +- * ColumnarToRow (2)
-      :                    :           :     :     :     :     +- Scan parquet default.catalog_sales (1)
-      :                    :           :     :     :     +- BroadcastExchange (8)
-      :                    :           :     :     :        +- * Project (7)
-      :                    :           :     :     :           +- * Filter (6)
-      :                    :           :     :     :              +- * ColumnarToRow (5)
-      :                    :           :     :     :                 +- Scan parquet default.item (4)
-      :                    :           :     :     +- BroadcastExchange (14)
-      :                    :           :     :        +- * Filter (13)
-      :                    :           :     :           +- * ColumnarToRow (12)
-      :                    :           :     :              +- Scan parquet default.date_dim (11)
-      :                    :           :     +- BroadcastExchange (20)
-      :                    :           :        +- * Filter (19)
-      :                    :           :           +- * ColumnarToRow (18)
-      :                    :           :              +- Scan parquet default.catalog_returns (17)
-      :                    :           +- * Project (37)
-      :                    :              +- * BroadcastHashJoin LeftOuter BuildRight (36)
-      :                    :                 :- * Project (31)
-      :                    :                 :  +- * BroadcastHashJoin Inner BuildRight (30)
-      :                    :                 :     :- * Project (28)
-      :                    :                 :     :  +- * BroadcastHashJoin Inner BuildRight (27)
-      :                    :                 :     :     :- * Filter (25)
-      :                    :                 :     :     :  +- * ColumnarToRow (24)
-      :                    :                 :     :     :     +- Scan parquet default.store_sales (23)
-      :                    :                 :     :     +- ReusedExchange (26)
-      :                    :                 :     +- ReusedExchange (29)
-      :                    :                 +- BroadcastExchange (35)
-      :                    :                    +- * Filter (34)
-      :                    :                       +- * ColumnarToRow (33)
-      :                    :                          +- Scan parquet default.store_returns (32)
-      :                    +- * Project (56)
-      :                       +- * BroadcastHashJoin LeftOuter BuildRight (55)
-      :                          :- * Project (50)
-      :                          :  +- * BroadcastHashJoin Inner BuildRight (49)
-      :                          :     :- * Project (47)
-      :                          :     :  +- * BroadcastHashJoin Inner BuildRight (46)
-      :                          :     :     :- * Filter (44)
-      :                          :     :     :  +- * ColumnarToRow (43)
-      :                          :     :     :     +- Scan parquet default.web_sales (42)
-      :                          :     :     +- ReusedExchange (45)
-      :                          :     +- ReusedExchange (48)
-      :                          +- BroadcastExchange (54)
-      :                             +- * Filter (53)
-      :                                +- * ColumnarToRow (52)
-      :                                   +- Scan parquet default.web_returns (51)
-      +- BroadcastExchange (114)
-         +- * HashAggregate (113)
-            +- Exchange (112)
-               +- * HashAggregate (111)
-                  +- * HashAggregate (110)
-                     +- Exchange (109)
-                        +- * HashAggregate (108)
-                           +- Union (107)
-                              :- * HashAggregate (94)
-                              :  +- Exchange (93)
-                              :     +- * HashAggregate (92)
-                              :        +- Union (91)
-                              :           :- * Project (78)
-                              :           :  +- * BroadcastHashJoin LeftOuter BuildRight (77)
-                              :           :     :- * Project (75)
-                              :           :     :  +- * BroadcastHashJoin Inner BuildRight (74)
-                              :           :     :     :- * Project (69)
-                              :           :     :     :  +- * BroadcastHashJoin Inner BuildRight (68)
-                              :           :     :     :     :- * Filter (66)
-                              :           :     :     :     :  +- * ColumnarToRow (65)
-                              :           :     :     :     :     +- Scan parquet default.catalog_sales (64)
-                              :           :     :     :     +- ReusedExchange (67)
-                              :           :     :     +- BroadcastExchange (73)
-                              :           :     :        +- * Filter (72)
-                              :           :     :           +- * ColumnarToRow (71)
-                              :           :     :              +- Scan parquet default.date_dim (70)
-                              :           :     +- ReusedExchange (76)
-                              :           +- * Project (90)
-                              :              +- * BroadcastHashJoin LeftOuter BuildRight (89)
-                              :                 :- * Project (87)
-                              :                 :  +- * BroadcastHashJoin Inner BuildRight (86)
-                              :                 :     :- * Project (84)
-                              :                 :     :  +- * BroadcastHashJoin Inner BuildRight (83)
-                              :                 :     :     :- * Filter (81)
-                              :                 :     :     :  +- * ColumnarToRow (80)
-                              :                 :     :     :     +- Scan parquet default.store_sales (79)
-                              :                 :     :     +- ReusedExchange (82)
-                              :                 :     +- ReusedExchange (85)
-                              :                 +- ReusedExchange (88)
-                              +- * Project (106)
-                                 +- * BroadcastHashJoin LeftOuter BuildRight (105)
-                                    :- * Project (103)
-                                    :  +- * BroadcastHashJoin Inner BuildRight (102)
-                                    :     :- * Project (100)
-                                    :     :  +- * BroadcastHashJoin Inner BuildRight (99)
-                                    :     :     :- * Filter (97)
-                                    :     :     :  +- * ColumnarToRow (96)
-                                    :     :     :     +- Scan parquet default.web_sales (95)
-                                    :     :     +- ReusedExchange (98)
-                                    :     +- ReusedExchange (101)
-                                    +- ReusedExchange (104)
+TakeOrderedAndProject (109)
++- * Project (108)
+   +- * BroadcastHashJoin Inner BuildRight (107)
+      :- * HashAggregate (59)
+      :  +- Exchange (58)
+      :     +- * HashAggregate (57)
+      :        +- * HashAggregate (56)
+      :           +- Exchange (55)
+      :              +- * HashAggregate (54)
+      :                 +- Union (53)
+      :                    :- * Project (22)
+      :                    :  +- * BroadcastHashJoin LeftOuter BuildRight (21)
+      :                    :     :- * Project (16)
+      :                    :     :  +- * BroadcastHashJoin Inner BuildRight (15)
+      :                    :     :     :- * Project (10)
+      :                    :     :     :  +- * BroadcastHashJoin Inner BuildRight (9)
+      :                    :     :     :     :- * Filter (3)
+      :                    :     :     :     :  +- * ColumnarToRow (2)
+      :                    :     :     :     :     +- Scan parquet default.catalog_sales (1)
+      :                    :     :     :     +- BroadcastExchange (8)
+      :                    :     :     :        +- * Project (7)
+      :                    :     :     :           +- * Filter (6)
+      :                    :     :     :              +- * ColumnarToRow (5)
+      :                    :     :     :                 +- Scan parquet default.item (4)
+      :                    :     :     +- BroadcastExchange (14)
+      :                    :     :        +- * Filter (13)
+      :                    :     :           +- * ColumnarToRow (12)
+      :                    :     :              +- Scan parquet default.date_dim (11)
+      :                    :     +- BroadcastExchange (20)
+      :                    :        +- * Filter (19)
+      :                    :           +- * ColumnarToRow (18)
+      :                    :              +- Scan parquet default.catalog_returns (17)
+      :                    :- * Project (37)
+      :                    :  +- * BroadcastHashJoin LeftOuter BuildRight (36)
+      :                    :     :- * Project (31)
+      :                    :     :  +- * BroadcastHashJoin Inner BuildRight (30)
+      :                    :     :     :- * Project (28)
+      :                    :     :     :  +- * BroadcastHashJoin Inner BuildRight (27)
+      :                    :     :     :     :- * Filter (25)
+      :                    :     :     :     :  +- * ColumnarToRow (24)
+      :                    :     :     :     :     +- Scan parquet default.store_sales (23)
+      :                    :     :     :     +- ReusedExchange (26)
+      :                    :     :     +- ReusedExchange (29)
+      :                    :     +- BroadcastExchange (35)
+      :                    :        +- * Filter (34)
+      :                    :           +- * ColumnarToRow (33)
+      :                    :              +- Scan parquet default.store_returns (32)
+      :                    +- * Project (52)
+      :                       +- * BroadcastHashJoin LeftOuter BuildRight (51)
+      :                          :- * Project (46)
+      :                          :  +- * BroadcastHashJoin Inner BuildRight (45)
+      :                          :     :- * Project (43)
+      :                          :     :  +- * BroadcastHashJoin Inner BuildRight (42)
+      :                          :     :     :- * Filter (40)
+      :                          :     :     :  +- * ColumnarToRow (39)
+      :                          :     :     :     +- Scan parquet default.web_sales (38)
+      :                          :     :     +- ReusedExchange (41)
+      :                          :     +- ReusedExchange (44)
+      :                          +- BroadcastExchange (50)
+      :                             +- * Filter (49)
+      :                                +- * ColumnarToRow (48)
+      :                                   +- Scan parquet default.web_returns (47)
+      +- BroadcastExchange (106)
+         +- * HashAggregate (105)
+            +- Exchange (104)
+               +- * HashAggregate (103)
+                  +- * HashAggregate (102)
+                     +- Exchange (101)
+                        +- * HashAggregate (100)
+                           +- Union (99)
+                              :- * Project (74)
+                              :  +- * BroadcastHashJoin LeftOuter BuildRight (73)
+                              :     :- * Project (71)
+                              :     :  +- * BroadcastHashJoin Inner BuildRight (70)
+                              :     :     :- * Project (65)
+                              :     :     :  +- * BroadcastHashJoin Inner BuildRight (64)
+                              :     :     :     :- * Filter (62)
+                              :     :     :     :  +- * ColumnarToRow (61)
+                              :     :     :     :     +- Scan parquet default.catalog_sales (60)
+                              :     :     :     +- ReusedExchange (63)
+                              :     :     +- BroadcastExchange (69)
+                              :     :        +- * Filter (68)
+                              :     :           +- * ColumnarToRow (67)
+                              :     :              +- Scan parquet default.date_dim (66)
+                              :     +- ReusedExchange (72)
+                              :- * Project (86)
+                              :  +- * BroadcastHashJoin LeftOuter BuildRight (85)
+                              :     :- * Project (83)
+                              :     :  +- * BroadcastHashJoin Inner BuildRight (82)
+                              :     :     :- * Project (80)
+                              :     :     :  +- * BroadcastHashJoin Inner BuildRight (79)
+                              :     :     :     :- * Filter (77)
+                              :     :     :     :  +- * ColumnarToRow (76)
+                              :     :     :     :     +- Scan parquet default.store_sales (75)
+                              :     :     :     +- ReusedExchange (78)
+                              :     :     +- ReusedExchange (81)
+                              :     +- ReusedExchange (84)
+                              +- * Project (98)
+                                 +- * BroadcastHashJoin LeftOuter BuildRight (97)
+                                    :- * Project (95)
+                                    :  +- * BroadcastHashJoin Inner BuildRight (94)
+                                    :     :- * Project (92)
+                                    :     :  +- * BroadcastHashJoin Inner BuildRight (91)
+                                    :     :     :- * Filter (89)
+                                    :     :     :  +- * ColumnarToRow (88)
+                                    :     :     :     +- Scan parquet default.web_sales (87)
+                                    :     :     +- ReusedExchange (90)
+                                    :     +- ReusedExchange (93)
+                                    +- ReusedExchange (96)
 
 
 (1) Scan parquet default.catalog_sales
@@ -282,366 +274,326 @@ Join condition: None
 Output [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, (ss_quantity#26 - coalesce(sr_return_quantity#30, 0)) AS sales_cnt#33, CheckOverflow((promote_precision(cast(ss_ext_sales_price#27 as decimal(8,2))) - promote_precision(cast(coalesce(sr_return_amt#31, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#34]
 Input [13]: [ss_item_sk#24, ss_ticket_number#25, ss_quantity#26, ss_ext_sales_price#27, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14, sr_item_sk#28, sr_ticket_number#29, sr_return_quantity#30, sr_return_amt#31]
 
-(38) Union
-
-(39) HashAggregate [codegen id : 9]
-Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22]
-Keys [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22]
-Functions: []
-Aggregate Attributes: []
-Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22]
-
-(40) Exchange
-Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22]
-Arguments: hashpartitioning(d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22, 5), true, [id=#35]
-
-(41) HashAggregate [codegen id : 10]
-Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22]
-Keys [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22]
-Functions: []
-Aggregate Attributes: []
-Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22]
-
-(42) Scan parquet default.web_sales
-Output [5]: [ws_sold_date_sk#36, ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40]
+(38) Scan parquet default.web_sales
+Output [5]: [ws_sold_date_sk#35, ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_sales]
 PushedFilters: [IsNotNull(ws_item_sk), IsNotNull(ws_sold_date_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_item_sk:int,ws_order_number:int,ws_quantity:int,ws_ext_sales_price:decimal(7,2)>
 
-(43) ColumnarToRow [codegen id : 14]
-Input [5]: [ws_sold_date_sk#36, ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40]
+(39) ColumnarToRow [codegen id : 12]
+Input [5]: [ws_sold_date_sk#35, ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39]
 
-(44) Filter [codegen id : 14]
-Input [5]: [ws_sold_date_sk#36, ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40]
-Condition : (isnotnull(ws_item_sk#37) AND isnotnull(ws_sold_date_sk#36))
+(40) Filter [codegen id : 12]
+Input [5]: [ws_sold_date_sk#35, ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39]
+Condition : (isnotnull(ws_item_sk#36) AND isnotnull(ws_sold_date_sk#35))
 
-(45) ReusedExchange [Reuses operator id: 8]
+(41) ReusedExchange [Reuses operator id: 8]
 Output [5]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
 
-(46) BroadcastHashJoin [codegen id : 14]
-Left keys [1]: [ws_item_sk#37]
+(42) BroadcastHashJoin [codegen id : 12]
+Left keys [1]: [ws_item_sk#36]
 Right keys [1]: [i_item_sk#6]
 Join condition: None
 
-(47) Project [codegen id : 14]
-Output [9]: [ws_sold_date_sk#36, ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
-Input [10]: [ws_sold_date_sk#36, ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40, i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
+(43) Project [codegen id : 12]
+Output [9]: [ws_sold_date_sk#35, ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
+Input [10]: [ws_sold_date_sk#35, ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39, i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
 
-(48) ReusedExchange [Reuses operator id: 14]
+(44) ReusedExchange [Reuses operator id: 14]
 Output [2]: [d_date_sk#13, d_year#14]
 
-(49) BroadcastHashJoin [codegen id : 14]
-Left keys [1]: [ws_sold_date_sk#36]
+(45) BroadcastHashJoin [codegen id : 12]
+Left keys [1]: [ws_sold_date_sk#35]
 Right keys [1]: [d_date_sk#13]
 Join condition: None
 
-(50) Project [codegen id : 14]
-Output [9]: [ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14]
-Input [11]: [ws_sold_date_sk#36, ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_date_sk#13, d_year#14]
+(46) Project [codegen id : 12]
+Output [9]: [ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14]
+Input [11]: [ws_sold_date_sk#35, ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_date_sk#13, d_year#14]
 
-(51) Scan parquet default.web_returns
-Output [4]: [wr_item_sk#41, wr_order_number#42, wr_return_quantity#43, wr_return_amt#44]
+(47) Scan parquet default.web_returns
+Output [4]: [wr_item_sk#40, wr_order_number#41, wr_return_quantity#42, wr_return_amt#43]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_returns]
 PushedFilters: [IsNotNull(wr_order_number), IsNotNull(wr_item_sk)]
 ReadSchema: struct<wr_item_sk:bigint,wr_order_number:bigint,wr_return_quantity:int,wr_return_amt:decimal(7,2)>
 
-(52) ColumnarToRow [codegen id : 13]
-Input [4]: [wr_item_sk#41, wr_order_number#42, wr_return_quantity#43, wr_return_amt#44]
+(48) ColumnarToRow [codegen id : 11]
+Input [4]: [wr_item_sk#40, wr_order_number#41, wr_return_quantity#42, wr_return_amt#43]
 
-(53) Filter [codegen id : 13]
-Input [4]: [wr_item_sk#41, wr_order_number#42, wr_return_quantity#43, wr_return_amt#44]
-Condition : (isnotnull(wr_order_number#42) AND isnotnull(wr_item_sk#41))
+(49) Filter [codegen id : 11]
+Input [4]: [wr_item_sk#40, wr_order_number#41, wr_return_quantity#42, wr_return_amt#43]
+Condition : (isnotnull(wr_order_number#41) AND isnotnull(wr_item_sk#40))
 
-(54) BroadcastExchange
-Input [4]: [wr_item_sk#41, wr_order_number#42, wr_return_quantity#43, wr_return_amt#44]
-Arguments: HashedRelationBroadcastMode(List(input[1, bigint, false], input[0, bigint, false]),false), [id=#45]
+(50) BroadcastExchange
+Input [4]: [wr_item_sk#40, wr_order_number#41, wr_return_quantity#42, wr_return_amt#43]
+Arguments: HashedRelationBroadcastMode(List(input[1, bigint, false], input[0, bigint, false]),false), [id=#44]
 
-(55) BroadcastHashJoin [codegen id : 14]
-Left keys [2]: [cast(ws_order_number#38 as bigint), cast(ws_item_sk#37 as bigint)]
-Right keys [2]: [wr_order_number#42, wr_item_sk#41]
+(51) BroadcastHashJoin [codegen id : 12]
+Left keys [2]: [cast(ws_order_number#37 as bigint), cast(ws_item_sk#36 as bigint)]
+Right keys [2]: [wr_order_number#41, wr_item_sk#40]
 Join condition: None
 
-(56) Project [codegen id : 14]
-Output [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, (ws_quantity#39 - coalesce(wr_return_quantity#43, 0)) AS sales_cnt#46, CheckOverflow((promote_precision(cast(ws_ext_sales_price#40 as decimal(8,2))) - promote_precision(cast(coalesce(wr_return_amt#44, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#47]
-Input [13]: [ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14, wr_item_sk#41, wr_order_number#42, wr_return_quantity#43, wr_return_amt#44]
+(52) Project [codegen id : 12]
+Output [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, (ws_quantity#38 - coalesce(wr_return_quantity#42, 0)) AS sales_cnt#45, CheckOverflow((promote_precision(cast(ws_ext_sales_price#39 as decimal(8,2))) - promote_precision(cast(coalesce(wr_return_amt#43, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#46]
+Input [13]: [ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14, wr_item_sk#40, wr_order_number#41, wr_return_quantity#42, wr_return_amt#43]
 
-(57) Union
+(53) Union
 
-(58) HashAggregate [codegen id : 15]
+(54) HashAggregate [codegen id : 13]
 Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22]
 Keys [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22]
 Functions: []
 Aggregate Attributes: []
 Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22]
 
-(59) Exchange
+(55) Exchange
 Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22]
-Arguments: hashpartitioning(d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22, 5), true, [id=#48]
+Arguments: hashpartitioning(d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22, 5), ENSURE_REQUIREMENTS, [id=#47]
 
-(60) HashAggregate [codegen id : 16]
+(56) HashAggregate [codegen id : 14]
 Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22]
 Keys [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22]
 Functions: []
 Aggregate Attributes: []
 Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22]
 
-(61) HashAggregate [codegen id : 16]
+(57) HashAggregate [codegen id : 14]
 Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22]
 Keys [5]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
 Functions [2]: [partial_sum(cast(sales_cnt#21 as bigint)), partial_sum(UnscaledValue(sales_amt#22))]
-Aggregate Attributes [2]: [sum#49, sum#50]
-Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum#51, sum#52]
+Aggregate Attributes [2]: [sum#48, sum#49]
+Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum#50, sum#51]
 
-(62) Exchange
-Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum#51, sum#52]
-Arguments: hashpartitioning(d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, 5), true, [id=#53]
+(58) Exchange
+Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum#50, sum#51]
+Arguments: hashpartitioning(d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, 5), ENSURE_REQUIREMENTS, [id=#52]
 
-(63) HashAggregate [codegen id : 34]
-Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum#51, sum#52]
+(59) HashAggregate [codegen id : 30]
+Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum#50, sum#51]
 Keys [5]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
 Functions [2]: [sum(cast(sales_cnt#21 as bigint)), sum(UnscaledValue(sales_amt#22))]
-Aggregate Attributes [2]: [sum(cast(sales_cnt#21 as bigint))#54, sum(UnscaledValue(sales_amt#22))#55]
-Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum(cast(sales_cnt#21 as bigint))#54 AS sales_cnt#56, MakeDecimal(sum(UnscaledValue(sales_amt#22))#55,18,2) AS sales_amt#57]
+Aggregate Attributes [2]: [sum(cast(sales_cnt#21 as bigint))#53, sum(UnscaledValue(sales_amt#22))#54]
+Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum(cast(sales_cnt#21 as bigint))#53 AS sales_cnt#55, MakeDecimal(sum(UnscaledValue(sales_amt#22))#54,18,2) AS sales_amt#56]
 
-(64) Scan parquet default.catalog_sales
+(60) Scan parquet default.catalog_sales
 Output [5]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_sales]
 PushedFilters: [IsNotNull(cs_item_sk), IsNotNull(cs_sold_date_sk)]
 ReadSchema: struct<cs_sold_date_sk:int,cs_item_sk:int,cs_order_number:int,cs_quantity:int,cs_ext_sales_price:decimal(7,2)>
 
-(65) ColumnarToRow [codegen id : 20]
+(61) ColumnarToRow [codegen id : 18]
 Input [5]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5]
 
-(66) Filter [codegen id : 20]
+(62) Filter [codegen id : 18]
 Input [5]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5]
 Condition : (isnotnull(cs_item_sk#2) AND isnotnull(cs_sold_date_sk#1))
 
-(67) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#58, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62]
+(63) ReusedExchange [Reuses operator id: 8]
+Output [5]: [i_item_sk#57, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61]
 
-(68) BroadcastHashJoin [codegen id : 20]
+(64) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [cs_item_sk#2]
-Right keys [1]: [i_item_sk#58]
+Right keys [1]: [i_item_sk#57]
 Join condition: None
 
-(69) Project [codegen id : 20]
-Output [9]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62]
-Input [10]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_item_sk#58, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62]
+(65) Project [codegen id : 18]
+Output [9]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61]
+Input [10]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_item_sk#57, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61]
 
-(70) Scan parquet default.date_dim
-Output [2]: [d_date_sk#63, d_year#64]
+(66) Scan parquet default.date_dim
+Output [2]: [d_date_sk#62, d_year#63]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(71) ColumnarToRow [codegen id : 18]
-Input [2]: [d_date_sk#63, d_year#64]
+(67) ColumnarToRow [codegen id : 16]
+Input [2]: [d_date_sk#62, d_year#63]
 
-(72) Filter [codegen id : 18]
-Input [2]: [d_date_sk#63, d_year#64]
-Condition : ((isnotnull(d_year#64) AND (d_year#64 = 2001)) AND isnotnull(d_date_sk#63))
+(68) Filter [codegen id : 16]
+Input [2]: [d_date_sk#62, d_year#63]
+Condition : ((isnotnull(d_year#63) AND (d_year#63 = 2001)) AND isnotnull(d_date_sk#62))
 
-(73) BroadcastExchange
-Input [2]: [d_date_sk#63, d_year#64]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#65]
+(69) BroadcastExchange
+Input [2]: [d_date_sk#62, d_year#63]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#64]
 
-(74) BroadcastHashJoin [codegen id : 20]
+(70) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [cs_sold_date_sk#1]
-Right keys [1]: [d_date_sk#63]
+Right keys [1]: [d_date_sk#62]
 Join condition: None
 
-(75) Project [codegen id : 20]
-Output [9]: [cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, d_year#64]
-Input [11]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, d_date_sk#63, d_year#64]
+(71) Project [codegen id : 18]
+Output [9]: [cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, d_year#63]
+Input [11]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, d_date_sk#62, d_year#63]
 
-(76) ReusedExchange [Reuses operator id: 20]
+(72) ReusedExchange [Reuses operator id: 20]
 Output [4]: [cr_item_sk#16, cr_order_number#17, cr_return_quantity#18, cr_return_amount#19]
 
-(77) BroadcastHashJoin [codegen id : 20]
+(73) BroadcastHashJoin [codegen id : 18]
 Left keys [2]: [cs_order_number#3, cs_item_sk#2]
 Right keys [2]: [cr_order_number#17, cr_item_sk#16]
 Join condition: None
 
-(78) Project [codegen id : 20]
-Output [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, (cs_quantity#4 - coalesce(cr_return_quantity#18, 0)) AS sales_cnt#21, CheckOverflow((promote_precision(cast(cs_ext_sales_price#5 as decimal(8,2))) - promote_precision(cast(coalesce(cr_return_amount#19, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#22]
-Input [13]: [cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, d_year#64, cr_item_sk#16, cr_order_number#17, cr_return_quantity#18, cr_return_amount#19]
+(74) Project [codegen id : 18]
+Output [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, (cs_quantity#4 - coalesce(cr_return_quantity#18, 0)) AS sales_cnt#21, CheckOverflow((promote_precision(cast(cs_ext_sales_price#5 as decimal(8,2))) - promote_precision(cast(coalesce(cr_return_amount#19, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#22]
+Input [13]: [cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, d_year#63, cr_item_sk#16, cr_order_number#17, cr_return_quantity#18, cr_return_amount#19]
 
-(79) Scan parquet default.store_sales
+(75) Scan parquet default.store_sales
 Output [5]: [ss_sold_date_sk#23, ss_item_sk#24, ss_ticket_number#25, ss_quantity#26, ss_ext_sales_price#27]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_sold_date_sk)]
 ReadSchema: struct<ss_sold_date_sk:int,ss_item_sk:int,ss_ticket_number:int,ss_quantity:int,ss_ext_sales_price:decimal(7,2)>
 
-(80) ColumnarToRow [codegen id : 24]
+(76) ColumnarToRow [codegen id : 22]
 Input [5]: [ss_sold_date_sk#23, ss_item_sk#24, ss_ticket_number#25, ss_quantity#26, ss_ext_sales_price#27]
 
-(81) Filter [codegen id : 24]
+(77) Filter [codegen id : 22]
 Input [5]: [ss_sold_date_sk#23, ss_item_sk#24, ss_ticket_number#25, ss_quantity#26, ss_ext_sales_price#27]
 Condition : (isnotnull(ss_item_sk#24) AND isnotnull(ss_sold_date_sk#23))
 
-(82) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#58, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62]
+(78) ReusedExchange [Reuses operator id: 8]
+Output [5]: [i_item_sk#57, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61]
 
-(83) BroadcastHashJoin [codegen id : 24]
+(79) BroadcastHashJoin [codegen id : 22]
 Left keys [1]: [ss_item_sk#24]
-Right keys [1]: [i_item_sk#58]
+Right keys [1]: [i_item_sk#57]
 Join condition: None
 
-(84) Project [codegen id : 24]
-Output [9]: [ss_sold_date_sk#23, ss_item_sk#24, ss_ticket_number#25, ss_quantity#26, ss_ext_sales_price#27, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62]
-Input [10]: [ss_sold_date_sk#23, ss_item_sk#24, ss_ticket_number#25, ss_quantity#26, ss_ext_sales_price#27, i_item_sk#58, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62]
+(80) Project [codegen id : 22]
+Output [9]: [ss_sold_date_sk#23, ss_item_sk#24, ss_ticket_number#25, ss_quantity#26, ss_ext_sales_price#27, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61]
+Input [10]: [ss_sold_date_sk#23, ss_item_sk#24, ss_ticket_number#25, ss_quantity#26, ss_ext_sales_price#27, i_item_sk#57, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61]
 
-(85) ReusedExchange [Reuses operator id: 73]
-Output [2]: [d_date_sk#63, d_year#64]
+(81) ReusedExchange [Reuses operator id: 69]
+Output [2]: [d_date_sk#62, d_year#63]
 
-(86) BroadcastHashJoin [codegen id : 24]
+(82) BroadcastHashJoin [codegen id : 22]
 Left keys [1]: [ss_sold_date_sk#23]
-Right keys [1]: [d_date_sk#63]
+Right keys [1]: [d_date_sk#62]
 Join condition: None
 
-(87) Project [codegen id : 24]
-Output [9]: [ss_item_sk#24, ss_ticket_number#25, ss_quantity#26, ss_ext_sales_price#27, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, d_year#64]
-Input [11]: [ss_sold_date_sk#23, ss_item_sk#24, ss_ticket_number#25, ss_quantity#26, ss_ext_sales_price#27, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, d_date_sk#63, d_year#64]
+(83) Project [codegen id : 22]
+Output [9]: [ss_item_sk#24, ss_ticket_number#25, ss_quantity#26, ss_ext_sales_price#27, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, d_year#63]
+Input [11]: [ss_sold_date_sk#23, ss_item_sk#24, ss_ticket_number#25, ss_quantity#26, ss_ext_sales_price#27, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, d_date_sk#62, d_year#63]
 
-(88) ReusedExchange [Reuses operator id: 35]
+(84) ReusedExchange [Reuses operator id: 35]
 Output [4]: [sr_item_sk#28, sr_ticket_number#29, sr_return_quantity#30, sr_return_amt#31]
 
-(89) BroadcastHashJoin [codegen id : 24]
+(85) BroadcastHashJoin [codegen id : 22]
 Left keys [2]: [cast(ss_ticket_number#25 as bigint), cast(ss_item_sk#24 as bigint)]
 Right keys [2]: [sr_ticket_number#29, sr_item_sk#28]
 Join condition: None
 
-(90) Project [codegen id : 24]
-Output [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, (ss_quantity#26 - coalesce(sr_return_quantity#30, 0)) AS sales_cnt#66, CheckOverflow((promote_precision(cast(ss_ext_sales_price#27 as decimal(8,2))) - promote_precision(cast(coalesce(sr_return_amt#31, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#67]
-Input [13]: [ss_item_sk#24, ss_ticket_number#25, ss_quantity#26, ss_ext_sales_price#27, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, d_year#64, sr_item_sk#28, sr_ticket_number#29, sr_return_quantity#30, sr_return_amt#31]
+(86) Project [codegen id : 22]
+Output [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, (ss_quantity#26 - coalesce(sr_return_quantity#30, 0)) AS sales_cnt#65, CheckOverflow((promote_precision(cast(ss_ext_sales_price#27 as decimal(8,2))) - promote_precision(cast(coalesce(sr_return_amt#31, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#66]
+Input [13]: [ss_item_sk#24, ss_ticket_number#25, ss_quantity#26, ss_ext_sales_price#27, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, d_year#63, sr_item_sk#28, sr_ticket_number#29, sr_return_quantity#30, sr_return_amt#31]
 
-(91) Union
-
-(92) HashAggregate [codegen id : 25]
-Input [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22]
-Keys [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22]
-Functions: []
-Aggregate Attributes: []
-Results [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22]
-
-(93) Exchange
-Input [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22]
-Arguments: hashpartitioning(d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22, 5), true, [id=#68]
-
-(94) HashAggregate [codegen id : 26]
-Input [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22]
-Keys [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22]
-Functions: []
-Aggregate Attributes: []
-Results [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22]
-
-(95) Scan parquet default.web_sales
-Output [5]: [ws_sold_date_sk#36, ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40]
+(87) Scan parquet default.web_sales
+Output [5]: [ws_sold_date_sk#35, ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_sales]
 PushedFilters: [IsNotNull(ws_item_sk), IsNotNull(ws_sold_date_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_item_sk:int,ws_order_number:int,ws_quantity:int,ws_ext_sales_price:decimal(7,2)>
 
-(96) ColumnarToRow [codegen id : 30]
-Input [5]: [ws_sold_date_sk#36, ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40]
+(88) ColumnarToRow [codegen id : 26]
+Input [5]: [ws_sold_date_sk#35, ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39]
 
-(97) Filter [codegen id : 30]
-Input [5]: [ws_sold_date_sk#36, ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40]
-Condition : (isnotnull(ws_item_sk#37) AND isnotnull(ws_sold_date_sk#36))
+(89) Filter [codegen id : 26]
+Input [5]: [ws_sold_date_sk#35, ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39]
+Condition : (isnotnull(ws_item_sk#36) AND isnotnull(ws_sold_date_sk#35))
 
-(98) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#58, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62]
+(90) ReusedExchange [Reuses operator id: 8]
+Output [5]: [i_item_sk#57, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61]
 
-(99) BroadcastHashJoin [codegen id : 30]
-Left keys [1]: [ws_item_sk#37]
-Right keys [1]: [i_item_sk#58]
+(91) BroadcastHashJoin [codegen id : 26]
+Left keys [1]: [ws_item_sk#36]
+Right keys [1]: [i_item_sk#57]
 Join condition: None
 
-(100) Project [codegen id : 30]
-Output [9]: [ws_sold_date_sk#36, ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62]
-Input [10]: [ws_sold_date_sk#36, ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40, i_item_sk#58, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62]
+(92) Project [codegen id : 26]
+Output [9]: [ws_sold_date_sk#35, ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61]
+Input [10]: [ws_sold_date_sk#35, ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39, i_item_sk#57, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61]
 
-(101) ReusedExchange [Reuses operator id: 73]
-Output [2]: [d_date_sk#63, d_year#64]
+(93) ReusedExchange [Reuses operator id: 69]
+Output [2]: [d_date_sk#62, d_year#63]
 
-(102) BroadcastHashJoin [codegen id : 30]
-Left keys [1]: [ws_sold_date_sk#36]
-Right keys [1]: [d_date_sk#63]
+(94) BroadcastHashJoin [codegen id : 26]
+Left keys [1]: [ws_sold_date_sk#35]
+Right keys [1]: [d_date_sk#62]
 Join condition: None
 
-(103) Project [codegen id : 30]
-Output [9]: [ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, d_year#64]
-Input [11]: [ws_sold_date_sk#36, ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, d_date_sk#63, d_year#64]
+(95) Project [codegen id : 26]
+Output [9]: [ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, d_year#63]
+Input [11]: [ws_sold_date_sk#35, ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, d_date_sk#62, d_year#63]
 
-(104) ReusedExchange [Reuses operator id: 54]
-Output [4]: [wr_item_sk#41, wr_order_number#42, wr_return_quantity#43, wr_return_amt#44]
+(96) ReusedExchange [Reuses operator id: 50]
+Output [4]: [wr_item_sk#40, wr_order_number#41, wr_return_quantity#42, wr_return_amt#43]
 
-(105) BroadcastHashJoin [codegen id : 30]
-Left keys [2]: [cast(ws_order_number#38 as bigint), cast(ws_item_sk#37 as bigint)]
-Right keys [2]: [wr_order_number#42, wr_item_sk#41]
+(97) BroadcastHashJoin [codegen id : 26]
+Left keys [2]: [cast(ws_order_number#37 as bigint), cast(ws_item_sk#36 as bigint)]
+Right keys [2]: [wr_order_number#41, wr_item_sk#40]
 Join condition: None
 
-(106) Project [codegen id : 30]
-Output [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, (ws_quantity#39 - coalesce(wr_return_quantity#43, 0)) AS sales_cnt#69, CheckOverflow((promote_precision(cast(ws_ext_sales_price#40 as decimal(8,2))) - promote_precision(cast(coalesce(wr_return_amt#44, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#70]
-Input [13]: [ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, d_year#64, wr_item_sk#41, wr_order_number#42, wr_return_quantity#43, wr_return_amt#44]
+(98) Project [codegen id : 26]
+Output [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, (ws_quantity#38 - coalesce(wr_return_quantity#42, 0)) AS sales_cnt#67, CheckOverflow((promote_precision(cast(ws_ext_sales_price#39 as decimal(8,2))) - promote_precision(cast(coalesce(wr_return_amt#43, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#68]
+Input [13]: [ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, d_year#63, wr_item_sk#40, wr_order_number#41, wr_return_quantity#42, wr_return_amt#43]
 
-(107) Union
+(99) Union
 
-(108) HashAggregate [codegen id : 31]
-Input [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22]
-Keys [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22]
+(100) HashAggregate [codegen id : 27]
+Input [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, sales_cnt#21, sales_amt#22]
+Keys [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, sales_cnt#21, sales_amt#22]
 Functions: []
 Aggregate Attributes: []
-Results [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22]
+Results [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, sales_cnt#21, sales_amt#22]
 
-(109) Exchange
-Input [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22]
-Arguments: hashpartitioning(d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22, 5), true, [id=#71]
+(101) Exchange
+Input [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, sales_cnt#21, sales_amt#22]
+Arguments: hashpartitioning(d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, sales_cnt#21, sales_amt#22, 5), ENSURE_REQUIREMENTS, [id=#69]
 
-(110) HashAggregate [codegen id : 32]
-Input [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22]
-Keys [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22]
+(102) HashAggregate [codegen id : 28]
+Input [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, sales_cnt#21, sales_amt#22]
+Keys [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, sales_cnt#21, sales_amt#22]
 Functions: []
 Aggregate Attributes: []
-Results [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22]
+Results [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, sales_cnt#21, sales_amt#22]
 
-(111) HashAggregate [codegen id : 32]
-Input [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22]
-Keys [5]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62]
+(103) HashAggregate [codegen id : 28]
+Input [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, sales_cnt#21, sales_amt#22]
+Keys [5]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61]
 Functions [2]: [partial_sum(cast(sales_cnt#21 as bigint)), partial_sum(UnscaledValue(sales_amt#22))]
-Aggregate Attributes [2]: [sum#72, sum#73]
-Results [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sum#74, sum#75]
+Aggregate Attributes [2]: [sum#70, sum#71]
+Results [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, sum#72, sum#73]
 
-(112) Exchange
-Input [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sum#74, sum#75]
-Arguments: hashpartitioning(d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, 5), true, [id=#76]
+(104) Exchange
+Input [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, sum#72, sum#73]
+Arguments: hashpartitioning(d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, 5), ENSURE_REQUIREMENTS, [id=#74]
 
-(113) HashAggregate [codegen id : 33]
-Input [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sum#74, sum#75]
-Keys [5]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62]
+(105) HashAggregate [codegen id : 29]
+Input [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, sum#72, sum#73]
+Keys [5]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61]
 Functions [2]: [sum(cast(sales_cnt#21 as bigint)), sum(UnscaledValue(sales_amt#22))]
-Aggregate Attributes [2]: [sum(cast(sales_cnt#21 as bigint))#77, sum(UnscaledValue(sales_amt#22))#78]
-Results [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sum(cast(sales_cnt#21 as bigint))#77 AS sales_cnt#79, MakeDecimal(sum(UnscaledValue(sales_amt#22))#78,18,2) AS sales_amt#80]
+Aggregate Attributes [2]: [sum(cast(sales_cnt#21 as bigint))#75, sum(UnscaledValue(sales_amt#22))#76]
+Results [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, sum(cast(sales_cnt#21 as bigint))#75 AS sales_cnt#77, MakeDecimal(sum(UnscaledValue(sales_amt#22))#76,18,2) AS sales_amt#78]
 
-(114) BroadcastExchange
-Input [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#79, sales_amt#80]
-Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, true], input[3, int, true], input[4, int, true]),false), [id=#81]
+(106) BroadcastExchange
+Input [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, sales_cnt#77, sales_amt#78]
+Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, true], input[3, int, true], input[4, int, true]),false), [id=#79]
 
-(115) BroadcastHashJoin [codegen id : 34]
+(107) BroadcastHashJoin [codegen id : 30]
 Left keys [4]: [i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
-Right keys [4]: [i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62]
-Join condition: (CheckOverflow((promote_precision(cast(sales_cnt#56 as decimal(17,2))) / promote_precision(cast(sales_cnt#79 as decimal(17,2)))), DecimalType(37,20), true) < 0.90000000000000000000)
+Right keys [4]: [i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61]
+Join condition: (CheckOverflow((promote_precision(cast(sales_cnt#55 as decimal(17,2))) / promote_precision(cast(sales_cnt#77 as decimal(17,2)))), DecimalType(37,20), true) < 0.90000000000000000000)
 
-(116) Project [codegen id : 34]
-Output [10]: [d_year#64 AS prev_year#82, d_year#14 AS year#83, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#79 AS prev_yr_cnt#84, sales_cnt#56 AS curr_yr_cnt#85, (sales_cnt#56 - sales_cnt#79) AS sales_cnt_diff#86, CheckOverflow((promote_precision(cast(sales_amt#57 as decimal(19,2))) - promote_precision(cast(sales_amt#80 as decimal(19,2)))), DecimalType(19,2), true) AS sales_amt_diff#87]
-Input [14]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#56, sales_amt#57, d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#79, sales_amt#80]
+(108) Project [codegen id : 30]
+Output [10]: [d_year#63 AS prev_year#80, d_year#14 AS year#81, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#77 AS prev_yr_cnt#82, sales_cnt#55 AS curr_yr_cnt#83, (sales_cnt#55 - sales_cnt#77) AS sales_cnt_diff#84, CheckOverflow((promote_precision(cast(sales_amt#56 as decimal(19,2))) - promote_precision(cast(sales_amt#78 as decimal(19,2)))), DecimalType(19,2), true) AS sales_amt_diff#85]
+Input [14]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#55, sales_amt#56, d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, sales_cnt#77, sales_amt#78]
 
-(117) TakeOrderedAndProject
-Input [10]: [prev_year#82, year#83, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, prev_yr_cnt#84, curr_yr_cnt#85, sales_cnt_diff#86, sales_amt_diff#87]
-Arguments: 100, [sales_cnt_diff#86 ASC NULLS FIRST], [prev_year#82, year#83, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, prev_yr_cnt#84, curr_yr_cnt#85, sales_cnt_diff#86, sales_amt_diff#87]
+(109) TakeOrderedAndProject
+Input [10]: [prev_year#80, year#81, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, prev_yr_cnt#82, curr_yr_cnt#83, sales_cnt_diff#84, sales_amt_diff#85]
+Arguments: 100, [sales_cnt_diff#84 ASC NULLS FIRST], [prev_year#80, year#81, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, prev_yr_cnt#82, curr_yr_cnt#83, sales_cnt_diff#84, sales_amt_diff#85]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q75/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q75/simplified.txt
@@ -1,83 +1,75 @@
 TakeOrderedAndProject [sales_cnt_diff,prev_year,year,i_brand_id,i_class_id,i_category_id,i_manufact_id,prev_yr_cnt,curr_yr_cnt,sales_amt_diff]
-  WholeStageCodegen (34)
+  WholeStageCodegen (30)
     Project [d_year,d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_cnt,sales_amt,sales_amt]
       BroadcastHashJoin [i_brand_id,i_class_id,i_category_id,i_manufact_id,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_cnt]
         HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sum,sum] [sum(cast(sales_cnt as bigint)),sum(UnscaledValue(sales_amt)),sales_cnt,sales_amt,sum,sum]
           InputAdapter
             Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id] #1
-              WholeStageCodegen (16)
+              WholeStageCodegen (14)
                 HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] [sum,sum,sum,sum]
                   HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
                     InputAdapter
                       Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #2
-                        WholeStageCodegen (15)
+                        WholeStageCodegen (13)
                           HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
                             InputAdapter
                               Union
-                                WholeStageCodegen (10)
-                                  HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
-                                    InputAdapter
-                                      Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #3
-                                        WholeStageCodegen (9)
-                                          HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
-                                            InputAdapter
-                                              Union
-                                                WholeStageCodegen (4)
-                                                  Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,cs_quantity,cr_return_quantity,cs_ext_sales_price,cr_return_amount]
-                                                    BroadcastHashJoin [cs_order_number,cs_item_sk,cr_order_number,cr_item_sk]
-                                                      Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                        BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                          Project [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                            BroadcastHashJoin [cs_item_sk,i_item_sk]
-                                                              Filter [cs_item_sk,cs_sold_date_sk]
-                                                                ColumnarToRow
-                                                                  InputAdapter
-                                                                    Scan parquet default.catalog_sales [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price]
-                                                              InputAdapter
-                                                                BroadcastExchange #4
-                                                                  WholeStageCodegen (1)
-                                                                    Project [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                      Filter [i_category,i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                        ColumnarToRow
-                                                                          InputAdapter
-                                                                            Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id,i_category,i_manufact_id]
+                                WholeStageCodegen (4)
+                                  Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,cs_quantity,cr_return_quantity,cs_ext_sales_price,cr_return_amount]
+                                    BroadcastHashJoin [cs_order_number,cs_item_sk,cr_order_number,cr_item_sk]
+                                      Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
+                                        BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                          Project [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                            BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                              Filter [cs_item_sk,cs_sold_date_sk]
+                                                ColumnarToRow
+                                                  InputAdapter
+                                                    Scan parquet default.catalog_sales [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price]
+                                              InputAdapter
+                                                BroadcastExchange #3
+                                                  WholeStageCodegen (1)
+                                                    Project [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                      Filter [i_category,i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                        ColumnarToRow
                                                           InputAdapter
-                                                            BroadcastExchange #5
-                                                              WholeStageCodegen (2)
-                                                                Filter [d_year,d_date_sk]
-                                                                  ColumnarToRow
-                                                                    InputAdapter
-                                                                      Scan parquet default.date_dim [d_date_sk,d_year]
-                                                      InputAdapter
-                                                        BroadcastExchange #6
-                                                          WholeStageCodegen (3)
-                                                            Filter [cr_order_number,cr_item_sk]
-                                                              ColumnarToRow
-                                                                InputAdapter
-                                                                  Scan parquet default.catalog_returns [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount]
-                                                WholeStageCodegen (8)
-                                                  Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ss_quantity,sr_return_quantity,ss_ext_sales_price,sr_return_amt]
-                                                    BroadcastHashJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
-                                                      Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                        BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                          Project [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                            BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                              Filter [ss_item_sk,ss_sold_date_sk]
-                                                                ColumnarToRow
-                                                                  InputAdapter
-                                                                    Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price]
-                                                              InputAdapter
-                                                                ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #4
-                                                          InputAdapter
-                                                            ReusedExchange [d_date_sk,d_year] #5
-                                                      InputAdapter
-                                                        BroadcastExchange #7
-                                                          WholeStageCodegen (7)
-                                                            Filter [sr_ticket_number,sr_item_sk]
-                                                              ColumnarToRow
-                                                                InputAdapter
-                                                                  Scan parquet default.store_returns [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt]
-                                WholeStageCodegen (14)
+                                                            Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id,i_category,i_manufact_id]
+                                          InputAdapter
+                                            BroadcastExchange #4
+                                              WholeStageCodegen (2)
+                                                Filter [d_year,d_date_sk]
+                                                  ColumnarToRow
+                                                    InputAdapter
+                                                      Scan parquet default.date_dim [d_date_sk,d_year]
+                                      InputAdapter
+                                        BroadcastExchange #5
+                                          WholeStageCodegen (3)
+                                            Filter [cr_order_number,cr_item_sk]
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet default.catalog_returns [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount]
+                                WholeStageCodegen (8)
+                                  Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ss_quantity,sr_return_quantity,ss_ext_sales_price,sr_return_amt]
+                                    BroadcastHashJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
+                                      Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
+                                        BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                          Project [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                            BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                              Filter [ss_item_sk,ss_sold_date_sk]
+                                                ColumnarToRow
+                                                  InputAdapter
+                                                    Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price]
+                                              InputAdapter
+                                                ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #3
+                                          InputAdapter
+                                            ReusedExchange [d_date_sk,d_year] #4
+                                      InputAdapter
+                                        BroadcastExchange #6
+                                          WholeStageCodegen (7)
+                                            Filter [sr_ticket_number,sr_item_sk]
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet default.store_returns [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt]
+                                WholeStageCodegen (12)
                                   Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ws_quantity,wr_return_quantity,ws_ext_sales_price,wr_return_amt]
                                     BroadcastHashJoin [ws_order_number,ws_item_sk,wr_order_number,wr_item_sk]
                                       Project [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
@@ -89,79 +81,71 @@ TakeOrderedAndProject [sales_cnt_diff,prev_year,year,i_brand_id,i_class_id,i_cat
                                                   InputAdapter
                                                     Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price]
                                               InputAdapter
-                                                ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #4
+                                                ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #3
                                           InputAdapter
-                                            ReusedExchange [d_date_sk,d_year] #5
+                                            ReusedExchange [d_date_sk,d_year] #4
                                       InputAdapter
-                                        BroadcastExchange #8
-                                          WholeStageCodegen (13)
+                                        BroadcastExchange #7
+                                          WholeStageCodegen (11)
                                             Filter [wr_order_number,wr_item_sk]
                                               ColumnarToRow
                                                 InputAdapter
                                                   Scan parquet default.web_returns [wr_item_sk,wr_order_number,wr_return_quantity,wr_return_amt]
         InputAdapter
-          BroadcastExchange #9
-            WholeStageCodegen (33)
+          BroadcastExchange #8
+            WholeStageCodegen (29)
               HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sum,sum] [sum(cast(sales_cnt as bigint)),sum(UnscaledValue(sales_amt)),sales_cnt,sales_amt,sum,sum]
                 InputAdapter
-                  Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id] #10
-                    WholeStageCodegen (32)
+                  Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id] #9
+                    WholeStageCodegen (28)
                       HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] [sum,sum,sum,sum]
                         HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
                           InputAdapter
-                            Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #11
-                              WholeStageCodegen (31)
+                            Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #10
+                              WholeStageCodegen (27)
                                 HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
                                   InputAdapter
                                     Union
+                                      WholeStageCodegen (18)
+                                        Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,cs_quantity,cr_return_quantity,cs_ext_sales_price,cr_return_amount]
+                                          BroadcastHashJoin [cs_order_number,cs_item_sk,cr_order_number,cr_item_sk]
+                                            Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
+                                              BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                Project [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                  BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                    Filter [cs_item_sk,cs_sold_date_sk]
+                                                      ColumnarToRow
+                                                        InputAdapter
+                                                          Scan parquet default.catalog_sales [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price]
+                                                    InputAdapter
+                                                      ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #3
+                                                InputAdapter
+                                                  BroadcastExchange #11
+                                                    WholeStageCodegen (16)
+                                                      Filter [d_year,d_date_sk]
+                                                        ColumnarToRow
+                                                          InputAdapter
+                                                            Scan parquet default.date_dim [d_date_sk,d_year]
+                                            InputAdapter
+                                              ReusedExchange [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount] #5
+                                      WholeStageCodegen (22)
+                                        Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ss_quantity,sr_return_quantity,ss_ext_sales_price,sr_return_amt]
+                                          BroadcastHashJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
+                                            Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
+                                              BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                Project [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                  BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                    Filter [ss_item_sk,ss_sold_date_sk]
+                                                      ColumnarToRow
+                                                        InputAdapter
+                                                          Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price]
+                                                    InputAdapter
+                                                      ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #3
+                                                InputAdapter
+                                                  ReusedExchange [d_date_sk,d_year] #11
+                                            InputAdapter
+                                              ReusedExchange [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt] #6
                                       WholeStageCodegen (26)
-                                        HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
-                                          InputAdapter
-                                            Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #12
-                                              WholeStageCodegen (25)
-                                                HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
-                                                  InputAdapter
-                                                    Union
-                                                      WholeStageCodegen (20)
-                                                        Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,cs_quantity,cr_return_quantity,cs_ext_sales_price,cr_return_amount]
-                                                          BroadcastHashJoin [cs_order_number,cs_item_sk,cr_order_number,cr_item_sk]
-                                                            Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                              BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                Project [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                  BroadcastHashJoin [cs_item_sk,i_item_sk]
-                                                                    Filter [cs_item_sk,cs_sold_date_sk]
-                                                                      ColumnarToRow
-                                                                        InputAdapter
-                                                                          Scan parquet default.catalog_sales [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price]
-                                                                    InputAdapter
-                                                                      ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #4
-                                                                InputAdapter
-                                                                  BroadcastExchange #13
-                                                                    WholeStageCodegen (18)
-                                                                      Filter [d_year,d_date_sk]
-                                                                        ColumnarToRow
-                                                                          InputAdapter
-                                                                            Scan parquet default.date_dim [d_date_sk,d_year]
-                                                            InputAdapter
-                                                              ReusedExchange [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount] #6
-                                                      WholeStageCodegen (24)
-                                                        Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ss_quantity,sr_return_quantity,ss_ext_sales_price,sr_return_amt]
-                                                          BroadcastHashJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
-                                                            Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                              BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                Project [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                  BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                                    Filter [ss_item_sk,ss_sold_date_sk]
-                                                                      ColumnarToRow
-                                                                        InputAdapter
-                                                                          Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price]
-                                                                    InputAdapter
-                                                                      ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #4
-                                                                InputAdapter
-                                                                  ReusedExchange [d_date_sk,d_year] #13
-                                                            InputAdapter
-                                                              ReusedExchange [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt] #7
-                                      WholeStageCodegen (30)
                                         Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ws_quantity,wr_return_quantity,ws_ext_sales_price,wr_return_amt]
                                           BroadcastHashJoin [ws_order_number,ws_item_sk,wr_order_number,wr_item_sk]
                                             Project [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
@@ -173,8 +157,8 @@ TakeOrderedAndProject [sales_cnt_diff,prev_year,year,i_brand_id,i_class_id,i_cat
                                                         InputAdapter
                                                           Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price]
                                                     InputAdapter
-                                                      ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #4
+                                                      ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #3
                                                 InputAdapter
-                                                  ReusedExchange [d_date_sk,d_year] #13
+                                                  ReusedExchange [d_date_sk,d_year] #11
                                             InputAdapter
-                                              ReusedExchange [wr_item_sk,wr_order_number,wr_return_quantity,wr_return_amt] #8
+                                              ReusedExchange [wr_item_sk,wr_order_number,wr_return_quantity,wr_return_amt] #7

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a.sf100/explain.txt
@@ -1,226 +1,214 @@
 == Physical Plan ==
-TakeOrderedAndProject (222)
-+- * HashAggregate (221)
-   +- Exchange (220)
-      +- * HashAggregate (219)
-         +- Union (218)
-            :- * HashAggregate (198)
-            :  +- Exchange (197)
-            :     +- * HashAggregate (196)
-            :        +- Union (195)
-            :           :- * HashAggregate (175)
-            :           :  +- Exchange (174)
-            :           :     +- * HashAggregate (173)
-            :           :        +- Union (172)
-            :           :           :- * HashAggregate (152)
-            :           :           :  +- Exchange (151)
-            :           :           :     +- * HashAggregate (150)
-            :           :           :        +- Union (149)
-            :           :           :           :- * HashAggregate (129)
-            :           :           :           :  +- Exchange (128)
-            :           :           :           :     +- * HashAggregate (127)
-            :           :           :           :        +- Union (126)
-            :           :           :           :           :- * Project (87)
-            :           :           :           :           :  +- * Filter (86)
-            :           :           :           :           :     +- * HashAggregate (85)
-            :           :           :           :           :        +- Exchange (84)
-            :           :           :           :           :           +- * HashAggregate (83)
-            :           :           :           :           :              +- * Project (82)
-            :           :           :           :           :                 +- * BroadcastHashJoin Inner BuildRight (81)
-            :           :           :           :           :                    :- * Project (71)
-            :           :           :           :           :                    :  +- * BroadcastHashJoin Inner BuildRight (70)
-            :           :           :           :           :                    :     :- SortMergeJoin LeftSemi (64)
-            :           :           :           :           :                    :     :  :- * Sort (5)
-            :           :           :           :           :                    :     :  :  +- Exchange (4)
-            :           :           :           :           :                    :     :  :     +- * Filter (3)
-            :           :           :           :           :                    :     :  :        +- * ColumnarToRow (2)
-            :           :           :           :           :                    :     :  :           +- Scan parquet default.store_sales (1)
-            :           :           :           :           :                    :     :  +- * Sort (63)
-            :           :           :           :           :                    :     :     +- Exchange (62)
-            :           :           :           :           :                    :     :        +- * Project (61)
-            :           :           :           :           :                    :     :           +- * BroadcastHashJoin Inner BuildRight (60)
-            :           :           :           :           :                    :     :              :- * Filter (8)
-            :           :           :           :           :                    :     :              :  +- * ColumnarToRow (7)
-            :           :           :           :           :                    :     :              :     +- Scan parquet default.item (6)
-            :           :           :           :           :                    :     :              +- BroadcastExchange (59)
-            :           :           :           :           :                    :     :                 +- * HashAggregate (58)
-            :           :           :           :           :                    :     :                    +- * HashAggregate (57)
-            :           :           :           :           :                    :     :                       +- * HashAggregate (56)
-            :           :           :           :           :                    :     :                          +- Exchange (55)
-            :           :           :           :           :                    :     :                             +- * HashAggregate (54)
-            :           :           :           :           :                    :     :                                +- SortMergeJoin LeftSemi (53)
-            :           :           :           :           :                    :     :                                   :- SortMergeJoin LeftSemi (41)
-            :           :           :           :           :                    :     :                                   :  :- * Sort (26)
-            :           :           :           :           :                    :     :                                   :  :  +- Exchange (25)
-            :           :           :           :           :                    :     :                                   :  :     +- * Project (24)
-            :           :           :           :           :                    :     :                                   :  :        +- * BroadcastHashJoin Inner BuildRight (23)
-            :           :           :           :           :                    :     :                                   :  :           :- * Project (18)
-            :           :           :           :           :                    :     :                                   :  :           :  +- * BroadcastHashJoin Inner BuildRight (17)
-            :           :           :           :           :                    :     :                                   :  :           :     :- * Filter (11)
-            :           :           :           :           :                    :     :                                   :  :           :     :  +- * ColumnarToRow (10)
-            :           :           :           :           :                    :     :                                   :  :           :     :     +- Scan parquet default.store_sales (9)
-            :           :           :           :           :                    :     :                                   :  :           :     +- BroadcastExchange (16)
-            :           :           :           :           :                    :     :                                   :  :           :        +- * Project (15)
-            :           :           :           :           :                    :     :                                   :  :           :           +- * Filter (14)
-            :           :           :           :           :                    :     :                                   :  :           :              +- * ColumnarToRow (13)
-            :           :           :           :           :                    :     :                                   :  :           :                 +- Scan parquet default.date_dim (12)
-            :           :           :           :           :                    :     :                                   :  :           +- BroadcastExchange (22)
-            :           :           :           :           :                    :     :                                   :  :              +- * Filter (21)
-            :           :           :           :           :                    :     :                                   :  :                 +- * ColumnarToRow (20)
-            :           :           :           :           :                    :     :                                   :  :                    +- Scan parquet default.item (19)
-            :           :           :           :           :                    :     :                                   :  +- * Sort (40)
-            :           :           :           :           :                    :     :                                   :     +- Exchange (39)
-            :           :           :           :           :                    :     :                                   :        +- * Project (38)
-            :           :           :           :           :                    :     :                                   :           +- * BroadcastHashJoin Inner BuildRight (37)
-            :           :           :           :           :                    :     :                                   :              :- * Project (32)
-            :           :           :           :           :                    :     :                                   :              :  +- * BroadcastHashJoin Inner BuildRight (31)
-            :           :           :           :           :                    :     :                                   :              :     :- * Filter (29)
-            :           :           :           :           :                    :     :                                   :              :     :  +- * ColumnarToRow (28)
-            :           :           :           :           :                    :     :                                   :              :     :     +- Scan parquet default.catalog_sales (27)
-            :           :           :           :           :                    :     :                                   :              :     +- ReusedExchange (30)
-            :           :           :           :           :                    :     :                                   :              +- BroadcastExchange (36)
-            :           :           :           :           :                    :     :                                   :                 +- * Filter (35)
-            :           :           :           :           :                    :     :                                   :                    +- * ColumnarToRow (34)
-            :           :           :           :           :                    :     :                                   :                       +- Scan parquet default.item (33)
-            :           :           :           :           :                    :     :                                   +- * Sort (52)
-            :           :           :           :           :                    :     :                                      +- Exchange (51)
-            :           :           :           :           :                    :     :                                         +- * Project (50)
-            :           :           :           :           :                    :     :                                            +- * BroadcastHashJoin Inner BuildRight (49)
-            :           :           :           :           :                    :     :                                               :- * Project (47)
-            :           :           :           :           :                    :     :                                               :  +- * BroadcastHashJoin Inner BuildRight (46)
-            :           :           :           :           :                    :     :                                               :     :- * Filter (44)
-            :           :           :           :           :                    :     :                                               :     :  +- * ColumnarToRow (43)
-            :           :           :           :           :                    :     :                                               :     :     +- Scan parquet default.web_sales (42)
-            :           :           :           :           :                    :     :                                               :     +- ReusedExchange (45)
-            :           :           :           :           :                    :     :                                               +- ReusedExchange (48)
-            :           :           :           :           :                    :     +- BroadcastExchange (69)
-            :           :           :           :           :                    :        +- * Project (68)
-            :           :           :           :           :                    :           +- * Filter (67)
-            :           :           :           :           :                    :              +- * ColumnarToRow (66)
-            :           :           :           :           :                    :                 +- Scan parquet default.date_dim (65)
-            :           :           :           :           :                    +- BroadcastExchange (80)
-            :           :           :           :           :                       +- SortMergeJoin LeftSemi (79)
-            :           :           :           :           :                          :- * Sort (76)
-            :           :           :           :           :                          :  +- Exchange (75)
-            :           :           :           :           :                          :     +- * Filter (74)
-            :           :           :           :           :                          :        +- * ColumnarToRow (73)
-            :           :           :           :           :                          :           +- Scan parquet default.item (72)
-            :           :           :           :           :                          +- * Sort (78)
-            :           :           :           :           :                             +- ReusedExchange (77)
-            :           :           :           :           :- * Project (106)
-            :           :           :           :           :  +- * Filter (105)
-            :           :           :           :           :     +- * HashAggregate (104)
-            :           :           :           :           :        +- Exchange (103)
-            :           :           :           :           :           +- * HashAggregate (102)
-            :           :           :           :           :              +- * Project (101)
-            :           :           :           :           :                 +- * BroadcastHashJoin Inner BuildRight (100)
-            :           :           :           :           :                    :- * Project (98)
-            :           :           :           :           :                    :  +- * BroadcastHashJoin Inner BuildRight (97)
-            :           :           :           :           :                    :     :- SortMergeJoin LeftSemi (95)
-            :           :           :           :           :                    :     :  :- * Sort (92)
-            :           :           :           :           :                    :     :  :  +- Exchange (91)
-            :           :           :           :           :                    :     :  :     +- * Filter (90)
-            :           :           :           :           :                    :     :  :        +- * ColumnarToRow (89)
-            :           :           :           :           :                    :     :  :           +- Scan parquet default.catalog_sales (88)
-            :           :           :           :           :                    :     :  +- * Sort (94)
-            :           :           :           :           :                    :     :     +- ReusedExchange (93)
-            :           :           :           :           :                    :     +- ReusedExchange (96)
-            :           :           :           :           :                    +- ReusedExchange (99)
-            :           :           :           :           +- * Project (125)
-            :           :           :           :              +- * Filter (124)
-            :           :           :           :                 +- * HashAggregate (123)
-            :           :           :           :                    +- Exchange (122)
-            :           :           :           :                       +- * HashAggregate (121)
-            :           :           :           :                          +- * Project (120)
-            :           :           :           :                             +- * BroadcastHashJoin Inner BuildRight (119)
-            :           :           :           :                                :- * Project (117)
-            :           :           :           :                                :  +- * BroadcastHashJoin Inner BuildRight (116)
-            :           :           :           :                                :     :- SortMergeJoin LeftSemi (114)
-            :           :           :           :                                :     :  :- * Sort (111)
-            :           :           :           :                                :     :  :  +- Exchange (110)
-            :           :           :           :                                :     :  :     +- * Filter (109)
-            :           :           :           :                                :     :  :        +- * ColumnarToRow (108)
-            :           :           :           :                                :     :  :           +- Scan parquet default.web_sales (107)
-            :           :           :           :                                :     :  +- * Sort (113)
-            :           :           :           :                                :     :     +- ReusedExchange (112)
-            :           :           :           :                                :     +- ReusedExchange (115)
-            :           :           :           :                                +- ReusedExchange (118)
-            :           :           :           +- * HashAggregate (148)
-            :           :           :              +- Exchange (147)
-            :           :           :                 +- * HashAggregate (146)
-            :           :           :                    +- * HashAggregate (145)
-            :           :           :                       +- Exchange (144)
-            :           :           :                          +- * HashAggregate (143)
-            :           :           :                             +- Union (142)
-            :           :           :                                :- * Project (133)
-            :           :           :                                :  +- * Filter (132)
-            :           :           :                                :     +- * HashAggregate (131)
-            :           :           :                                :        +- ReusedExchange (130)
-            :           :           :                                :- * Project (137)
-            :           :           :                                :  +- * Filter (136)
-            :           :           :                                :     +- * HashAggregate (135)
-            :           :           :                                :        +- ReusedExchange (134)
-            :           :           :                                +- * Project (141)
-            :           :           :                                   +- * Filter (140)
-            :           :           :                                      +- * HashAggregate (139)
-            :           :           :                                         +- ReusedExchange (138)
-            :           :           +- * HashAggregate (171)
-            :           :              +- Exchange (170)
-            :           :                 +- * HashAggregate (169)
-            :           :                    +- * HashAggregate (168)
-            :           :                       +- Exchange (167)
-            :           :                          +- * HashAggregate (166)
-            :           :                             +- Union (165)
-            :           :                                :- * Project (156)
-            :           :                                :  +- * Filter (155)
-            :           :                                :     +- * HashAggregate (154)
-            :           :                                :        +- ReusedExchange (153)
-            :           :                                :- * Project (160)
-            :           :                                :  +- * Filter (159)
-            :           :                                :     +- * HashAggregate (158)
-            :           :                                :        +- ReusedExchange (157)
-            :           :                                +- * Project (164)
-            :           :                                   +- * Filter (163)
-            :           :                                      +- * HashAggregate (162)
-            :           :                                         +- ReusedExchange (161)
-            :           +- * HashAggregate (194)
-            :              +- Exchange (193)
-            :                 +- * HashAggregate (192)
-            :                    +- * HashAggregate (191)
-            :                       +- Exchange (190)
-            :                          +- * HashAggregate (189)
-            :                             +- Union (188)
-            :                                :- * Project (179)
-            :                                :  +- * Filter (178)
-            :                                :     +- * HashAggregate (177)
-            :                                :        +- ReusedExchange (176)
-            :                                :- * Project (183)
-            :                                :  +- * Filter (182)
-            :                                :     +- * HashAggregate (181)
-            :                                :        +- ReusedExchange (180)
-            :                                +- * Project (187)
-            :                                   +- * Filter (186)
-            :                                      +- * HashAggregate (185)
-            :                                         +- ReusedExchange (184)
-            +- * HashAggregate (217)
-               +- Exchange (216)
-                  +- * HashAggregate (215)
-                     +- * HashAggregate (214)
-                        +- Exchange (213)
-                           +- * HashAggregate (212)
-                              +- Union (211)
-                                 :- * Project (202)
-                                 :  +- * Filter (201)
-                                 :     +- * HashAggregate (200)
-                                 :        +- ReusedExchange (199)
-                                 :- * Project (206)
-                                 :  +- * Filter (205)
-                                 :     +- * HashAggregate (204)
-                                 :        +- ReusedExchange (203)
-                                 +- * Project (210)
-                                    +- * Filter (209)
-                                       +- * HashAggregate (208)
-                                          +- ReusedExchange (207)
+TakeOrderedAndProject (210)
++- * HashAggregate (209)
+   +- Exchange (208)
+      +- * HashAggregate (207)
+         +- Union (206)
+            :- * HashAggregate (129)
+            :  +- Exchange (128)
+            :     +- * HashAggregate (127)
+            :        +- Union (126)
+            :           :- * Project (87)
+            :           :  +- * Filter (86)
+            :           :     +- * HashAggregate (85)
+            :           :        +- Exchange (84)
+            :           :           +- * HashAggregate (83)
+            :           :              +- * Project (82)
+            :           :                 +- * BroadcastHashJoin Inner BuildRight (81)
+            :           :                    :- * Project (71)
+            :           :                    :  +- * BroadcastHashJoin Inner BuildRight (70)
+            :           :                    :     :- SortMergeJoin LeftSemi (64)
+            :           :                    :     :  :- * Sort (5)
+            :           :                    :     :  :  +- Exchange (4)
+            :           :                    :     :  :     +- * Filter (3)
+            :           :                    :     :  :        +- * ColumnarToRow (2)
+            :           :                    :     :  :           +- Scan parquet default.store_sales (1)
+            :           :                    :     :  +- * Sort (63)
+            :           :                    :     :     +- Exchange (62)
+            :           :                    :     :        +- * Project (61)
+            :           :                    :     :           +- * BroadcastHashJoin Inner BuildRight (60)
+            :           :                    :     :              :- * Filter (8)
+            :           :                    :     :              :  +- * ColumnarToRow (7)
+            :           :                    :     :              :     +- Scan parquet default.item (6)
+            :           :                    :     :              +- BroadcastExchange (59)
+            :           :                    :     :                 +- * HashAggregate (58)
+            :           :                    :     :                    +- * HashAggregate (57)
+            :           :                    :     :                       +- * HashAggregate (56)
+            :           :                    :     :                          +- Exchange (55)
+            :           :                    :     :                             +- * HashAggregate (54)
+            :           :                    :     :                                +- SortMergeJoin LeftSemi (53)
+            :           :                    :     :                                   :- SortMergeJoin LeftSemi (41)
+            :           :                    :     :                                   :  :- * Sort (26)
+            :           :                    :     :                                   :  :  +- Exchange (25)
+            :           :                    :     :                                   :  :     +- * Project (24)
+            :           :                    :     :                                   :  :        +- * BroadcastHashJoin Inner BuildRight (23)
+            :           :                    :     :                                   :  :           :- * Project (18)
+            :           :                    :     :                                   :  :           :  +- * BroadcastHashJoin Inner BuildRight (17)
+            :           :                    :     :                                   :  :           :     :- * Filter (11)
+            :           :                    :     :                                   :  :           :     :  +- * ColumnarToRow (10)
+            :           :                    :     :                                   :  :           :     :     +- Scan parquet default.store_sales (9)
+            :           :                    :     :                                   :  :           :     +- BroadcastExchange (16)
+            :           :                    :     :                                   :  :           :        +- * Project (15)
+            :           :                    :     :                                   :  :           :           +- * Filter (14)
+            :           :                    :     :                                   :  :           :              +- * ColumnarToRow (13)
+            :           :                    :     :                                   :  :           :                 +- Scan parquet default.date_dim (12)
+            :           :                    :     :                                   :  :           +- BroadcastExchange (22)
+            :           :                    :     :                                   :  :              +- * Filter (21)
+            :           :                    :     :                                   :  :                 +- * ColumnarToRow (20)
+            :           :                    :     :                                   :  :                    +- Scan parquet default.item (19)
+            :           :                    :     :                                   :  +- * Sort (40)
+            :           :                    :     :                                   :     +- Exchange (39)
+            :           :                    :     :                                   :        +- * Project (38)
+            :           :                    :     :                                   :           +- * BroadcastHashJoin Inner BuildRight (37)
+            :           :                    :     :                                   :              :- * Project (32)
+            :           :                    :     :                                   :              :  +- * BroadcastHashJoin Inner BuildRight (31)
+            :           :                    :     :                                   :              :     :- * Filter (29)
+            :           :                    :     :                                   :              :     :  +- * ColumnarToRow (28)
+            :           :                    :     :                                   :              :     :     +- Scan parquet default.catalog_sales (27)
+            :           :                    :     :                                   :              :     +- ReusedExchange (30)
+            :           :                    :     :                                   :              +- BroadcastExchange (36)
+            :           :                    :     :                                   :                 +- * Filter (35)
+            :           :                    :     :                                   :                    +- * ColumnarToRow (34)
+            :           :                    :     :                                   :                       +- Scan parquet default.item (33)
+            :           :                    :     :                                   +- * Sort (52)
+            :           :                    :     :                                      +- Exchange (51)
+            :           :                    :     :                                         +- * Project (50)
+            :           :                    :     :                                            +- * BroadcastHashJoin Inner BuildRight (49)
+            :           :                    :     :                                               :- * Project (47)
+            :           :                    :     :                                               :  +- * BroadcastHashJoin Inner BuildRight (46)
+            :           :                    :     :                                               :     :- * Filter (44)
+            :           :                    :     :                                               :     :  +- * ColumnarToRow (43)
+            :           :                    :     :                                               :     :     +- Scan parquet default.web_sales (42)
+            :           :                    :     :                                               :     +- ReusedExchange (45)
+            :           :                    :     :                                               +- ReusedExchange (48)
+            :           :                    :     +- BroadcastExchange (69)
+            :           :                    :        +- * Project (68)
+            :           :                    :           +- * Filter (67)
+            :           :                    :              +- * ColumnarToRow (66)
+            :           :                    :                 +- Scan parquet default.date_dim (65)
+            :           :                    +- BroadcastExchange (80)
+            :           :                       +- SortMergeJoin LeftSemi (79)
+            :           :                          :- * Sort (76)
+            :           :                          :  +- Exchange (75)
+            :           :                          :     +- * Filter (74)
+            :           :                          :        +- * ColumnarToRow (73)
+            :           :                          :           +- Scan parquet default.item (72)
+            :           :                          +- * Sort (78)
+            :           :                             +- ReusedExchange (77)
+            :           :- * Project (106)
+            :           :  +- * Filter (105)
+            :           :     +- * HashAggregate (104)
+            :           :        +- Exchange (103)
+            :           :           +- * HashAggregate (102)
+            :           :              +- * Project (101)
+            :           :                 +- * BroadcastHashJoin Inner BuildRight (100)
+            :           :                    :- * Project (98)
+            :           :                    :  +- * BroadcastHashJoin Inner BuildRight (97)
+            :           :                    :     :- SortMergeJoin LeftSemi (95)
+            :           :                    :     :  :- * Sort (92)
+            :           :                    :     :  :  +- Exchange (91)
+            :           :                    :     :  :     +- * Filter (90)
+            :           :                    :     :  :        +- * ColumnarToRow (89)
+            :           :                    :     :  :           +- Scan parquet default.catalog_sales (88)
+            :           :                    :     :  +- * Sort (94)
+            :           :                    :     :     +- ReusedExchange (93)
+            :           :                    :     +- ReusedExchange (96)
+            :           :                    +- ReusedExchange (99)
+            :           +- * Project (125)
+            :              +- * Filter (124)
+            :                 +- * HashAggregate (123)
+            :                    +- Exchange (122)
+            :                       +- * HashAggregate (121)
+            :                          +- * Project (120)
+            :                             +- * BroadcastHashJoin Inner BuildRight (119)
+            :                                :- * Project (117)
+            :                                :  +- * BroadcastHashJoin Inner BuildRight (116)
+            :                                :     :- SortMergeJoin LeftSemi (114)
+            :                                :     :  :- * Sort (111)
+            :                                :     :  :  +- Exchange (110)
+            :                                :     :  :     +- * Filter (109)
+            :                                :     :  :        +- * ColumnarToRow (108)
+            :                                :     :  :           +- Scan parquet default.web_sales (107)
+            :                                :     :  +- * Sort (113)
+            :                                :     :     +- ReusedExchange (112)
+            :                                :     +- ReusedExchange (115)
+            :                                +- ReusedExchange (118)
+            :- * HashAggregate (148)
+            :  +- Exchange (147)
+            :     +- * HashAggregate (146)
+            :        +- * HashAggregate (145)
+            :           +- Exchange (144)
+            :              +- * HashAggregate (143)
+            :                 +- Union (142)
+            :                    :- * Project (133)
+            :                    :  +- * Filter (132)
+            :                    :     +- * HashAggregate (131)
+            :                    :        +- ReusedExchange (130)
+            :                    :- * Project (137)
+            :                    :  +- * Filter (136)
+            :                    :     +- * HashAggregate (135)
+            :                    :        +- ReusedExchange (134)
+            :                    +- * Project (141)
+            :                       +- * Filter (140)
+            :                          +- * HashAggregate (139)
+            :                             +- ReusedExchange (138)
+            :- * HashAggregate (167)
+            :  +- Exchange (166)
+            :     +- * HashAggregate (165)
+            :        +- * HashAggregate (164)
+            :           +- Exchange (163)
+            :              +- * HashAggregate (162)
+            :                 +- Union (161)
+            :                    :- * Project (152)
+            :                    :  +- * Filter (151)
+            :                    :     +- * HashAggregate (150)
+            :                    :        +- ReusedExchange (149)
+            :                    :- * Project (156)
+            :                    :  +- * Filter (155)
+            :                    :     +- * HashAggregate (154)
+            :                    :        +- ReusedExchange (153)
+            :                    +- * Project (160)
+            :                       +- * Filter (159)
+            :                          +- * HashAggregate (158)
+            :                             +- ReusedExchange (157)
+            :- * HashAggregate (186)
+            :  +- Exchange (185)
+            :     +- * HashAggregate (184)
+            :        +- * HashAggregate (183)
+            :           +- Exchange (182)
+            :              +- * HashAggregate (181)
+            :                 +- Union (180)
+            :                    :- * Project (171)
+            :                    :  +- * Filter (170)
+            :                    :     +- * HashAggregate (169)
+            :                    :        +- ReusedExchange (168)
+            :                    :- * Project (175)
+            :                    :  +- * Filter (174)
+            :                    :     +- * HashAggregate (173)
+            :                    :        +- ReusedExchange (172)
+            :                    +- * Project (179)
+            :                       +- * Filter (178)
+            :                          +- * HashAggregate (177)
+            :                             +- ReusedExchange (176)
+            +- * HashAggregate (205)
+               +- Exchange (204)
+                  +- * HashAggregate (203)
+                     +- * HashAggregate (202)
+                        +- Exchange (201)
+                           +- * HashAggregate (200)
+                              +- Union (199)
+                                 :- * Project (190)
+                                 :  +- * Filter (189)
+                                 :     +- * HashAggregate (188)
+                                 :        +- ReusedExchange (187)
+                                 :- * Project (194)
+                                 :  +- * Filter (193)
+                                 :     +- * HashAggregate (192)
+                                 :        +- ReusedExchange (191)
+                                 +- * Project (198)
+                                    +- * Filter (197)
+                                       +- * HashAggregate (196)
+                                          +- ReusedExchange (195)
 
 
 (1) Scan parquet default.store_sales
@@ -239,7 +227,7 @@ Condition : (isnotnull(ss_item_sk#2) AND isnotnull(ss_sold_date_sk#1))
 
 (4) Exchange
 Input [4]: [ss_sold_date_sk#1, ss_item_sk#2, ss_quantity#3, ss_list_price#4]
-Arguments: hashpartitioning(ss_item_sk#2, 5), true, [id=#5]
+Arguments: hashpartitioning(ss_item_sk#2, 5), ENSURE_REQUIREMENTS, [id=#5]
 
 (5) Sort [codegen id : 2]
 Input [4]: [ss_sold_date_sk#1, ss_item_sk#2, ss_quantity#3, ss_list_price#4]
@@ -333,7 +321,7 @@ Input [5]: [ss_item_sk#2, i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id
 
 (25) Exchange
 Input [3]: [brand_id#14, class_id#15, category_id#16]
-Arguments: hashpartitioning(coalesce(brand_id#14, 0), isnull(brand_id#14), coalesce(class_id#15, 0), isnull(class_id#15), coalesce(category_id#16, 0), isnull(category_id#16), 5), true, [id=#17]
+Arguments: hashpartitioning(coalesce(brand_id#14, 0), isnull(brand_id#14), coalesce(class_id#15, 0), isnull(class_id#15), coalesce(category_id#16, 0), isnull(category_id#16), 5), ENSURE_REQUIREMENTS, [id=#17]
 
 (26) Sort [codegen id : 6]
 Input [3]: [brand_id#14, class_id#15, category_id#16]
@@ -394,7 +382,7 @@ Input [5]: [cs_item_sk#19, i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_i
 
 (39) Exchange
 Input [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
-Arguments: hashpartitioning(coalesce(i_brand_id#7, 0), isnull(i_brand_id#7), coalesce(i_class_id#8, 0), isnull(i_class_id#8), coalesce(i_category_id#9, 0), isnull(i_category_id#9), 5), true, [id=#21]
+Arguments: hashpartitioning(coalesce(i_brand_id#7, 0), isnull(i_brand_id#7), coalesce(i_class_id#8, 0), isnull(i_class_id#8), coalesce(i_category_id#9, 0), isnull(i_category_id#9), 5), ENSURE_REQUIREMENTS, [id=#21]
 
 (40) Sort [codegen id : 10]
 Input [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
@@ -445,7 +433,7 @@ Input [5]: [ws_item_sk#23, i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_i
 
 (51) Exchange
 Input [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
-Arguments: hashpartitioning(coalesce(i_brand_id#7, 0), isnull(i_brand_id#7), coalesce(i_class_id#8, 0), isnull(i_class_id#8), coalesce(i_category_id#9, 0), isnull(i_category_id#9), 5), true, [id=#24]
+Arguments: hashpartitioning(coalesce(i_brand_id#7, 0), isnull(i_brand_id#7), coalesce(i_class_id#8, 0), isnull(i_class_id#8), coalesce(i_category_id#9, 0), isnull(i_category_id#9), 5), ENSURE_REQUIREMENTS, [id=#24]
 
 (52) Sort [codegen id : 14]
 Input [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
@@ -465,7 +453,7 @@ Results [3]: [brand_id#14, class_id#15, category_id#16]
 
 (55) Exchange
 Input [3]: [brand_id#14, class_id#15, category_id#16]
-Arguments: hashpartitioning(brand_id#14, class_id#15, category_id#16, 5), true, [id=#25]
+Arguments: hashpartitioning(brand_id#14, class_id#15, category_id#16, 5), ENSURE_REQUIREMENTS, [id=#25]
 
 (56) HashAggregate [codegen id : 16]
 Input [3]: [brand_id#14, class_id#15, category_id#16]
@@ -503,7 +491,7 @@ Input [7]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9, brand_id#1
 
 (62) Exchange
 Input [1]: [ss_item_sk#27]
-Arguments: hashpartitioning(ss_item_sk#27, 5), true, [id=#28]
+Arguments: hashpartitioning(ss_item_sk#27, 5), ENSURE_REQUIREMENTS, [id=#28]
 
 (63) Sort [codegen id : 18]
 Input [1]: [ss_item_sk#27]
@@ -561,7 +549,7 @@ Condition : isnotnull(i_item_sk#6)
 
 (75) Exchange
 Input [4]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
-Arguments: hashpartitioning(i_item_sk#6, 5), true, [id=#31]
+Arguments: hashpartitioning(i_item_sk#6, 5), ENSURE_REQUIREMENTS, [id=#31]
 
 (76) Sort [codegen id : 21]
 Input [4]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
@@ -601,7 +589,7 @@ Results [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#36, isEmpty#37, c
 
 (84) Exchange
 Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#36, isEmpty#37, count#38]
-Arguments: hashpartitioning(i_brand_id#7, i_class_id#8, i_category_id#9, 5), true, [id=#39]
+Arguments: hashpartitioning(i_brand_id#7, i_class_id#8, i_category_id#9, 5), ENSURE_REQUIREMENTS, [id=#39]
 
 (85) HashAggregate [codegen id : 39]
 Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#36, isEmpty#37, count#38]
@@ -634,7 +622,7 @@ Condition : (isnotnull(cs_item_sk#19) AND isnotnull(cs_sold_date_sk#18))
 
 (91) Exchange
 Input [4]: [cs_sold_date_sk#18, cs_item_sk#19, cs_quantity#48, cs_list_price#49]
-Arguments: hashpartitioning(cs_item_sk#19, 5), true, [id=#50]
+Arguments: hashpartitioning(cs_item_sk#19, 5), ENSURE_REQUIREMENTS, [id=#50]
 
 (92) Sort [codegen id : 41]
 Input [4]: [cs_sold_date_sk#18, cs_item_sk#19, cs_quantity#48, cs_list_price#49]
@@ -685,7 +673,7 @@ Results [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#54, isEmpty#55, c
 
 (103) Exchange
 Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#54, isEmpty#55, count#56]
-Arguments: hashpartitioning(i_brand_id#7, i_class_id#8, i_category_id#9, 5), true, [id=#57]
+Arguments: hashpartitioning(i_brand_id#7, i_class_id#8, i_category_id#9, 5), ENSURE_REQUIREMENTS, [id=#57]
 
 (104) HashAggregate [codegen id : 78]
 Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#54, isEmpty#55, count#56]
@@ -718,7 +706,7 @@ Condition : (isnotnull(ws_item_sk#23) AND isnotnull(ws_sold_date_sk#22))
 
 (110) Exchange
 Input [4]: [ws_sold_date_sk#22, ws_item_sk#23, ws_quantity#64, ws_list_price#65]
-Arguments: hashpartitioning(ws_item_sk#23, 5), true, [id=#66]
+Arguments: hashpartitioning(ws_item_sk#23, 5), ENSURE_REQUIREMENTS, [id=#66]
 
 (111) Sort [codegen id : 80]
 Input [4]: [ws_sold_date_sk#22, ws_item_sk#23, ws_quantity#64, ws_list_price#65]
@@ -769,7 +757,7 @@ Results [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#70, isEmpty#71, c
 
 (122) Exchange
 Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#70, isEmpty#71, count#72]
-Arguments: hashpartitioning(i_brand_id#7, i_class_id#8, i_category_id#9, 5), true, [id=#73]
+Arguments: hashpartitioning(i_brand_id#7, i_class_id#8, i_category_id#9, 5), ENSURE_REQUIREMENTS, [id=#73]
 
 (123) HashAggregate [codegen id : 117]
 Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#70, isEmpty#71, count#72]
@@ -797,7 +785,7 @@ Results [7]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum#83, i
 
 (128) Exchange
 Input [7]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum#83, isEmpty#84, sum#85]
-Arguments: hashpartitioning(channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, 5), true, [id=#86]
+Arguments: hashpartitioning(channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, 5), ENSURE_REQUIREMENTS, [id=#86]
 
 (129) HashAggregate [codegen id : 119]
 Input [7]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum#83, isEmpty#84, sum#85]
@@ -871,7 +859,7 @@ Results [7]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum#114, 
 
 (144) Exchange
 Input [7]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum#114, isEmpty#115, sum#116]
-Arguments: hashpartitioning(channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, 5), true, [id=#117]
+Arguments: hashpartitioning(channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, 5), ENSURE_REQUIREMENTS, [id=#117]
 
 (145) HashAggregate [codegen id : 238]
 Input [7]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum#114, isEmpty#115, sum#116]
@@ -889,7 +877,7 @@ Results [6]: [channel#47, i_brand_id#7, i_class_id#8, sum#123, isEmpty#124, sum#
 
 (147) Exchange
 Input [6]: [channel#47, i_brand_id#7, i_class_id#8, sum#123, isEmpty#124, sum#125]
-Arguments: hashpartitioning(channel#47, i_brand_id#7, i_class_id#8, 5), true, [id=#126]
+Arguments: hashpartitioning(channel#47, i_brand_id#7, i_class_id#8, 5), ENSURE_REQUIREMENTS, [id=#126]
 
 (148) HashAggregate [codegen id : 239]
 Input [6]: [channel#47, i_brand_id#7, i_class_id#8, sum#123, isEmpty#124, sum#125]
@@ -898,536 +886,476 @@ Functions [2]: [sum(sum_sales#89), sum(number_sales#90)]
 Aggregate Attributes [2]: [sum(sum_sales#89)#127, sum(number_sales#90)#128]
 Results [6]: [channel#47, i_brand_id#7, i_class_id#8, null AS i_category_id#129, sum(sum_sales#89)#127 AS sum(sum_sales)#130, sum(number_sales#90)#128 AS sum(number_sales)#131]
 
-(149) Union
+(149) ReusedExchange [Reuses operator id: 84]
+Output [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#132, isEmpty#133, count#134]
 
-(150) HashAggregate [codegen id : 240]
-Input [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90]
-Keys [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90]
-Functions: []
-Aggregate Attributes: []
-Results [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90]
-
-(151) Exchange
-Input [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90]
-Arguments: hashpartitioning(channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90, 5), true, [id=#132]
-
-(152) HashAggregate [codegen id : 241]
-Input [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90]
-Keys [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90]
-Functions: []
-Aggregate Attributes: []
-Results [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90]
-
-(153) ReusedExchange [Reuses operator id: 84]
-Output [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#133, isEmpty#134, count#135]
-
-(154) HashAggregate [codegen id : 280]
-Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#133, isEmpty#134, count#135]
+(150) HashAggregate [codegen id : 278]
+Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#132, isEmpty#133, count#134]
 Keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
 Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#136, count(1)#137]
-Results [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#136 AS sales#42, count(1)#137 AS number_sales#43, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#136 AS sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#138]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#135, count(1)#136]
+Results [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#135 AS sales#42, count(1)#136 AS number_sales#43, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#135 AS sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#137]
 
-(155) Filter [codegen id : 280]
-Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#42, number_sales#43, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#138]
-Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#138) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#138 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#45, [id=#46] as decimal(32,6))))
+(151) Filter [codegen id : 278]
+Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#42, number_sales#43, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#137]
+Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#137) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#137 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#45, [id=#46] as decimal(32,6))))
 
-(156) Project [codegen id : 280]
+(152) Project [codegen id : 278]
 Output [6]: [store AS channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sales#42, number_sales#43]
-Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#42, number_sales#43, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#138]
+Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#42, number_sales#43, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#137]
 
-(157) ReusedExchange [Reuses operator id: 103]
-Output [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#139, isEmpty#140, count#141]
+(153) ReusedExchange [Reuses operator id: 103]
+Output [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#138, isEmpty#139, count#140]
 
-(158) HashAggregate [codegen id : 319]
-Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#139, isEmpty#140, count#141]
+(154) HashAggregate [codegen id : 317]
+Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#138, isEmpty#139, count#140]
 Keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
 Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#142, count(1)#143]
-Results [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#142 AS sales#60, count(1)#143 AS number_sales#61, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#142 AS sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#144]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#141, count(1)#142]
+Results [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#141 AS sales#60, count(1)#142 AS number_sales#61, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#141 AS sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#143]
 
-(159) Filter [codegen id : 319]
-Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#60, number_sales#61, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#144]
-Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#144) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#144 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#45, [id=#46] as decimal(32,6))))
+(155) Filter [codegen id : 317]
+Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#60, number_sales#61, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#143]
+Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#143) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#143 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#45, [id=#46] as decimal(32,6))))
 
-(160) Project [codegen id : 319]
-Output [6]: [catalog AS channel#145, i_brand_id#7, i_class_id#8, i_category_id#9, sales#60, number_sales#61]
-Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#60, number_sales#61, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#144]
+(156) Project [codegen id : 317]
+Output [6]: [catalog AS channel#144, i_brand_id#7, i_class_id#8, i_category_id#9, sales#60, number_sales#61]
+Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#60, number_sales#61, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#143]
 
-(161) ReusedExchange [Reuses operator id: 122]
-Output [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#146, isEmpty#147, count#148]
+(157) ReusedExchange [Reuses operator id: 122]
+Output [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#145, isEmpty#146, count#147]
 
-(162) HashAggregate [codegen id : 358]
-Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#146, isEmpty#147, count#148]
+(158) HashAggregate [codegen id : 356]
+Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#145, isEmpty#146, count#147]
 Keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
 Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#149, count(1)#150]
-Results [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#149 AS sales#76, count(1)#150 AS number_sales#77, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#149 AS sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#151]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#148, count(1)#149]
+Results [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#148 AS sales#76, count(1)#149 AS number_sales#77, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#148 AS sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#150]
 
-(163) Filter [codegen id : 358]
-Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#76, number_sales#77, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#151]
-Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#151) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#151 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#45, [id=#46] as decimal(32,6))))
+(159) Filter [codegen id : 356]
+Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#76, number_sales#77, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#150]
+Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#150) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#150 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#45, [id=#46] as decimal(32,6))))
 
-(164) Project [codegen id : 358]
-Output [6]: [web AS channel#152, i_brand_id#7, i_class_id#8, i_category_id#9, sales#76, number_sales#77]
-Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#76, number_sales#77, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#151]
+(160) Project [codegen id : 356]
+Output [6]: [web AS channel#151, i_brand_id#7, i_class_id#8, i_category_id#9, sales#76, number_sales#77]
+Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#76, number_sales#77, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#150]
 
-(165) Union
+(161) Union
 
-(166) HashAggregate [codegen id : 359]
+(162) HashAggregate [codegen id : 357]
 Input [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sales#42, number_sales#43]
 Keys [4]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9]
 Functions [2]: [partial_sum(sales#42), partial_sum(number_sales#43)]
-Aggregate Attributes [3]: [sum#153, isEmpty#154, sum#155]
-Results [7]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum#156, isEmpty#157, sum#158]
+Aggregate Attributes [3]: [sum#152, isEmpty#153, sum#154]
+Results [7]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum#155, isEmpty#156, sum#157]
 
-(167) Exchange
-Input [7]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum#156, isEmpty#157, sum#158]
-Arguments: hashpartitioning(channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, 5), true, [id=#159]
+(163) Exchange
+Input [7]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum#155, isEmpty#156, sum#157]
+Arguments: hashpartitioning(channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, 5), ENSURE_REQUIREMENTS, [id=#158]
 
-(168) HashAggregate [codegen id : 360]
-Input [7]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum#156, isEmpty#157, sum#158]
+(164) HashAggregate [codegen id : 358]
+Input [7]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum#155, isEmpty#156, sum#157]
 Keys [4]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9]
 Functions [2]: [sum(sales#42), sum(number_sales#43)]
-Aggregate Attributes [2]: [sum(sales#42)#160, sum(number_sales#43)#161]
-Results [4]: [channel#47, i_brand_id#7, sum(sales#42)#160 AS sum_sales#89, sum(number_sales#43)#161 AS number_sales#90]
+Aggregate Attributes [2]: [sum(sales#42)#159, sum(number_sales#43)#160]
+Results [4]: [channel#47, i_brand_id#7, sum(sales#42)#159 AS sum_sales#89, sum(number_sales#43)#160 AS number_sales#90]
 
-(169) HashAggregate [codegen id : 360]
+(165) HashAggregate [codegen id : 358]
 Input [4]: [channel#47, i_brand_id#7, sum_sales#89, number_sales#90]
 Keys [2]: [channel#47, i_brand_id#7]
 Functions [2]: [partial_sum(sum_sales#89), partial_sum(number_sales#90)]
-Aggregate Attributes [3]: [sum#162, isEmpty#163, sum#164]
-Results [5]: [channel#47, i_brand_id#7, sum#165, isEmpty#166, sum#167]
+Aggregate Attributes [3]: [sum#161, isEmpty#162, sum#163]
+Results [5]: [channel#47, i_brand_id#7, sum#164, isEmpty#165, sum#166]
 
-(170) Exchange
-Input [5]: [channel#47, i_brand_id#7, sum#165, isEmpty#166, sum#167]
-Arguments: hashpartitioning(channel#47, i_brand_id#7, 5), true, [id=#168]
+(166) Exchange
+Input [5]: [channel#47, i_brand_id#7, sum#164, isEmpty#165, sum#166]
+Arguments: hashpartitioning(channel#47, i_brand_id#7, 5), ENSURE_REQUIREMENTS, [id=#167]
 
-(171) HashAggregate [codegen id : 361]
-Input [5]: [channel#47, i_brand_id#7, sum#165, isEmpty#166, sum#167]
+(167) HashAggregate [codegen id : 359]
+Input [5]: [channel#47, i_brand_id#7, sum#164, isEmpty#165, sum#166]
 Keys [2]: [channel#47, i_brand_id#7]
 Functions [2]: [sum(sum_sales#89), sum(number_sales#90)]
-Aggregate Attributes [2]: [sum(sum_sales#89)#169, sum(number_sales#90)#170]
-Results [6]: [channel#47, i_brand_id#7, null AS i_class_id#171, null AS i_category_id#172, sum(sum_sales#89)#169 AS sum(sum_sales)#173, sum(number_sales#90)#170 AS sum(number_sales)#174]
+Aggregate Attributes [2]: [sum(sum_sales#89)#168, sum(number_sales#90)#169]
+Results [6]: [channel#47, i_brand_id#7, null AS i_class_id#170, null AS i_category_id#171, sum(sum_sales#89)#168 AS sum(sum_sales)#172, sum(number_sales#90)#169 AS sum(number_sales)#173]
 
-(172) Union
+(168) ReusedExchange [Reuses operator id: 84]
+Output [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#174, isEmpty#175, count#176]
 
-(173) HashAggregate [codegen id : 362]
-Input [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90]
-Keys [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90]
-Functions: []
-Aggregate Attributes: []
-Results [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90]
-
-(174) Exchange
-Input [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90]
-Arguments: hashpartitioning(channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90, 5), true, [id=#175]
-
-(175) HashAggregate [codegen id : 363]
-Input [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90]
-Keys [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90]
-Functions: []
-Aggregate Attributes: []
-Results [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90]
-
-(176) ReusedExchange [Reuses operator id: 84]
-Output [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#176, isEmpty#177, count#178]
-
-(177) HashAggregate [codegen id : 402]
-Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#176, isEmpty#177, count#178]
+(169) HashAggregate [codegen id : 398]
+Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#174, isEmpty#175, count#176]
 Keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
 Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#179, count(1)#180]
-Results [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#179 AS sales#42, count(1)#180 AS number_sales#43, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#179 AS sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#181]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#177, count(1)#178]
+Results [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#177 AS sales#42, count(1)#178 AS number_sales#43, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#177 AS sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#179]
 
-(178) Filter [codegen id : 402]
-Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#42, number_sales#43, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#181]
-Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#181) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#181 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#45, [id=#46] as decimal(32,6))))
+(170) Filter [codegen id : 398]
+Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#42, number_sales#43, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#179]
+Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#179) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#179 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#45, [id=#46] as decimal(32,6))))
 
-(179) Project [codegen id : 402]
+(171) Project [codegen id : 398]
 Output [6]: [store AS channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sales#42, number_sales#43]
-Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#42, number_sales#43, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#181]
+Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#42, number_sales#43, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#179]
 
-(180) ReusedExchange [Reuses operator id: 103]
-Output [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#182, isEmpty#183, count#184]
+(172) ReusedExchange [Reuses operator id: 103]
+Output [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#180, isEmpty#181, count#182]
 
-(181) HashAggregate [codegen id : 441]
-Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#182, isEmpty#183, count#184]
+(173) HashAggregate [codegen id : 437]
+Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#180, isEmpty#181, count#182]
 Keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
 Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#185, count(1)#186]
-Results [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#185 AS sales#60, count(1)#186 AS number_sales#61, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#185 AS sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#187]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#183, count(1)#184]
+Results [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#183 AS sales#60, count(1)#184 AS number_sales#61, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#183 AS sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#185]
 
-(182) Filter [codegen id : 441]
-Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#60, number_sales#61, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#187]
-Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#187) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#187 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#45, [id=#46] as decimal(32,6))))
+(174) Filter [codegen id : 437]
+Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#60, number_sales#61, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#185]
+Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#185) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#185 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#45, [id=#46] as decimal(32,6))))
 
-(183) Project [codegen id : 441]
-Output [6]: [catalog AS channel#188, i_brand_id#7, i_class_id#8, i_category_id#9, sales#60, number_sales#61]
-Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#60, number_sales#61, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#187]
+(175) Project [codegen id : 437]
+Output [6]: [catalog AS channel#186, i_brand_id#7, i_class_id#8, i_category_id#9, sales#60, number_sales#61]
+Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#60, number_sales#61, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#185]
 
-(184) ReusedExchange [Reuses operator id: 122]
-Output [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#189, isEmpty#190, count#191]
+(176) ReusedExchange [Reuses operator id: 122]
+Output [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#187, isEmpty#188, count#189]
 
-(185) HashAggregate [codegen id : 480]
-Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#189, isEmpty#190, count#191]
+(177) HashAggregate [codegen id : 476]
+Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#187, isEmpty#188, count#189]
 Keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
 Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#192, count(1)#193]
-Results [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#192 AS sales#76, count(1)#193 AS number_sales#77, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#192 AS sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#194]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#190, count(1)#191]
+Results [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#190 AS sales#76, count(1)#191 AS number_sales#77, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#190 AS sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#192]
 
-(186) Filter [codegen id : 480]
-Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#76, number_sales#77, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#194]
-Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#194) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#194 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#45, [id=#46] as decimal(32,6))))
+(178) Filter [codegen id : 476]
+Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#76, number_sales#77, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#192]
+Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#192) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#192 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#45, [id=#46] as decimal(32,6))))
 
-(187) Project [codegen id : 480]
-Output [6]: [web AS channel#195, i_brand_id#7, i_class_id#8, i_category_id#9, sales#76, number_sales#77]
-Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#76, number_sales#77, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#194]
+(179) Project [codegen id : 476]
+Output [6]: [web AS channel#193, i_brand_id#7, i_class_id#8, i_category_id#9, sales#76, number_sales#77]
+Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#76, number_sales#77, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#192]
 
-(188) Union
+(180) Union
 
-(189) HashAggregate [codegen id : 481]
+(181) HashAggregate [codegen id : 477]
 Input [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sales#42, number_sales#43]
 Keys [4]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9]
 Functions [2]: [partial_sum(sales#42), partial_sum(number_sales#43)]
-Aggregate Attributes [3]: [sum#196, isEmpty#197, sum#198]
-Results [7]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum#199, isEmpty#200, sum#201]
+Aggregate Attributes [3]: [sum#194, isEmpty#195, sum#196]
+Results [7]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum#197, isEmpty#198, sum#199]
 
-(190) Exchange
-Input [7]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum#199, isEmpty#200, sum#201]
-Arguments: hashpartitioning(channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, 5), true, [id=#202]
+(182) Exchange
+Input [7]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum#197, isEmpty#198, sum#199]
+Arguments: hashpartitioning(channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, 5), ENSURE_REQUIREMENTS, [id=#200]
 
-(191) HashAggregate [codegen id : 482]
-Input [7]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum#199, isEmpty#200, sum#201]
+(183) HashAggregate [codegen id : 478]
+Input [7]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum#197, isEmpty#198, sum#199]
 Keys [4]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9]
 Functions [2]: [sum(sales#42), sum(number_sales#43)]
-Aggregate Attributes [2]: [sum(sales#42)#203, sum(number_sales#43)#204]
-Results [3]: [channel#47, sum(sales#42)#203 AS sum_sales#89, sum(number_sales#43)#204 AS number_sales#90]
+Aggregate Attributes [2]: [sum(sales#42)#201, sum(number_sales#43)#202]
+Results [3]: [channel#47, sum(sales#42)#201 AS sum_sales#89, sum(number_sales#43)#202 AS number_sales#90]
 
-(192) HashAggregate [codegen id : 482]
+(184) HashAggregate [codegen id : 478]
 Input [3]: [channel#47, sum_sales#89, number_sales#90]
 Keys [1]: [channel#47]
 Functions [2]: [partial_sum(sum_sales#89), partial_sum(number_sales#90)]
-Aggregate Attributes [3]: [sum#205, isEmpty#206, sum#207]
-Results [4]: [channel#47, sum#208, isEmpty#209, sum#210]
+Aggregate Attributes [3]: [sum#203, isEmpty#204, sum#205]
+Results [4]: [channel#47, sum#206, isEmpty#207, sum#208]
 
-(193) Exchange
-Input [4]: [channel#47, sum#208, isEmpty#209, sum#210]
-Arguments: hashpartitioning(channel#47, 5), true, [id=#211]
+(185) Exchange
+Input [4]: [channel#47, sum#206, isEmpty#207, sum#208]
+Arguments: hashpartitioning(channel#47, 5), ENSURE_REQUIREMENTS, [id=#209]
 
-(194) HashAggregate [codegen id : 483]
-Input [4]: [channel#47, sum#208, isEmpty#209, sum#210]
+(186) HashAggregate [codegen id : 479]
+Input [4]: [channel#47, sum#206, isEmpty#207, sum#208]
 Keys [1]: [channel#47]
 Functions [2]: [sum(sum_sales#89), sum(number_sales#90)]
-Aggregate Attributes [2]: [sum(sum_sales#89)#212, sum(number_sales#90)#213]
-Results [6]: [channel#47, null AS i_brand_id#214, null AS i_class_id#215, null AS i_category_id#216, sum(sum_sales#89)#212 AS sum(sum_sales)#217, sum(number_sales#90)#213 AS sum(number_sales)#218]
+Aggregate Attributes [2]: [sum(sum_sales#89)#210, sum(number_sales#90)#211]
+Results [6]: [channel#47, null AS i_brand_id#212, null AS i_class_id#213, null AS i_category_id#214, sum(sum_sales#89)#210 AS sum(sum_sales)#215, sum(number_sales#90)#211 AS sum(number_sales)#216]
 
-(195) Union
+(187) ReusedExchange [Reuses operator id: 84]
+Output [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#217, isEmpty#218, count#219]
 
-(196) HashAggregate [codegen id : 484]
-Input [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90]
-Keys [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90]
-Functions: []
-Aggregate Attributes: []
-Results [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90]
-
-(197) Exchange
-Input [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90]
-Arguments: hashpartitioning(channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90, 5), true, [id=#219]
-
-(198) HashAggregate [codegen id : 485]
-Input [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90]
-Keys [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90]
-Functions: []
-Aggregate Attributes: []
-Results [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90]
-
-(199) ReusedExchange [Reuses operator id: 84]
-Output [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#220, isEmpty#221, count#222]
-
-(200) HashAggregate [codegen id : 524]
-Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#220, isEmpty#221, count#222]
+(188) HashAggregate [codegen id : 518]
+Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#217, isEmpty#218, count#219]
 Keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
 Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#223, count(1)#224]
-Results [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#223 AS sales#42, count(1)#224 AS number_sales#43, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#223 AS sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#225]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#220, count(1)#221]
+Results [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#220 AS sales#42, count(1)#221 AS number_sales#43, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#220 AS sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#222]
 
-(201) Filter [codegen id : 524]
-Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#42, number_sales#43, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#225]
-Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#225) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#225 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#45, [id=#46] as decimal(32,6))))
+(189) Filter [codegen id : 518]
+Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#42, number_sales#43, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#222]
+Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#222) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#222 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#45, [id=#46] as decimal(32,6))))
 
-(202) Project [codegen id : 524]
+(190) Project [codegen id : 518]
 Output [6]: [store AS channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sales#42, number_sales#43]
-Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#42, number_sales#43, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#225]
+Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#42, number_sales#43, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#222]
 
-(203) ReusedExchange [Reuses operator id: 103]
-Output [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#226, isEmpty#227, count#228]
+(191) ReusedExchange [Reuses operator id: 103]
+Output [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#223, isEmpty#224, count#225]
 
-(204) HashAggregate [codegen id : 563]
-Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#226, isEmpty#227, count#228]
+(192) HashAggregate [codegen id : 557]
+Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#223, isEmpty#224, count#225]
 Keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
 Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#229, count(1)#230]
-Results [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#229 AS sales#60, count(1)#230 AS number_sales#61, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#229 AS sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#231]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#226, count(1)#227]
+Results [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#226 AS sales#60, count(1)#227 AS number_sales#61, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#226 AS sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#228]
 
-(205) Filter [codegen id : 563]
-Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#60, number_sales#61, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#231]
-Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#231) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#231 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#45, [id=#46] as decimal(32,6))))
+(193) Filter [codegen id : 557]
+Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#60, number_sales#61, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#228]
+Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#228) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#228 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#45, [id=#46] as decimal(32,6))))
 
-(206) Project [codegen id : 563]
-Output [6]: [catalog AS channel#232, i_brand_id#7, i_class_id#8, i_category_id#9, sales#60, number_sales#61]
-Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#60, number_sales#61, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#231]
+(194) Project [codegen id : 557]
+Output [6]: [catalog AS channel#229, i_brand_id#7, i_class_id#8, i_category_id#9, sales#60, number_sales#61]
+Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#60, number_sales#61, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#48 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#49 as decimal(12,2)))), DecimalType(18,2), true))#228]
 
-(207) ReusedExchange [Reuses operator id: 122]
-Output [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#233, isEmpty#234, count#235]
+(195) ReusedExchange [Reuses operator id: 122]
+Output [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#230, isEmpty#231, count#232]
 
-(208) HashAggregate [codegen id : 602]
-Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#233, isEmpty#234, count#235]
+(196) HashAggregate [codegen id : 596]
+Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#230, isEmpty#231, count#232]
 Keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
 Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#236, count(1)#237]
-Results [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#236 AS sales#76, count(1)#237 AS number_sales#77, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#236 AS sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#238]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#233, count(1)#234]
+Results [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#233 AS sales#76, count(1)#234 AS number_sales#77, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#233 AS sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#235]
 
-(209) Filter [codegen id : 602]
-Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#76, number_sales#77, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#238]
-Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#238) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#238 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#45, [id=#46] as decimal(32,6))))
+(197) Filter [codegen id : 596]
+Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#76, number_sales#77, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#235]
+Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#235) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#235 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#45, [id=#46] as decimal(32,6))))
 
-(210) Project [codegen id : 602]
-Output [6]: [web AS channel#239, i_brand_id#7, i_class_id#8, i_category_id#9, sales#76, number_sales#77]
-Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#76, number_sales#77, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#238]
+(198) Project [codegen id : 596]
+Output [6]: [web AS channel#236, i_brand_id#7, i_class_id#8, i_category_id#9, sales#76, number_sales#77]
+Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#76, number_sales#77, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#64 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#65 as decimal(12,2)))), DecimalType(18,2), true))#235]
 
-(211) Union
+(199) Union
 
-(212) HashAggregate [codegen id : 603]
+(200) HashAggregate [codegen id : 597]
 Input [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sales#42, number_sales#43]
 Keys [4]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9]
 Functions [2]: [partial_sum(sales#42), partial_sum(number_sales#43)]
-Aggregate Attributes [3]: [sum#240, isEmpty#241, sum#242]
-Results [7]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum#243, isEmpty#244, sum#245]
+Aggregate Attributes [3]: [sum#237, isEmpty#238, sum#239]
+Results [7]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum#240, isEmpty#241, sum#242]
 
-(213) Exchange
-Input [7]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum#243, isEmpty#244, sum#245]
-Arguments: hashpartitioning(channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, 5), true, [id=#246]
+(201) Exchange
+Input [7]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum#240, isEmpty#241, sum#242]
+Arguments: hashpartitioning(channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, 5), ENSURE_REQUIREMENTS, [id=#243]
 
-(214) HashAggregate [codegen id : 604]
-Input [7]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum#243, isEmpty#244, sum#245]
+(202) HashAggregate [codegen id : 598]
+Input [7]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum#240, isEmpty#241, sum#242]
 Keys [4]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9]
 Functions [2]: [sum(sales#42), sum(number_sales#43)]
-Aggregate Attributes [2]: [sum(sales#42)#247, sum(number_sales#43)#248]
-Results [2]: [sum(sales#42)#247 AS sum_sales#89, sum(number_sales#43)#248 AS number_sales#90]
+Aggregate Attributes [2]: [sum(sales#42)#244, sum(number_sales#43)#245]
+Results [2]: [sum(sales#42)#244 AS sum_sales#89, sum(number_sales#43)#245 AS number_sales#90]
 
-(215) HashAggregate [codegen id : 604]
+(203) HashAggregate [codegen id : 598]
 Input [2]: [sum_sales#89, number_sales#90]
 Keys: []
 Functions [2]: [partial_sum(sum_sales#89), partial_sum(number_sales#90)]
-Aggregate Attributes [3]: [sum#249, isEmpty#250, sum#251]
-Results [3]: [sum#252, isEmpty#253, sum#254]
+Aggregate Attributes [3]: [sum#246, isEmpty#247, sum#248]
+Results [3]: [sum#249, isEmpty#250, sum#251]
 
-(216) Exchange
-Input [3]: [sum#252, isEmpty#253, sum#254]
-Arguments: SinglePartition, true, [id=#255]
+(204) Exchange
+Input [3]: [sum#249, isEmpty#250, sum#251]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#252]
 
-(217) HashAggregate [codegen id : 605]
-Input [3]: [sum#252, isEmpty#253, sum#254]
+(205) HashAggregate [codegen id : 599]
+Input [3]: [sum#249, isEmpty#250, sum#251]
 Keys: []
 Functions [2]: [sum(sum_sales#89), sum(number_sales#90)]
-Aggregate Attributes [2]: [sum(sum_sales#89)#256, sum(number_sales#90)#257]
-Results [6]: [null AS channel#258, null AS i_brand_id#259, null AS i_class_id#260, null AS i_category_id#261, sum(sum_sales#89)#256 AS sum(sum_sales)#262, sum(number_sales#90)#257 AS sum(number_sales)#263]
+Aggregate Attributes [2]: [sum(sum_sales#89)#253, sum(number_sales#90)#254]
+Results [6]: [null AS channel#255, null AS i_brand_id#256, null AS i_class_id#257, null AS i_category_id#258, sum(sum_sales#89)#253 AS sum(sum_sales)#259, sum(number_sales#90)#254 AS sum(number_sales)#260]
 
-(218) Union
+(206) Union
 
-(219) HashAggregate [codegen id : 606]
+(207) HashAggregate [codegen id : 600]
 Input [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90]
 Keys [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90]
 Functions: []
 Aggregate Attributes: []
 Results [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90]
 
-(220) Exchange
+(208) Exchange
 Input [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90]
-Arguments: hashpartitioning(channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90, 5), true, [id=#264]
+Arguments: hashpartitioning(channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90, 5), ENSURE_REQUIREMENTS, [id=#261]
 
-(221) HashAggregate [codegen id : 607]
+(209) HashAggregate [codegen id : 601]
 Input [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90]
 Keys [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90]
 Functions: []
 Aggregate Attributes: []
 Results [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90]
 
-(222) TakeOrderedAndProject
+(210) TakeOrderedAndProject
 Input [6]: [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90]
 Arguments: 100, [channel#47 ASC NULLS FIRST, i_brand_id#7 ASC NULLS FIRST, i_class_id#8 ASC NULLS FIRST, i_category_id#9 ASC NULLS FIRST], [channel#47, i_brand_id#7, i_class_id#8, i_category_id#9, sum_sales#89, number_sales#90]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 86 Hosting Expression = Subquery scalar-subquery#45, [id=#46]
-* HashAggregate (252)
-+- Exchange (251)
-   +- * HashAggregate (250)
-      +- Union (249)
-         :- * Project (232)
-         :  +- * BroadcastHashJoin Inner BuildRight (231)
-         :     :- * Filter (225)
-         :     :  +- * ColumnarToRow (224)
-         :     :     +- Scan parquet default.store_sales (223)
-         :     +- BroadcastExchange (230)
-         :        +- * Project (229)
-         :           +- * Filter (228)
-         :              +- * ColumnarToRow (227)
-         :                 +- Scan parquet default.date_dim (226)
-         :- * Project (242)
-         :  +- * BroadcastHashJoin Inner BuildRight (241)
-         :     :- * Filter (235)
-         :     :  +- * ColumnarToRow (234)
-         :     :     +- Scan parquet default.catalog_sales (233)
-         :     +- BroadcastExchange (240)
-         :        +- * Project (239)
-         :           +- * Filter (238)
-         :              +- * ColumnarToRow (237)
-         :                 +- Scan parquet default.date_dim (236)
-         +- * Project (248)
-            +- * BroadcastHashJoin Inner BuildRight (247)
-               :- * Filter (245)
-               :  +- * ColumnarToRow (244)
-               :     +- Scan parquet default.web_sales (243)
-               +- ReusedExchange (246)
+* HashAggregate (240)
++- Exchange (239)
+   +- * HashAggregate (238)
+      +- Union (237)
+         :- * Project (220)
+         :  +- * BroadcastHashJoin Inner BuildRight (219)
+         :     :- * Filter (213)
+         :     :  +- * ColumnarToRow (212)
+         :     :     +- Scan parquet default.store_sales (211)
+         :     +- BroadcastExchange (218)
+         :        +- * Project (217)
+         :           +- * Filter (216)
+         :              +- * ColumnarToRow (215)
+         :                 +- Scan parquet default.date_dim (214)
+         :- * Project (230)
+         :  +- * BroadcastHashJoin Inner BuildRight (229)
+         :     :- * Filter (223)
+         :     :  +- * ColumnarToRow (222)
+         :     :     +- Scan parquet default.catalog_sales (221)
+         :     +- BroadcastExchange (228)
+         :        +- * Project (227)
+         :           +- * Filter (226)
+         :              +- * ColumnarToRow (225)
+         :                 +- Scan parquet default.date_dim (224)
+         +- * Project (236)
+            +- * BroadcastHashJoin Inner BuildRight (235)
+               :- * Filter (233)
+               :  +- * ColumnarToRow (232)
+               :     +- Scan parquet default.web_sales (231)
+               +- ReusedExchange (234)
 
 
-(223) Scan parquet default.store_sales
+(211) Scan parquet default.store_sales
 Output [3]: [ss_sold_date_sk#1, ss_quantity#3, ss_list_price#4]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_sold_date_sk)]
 ReadSchema: struct<ss_sold_date_sk:int,ss_quantity:int,ss_list_price:decimal(7,2)>
 
-(224) ColumnarToRow [codegen id : 2]
+(212) ColumnarToRow [codegen id : 2]
 Input [3]: [ss_sold_date_sk#1, ss_quantity#3, ss_list_price#4]
 
-(225) Filter [codegen id : 2]
+(213) Filter [codegen id : 2]
 Input [3]: [ss_sold_date_sk#1, ss_quantity#3, ss_list_price#4]
 Condition : isnotnull(ss_sold_date_sk#1)
 
-(226) Scan parquet default.date_dim
+(214) Scan parquet default.date_dim
 Output [2]: [d_date_sk#10, d_year#11]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), GreaterThanOrEqual(d_year,1999), LessThanOrEqual(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(227) ColumnarToRow [codegen id : 1]
+(215) ColumnarToRow [codegen id : 1]
 Input [2]: [d_date_sk#10, d_year#11]
 
-(228) Filter [codegen id : 1]
+(216) Filter [codegen id : 1]
 Input [2]: [d_date_sk#10, d_year#11]
 Condition : (((isnotnull(d_year#11) AND (d_year#11 >= 1999)) AND (d_year#11 <= 2001)) AND isnotnull(d_date_sk#10))
 
-(229) Project [codegen id : 1]
+(217) Project [codegen id : 1]
 Output [1]: [d_date_sk#10]
 Input [2]: [d_date_sk#10, d_year#11]
 
-(230) BroadcastExchange
+(218) BroadcastExchange
 Input [1]: [d_date_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#265]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#262]
 
-(231) BroadcastHashJoin [codegen id : 2]
+(219) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#1]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
-(232) Project [codegen id : 2]
-Output [2]: [ss_quantity#3 AS quantity#266, ss_list_price#4 AS list_price#267]
+(220) Project [codegen id : 2]
+Output [2]: [ss_quantity#3 AS quantity#263, ss_list_price#4 AS list_price#264]
 Input [4]: [ss_sold_date_sk#1, ss_quantity#3, ss_list_price#4, d_date_sk#10]
 
-(233) Scan parquet default.catalog_sales
+(221) Scan parquet default.catalog_sales
 Output [3]: [cs_sold_date_sk#18, cs_quantity#48, cs_list_price#49]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_sales]
 PushedFilters: [IsNotNull(cs_sold_date_sk)]
 ReadSchema: struct<cs_sold_date_sk:int,cs_quantity:int,cs_list_price:decimal(7,2)>
 
-(234) ColumnarToRow [codegen id : 4]
+(222) ColumnarToRow [codegen id : 4]
 Input [3]: [cs_sold_date_sk#18, cs_quantity#48, cs_list_price#49]
 
-(235) Filter [codegen id : 4]
+(223) Filter [codegen id : 4]
 Input [3]: [cs_sold_date_sk#18, cs_quantity#48, cs_list_price#49]
 Condition : isnotnull(cs_sold_date_sk#18)
 
-(236) Scan parquet default.date_dim
+(224) Scan parquet default.date_dim
 Output [2]: [d_date_sk#10, d_year#11]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), GreaterThanOrEqual(d_year,1998), LessThanOrEqual(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(237) ColumnarToRow [codegen id : 3]
+(225) ColumnarToRow [codegen id : 3]
 Input [2]: [d_date_sk#10, d_year#11]
 
-(238) Filter [codegen id : 3]
+(226) Filter [codegen id : 3]
 Input [2]: [d_date_sk#10, d_year#11]
 Condition : (((isnotnull(d_year#11) AND (d_year#11 >= 1998)) AND (d_year#11 <= 2000)) AND isnotnull(d_date_sk#10))
 
-(239) Project [codegen id : 3]
+(227) Project [codegen id : 3]
 Output [1]: [d_date_sk#10]
 Input [2]: [d_date_sk#10, d_year#11]
 
-(240) BroadcastExchange
+(228) BroadcastExchange
 Input [1]: [d_date_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#268]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#265]
 
-(241) BroadcastHashJoin [codegen id : 4]
+(229) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_sold_date_sk#18]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
-(242) Project [codegen id : 4]
-Output [2]: [cs_quantity#48 AS quantity#269, cs_list_price#49 AS list_price#270]
+(230) Project [codegen id : 4]
+Output [2]: [cs_quantity#48 AS quantity#266, cs_list_price#49 AS list_price#267]
 Input [4]: [cs_sold_date_sk#18, cs_quantity#48, cs_list_price#49, d_date_sk#10]
 
-(243) Scan parquet default.web_sales
+(231) Scan parquet default.web_sales
 Output [3]: [ws_sold_date_sk#22, ws_quantity#64, ws_list_price#65]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_sales]
 PushedFilters: [IsNotNull(ws_sold_date_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_quantity:int,ws_list_price:decimal(7,2)>
 
-(244) ColumnarToRow [codegen id : 6]
+(232) ColumnarToRow [codegen id : 6]
 Input [3]: [ws_sold_date_sk#22, ws_quantity#64, ws_list_price#65]
 
-(245) Filter [codegen id : 6]
+(233) Filter [codegen id : 6]
 Input [3]: [ws_sold_date_sk#22, ws_quantity#64, ws_list_price#65]
 Condition : isnotnull(ws_sold_date_sk#22)
 
-(246) ReusedExchange [Reuses operator id: 240]
+(234) ReusedExchange [Reuses operator id: 228]
 Output [1]: [d_date_sk#10]
 
-(247) BroadcastHashJoin [codegen id : 6]
+(235) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ws_sold_date_sk#22]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
-(248) Project [codegen id : 6]
-Output [2]: [ws_quantity#64 AS quantity#271, ws_list_price#65 AS list_price#272]
+(236) Project [codegen id : 6]
+Output [2]: [ws_quantity#64 AS quantity#268, ws_list_price#65 AS list_price#269]
 Input [4]: [ws_sold_date_sk#22, ws_quantity#64, ws_list_price#65, d_date_sk#10]
 
-(249) Union
+(237) Union
 
-(250) HashAggregate [codegen id : 7]
-Input [2]: [quantity#266, list_price#267]
+(238) HashAggregate [codegen id : 7]
+Input [2]: [quantity#263, list_price#264]
 Keys: []
-Functions [1]: [partial_avg(CheckOverflow((promote_precision(cast(cast(quantity#266 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#267 as decimal(12,2)))), DecimalType(18,2), true))]
-Aggregate Attributes [2]: [sum#273, count#274]
-Results [2]: [sum#275, count#276]
+Functions [1]: [partial_avg(CheckOverflow((promote_precision(cast(cast(quantity#263 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#264 as decimal(12,2)))), DecimalType(18,2), true))]
+Aggregate Attributes [2]: [sum#270, count#271]
+Results [2]: [sum#272, count#273]
 
-(251) Exchange
-Input [2]: [sum#275, count#276]
-Arguments: SinglePartition, true, [id=#277]
+(239) Exchange
+Input [2]: [sum#272, count#273]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#274]
 
-(252) HashAggregate [codegen id : 8]
-Input [2]: [sum#275, count#276]
+(240) HashAggregate [codegen id : 8]
+Input [2]: [sum#272, count#273]
 Keys: []
-Functions [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#266 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#267 as decimal(12,2)))), DecimalType(18,2), true))]
-Aggregate Attributes [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#266 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#267 as decimal(12,2)))), DecimalType(18,2), true))#278]
-Results [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#266 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#267 as decimal(12,2)))), DecimalType(18,2), true))#278 AS average_sales#279]
+Functions [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#263 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#264 as decimal(12,2)))), DecimalType(18,2), true))]
+Aggregate Attributes [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#263 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#264 as decimal(12,2)))), DecimalType(18,2), true))#275]
+Results [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#263 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#264 as decimal(12,2)))), DecimalType(18,2), true))#275 AS average_sales#276]
 
 Subquery:2 Hosting operator id = 105 Hosting Expression = ReusedSubquery Subquery scalar-subquery#45, [id=#46]
 
@@ -1439,22 +1367,22 @@ Subquery:5 Hosting operator id = 136 Hosting Expression = ReusedSubquery Subquer
 
 Subquery:6 Hosting operator id = 140 Hosting Expression = ReusedSubquery Subquery scalar-subquery#45, [id=#46]
 
-Subquery:7 Hosting operator id = 155 Hosting Expression = ReusedSubquery Subquery scalar-subquery#45, [id=#46]
+Subquery:7 Hosting operator id = 151 Hosting Expression = ReusedSubquery Subquery scalar-subquery#45, [id=#46]
 
-Subquery:8 Hosting operator id = 159 Hosting Expression = ReusedSubquery Subquery scalar-subquery#45, [id=#46]
+Subquery:8 Hosting operator id = 155 Hosting Expression = ReusedSubquery Subquery scalar-subquery#45, [id=#46]
 
-Subquery:9 Hosting operator id = 163 Hosting Expression = ReusedSubquery Subquery scalar-subquery#45, [id=#46]
+Subquery:9 Hosting operator id = 159 Hosting Expression = ReusedSubquery Subquery scalar-subquery#45, [id=#46]
 
-Subquery:10 Hosting operator id = 178 Hosting Expression = ReusedSubquery Subquery scalar-subquery#45, [id=#46]
+Subquery:10 Hosting operator id = 170 Hosting Expression = ReusedSubquery Subquery scalar-subquery#45, [id=#46]
 
-Subquery:11 Hosting operator id = 182 Hosting Expression = ReusedSubquery Subquery scalar-subquery#45, [id=#46]
+Subquery:11 Hosting operator id = 174 Hosting Expression = ReusedSubquery Subquery scalar-subquery#45, [id=#46]
 
-Subquery:12 Hosting operator id = 186 Hosting Expression = ReusedSubquery Subquery scalar-subquery#45, [id=#46]
+Subquery:12 Hosting operator id = 178 Hosting Expression = ReusedSubquery Subquery scalar-subquery#45, [id=#46]
 
-Subquery:13 Hosting operator id = 201 Hosting Expression = ReusedSubquery Subquery scalar-subquery#45, [id=#46]
+Subquery:13 Hosting operator id = 189 Hosting Expression = ReusedSubquery Subquery scalar-subquery#45, [id=#46]
 
-Subquery:14 Hosting operator id = 205 Hosting Expression = ReusedSubquery Subquery scalar-subquery#45, [id=#46]
+Subquery:14 Hosting operator id = 193 Hosting Expression = ReusedSubquery Subquery scalar-subquery#45, [id=#46]
 
-Subquery:15 Hosting operator id = 209 Hosting Expression = ReusedSubquery Subquery scalar-subquery#45, [id=#46]
+Subquery:15 Hosting operator id = 197 Hosting Expression = ReusedSubquery Subquery scalar-subquery#45, [id=#46]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a.sf100/simplified.txt
@@ -1,427 +1,403 @@
 TakeOrderedAndProject [channel,i_brand_id,i_class_id,i_category_id,sum_sales,number_sales]
-  WholeStageCodegen (607)
+  WholeStageCodegen (601)
     HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum_sales,number_sales]
       InputAdapter
         Exchange [channel,i_brand_id,i_class_id,i_category_id,sum_sales,number_sales] #1
-          WholeStageCodegen (606)
+          WholeStageCodegen (600)
             HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum_sales,number_sales]
               InputAdapter
                 Union
-                  WholeStageCodegen (485)
-                    HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum_sales,number_sales]
+                  WholeStageCodegen (119)
+                    HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum,isEmpty,sum] [sum(sales),sum(number_salesL),sum_sales,number_sales,sum,isEmpty,sum]
                       InputAdapter
-                        Exchange [channel,i_brand_id,i_class_id,i_category_id,sum_sales,number_sales] #2
-                          WholeStageCodegen (484)
-                            HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum_sales,number_sales]
+                        Exchange [channel,i_brand_id,i_class_id,i_category_id] #2
+                          WholeStageCodegen (118)
+                            HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
                               InputAdapter
                                 Union
-                                  WholeStageCodegen (363)
-                                    HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum_sales,number_sales]
-                                      InputAdapter
-                                        Exchange [channel,i_brand_id,i_class_id,i_category_id,sum_sales,number_sales] #3
-                                          WholeStageCodegen (362)
-                                            HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum_sales,number_sales]
+                                  WholeStageCodegen (39)
+                                    Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
+                                      Filter [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true))]
+                                        Subquery #1
+                                          WholeStageCodegen (8)
+                                            HashAggregate [sum,count] [avg(CheckOverflow((promote_precision(cast(cast(quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price as decimal(12,2)))), DecimalType(18,2), true)),average_sales,sum,count]
                                               InputAdapter
-                                                Union
-                                                  WholeStageCodegen (241)
-                                                    HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum_sales,number_sales]
+                                                Exchange #17
+                                                  WholeStageCodegen (7)
+                                                    HashAggregate [quantity,list_price] [sum,count,sum,count]
                                                       InputAdapter
-                                                        Exchange [channel,i_brand_id,i_class_id,i_category_id,sum_sales,number_sales] #4
-                                                          WholeStageCodegen (240)
-                                                            HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum_sales,number_sales]
-                                                              InputAdapter
-                                                                Union
-                                                                  WholeStageCodegen (119)
-                                                                    HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum,isEmpty,sum] [sum(sales),sum(number_salesL),sum_sales,number_sales,sum,isEmpty,sum]
-                                                                      InputAdapter
-                                                                        Exchange [channel,i_brand_id,i_class_id,i_category_id] #5
-                                                                          WholeStageCodegen (118)
-                                                                            HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
-                                                                              InputAdapter
-                                                                                Union
-                                                                                  WholeStageCodegen (39)
-                                                                                    Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
-                                                                                      Filter [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true))]
-                                                                                        Subquery #1
-                                                                                          WholeStageCodegen (8)
-                                                                                            HashAggregate [sum,count] [avg(CheckOverflow((promote_precision(cast(cast(quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price as decimal(12,2)))), DecimalType(18,2), true)),average_sales,sum,count]
-                                                                                              InputAdapter
-                                                                                                Exchange #20
-                                                                                                  WholeStageCodegen (7)
-                                                                                                    HashAggregate [quantity,list_price] [sum,count,sum,count]
-                                                                                                      InputAdapter
-                                                                                                        Union
-                                                                                                          WholeStageCodegen (2)
-                                                                                                            Project [ss_quantity,ss_list_price]
-                                                                                                              BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                                                                Filter [ss_sold_date_sk]
-                                                                                                                  ColumnarToRow
-                                                                                                                    InputAdapter
-                                                                                                                      Scan parquet default.store_sales [ss_sold_date_sk,ss_quantity,ss_list_price]
-                                                                                                                InputAdapter
-                                                                                                                  BroadcastExchange #21
-                                                                                                                    WholeStageCodegen (1)
-                                                                                                                      Project [d_date_sk]
-                                                                                                                        Filter [d_year,d_date_sk]
-                                                                                                                          ColumnarToRow
-                                                                                                                            InputAdapter
-                                                                                                                              Scan parquet default.date_dim [d_date_sk,d_year]
-                                                                                                          WholeStageCodegen (4)
-                                                                                                            Project [cs_quantity,cs_list_price]
-                                                                                                              BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                                                                Filter [cs_sold_date_sk]
-                                                                                                                  ColumnarToRow
-                                                                                                                    InputAdapter
-                                                                                                                      Scan parquet default.catalog_sales [cs_sold_date_sk,cs_quantity,cs_list_price]
-                                                                                                                InputAdapter
-                                                                                                                  BroadcastExchange #22
-                                                                                                                    WholeStageCodegen (3)
-                                                                                                                      Project [d_date_sk]
-                                                                                                                        Filter [d_year,d_date_sk]
-                                                                                                                          ColumnarToRow
-                                                                                                                            InputAdapter
-                                                                                                                              Scan parquet default.date_dim [d_date_sk,d_year]
-                                                                                                          WholeStageCodegen (6)
-                                                                                                            Project [ws_quantity,ws_list_price]
-                                                                                                              BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                                                                Filter [ws_sold_date_sk]
-                                                                                                                  ColumnarToRow
-                                                                                                                    InputAdapter
-                                                                                                                      Scan parquet default.web_sales [ws_sold_date_sk,ws_quantity,ws_list_price]
-                                                                                                                InputAdapter
-                                                                                                                  ReusedExchange [d_date_sk] #22
-                                                                                        HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
-                                                                                          InputAdapter
-                                                                                            Exchange [i_brand_id,i_class_id,i_category_id] #6
-                                                                                              WholeStageCodegen (38)
-                                                                                                HashAggregate [i_brand_id,i_class_id,i_category_id,ss_quantity,ss_list_price] [sum,isEmpty,count,sum,isEmpty,count]
-                                                                                                  Project [ss_quantity,ss_list_price,i_brand_id,i_class_id,i_category_id]
-                                                                                                    BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                                                                      Project [ss_item_sk,ss_quantity,ss_list_price]
-                                                                                                        BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                        Union
+                                                          WholeStageCodegen (2)
+                                                            Project [ss_quantity,ss_list_price]
+                                                              BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                                Filter [ss_sold_date_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet default.store_sales [ss_sold_date_sk,ss_quantity,ss_list_price]
+                                                                InputAdapter
+                                                                  BroadcastExchange #18
+                                                                    WholeStageCodegen (1)
+                                                                      Project [d_date_sk]
+                                                                        Filter [d_year,d_date_sk]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet default.date_dim [d_date_sk,d_year]
+                                                          WholeStageCodegen (4)
+                                                            Project [cs_quantity,cs_list_price]
+                                                              BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                                Filter [cs_sold_date_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet default.catalog_sales [cs_sold_date_sk,cs_quantity,cs_list_price]
+                                                                InputAdapter
+                                                                  BroadcastExchange #19
+                                                                    WholeStageCodegen (3)
+                                                                      Project [d_date_sk]
+                                                                        Filter [d_year,d_date_sk]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet default.date_dim [d_date_sk,d_year]
+                                                          WholeStageCodegen (6)
+                                                            Project [ws_quantity,ws_list_price]
+                                                              BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                                Filter [ws_sold_date_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet default.web_sales [ws_sold_date_sk,ws_quantity,ws_list_price]
+                                                                InputAdapter
+                                                                  ReusedExchange [d_date_sk] #19
+                                        HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
+                                          InputAdapter
+                                            Exchange [i_brand_id,i_class_id,i_category_id] #3
+                                              WholeStageCodegen (38)
+                                                HashAggregate [i_brand_id,i_class_id,i_category_id,ss_quantity,ss_list_price] [sum,isEmpty,count,sum,isEmpty,count]
+                                                  Project [ss_quantity,ss_list_price,i_brand_id,i_class_id,i_category_id]
+                                                    BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                      Project [ss_item_sk,ss_quantity,ss_list_price]
+                                                        BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                          InputAdapter
+                                                            SortMergeJoin [ss_item_sk,ss_item_sk]
+                                                              WholeStageCodegen (2)
+                                                                Sort [ss_item_sk]
+                                                                  InputAdapter
+                                                                    Exchange [ss_item_sk] #4
+                                                                      WholeStageCodegen (1)
+                                                                        Filter [ss_item_sk,ss_sold_date_sk]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk,ss_quantity,ss_list_price]
+                                                              WholeStageCodegen (18)
+                                                                Sort [ss_item_sk]
+                                                                  InputAdapter
+                                                                    Exchange [ss_item_sk] #5
+                                                                      WholeStageCodegen (17)
+                                                                        Project [i_item_sk]
+                                                                          BroadcastHashJoin [i_brand_id,i_class_id,i_category_id,brand_id,class_id,category_id]
+                                                                            Filter [i_brand_id,i_class_id,i_category_id]
+                                                                              ColumnarToRow
+                                                                                InputAdapter
+                                                                                  Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                            InputAdapter
+                                                                              BroadcastExchange #6
+                                                                                WholeStageCodegen (16)
+                                                                                  HashAggregate [brand_id,class_id,category_id]
+                                                                                    HashAggregate [brand_id,class_id,category_id]
+                                                                                      HashAggregate [brand_id,class_id,category_id]
+                                                                                        InputAdapter
+                                                                                          Exchange [brand_id,class_id,category_id] #7
+                                                                                            WholeStageCodegen (15)
+                                                                                              HashAggregate [brand_id,class_id,category_id]
+                                                                                                InputAdapter
+                                                                                                  SortMergeJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
+                                                                                                    SortMergeJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
+                                                                                                      WholeStageCodegen (6)
+                                                                                                        Sort [brand_id,class_id,category_id]
                                                                                                           InputAdapter
-                                                                                                            SortMergeJoin [ss_item_sk,ss_item_sk]
-                                                                                                              WholeStageCodegen (2)
-                                                                                                                Sort [ss_item_sk]
-                                                                                                                  InputAdapter
-                                                                                                                    Exchange [ss_item_sk] #7
-                                                                                                                      WholeStageCodegen (1)
+                                                                                                            Exchange [brand_id,class_id,category_id] #8
+                                                                                                              WholeStageCodegen (5)
+                                                                                                                Project [i_brand_id,i_class_id,i_category_id]
+                                                                                                                  BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                                                                                    Project [ss_item_sk]
+                                                                                                                      BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                                                                         Filter [ss_item_sk,ss_sold_date_sk]
                                                                                                                           ColumnarToRow
                                                                                                                             InputAdapter
-                                                                                                                              Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk,ss_quantity,ss_list_price]
-                                                                                                              WholeStageCodegen (18)
-                                                                                                                Sort [ss_item_sk]
-                                                                                                                  InputAdapter
-                                                                                                                    Exchange [ss_item_sk] #8
-                                                                                                                      WholeStageCodegen (17)
-                                                                                                                        Project [i_item_sk]
-                                                                                                                          BroadcastHashJoin [i_brand_id,i_class_id,i_category_id,brand_id,class_id,category_id]
-                                                                                                                            Filter [i_brand_id,i_class_id,i_category_id]
-                                                                                                                              ColumnarToRow
-                                                                                                                                InputAdapter
-                                                                                                                                  Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                                                            InputAdapter
-                                                                                                                              BroadcastExchange #9
-                                                                                                                                WholeStageCodegen (16)
-                                                                                                                                  HashAggregate [brand_id,class_id,category_id]
-                                                                                                                                    HashAggregate [brand_id,class_id,category_id]
-                                                                                                                                      HashAggregate [brand_id,class_id,category_id]
-                                                                                                                                        InputAdapter
-                                                                                                                                          Exchange [brand_id,class_id,category_id] #10
-                                                                                                                                            WholeStageCodegen (15)
-                                                                                                                                              HashAggregate [brand_id,class_id,category_id]
-                                                                                                                                                InputAdapter
-                                                                                                                                                  SortMergeJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
-                                                                                                                                                    SortMergeJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
-                                                                                                                                                      WholeStageCodegen (6)
-                                                                                                                                                        Sort [brand_id,class_id,category_id]
-                                                                                                                                                          InputAdapter
-                                                                                                                                                            Exchange [brand_id,class_id,category_id] #11
-                                                                                                                                                              WholeStageCodegen (5)
-                                                                                                                                                                Project [i_brand_id,i_class_id,i_category_id]
-                                                                                                                                                                  BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                                                                                                                                    Project [ss_item_sk]
-                                                                                                                                                                      BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                                                                                                                        Filter [ss_item_sk,ss_sold_date_sk]
-                                                                                                                                                                          ColumnarToRow
-                                                                                                                                                                            InputAdapter
-                                                                                                                                                                              Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk]
-                                                                                                                                                                        InputAdapter
-                                                                                                                                                                          BroadcastExchange #12
-                                                                                                                                                                            WholeStageCodegen (3)
-                                                                                                                                                                              Project [d_date_sk]
-                                                                                                                                                                                Filter [d_year,d_date_sk]
-                                                                                                                                                                                  ColumnarToRow
-                                                                                                                                                                                    InputAdapter
-                                                                                                                                                                                      Scan parquet default.date_dim [d_date_sk,d_year]
-                                                                                                                                                                    InputAdapter
-                                                                                                                                                                      BroadcastExchange #13
-                                                                                                                                                                        WholeStageCodegen (4)
-                                                                                                                                                                          Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                                                                                                            ColumnarToRow
-                                                                                                                                                                              InputAdapter
-                                                                                                                                                                                Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                                                                                      WholeStageCodegen (10)
-                                                                                                                                                        Sort [i_brand_id,i_class_id,i_category_id]
-                                                                                                                                                          InputAdapter
-                                                                                                                                                            Exchange [i_brand_id,i_class_id,i_category_id] #14
-                                                                                                                                                              WholeStageCodegen (9)
-                                                                                                                                                                Project [i_brand_id,i_class_id,i_category_id]
-                                                                                                                                                                  BroadcastHashJoin [cs_item_sk,i_item_sk]
-                                                                                                                                                                    Project [cs_item_sk]
-                                                                                                                                                                      BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                                                                                                                        Filter [cs_item_sk,cs_sold_date_sk]
-                                                                                                                                                                          ColumnarToRow
-                                                                                                                                                                            InputAdapter
-                                                                                                                                                                              Scan parquet default.catalog_sales [cs_sold_date_sk,cs_item_sk]
-                                                                                                                                                                        InputAdapter
-                                                                                                                                                                          ReusedExchange [d_date_sk] #12
-                                                                                                                                                                    InputAdapter
-                                                                                                                                                                      BroadcastExchange #15
-                                                                                                                                                                        WholeStageCodegen (8)
-                                                                                                                                                                          Filter [i_item_sk]
-                                                                                                                                                                            ColumnarToRow
-                                                                                                                                                                              InputAdapter
-                                                                                                                                                                                Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                                                                                    WholeStageCodegen (14)
-                                                                                                                                                      Sort [i_brand_id,i_class_id,i_category_id]
-                                                                                                                                                        InputAdapter
-                                                                                                                                                          Exchange [i_brand_id,i_class_id,i_category_id] #16
-                                                                                                                                                            WholeStageCodegen (13)
-                                                                                                                                                              Project [i_brand_id,i_class_id,i_category_id]
-                                                                                                                                                                BroadcastHashJoin [ws_item_sk,i_item_sk]
-                                                                                                                                                                  Project [ws_item_sk]
-                                                                                                                                                                    BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                                                                                                                      Filter [ws_item_sk,ws_sold_date_sk]
-                                                                                                                                                                        ColumnarToRow
-                                                                                                                                                                          InputAdapter
-                                                                                                                                                                            Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk]
-                                                                                                                                                                      InputAdapter
-                                                                                                                                                                        ReusedExchange [d_date_sk] #12
-                                                                                                                                                                  InputAdapter
-                                                                                                                                                                    ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #15
+                                                                                                                              Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk]
+                                                                                                                        InputAdapter
+                                                                                                                          BroadcastExchange #9
+                                                                                                                            WholeStageCodegen (3)
+                                                                                                                              Project [d_date_sk]
+                                                                                                                                Filter [d_year,d_date_sk]
+                                                                                                                                  ColumnarToRow
+                                                                                                                                    InputAdapter
+                                                                                                                                      Scan parquet default.date_dim [d_date_sk,d_year]
+                                                                                                                    InputAdapter
+                                                                                                                      BroadcastExchange #10
+                                                                                                                        WholeStageCodegen (4)
+                                                                                                                          Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                                                                            ColumnarToRow
+                                                                                                                              InputAdapter
+                                                                                                                                Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                                                      WholeStageCodegen (10)
+                                                                                                        Sort [i_brand_id,i_class_id,i_category_id]
                                                                                                           InputAdapter
-                                                                                                            BroadcastExchange #17
-                                                                                                              WholeStageCodegen (19)
-                                                                                                                Project [d_date_sk]
-                                                                                                                  Filter [d_year,d_moy,d_date_sk]
-                                                                                                                    ColumnarToRow
-                                                                                                                      InputAdapter
-                                                                                                                        Scan parquet default.date_dim [d_date_sk,d_year,d_moy]
-                                                                                                      InputAdapter
-                                                                                                        BroadcastExchange #18
-                                                                                                          SortMergeJoin [i_item_sk,ss_item_sk]
-                                                                                                            WholeStageCodegen (21)
-                                                                                                              Sort [i_item_sk]
-                                                                                                                InputAdapter
-                                                                                                                  Exchange [i_item_sk] #19
-                                                                                                                    WholeStageCodegen (20)
-                                                                                                                      Filter [i_item_sk]
-                                                                                                                        ColumnarToRow
-                                                                                                                          InputAdapter
-                                                                                                                            Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                                            WholeStageCodegen (37)
-                                                                                                              Sort [ss_item_sk]
-                                                                                                                InputAdapter
-                                                                                                                  ReusedExchange [ss_item_sk] #8
-                                                                                  WholeStageCodegen (78)
-                                                                                    Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
-                                                                                      Filter [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true))]
-                                                                                        ReusedSubquery [average_sales] #1
-                                                                                        HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
-                                                                                          InputAdapter
-                                                                                            Exchange [i_brand_id,i_class_id,i_category_id] #23
-                                                                                              WholeStageCodegen (77)
-                                                                                                HashAggregate [i_brand_id,i_class_id,i_category_id,cs_quantity,cs_list_price] [sum,isEmpty,count,sum,isEmpty,count]
-                                                                                                  Project [cs_quantity,cs_list_price,i_brand_id,i_class_id,i_category_id]
-                                                                                                    BroadcastHashJoin [cs_item_sk,i_item_sk]
-                                                                                                      Project [cs_item_sk,cs_quantity,cs_list_price]
-                                                                                                        BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                                                          InputAdapter
-                                                                                                            SortMergeJoin [cs_item_sk,ss_item_sk]
-                                                                                                              WholeStageCodegen (41)
-                                                                                                                Sort [cs_item_sk]
-                                                                                                                  InputAdapter
-                                                                                                                    Exchange [cs_item_sk] #24
-                                                                                                                      WholeStageCodegen (40)
+                                                                                                            Exchange [i_brand_id,i_class_id,i_category_id] #11
+                                                                                                              WholeStageCodegen (9)
+                                                                                                                Project [i_brand_id,i_class_id,i_category_id]
+                                                                                                                  BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                                                                                    Project [cs_item_sk]
+                                                                                                                      BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
                                                                                                                         Filter [cs_item_sk,cs_sold_date_sk]
                                                                                                                           ColumnarToRow
                                                                                                                             InputAdapter
-                                                                                                                              Scan parquet default.catalog_sales [cs_sold_date_sk,cs_item_sk,cs_quantity,cs_list_price]
-                                                                                                              WholeStageCodegen (57)
-                                                                                                                Sort [ss_item_sk]
+                                                                                                                              Scan parquet default.catalog_sales [cs_sold_date_sk,cs_item_sk]
+                                                                                                                        InputAdapter
+                                                                                                                          ReusedExchange [d_date_sk] #9
+                                                                                                                    InputAdapter
+                                                                                                                      BroadcastExchange #12
+                                                                                                                        WholeStageCodegen (8)
+                                                                                                                          Filter [i_item_sk]
+                                                                                                                            ColumnarToRow
+                                                                                                                              InputAdapter
+                                                                                                                                Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                                                    WholeStageCodegen (14)
+                                                                                                      Sort [i_brand_id,i_class_id,i_category_id]
+                                                                                                        InputAdapter
+                                                                                                          Exchange [i_brand_id,i_class_id,i_category_id] #13
+                                                                                                            WholeStageCodegen (13)
+                                                                                                              Project [i_brand_id,i_class_id,i_category_id]
+                                                                                                                BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                                                                                  Project [ws_item_sk]
+                                                                                                                    BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                                                                                      Filter [ws_item_sk,ws_sold_date_sk]
+                                                                                                                        ColumnarToRow
+                                                                                                                          InputAdapter
+                                                                                                                            Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk]
+                                                                                                                      InputAdapter
+                                                                                                                        ReusedExchange [d_date_sk] #9
                                                                                                                   InputAdapter
-                                                                                                                    ReusedExchange [ss_item_sk] #8
-                                                                                                          InputAdapter
-                                                                                                            ReusedExchange [d_date_sk] #17
-                                                                                                      InputAdapter
-                                                                                                        ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #18
-                                                                                  WholeStageCodegen (117)
-                                                                                    Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
-                                                                                      Filter [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true))]
-                                                                                        ReusedSubquery [average_sales] #1
-                                                                                        HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
-                                                                                          InputAdapter
-                                                                                            Exchange [i_brand_id,i_class_id,i_category_id] #25
-                                                                                              WholeStageCodegen (116)
-                                                                                                HashAggregate [i_brand_id,i_class_id,i_category_id,ws_quantity,ws_list_price] [sum,isEmpty,count,sum,isEmpty,count]
-                                                                                                  Project [ws_quantity,ws_list_price,i_brand_id,i_class_id,i_category_id]
-                                                                                                    BroadcastHashJoin [ws_item_sk,i_item_sk]
-                                                                                                      Project [ws_item_sk,ws_quantity,ws_list_price]
-                                                                                                        BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                                                          InputAdapter
-                                                                                                            SortMergeJoin [ws_item_sk,ss_item_sk]
-                                                                                                              WholeStageCodegen (80)
-                                                                                                                Sort [ws_item_sk]
-                                                                                                                  InputAdapter
-                                                                                                                    Exchange [ws_item_sk] #26
-                                                                                                                      WholeStageCodegen (79)
-                                                                                                                        Filter [ws_item_sk,ws_sold_date_sk]
-                                                                                                                          ColumnarToRow
-                                                                                                                            InputAdapter
-                                                                                                                              Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk,ws_quantity,ws_list_price]
-                                                                                                              WholeStageCodegen (96)
-                                                                                                                Sort [ss_item_sk]
-                                                                                                                  InputAdapter
-                                                                                                                    ReusedExchange [ss_item_sk] #8
-                                                                                                          InputAdapter
-                                                                                                            ReusedExchange [d_date_sk] #17
-                                                                                                      InputAdapter
-                                                                                                        ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #18
-                                                                  WholeStageCodegen (239)
-                                                                    HashAggregate [channel,i_brand_id,i_class_id,sum,isEmpty,sum] [sum(sum_sales),sum(number_salesL),i_category_id,sum(sum_sales),sum(number_sales),sum,isEmpty,sum]
+                                                                                                                    ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #12
+                                                          InputAdapter
+                                                            BroadcastExchange #14
+                                                              WholeStageCodegen (19)
+                                                                Project [d_date_sk]
+                                                                  Filter [d_year,d_moy,d_date_sk]
+                                                                    ColumnarToRow
                                                                       InputAdapter
-                                                                        Exchange [channel,i_brand_id,i_class_id] #27
-                                                                          WholeStageCodegen (238)
-                                                                            HashAggregate [channel,i_brand_id,i_class_id,sum_sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
-                                                                              HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum,isEmpty,sum] [sum(sales),sum(number_salesL),sum_sales,number_sales,sum,isEmpty,sum]
-                                                                                InputAdapter
-                                                                                  Exchange [channel,i_brand_id,i_class_id,i_category_id] #28
-                                                                                    WholeStageCodegen (237)
-                                                                                      HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
-                                                                                        InputAdapter
-                                                                                          Union
-                                                                                            WholeStageCodegen (158)
-                                                                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
-                                                                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true))]
-                                                                                                  ReusedSubquery [average_sales] #1
-                                                                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
-                                                                                                    InputAdapter
-                                                                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #6
-                                                                                            WholeStageCodegen (197)
-                                                                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
-                                                                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true))]
-                                                                                                  ReusedSubquery [average_sales] #1
-                                                                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
-                                                                                                    InputAdapter
-                                                                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #23
-                                                                                            WholeStageCodegen (236)
-                                                                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
-                                                                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true))]
-                                                                                                  ReusedSubquery [average_sales] #1
-                                                                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
-                                                                                                    InputAdapter
-                                                                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #25
-                                                  WholeStageCodegen (361)
-                                                    HashAggregate [channel,i_brand_id,sum,isEmpty,sum] [sum(sum_sales),sum(number_salesL),i_class_id,i_category_id,sum(sum_sales),sum(number_sales),sum,isEmpty,sum]
+                                                                        Scan parquet default.date_dim [d_date_sk,d_year,d_moy]
                                                       InputAdapter
-                                                        Exchange [channel,i_brand_id] #29
-                                                          WholeStageCodegen (360)
-                                                            HashAggregate [channel,i_brand_id,sum_sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
-                                                              HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum,isEmpty,sum] [sum(sales),sum(number_salesL),sum_sales,number_sales,sum,isEmpty,sum]
+                                                        BroadcastExchange #15
+                                                          SortMergeJoin [i_item_sk,ss_item_sk]
+                                                            WholeStageCodegen (21)
+                                                              Sort [i_item_sk]
                                                                 InputAdapter
-                                                                  Exchange [channel,i_brand_id,i_class_id,i_category_id] #30
-                                                                    WholeStageCodegen (359)
-                                                                      HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
-                                                                        InputAdapter
-                                                                          Union
-                                                                            WholeStageCodegen (280)
-                                                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
-                                                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true))]
-                                                                                  ReusedSubquery [average_sales] #1
-                                                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
-                                                                                    InputAdapter
-                                                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #6
-                                                                            WholeStageCodegen (319)
-                                                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
-                                                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true))]
-                                                                                  ReusedSubquery [average_sales] #1
-                                                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
-                                                                                    InputAdapter
-                                                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #23
-                                                                            WholeStageCodegen (358)
-                                                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
-                                                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true))]
-                                                                                  ReusedSubquery [average_sales] #1
-                                                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
-                                                                                    InputAdapter
-                                                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #25
-                                  WholeStageCodegen (483)
-                                    HashAggregate [channel,sum,isEmpty,sum] [sum(sum_sales),sum(number_salesL),i_brand_id,i_class_id,i_category_id,sum(sum_sales),sum(number_sales),sum,isEmpty,sum]
-                                      InputAdapter
-                                        Exchange [channel] #31
-                                          WholeStageCodegen (482)
-                                            HashAggregate [channel,sum_sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
-                                              HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum,isEmpty,sum] [sum(sales),sum(number_salesL),sum_sales,number_sales,sum,isEmpty,sum]
-                                                InputAdapter
-                                                  Exchange [channel,i_brand_id,i_class_id,i_category_id] #32
-                                                    WholeStageCodegen (481)
-                                                      HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
-                                                        InputAdapter
-                                                          Union
-                                                            WholeStageCodegen (402)
-                                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
-                                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true))]
-                                                                  ReusedSubquery [average_sales] #1
-                                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
-                                                                    InputAdapter
-                                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #6
-                                                            WholeStageCodegen (441)
-                                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
-                                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true))]
-                                                                  ReusedSubquery [average_sales] #1
-                                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
-                                                                    InputAdapter
-                                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #23
-                                                            WholeStageCodegen (480)
-                                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
-                                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true))]
-                                                                  ReusedSubquery [average_sales] #1
-                                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
-                                                                    InputAdapter
-                                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #25
-                  WholeStageCodegen (605)
-                    HashAggregate [sum,isEmpty,sum] [sum(sum_sales),sum(number_salesL),channel,i_brand_id,i_class_id,i_category_id,sum(sum_sales),sum(number_sales),sum,isEmpty,sum]
+                                                                  Exchange [i_item_sk] #16
+                                                                    WholeStageCodegen (20)
+                                                                      Filter [i_item_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                            WholeStageCodegen (37)
+                                                              Sort [ss_item_sk]
+                                                                InputAdapter
+                                                                  ReusedExchange [ss_item_sk] #5
+                                  WholeStageCodegen (78)
+                                    Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
+                                      Filter [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true))]
+                                        ReusedSubquery [average_sales] #1
+                                        HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
+                                          InputAdapter
+                                            Exchange [i_brand_id,i_class_id,i_category_id] #20
+                                              WholeStageCodegen (77)
+                                                HashAggregate [i_brand_id,i_class_id,i_category_id,cs_quantity,cs_list_price] [sum,isEmpty,count,sum,isEmpty,count]
+                                                  Project [cs_quantity,cs_list_price,i_brand_id,i_class_id,i_category_id]
+                                                    BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                      Project [cs_item_sk,cs_quantity,cs_list_price]
+                                                        BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                          InputAdapter
+                                                            SortMergeJoin [cs_item_sk,ss_item_sk]
+                                                              WholeStageCodegen (41)
+                                                                Sort [cs_item_sk]
+                                                                  InputAdapter
+                                                                    Exchange [cs_item_sk] #21
+                                                                      WholeStageCodegen (40)
+                                                                        Filter [cs_item_sk,cs_sold_date_sk]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet default.catalog_sales [cs_sold_date_sk,cs_item_sk,cs_quantity,cs_list_price]
+                                                              WholeStageCodegen (57)
+                                                                Sort [ss_item_sk]
+                                                                  InputAdapter
+                                                                    ReusedExchange [ss_item_sk] #5
+                                                          InputAdapter
+                                                            ReusedExchange [d_date_sk] #14
+                                                      InputAdapter
+                                                        ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #15
+                                  WholeStageCodegen (117)
+                                    Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
+                                      Filter [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true))]
+                                        ReusedSubquery [average_sales] #1
+                                        HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
+                                          InputAdapter
+                                            Exchange [i_brand_id,i_class_id,i_category_id] #22
+                                              WholeStageCodegen (116)
+                                                HashAggregate [i_brand_id,i_class_id,i_category_id,ws_quantity,ws_list_price] [sum,isEmpty,count,sum,isEmpty,count]
+                                                  Project [ws_quantity,ws_list_price,i_brand_id,i_class_id,i_category_id]
+                                                    BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                      Project [ws_item_sk,ws_quantity,ws_list_price]
+                                                        BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                          InputAdapter
+                                                            SortMergeJoin [ws_item_sk,ss_item_sk]
+                                                              WholeStageCodegen (80)
+                                                                Sort [ws_item_sk]
+                                                                  InputAdapter
+                                                                    Exchange [ws_item_sk] #23
+                                                                      WholeStageCodegen (79)
+                                                                        Filter [ws_item_sk,ws_sold_date_sk]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk,ws_quantity,ws_list_price]
+                                                              WholeStageCodegen (96)
+                                                                Sort [ss_item_sk]
+                                                                  InputAdapter
+                                                                    ReusedExchange [ss_item_sk] #5
+                                                          InputAdapter
+                                                            ReusedExchange [d_date_sk] #14
+                                                      InputAdapter
+                                                        ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #15
+                  WholeStageCodegen (239)
+                    HashAggregate [channel,i_brand_id,i_class_id,sum,isEmpty,sum] [sum(sum_sales),sum(number_salesL),i_category_id,sum(sum_sales),sum(number_sales),sum,isEmpty,sum]
                       InputAdapter
-                        Exchange #33
-                          WholeStageCodegen (604)
-                            HashAggregate [sum_sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
+                        Exchange [channel,i_brand_id,i_class_id] #24
+                          WholeStageCodegen (238)
+                            HashAggregate [channel,i_brand_id,i_class_id,sum_sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
                               HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum,isEmpty,sum] [sum(sales),sum(number_salesL),sum_sales,number_sales,sum,isEmpty,sum]
                                 InputAdapter
-                                  Exchange [channel,i_brand_id,i_class_id,i_category_id] #34
-                                    WholeStageCodegen (603)
+                                  Exchange [channel,i_brand_id,i_class_id,i_category_id] #25
+                                    WholeStageCodegen (237)
                                       HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
                                         InputAdapter
                                           Union
-                                            WholeStageCodegen (524)
+                                            WholeStageCodegen (158)
                                               Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
                                                 Filter [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true))]
                                                   ReusedSubquery [average_sales] #1
                                                   HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
                                                     InputAdapter
-                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #6
-                                            WholeStageCodegen (563)
+                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #3
+                                            WholeStageCodegen (197)
                                               Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
                                                 Filter [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true))]
                                                   ReusedSubquery [average_sales] #1
                                                   HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
                                                     InputAdapter
-                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #23
-                                            WholeStageCodegen (602)
+                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #20
+                                            WholeStageCodegen (236)
                                               Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
                                                 Filter [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true))]
                                                   ReusedSubquery [average_sales] #1
                                                   HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
                                                     InputAdapter
-                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #25
+                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #22
+                  WholeStageCodegen (359)
+                    HashAggregate [channel,i_brand_id,sum,isEmpty,sum] [sum(sum_sales),sum(number_salesL),i_class_id,i_category_id,sum(sum_sales),sum(number_sales),sum,isEmpty,sum]
+                      InputAdapter
+                        Exchange [channel,i_brand_id] #26
+                          WholeStageCodegen (358)
+                            HashAggregate [channel,i_brand_id,sum_sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
+                              HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum,isEmpty,sum] [sum(sales),sum(number_salesL),sum_sales,number_sales,sum,isEmpty,sum]
+                                InputAdapter
+                                  Exchange [channel,i_brand_id,i_class_id,i_category_id] #27
+                                    WholeStageCodegen (357)
+                                      HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
+                                        InputAdapter
+                                          Union
+                                            WholeStageCodegen (278)
+                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
+                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true))]
+                                                  ReusedSubquery [average_sales] #1
+                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
+                                                    InputAdapter
+                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #3
+                                            WholeStageCodegen (317)
+                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
+                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true))]
+                                                  ReusedSubquery [average_sales] #1
+                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
+                                                    InputAdapter
+                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #20
+                                            WholeStageCodegen (356)
+                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
+                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true))]
+                                                  ReusedSubquery [average_sales] #1
+                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
+                                                    InputAdapter
+                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #22
+                  WholeStageCodegen (479)
+                    HashAggregate [channel,sum,isEmpty,sum] [sum(sum_sales),sum(number_salesL),i_brand_id,i_class_id,i_category_id,sum(sum_sales),sum(number_sales),sum,isEmpty,sum]
+                      InputAdapter
+                        Exchange [channel] #28
+                          WholeStageCodegen (478)
+                            HashAggregate [channel,sum_sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
+                              HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum,isEmpty,sum] [sum(sales),sum(number_salesL),sum_sales,number_sales,sum,isEmpty,sum]
+                                InputAdapter
+                                  Exchange [channel,i_brand_id,i_class_id,i_category_id] #29
+                                    WholeStageCodegen (477)
+                                      HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
+                                        InputAdapter
+                                          Union
+                                            WholeStageCodegen (398)
+                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
+                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true))]
+                                                  ReusedSubquery [average_sales] #1
+                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
+                                                    InputAdapter
+                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #3
+                                            WholeStageCodegen (437)
+                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
+                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true))]
+                                                  ReusedSubquery [average_sales] #1
+                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
+                                                    InputAdapter
+                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #20
+                                            WholeStageCodegen (476)
+                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
+                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true))]
+                                                  ReusedSubquery [average_sales] #1
+                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
+                                                    InputAdapter
+                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #22
+                  WholeStageCodegen (599)
+                    HashAggregate [sum,isEmpty,sum] [sum(sum_sales),sum(number_salesL),channel,i_brand_id,i_class_id,i_category_id,sum(sum_sales),sum(number_sales),sum,isEmpty,sum]
+                      InputAdapter
+                        Exchange #30
+                          WholeStageCodegen (598)
+                            HashAggregate [sum_sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
+                              HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum,isEmpty,sum] [sum(sales),sum(number_salesL),sum_sales,number_sales,sum,isEmpty,sum]
+                                InputAdapter
+                                  Exchange [channel,i_brand_id,i_class_id,i_category_id] #31
+                                    WholeStageCodegen (597)
+                                      HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
+                                        InputAdapter
+                                          Union
+                                            WholeStageCodegen (518)
+                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
+                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true))]
+                                                  ReusedSubquery [average_sales] #1
+                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
+                                                    InputAdapter
+                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #3
+                                            WholeStageCodegen (557)
+                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
+                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true))]
+                                                  ReusedSubquery [average_sales] #1
+                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
+                                                    InputAdapter
+                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #20
+                                            WholeStageCodegen (596)
+                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
+                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true))]
+                                                  ReusedSubquery [average_sales] #1
+                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
+                                                    InputAdapter
+                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #22

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a/explain.txt
@@ -1,210 +1,198 @@
 == Physical Plan ==
-TakeOrderedAndProject (206)
-+- * HashAggregate (205)
-   +- Exchange (204)
-      +- * HashAggregate (203)
-         +- Union (202)
-            :- * HashAggregate (182)
-            :  +- Exchange (181)
-            :     +- * HashAggregate (180)
-            :        +- Union (179)
-            :           :- * HashAggregate (159)
-            :           :  +- Exchange (158)
-            :           :     +- * HashAggregate (157)
-            :           :        +- Union (156)
-            :           :           :- * HashAggregate (136)
-            :           :           :  +- Exchange (135)
-            :           :           :     +- * HashAggregate (134)
-            :           :           :        +- Union (133)
-            :           :           :           :- * HashAggregate (113)
-            :           :           :           :  +- Exchange (112)
-            :           :           :           :     +- * HashAggregate (111)
-            :           :           :           :        +- Union (110)
-            :           :           :           :           :- * Project (77)
-            :           :           :           :           :  +- * Filter (76)
-            :           :           :           :           :     +- * HashAggregate (75)
-            :           :           :           :           :        +- Exchange (74)
-            :           :           :           :           :           +- * HashAggregate (73)
-            :           :           :           :           :              +- * Project (72)
-            :           :           :           :           :                 +- * BroadcastHashJoin Inner BuildRight (71)
-            :           :           :           :           :                    :- * Project (65)
-            :           :           :           :           :                    :  +- * BroadcastHashJoin Inner BuildRight (64)
-            :           :           :           :           :                    :     :- * BroadcastHashJoin LeftSemi BuildRight (57)
-            :           :           :           :           :                    :     :  :- * Filter (3)
-            :           :           :           :           :                    :     :  :  +- * ColumnarToRow (2)
-            :           :           :           :           :                    :     :  :     +- Scan parquet default.store_sales (1)
-            :           :           :           :           :                    :     :  +- BroadcastExchange (56)
-            :           :           :           :           :                    :     :     +- * Project (55)
-            :           :           :           :           :                    :     :        +- * BroadcastHashJoin Inner BuildRight (54)
-            :           :           :           :           :                    :     :           :- * Filter (6)
-            :           :           :           :           :                    :     :           :  +- * ColumnarToRow (5)
-            :           :           :           :           :                    :     :           :     +- Scan parquet default.item (4)
-            :           :           :           :           :                    :     :           +- BroadcastExchange (53)
-            :           :           :           :           :                    :     :              +- * HashAggregate (52)
-            :           :           :           :           :                    :     :                 +- * HashAggregate (51)
-            :           :           :           :           :                    :     :                    +- * HashAggregate (50)
-            :           :           :           :           :                    :     :                       +- Exchange (49)
-            :           :           :           :           :                    :     :                          +- * HashAggregate (48)
-            :           :           :           :           :                    :     :                             +- * BroadcastHashJoin LeftSemi BuildRight (47)
-            :           :           :           :           :                    :     :                                :- * BroadcastHashJoin LeftSemi BuildRight (36)
-            :           :           :           :           :                    :     :                                :  :- * Project (22)
-            :           :           :           :           :                    :     :                                :  :  +- * BroadcastHashJoin Inner BuildRight (21)
-            :           :           :           :           :                    :     :                                :  :     :- * Project (15)
-            :           :           :           :           :                    :     :                                :  :     :  +- * BroadcastHashJoin Inner BuildRight (14)
-            :           :           :           :           :                    :     :                                :  :     :     :- * Filter (9)
-            :           :           :           :           :                    :     :                                :  :     :     :  +- * ColumnarToRow (8)
-            :           :           :           :           :                    :     :                                :  :     :     :     +- Scan parquet default.store_sales (7)
-            :           :           :           :           :                    :     :                                :  :     :     +- BroadcastExchange (13)
-            :           :           :           :           :                    :     :                                :  :     :        +- * Filter (12)
-            :           :           :           :           :                    :     :                                :  :     :           +- * ColumnarToRow (11)
-            :           :           :           :           :                    :     :                                :  :     :              +- Scan parquet default.item (10)
-            :           :           :           :           :                    :     :                                :  :     +- BroadcastExchange (20)
-            :           :           :           :           :                    :     :                                :  :        +- * Project (19)
-            :           :           :           :           :                    :     :                                :  :           +- * Filter (18)
-            :           :           :           :           :                    :     :                                :  :              +- * ColumnarToRow (17)
-            :           :           :           :           :                    :     :                                :  :                 +- Scan parquet default.date_dim (16)
-            :           :           :           :           :                    :     :                                :  +- BroadcastExchange (35)
-            :           :           :           :           :                    :     :                                :     +- * Project (34)
-            :           :           :           :           :                    :     :                                :        +- * BroadcastHashJoin Inner BuildRight (33)
-            :           :           :           :           :                    :     :                                :           :- * Project (31)
-            :           :           :           :           :                    :     :                                :           :  +- * BroadcastHashJoin Inner BuildRight (30)
-            :           :           :           :           :                    :     :                                :           :     :- * Filter (25)
-            :           :           :           :           :                    :     :                                :           :     :  +- * ColumnarToRow (24)
-            :           :           :           :           :                    :     :                                :           :     :     +- Scan parquet default.catalog_sales (23)
-            :           :           :           :           :                    :     :                                :           :     +- BroadcastExchange (29)
-            :           :           :           :           :                    :     :                                :           :        +- * Filter (28)
-            :           :           :           :           :                    :     :                                :           :           +- * ColumnarToRow (27)
-            :           :           :           :           :                    :     :                                :           :              +- Scan parquet default.item (26)
-            :           :           :           :           :                    :     :                                :           +- ReusedExchange (32)
-            :           :           :           :           :                    :     :                                +- BroadcastExchange (46)
-            :           :           :           :           :                    :     :                                   +- * Project (45)
-            :           :           :           :           :                    :     :                                      +- * BroadcastHashJoin Inner BuildRight (44)
-            :           :           :           :           :                    :     :                                         :- * Project (42)
-            :           :           :           :           :                    :     :                                         :  +- * BroadcastHashJoin Inner BuildRight (41)
-            :           :           :           :           :                    :     :                                         :     :- * Filter (39)
-            :           :           :           :           :                    :     :                                         :     :  +- * ColumnarToRow (38)
-            :           :           :           :           :                    :     :                                         :     :     +- Scan parquet default.web_sales (37)
-            :           :           :           :           :                    :     :                                         :     +- ReusedExchange (40)
-            :           :           :           :           :                    :     :                                         +- ReusedExchange (43)
-            :           :           :           :           :                    :     +- BroadcastExchange (63)
-            :           :           :           :           :                    :        +- * BroadcastHashJoin LeftSemi BuildRight (62)
-            :           :           :           :           :                    :           :- * Filter (60)
-            :           :           :           :           :                    :           :  +- * ColumnarToRow (59)
-            :           :           :           :           :                    :           :     +- Scan parquet default.item (58)
-            :           :           :           :           :                    :           +- ReusedExchange (61)
-            :           :           :           :           :                    +- BroadcastExchange (70)
-            :           :           :           :           :                       +- * Project (69)
-            :           :           :           :           :                          +- * Filter (68)
-            :           :           :           :           :                             +- * ColumnarToRow (67)
-            :           :           :           :           :                                +- Scan parquet default.date_dim (66)
-            :           :           :           :           :- * Project (93)
-            :           :           :           :           :  +- * Filter (92)
-            :           :           :           :           :     +- * HashAggregate (91)
-            :           :           :           :           :        +- Exchange (90)
-            :           :           :           :           :           +- * HashAggregate (89)
-            :           :           :           :           :              +- * Project (88)
-            :           :           :           :           :                 +- * BroadcastHashJoin Inner BuildRight (87)
-            :           :           :           :           :                    :- * Project (85)
-            :           :           :           :           :                    :  +- * BroadcastHashJoin Inner BuildRight (84)
-            :           :           :           :           :                    :     :- * BroadcastHashJoin LeftSemi BuildRight (82)
-            :           :           :           :           :                    :     :  :- * Filter (80)
-            :           :           :           :           :                    :     :  :  +- * ColumnarToRow (79)
-            :           :           :           :           :                    :     :  :     +- Scan parquet default.catalog_sales (78)
-            :           :           :           :           :                    :     :  +- ReusedExchange (81)
-            :           :           :           :           :                    :     +- ReusedExchange (83)
-            :           :           :           :           :                    +- ReusedExchange (86)
-            :           :           :           :           +- * Project (109)
-            :           :           :           :              +- * Filter (108)
-            :           :           :           :                 +- * HashAggregate (107)
-            :           :           :           :                    +- Exchange (106)
-            :           :           :           :                       +- * HashAggregate (105)
-            :           :           :           :                          +- * Project (104)
-            :           :           :           :                             +- * BroadcastHashJoin Inner BuildRight (103)
-            :           :           :           :                                :- * Project (101)
-            :           :           :           :                                :  +- * BroadcastHashJoin Inner BuildRight (100)
-            :           :           :           :                                :     :- * BroadcastHashJoin LeftSemi BuildRight (98)
-            :           :           :           :                                :     :  :- * Filter (96)
-            :           :           :           :                                :     :  :  +- * ColumnarToRow (95)
-            :           :           :           :                                :     :  :     +- Scan parquet default.web_sales (94)
-            :           :           :           :                                :     :  +- ReusedExchange (97)
-            :           :           :           :                                :     +- ReusedExchange (99)
-            :           :           :           :                                +- ReusedExchange (102)
-            :           :           :           +- * HashAggregate (132)
-            :           :           :              +- Exchange (131)
-            :           :           :                 +- * HashAggregate (130)
-            :           :           :                    +- * HashAggregate (129)
-            :           :           :                       +- Exchange (128)
-            :           :           :                          +- * HashAggregate (127)
-            :           :           :                             +- Union (126)
-            :           :           :                                :- * Project (117)
-            :           :           :                                :  +- * Filter (116)
-            :           :           :                                :     +- * HashAggregate (115)
-            :           :           :                                :        +- ReusedExchange (114)
-            :           :           :                                :- * Project (121)
-            :           :           :                                :  +- * Filter (120)
-            :           :           :                                :     +- * HashAggregate (119)
-            :           :           :                                :        +- ReusedExchange (118)
-            :           :           :                                +- * Project (125)
-            :           :           :                                   +- * Filter (124)
-            :           :           :                                      +- * HashAggregate (123)
-            :           :           :                                         +- ReusedExchange (122)
-            :           :           +- * HashAggregate (155)
-            :           :              +- Exchange (154)
-            :           :                 +- * HashAggregate (153)
-            :           :                    +- * HashAggregate (152)
-            :           :                       +- Exchange (151)
-            :           :                          +- * HashAggregate (150)
-            :           :                             +- Union (149)
-            :           :                                :- * Project (140)
-            :           :                                :  +- * Filter (139)
-            :           :                                :     +- * HashAggregate (138)
-            :           :                                :        +- ReusedExchange (137)
-            :           :                                :- * Project (144)
-            :           :                                :  +- * Filter (143)
-            :           :                                :     +- * HashAggregate (142)
-            :           :                                :        +- ReusedExchange (141)
-            :           :                                +- * Project (148)
-            :           :                                   +- * Filter (147)
-            :           :                                      +- * HashAggregate (146)
-            :           :                                         +- ReusedExchange (145)
-            :           +- * HashAggregate (178)
-            :              +- Exchange (177)
-            :                 +- * HashAggregate (176)
-            :                    +- * HashAggregate (175)
-            :                       +- Exchange (174)
-            :                          +- * HashAggregate (173)
-            :                             +- Union (172)
-            :                                :- * Project (163)
-            :                                :  +- * Filter (162)
-            :                                :     +- * HashAggregate (161)
-            :                                :        +- ReusedExchange (160)
-            :                                :- * Project (167)
-            :                                :  +- * Filter (166)
-            :                                :     +- * HashAggregate (165)
-            :                                :        +- ReusedExchange (164)
-            :                                +- * Project (171)
-            :                                   +- * Filter (170)
-            :                                      +- * HashAggregate (169)
-            :                                         +- ReusedExchange (168)
-            +- * HashAggregate (201)
-               +- Exchange (200)
-                  +- * HashAggregate (199)
-                     +- * HashAggregate (198)
-                        +- Exchange (197)
-                           +- * HashAggregate (196)
-                              +- Union (195)
-                                 :- * Project (186)
-                                 :  +- * Filter (185)
-                                 :     +- * HashAggregate (184)
-                                 :        +- ReusedExchange (183)
-                                 :- * Project (190)
-                                 :  +- * Filter (189)
-                                 :     +- * HashAggregate (188)
-                                 :        +- ReusedExchange (187)
-                                 +- * Project (194)
-                                    +- * Filter (193)
-                                       +- * HashAggregate (192)
-                                          +- ReusedExchange (191)
+TakeOrderedAndProject (194)
++- * HashAggregate (193)
+   +- Exchange (192)
+      +- * HashAggregate (191)
+         +- Union (190)
+            :- * HashAggregate (113)
+            :  +- Exchange (112)
+            :     +- * HashAggregate (111)
+            :        +- Union (110)
+            :           :- * Project (77)
+            :           :  +- * Filter (76)
+            :           :     +- * HashAggregate (75)
+            :           :        +- Exchange (74)
+            :           :           +- * HashAggregate (73)
+            :           :              +- * Project (72)
+            :           :                 +- * BroadcastHashJoin Inner BuildRight (71)
+            :           :                    :- * Project (65)
+            :           :                    :  +- * BroadcastHashJoin Inner BuildRight (64)
+            :           :                    :     :- * BroadcastHashJoin LeftSemi BuildRight (57)
+            :           :                    :     :  :- * Filter (3)
+            :           :                    :     :  :  +- * ColumnarToRow (2)
+            :           :                    :     :  :     +- Scan parquet default.store_sales (1)
+            :           :                    :     :  +- BroadcastExchange (56)
+            :           :                    :     :     +- * Project (55)
+            :           :                    :     :        +- * BroadcastHashJoin Inner BuildRight (54)
+            :           :                    :     :           :- * Filter (6)
+            :           :                    :     :           :  +- * ColumnarToRow (5)
+            :           :                    :     :           :     +- Scan parquet default.item (4)
+            :           :                    :     :           +- BroadcastExchange (53)
+            :           :                    :     :              +- * HashAggregate (52)
+            :           :                    :     :                 +- * HashAggregate (51)
+            :           :                    :     :                    +- * HashAggregate (50)
+            :           :                    :     :                       +- Exchange (49)
+            :           :                    :     :                          +- * HashAggregate (48)
+            :           :                    :     :                             +- * BroadcastHashJoin LeftSemi BuildRight (47)
+            :           :                    :     :                                :- * BroadcastHashJoin LeftSemi BuildRight (36)
+            :           :                    :     :                                :  :- * Project (22)
+            :           :                    :     :                                :  :  +- * BroadcastHashJoin Inner BuildRight (21)
+            :           :                    :     :                                :  :     :- * Project (15)
+            :           :                    :     :                                :  :     :  +- * BroadcastHashJoin Inner BuildRight (14)
+            :           :                    :     :                                :  :     :     :- * Filter (9)
+            :           :                    :     :                                :  :     :     :  +- * ColumnarToRow (8)
+            :           :                    :     :                                :  :     :     :     +- Scan parquet default.store_sales (7)
+            :           :                    :     :                                :  :     :     +- BroadcastExchange (13)
+            :           :                    :     :                                :  :     :        +- * Filter (12)
+            :           :                    :     :                                :  :     :           +- * ColumnarToRow (11)
+            :           :                    :     :                                :  :     :              +- Scan parquet default.item (10)
+            :           :                    :     :                                :  :     +- BroadcastExchange (20)
+            :           :                    :     :                                :  :        +- * Project (19)
+            :           :                    :     :                                :  :           +- * Filter (18)
+            :           :                    :     :                                :  :              +- * ColumnarToRow (17)
+            :           :                    :     :                                :  :                 +- Scan parquet default.date_dim (16)
+            :           :                    :     :                                :  +- BroadcastExchange (35)
+            :           :                    :     :                                :     +- * Project (34)
+            :           :                    :     :                                :        +- * BroadcastHashJoin Inner BuildRight (33)
+            :           :                    :     :                                :           :- * Project (31)
+            :           :                    :     :                                :           :  +- * BroadcastHashJoin Inner BuildRight (30)
+            :           :                    :     :                                :           :     :- * Filter (25)
+            :           :                    :     :                                :           :     :  +- * ColumnarToRow (24)
+            :           :                    :     :                                :           :     :     +- Scan parquet default.catalog_sales (23)
+            :           :                    :     :                                :           :     +- BroadcastExchange (29)
+            :           :                    :     :                                :           :        +- * Filter (28)
+            :           :                    :     :                                :           :           +- * ColumnarToRow (27)
+            :           :                    :     :                                :           :              +- Scan parquet default.item (26)
+            :           :                    :     :                                :           +- ReusedExchange (32)
+            :           :                    :     :                                +- BroadcastExchange (46)
+            :           :                    :     :                                   +- * Project (45)
+            :           :                    :     :                                      +- * BroadcastHashJoin Inner BuildRight (44)
+            :           :                    :     :                                         :- * Project (42)
+            :           :                    :     :                                         :  +- * BroadcastHashJoin Inner BuildRight (41)
+            :           :                    :     :                                         :     :- * Filter (39)
+            :           :                    :     :                                         :     :  +- * ColumnarToRow (38)
+            :           :                    :     :                                         :     :     +- Scan parquet default.web_sales (37)
+            :           :                    :     :                                         :     +- ReusedExchange (40)
+            :           :                    :     :                                         +- ReusedExchange (43)
+            :           :                    :     +- BroadcastExchange (63)
+            :           :                    :        +- * BroadcastHashJoin LeftSemi BuildRight (62)
+            :           :                    :           :- * Filter (60)
+            :           :                    :           :  +- * ColumnarToRow (59)
+            :           :                    :           :     +- Scan parquet default.item (58)
+            :           :                    :           +- ReusedExchange (61)
+            :           :                    +- BroadcastExchange (70)
+            :           :                       +- * Project (69)
+            :           :                          +- * Filter (68)
+            :           :                             +- * ColumnarToRow (67)
+            :           :                                +- Scan parquet default.date_dim (66)
+            :           :- * Project (93)
+            :           :  +- * Filter (92)
+            :           :     +- * HashAggregate (91)
+            :           :        +- Exchange (90)
+            :           :           +- * HashAggregate (89)
+            :           :              +- * Project (88)
+            :           :                 +- * BroadcastHashJoin Inner BuildRight (87)
+            :           :                    :- * Project (85)
+            :           :                    :  +- * BroadcastHashJoin Inner BuildRight (84)
+            :           :                    :     :- * BroadcastHashJoin LeftSemi BuildRight (82)
+            :           :                    :     :  :- * Filter (80)
+            :           :                    :     :  :  +- * ColumnarToRow (79)
+            :           :                    :     :  :     +- Scan parquet default.catalog_sales (78)
+            :           :                    :     :  +- ReusedExchange (81)
+            :           :                    :     +- ReusedExchange (83)
+            :           :                    +- ReusedExchange (86)
+            :           +- * Project (109)
+            :              +- * Filter (108)
+            :                 +- * HashAggregate (107)
+            :                    +- Exchange (106)
+            :                       +- * HashAggregate (105)
+            :                          +- * Project (104)
+            :                             +- * BroadcastHashJoin Inner BuildRight (103)
+            :                                :- * Project (101)
+            :                                :  +- * BroadcastHashJoin Inner BuildRight (100)
+            :                                :     :- * BroadcastHashJoin LeftSemi BuildRight (98)
+            :                                :     :  :- * Filter (96)
+            :                                :     :  :  +- * ColumnarToRow (95)
+            :                                :     :  :     +- Scan parquet default.web_sales (94)
+            :                                :     :  +- ReusedExchange (97)
+            :                                :     +- ReusedExchange (99)
+            :                                +- ReusedExchange (102)
+            :- * HashAggregate (132)
+            :  +- Exchange (131)
+            :     +- * HashAggregate (130)
+            :        +- * HashAggregate (129)
+            :           +- Exchange (128)
+            :              +- * HashAggregate (127)
+            :                 +- Union (126)
+            :                    :- * Project (117)
+            :                    :  +- * Filter (116)
+            :                    :     +- * HashAggregate (115)
+            :                    :        +- ReusedExchange (114)
+            :                    :- * Project (121)
+            :                    :  +- * Filter (120)
+            :                    :     +- * HashAggregate (119)
+            :                    :        +- ReusedExchange (118)
+            :                    +- * Project (125)
+            :                       +- * Filter (124)
+            :                          +- * HashAggregate (123)
+            :                             +- ReusedExchange (122)
+            :- * HashAggregate (151)
+            :  +- Exchange (150)
+            :     +- * HashAggregate (149)
+            :        +- * HashAggregate (148)
+            :           +- Exchange (147)
+            :              +- * HashAggregate (146)
+            :                 +- Union (145)
+            :                    :- * Project (136)
+            :                    :  +- * Filter (135)
+            :                    :     +- * HashAggregate (134)
+            :                    :        +- ReusedExchange (133)
+            :                    :- * Project (140)
+            :                    :  +- * Filter (139)
+            :                    :     +- * HashAggregate (138)
+            :                    :        +- ReusedExchange (137)
+            :                    +- * Project (144)
+            :                       +- * Filter (143)
+            :                          +- * HashAggregate (142)
+            :                             +- ReusedExchange (141)
+            :- * HashAggregate (170)
+            :  +- Exchange (169)
+            :     +- * HashAggregate (168)
+            :        +- * HashAggregate (167)
+            :           +- Exchange (166)
+            :              +- * HashAggregate (165)
+            :                 +- Union (164)
+            :                    :- * Project (155)
+            :                    :  +- * Filter (154)
+            :                    :     +- * HashAggregate (153)
+            :                    :        +- ReusedExchange (152)
+            :                    :- * Project (159)
+            :                    :  +- * Filter (158)
+            :                    :     +- * HashAggregate (157)
+            :                    :        +- ReusedExchange (156)
+            :                    +- * Project (163)
+            :                       +- * Filter (162)
+            :                          +- * HashAggregate (161)
+            :                             +- ReusedExchange (160)
+            +- * HashAggregate (189)
+               +- Exchange (188)
+                  +- * HashAggregate (187)
+                     +- * HashAggregate (186)
+                        +- Exchange (185)
+                           +- * HashAggregate (184)
+                              +- Union (183)
+                                 :- * Project (174)
+                                 :  +- * Filter (173)
+                                 :     +- * HashAggregate (172)
+                                 :        +- ReusedExchange (171)
+                                 :- * Project (178)
+                                 :  +- * Filter (177)
+                                 :     +- * HashAggregate (176)
+                                 :        +- ReusedExchange (175)
+                                 +- * Project (182)
+                                    +- * Filter (181)
+                                       +- * HashAggregate (180)
+                                          +- ReusedExchange (179)
 
 
 (1) Scan parquet default.store_sales
@@ -425,7 +413,7 @@ Results [3]: [brand_id#13, class_id#14, category_id#15]
 
 (49) Exchange
 Input [3]: [brand_id#13, class_id#14, category_id#15]
-Arguments: hashpartitioning(brand_id#13, class_id#14, category_id#15, 5), true, [id=#23]
+Arguments: hashpartitioning(brand_id#13, class_id#14, category_id#15, 5), ENSURE_REQUIREMENTS, [id=#23]
 
 (50) HashAggregate [codegen id : 10]
 Input [3]: [brand_id#13, class_id#14, category_id#15]
@@ -545,7 +533,7 @@ Results [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#33, isEmpty#34, c
 
 (74) Exchange
 Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#33, isEmpty#34, count#35]
-Arguments: hashpartitioning(i_brand_id#6, i_class_id#7, i_category_id#8, 5), true, [id=#36]
+Arguments: hashpartitioning(i_brand_id#6, i_class_id#7, i_category_id#8, 5), ENSURE_REQUIREMENTS, [id=#36]
 
 (75) HashAggregate [codegen id : 26]
 Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#33, isEmpty#34, count#35]
@@ -617,7 +605,7 @@ Results [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#50, isEmpty#51, c
 
 (90) Exchange
 Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#50, isEmpty#51, count#52]
-Arguments: hashpartitioning(i_brand_id#6, i_class_id#7, i_category_id#8, 5), true, [id=#53]
+Arguments: hashpartitioning(i_brand_id#6, i_class_id#7, i_category_id#8, 5), ENSURE_REQUIREMENTS, [id=#53]
 
 (91) HashAggregate [codegen id : 52]
 Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#50, isEmpty#51, count#52]
@@ -689,7 +677,7 @@ Results [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#65, isEmpty#66, c
 
 (106) Exchange
 Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#65, isEmpty#66, count#67]
-Arguments: hashpartitioning(i_brand_id#6, i_class_id#7, i_category_id#8, 5), true, [id=#68]
+Arguments: hashpartitioning(i_brand_id#6, i_class_id#7, i_category_id#8, 5), ENSURE_REQUIREMENTS, [id=#68]
 
 (107) HashAggregate [codegen id : 78]
 Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#65, isEmpty#66, count#67]
@@ -717,7 +705,7 @@ Results [7]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum#78, i
 
 (112) Exchange
 Input [7]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum#78, isEmpty#79, sum#80]
-Arguments: hashpartitioning(channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, 5), true, [id=#81]
+Arguments: hashpartitioning(channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, 5), ENSURE_REQUIREMENTS, [id=#81]
 
 (113) HashAggregate [codegen id : 80]
 Input [7]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum#78, isEmpty#79, sum#80]
@@ -791,7 +779,7 @@ Results [7]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum#109, 
 
 (128) Exchange
 Input [7]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum#109, isEmpty#110, sum#111]
-Arguments: hashpartitioning(channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, 5), true, [id=#112]
+Arguments: hashpartitioning(channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, 5), ENSURE_REQUIREMENTS, [id=#112]
 
 (129) HashAggregate [codegen id : 160]
 Input [7]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum#109, isEmpty#110, sum#111]
@@ -809,7 +797,7 @@ Results [6]: [channel#44, i_brand_id#6, i_class_id#7, sum#118, isEmpty#119, sum#
 
 (131) Exchange
 Input [6]: [channel#44, i_brand_id#6, i_class_id#7, sum#118, isEmpty#119, sum#120]
-Arguments: hashpartitioning(channel#44, i_brand_id#6, i_class_id#7, 5), true, [id=#121]
+Arguments: hashpartitioning(channel#44, i_brand_id#6, i_class_id#7, 5), ENSURE_REQUIREMENTS, [id=#121]
 
 (132) HashAggregate [codegen id : 161]
 Input [6]: [channel#44, i_brand_id#6, i_class_id#7, sum#118, isEmpty#119, sum#120]
@@ -818,536 +806,476 @@ Functions [2]: [sum(sum_sales#84), sum(number_sales#85)]
 Aggregate Attributes [2]: [sum(sum_sales#84)#122, sum(number_sales#85)#123]
 Results [6]: [channel#44, i_brand_id#6, i_class_id#7, null AS i_category_id#124, sum(sum_sales#84)#122 AS sum(sum_sales)#125, sum(number_sales#85)#123 AS sum(number_sales)#126]
 
-(133) Union
+(133) ReusedExchange [Reuses operator id: 74]
+Output [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#127, isEmpty#128, count#129]
 
-(134) HashAggregate [codegen id : 162]
-Input [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85]
-Keys [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85]
-Functions: []
-Aggregate Attributes: []
-Results [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85]
-
-(135) Exchange
-Input [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85]
-Arguments: hashpartitioning(channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85, 5), true, [id=#127]
-
-(136) HashAggregate [codegen id : 163]
-Input [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85]
-Keys [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85]
-Functions: []
-Aggregate Attributes: []
-Results [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85]
-
-(137) ReusedExchange [Reuses operator id: 74]
-Output [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#128, isEmpty#129, count#130]
-
-(138) HashAggregate [codegen id : 189]
-Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#128, isEmpty#129, count#130]
+(134) HashAggregate [codegen id : 187]
+Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#127, isEmpty#128, count#129]
 Keys [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
 Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#131, count(1)#132]
-Results [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#131 AS sales#39, count(1)#132 AS number_sales#40, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#131 AS sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#133]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#130, count(1)#131]
+Results [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#130 AS sales#39, count(1)#131 AS number_sales#40, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#130 AS sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#132]
 
-(139) Filter [codegen id : 189]
-Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#39, number_sales#40, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#133]
-Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#133) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#133 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#42, [id=#43] as decimal(32,6))))
+(135) Filter [codegen id : 187]
+Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#39, number_sales#40, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#132]
+Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#132) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#132 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#42, [id=#43] as decimal(32,6))))
 
-(140) Project [codegen id : 189]
+(136) Project [codegen id : 187]
 Output [6]: [store AS channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sales#39, number_sales#40]
-Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#39, number_sales#40, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#133]
+Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#39, number_sales#40, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#132]
 
-(141) ReusedExchange [Reuses operator id: 90]
-Output [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#134, isEmpty#135, count#136]
+(137) ReusedExchange [Reuses operator id: 90]
+Output [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#133, isEmpty#134, count#135]
 
-(142) HashAggregate [codegen id : 215]
-Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#134, isEmpty#135, count#136]
+(138) HashAggregate [codegen id : 213]
+Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#133, isEmpty#134, count#135]
 Keys [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
 Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#137, count(1)#138]
-Results [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#137 AS sales#56, count(1)#138 AS number_sales#57, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#137 AS sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#139]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#136, count(1)#137]
+Results [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#136 AS sales#56, count(1)#137 AS number_sales#57, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#136 AS sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#138]
 
-(143) Filter [codegen id : 215]
-Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#56, number_sales#57, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#139]
-Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#139) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#139 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#42, [id=#43] as decimal(32,6))))
+(139) Filter [codegen id : 213]
+Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#56, number_sales#57, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#138]
+Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#138) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#138 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#42, [id=#43] as decimal(32,6))))
 
-(144) Project [codegen id : 215]
-Output [6]: [catalog AS channel#140, i_brand_id#6, i_class_id#7, i_category_id#8, sales#56, number_sales#57]
-Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#56, number_sales#57, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#139]
+(140) Project [codegen id : 213]
+Output [6]: [catalog AS channel#139, i_brand_id#6, i_class_id#7, i_category_id#8, sales#56, number_sales#57]
+Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#56, number_sales#57, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#138]
 
-(145) ReusedExchange [Reuses operator id: 106]
-Output [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#141, isEmpty#142, count#143]
+(141) ReusedExchange [Reuses operator id: 106]
+Output [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#140, isEmpty#141, count#142]
 
-(146) HashAggregate [codegen id : 241]
-Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#141, isEmpty#142, count#143]
+(142) HashAggregate [codegen id : 239]
+Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#140, isEmpty#141, count#142]
 Keys [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
 Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#144, count(1)#145]
-Results [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#144 AS sales#71, count(1)#145 AS number_sales#72, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#144 AS sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#146]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#143, count(1)#144]
+Results [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#143 AS sales#71, count(1)#144 AS number_sales#72, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#143 AS sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#145]
 
-(147) Filter [codegen id : 241]
-Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#71, number_sales#72, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#146]
-Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#146) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#146 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#42, [id=#43] as decimal(32,6))))
+(143) Filter [codegen id : 239]
+Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#71, number_sales#72, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#145]
+Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#145) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#145 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#42, [id=#43] as decimal(32,6))))
 
-(148) Project [codegen id : 241]
-Output [6]: [web AS channel#147, i_brand_id#6, i_class_id#7, i_category_id#8, sales#71, number_sales#72]
-Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#71, number_sales#72, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#146]
+(144) Project [codegen id : 239]
+Output [6]: [web AS channel#146, i_brand_id#6, i_class_id#7, i_category_id#8, sales#71, number_sales#72]
+Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#71, number_sales#72, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#145]
 
-(149) Union
+(145) Union
 
-(150) HashAggregate [codegen id : 242]
+(146) HashAggregate [codegen id : 240]
 Input [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sales#39, number_sales#40]
 Keys [4]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8]
 Functions [2]: [partial_sum(sales#39), partial_sum(number_sales#40)]
-Aggregate Attributes [3]: [sum#148, isEmpty#149, sum#150]
-Results [7]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum#151, isEmpty#152, sum#153]
+Aggregate Attributes [3]: [sum#147, isEmpty#148, sum#149]
+Results [7]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum#150, isEmpty#151, sum#152]
 
-(151) Exchange
-Input [7]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum#151, isEmpty#152, sum#153]
-Arguments: hashpartitioning(channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, 5), true, [id=#154]
+(147) Exchange
+Input [7]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum#150, isEmpty#151, sum#152]
+Arguments: hashpartitioning(channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, 5), ENSURE_REQUIREMENTS, [id=#153]
 
-(152) HashAggregate [codegen id : 243]
-Input [7]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum#151, isEmpty#152, sum#153]
+(148) HashAggregate [codegen id : 241]
+Input [7]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum#150, isEmpty#151, sum#152]
 Keys [4]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8]
 Functions [2]: [sum(sales#39), sum(number_sales#40)]
-Aggregate Attributes [2]: [sum(sales#39)#155, sum(number_sales#40)#156]
-Results [4]: [channel#44, i_brand_id#6, sum(sales#39)#155 AS sum_sales#84, sum(number_sales#40)#156 AS number_sales#85]
+Aggregate Attributes [2]: [sum(sales#39)#154, sum(number_sales#40)#155]
+Results [4]: [channel#44, i_brand_id#6, sum(sales#39)#154 AS sum_sales#84, sum(number_sales#40)#155 AS number_sales#85]
 
-(153) HashAggregate [codegen id : 243]
+(149) HashAggregate [codegen id : 241]
 Input [4]: [channel#44, i_brand_id#6, sum_sales#84, number_sales#85]
 Keys [2]: [channel#44, i_brand_id#6]
 Functions [2]: [partial_sum(sum_sales#84), partial_sum(number_sales#85)]
-Aggregate Attributes [3]: [sum#157, isEmpty#158, sum#159]
-Results [5]: [channel#44, i_brand_id#6, sum#160, isEmpty#161, sum#162]
+Aggregate Attributes [3]: [sum#156, isEmpty#157, sum#158]
+Results [5]: [channel#44, i_brand_id#6, sum#159, isEmpty#160, sum#161]
 
-(154) Exchange
-Input [5]: [channel#44, i_brand_id#6, sum#160, isEmpty#161, sum#162]
-Arguments: hashpartitioning(channel#44, i_brand_id#6, 5), true, [id=#163]
+(150) Exchange
+Input [5]: [channel#44, i_brand_id#6, sum#159, isEmpty#160, sum#161]
+Arguments: hashpartitioning(channel#44, i_brand_id#6, 5), ENSURE_REQUIREMENTS, [id=#162]
 
-(155) HashAggregate [codegen id : 244]
-Input [5]: [channel#44, i_brand_id#6, sum#160, isEmpty#161, sum#162]
+(151) HashAggregate [codegen id : 242]
+Input [5]: [channel#44, i_brand_id#6, sum#159, isEmpty#160, sum#161]
 Keys [2]: [channel#44, i_brand_id#6]
 Functions [2]: [sum(sum_sales#84), sum(number_sales#85)]
-Aggregate Attributes [2]: [sum(sum_sales#84)#164, sum(number_sales#85)#165]
-Results [6]: [channel#44, i_brand_id#6, null AS i_class_id#166, null AS i_category_id#167, sum(sum_sales#84)#164 AS sum(sum_sales)#168, sum(number_sales#85)#165 AS sum(number_sales)#169]
+Aggregate Attributes [2]: [sum(sum_sales#84)#163, sum(number_sales#85)#164]
+Results [6]: [channel#44, i_brand_id#6, null AS i_class_id#165, null AS i_category_id#166, sum(sum_sales#84)#163 AS sum(sum_sales)#167, sum(number_sales#85)#164 AS sum(number_sales)#168]
 
-(156) Union
+(152) ReusedExchange [Reuses operator id: 74]
+Output [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#169, isEmpty#170, count#171]
 
-(157) HashAggregate [codegen id : 245]
-Input [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85]
-Keys [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85]
-Functions: []
-Aggregate Attributes: []
-Results [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85]
-
-(158) Exchange
-Input [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85]
-Arguments: hashpartitioning(channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85, 5), true, [id=#170]
-
-(159) HashAggregate [codegen id : 246]
-Input [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85]
-Keys [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85]
-Functions: []
-Aggregate Attributes: []
-Results [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85]
-
-(160) ReusedExchange [Reuses operator id: 74]
-Output [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#171, isEmpty#172, count#173]
-
-(161) HashAggregate [codegen id : 272]
-Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#171, isEmpty#172, count#173]
+(153) HashAggregate [codegen id : 268]
+Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#169, isEmpty#170, count#171]
 Keys [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
 Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#174, count(1)#175]
-Results [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#174 AS sales#39, count(1)#175 AS number_sales#40, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#174 AS sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#176]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#172, count(1)#173]
+Results [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#172 AS sales#39, count(1)#173 AS number_sales#40, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#172 AS sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#174]
 
-(162) Filter [codegen id : 272]
-Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#39, number_sales#40, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#176]
-Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#176) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#176 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#42, [id=#43] as decimal(32,6))))
+(154) Filter [codegen id : 268]
+Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#39, number_sales#40, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#174]
+Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#174) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#174 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#42, [id=#43] as decimal(32,6))))
 
-(163) Project [codegen id : 272]
+(155) Project [codegen id : 268]
 Output [6]: [store AS channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sales#39, number_sales#40]
-Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#39, number_sales#40, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#176]
+Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#39, number_sales#40, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#174]
 
-(164) ReusedExchange [Reuses operator id: 90]
-Output [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#177, isEmpty#178, count#179]
+(156) ReusedExchange [Reuses operator id: 90]
+Output [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#175, isEmpty#176, count#177]
 
-(165) HashAggregate [codegen id : 298]
-Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#177, isEmpty#178, count#179]
+(157) HashAggregate [codegen id : 294]
+Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#175, isEmpty#176, count#177]
 Keys [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
 Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#180, count(1)#181]
-Results [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#180 AS sales#56, count(1)#181 AS number_sales#57, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#180 AS sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#182]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#178, count(1)#179]
+Results [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#178 AS sales#56, count(1)#179 AS number_sales#57, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#178 AS sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#180]
 
-(166) Filter [codegen id : 298]
-Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#56, number_sales#57, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#182]
-Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#182) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#182 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#42, [id=#43] as decimal(32,6))))
+(158) Filter [codegen id : 294]
+Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#56, number_sales#57, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#180]
+Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#180) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#180 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#42, [id=#43] as decimal(32,6))))
 
-(167) Project [codegen id : 298]
-Output [6]: [catalog AS channel#183, i_brand_id#6, i_class_id#7, i_category_id#8, sales#56, number_sales#57]
-Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#56, number_sales#57, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#182]
+(159) Project [codegen id : 294]
+Output [6]: [catalog AS channel#181, i_brand_id#6, i_class_id#7, i_category_id#8, sales#56, number_sales#57]
+Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#56, number_sales#57, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#180]
 
-(168) ReusedExchange [Reuses operator id: 106]
-Output [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#184, isEmpty#185, count#186]
+(160) ReusedExchange [Reuses operator id: 106]
+Output [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#182, isEmpty#183, count#184]
 
-(169) HashAggregate [codegen id : 324]
-Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#184, isEmpty#185, count#186]
+(161) HashAggregate [codegen id : 320]
+Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#182, isEmpty#183, count#184]
 Keys [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
 Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#187, count(1)#188]
-Results [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#187 AS sales#71, count(1)#188 AS number_sales#72, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#187 AS sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#189]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#185, count(1)#186]
+Results [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#185 AS sales#71, count(1)#186 AS number_sales#72, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#185 AS sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#187]
 
-(170) Filter [codegen id : 324]
-Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#71, number_sales#72, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#189]
-Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#189) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#189 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#42, [id=#43] as decimal(32,6))))
+(162) Filter [codegen id : 320]
+Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#71, number_sales#72, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#187]
+Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#187) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#187 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#42, [id=#43] as decimal(32,6))))
 
-(171) Project [codegen id : 324]
-Output [6]: [web AS channel#190, i_brand_id#6, i_class_id#7, i_category_id#8, sales#71, number_sales#72]
-Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#71, number_sales#72, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#189]
+(163) Project [codegen id : 320]
+Output [6]: [web AS channel#188, i_brand_id#6, i_class_id#7, i_category_id#8, sales#71, number_sales#72]
+Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#71, number_sales#72, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#187]
 
-(172) Union
+(164) Union
 
-(173) HashAggregate [codegen id : 325]
+(165) HashAggregate [codegen id : 321]
 Input [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sales#39, number_sales#40]
 Keys [4]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8]
 Functions [2]: [partial_sum(sales#39), partial_sum(number_sales#40)]
-Aggregate Attributes [3]: [sum#191, isEmpty#192, sum#193]
-Results [7]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum#194, isEmpty#195, sum#196]
+Aggregate Attributes [3]: [sum#189, isEmpty#190, sum#191]
+Results [7]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum#192, isEmpty#193, sum#194]
 
-(174) Exchange
-Input [7]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum#194, isEmpty#195, sum#196]
-Arguments: hashpartitioning(channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, 5), true, [id=#197]
+(166) Exchange
+Input [7]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum#192, isEmpty#193, sum#194]
+Arguments: hashpartitioning(channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, 5), ENSURE_REQUIREMENTS, [id=#195]
 
-(175) HashAggregate [codegen id : 326]
-Input [7]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum#194, isEmpty#195, sum#196]
+(167) HashAggregate [codegen id : 322]
+Input [7]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum#192, isEmpty#193, sum#194]
 Keys [4]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8]
 Functions [2]: [sum(sales#39), sum(number_sales#40)]
-Aggregate Attributes [2]: [sum(sales#39)#198, sum(number_sales#40)#199]
-Results [3]: [channel#44, sum(sales#39)#198 AS sum_sales#84, sum(number_sales#40)#199 AS number_sales#85]
+Aggregate Attributes [2]: [sum(sales#39)#196, sum(number_sales#40)#197]
+Results [3]: [channel#44, sum(sales#39)#196 AS sum_sales#84, sum(number_sales#40)#197 AS number_sales#85]
 
-(176) HashAggregate [codegen id : 326]
+(168) HashAggregate [codegen id : 322]
 Input [3]: [channel#44, sum_sales#84, number_sales#85]
 Keys [1]: [channel#44]
 Functions [2]: [partial_sum(sum_sales#84), partial_sum(number_sales#85)]
-Aggregate Attributes [3]: [sum#200, isEmpty#201, sum#202]
-Results [4]: [channel#44, sum#203, isEmpty#204, sum#205]
+Aggregate Attributes [3]: [sum#198, isEmpty#199, sum#200]
+Results [4]: [channel#44, sum#201, isEmpty#202, sum#203]
 
-(177) Exchange
-Input [4]: [channel#44, sum#203, isEmpty#204, sum#205]
-Arguments: hashpartitioning(channel#44, 5), true, [id=#206]
+(169) Exchange
+Input [4]: [channel#44, sum#201, isEmpty#202, sum#203]
+Arguments: hashpartitioning(channel#44, 5), ENSURE_REQUIREMENTS, [id=#204]
 
-(178) HashAggregate [codegen id : 327]
-Input [4]: [channel#44, sum#203, isEmpty#204, sum#205]
+(170) HashAggregate [codegen id : 323]
+Input [4]: [channel#44, sum#201, isEmpty#202, sum#203]
 Keys [1]: [channel#44]
 Functions [2]: [sum(sum_sales#84), sum(number_sales#85)]
-Aggregate Attributes [2]: [sum(sum_sales#84)#207, sum(number_sales#85)#208]
-Results [6]: [channel#44, null AS i_brand_id#209, null AS i_class_id#210, null AS i_category_id#211, sum(sum_sales#84)#207 AS sum(sum_sales)#212, sum(number_sales#85)#208 AS sum(number_sales)#213]
+Aggregate Attributes [2]: [sum(sum_sales#84)#205, sum(number_sales#85)#206]
+Results [6]: [channel#44, null AS i_brand_id#207, null AS i_class_id#208, null AS i_category_id#209, sum(sum_sales#84)#205 AS sum(sum_sales)#210, sum(number_sales#85)#206 AS sum(number_sales)#211]
 
-(179) Union
+(171) ReusedExchange [Reuses operator id: 74]
+Output [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#212, isEmpty#213, count#214]
 
-(180) HashAggregate [codegen id : 328]
-Input [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85]
-Keys [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85]
-Functions: []
-Aggregate Attributes: []
-Results [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85]
-
-(181) Exchange
-Input [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85]
-Arguments: hashpartitioning(channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85, 5), true, [id=#214]
-
-(182) HashAggregate [codegen id : 329]
-Input [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85]
-Keys [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85]
-Functions: []
-Aggregate Attributes: []
-Results [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85]
-
-(183) ReusedExchange [Reuses operator id: 74]
-Output [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#215, isEmpty#216, count#217]
-
-(184) HashAggregate [codegen id : 355]
-Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#215, isEmpty#216, count#217]
+(172) HashAggregate [codegen id : 349]
+Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#212, isEmpty#213, count#214]
 Keys [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
 Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#218, count(1)#219]
-Results [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#218 AS sales#39, count(1)#219 AS number_sales#40, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#218 AS sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#220]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#215, count(1)#216]
+Results [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#215 AS sales#39, count(1)#216 AS number_sales#40, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#215 AS sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#217]
 
-(185) Filter [codegen id : 355]
-Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#39, number_sales#40, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#220]
-Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#220) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#220 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#42, [id=#43] as decimal(32,6))))
+(173) Filter [codegen id : 349]
+Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#39, number_sales#40, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#217]
+Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#217) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#217 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#42, [id=#43] as decimal(32,6))))
 
-(186) Project [codegen id : 355]
+(174) Project [codegen id : 349]
 Output [6]: [store AS channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sales#39, number_sales#40]
-Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#39, number_sales#40, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#220]
+Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#39, number_sales#40, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#217]
 
-(187) ReusedExchange [Reuses operator id: 90]
-Output [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#221, isEmpty#222, count#223]
+(175) ReusedExchange [Reuses operator id: 90]
+Output [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#218, isEmpty#219, count#220]
 
-(188) HashAggregate [codegen id : 381]
-Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#221, isEmpty#222, count#223]
+(176) HashAggregate [codegen id : 375]
+Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#218, isEmpty#219, count#220]
 Keys [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
 Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#224, count(1)#225]
-Results [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#224 AS sales#56, count(1)#225 AS number_sales#57, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#224 AS sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#226]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#221, count(1)#222]
+Results [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#221 AS sales#56, count(1)#222 AS number_sales#57, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#221 AS sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#223]
 
-(189) Filter [codegen id : 381]
-Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#56, number_sales#57, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#226]
-Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#226) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#226 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#42, [id=#43] as decimal(32,6))))
+(177) Filter [codegen id : 375]
+Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#56, number_sales#57, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#223]
+Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#223) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#223 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#42, [id=#43] as decimal(32,6))))
 
-(190) Project [codegen id : 381]
-Output [6]: [catalog AS channel#227, i_brand_id#6, i_class_id#7, i_category_id#8, sales#56, number_sales#57]
-Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#56, number_sales#57, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#226]
+(178) Project [codegen id : 375]
+Output [6]: [catalog AS channel#224, i_brand_id#6, i_class_id#7, i_category_id#8, sales#56, number_sales#57]
+Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#56, number_sales#57, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#223]
 
-(191) ReusedExchange [Reuses operator id: 106]
-Output [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#228, isEmpty#229, count#230]
+(179) ReusedExchange [Reuses operator id: 106]
+Output [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#225, isEmpty#226, count#227]
 
-(192) HashAggregate [codegen id : 407]
-Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#228, isEmpty#229, count#230]
+(180) HashAggregate [codegen id : 401]
+Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#225, isEmpty#226, count#227]
 Keys [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
 Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#231, count(1)#232]
-Results [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#231 AS sales#71, count(1)#232 AS number_sales#72, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#231 AS sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#233]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#228, count(1)#229]
+Results [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#228 AS sales#71, count(1)#229 AS number_sales#72, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#228 AS sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#230]
 
-(193) Filter [codegen id : 407]
-Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#71, number_sales#72, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#233]
-Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#233) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#233 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#42, [id=#43] as decimal(32,6))))
+(181) Filter [codegen id : 401]
+Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#71, number_sales#72, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#230]
+Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#230) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#230 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#42, [id=#43] as decimal(32,6))))
 
-(194) Project [codegen id : 407]
-Output [6]: [web AS channel#234, i_brand_id#6, i_class_id#7, i_category_id#8, sales#71, number_sales#72]
-Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#71, number_sales#72, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#233]
+(182) Project [codegen id : 401]
+Output [6]: [web AS channel#231, i_brand_id#6, i_class_id#7, i_category_id#8, sales#71, number_sales#72]
+Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#71, number_sales#72, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#60 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#61 as decimal(12,2)))), DecimalType(18,2), true))#230]
 
-(195) Union
+(183) Union
 
-(196) HashAggregate [codegen id : 408]
+(184) HashAggregate [codegen id : 402]
 Input [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sales#39, number_sales#40]
 Keys [4]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8]
 Functions [2]: [partial_sum(sales#39), partial_sum(number_sales#40)]
-Aggregate Attributes [3]: [sum#235, isEmpty#236, sum#237]
-Results [7]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum#238, isEmpty#239, sum#240]
+Aggregate Attributes [3]: [sum#232, isEmpty#233, sum#234]
+Results [7]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum#235, isEmpty#236, sum#237]
 
-(197) Exchange
-Input [7]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum#238, isEmpty#239, sum#240]
-Arguments: hashpartitioning(channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, 5), true, [id=#241]
+(185) Exchange
+Input [7]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum#235, isEmpty#236, sum#237]
+Arguments: hashpartitioning(channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, 5), ENSURE_REQUIREMENTS, [id=#238]
 
-(198) HashAggregate [codegen id : 409]
-Input [7]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum#238, isEmpty#239, sum#240]
+(186) HashAggregate [codegen id : 403]
+Input [7]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum#235, isEmpty#236, sum#237]
 Keys [4]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8]
 Functions [2]: [sum(sales#39), sum(number_sales#40)]
-Aggregate Attributes [2]: [sum(sales#39)#242, sum(number_sales#40)#243]
-Results [2]: [sum(sales#39)#242 AS sum_sales#84, sum(number_sales#40)#243 AS number_sales#85]
+Aggregate Attributes [2]: [sum(sales#39)#239, sum(number_sales#40)#240]
+Results [2]: [sum(sales#39)#239 AS sum_sales#84, sum(number_sales#40)#240 AS number_sales#85]
 
-(199) HashAggregate [codegen id : 409]
+(187) HashAggregate [codegen id : 403]
 Input [2]: [sum_sales#84, number_sales#85]
 Keys: []
 Functions [2]: [partial_sum(sum_sales#84), partial_sum(number_sales#85)]
-Aggregate Attributes [3]: [sum#244, isEmpty#245, sum#246]
-Results [3]: [sum#247, isEmpty#248, sum#249]
+Aggregate Attributes [3]: [sum#241, isEmpty#242, sum#243]
+Results [3]: [sum#244, isEmpty#245, sum#246]
 
-(200) Exchange
-Input [3]: [sum#247, isEmpty#248, sum#249]
-Arguments: SinglePartition, true, [id=#250]
+(188) Exchange
+Input [3]: [sum#244, isEmpty#245, sum#246]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#247]
 
-(201) HashAggregate [codegen id : 410]
-Input [3]: [sum#247, isEmpty#248, sum#249]
+(189) HashAggregate [codegen id : 404]
+Input [3]: [sum#244, isEmpty#245, sum#246]
 Keys: []
 Functions [2]: [sum(sum_sales#84), sum(number_sales#85)]
-Aggregate Attributes [2]: [sum(sum_sales#84)#251, sum(number_sales#85)#252]
-Results [6]: [null AS channel#253, null AS i_brand_id#254, null AS i_class_id#255, null AS i_category_id#256, sum(sum_sales#84)#251 AS sum(sum_sales)#257, sum(number_sales#85)#252 AS sum(number_sales)#258]
+Aggregate Attributes [2]: [sum(sum_sales#84)#248, sum(number_sales#85)#249]
+Results [6]: [null AS channel#250, null AS i_brand_id#251, null AS i_class_id#252, null AS i_category_id#253, sum(sum_sales#84)#248 AS sum(sum_sales)#254, sum(number_sales#85)#249 AS sum(number_sales)#255]
 
-(202) Union
+(190) Union
 
-(203) HashAggregate [codegen id : 411]
+(191) HashAggregate [codegen id : 405]
 Input [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85]
 Keys [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85]
 Functions: []
 Aggregate Attributes: []
 Results [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85]
 
-(204) Exchange
+(192) Exchange
 Input [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85]
-Arguments: hashpartitioning(channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85, 5), true, [id=#259]
+Arguments: hashpartitioning(channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85, 5), ENSURE_REQUIREMENTS, [id=#256]
 
-(205) HashAggregate [codegen id : 412]
+(193) HashAggregate [codegen id : 406]
 Input [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85]
 Keys [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85]
 Functions: []
 Aggregate Attributes: []
 Results [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85]
 
-(206) TakeOrderedAndProject
+(194) TakeOrderedAndProject
 Input [6]: [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85]
 Arguments: 100, [channel#44 ASC NULLS FIRST, i_brand_id#6 ASC NULLS FIRST, i_class_id#7 ASC NULLS FIRST, i_category_id#8 ASC NULLS FIRST], [channel#44, i_brand_id#6, i_class_id#7, i_category_id#8, sum_sales#84, number_sales#85]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 76 Hosting Expression = Subquery scalar-subquery#42, [id=#43]
-* HashAggregate (236)
-+- Exchange (235)
-   +- * HashAggregate (234)
-      +- Union (233)
-         :- * Project (216)
-         :  +- * BroadcastHashJoin Inner BuildRight (215)
-         :     :- * Filter (209)
-         :     :  +- * ColumnarToRow (208)
-         :     :     +- Scan parquet default.store_sales (207)
-         :     +- BroadcastExchange (214)
-         :        +- * Project (213)
-         :           +- * Filter (212)
-         :              +- * ColumnarToRow (211)
-         :                 +- Scan parquet default.date_dim (210)
-         :- * Project (226)
-         :  +- * BroadcastHashJoin Inner BuildRight (225)
-         :     :- * Filter (219)
-         :     :  +- * ColumnarToRow (218)
-         :     :     +- Scan parquet default.catalog_sales (217)
-         :     +- BroadcastExchange (224)
-         :        +- * Project (223)
-         :           +- * Filter (222)
-         :              +- * ColumnarToRow (221)
-         :                 +- Scan parquet default.date_dim (220)
-         +- * Project (232)
-            +- * BroadcastHashJoin Inner BuildRight (231)
-               :- * Filter (229)
-               :  +- * ColumnarToRow (228)
-               :     +- Scan parquet default.web_sales (227)
-               +- ReusedExchange (230)
+* HashAggregate (224)
++- Exchange (223)
+   +- * HashAggregate (222)
+      +- Union (221)
+         :- * Project (204)
+         :  +- * BroadcastHashJoin Inner BuildRight (203)
+         :     :- * Filter (197)
+         :     :  +- * ColumnarToRow (196)
+         :     :     +- Scan parquet default.store_sales (195)
+         :     +- BroadcastExchange (202)
+         :        +- * Project (201)
+         :           +- * Filter (200)
+         :              +- * ColumnarToRow (199)
+         :                 +- Scan parquet default.date_dim (198)
+         :- * Project (214)
+         :  +- * BroadcastHashJoin Inner BuildRight (213)
+         :     :- * Filter (207)
+         :     :  +- * ColumnarToRow (206)
+         :     :     +- Scan parquet default.catalog_sales (205)
+         :     +- BroadcastExchange (212)
+         :        +- * Project (211)
+         :           +- * Filter (210)
+         :              +- * ColumnarToRow (209)
+         :                 +- Scan parquet default.date_dim (208)
+         +- * Project (220)
+            +- * BroadcastHashJoin Inner BuildRight (219)
+               :- * Filter (217)
+               :  +- * ColumnarToRow (216)
+               :     +- Scan parquet default.web_sales (215)
+               +- ReusedExchange (218)
 
 
-(207) Scan parquet default.store_sales
+(195) Scan parquet default.store_sales
 Output [3]: [ss_sold_date_sk#1, ss_quantity#3, ss_list_price#4]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_sold_date_sk)]
 ReadSchema: struct<ss_sold_date_sk:int,ss_quantity:int,ss_list_price:decimal(7,2)>
 
-(208) ColumnarToRow [codegen id : 2]
+(196) ColumnarToRow [codegen id : 2]
 Input [3]: [ss_sold_date_sk#1, ss_quantity#3, ss_list_price#4]
 
-(209) Filter [codegen id : 2]
+(197) Filter [codegen id : 2]
 Input [3]: [ss_sold_date_sk#1, ss_quantity#3, ss_list_price#4]
 Condition : isnotnull(ss_sold_date_sk#1)
 
-(210) Scan parquet default.date_dim
+(198) Scan parquet default.date_dim
 Output [2]: [d_date_sk#10, d_year#11]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), GreaterThanOrEqual(d_year,1999), LessThanOrEqual(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(211) ColumnarToRow [codegen id : 1]
+(199) ColumnarToRow [codegen id : 1]
 Input [2]: [d_date_sk#10, d_year#11]
 
-(212) Filter [codegen id : 1]
+(200) Filter [codegen id : 1]
 Input [2]: [d_date_sk#10, d_year#11]
 Condition : (((isnotnull(d_year#11) AND (d_year#11 >= 1999)) AND (d_year#11 <= 2001)) AND isnotnull(d_date_sk#10))
 
-(213) Project [codegen id : 1]
+(201) Project [codegen id : 1]
 Output [1]: [d_date_sk#10]
 Input [2]: [d_date_sk#10, d_year#11]
 
-(214) BroadcastExchange
+(202) BroadcastExchange
 Input [1]: [d_date_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#260]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#257]
 
-(215) BroadcastHashJoin [codegen id : 2]
+(203) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#1]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
-(216) Project [codegen id : 2]
-Output [2]: [ss_quantity#3 AS quantity#261, ss_list_price#4 AS list_price#262]
+(204) Project [codegen id : 2]
+Output [2]: [ss_quantity#3 AS quantity#258, ss_list_price#4 AS list_price#259]
 Input [4]: [ss_sold_date_sk#1, ss_quantity#3, ss_list_price#4, d_date_sk#10]
 
-(217) Scan parquet default.catalog_sales
+(205) Scan parquet default.catalog_sales
 Output [3]: [cs_sold_date_sk#16, cs_quantity#45, cs_list_price#46]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_sales]
 PushedFilters: [IsNotNull(cs_sold_date_sk)]
 ReadSchema: struct<cs_sold_date_sk:int,cs_quantity:int,cs_list_price:decimal(7,2)>
 
-(218) ColumnarToRow [codegen id : 4]
+(206) ColumnarToRow [codegen id : 4]
 Input [3]: [cs_sold_date_sk#16, cs_quantity#45, cs_list_price#46]
 
-(219) Filter [codegen id : 4]
+(207) Filter [codegen id : 4]
 Input [3]: [cs_sold_date_sk#16, cs_quantity#45, cs_list_price#46]
 Condition : isnotnull(cs_sold_date_sk#16)
 
-(220) Scan parquet default.date_dim
+(208) Scan parquet default.date_dim
 Output [2]: [d_date_sk#10, d_year#11]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), GreaterThanOrEqual(d_year,1998), LessThanOrEqual(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(221) ColumnarToRow [codegen id : 3]
+(209) ColumnarToRow [codegen id : 3]
 Input [2]: [d_date_sk#10, d_year#11]
 
-(222) Filter [codegen id : 3]
+(210) Filter [codegen id : 3]
 Input [2]: [d_date_sk#10, d_year#11]
 Condition : (((isnotnull(d_year#11) AND (d_year#11 >= 1998)) AND (d_year#11 <= 2000)) AND isnotnull(d_date_sk#10))
 
-(223) Project [codegen id : 3]
+(211) Project [codegen id : 3]
 Output [1]: [d_date_sk#10]
 Input [2]: [d_date_sk#10, d_year#11]
 
-(224) BroadcastExchange
+(212) BroadcastExchange
 Input [1]: [d_date_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#263]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#260]
 
-(225) BroadcastHashJoin [codegen id : 4]
+(213) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_sold_date_sk#16]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
-(226) Project [codegen id : 4]
-Output [2]: [cs_quantity#45 AS quantity#264, cs_list_price#46 AS list_price#265]
+(214) Project [codegen id : 4]
+Output [2]: [cs_quantity#45 AS quantity#261, cs_list_price#46 AS list_price#262]
 Input [4]: [cs_sold_date_sk#16, cs_quantity#45, cs_list_price#46, d_date_sk#10]
 
-(227) Scan parquet default.web_sales
+(215) Scan parquet default.web_sales
 Output [3]: [ws_sold_date_sk#20, ws_quantity#60, ws_list_price#61]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_sales]
 PushedFilters: [IsNotNull(ws_sold_date_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_quantity:int,ws_list_price:decimal(7,2)>
 
-(228) ColumnarToRow [codegen id : 6]
+(216) ColumnarToRow [codegen id : 6]
 Input [3]: [ws_sold_date_sk#20, ws_quantity#60, ws_list_price#61]
 
-(229) Filter [codegen id : 6]
+(217) Filter [codegen id : 6]
 Input [3]: [ws_sold_date_sk#20, ws_quantity#60, ws_list_price#61]
 Condition : isnotnull(ws_sold_date_sk#20)
 
-(230) ReusedExchange [Reuses operator id: 224]
+(218) ReusedExchange [Reuses operator id: 212]
 Output [1]: [d_date_sk#10]
 
-(231) BroadcastHashJoin [codegen id : 6]
+(219) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ws_sold_date_sk#20]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
-(232) Project [codegen id : 6]
-Output [2]: [ws_quantity#60 AS quantity#266, ws_list_price#61 AS list_price#267]
+(220) Project [codegen id : 6]
+Output [2]: [ws_quantity#60 AS quantity#263, ws_list_price#61 AS list_price#264]
 Input [4]: [ws_sold_date_sk#20, ws_quantity#60, ws_list_price#61, d_date_sk#10]
 
-(233) Union
+(221) Union
 
-(234) HashAggregate [codegen id : 7]
-Input [2]: [quantity#261, list_price#262]
+(222) HashAggregate [codegen id : 7]
+Input [2]: [quantity#258, list_price#259]
 Keys: []
-Functions [1]: [partial_avg(CheckOverflow((promote_precision(cast(cast(quantity#261 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#262 as decimal(12,2)))), DecimalType(18,2), true))]
-Aggregate Attributes [2]: [sum#268, count#269]
-Results [2]: [sum#270, count#271]
+Functions [1]: [partial_avg(CheckOverflow((promote_precision(cast(cast(quantity#258 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#259 as decimal(12,2)))), DecimalType(18,2), true))]
+Aggregate Attributes [2]: [sum#265, count#266]
+Results [2]: [sum#267, count#268]
 
-(235) Exchange
-Input [2]: [sum#270, count#271]
-Arguments: SinglePartition, true, [id=#272]
+(223) Exchange
+Input [2]: [sum#267, count#268]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#269]
 
-(236) HashAggregate [codegen id : 8]
-Input [2]: [sum#270, count#271]
+(224) HashAggregate [codegen id : 8]
+Input [2]: [sum#267, count#268]
 Keys: []
-Functions [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#261 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#262 as decimal(12,2)))), DecimalType(18,2), true))]
-Aggregate Attributes [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#261 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#262 as decimal(12,2)))), DecimalType(18,2), true))#273]
-Results [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#261 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#262 as decimal(12,2)))), DecimalType(18,2), true))#273 AS average_sales#274]
+Functions [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#258 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#259 as decimal(12,2)))), DecimalType(18,2), true))]
+Aggregate Attributes [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#258 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#259 as decimal(12,2)))), DecimalType(18,2), true))#270]
+Results [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#258 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#259 as decimal(12,2)))), DecimalType(18,2), true))#270 AS average_sales#271]
 
 Subquery:2 Hosting operator id = 92 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#43]
 
@@ -1359,22 +1287,22 @@ Subquery:5 Hosting operator id = 120 Hosting Expression = ReusedSubquery Subquer
 
 Subquery:6 Hosting operator id = 124 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#43]
 
-Subquery:7 Hosting operator id = 139 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#43]
+Subquery:7 Hosting operator id = 135 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#43]
 
-Subquery:8 Hosting operator id = 143 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#43]
+Subquery:8 Hosting operator id = 139 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#43]
 
-Subquery:9 Hosting operator id = 147 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#43]
+Subquery:9 Hosting operator id = 143 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#43]
 
-Subquery:10 Hosting operator id = 162 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#43]
+Subquery:10 Hosting operator id = 154 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#43]
 
-Subquery:11 Hosting operator id = 166 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#43]
+Subquery:11 Hosting operator id = 158 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#43]
 
-Subquery:12 Hosting operator id = 170 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#43]
+Subquery:12 Hosting operator id = 162 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#43]
 
-Subquery:13 Hosting operator id = 185 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#43]
+Subquery:13 Hosting operator id = 173 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#43]
 
-Subquery:14 Hosting operator id = 189 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#43]
+Subquery:14 Hosting operator id = 177 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#43]
 
-Subquery:15 Hosting operator id = 193 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#43]
+Subquery:15 Hosting operator id = 181 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#43]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a/simplified.txt
@@ -1,387 +1,363 @@
 TakeOrderedAndProject [channel,i_brand_id,i_class_id,i_category_id,sum_sales,number_sales]
-  WholeStageCodegen (412)
+  WholeStageCodegen (406)
     HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum_sales,number_sales]
       InputAdapter
         Exchange [channel,i_brand_id,i_class_id,i_category_id,sum_sales,number_sales] #1
-          WholeStageCodegen (411)
+          WholeStageCodegen (405)
             HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum_sales,number_sales]
               InputAdapter
                 Union
-                  WholeStageCodegen (329)
-                    HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum_sales,number_sales]
+                  WholeStageCodegen (80)
+                    HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum,isEmpty,sum] [sum(sales),sum(number_salesL),sum_sales,number_sales,sum,isEmpty,sum]
                       InputAdapter
-                        Exchange [channel,i_brand_id,i_class_id,i_category_id,sum_sales,number_sales] #2
-                          WholeStageCodegen (328)
-                            HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum_sales,number_sales]
+                        Exchange [channel,i_brand_id,i_class_id,i_category_id] #2
+                          WholeStageCodegen (79)
+                            HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
                               InputAdapter
                                 Union
-                                  WholeStageCodegen (246)
-                                    HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum_sales,number_sales]
-                                      InputAdapter
-                                        Exchange [channel,i_brand_id,i_class_id,i_category_id,sum_sales,number_sales] #3
-                                          WholeStageCodegen (245)
-                                            HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum_sales,number_sales]
+                                  WholeStageCodegen (26)
+                                    Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
+                                      Filter [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true))]
+                                        Subquery #1
+                                          WholeStageCodegen (8)
+                                            HashAggregate [sum,count] [avg(CheckOverflow((promote_precision(cast(cast(quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price as decimal(12,2)))), DecimalType(18,2), true)),average_sales,sum,count]
                                               InputAdapter
-                                                Union
-                                                  WholeStageCodegen (163)
-                                                    HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum_sales,number_sales]
+                                                Exchange #14
+                                                  WholeStageCodegen (7)
+                                                    HashAggregate [quantity,list_price] [sum,count,sum,count]
                                                       InputAdapter
-                                                        Exchange [channel,i_brand_id,i_class_id,i_category_id,sum_sales,number_sales] #4
-                                                          WholeStageCodegen (162)
-                                                            HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum_sales,number_sales]
-                                                              InputAdapter
-                                                                Union
-                                                                  WholeStageCodegen (80)
-                                                                    HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum,isEmpty,sum] [sum(sales),sum(number_salesL),sum_sales,number_sales,sum,isEmpty,sum]
+                                                        Union
+                                                          WholeStageCodegen (2)
+                                                            Project [ss_quantity,ss_list_price]
+                                                              BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                                Filter [ss_sold_date_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet default.store_sales [ss_sold_date_sk,ss_quantity,ss_list_price]
+                                                                InputAdapter
+                                                                  BroadcastExchange #15
+                                                                    WholeStageCodegen (1)
+                                                                      Project [d_date_sk]
+                                                                        Filter [d_year,d_date_sk]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet default.date_dim [d_date_sk,d_year]
+                                                          WholeStageCodegen (4)
+                                                            Project [cs_quantity,cs_list_price]
+                                                              BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                                Filter [cs_sold_date_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet default.catalog_sales [cs_sold_date_sk,cs_quantity,cs_list_price]
+                                                                InputAdapter
+                                                                  BroadcastExchange #16
+                                                                    WholeStageCodegen (3)
+                                                                      Project [d_date_sk]
+                                                                        Filter [d_year,d_date_sk]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet default.date_dim [d_date_sk,d_year]
+                                                          WholeStageCodegen (6)
+                                                            Project [ws_quantity,ws_list_price]
+                                                              BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                                Filter [ws_sold_date_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet default.web_sales [ws_sold_date_sk,ws_quantity,ws_list_price]
+                                                                InputAdapter
+                                                                  ReusedExchange [d_date_sk] #16
+                                        HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
+                                          InputAdapter
+                                            Exchange [i_brand_id,i_class_id,i_category_id] #3
+                                              WholeStageCodegen (25)
+                                                HashAggregate [i_brand_id,i_class_id,i_category_id,ss_quantity,ss_list_price] [sum,isEmpty,count,sum,isEmpty,count]
+                                                  Project [ss_quantity,ss_list_price,i_brand_id,i_class_id,i_category_id]
+                                                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                      Project [ss_sold_date_sk,ss_quantity,ss_list_price,i_brand_id,i_class_id,i_category_id]
+                                                        BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                          BroadcastHashJoin [ss_item_sk,ss_item_sk]
+                                                            Filter [ss_item_sk,ss_sold_date_sk]
+                                                              ColumnarToRow
+                                                                InputAdapter
+                                                                  Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk,ss_quantity,ss_list_price]
+                                                            InputAdapter
+                                                              BroadcastExchange #4
+                                                                WholeStageCodegen (11)
+                                                                  Project [i_item_sk]
+                                                                    BroadcastHashJoin [i_brand_id,i_class_id,i_category_id,brand_id,class_id,category_id]
+                                                                      Filter [i_brand_id,i_class_id,i_category_id]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
                                                                       InputAdapter
-                                                                        Exchange [channel,i_brand_id,i_class_id,i_category_id] #5
-                                                                          WholeStageCodegen (79)
-                                                                            HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
-                                                                              InputAdapter
-                                                                                Union
-                                                                                  WholeStageCodegen (26)
-                                                                                    Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
-                                                                                      Filter [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true))]
-                                                                                        Subquery #1
-                                                                                          WholeStageCodegen (8)
-                                                                                            HashAggregate [sum,count] [avg(CheckOverflow((promote_precision(cast(cast(quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price as decimal(12,2)))), DecimalType(18,2), true)),average_sales,sum,count]
-                                                                                              InputAdapter
-                                                                                                Exchange #17
-                                                                                                  WholeStageCodegen (7)
-                                                                                                    HashAggregate [quantity,list_price] [sum,count,sum,count]
+                                                                        BroadcastExchange #5
+                                                                          WholeStageCodegen (10)
+                                                                            HashAggregate [brand_id,class_id,category_id]
+                                                                              HashAggregate [brand_id,class_id,category_id]
+                                                                                HashAggregate [brand_id,class_id,category_id]
+                                                                                  InputAdapter
+                                                                                    Exchange [brand_id,class_id,category_id] #6
+                                                                                      WholeStageCodegen (9)
+                                                                                        HashAggregate [brand_id,class_id,category_id]
+                                                                                          BroadcastHashJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
+                                                                                            BroadcastHashJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
+                                                                                              Project [i_brand_id,i_class_id,i_category_id]
+                                                                                                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                                                                  Project [ss_sold_date_sk,i_brand_id,i_class_id,i_category_id]
+                                                                                                    BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                                                                      Filter [ss_item_sk,ss_sold_date_sk]
+                                                                                                        ColumnarToRow
+                                                                                                          InputAdapter
+                                                                                                            Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk]
                                                                                                       InputAdapter
-                                                                                                        Union
-                                                                                                          WholeStageCodegen (2)
-                                                                                                            Project [ss_quantity,ss_list_price]
-                                                                                                              BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                                                                Filter [ss_sold_date_sk]
-                                                                                                                  ColumnarToRow
-                                                                                                                    InputAdapter
-                                                                                                                      Scan parquet default.store_sales [ss_sold_date_sk,ss_quantity,ss_list_price]
-                                                                                                                InputAdapter
-                                                                                                                  BroadcastExchange #18
-                                                                                                                    WholeStageCodegen (1)
-                                                                                                                      Project [d_date_sk]
-                                                                                                                        Filter [d_year,d_date_sk]
-                                                                                                                          ColumnarToRow
-                                                                                                                            InputAdapter
-                                                                                                                              Scan parquet default.date_dim [d_date_sk,d_year]
-                                                                                                          WholeStageCodegen (4)
-                                                                                                            Project [cs_quantity,cs_list_price]
-                                                                                                              BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                                                                Filter [cs_sold_date_sk]
-                                                                                                                  ColumnarToRow
-                                                                                                                    InputAdapter
-                                                                                                                      Scan parquet default.catalog_sales [cs_sold_date_sk,cs_quantity,cs_list_price]
-                                                                                                                InputAdapter
-                                                                                                                  BroadcastExchange #19
-                                                                                                                    WholeStageCodegen (3)
-                                                                                                                      Project [d_date_sk]
-                                                                                                                        Filter [d_year,d_date_sk]
-                                                                                                                          ColumnarToRow
-                                                                                                                            InputAdapter
-                                                                                                                              Scan parquet default.date_dim [d_date_sk,d_year]
-                                                                                                          WholeStageCodegen (6)
-                                                                                                            Project [ws_quantity,ws_list_price]
-                                                                                                              BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                                                                Filter [ws_sold_date_sk]
-                                                                                                                  ColumnarToRow
-                                                                                                                    InputAdapter
-                                                                                                                      Scan parquet default.web_sales [ws_sold_date_sk,ws_quantity,ws_list_price]
-                                                                                                                InputAdapter
-                                                                                                                  ReusedExchange [d_date_sk] #19
-                                                                                        HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
-                                                                                          InputAdapter
-                                                                                            Exchange [i_brand_id,i_class_id,i_category_id] #6
-                                                                                              WholeStageCodegen (25)
-                                                                                                HashAggregate [i_brand_id,i_class_id,i_category_id,ss_quantity,ss_list_price] [sum,isEmpty,count,sum,isEmpty,count]
-                                                                                                  Project [ss_quantity,ss_list_price,i_brand_id,i_class_id,i_category_id]
-                                                                                                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                                                      Project [ss_sold_date_sk,ss_quantity,ss_list_price,i_brand_id,i_class_id,i_category_id]
-                                                                                                        BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                                                                          BroadcastHashJoin [ss_item_sk,ss_item_sk]
-                                                                                                            Filter [ss_item_sk,ss_sold_date_sk]
+                                                                                                        BroadcastExchange #7
+                                                                                                          WholeStageCodegen (1)
+                                                                                                            Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
                                                                                                               ColumnarToRow
                                                                                                                 InputAdapter
-                                                                                                                  Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk,ss_quantity,ss_list_price]
+                                                                                                                  Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                                                  InputAdapter
+                                                                                                    BroadcastExchange #8
+                                                                                                      WholeStageCodegen (2)
+                                                                                                        Project [d_date_sk]
+                                                                                                          Filter [d_year,d_date_sk]
+                                                                                                            ColumnarToRow
+                                                                                                              InputAdapter
+                                                                                                                Scan parquet default.date_dim [d_date_sk,d_year]
+                                                                                              InputAdapter
+                                                                                                BroadcastExchange #9
+                                                                                                  WholeStageCodegen (5)
+                                                                                                    Project [i_brand_id,i_class_id,i_category_id]
+                                                                                                      BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                                                                        Project [cs_sold_date_sk,i_brand_id,i_class_id,i_category_id]
+                                                                                                          BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                                                                            Filter [cs_item_sk,cs_sold_date_sk]
+                                                                                                              ColumnarToRow
+                                                                                                                InputAdapter
+                                                                                                                  Scan parquet default.catalog_sales [cs_sold_date_sk,cs_item_sk]
                                                                                                             InputAdapter
-                                                                                                              BroadcastExchange #7
-                                                                                                                WholeStageCodegen (11)
-                                                                                                                  Project [i_item_sk]
-                                                                                                                    BroadcastHashJoin [i_brand_id,i_class_id,i_category_id,brand_id,class_id,category_id]
-                                                                                                                      Filter [i_brand_id,i_class_id,i_category_id]
-                                                                                                                        ColumnarToRow
-                                                                                                                          InputAdapter
-                                                                                                                            Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                                                      InputAdapter
-                                                                                                                        BroadcastExchange #8
-                                                                                                                          WholeStageCodegen (10)
-                                                                                                                            HashAggregate [brand_id,class_id,category_id]
-                                                                                                                              HashAggregate [brand_id,class_id,category_id]
-                                                                                                                                HashAggregate [brand_id,class_id,category_id]
-                                                                                                                                  InputAdapter
-                                                                                                                                    Exchange [brand_id,class_id,category_id] #9
-                                                                                                                                      WholeStageCodegen (9)
-                                                                                                                                        HashAggregate [brand_id,class_id,category_id]
-                                                                                                                                          BroadcastHashJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
-                                                                                                                                            BroadcastHashJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
-                                                                                                                                              Project [i_brand_id,i_class_id,i_category_id]
-                                                                                                                                                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                                                                                                  Project [ss_sold_date_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                                                                                    BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                                                                                                                      Filter [ss_item_sk,ss_sold_date_sk]
-                                                                                                                                                        ColumnarToRow
-                                                                                                                                                          InputAdapter
-                                                                                                                                                            Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk]
-                                                                                                                                                      InputAdapter
-                                                                                                                                                        BroadcastExchange #10
-                                                                                                                                                          WholeStageCodegen (1)
-                                                                                                                                                            Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                                                                                              ColumnarToRow
-                                                                                                                                                                InputAdapter
-                                                                                                                                                                  Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                                                                                  InputAdapter
-                                                                                                                                                    BroadcastExchange #11
-                                                                                                                                                      WholeStageCodegen (2)
-                                                                                                                                                        Project [d_date_sk]
-                                                                                                                                                          Filter [d_year,d_date_sk]
-                                                                                                                                                            ColumnarToRow
-                                                                                                                                                              InputAdapter
-                                                                                                                                                                Scan parquet default.date_dim [d_date_sk,d_year]
-                                                                                                                                              InputAdapter
-                                                                                                                                                BroadcastExchange #12
-                                                                                                                                                  WholeStageCodegen (5)
-                                                                                                                                                    Project [i_brand_id,i_class_id,i_category_id]
-                                                                                                                                                      BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                                                                                                        Project [cs_sold_date_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                                                                                          BroadcastHashJoin [cs_item_sk,i_item_sk]
-                                                                                                                                                            Filter [cs_item_sk,cs_sold_date_sk]
-                                                                                                                                                              ColumnarToRow
-                                                                                                                                                                InputAdapter
-                                                                                                                                                                  Scan parquet default.catalog_sales [cs_sold_date_sk,cs_item_sk]
-                                                                                                                                                            InputAdapter
-                                                                                                                                                              BroadcastExchange #13
-                                                                                                                                                                WholeStageCodegen (3)
-                                                                                                                                                                  Filter [i_item_sk]
-                                                                                                                                                                    ColumnarToRow
-                                                                                                                                                                      InputAdapter
-                                                                                                                                                                        Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                                                                                        InputAdapter
-                                                                                                                                                          ReusedExchange [d_date_sk] #11
-                                                                                                                                            InputAdapter
-                                                                                                                                              BroadcastExchange #14
-                                                                                                                                                WholeStageCodegen (8)
-                                                                                                                                                  Project [i_brand_id,i_class_id,i_category_id]
-                                                                                                                                                    BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                                                                                                      Project [ws_sold_date_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                                                                                        BroadcastHashJoin [ws_item_sk,i_item_sk]
-                                                                                                                                                          Filter [ws_item_sk,ws_sold_date_sk]
-                                                                                                                                                            ColumnarToRow
-                                                                                                                                                              InputAdapter
-                                                                                                                                                                Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk]
-                                                                                                                                                          InputAdapter
-                                                                                                                                                            ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #13
-                                                                                                                                                      InputAdapter
-                                                                                                                                                        ReusedExchange [d_date_sk] #11
-                                                                                                          InputAdapter
-                                                                                                            BroadcastExchange #15
-                                                                                                              WholeStageCodegen (23)
-                                                                                                                BroadcastHashJoin [i_item_sk,ss_item_sk]
+                                                                                                              BroadcastExchange #10
+                                                                                                                WholeStageCodegen (3)
                                                                                                                   Filter [i_item_sk]
                                                                                                                     ColumnarToRow
                                                                                                                       InputAdapter
                                                                                                                         Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                                                  InputAdapter
-                                                                                                                    ReusedExchange [ss_item_sk] #7
-                                                                                                      InputAdapter
-                                                                                                        BroadcastExchange #16
-                                                                                                          WholeStageCodegen (24)
-                                                                                                            Project [d_date_sk]
-                                                                                                              Filter [d_year,d_moy,d_date_sk]
-                                                                                                                ColumnarToRow
-                                                                                                                  InputAdapter
-                                                                                                                    Scan parquet default.date_dim [d_date_sk,d_year,d_moy]
-                                                                                  WholeStageCodegen (52)
-                                                                                    Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
-                                                                                      Filter [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true))]
-                                                                                        ReusedSubquery [average_sales] #1
-                                                                                        HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
-                                                                                          InputAdapter
-                                                                                            Exchange [i_brand_id,i_class_id,i_category_id] #20
-                                                                                              WholeStageCodegen (51)
-                                                                                                HashAggregate [i_brand_id,i_class_id,i_category_id,cs_quantity,cs_list_price] [sum,isEmpty,count,sum,isEmpty,count]
-                                                                                                  Project [cs_quantity,cs_list_price,i_brand_id,i_class_id,i_category_id]
-                                                                                                    BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                                                      Project [cs_sold_date_sk,cs_quantity,cs_list_price,i_brand_id,i_class_id,i_category_id]
-                                                                                                        BroadcastHashJoin [cs_item_sk,i_item_sk]
-                                                                                                          BroadcastHashJoin [cs_item_sk,ss_item_sk]
-                                                                                                            Filter [cs_item_sk,cs_sold_date_sk]
-                                                                                                              ColumnarToRow
-                                                                                                                InputAdapter
-                                                                                                                  Scan parquet default.catalog_sales [cs_sold_date_sk,cs_item_sk,cs_quantity,cs_list_price]
-                                                                                                            InputAdapter
-                                                                                                              ReusedExchange [ss_item_sk] #7
-                                                                                                          InputAdapter
-                                                                                                            ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #15
-                                                                                                      InputAdapter
-                                                                                                        ReusedExchange [d_date_sk] #16
-                                                                                  WholeStageCodegen (78)
-                                                                                    Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
-                                                                                      Filter [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true))]
-                                                                                        ReusedSubquery [average_sales] #1
-                                                                                        HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
-                                                                                          InputAdapter
-                                                                                            Exchange [i_brand_id,i_class_id,i_category_id] #21
-                                                                                              WholeStageCodegen (77)
-                                                                                                HashAggregate [i_brand_id,i_class_id,i_category_id,ws_quantity,ws_list_price] [sum,isEmpty,count,sum,isEmpty,count]
-                                                                                                  Project [ws_quantity,ws_list_price,i_brand_id,i_class_id,i_category_id]
+                                                                                                        InputAdapter
+                                                                                                          ReusedExchange [d_date_sk] #8
+                                                                                            InputAdapter
+                                                                                              BroadcastExchange #11
+                                                                                                WholeStageCodegen (8)
+                                                                                                  Project [i_brand_id,i_class_id,i_category_id]
                                                                                                     BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                                                      Project [ws_sold_date_sk,ws_quantity,ws_list_price,i_brand_id,i_class_id,i_category_id]
+                                                                                                      Project [ws_sold_date_sk,i_brand_id,i_class_id,i_category_id]
                                                                                                         BroadcastHashJoin [ws_item_sk,i_item_sk]
-                                                                                                          BroadcastHashJoin [ws_item_sk,ss_item_sk]
-                                                                                                            Filter [ws_item_sk,ws_sold_date_sk]
-                                                                                                              ColumnarToRow
-                                                                                                                InputAdapter
-                                                                                                                  Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk,ws_quantity,ws_list_price]
-                                                                                                            InputAdapter
-                                                                                                              ReusedExchange [ss_item_sk] #7
+                                                                                                          Filter [ws_item_sk,ws_sold_date_sk]
+                                                                                                            ColumnarToRow
+                                                                                                              InputAdapter
+                                                                                                                Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk]
                                                                                                           InputAdapter
-                                                                                                            ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #15
+                                                                                                            ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #10
                                                                                                       InputAdapter
-                                                                                                        ReusedExchange [d_date_sk] #16
-                                                                  WholeStageCodegen (161)
-                                                                    HashAggregate [channel,i_brand_id,i_class_id,sum,isEmpty,sum] [sum(sum_sales),sum(number_salesL),i_category_id,sum(sum_sales),sum(number_sales),sum,isEmpty,sum]
+                                                                                                        ReusedExchange [d_date_sk] #8
+                                                          InputAdapter
+                                                            BroadcastExchange #12
+                                                              WholeStageCodegen (23)
+                                                                BroadcastHashJoin [i_item_sk,ss_item_sk]
+                                                                  Filter [i_item_sk]
+                                                                    ColumnarToRow
                                                                       InputAdapter
-                                                                        Exchange [channel,i_brand_id,i_class_id] #22
-                                                                          WholeStageCodegen (160)
-                                                                            HashAggregate [channel,i_brand_id,i_class_id,sum_sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
-                                                                              HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum,isEmpty,sum] [sum(sales),sum(number_salesL),sum_sales,number_sales,sum,isEmpty,sum]
-                                                                                InputAdapter
-                                                                                  Exchange [channel,i_brand_id,i_class_id,i_category_id] #23
-                                                                                    WholeStageCodegen (159)
-                                                                                      HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
-                                                                                        InputAdapter
-                                                                                          Union
-                                                                                            WholeStageCodegen (106)
-                                                                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
-                                                                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true))]
-                                                                                                  ReusedSubquery [average_sales] #1
-                                                                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
-                                                                                                    InputAdapter
-                                                                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #6
-                                                                                            WholeStageCodegen (132)
-                                                                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
-                                                                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true))]
-                                                                                                  ReusedSubquery [average_sales] #1
-                                                                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
-                                                                                                    InputAdapter
-                                                                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #20
-                                                                                            WholeStageCodegen (158)
-                                                                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
-                                                                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true))]
-                                                                                                  ReusedSubquery [average_sales] #1
-                                                                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
-                                                                                                    InputAdapter
-                                                                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #21
-                                                  WholeStageCodegen (244)
-                                                    HashAggregate [channel,i_brand_id,sum,isEmpty,sum] [sum(sum_sales),sum(number_salesL),i_class_id,i_category_id,sum(sum_sales),sum(number_sales),sum,isEmpty,sum]
+                                                                        Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                  InputAdapter
+                                                                    ReusedExchange [ss_item_sk] #4
                                                       InputAdapter
-                                                        Exchange [channel,i_brand_id] #24
-                                                          WholeStageCodegen (243)
-                                                            HashAggregate [channel,i_brand_id,sum_sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
-                                                              HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum,isEmpty,sum] [sum(sales),sum(number_salesL),sum_sales,number_sales,sum,isEmpty,sum]
+                                                        BroadcastExchange #13
+                                                          WholeStageCodegen (24)
+                                                            Project [d_date_sk]
+                                                              Filter [d_year,d_moy,d_date_sk]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet default.date_dim [d_date_sk,d_year,d_moy]
+                                  WholeStageCodegen (52)
+                                    Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
+                                      Filter [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true))]
+                                        ReusedSubquery [average_sales] #1
+                                        HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
+                                          InputAdapter
+                                            Exchange [i_brand_id,i_class_id,i_category_id] #17
+                                              WholeStageCodegen (51)
+                                                HashAggregate [i_brand_id,i_class_id,i_category_id,cs_quantity,cs_list_price] [sum,isEmpty,count,sum,isEmpty,count]
+                                                  Project [cs_quantity,cs_list_price,i_brand_id,i_class_id,i_category_id]
+                                                    BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                      Project [cs_sold_date_sk,cs_quantity,cs_list_price,i_brand_id,i_class_id,i_category_id]
+                                                        BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                          BroadcastHashJoin [cs_item_sk,ss_item_sk]
+                                                            Filter [cs_item_sk,cs_sold_date_sk]
+                                                              ColumnarToRow
                                                                 InputAdapter
-                                                                  Exchange [channel,i_brand_id,i_class_id,i_category_id] #25
-                                                                    WholeStageCodegen (242)
-                                                                      HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
-                                                                        InputAdapter
-                                                                          Union
-                                                                            WholeStageCodegen (189)
-                                                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
-                                                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true))]
-                                                                                  ReusedSubquery [average_sales] #1
-                                                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
-                                                                                    InputAdapter
-                                                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #6
-                                                                            WholeStageCodegen (215)
-                                                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
-                                                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true))]
-                                                                                  ReusedSubquery [average_sales] #1
-                                                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
-                                                                                    InputAdapter
-                                                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #20
-                                                                            WholeStageCodegen (241)
-                                                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
-                                                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true))]
-                                                                                  ReusedSubquery [average_sales] #1
-                                                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
-                                                                                    InputAdapter
-                                                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #21
-                                  WholeStageCodegen (327)
-                                    HashAggregate [channel,sum,isEmpty,sum] [sum(sum_sales),sum(number_salesL),i_brand_id,i_class_id,i_category_id,sum(sum_sales),sum(number_sales),sum,isEmpty,sum]
-                                      InputAdapter
-                                        Exchange [channel] #26
-                                          WholeStageCodegen (326)
-                                            HashAggregate [channel,sum_sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
-                                              HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum,isEmpty,sum] [sum(sales),sum(number_salesL),sum_sales,number_sales,sum,isEmpty,sum]
-                                                InputAdapter
-                                                  Exchange [channel,i_brand_id,i_class_id,i_category_id] #27
-                                                    WholeStageCodegen (325)
-                                                      HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
-                                                        InputAdapter
-                                                          Union
-                                                            WholeStageCodegen (272)
-                                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
-                                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true))]
-                                                                  ReusedSubquery [average_sales] #1
-                                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
-                                                                    InputAdapter
-                                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #6
-                                                            WholeStageCodegen (298)
-                                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
-                                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true))]
-                                                                  ReusedSubquery [average_sales] #1
-                                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
-                                                                    InputAdapter
-                                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #20
-                                                            WholeStageCodegen (324)
-                                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
-                                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true))]
-                                                                  ReusedSubquery [average_sales] #1
-                                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
-                                                                    InputAdapter
-                                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #21
-                  WholeStageCodegen (410)
-                    HashAggregate [sum,isEmpty,sum] [sum(sum_sales),sum(number_salesL),channel,i_brand_id,i_class_id,i_category_id,sum(sum_sales),sum(number_sales),sum,isEmpty,sum]
+                                                                  Scan parquet default.catalog_sales [cs_sold_date_sk,cs_item_sk,cs_quantity,cs_list_price]
+                                                            InputAdapter
+                                                              ReusedExchange [ss_item_sk] #4
+                                                          InputAdapter
+                                                            ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #12
+                                                      InputAdapter
+                                                        ReusedExchange [d_date_sk] #13
+                                  WholeStageCodegen (78)
+                                    Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
+                                      Filter [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true))]
+                                        ReusedSubquery [average_sales] #1
+                                        HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
+                                          InputAdapter
+                                            Exchange [i_brand_id,i_class_id,i_category_id] #18
+                                              WholeStageCodegen (77)
+                                                HashAggregate [i_brand_id,i_class_id,i_category_id,ws_quantity,ws_list_price] [sum,isEmpty,count,sum,isEmpty,count]
+                                                  Project [ws_quantity,ws_list_price,i_brand_id,i_class_id,i_category_id]
+                                                    BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                      Project [ws_sold_date_sk,ws_quantity,ws_list_price,i_brand_id,i_class_id,i_category_id]
+                                                        BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                          BroadcastHashJoin [ws_item_sk,ss_item_sk]
+                                                            Filter [ws_item_sk,ws_sold_date_sk]
+                                                              ColumnarToRow
+                                                                InputAdapter
+                                                                  Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk,ws_quantity,ws_list_price]
+                                                            InputAdapter
+                                                              ReusedExchange [ss_item_sk] #4
+                                                          InputAdapter
+                                                            ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #12
+                                                      InputAdapter
+                                                        ReusedExchange [d_date_sk] #13
+                  WholeStageCodegen (161)
+                    HashAggregate [channel,i_brand_id,i_class_id,sum,isEmpty,sum] [sum(sum_sales),sum(number_salesL),i_category_id,sum(sum_sales),sum(number_sales),sum,isEmpty,sum]
                       InputAdapter
-                        Exchange #28
-                          WholeStageCodegen (409)
-                            HashAggregate [sum_sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
+                        Exchange [channel,i_brand_id,i_class_id] #19
+                          WholeStageCodegen (160)
+                            HashAggregate [channel,i_brand_id,i_class_id,sum_sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
                               HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum,isEmpty,sum] [sum(sales),sum(number_salesL),sum_sales,number_sales,sum,isEmpty,sum]
                                 InputAdapter
-                                  Exchange [channel,i_brand_id,i_class_id,i_category_id] #29
-                                    WholeStageCodegen (408)
+                                  Exchange [channel,i_brand_id,i_class_id,i_category_id] #20
+                                    WholeStageCodegen (159)
                                       HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
                                         InputAdapter
                                           Union
-                                            WholeStageCodegen (355)
+                                            WholeStageCodegen (106)
                                               Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
                                                 Filter [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true))]
                                                   ReusedSubquery [average_sales] #1
                                                   HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
                                                     InputAdapter
-                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #6
-                                            WholeStageCodegen (381)
+                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #3
+                                            WholeStageCodegen (132)
                                               Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
                                                 Filter [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true))]
                                                   ReusedSubquery [average_sales] #1
                                                   HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
                                                     InputAdapter
-                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #20
-                                            WholeStageCodegen (407)
+                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #17
+                                            WholeStageCodegen (158)
                                               Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
                                                 Filter [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true))]
                                                   ReusedSubquery [average_sales] #1
                                                   HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
                                                     InputAdapter
-                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #21
+                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #18
+                  WholeStageCodegen (242)
+                    HashAggregate [channel,i_brand_id,sum,isEmpty,sum] [sum(sum_sales),sum(number_salesL),i_class_id,i_category_id,sum(sum_sales),sum(number_sales),sum,isEmpty,sum]
+                      InputAdapter
+                        Exchange [channel,i_brand_id] #21
+                          WholeStageCodegen (241)
+                            HashAggregate [channel,i_brand_id,sum_sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
+                              HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum,isEmpty,sum] [sum(sales),sum(number_salesL),sum_sales,number_sales,sum,isEmpty,sum]
+                                InputAdapter
+                                  Exchange [channel,i_brand_id,i_class_id,i_category_id] #22
+                                    WholeStageCodegen (240)
+                                      HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
+                                        InputAdapter
+                                          Union
+                                            WholeStageCodegen (187)
+                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
+                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true))]
+                                                  ReusedSubquery [average_sales] #1
+                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
+                                                    InputAdapter
+                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #3
+                                            WholeStageCodegen (213)
+                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
+                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true))]
+                                                  ReusedSubquery [average_sales] #1
+                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
+                                                    InputAdapter
+                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #17
+                                            WholeStageCodegen (239)
+                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
+                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true))]
+                                                  ReusedSubquery [average_sales] #1
+                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
+                                                    InputAdapter
+                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #18
+                  WholeStageCodegen (323)
+                    HashAggregate [channel,sum,isEmpty,sum] [sum(sum_sales),sum(number_salesL),i_brand_id,i_class_id,i_category_id,sum(sum_sales),sum(number_sales),sum,isEmpty,sum]
+                      InputAdapter
+                        Exchange [channel] #23
+                          WholeStageCodegen (322)
+                            HashAggregate [channel,sum_sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
+                              HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum,isEmpty,sum] [sum(sales),sum(number_salesL),sum_sales,number_sales,sum,isEmpty,sum]
+                                InputAdapter
+                                  Exchange [channel,i_brand_id,i_class_id,i_category_id] #24
+                                    WholeStageCodegen (321)
+                                      HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
+                                        InputAdapter
+                                          Union
+                                            WholeStageCodegen (268)
+                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
+                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true))]
+                                                  ReusedSubquery [average_sales] #1
+                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
+                                                    InputAdapter
+                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #3
+                                            WholeStageCodegen (294)
+                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
+                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true))]
+                                                  ReusedSubquery [average_sales] #1
+                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
+                                                    InputAdapter
+                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #17
+                                            WholeStageCodegen (320)
+                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
+                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true))]
+                                                  ReusedSubquery [average_sales] #1
+                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
+                                                    InputAdapter
+                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #18
+                  WholeStageCodegen (404)
+                    HashAggregate [sum,isEmpty,sum] [sum(sum_sales),sum(number_salesL),channel,i_brand_id,i_class_id,i_category_id,sum(sum_sales),sum(number_sales),sum,isEmpty,sum]
+                      InputAdapter
+                        Exchange #25
+                          WholeStageCodegen (403)
+                            HashAggregate [sum_sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
+                              HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum,isEmpty,sum] [sum(sales),sum(number_salesL),sum_sales,number_sales,sum,isEmpty,sum]
+                                InputAdapter
+                                  Exchange [channel,i_brand_id,i_class_id,i_category_id] #26
+                                    WholeStageCodegen (402)
+                                      HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
+                                        InputAdapter
+                                          Union
+                                            WholeStageCodegen (349)
+                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
+                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true))]
+                                                  ReusedSubquery [average_sales] #1
+                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
+                                                    InputAdapter
+                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #3
+                                            WholeStageCodegen (375)
+                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
+                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true))]
+                                                  ReusedSubquery [average_sales] #1
+                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
+                                                    InputAdapter
+                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #17
+                                            WholeStageCodegen (401)
+                                              Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
+                                                Filter [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true))]
+                                                  ReusedSubquery [average_sales] #1
+                                                  HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
+                                                    InputAdapter
+                                                      ReusedExchange [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] #18

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a.sf100/explain.txt
@@ -1,53 +1,49 @@
 == Physical Plan ==
-TakeOrderedAndProject (49)
-+- * Project (48)
-   +- Window (47)
-      +- * Sort (46)
-         +- Exchange (45)
-            +- * HashAggregate (44)
-               +- Exchange (43)
-                  +- * HashAggregate (42)
-                     +- Union (41)
-                        :- * HashAggregate (35)
-                        :  +- Exchange (34)
-                        :     +- * HashAggregate (33)
-                        :        +- Union (32)
-                        :           :- * HashAggregate (26)
-                        :           :  +- Exchange (25)
-                        :           :     +- * HashAggregate (24)
-                        :           :        +- * Project (23)
-                        :           :           +- * BroadcastHashJoin Inner BuildRight (22)
-                        :           :              :- * Project (17)
-                        :           :              :  +- * BroadcastHashJoin Inner BuildRight (16)
-                        :           :              :     :- * Project (10)
-                        :           :              :     :  +- * BroadcastHashJoin Inner BuildRight (9)
-                        :           :              :     :     :- * Filter (3)
-                        :           :              :     :     :  +- * ColumnarToRow (2)
-                        :           :              :     :     :     +- Scan parquet default.store_sales (1)
-                        :           :              :     :     +- BroadcastExchange (8)
-                        :           :              :     :        +- * Project (7)
-                        :           :              :     :           +- * Filter (6)
-                        :           :              :     :              +- * ColumnarToRow (5)
-                        :           :              :     :                 +- Scan parquet default.date_dim (4)
-                        :           :              :     +- BroadcastExchange (15)
-                        :           :              :        +- * Project (14)
-                        :           :              :           +- * Filter (13)
-                        :           :              :              +- * ColumnarToRow (12)
-                        :           :              :                 +- Scan parquet default.store (11)
-                        :           :              +- BroadcastExchange (21)
-                        :           :                 +- * Filter (20)
-                        :           :                    +- * ColumnarToRow (19)
-                        :           :                       +- Scan parquet default.item (18)
-                        :           +- * HashAggregate (31)
-                        :              +- Exchange (30)
-                        :                 +- * HashAggregate (29)
-                        :                    +- * HashAggregate (28)
-                        :                       +- ReusedExchange (27)
-                        +- * HashAggregate (40)
-                           +- Exchange (39)
-                              +- * HashAggregate (38)
-                                 +- * HashAggregate (37)
-                                    +- ReusedExchange (36)
+TakeOrderedAndProject (45)
++- * Project (44)
+   +- Window (43)
+      +- * Sort (42)
+         +- Exchange (41)
+            +- * HashAggregate (40)
+               +- Exchange (39)
+                  +- * HashAggregate (38)
+                     +- Union (37)
+                        :- * HashAggregate (26)
+                        :  +- Exchange (25)
+                        :     +- * HashAggregate (24)
+                        :        +- * Project (23)
+                        :           +- * BroadcastHashJoin Inner BuildRight (22)
+                        :              :- * Project (17)
+                        :              :  +- * BroadcastHashJoin Inner BuildRight (16)
+                        :              :     :- * Project (10)
+                        :              :     :  +- * BroadcastHashJoin Inner BuildRight (9)
+                        :              :     :     :- * Filter (3)
+                        :              :     :     :  +- * ColumnarToRow (2)
+                        :              :     :     :     +- Scan parquet default.store_sales (1)
+                        :              :     :     +- BroadcastExchange (8)
+                        :              :     :        +- * Project (7)
+                        :              :     :           +- * Filter (6)
+                        :              :     :              +- * ColumnarToRow (5)
+                        :              :     :                 +- Scan parquet default.date_dim (4)
+                        :              :     +- BroadcastExchange (15)
+                        :              :        +- * Project (14)
+                        :              :           +- * Filter (13)
+                        :              :              +- * ColumnarToRow (12)
+                        :              :                 +- Scan parquet default.store (11)
+                        :              +- BroadcastExchange (21)
+                        :                 +- * Filter (20)
+                        :                    +- * ColumnarToRow (19)
+                        :                       +- Scan parquet default.item (18)
+                        :- * HashAggregate (31)
+                        :  +- Exchange (30)
+                        :     +- * HashAggregate (29)
+                        :        +- * HashAggregate (28)
+                        :           +- ReusedExchange (27)
+                        +- * HashAggregate (36)
+                           +- Exchange (35)
+                              +- * HashAggregate (34)
+                                 +- * HashAggregate (33)
+                                    +- ReusedExchange (32)
 
 
 (1) Scan parquet default.store_sales
@@ -162,7 +158,7 @@ Results [4]: [i_category#14, i_class#13, sum#18, sum#19]
 
 (25) Exchange
 Input [4]: [i_category#14, i_class#13, sum#18, sum#19]
-Arguments: hashpartitioning(i_category#14, i_class#13, 5), true, [id=#20]
+Arguments: hashpartitioning(i_category#14, i_class#13, 5), ENSURE_REQUIREMENTS, [id=#20]
 
 (26) HashAggregate [codegen id : 5]
 Input [4]: [i_category#14, i_class#13, sum#18, sum#19]
@@ -190,7 +186,7 @@ Results [5]: [i_category#14, sum#37, isEmpty#38, sum#39, isEmpty#40]
 
 (30) Exchange
 Input [5]: [i_category#14, sum#37, isEmpty#38, sum#39, isEmpty#40]
-Arguments: hashpartitioning(i_category#14, 5), true, [id=#41]
+Arguments: hashpartitioning(i_category#14, 5), ENSURE_REQUIREMENTS, [id=#41]
 
 (31) HashAggregate [codegen id : 11]
 Input [5]: [i_category#14, sum#37, isEmpty#38, sum#39, isEmpty#40]
@@ -199,91 +195,71 @@ Functions [2]: [sum(ss_net_profit#31), sum(ss_ext_sales_price#32)]
 Aggregate Attributes [2]: [sum(ss_net_profit#31)#42, sum(ss_ext_sales_price#32)#43]
 Results [6]: [cast(CheckOverflow((promote_precision(sum(ss_net_profit#31)#42) / promote_precision(sum(ss_ext_sales_price#32)#43)), DecimalType(38,11), true) as decimal(38,20)) AS gross_margin#44, i_category#14, null AS i_class#45, 0 AS t_category#46, 1 AS t_class#47, 1 AS lochierarchy#48]
 
-(32) Union
+(32) ReusedExchange [Reuses operator id: 25]
+Output [4]: [i_category#14, i_class#13, sum#49, sum#50]
 
-(33) HashAggregate [codegen id : 12]
-Input [6]: [gross_margin#23, i_category#14, i_class#13, t_category#24, t_class#25, lochierarchy#26]
-Keys [6]: [gross_margin#23, i_category#14, i_class#13, t_category#24, t_class#25, lochierarchy#26]
-Functions: []
-Aggregate Attributes: []
-Results [6]: [gross_margin#23, i_category#14, i_class#13, t_category#24, t_class#25, lochierarchy#26]
-
-(34) Exchange
-Input [6]: [gross_margin#23, i_category#14, i_class#13, t_category#24, t_class#25, lochierarchy#26]
-Arguments: hashpartitioning(gross_margin#23, i_category#14, i_class#13, t_category#24, t_class#25, lochierarchy#26, 5), true, [id=#49]
-
-(35) HashAggregate [codegen id : 13]
-Input [6]: [gross_margin#23, i_category#14, i_class#13, t_category#24, t_class#25, lochierarchy#26]
-Keys [6]: [gross_margin#23, i_category#14, i_class#13, t_category#24, t_class#25, lochierarchy#26]
-Functions: []
-Aggregate Attributes: []
-Results [6]: [gross_margin#23, i_category#14, i_class#13, t_category#24, t_class#25, lochierarchy#26]
-
-(36) ReusedExchange [Reuses operator id: 25]
-Output [4]: [i_category#14, i_class#13, sum#50, sum#51]
-
-(37) HashAggregate [codegen id : 18]
-Input [4]: [i_category#14, i_class#13, sum#50, sum#51]
+(33) HashAggregate [codegen id : 16]
+Input [4]: [i_category#14, i_class#13, sum#49, sum#50]
 Keys [2]: [i_category#14, i_class#13]
 Functions [2]: [sum(UnscaledValue(ss_net_profit#5)), sum(UnscaledValue(ss_ext_sales_price#4))]
-Aggregate Attributes [2]: [sum(UnscaledValue(ss_net_profit#5))#52, sum(UnscaledValue(ss_ext_sales_price#4))#53]
-Results [2]: [MakeDecimal(sum(UnscaledValue(ss_net_profit#5))#52,17,2) AS ss_net_profit#31, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#4))#53,17,2) AS ss_ext_sales_price#32]
+Aggregate Attributes [2]: [sum(UnscaledValue(ss_net_profit#5))#51, sum(UnscaledValue(ss_ext_sales_price#4))#52]
+Results [2]: [MakeDecimal(sum(UnscaledValue(ss_net_profit#5))#51,17,2) AS ss_net_profit#31, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#4))#52,17,2) AS ss_ext_sales_price#32]
 
-(38) HashAggregate [codegen id : 18]
+(34) HashAggregate [codegen id : 16]
 Input [2]: [ss_net_profit#31, ss_ext_sales_price#32]
 Keys: []
 Functions [2]: [partial_sum(ss_net_profit#31), partial_sum(ss_ext_sales_price#32)]
-Aggregate Attributes [4]: [sum#54, isEmpty#55, sum#56, isEmpty#57]
-Results [4]: [sum#58, isEmpty#59, sum#60, isEmpty#61]
+Aggregate Attributes [4]: [sum#53, isEmpty#54, sum#55, isEmpty#56]
+Results [4]: [sum#57, isEmpty#58, sum#59, isEmpty#60]
 
-(39) Exchange
-Input [4]: [sum#58, isEmpty#59, sum#60, isEmpty#61]
-Arguments: SinglePartition, true, [id=#62]
+(35) Exchange
+Input [4]: [sum#57, isEmpty#58, sum#59, isEmpty#60]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#61]
 
-(40) HashAggregate [codegen id : 19]
-Input [4]: [sum#58, isEmpty#59, sum#60, isEmpty#61]
+(36) HashAggregate [codegen id : 17]
+Input [4]: [sum#57, isEmpty#58, sum#59, isEmpty#60]
 Keys: []
 Functions [2]: [sum(ss_net_profit#31), sum(ss_ext_sales_price#32)]
-Aggregate Attributes [2]: [sum(ss_net_profit#31)#63, sum(ss_ext_sales_price#32)#64]
-Results [6]: [cast(CheckOverflow((promote_precision(sum(ss_net_profit#31)#63) / promote_precision(sum(ss_ext_sales_price#32)#64)), DecimalType(38,11), true) as decimal(38,20)) AS gross_margin#65, null AS i_category#66, null AS i_class#67, 1 AS t_category#68, 1 AS t_class#69, 2 AS lochierarchy#70]
+Aggregate Attributes [2]: [sum(ss_net_profit#31)#62, sum(ss_ext_sales_price#32)#63]
+Results [6]: [cast(CheckOverflow((promote_precision(sum(ss_net_profit#31)#62) / promote_precision(sum(ss_ext_sales_price#32)#63)), DecimalType(38,11), true) as decimal(38,20)) AS gross_margin#64, null AS i_category#65, null AS i_class#66, 1 AS t_category#67, 1 AS t_class#68, 2 AS lochierarchy#69]
 
-(41) Union
+(37) Union
 
-(42) HashAggregate [codegen id : 20]
+(38) HashAggregate [codegen id : 18]
 Input [6]: [gross_margin#23, i_category#14, i_class#13, t_category#24, t_class#25, lochierarchy#26]
 Keys [6]: [gross_margin#23, i_category#14, i_class#13, t_category#24, t_class#25, lochierarchy#26]
 Functions: []
 Aggregate Attributes: []
 Results [6]: [gross_margin#23, i_category#14, i_class#13, t_category#24, t_class#25, lochierarchy#26]
 
-(43) Exchange
+(39) Exchange
 Input [6]: [gross_margin#23, i_category#14, i_class#13, t_category#24, t_class#25, lochierarchy#26]
-Arguments: hashpartitioning(gross_margin#23, i_category#14, i_class#13, t_category#24, t_class#25, lochierarchy#26, 5), true, [id=#71]
+Arguments: hashpartitioning(gross_margin#23, i_category#14, i_class#13, t_category#24, t_class#25, lochierarchy#26, 5), ENSURE_REQUIREMENTS, [id=#70]
 
-(44) HashAggregate [codegen id : 21]
+(40) HashAggregate [codegen id : 19]
 Input [6]: [gross_margin#23, i_category#14, i_class#13, t_category#24, t_class#25, lochierarchy#26]
 Keys [6]: [gross_margin#23, i_category#14, i_class#13, t_category#24, t_class#25, lochierarchy#26]
 Functions: []
 Aggregate Attributes: []
-Results [5]: [gross_margin#23, i_category#14, i_class#13, lochierarchy#26, CASE WHEN (t_class#25 = 0) THEN i_category#14 END AS _w0#72]
+Results [5]: [gross_margin#23, i_category#14, i_class#13, lochierarchy#26, CASE WHEN (t_class#25 = 0) THEN i_category#14 END AS _w0#71]
 
-(45) Exchange
-Input [5]: [gross_margin#23, i_category#14, i_class#13, lochierarchy#26, _w0#72]
-Arguments: hashpartitioning(lochierarchy#26, _w0#72, 5), true, [id=#73]
+(41) Exchange
+Input [5]: [gross_margin#23, i_category#14, i_class#13, lochierarchy#26, _w0#71]
+Arguments: hashpartitioning(lochierarchy#26, _w0#71, 5), ENSURE_REQUIREMENTS, [id=#72]
 
-(46) Sort [codegen id : 22]
-Input [5]: [gross_margin#23, i_category#14, i_class#13, lochierarchy#26, _w0#72]
-Arguments: [lochierarchy#26 ASC NULLS FIRST, _w0#72 ASC NULLS FIRST, gross_margin#23 ASC NULLS FIRST], false, 0
+(42) Sort [codegen id : 20]
+Input [5]: [gross_margin#23, i_category#14, i_class#13, lochierarchy#26, _w0#71]
+Arguments: [lochierarchy#26 ASC NULLS FIRST, _w0#71 ASC NULLS FIRST, gross_margin#23 ASC NULLS FIRST], false, 0
 
-(47) Window
-Input [5]: [gross_margin#23, i_category#14, i_class#13, lochierarchy#26, _w0#72]
-Arguments: [rank(gross_margin#23) windowspecdefinition(lochierarchy#26, _w0#72, gross_margin#23 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank_within_parent#74], [lochierarchy#26, _w0#72], [gross_margin#23 ASC NULLS FIRST]
+(43) Window
+Input [5]: [gross_margin#23, i_category#14, i_class#13, lochierarchy#26, _w0#71]
+Arguments: [rank(gross_margin#23) windowspecdefinition(lochierarchy#26, _w0#71, gross_margin#23 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank_within_parent#73], [lochierarchy#26, _w0#71], [gross_margin#23 ASC NULLS FIRST]
 
-(48) Project [codegen id : 23]
-Output [5]: [gross_margin#23, i_category#14, i_class#13, lochierarchy#26, rank_within_parent#74]
-Input [6]: [gross_margin#23, i_category#14, i_class#13, lochierarchy#26, _w0#72, rank_within_parent#74]
+(44) Project [codegen id : 21]
+Output [5]: [gross_margin#23, i_category#14, i_class#13, lochierarchy#26, rank_within_parent#73]
+Input [6]: [gross_margin#23, i_category#14, i_class#13, lochierarchy#26, _w0#71, rank_within_parent#73]
 
-(49) TakeOrderedAndProject
-Input [5]: [gross_margin#23, i_category#14, i_class#13, lochierarchy#26, rank_within_parent#74]
-Arguments: 100, [lochierarchy#26 DESC NULLS LAST, CASE WHEN (lochierarchy#26 = 0) THEN i_category#14 END ASC NULLS FIRST, rank_within_parent#74 ASC NULLS FIRST], [gross_margin#23, i_category#14, i_class#13, lochierarchy#26, rank_within_parent#74]
+(45) TakeOrderedAndProject
+Input [5]: [gross_margin#23, i_category#14, i_class#13, lochierarchy#26, rank_within_parent#73]
+Arguments: 100, [lochierarchy#26 DESC NULLS LAST, CASE WHEN (lochierarchy#26 = 0) THEN i_category#14 END ASC NULLS FIRST, rank_within_parent#73 ASC NULLS FIRST], [gross_margin#23, i_category#14, i_class#13, lochierarchy#26, rank_within_parent#73]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a.sf100/simplified.txt
@@ -1,82 +1,74 @@
 TakeOrderedAndProject [lochierarchy,i_category,rank_within_parent,gross_margin,i_class]
-  WholeStageCodegen (23)
+  WholeStageCodegen (21)
     Project [gross_margin,i_category,i_class,lochierarchy,rank_within_parent]
       InputAdapter
         Window [gross_margin,lochierarchy,_w0]
-          WholeStageCodegen (22)
+          WholeStageCodegen (20)
             Sort [lochierarchy,_w0,gross_margin]
               InputAdapter
                 Exchange [lochierarchy,_w0] #1
-                  WholeStageCodegen (21)
+                  WholeStageCodegen (19)
                     HashAggregate [gross_margin,i_category,i_class,t_category,t_class,lochierarchy] [_w0]
                       InputAdapter
                         Exchange [gross_margin,i_category,i_class,t_category,t_class,lochierarchy] #2
-                          WholeStageCodegen (20)
+                          WholeStageCodegen (18)
                             HashAggregate [gross_margin,i_category,i_class,t_category,t_class,lochierarchy]
                               InputAdapter
                                 Union
-                                  WholeStageCodegen (13)
-                                    HashAggregate [gross_margin,i_category,i_class,t_category,t_class,lochierarchy]
+                                  WholeStageCodegen (5)
+                                    HashAggregate [i_category,i_class,sum,sum] [sum(UnscaledValue(ss_net_profit)),sum(UnscaledValue(ss_ext_sales_price)),gross_margin,t_category,t_class,lochierarchy,sum,sum]
                                       InputAdapter
-                                        Exchange [gross_margin,i_category,i_class,t_category,t_class,lochierarchy] #3
-                                          WholeStageCodegen (12)
-                                            HashAggregate [gross_margin,i_category,i_class,t_category,t_class,lochierarchy]
-                                              InputAdapter
-                                                Union
-                                                  WholeStageCodegen (5)
-                                                    HashAggregate [i_category,i_class,sum,sum] [sum(UnscaledValue(ss_net_profit)),sum(UnscaledValue(ss_ext_sales_price)),gross_margin,t_category,t_class,lochierarchy,sum,sum]
-                                                      InputAdapter
-                                                        Exchange [i_category,i_class] #4
-                                                          WholeStageCodegen (4)
-                                                            HashAggregate [i_category,i_class,ss_net_profit,ss_ext_sales_price] [sum,sum,sum,sum]
-                                                              Project [ss_ext_sales_price,ss_net_profit,i_class,i_category]
-                                                                BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                                  Project [ss_item_sk,ss_ext_sales_price,ss_net_profit]
-                                                                    BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                                      Project [ss_item_sk,ss_store_sk,ss_ext_sales_price,ss_net_profit]
-                                                                        BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                          Filter [ss_sold_date_sk,ss_item_sk,ss_store_sk]
-                                                                            ColumnarToRow
-                                                                              InputAdapter
-                                                                                Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk,ss_store_sk,ss_ext_sales_price,ss_net_profit]
-                                                                          InputAdapter
-                                                                            BroadcastExchange #5
-                                                                              WholeStageCodegen (1)
-                                                                                Project [d_date_sk]
-                                                                                  Filter [d_year,d_date_sk]
-                                                                                    ColumnarToRow
-                                                                                      InputAdapter
-                                                                                        Scan parquet default.date_dim [d_date_sk,d_year]
+                                        Exchange [i_category,i_class] #3
+                                          WholeStageCodegen (4)
+                                            HashAggregate [i_category,i_class,ss_net_profit,ss_ext_sales_price] [sum,sum,sum,sum]
+                                              Project [ss_ext_sales_price,ss_net_profit,i_class,i_category]
+                                                BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                  Project [ss_item_sk,ss_ext_sales_price,ss_net_profit]
+                                                    BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                                      Project [ss_item_sk,ss_store_sk,ss_ext_sales_price,ss_net_profit]
+                                                        BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                          Filter [ss_sold_date_sk,ss_item_sk,ss_store_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk,ss_store_sk,ss_ext_sales_price,ss_net_profit]
+                                                          InputAdapter
+                                                            BroadcastExchange #4
+                                                              WholeStageCodegen (1)
+                                                                Project [d_date_sk]
+                                                                  Filter [d_year,d_date_sk]
+                                                                    ColumnarToRow
                                                                       InputAdapter
-                                                                        BroadcastExchange #6
-                                                                          WholeStageCodegen (2)
-                                                                            Project [s_store_sk]
-                                                                              Filter [s_state,s_store_sk]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet default.store [s_store_sk,s_state]
-                                                                  InputAdapter
-                                                                    BroadcastExchange #7
-                                                                      WholeStageCodegen (3)
-                                                                        Filter [i_item_sk]
-                                                                          ColumnarToRow
-                                                                            InputAdapter
-                                                                              Scan parquet default.item [i_item_sk,i_class,i_category]
-                                                  WholeStageCodegen (11)
-                                                    HashAggregate [i_category,sum,isEmpty,sum,isEmpty] [sum(ss_net_profit),sum(ss_ext_sales_price),gross_margin,i_class,t_category,t_class,lochierarchy,sum,isEmpty,sum,isEmpty]
+                                                                        Scan parquet default.date_dim [d_date_sk,d_year]
                                                       InputAdapter
-                                                        Exchange [i_category] #8
-                                                          WholeStageCodegen (10)
-                                                            HashAggregate [i_category,ss_net_profit,ss_ext_sales_price] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
-                                                              HashAggregate [i_category,i_class,sum,sum] [sum(UnscaledValue(ss_net_profit)),sum(UnscaledValue(ss_ext_sales_price)),ss_net_profit,ss_ext_sales_price,sum,sum]
-                                                                InputAdapter
-                                                                  ReusedExchange [i_category,i_class,sum,sum] #4
-                                  WholeStageCodegen (19)
+                                                        BroadcastExchange #5
+                                                          WholeStageCodegen (2)
+                                                            Project [s_store_sk]
+                                                              Filter [s_state,s_store_sk]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet default.store [s_store_sk,s_state]
+                                                  InputAdapter
+                                                    BroadcastExchange #6
+                                                      WholeStageCodegen (3)
+                                                        Filter [i_item_sk]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet default.item [i_item_sk,i_class,i_category]
+                                  WholeStageCodegen (11)
+                                    HashAggregate [i_category,sum,isEmpty,sum,isEmpty] [sum(ss_net_profit),sum(ss_ext_sales_price),gross_margin,i_class,t_category,t_class,lochierarchy,sum,isEmpty,sum,isEmpty]
+                                      InputAdapter
+                                        Exchange [i_category] #7
+                                          WholeStageCodegen (10)
+                                            HashAggregate [i_category,ss_net_profit,ss_ext_sales_price] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                                              HashAggregate [i_category,i_class,sum,sum] [sum(UnscaledValue(ss_net_profit)),sum(UnscaledValue(ss_ext_sales_price)),ss_net_profit,ss_ext_sales_price,sum,sum]
+                                                InputAdapter
+                                                  ReusedExchange [i_category,i_class,sum,sum] #3
+                                  WholeStageCodegen (17)
                                     HashAggregate [sum,isEmpty,sum,isEmpty] [sum(ss_net_profit),sum(ss_ext_sales_price),gross_margin,i_category,i_class,t_category,t_class,lochierarchy,sum,isEmpty,sum,isEmpty]
                                       InputAdapter
-                                        Exchange #9
-                                          WholeStageCodegen (18)
+                                        Exchange #8
+                                          WholeStageCodegen (16)
                                             HashAggregate [ss_net_profit,ss_ext_sales_price] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                                               HashAggregate [i_category,i_class,sum,sum] [sum(UnscaledValue(ss_net_profit)),sum(UnscaledValue(ss_ext_sales_price)),ss_net_profit,ss_ext_sales_price,sum,sum]
                                                 InputAdapter
-                                                  ReusedExchange [i_category,i_class,sum,sum] #4
+                                                  ReusedExchange [i_category,i_class,sum,sum] #3

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a/explain.txt
@@ -1,53 +1,49 @@
 == Physical Plan ==
-TakeOrderedAndProject (49)
-+- * Project (48)
-   +- Window (47)
-      +- * Sort (46)
-         +- Exchange (45)
-            +- * HashAggregate (44)
-               +- Exchange (43)
-                  +- * HashAggregate (42)
-                     +- Union (41)
-                        :- * HashAggregate (35)
-                        :  +- Exchange (34)
-                        :     +- * HashAggregate (33)
-                        :        +- Union (32)
-                        :           :- * HashAggregate (26)
-                        :           :  +- Exchange (25)
-                        :           :     +- * HashAggregate (24)
-                        :           :        +- * Project (23)
-                        :           :           +- * BroadcastHashJoin Inner BuildRight (22)
-                        :           :              :- * Project (16)
-                        :           :              :  +- * BroadcastHashJoin Inner BuildRight (15)
-                        :           :              :     :- * Project (10)
-                        :           :              :     :  +- * BroadcastHashJoin Inner BuildRight (9)
-                        :           :              :     :     :- * Filter (3)
-                        :           :              :     :     :  +- * ColumnarToRow (2)
-                        :           :              :     :     :     +- Scan parquet default.store_sales (1)
-                        :           :              :     :     +- BroadcastExchange (8)
-                        :           :              :     :        +- * Project (7)
-                        :           :              :     :           +- * Filter (6)
-                        :           :              :     :              +- * ColumnarToRow (5)
-                        :           :              :     :                 +- Scan parquet default.date_dim (4)
-                        :           :              :     +- BroadcastExchange (14)
-                        :           :              :        +- * Filter (13)
-                        :           :              :           +- * ColumnarToRow (12)
-                        :           :              :              +- Scan parquet default.item (11)
-                        :           :              +- BroadcastExchange (21)
-                        :           :                 +- * Project (20)
-                        :           :                    +- * Filter (19)
-                        :           :                       +- * ColumnarToRow (18)
-                        :           :                          +- Scan parquet default.store (17)
-                        :           +- * HashAggregate (31)
-                        :              +- Exchange (30)
-                        :                 +- * HashAggregate (29)
-                        :                    +- * HashAggregate (28)
-                        :                       +- ReusedExchange (27)
-                        +- * HashAggregate (40)
-                           +- Exchange (39)
-                              +- * HashAggregate (38)
-                                 +- * HashAggregate (37)
-                                    +- ReusedExchange (36)
+TakeOrderedAndProject (45)
++- * Project (44)
+   +- Window (43)
+      +- * Sort (42)
+         +- Exchange (41)
+            +- * HashAggregate (40)
+               +- Exchange (39)
+                  +- * HashAggregate (38)
+                     +- Union (37)
+                        :- * HashAggregate (26)
+                        :  +- Exchange (25)
+                        :     +- * HashAggregate (24)
+                        :        +- * Project (23)
+                        :           +- * BroadcastHashJoin Inner BuildRight (22)
+                        :              :- * Project (16)
+                        :              :  +- * BroadcastHashJoin Inner BuildRight (15)
+                        :              :     :- * Project (10)
+                        :              :     :  +- * BroadcastHashJoin Inner BuildRight (9)
+                        :              :     :     :- * Filter (3)
+                        :              :     :     :  +- * ColumnarToRow (2)
+                        :              :     :     :     +- Scan parquet default.store_sales (1)
+                        :              :     :     +- BroadcastExchange (8)
+                        :              :     :        +- * Project (7)
+                        :              :     :           +- * Filter (6)
+                        :              :     :              +- * ColumnarToRow (5)
+                        :              :     :                 +- Scan parquet default.date_dim (4)
+                        :              :     +- BroadcastExchange (14)
+                        :              :        +- * Filter (13)
+                        :              :           +- * ColumnarToRow (12)
+                        :              :              +- Scan parquet default.item (11)
+                        :              +- BroadcastExchange (21)
+                        :                 +- * Project (20)
+                        :                    +- * Filter (19)
+                        :                       +- * ColumnarToRow (18)
+                        :                          +- Scan parquet default.store (17)
+                        :- * HashAggregate (31)
+                        :  +- Exchange (30)
+                        :     +- * HashAggregate (29)
+                        :        +- * HashAggregate (28)
+                        :           +- ReusedExchange (27)
+                        +- * HashAggregate (36)
+                           +- Exchange (35)
+                              +- * HashAggregate (34)
+                                 +- * HashAggregate (33)
+                                    +- ReusedExchange (32)
 
 
 (1) Scan parquet default.store_sales
@@ -162,7 +158,7 @@ Results [4]: [i_category#11, i_class#10, sum#18, sum#19]
 
 (25) Exchange
 Input [4]: [i_category#11, i_class#10, sum#18, sum#19]
-Arguments: hashpartitioning(i_category#11, i_class#10, 5), true, [id=#20]
+Arguments: hashpartitioning(i_category#11, i_class#10, 5), ENSURE_REQUIREMENTS, [id=#20]
 
 (26) HashAggregate [codegen id : 5]
 Input [4]: [i_category#11, i_class#10, sum#18, sum#19]
@@ -190,7 +186,7 @@ Results [5]: [i_category#11, sum#37, isEmpty#38, sum#39, isEmpty#40]
 
 (30) Exchange
 Input [5]: [i_category#11, sum#37, isEmpty#38, sum#39, isEmpty#40]
-Arguments: hashpartitioning(i_category#11, 5), true, [id=#41]
+Arguments: hashpartitioning(i_category#11, 5), ENSURE_REQUIREMENTS, [id=#41]
 
 (31) HashAggregate [codegen id : 11]
 Input [5]: [i_category#11, sum#37, isEmpty#38, sum#39, isEmpty#40]
@@ -199,91 +195,71 @@ Functions [2]: [sum(ss_net_profit#31), sum(ss_ext_sales_price#32)]
 Aggregate Attributes [2]: [sum(ss_net_profit#31)#42, sum(ss_ext_sales_price#32)#43]
 Results [6]: [cast(CheckOverflow((promote_precision(sum(ss_net_profit#31)#42) / promote_precision(sum(ss_ext_sales_price#32)#43)), DecimalType(38,11), true) as decimal(38,20)) AS gross_margin#44, i_category#11, null AS i_class#45, 0 AS t_category#46, 1 AS t_class#47, 1 AS lochierarchy#48]
 
-(32) Union
+(32) ReusedExchange [Reuses operator id: 25]
+Output [4]: [i_category#11, i_class#10, sum#49, sum#50]
 
-(33) HashAggregate [codegen id : 12]
-Input [6]: [gross_margin#23, i_category#11, i_class#10, t_category#24, t_class#25, lochierarchy#26]
-Keys [6]: [gross_margin#23, i_category#11, i_class#10, t_category#24, t_class#25, lochierarchy#26]
-Functions: []
-Aggregate Attributes: []
-Results [6]: [gross_margin#23, i_category#11, i_class#10, t_category#24, t_class#25, lochierarchy#26]
-
-(34) Exchange
-Input [6]: [gross_margin#23, i_category#11, i_class#10, t_category#24, t_class#25, lochierarchy#26]
-Arguments: hashpartitioning(gross_margin#23, i_category#11, i_class#10, t_category#24, t_class#25, lochierarchy#26, 5), true, [id=#49]
-
-(35) HashAggregate [codegen id : 13]
-Input [6]: [gross_margin#23, i_category#11, i_class#10, t_category#24, t_class#25, lochierarchy#26]
-Keys [6]: [gross_margin#23, i_category#11, i_class#10, t_category#24, t_class#25, lochierarchy#26]
-Functions: []
-Aggregate Attributes: []
-Results [6]: [gross_margin#23, i_category#11, i_class#10, t_category#24, t_class#25, lochierarchy#26]
-
-(36) ReusedExchange [Reuses operator id: 25]
-Output [4]: [i_category#11, i_class#10, sum#50, sum#51]
-
-(37) HashAggregate [codegen id : 18]
-Input [4]: [i_category#11, i_class#10, sum#50, sum#51]
+(33) HashAggregate [codegen id : 16]
+Input [4]: [i_category#11, i_class#10, sum#49, sum#50]
 Keys [2]: [i_category#11, i_class#10]
 Functions [2]: [sum(UnscaledValue(ss_net_profit#5)), sum(UnscaledValue(ss_ext_sales_price#4))]
-Aggregate Attributes [2]: [sum(UnscaledValue(ss_net_profit#5))#52, sum(UnscaledValue(ss_ext_sales_price#4))#53]
-Results [2]: [MakeDecimal(sum(UnscaledValue(ss_net_profit#5))#52,17,2) AS ss_net_profit#31, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#4))#53,17,2) AS ss_ext_sales_price#32]
+Aggregate Attributes [2]: [sum(UnscaledValue(ss_net_profit#5))#51, sum(UnscaledValue(ss_ext_sales_price#4))#52]
+Results [2]: [MakeDecimal(sum(UnscaledValue(ss_net_profit#5))#51,17,2) AS ss_net_profit#31, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#4))#52,17,2) AS ss_ext_sales_price#32]
 
-(38) HashAggregate [codegen id : 18]
+(34) HashAggregate [codegen id : 16]
 Input [2]: [ss_net_profit#31, ss_ext_sales_price#32]
 Keys: []
 Functions [2]: [partial_sum(ss_net_profit#31), partial_sum(ss_ext_sales_price#32)]
-Aggregate Attributes [4]: [sum#54, isEmpty#55, sum#56, isEmpty#57]
-Results [4]: [sum#58, isEmpty#59, sum#60, isEmpty#61]
+Aggregate Attributes [4]: [sum#53, isEmpty#54, sum#55, isEmpty#56]
+Results [4]: [sum#57, isEmpty#58, sum#59, isEmpty#60]
 
-(39) Exchange
-Input [4]: [sum#58, isEmpty#59, sum#60, isEmpty#61]
-Arguments: SinglePartition, true, [id=#62]
+(35) Exchange
+Input [4]: [sum#57, isEmpty#58, sum#59, isEmpty#60]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#61]
 
-(40) HashAggregate [codegen id : 19]
-Input [4]: [sum#58, isEmpty#59, sum#60, isEmpty#61]
+(36) HashAggregate [codegen id : 17]
+Input [4]: [sum#57, isEmpty#58, sum#59, isEmpty#60]
 Keys: []
 Functions [2]: [sum(ss_net_profit#31), sum(ss_ext_sales_price#32)]
-Aggregate Attributes [2]: [sum(ss_net_profit#31)#63, sum(ss_ext_sales_price#32)#64]
-Results [6]: [cast(CheckOverflow((promote_precision(sum(ss_net_profit#31)#63) / promote_precision(sum(ss_ext_sales_price#32)#64)), DecimalType(38,11), true) as decimal(38,20)) AS gross_margin#65, null AS i_category#66, null AS i_class#67, 1 AS t_category#68, 1 AS t_class#69, 2 AS lochierarchy#70]
+Aggregate Attributes [2]: [sum(ss_net_profit#31)#62, sum(ss_ext_sales_price#32)#63]
+Results [6]: [cast(CheckOverflow((promote_precision(sum(ss_net_profit#31)#62) / promote_precision(sum(ss_ext_sales_price#32)#63)), DecimalType(38,11), true) as decimal(38,20)) AS gross_margin#64, null AS i_category#65, null AS i_class#66, 1 AS t_category#67, 1 AS t_class#68, 2 AS lochierarchy#69]
 
-(41) Union
+(37) Union
 
-(42) HashAggregate [codegen id : 20]
+(38) HashAggregate [codegen id : 18]
 Input [6]: [gross_margin#23, i_category#11, i_class#10, t_category#24, t_class#25, lochierarchy#26]
 Keys [6]: [gross_margin#23, i_category#11, i_class#10, t_category#24, t_class#25, lochierarchy#26]
 Functions: []
 Aggregate Attributes: []
 Results [6]: [gross_margin#23, i_category#11, i_class#10, t_category#24, t_class#25, lochierarchy#26]
 
-(43) Exchange
+(39) Exchange
 Input [6]: [gross_margin#23, i_category#11, i_class#10, t_category#24, t_class#25, lochierarchy#26]
-Arguments: hashpartitioning(gross_margin#23, i_category#11, i_class#10, t_category#24, t_class#25, lochierarchy#26, 5), true, [id=#71]
+Arguments: hashpartitioning(gross_margin#23, i_category#11, i_class#10, t_category#24, t_class#25, lochierarchy#26, 5), ENSURE_REQUIREMENTS, [id=#70]
 
-(44) HashAggregate [codegen id : 21]
+(40) HashAggregate [codegen id : 19]
 Input [6]: [gross_margin#23, i_category#11, i_class#10, t_category#24, t_class#25, lochierarchy#26]
 Keys [6]: [gross_margin#23, i_category#11, i_class#10, t_category#24, t_class#25, lochierarchy#26]
 Functions: []
 Aggregate Attributes: []
-Results [5]: [gross_margin#23, i_category#11, i_class#10, lochierarchy#26, CASE WHEN (t_class#25 = 0) THEN i_category#11 END AS _w0#72]
+Results [5]: [gross_margin#23, i_category#11, i_class#10, lochierarchy#26, CASE WHEN (t_class#25 = 0) THEN i_category#11 END AS _w0#71]
 
-(45) Exchange
-Input [5]: [gross_margin#23, i_category#11, i_class#10, lochierarchy#26, _w0#72]
-Arguments: hashpartitioning(lochierarchy#26, _w0#72, 5), true, [id=#73]
+(41) Exchange
+Input [5]: [gross_margin#23, i_category#11, i_class#10, lochierarchy#26, _w0#71]
+Arguments: hashpartitioning(lochierarchy#26, _w0#71, 5), ENSURE_REQUIREMENTS, [id=#72]
 
-(46) Sort [codegen id : 22]
-Input [5]: [gross_margin#23, i_category#11, i_class#10, lochierarchy#26, _w0#72]
-Arguments: [lochierarchy#26 ASC NULLS FIRST, _w0#72 ASC NULLS FIRST, gross_margin#23 ASC NULLS FIRST], false, 0
+(42) Sort [codegen id : 20]
+Input [5]: [gross_margin#23, i_category#11, i_class#10, lochierarchy#26, _w0#71]
+Arguments: [lochierarchy#26 ASC NULLS FIRST, _w0#71 ASC NULLS FIRST, gross_margin#23 ASC NULLS FIRST], false, 0
 
-(47) Window
-Input [5]: [gross_margin#23, i_category#11, i_class#10, lochierarchy#26, _w0#72]
-Arguments: [rank(gross_margin#23) windowspecdefinition(lochierarchy#26, _w0#72, gross_margin#23 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank_within_parent#74], [lochierarchy#26, _w0#72], [gross_margin#23 ASC NULLS FIRST]
+(43) Window
+Input [5]: [gross_margin#23, i_category#11, i_class#10, lochierarchy#26, _w0#71]
+Arguments: [rank(gross_margin#23) windowspecdefinition(lochierarchy#26, _w0#71, gross_margin#23 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank_within_parent#73], [lochierarchy#26, _w0#71], [gross_margin#23 ASC NULLS FIRST]
 
-(48) Project [codegen id : 23]
-Output [5]: [gross_margin#23, i_category#11, i_class#10, lochierarchy#26, rank_within_parent#74]
-Input [6]: [gross_margin#23, i_category#11, i_class#10, lochierarchy#26, _w0#72, rank_within_parent#74]
+(44) Project [codegen id : 21]
+Output [5]: [gross_margin#23, i_category#11, i_class#10, lochierarchy#26, rank_within_parent#73]
+Input [6]: [gross_margin#23, i_category#11, i_class#10, lochierarchy#26, _w0#71, rank_within_parent#73]
 
-(49) TakeOrderedAndProject
-Input [5]: [gross_margin#23, i_category#11, i_class#10, lochierarchy#26, rank_within_parent#74]
-Arguments: 100, [lochierarchy#26 DESC NULLS LAST, CASE WHEN (lochierarchy#26 = 0) THEN i_category#11 END ASC NULLS FIRST, rank_within_parent#74 ASC NULLS FIRST], [gross_margin#23, i_category#11, i_class#10, lochierarchy#26, rank_within_parent#74]
+(45) TakeOrderedAndProject
+Input [5]: [gross_margin#23, i_category#11, i_class#10, lochierarchy#26, rank_within_parent#73]
+Arguments: 100, [lochierarchy#26 DESC NULLS LAST, CASE WHEN (lochierarchy#26 = 0) THEN i_category#11 END ASC NULLS FIRST, rank_within_parent#73 ASC NULLS FIRST], [gross_margin#23, i_category#11, i_class#10, lochierarchy#26, rank_within_parent#73]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a/simplified.txt
@@ -1,82 +1,74 @@
 TakeOrderedAndProject [lochierarchy,i_category,rank_within_parent,gross_margin,i_class]
-  WholeStageCodegen (23)
+  WholeStageCodegen (21)
     Project [gross_margin,i_category,i_class,lochierarchy,rank_within_parent]
       InputAdapter
         Window [gross_margin,lochierarchy,_w0]
-          WholeStageCodegen (22)
+          WholeStageCodegen (20)
             Sort [lochierarchy,_w0,gross_margin]
               InputAdapter
                 Exchange [lochierarchy,_w0] #1
-                  WholeStageCodegen (21)
+                  WholeStageCodegen (19)
                     HashAggregate [gross_margin,i_category,i_class,t_category,t_class,lochierarchy] [_w0]
                       InputAdapter
                         Exchange [gross_margin,i_category,i_class,t_category,t_class,lochierarchy] #2
-                          WholeStageCodegen (20)
+                          WholeStageCodegen (18)
                             HashAggregate [gross_margin,i_category,i_class,t_category,t_class,lochierarchy]
                               InputAdapter
                                 Union
-                                  WholeStageCodegen (13)
-                                    HashAggregate [gross_margin,i_category,i_class,t_category,t_class,lochierarchy]
+                                  WholeStageCodegen (5)
+                                    HashAggregate [i_category,i_class,sum,sum] [sum(UnscaledValue(ss_net_profit)),sum(UnscaledValue(ss_ext_sales_price)),gross_margin,t_category,t_class,lochierarchy,sum,sum]
                                       InputAdapter
-                                        Exchange [gross_margin,i_category,i_class,t_category,t_class,lochierarchy] #3
-                                          WholeStageCodegen (12)
-                                            HashAggregate [gross_margin,i_category,i_class,t_category,t_class,lochierarchy]
-                                              InputAdapter
-                                                Union
-                                                  WholeStageCodegen (5)
-                                                    HashAggregate [i_category,i_class,sum,sum] [sum(UnscaledValue(ss_net_profit)),sum(UnscaledValue(ss_ext_sales_price)),gross_margin,t_category,t_class,lochierarchy,sum,sum]
-                                                      InputAdapter
-                                                        Exchange [i_category,i_class] #4
-                                                          WholeStageCodegen (4)
-                                                            HashAggregate [i_category,i_class,ss_net_profit,ss_ext_sales_price] [sum,sum,sum,sum]
-                                                              Project [ss_ext_sales_price,ss_net_profit,i_class,i_category]
-                                                                BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                                  Project [ss_store_sk,ss_ext_sales_price,ss_net_profit,i_class,i_category]
-                                                                    BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                                      Project [ss_item_sk,ss_store_sk,ss_ext_sales_price,ss_net_profit]
-                                                                        BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                          Filter [ss_sold_date_sk,ss_item_sk,ss_store_sk]
-                                                                            ColumnarToRow
-                                                                              InputAdapter
-                                                                                Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk,ss_store_sk,ss_ext_sales_price,ss_net_profit]
-                                                                          InputAdapter
-                                                                            BroadcastExchange #5
-                                                                              WholeStageCodegen (1)
-                                                                                Project [d_date_sk]
-                                                                                  Filter [d_year,d_date_sk]
-                                                                                    ColumnarToRow
-                                                                                      InputAdapter
-                                                                                        Scan parquet default.date_dim [d_date_sk,d_year]
+                                        Exchange [i_category,i_class] #3
+                                          WholeStageCodegen (4)
+                                            HashAggregate [i_category,i_class,ss_net_profit,ss_ext_sales_price] [sum,sum,sum,sum]
+                                              Project [ss_ext_sales_price,ss_net_profit,i_class,i_category]
+                                                BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                                  Project [ss_store_sk,ss_ext_sales_price,ss_net_profit,i_class,i_category]
+                                                    BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                      Project [ss_item_sk,ss_store_sk,ss_ext_sales_price,ss_net_profit]
+                                                        BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                          Filter [ss_sold_date_sk,ss_item_sk,ss_store_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk,ss_store_sk,ss_ext_sales_price,ss_net_profit]
+                                                          InputAdapter
+                                                            BroadcastExchange #4
+                                                              WholeStageCodegen (1)
+                                                                Project [d_date_sk]
+                                                                  Filter [d_year,d_date_sk]
+                                                                    ColumnarToRow
                                                                       InputAdapter
-                                                                        BroadcastExchange #6
-                                                                          WholeStageCodegen (2)
-                                                                            Filter [i_item_sk]
-                                                                              ColumnarToRow
-                                                                                InputAdapter
-                                                                                  Scan parquet default.item [i_item_sk,i_class,i_category]
-                                                                  InputAdapter
-                                                                    BroadcastExchange #7
-                                                                      WholeStageCodegen (3)
-                                                                        Project [s_store_sk]
-                                                                          Filter [s_state,s_store_sk]
-                                                                            ColumnarToRow
-                                                                              InputAdapter
-                                                                                Scan parquet default.store [s_store_sk,s_state]
-                                                  WholeStageCodegen (11)
-                                                    HashAggregate [i_category,sum,isEmpty,sum,isEmpty] [sum(ss_net_profit),sum(ss_ext_sales_price),gross_margin,i_class,t_category,t_class,lochierarchy,sum,isEmpty,sum,isEmpty]
+                                                                        Scan parquet default.date_dim [d_date_sk,d_year]
                                                       InputAdapter
-                                                        Exchange [i_category] #8
-                                                          WholeStageCodegen (10)
-                                                            HashAggregate [i_category,ss_net_profit,ss_ext_sales_price] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
-                                                              HashAggregate [i_category,i_class,sum,sum] [sum(UnscaledValue(ss_net_profit)),sum(UnscaledValue(ss_ext_sales_price)),ss_net_profit,ss_ext_sales_price,sum,sum]
+                                                        BroadcastExchange #5
+                                                          WholeStageCodegen (2)
+                                                            Filter [i_item_sk]
+                                                              ColumnarToRow
                                                                 InputAdapter
-                                                                  ReusedExchange [i_category,i_class,sum,sum] #4
-                                  WholeStageCodegen (19)
+                                                                  Scan parquet default.item [i_item_sk,i_class,i_category]
+                                                  InputAdapter
+                                                    BroadcastExchange #6
+                                                      WholeStageCodegen (3)
+                                                        Project [s_store_sk]
+                                                          Filter [s_state,s_store_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet default.store [s_store_sk,s_state]
+                                  WholeStageCodegen (11)
+                                    HashAggregate [i_category,sum,isEmpty,sum,isEmpty] [sum(ss_net_profit),sum(ss_ext_sales_price),gross_margin,i_class,t_category,t_class,lochierarchy,sum,isEmpty,sum,isEmpty]
+                                      InputAdapter
+                                        Exchange [i_category] #7
+                                          WholeStageCodegen (10)
+                                            HashAggregate [i_category,ss_net_profit,ss_ext_sales_price] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                                              HashAggregate [i_category,i_class,sum,sum] [sum(UnscaledValue(ss_net_profit)),sum(UnscaledValue(ss_ext_sales_price)),ss_net_profit,ss_ext_sales_price,sum,sum]
+                                                InputAdapter
+                                                  ReusedExchange [i_category,i_class,sum,sum] #3
+                                  WholeStageCodegen (17)
                                     HashAggregate [sum,isEmpty,sum,isEmpty] [sum(ss_net_profit),sum(ss_ext_sales_price),gross_margin,i_category,i_class,t_category,t_class,lochierarchy,sum,isEmpty,sum,isEmpty]
                                       InputAdapter
-                                        Exchange #9
-                                          WholeStageCodegen (18)
+                                        Exchange #8
+                                          WholeStageCodegen (16)
                                             HashAggregate [ss_net_profit,ss_ext_sales_price] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                                               HashAggregate [i_category,i_class,sum,sum] [sum(UnscaledValue(ss_net_profit)),sum(UnscaledValue(ss_ext_sales_price)),ss_net_profit,ss_ext_sales_price,sum,sum]
                                                 InputAdapter
-                                                  ReusedExchange [i_category,i_class,sum,sum] #4
+                                                  ReusedExchange [i_category,i_class,sum,sum] #3

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q5a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q5a.sf100/explain.txt
@@ -1,102 +1,98 @@
 == Physical Plan ==
-TakeOrderedAndProject (98)
-+- * HashAggregate (97)
-   +- Exchange (96)
-      +- * HashAggregate (95)
-         +- Union (94)
-            :- * HashAggregate (88)
-            :  +- Exchange (87)
-            :     +- * HashAggregate (86)
-            :        +- Union (85)
-            :           :- * HashAggregate (79)
-            :           :  +- Exchange (78)
-            :           :     +- * HashAggregate (77)
-            :           :        +- Union (76)
-            :           :           :- * HashAggregate (25)
-            :           :           :  +- Exchange (24)
-            :           :           :     +- * HashAggregate (23)
-            :           :           :        +- * Project (22)
-            :           :           :           +- * BroadcastHashJoin Inner BuildRight (21)
-            :           :           :              :- * Project (16)
-            :           :           :              :  +- * BroadcastHashJoin Inner BuildRight (15)
-            :           :           :              :     :- Union (9)
-            :           :           :              :     :  :- * Project (4)
-            :           :           :              :     :  :  +- * Filter (3)
-            :           :           :              :     :  :     +- * ColumnarToRow (2)
-            :           :           :              :     :  :        +- Scan parquet default.store_sales (1)
-            :           :           :              :     :  +- * Project (8)
-            :           :           :              :     :     +- * Filter (7)
-            :           :           :              :     :        +- * ColumnarToRow (6)
-            :           :           :              :     :           +- Scan parquet default.store_returns (5)
-            :           :           :              :     +- BroadcastExchange (14)
-            :           :           :              :        +- * Project (13)
-            :           :           :              :           +- * Filter (12)
-            :           :           :              :              +- * ColumnarToRow (11)
-            :           :           :              :                 +- Scan parquet default.date_dim (10)
-            :           :           :              +- BroadcastExchange (20)
-            :           :           :                 +- * Filter (19)
-            :           :           :                    +- * ColumnarToRow (18)
-            :           :           :                       +- Scan parquet default.store (17)
-            :           :           :- * HashAggregate (46)
-            :           :           :  +- Exchange (45)
-            :           :           :     +- * HashAggregate (44)
-            :           :           :        +- * Project (43)
-            :           :           :           +- * BroadcastHashJoin Inner BuildRight (42)
-            :           :           :              :- * Project (37)
-            :           :           :              :  +- * BroadcastHashJoin Inner BuildRight (36)
-            :           :           :              :     :- Union (34)
-            :           :           :              :     :  :- * Project (29)
-            :           :           :              :     :  :  +- * Filter (28)
-            :           :           :              :     :  :     +- * ColumnarToRow (27)
-            :           :           :              :     :  :        +- Scan parquet default.catalog_sales (26)
-            :           :           :              :     :  +- * Project (33)
-            :           :           :              :     :     +- * Filter (32)
-            :           :           :              :     :        +- * ColumnarToRow (31)
-            :           :           :              :     :           +- Scan parquet default.catalog_returns (30)
-            :           :           :              :     +- ReusedExchange (35)
-            :           :           :              +- BroadcastExchange (41)
-            :           :           :                 +- * Filter (40)
-            :           :           :                    +- * ColumnarToRow (39)
-            :           :           :                       +- Scan parquet default.catalog_page (38)
-            :           :           +- * HashAggregate (75)
-            :           :              +- Exchange (74)
-            :           :                 +- * HashAggregate (73)
-            :           :                    +- * Project (72)
-            :           :                       +- * BroadcastHashJoin Inner BuildRight (71)
-            :           :                          :- * Project (66)
-            :           :                          :  +- * BroadcastHashJoin Inner BuildRight (65)
-            :           :                          :     :- Union (63)
-            :           :                          :     :  :- * Project (50)
-            :           :                          :     :  :  +- * Filter (49)
-            :           :                          :     :  :     +- * ColumnarToRow (48)
-            :           :                          :     :  :        +- Scan parquet default.web_sales (47)
-            :           :                          :     :  +- * Project (62)
-            :           :                          :     :     +- * SortMergeJoin Inner (61)
-            :           :                          :     :        :- * Sort (55)
-            :           :                          :     :        :  +- Exchange (54)
-            :           :                          :     :        :     +- * Filter (53)
-            :           :                          :     :        :        +- * ColumnarToRow (52)
-            :           :                          :     :        :           +- Scan parquet default.web_returns (51)
-            :           :                          :     :        +- * Sort (60)
-            :           :                          :     :           +- Exchange (59)
-            :           :                          :     :              +- * Filter (58)
-            :           :                          :     :                 +- * ColumnarToRow (57)
-            :           :                          :     :                    +- Scan parquet default.web_sales (56)
-            :           :                          :     +- ReusedExchange (64)
-            :           :                          +- BroadcastExchange (70)
-            :           :                             +- * Filter (69)
-            :           :                                +- * ColumnarToRow (68)
-            :           :                                   +- Scan parquet default.web_site (67)
-            :           +- * HashAggregate (84)
-            :              +- Exchange (83)
-            :                 +- * HashAggregate (82)
-            :                    +- * HashAggregate (81)
-            :                       +- ReusedExchange (80)
-            +- * HashAggregate (93)
-               +- Exchange (92)
-                  +- * HashAggregate (91)
-                     +- * HashAggregate (90)
-                        +- ReusedExchange (89)
+TakeOrderedAndProject (94)
++- * HashAggregate (93)
+   +- Exchange (92)
+      +- * HashAggregate (91)
+         +- Union (90)
+            :- * HashAggregate (79)
+            :  +- Exchange (78)
+            :     +- * HashAggregate (77)
+            :        +- Union (76)
+            :           :- * HashAggregate (25)
+            :           :  +- Exchange (24)
+            :           :     +- * HashAggregate (23)
+            :           :        +- * Project (22)
+            :           :           +- * BroadcastHashJoin Inner BuildRight (21)
+            :           :              :- * Project (16)
+            :           :              :  +- * BroadcastHashJoin Inner BuildRight (15)
+            :           :              :     :- Union (9)
+            :           :              :     :  :- * Project (4)
+            :           :              :     :  :  +- * Filter (3)
+            :           :              :     :  :     +- * ColumnarToRow (2)
+            :           :              :     :  :        +- Scan parquet default.store_sales (1)
+            :           :              :     :  +- * Project (8)
+            :           :              :     :     +- * Filter (7)
+            :           :              :     :        +- * ColumnarToRow (6)
+            :           :              :     :           +- Scan parquet default.store_returns (5)
+            :           :              :     +- BroadcastExchange (14)
+            :           :              :        +- * Project (13)
+            :           :              :           +- * Filter (12)
+            :           :              :              +- * ColumnarToRow (11)
+            :           :              :                 +- Scan parquet default.date_dim (10)
+            :           :              +- BroadcastExchange (20)
+            :           :                 +- * Filter (19)
+            :           :                    +- * ColumnarToRow (18)
+            :           :                       +- Scan parquet default.store (17)
+            :           :- * HashAggregate (46)
+            :           :  +- Exchange (45)
+            :           :     +- * HashAggregate (44)
+            :           :        +- * Project (43)
+            :           :           +- * BroadcastHashJoin Inner BuildRight (42)
+            :           :              :- * Project (37)
+            :           :              :  +- * BroadcastHashJoin Inner BuildRight (36)
+            :           :              :     :- Union (34)
+            :           :              :     :  :- * Project (29)
+            :           :              :     :  :  +- * Filter (28)
+            :           :              :     :  :     +- * ColumnarToRow (27)
+            :           :              :     :  :        +- Scan parquet default.catalog_sales (26)
+            :           :              :     :  +- * Project (33)
+            :           :              :     :     +- * Filter (32)
+            :           :              :     :        +- * ColumnarToRow (31)
+            :           :              :     :           +- Scan parquet default.catalog_returns (30)
+            :           :              :     +- ReusedExchange (35)
+            :           :              +- BroadcastExchange (41)
+            :           :                 +- * Filter (40)
+            :           :                    +- * ColumnarToRow (39)
+            :           :                       +- Scan parquet default.catalog_page (38)
+            :           +- * HashAggregate (75)
+            :              +- Exchange (74)
+            :                 +- * HashAggregate (73)
+            :                    +- * Project (72)
+            :                       +- * BroadcastHashJoin Inner BuildRight (71)
+            :                          :- * Project (66)
+            :                          :  +- * BroadcastHashJoin Inner BuildRight (65)
+            :                          :     :- Union (63)
+            :                          :     :  :- * Project (50)
+            :                          :     :  :  +- * Filter (49)
+            :                          :     :  :     +- * ColumnarToRow (48)
+            :                          :     :  :        +- Scan parquet default.web_sales (47)
+            :                          :     :  +- * Project (62)
+            :                          :     :     +- * SortMergeJoin Inner (61)
+            :                          :     :        :- * Sort (55)
+            :                          :     :        :  +- Exchange (54)
+            :                          :     :        :     +- * Filter (53)
+            :                          :     :        :        +- * ColumnarToRow (52)
+            :                          :     :        :           +- Scan parquet default.web_returns (51)
+            :                          :     :        +- * Sort (60)
+            :                          :     :           +- Exchange (59)
+            :                          :     :              +- * Filter (58)
+            :                          :     :                 +- * ColumnarToRow (57)
+            :                          :     :                    +- Scan parquet default.web_sales (56)
+            :                          :     +- ReusedExchange (64)
+            :                          +- BroadcastExchange (70)
+            :                             +- * Filter (69)
+            :                                +- * ColumnarToRow (68)
+            :                                   +- Scan parquet default.web_site (67)
+            :- * HashAggregate (84)
+            :  +- Exchange (83)
+            :     +- * HashAggregate (82)
+            :        +- * HashAggregate (81)
+            :           +- ReusedExchange (80)
+            +- * HashAggregate (89)
+               +- Exchange (88)
+                  +- * HashAggregate (87)
+                     +- * HashAggregate (86)
+                        +- ReusedExchange (85)
 
 
 (1) Scan parquet default.store_sales
@@ -203,7 +199,7 @@ Results [5]: [s_store_id#25, sum#31, sum#32, sum#33, sum#34]
 
 (24) Exchange
 Input [5]: [s_store_id#25, sum#31, sum#32, sum#33, sum#34]
-Arguments: hashpartitioning(s_store_id#25, 5), true, [id=#35]
+Arguments: hashpartitioning(s_store_id#25, 5), ENSURE_REQUIREMENTS, [id=#35]
 
 (25) HashAggregate [codegen id : 6]
 Input [5]: [s_store_id#25, sum#31, sum#32, sum#33, sum#34]
@@ -298,7 +294,7 @@ Results [5]: [cp_catalog_page_id#66, sum#72, sum#73, sum#74, sum#75]
 
 (45) Exchange
 Input [5]: [cp_catalog_page_id#66, sum#72, sum#73, sum#74, sum#75]
-Arguments: hashpartitioning(cp_catalog_page_id#66, 5), true, [id=#76]
+Arguments: hashpartitioning(cp_catalog_page_id#66, 5), ENSURE_REQUIREMENTS, [id=#76]
 
 (46) HashAggregate [codegen id : 12]
 Input [5]: [cp_catalog_page_id#66, sum#72, sum#73, sum#74, sum#75]
@@ -341,7 +337,7 @@ Condition : isnotnull(wr_returned_date_sk#96)
 
 (54) Exchange
 Input [5]: [wr_returned_date_sk#96, wr_item_sk#97, wr_order_number#98, wr_return_amt#99, wr_net_loss#100]
-Arguments: hashpartitioning(wr_item_sk#97, wr_order_number#98, 5), true, [id=#101]
+Arguments: hashpartitioning(wr_item_sk#97, wr_order_number#98, 5), ENSURE_REQUIREMENTS, [id=#101]
 
 (55) Sort [codegen id : 15]
 Input [5]: [wr_returned_date_sk#96, wr_item_sk#97, wr_order_number#98, wr_return_amt#99, wr_net_loss#100]
@@ -363,7 +359,7 @@ Condition : ((isnotnull(ws_item_sk#102) AND isnotnull(ws_order_number#103)) AND 
 
 (59) Exchange
 Input [3]: [ws_item_sk#102, ws_web_site_sk#87, ws_order_number#103]
-Arguments: hashpartitioning(cast(ws_item_sk#102 as bigint), cast(ws_order_number#103 as bigint), 5), true, [id=#104]
+Arguments: hashpartitioning(cast(ws_item_sk#102 as bigint), cast(ws_order_number#103 as bigint), 5), ENSURE_REQUIREMENTS, [id=#104]
 
 (60) Sort [codegen id : 17]
 Input [3]: [ws_item_sk#102, ws_web_site_sk#87, ws_order_number#103]
@@ -428,7 +424,7 @@ Results [5]: [web_site_id#112, sum#118, sum#119, sum#120, sum#121]
 
 (74) Exchange
 Input [5]: [web_site_id#112, sum#118, sum#119, sum#120, sum#121]
-Arguments: hashpartitioning(web_site_id#112, 5), true, [id=#122]
+Arguments: hashpartitioning(web_site_id#112, 5), ENSURE_REQUIREMENTS, [id=#122]
 
 (75) HashAggregate [codegen id : 22]
 Input [5]: [web_site_id#112, sum#118, sum#119, sum#120, sum#121]
@@ -448,7 +444,7 @@ Results [8]: [channel#40, id#41, sum#138, isEmpty#139, sum#140, isEmpty#141, sum
 
 (78) Exchange
 Input [8]: [channel#40, id#41, sum#138, isEmpty#139, sum#140, isEmpty#141, sum#142, isEmpty#143]
-Arguments: hashpartitioning(channel#40, id#41, 5), true, [id=#144]
+Arguments: hashpartitioning(channel#40, id#41, 5), ENSURE_REQUIREMENTS, [id=#144]
 
 (79) HashAggregate [codegen id : 24]
 Input [8]: [channel#40, id#41, sum#138, isEmpty#139, sum#140, isEmpty#141, sum#142, isEmpty#143]
@@ -476,7 +472,7 @@ Results [7]: [channel#40, sum#170, isEmpty#171, sum#172, isEmpty#173, sum#174, i
 
 (83) Exchange
 Input [7]: [channel#40, sum#170, isEmpty#171, sum#172, isEmpty#173, sum#174, isEmpty#175]
-Arguments: hashpartitioning(channel#40, 5), true, [id=#176]
+Arguments: hashpartitioning(channel#40, 5), ENSURE_REQUIREMENTS, [id=#176]
 
 (84) HashAggregate [codegen id : 49]
 Input [7]: [channel#40, sum#170, isEmpty#171, sum#172, isEmpty#173, sum#174, isEmpty#175]
@@ -485,75 +481,55 @@ Functions [3]: [sum(sales#161), sum(returns#162), sum(profit#163)]
 Aggregate Attributes [3]: [sum(sales#161)#177, sum(returns#162)#178, sum(profit#163)#179]
 Results [5]: [channel#40, null AS id#180, sum(sales#161)#177 AS sum(sales)#181, sum(returns#162)#178 AS sum(returns)#182, sum(profit#163)#179 AS sum(profit)#183]
 
-(85) Union
+(85) ReusedExchange [Reuses operator id: 78]
+Output [8]: [channel#40, id#41, sum#184, isEmpty#185, sum#186, isEmpty#187, sum#188, isEmpty#189]
 
-(86) HashAggregate [codegen id : 50]
-Input [5]: [channel#40, id#41, sales#148, returns#149, profit#150]
-Keys [5]: [channel#40, id#41, sales#148, returns#149, profit#150]
-Functions: []
-Aggregate Attributes: []
-Results [5]: [channel#40, id#41, sales#148, returns#149, profit#150]
-
-(87) Exchange
-Input [5]: [channel#40, id#41, sales#148, returns#149, profit#150]
-Arguments: hashpartitioning(channel#40, id#41, sales#148, returns#149, profit#150, 5), true, [id=#184]
-
-(88) HashAggregate [codegen id : 51]
-Input [5]: [channel#40, id#41, sales#148, returns#149, profit#150]
-Keys [5]: [channel#40, id#41, sales#148, returns#149, profit#150]
-Functions: []
-Aggregate Attributes: []
-Results [5]: [channel#40, id#41, sales#148, returns#149, profit#150]
-
-(89) ReusedExchange [Reuses operator id: 78]
-Output [8]: [channel#40, id#41, sum#185, isEmpty#186, sum#187, isEmpty#188, sum#189, isEmpty#190]
-
-(90) HashAggregate [codegen id : 75]
-Input [8]: [channel#40, id#41, sum#185, isEmpty#186, sum#187, isEmpty#188, sum#189, isEmpty#190]
+(86) HashAggregate [codegen id : 73]
+Input [8]: [channel#40, id#41, sum#184, isEmpty#185, sum#186, isEmpty#187, sum#188, isEmpty#189]
 Keys [2]: [channel#40, id#41]
-Functions [3]: [sum(sales#42), sum(returns#43), sum(profit#191)]
-Aggregate Attributes [3]: [sum(sales#42)#192, sum(returns#43)#193, sum(profit#191)#194]
-Results [3]: [sum(sales#42)#192 AS sales#161, sum(returns#43)#193 AS returns#162, sum(profit#191)#194 AS profit#163]
+Functions [3]: [sum(sales#42), sum(returns#43), sum(profit#190)]
+Aggregate Attributes [3]: [sum(sales#42)#191, sum(returns#43)#192, sum(profit#190)#193]
+Results [3]: [sum(sales#42)#191 AS sales#161, sum(returns#43)#192 AS returns#162, sum(profit#190)#193 AS profit#163]
 
-(91) HashAggregate [codegen id : 75]
+(87) HashAggregate [codegen id : 73]
 Input [3]: [sales#161, returns#162, profit#163]
 Keys: []
 Functions [3]: [partial_sum(sales#161), partial_sum(returns#162), partial_sum(profit#163)]
-Aggregate Attributes [6]: [sum#195, isEmpty#196, sum#197, isEmpty#198, sum#199, isEmpty#200]
-Results [6]: [sum#201, isEmpty#202, sum#203, isEmpty#204, sum#205, isEmpty#206]
+Aggregate Attributes [6]: [sum#194, isEmpty#195, sum#196, isEmpty#197, sum#198, isEmpty#199]
+Results [6]: [sum#200, isEmpty#201, sum#202, isEmpty#203, sum#204, isEmpty#205]
 
-(92) Exchange
-Input [6]: [sum#201, isEmpty#202, sum#203, isEmpty#204, sum#205, isEmpty#206]
-Arguments: SinglePartition, true, [id=#207]
+(88) Exchange
+Input [6]: [sum#200, isEmpty#201, sum#202, isEmpty#203, sum#204, isEmpty#205]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#206]
 
-(93) HashAggregate [codegen id : 76]
-Input [6]: [sum#201, isEmpty#202, sum#203, isEmpty#204, sum#205, isEmpty#206]
+(89) HashAggregate [codegen id : 74]
+Input [6]: [sum#200, isEmpty#201, sum#202, isEmpty#203, sum#204, isEmpty#205]
 Keys: []
 Functions [3]: [sum(sales#161), sum(returns#162), sum(profit#163)]
-Aggregate Attributes [3]: [sum(sales#161)#208, sum(returns#162)#209, sum(profit#163)#210]
-Results [5]: [null AS channel#211, null AS id#212, sum(sales#161)#208 AS sum(sales)#213, sum(returns#162)#209 AS sum(returns)#214, sum(profit#163)#210 AS sum(profit)#215]
+Aggregate Attributes [3]: [sum(sales#161)#207, sum(returns#162)#208, sum(profit#163)#209]
+Results [5]: [null AS channel#210, null AS id#211, sum(sales#161)#207 AS sum(sales)#212, sum(returns#162)#208 AS sum(returns)#213, sum(profit#163)#209 AS sum(profit)#214]
 
-(94) Union
+(90) Union
 
-(95) HashAggregate [codegen id : 77]
+(91) HashAggregate [codegen id : 75]
 Input [5]: [channel#40, id#41, sales#148, returns#149, profit#150]
 Keys [5]: [channel#40, id#41, sales#148, returns#149, profit#150]
 Functions: []
 Aggregate Attributes: []
 Results [5]: [channel#40, id#41, sales#148, returns#149, profit#150]
 
-(96) Exchange
+(92) Exchange
 Input [5]: [channel#40, id#41, sales#148, returns#149, profit#150]
-Arguments: hashpartitioning(channel#40, id#41, sales#148, returns#149, profit#150, 5), true, [id=#216]
+Arguments: hashpartitioning(channel#40, id#41, sales#148, returns#149, profit#150, 5), ENSURE_REQUIREMENTS, [id=#215]
 
-(97) HashAggregate [codegen id : 78]
+(93) HashAggregate [codegen id : 76]
 Input [5]: [channel#40, id#41, sales#148, returns#149, profit#150]
 Keys [5]: [channel#40, id#41, sales#148, returns#149, profit#150]
 Functions: []
 Aggregate Attributes: []
 Results [5]: [channel#40, id#41, sales#148, returns#149, profit#150]
 
-(98) TakeOrderedAndProject
+(94) TakeOrderedAndProject
 Input [5]: [channel#40, id#41, sales#148, returns#149, profit#150]
 Arguments: 100, [channel#40 ASC NULLS FIRST, id#41 ASC NULLS FIRST], [channel#40, id#41, sales#148, returns#149, profit#150]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q5a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q5a.sf100/simplified.txt
@@ -1,165 +1,157 @@
 TakeOrderedAndProject [channel,id,sales,returns,profit]
-  WholeStageCodegen (78)
+  WholeStageCodegen (76)
     HashAggregate [channel,id,sales,returns,profit]
       InputAdapter
         Exchange [channel,id,sales,returns,profit] #1
-          WholeStageCodegen (77)
+          WholeStageCodegen (75)
             HashAggregate [channel,id,sales,returns,profit]
               InputAdapter
                 Union
-                  WholeStageCodegen (51)
-                    HashAggregate [channel,id,sales,returns,profit]
+                  WholeStageCodegen (24)
+                    HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                       InputAdapter
-                        Exchange [channel,id,sales,returns,profit] #2
-                          WholeStageCodegen (50)
-                            HashAggregate [channel,id,sales,returns,profit]
+                        Exchange [channel,id] #2
+                          WholeStageCodegen (23)
+                            HashAggregate [channel,id,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                               InputAdapter
                                 Union
-                                  WholeStageCodegen (24)
-                                    HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                                  WholeStageCodegen (6)
+                                    HashAggregate [s_store_id,sum,sum,sum,sum] [sum(UnscaledValue(sales_price)),sum(UnscaledValue(return_amt)),sum(UnscaledValue(profit)),sum(UnscaledValue(net_loss)),channel,id,sales,returns,profit,sum,sum,sum,sum]
                                       InputAdapter
-                                        Exchange [channel,id] #3
-                                          WholeStageCodegen (23)
-                                            HashAggregate [channel,id,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
-                                              InputAdapter
-                                                Union
-                                                  WholeStageCodegen (6)
-                                                    HashAggregate [s_store_id,sum,sum,sum,sum] [sum(UnscaledValue(sales_price)),sum(UnscaledValue(return_amt)),sum(UnscaledValue(profit)),sum(UnscaledValue(net_loss)),channel,id,sales,returns,profit,sum,sum,sum,sum]
+                                        Exchange [s_store_id] #3
+                                          WholeStageCodegen (5)
+                                            HashAggregate [s_store_id,sales_price,return_amt,profit,net_loss] [sum,sum,sum,sum,sum,sum,sum,sum]
+                                              Project [sales_price,profit,return_amt,net_loss,s_store_id]
+                                                BroadcastHashJoin [store_sk,s_store_sk]
+                                                  Project [store_sk,sales_price,profit,return_amt,net_loss]
+                                                    BroadcastHashJoin [date_sk,d_date_sk]
                                                       InputAdapter
-                                                        Exchange [s_store_id] #4
-                                                          WholeStageCodegen (5)
-                                                            HashAggregate [s_store_id,sales_price,return_amt,profit,net_loss] [sum,sum,sum,sum,sum,sum,sum,sum]
-                                                              Project [sales_price,profit,return_amt,net_loss,s_store_id]
-                                                                BroadcastHashJoin [store_sk,s_store_sk]
-                                                                  Project [store_sk,sales_price,profit,return_amt,net_loss]
-                                                                    BroadcastHashJoin [date_sk,d_date_sk]
-                                                                      InputAdapter
-                                                                        Union
-                                                                          WholeStageCodegen (1)
-                                                                            Project [ss_store_sk,ss_sold_date_sk,ss_ext_sales_price,ss_net_profit]
-                                                                              Filter [ss_sold_date_sk,ss_store_sk]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet default.store_sales [ss_sold_date_sk,ss_store_sk,ss_ext_sales_price,ss_net_profit]
-                                                                          WholeStageCodegen (2)
-                                                                            Project [sr_store_sk,sr_returned_date_sk,sr_return_amt,sr_net_loss]
-                                                                              Filter [sr_returned_date_sk,sr_store_sk]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet default.store_returns [sr_returned_date_sk,sr_store_sk,sr_return_amt,sr_net_loss]
-                                                                      InputAdapter
-                                                                        BroadcastExchange #5
-                                                                          WholeStageCodegen (3)
-                                                                            Project [d_date_sk]
-                                                                              Filter [d_date,d_date_sk]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet default.date_dim [d_date_sk,d_date]
+                                                        Union
+                                                          WholeStageCodegen (1)
+                                                            Project [ss_store_sk,ss_sold_date_sk,ss_ext_sales_price,ss_net_profit]
+                                                              Filter [ss_sold_date_sk,ss_store_sk]
+                                                                ColumnarToRow
                                                                   InputAdapter
-                                                                    BroadcastExchange #6
-                                                                      WholeStageCodegen (4)
-                                                                        Filter [s_store_sk]
-                                                                          ColumnarToRow
-                                                                            InputAdapter
-                                                                              Scan parquet default.store [s_store_sk,s_store_id]
-                                                  WholeStageCodegen (12)
-                                                    HashAggregate [cp_catalog_page_id,sum,sum,sum,sum] [sum(UnscaledValue(sales_price)),sum(UnscaledValue(return_amt)),sum(UnscaledValue(profit)),sum(UnscaledValue(net_loss)),channel,id,sales,returns,profit,sum,sum,sum,sum]
+                                                                    Scan parquet default.store_sales [ss_sold_date_sk,ss_store_sk,ss_ext_sales_price,ss_net_profit]
+                                                          WholeStageCodegen (2)
+                                                            Project [sr_store_sk,sr_returned_date_sk,sr_return_amt,sr_net_loss]
+                                                              Filter [sr_returned_date_sk,sr_store_sk]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet default.store_returns [sr_returned_date_sk,sr_store_sk,sr_return_amt,sr_net_loss]
                                                       InputAdapter
-                                                        Exchange [cp_catalog_page_id] #7
-                                                          WholeStageCodegen (11)
-                                                            HashAggregate [cp_catalog_page_id,sales_price,return_amt,profit,net_loss] [sum,sum,sum,sum,sum,sum,sum,sum]
-                                                              Project [sales_price,profit,return_amt,net_loss,cp_catalog_page_id]
-                                                                BroadcastHashJoin [page_sk,cp_catalog_page_sk]
-                                                                  Project [page_sk,sales_price,profit,return_amt,net_loss]
-                                                                    BroadcastHashJoin [date_sk,d_date_sk]
-                                                                      InputAdapter
-                                                                        Union
-                                                                          WholeStageCodegen (7)
-                                                                            Project [cs_catalog_page_sk,cs_sold_date_sk,cs_ext_sales_price,cs_net_profit]
-                                                                              Filter [cs_sold_date_sk,cs_catalog_page_sk]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet default.catalog_sales [cs_sold_date_sk,cs_catalog_page_sk,cs_ext_sales_price,cs_net_profit]
-                                                                          WholeStageCodegen (8)
-                                                                            Project [cr_catalog_page_sk,cr_returned_date_sk,cr_return_amount,cr_net_loss]
-                                                                              Filter [cr_returned_date_sk,cr_catalog_page_sk]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet default.catalog_returns [cr_returned_date_sk,cr_catalog_page_sk,cr_return_amount,cr_net_loss]
-                                                                      InputAdapter
-                                                                        ReusedExchange [d_date_sk] #5
+                                                        BroadcastExchange #4
+                                                          WholeStageCodegen (3)
+                                                            Project [d_date_sk]
+                                                              Filter [d_date,d_date_sk]
+                                                                ColumnarToRow
                                                                   InputAdapter
-                                                                    BroadcastExchange #8
-                                                                      WholeStageCodegen (10)
-                                                                        Filter [cp_catalog_page_sk]
-                                                                          ColumnarToRow
-                                                                            InputAdapter
-                                                                              Scan parquet default.catalog_page [cp_catalog_page_sk,cp_catalog_page_id]
-                                                  WholeStageCodegen (22)
-                                                    HashAggregate [web_site_id,sum,sum,sum,sum] [sum(UnscaledValue(sales_price)),sum(UnscaledValue(return_amt)),sum(UnscaledValue(profit)),sum(UnscaledValue(net_loss)),channel,id,sales,returns,profit,sum,sum,sum,sum]
-                                                      InputAdapter
-                                                        Exchange [web_site_id] #9
-                                                          WholeStageCodegen (21)
-                                                            HashAggregate [web_site_id,sales_price,return_amt,profit,net_loss] [sum,sum,sum,sum,sum,sum,sum,sum]
-                                                              Project [sales_price,profit,return_amt,net_loss,web_site_id]
-                                                                BroadcastHashJoin [wsr_web_site_sk,web_site_sk]
-                                                                  Project [wsr_web_site_sk,sales_price,profit,return_amt,net_loss]
-                                                                    BroadcastHashJoin [date_sk,d_date_sk]
-                                                                      InputAdapter
-                                                                        Union
-                                                                          WholeStageCodegen (13)
-                                                                            Project [ws_web_site_sk,ws_sold_date_sk,ws_ext_sales_price,ws_net_profit]
-                                                                              Filter [ws_sold_date_sk,ws_web_site_sk]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet default.web_sales [ws_sold_date_sk,ws_web_site_sk,ws_ext_sales_price,ws_net_profit]
-                                                                          WholeStageCodegen (18)
-                                                                            Project [ws_web_site_sk,wr_returned_date_sk,wr_return_amt,wr_net_loss]
-                                                                              SortMergeJoin [wr_item_sk,wr_order_number,ws_item_sk,ws_order_number]
-                                                                                InputAdapter
-                                                                                  WholeStageCodegen (15)
-                                                                                    Sort [wr_item_sk,wr_order_number]
-                                                                                      InputAdapter
-                                                                                        Exchange [wr_item_sk,wr_order_number] #10
-                                                                                          WholeStageCodegen (14)
-                                                                                            Filter [wr_returned_date_sk]
-                                                                                              ColumnarToRow
-                                                                                                InputAdapter
-                                                                                                  Scan parquet default.web_returns [wr_returned_date_sk,wr_item_sk,wr_order_number,wr_return_amt,wr_net_loss]
-                                                                                InputAdapter
-                                                                                  WholeStageCodegen (17)
-                                                                                    Sort [ws_item_sk,ws_order_number]
-                                                                                      InputAdapter
-                                                                                        Exchange [ws_item_sk,ws_order_number] #11
-                                                                                          WholeStageCodegen (16)
-                                                                                            Filter [ws_item_sk,ws_order_number,ws_web_site_sk]
-                                                                                              ColumnarToRow
-                                                                                                InputAdapter
-                                                                                                  Scan parquet default.web_sales [ws_item_sk,ws_web_site_sk,ws_order_number]
-                                                                      InputAdapter
-                                                                        ReusedExchange [d_date_sk] #5
-                                                                  InputAdapter
-                                                                    BroadcastExchange #12
-                                                                      WholeStageCodegen (20)
-                                                                        Filter [web_site_sk]
-                                                                          ColumnarToRow
-                                                                            InputAdapter
-                                                                              Scan parquet default.web_site [web_site_sk,web_site_id]
-                                  WholeStageCodegen (49)
-                                    HashAggregate [channel,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),id,sum(sales),sum(returns),sum(profit),sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                                                                    Scan parquet default.date_dim [d_date_sk,d_date]
+                                                  InputAdapter
+                                                    BroadcastExchange #5
+                                                      WholeStageCodegen (4)
+                                                        Filter [s_store_sk]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet default.store [s_store_sk,s_store_id]
+                                  WholeStageCodegen (12)
+                                    HashAggregate [cp_catalog_page_id,sum,sum,sum,sum] [sum(UnscaledValue(sales_price)),sum(UnscaledValue(return_amt)),sum(UnscaledValue(profit)),sum(UnscaledValue(net_loss)),channel,id,sales,returns,profit,sum,sum,sum,sum]
                                       InputAdapter
-                                        Exchange [channel] #13
-                                          WholeStageCodegen (48)
-                                            HashAggregate [channel,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
-                                              HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
-                                                InputAdapter
-                                                  ReusedExchange [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] #3
-                  WholeStageCodegen (76)
+                                        Exchange [cp_catalog_page_id] #6
+                                          WholeStageCodegen (11)
+                                            HashAggregate [cp_catalog_page_id,sales_price,return_amt,profit,net_loss] [sum,sum,sum,sum,sum,sum,sum,sum]
+                                              Project [sales_price,profit,return_amt,net_loss,cp_catalog_page_id]
+                                                BroadcastHashJoin [page_sk,cp_catalog_page_sk]
+                                                  Project [page_sk,sales_price,profit,return_amt,net_loss]
+                                                    BroadcastHashJoin [date_sk,d_date_sk]
+                                                      InputAdapter
+                                                        Union
+                                                          WholeStageCodegen (7)
+                                                            Project [cs_catalog_page_sk,cs_sold_date_sk,cs_ext_sales_price,cs_net_profit]
+                                                              Filter [cs_sold_date_sk,cs_catalog_page_sk]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet default.catalog_sales [cs_sold_date_sk,cs_catalog_page_sk,cs_ext_sales_price,cs_net_profit]
+                                                          WholeStageCodegen (8)
+                                                            Project [cr_catalog_page_sk,cr_returned_date_sk,cr_return_amount,cr_net_loss]
+                                                              Filter [cr_returned_date_sk,cr_catalog_page_sk]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet default.catalog_returns [cr_returned_date_sk,cr_catalog_page_sk,cr_return_amount,cr_net_loss]
+                                                      InputAdapter
+                                                        ReusedExchange [d_date_sk] #4
+                                                  InputAdapter
+                                                    BroadcastExchange #7
+                                                      WholeStageCodegen (10)
+                                                        Filter [cp_catalog_page_sk]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet default.catalog_page [cp_catalog_page_sk,cp_catalog_page_id]
+                                  WholeStageCodegen (22)
+                                    HashAggregate [web_site_id,sum,sum,sum,sum] [sum(UnscaledValue(sales_price)),sum(UnscaledValue(return_amt)),sum(UnscaledValue(profit)),sum(UnscaledValue(net_loss)),channel,id,sales,returns,profit,sum,sum,sum,sum]
+                                      InputAdapter
+                                        Exchange [web_site_id] #8
+                                          WholeStageCodegen (21)
+                                            HashAggregate [web_site_id,sales_price,return_amt,profit,net_loss] [sum,sum,sum,sum,sum,sum,sum,sum]
+                                              Project [sales_price,profit,return_amt,net_loss,web_site_id]
+                                                BroadcastHashJoin [wsr_web_site_sk,web_site_sk]
+                                                  Project [wsr_web_site_sk,sales_price,profit,return_amt,net_loss]
+                                                    BroadcastHashJoin [date_sk,d_date_sk]
+                                                      InputAdapter
+                                                        Union
+                                                          WholeStageCodegen (13)
+                                                            Project [ws_web_site_sk,ws_sold_date_sk,ws_ext_sales_price,ws_net_profit]
+                                                              Filter [ws_sold_date_sk,ws_web_site_sk]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet default.web_sales [ws_sold_date_sk,ws_web_site_sk,ws_ext_sales_price,ws_net_profit]
+                                                          WholeStageCodegen (18)
+                                                            Project [ws_web_site_sk,wr_returned_date_sk,wr_return_amt,wr_net_loss]
+                                                              SortMergeJoin [wr_item_sk,wr_order_number,ws_item_sk,ws_order_number]
+                                                                InputAdapter
+                                                                  WholeStageCodegen (15)
+                                                                    Sort [wr_item_sk,wr_order_number]
+                                                                      InputAdapter
+                                                                        Exchange [wr_item_sk,wr_order_number] #9
+                                                                          WholeStageCodegen (14)
+                                                                            Filter [wr_returned_date_sk]
+                                                                              ColumnarToRow
+                                                                                InputAdapter
+                                                                                  Scan parquet default.web_returns [wr_returned_date_sk,wr_item_sk,wr_order_number,wr_return_amt,wr_net_loss]
+                                                                InputAdapter
+                                                                  WholeStageCodegen (17)
+                                                                    Sort [ws_item_sk,ws_order_number]
+                                                                      InputAdapter
+                                                                        Exchange [ws_item_sk,ws_order_number] #10
+                                                                          WholeStageCodegen (16)
+                                                                            Filter [ws_item_sk,ws_order_number,ws_web_site_sk]
+                                                                              ColumnarToRow
+                                                                                InputAdapter
+                                                                                  Scan parquet default.web_sales [ws_item_sk,ws_web_site_sk,ws_order_number]
+                                                      InputAdapter
+                                                        ReusedExchange [d_date_sk] #4
+                                                  InputAdapter
+                                                    BroadcastExchange #11
+                                                      WholeStageCodegen (20)
+                                                        Filter [web_site_sk]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet default.web_site [web_site_sk,web_site_id]
+                  WholeStageCodegen (49)
+                    HashAggregate [channel,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),id,sum(sales),sum(returns),sum(profit),sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                      InputAdapter
+                        Exchange [channel] #12
+                          WholeStageCodegen (48)
+                            HashAggregate [channel,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                              HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                                InputAdapter
+                                  ReusedExchange [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] #2
+                  WholeStageCodegen (74)
                     HashAggregate [sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),channel,id,sum(sales),sum(returns),sum(profit),sum,isEmpty,sum,isEmpty,sum,isEmpty]
                       InputAdapter
-                        Exchange #14
-                          WholeStageCodegen (75)
+                        Exchange #13
+                          WholeStageCodegen (73)
                             HashAggregate [sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                               HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                                 InputAdapter
-                                  ReusedExchange [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] #3
+                                  ReusedExchange [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] #2

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q5a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q5a/explain.txt
@@ -1,99 +1,95 @@
 == Physical Plan ==
-TakeOrderedAndProject (95)
-+- * HashAggregate (94)
-   +- Exchange (93)
-      +- * HashAggregate (92)
-         +- Union (91)
-            :- * HashAggregate (85)
-            :  +- Exchange (84)
-            :     +- * HashAggregate (83)
-            :        +- Union (82)
-            :           :- * HashAggregate (76)
-            :           :  +- Exchange (75)
-            :           :     +- * HashAggregate (74)
-            :           :        +- Union (73)
-            :           :           :- * HashAggregate (25)
-            :           :           :  +- Exchange (24)
-            :           :           :     +- * HashAggregate (23)
-            :           :           :        +- * Project (22)
-            :           :           :           +- * BroadcastHashJoin Inner BuildRight (21)
-            :           :           :              :- * Project (16)
-            :           :           :              :  +- * BroadcastHashJoin Inner BuildRight (15)
-            :           :           :              :     :- Union (9)
-            :           :           :              :     :  :- * Project (4)
-            :           :           :              :     :  :  +- * Filter (3)
-            :           :           :              :     :  :     +- * ColumnarToRow (2)
-            :           :           :              :     :  :        +- Scan parquet default.store_sales (1)
-            :           :           :              :     :  +- * Project (8)
-            :           :           :              :     :     +- * Filter (7)
-            :           :           :              :     :        +- * ColumnarToRow (6)
-            :           :           :              :     :           +- Scan parquet default.store_returns (5)
-            :           :           :              :     +- BroadcastExchange (14)
-            :           :           :              :        +- * Project (13)
-            :           :           :              :           +- * Filter (12)
-            :           :           :              :              +- * ColumnarToRow (11)
-            :           :           :              :                 +- Scan parquet default.date_dim (10)
-            :           :           :              +- BroadcastExchange (20)
-            :           :           :                 +- * Filter (19)
-            :           :           :                    +- * ColumnarToRow (18)
-            :           :           :                       +- Scan parquet default.store (17)
-            :           :           :- * HashAggregate (46)
-            :           :           :  +- Exchange (45)
-            :           :           :     +- * HashAggregate (44)
-            :           :           :        +- * Project (43)
-            :           :           :           +- * BroadcastHashJoin Inner BuildRight (42)
-            :           :           :              :- * Project (37)
-            :           :           :              :  +- * BroadcastHashJoin Inner BuildRight (36)
-            :           :           :              :     :- Union (34)
-            :           :           :              :     :  :- * Project (29)
-            :           :           :              :     :  :  +- * Filter (28)
-            :           :           :              :     :  :     +- * ColumnarToRow (27)
-            :           :           :              :     :  :        +- Scan parquet default.catalog_sales (26)
-            :           :           :              :     :  +- * Project (33)
-            :           :           :              :     :     +- * Filter (32)
-            :           :           :              :     :        +- * ColumnarToRow (31)
-            :           :           :              :     :           +- Scan parquet default.catalog_returns (30)
-            :           :           :              :     +- ReusedExchange (35)
-            :           :           :              +- BroadcastExchange (41)
-            :           :           :                 +- * Filter (40)
-            :           :           :                    +- * ColumnarToRow (39)
-            :           :           :                       +- Scan parquet default.catalog_page (38)
-            :           :           +- * HashAggregate (72)
-            :           :              +- Exchange (71)
-            :           :                 +- * HashAggregate (70)
-            :           :                    +- * Project (69)
-            :           :                       +- * BroadcastHashJoin Inner BuildRight (68)
-            :           :                          :- * Project (63)
-            :           :                          :  +- * BroadcastHashJoin Inner BuildRight (62)
-            :           :                          :     :- Union (60)
-            :           :                          :     :  :- * Project (50)
-            :           :                          :     :  :  +- * Filter (49)
-            :           :                          :     :  :     +- * ColumnarToRow (48)
-            :           :                          :     :  :        +- Scan parquet default.web_sales (47)
-            :           :                          :     :  +- * Project (59)
-            :           :                          :     :     +- * BroadcastHashJoin Inner BuildRight (58)
-            :           :                          :     :        :- * Filter (53)
-            :           :                          :     :        :  +- * ColumnarToRow (52)
-            :           :                          :     :        :     +- Scan parquet default.web_returns (51)
-            :           :                          :     :        +- BroadcastExchange (57)
-            :           :                          :     :           +- * Filter (56)
-            :           :                          :     :              +- * ColumnarToRow (55)
-            :           :                          :     :                 +- Scan parquet default.web_sales (54)
-            :           :                          :     +- ReusedExchange (61)
-            :           :                          +- BroadcastExchange (67)
-            :           :                             +- * Filter (66)
-            :           :                                +- * ColumnarToRow (65)
-            :           :                                   +- Scan parquet default.web_site (64)
-            :           +- * HashAggregate (81)
-            :              +- Exchange (80)
-            :                 +- * HashAggregate (79)
-            :                    +- * HashAggregate (78)
-            :                       +- ReusedExchange (77)
-            +- * HashAggregate (90)
-               +- Exchange (89)
-                  +- * HashAggregate (88)
-                     +- * HashAggregate (87)
-                        +- ReusedExchange (86)
+TakeOrderedAndProject (91)
++- * HashAggregate (90)
+   +- Exchange (89)
+      +- * HashAggregate (88)
+         +- Union (87)
+            :- * HashAggregate (76)
+            :  +- Exchange (75)
+            :     +- * HashAggregate (74)
+            :        +- Union (73)
+            :           :- * HashAggregate (25)
+            :           :  +- Exchange (24)
+            :           :     +- * HashAggregate (23)
+            :           :        +- * Project (22)
+            :           :           +- * BroadcastHashJoin Inner BuildRight (21)
+            :           :              :- * Project (16)
+            :           :              :  +- * BroadcastHashJoin Inner BuildRight (15)
+            :           :              :     :- Union (9)
+            :           :              :     :  :- * Project (4)
+            :           :              :     :  :  +- * Filter (3)
+            :           :              :     :  :     +- * ColumnarToRow (2)
+            :           :              :     :  :        +- Scan parquet default.store_sales (1)
+            :           :              :     :  +- * Project (8)
+            :           :              :     :     +- * Filter (7)
+            :           :              :     :        +- * ColumnarToRow (6)
+            :           :              :     :           +- Scan parquet default.store_returns (5)
+            :           :              :     +- BroadcastExchange (14)
+            :           :              :        +- * Project (13)
+            :           :              :           +- * Filter (12)
+            :           :              :              +- * ColumnarToRow (11)
+            :           :              :                 +- Scan parquet default.date_dim (10)
+            :           :              +- BroadcastExchange (20)
+            :           :                 +- * Filter (19)
+            :           :                    +- * ColumnarToRow (18)
+            :           :                       +- Scan parquet default.store (17)
+            :           :- * HashAggregate (46)
+            :           :  +- Exchange (45)
+            :           :     +- * HashAggregate (44)
+            :           :        +- * Project (43)
+            :           :           +- * BroadcastHashJoin Inner BuildRight (42)
+            :           :              :- * Project (37)
+            :           :              :  +- * BroadcastHashJoin Inner BuildRight (36)
+            :           :              :     :- Union (34)
+            :           :              :     :  :- * Project (29)
+            :           :              :     :  :  +- * Filter (28)
+            :           :              :     :  :     +- * ColumnarToRow (27)
+            :           :              :     :  :        +- Scan parquet default.catalog_sales (26)
+            :           :              :     :  +- * Project (33)
+            :           :              :     :     +- * Filter (32)
+            :           :              :     :        +- * ColumnarToRow (31)
+            :           :              :     :           +- Scan parquet default.catalog_returns (30)
+            :           :              :     +- ReusedExchange (35)
+            :           :              +- BroadcastExchange (41)
+            :           :                 +- * Filter (40)
+            :           :                    +- * ColumnarToRow (39)
+            :           :                       +- Scan parquet default.catalog_page (38)
+            :           +- * HashAggregate (72)
+            :              +- Exchange (71)
+            :                 +- * HashAggregate (70)
+            :                    +- * Project (69)
+            :                       +- * BroadcastHashJoin Inner BuildRight (68)
+            :                          :- * Project (63)
+            :                          :  +- * BroadcastHashJoin Inner BuildRight (62)
+            :                          :     :- Union (60)
+            :                          :     :  :- * Project (50)
+            :                          :     :  :  +- * Filter (49)
+            :                          :     :  :     +- * ColumnarToRow (48)
+            :                          :     :  :        +- Scan parquet default.web_sales (47)
+            :                          :     :  +- * Project (59)
+            :                          :     :     +- * BroadcastHashJoin Inner BuildRight (58)
+            :                          :     :        :- * Filter (53)
+            :                          :     :        :  +- * ColumnarToRow (52)
+            :                          :     :        :     +- Scan parquet default.web_returns (51)
+            :                          :     :        +- BroadcastExchange (57)
+            :                          :     :           +- * Filter (56)
+            :                          :     :              +- * ColumnarToRow (55)
+            :                          :     :                 +- Scan parquet default.web_sales (54)
+            :                          :     +- ReusedExchange (61)
+            :                          +- BroadcastExchange (67)
+            :                             +- * Filter (66)
+            :                                +- * ColumnarToRow (65)
+            :                                   +- Scan parquet default.web_site (64)
+            :- * HashAggregate (81)
+            :  +- Exchange (80)
+            :     +- * HashAggregate (79)
+            :        +- * HashAggregate (78)
+            :           +- ReusedExchange (77)
+            +- * HashAggregate (86)
+               +- Exchange (85)
+                  +- * HashAggregate (84)
+                     +- * HashAggregate (83)
+                        +- ReusedExchange (82)
 
 
 (1) Scan parquet default.store_sales
@@ -200,7 +196,7 @@ Results [5]: [s_store_id#25, sum#31, sum#32, sum#33, sum#34]
 
 (24) Exchange
 Input [5]: [s_store_id#25, sum#31, sum#32, sum#33, sum#34]
-Arguments: hashpartitioning(s_store_id#25, 5), true, [id=#35]
+Arguments: hashpartitioning(s_store_id#25, 5), ENSURE_REQUIREMENTS, [id=#35]
 
 (25) HashAggregate [codegen id : 6]
 Input [5]: [s_store_id#25, sum#31, sum#32, sum#33, sum#34]
@@ -295,7 +291,7 @@ Results [5]: [cp_catalog_page_id#66, sum#72, sum#73, sum#74, sum#75]
 
 (45) Exchange
 Input [5]: [cp_catalog_page_id#66, sum#72, sum#73, sum#74, sum#75]
-Arguments: hashpartitioning(cp_catalog_page_id#66, 5), true, [id=#76]
+Arguments: hashpartitioning(cp_catalog_page_id#66, 5), ENSURE_REQUIREMENTS, [id=#76]
 
 (46) HashAggregate [codegen id : 12]
 Input [5]: [cp_catalog_page_id#66, sum#72, sum#73, sum#74, sum#75]
@@ -413,7 +409,7 @@ Results [5]: [web_site_id#111, sum#117, sum#118, sum#119, sum#120]
 
 (71) Exchange
 Input [5]: [web_site_id#111, sum#117, sum#118, sum#119, sum#120]
-Arguments: hashpartitioning(web_site_id#111, 5), true, [id=#121]
+Arguments: hashpartitioning(web_site_id#111, 5), ENSURE_REQUIREMENTS, [id=#121]
 
 (72) HashAggregate [codegen id : 19]
 Input [5]: [web_site_id#111, sum#117, sum#118, sum#119, sum#120]
@@ -433,7 +429,7 @@ Results [8]: [channel#40, id#41, sum#137, isEmpty#138, sum#139, isEmpty#140, sum
 
 (75) Exchange
 Input [8]: [channel#40, id#41, sum#137, isEmpty#138, sum#139, isEmpty#140, sum#141, isEmpty#142]
-Arguments: hashpartitioning(channel#40, id#41, 5), true, [id=#143]
+Arguments: hashpartitioning(channel#40, id#41, 5), ENSURE_REQUIREMENTS, [id=#143]
 
 (76) HashAggregate [codegen id : 21]
 Input [8]: [channel#40, id#41, sum#137, isEmpty#138, sum#139, isEmpty#140, sum#141, isEmpty#142]
@@ -461,7 +457,7 @@ Results [7]: [channel#40, sum#169, isEmpty#170, sum#171, isEmpty#172, sum#173, i
 
 (80) Exchange
 Input [7]: [channel#40, sum#169, isEmpty#170, sum#171, isEmpty#172, sum#173, isEmpty#174]
-Arguments: hashpartitioning(channel#40, 5), true, [id=#175]
+Arguments: hashpartitioning(channel#40, 5), ENSURE_REQUIREMENTS, [id=#175]
 
 (81) HashAggregate [codegen id : 43]
 Input [7]: [channel#40, sum#169, isEmpty#170, sum#171, isEmpty#172, sum#173, isEmpty#174]
@@ -470,75 +466,55 @@ Functions [3]: [sum(sales#160), sum(returns#161), sum(profit#162)]
 Aggregate Attributes [3]: [sum(sales#160)#176, sum(returns#161)#177, sum(profit#162)#178]
 Results [5]: [channel#40, null AS id#179, sum(sales#160)#176 AS sum(sales)#180, sum(returns#161)#177 AS sum(returns)#181, sum(profit#162)#178 AS sum(profit)#182]
 
-(82) Union
+(82) ReusedExchange [Reuses operator id: 75]
+Output [8]: [channel#40, id#41, sum#183, isEmpty#184, sum#185, isEmpty#186, sum#187, isEmpty#188]
 
-(83) HashAggregate [codegen id : 44]
-Input [5]: [channel#40, id#41, sales#147, returns#148, profit#149]
-Keys [5]: [channel#40, id#41, sales#147, returns#148, profit#149]
-Functions: []
-Aggregate Attributes: []
-Results [5]: [channel#40, id#41, sales#147, returns#148, profit#149]
-
-(84) Exchange
-Input [5]: [channel#40, id#41, sales#147, returns#148, profit#149]
-Arguments: hashpartitioning(channel#40, id#41, sales#147, returns#148, profit#149, 5), true, [id=#183]
-
-(85) HashAggregate [codegen id : 45]
-Input [5]: [channel#40, id#41, sales#147, returns#148, profit#149]
-Keys [5]: [channel#40, id#41, sales#147, returns#148, profit#149]
-Functions: []
-Aggregate Attributes: []
-Results [5]: [channel#40, id#41, sales#147, returns#148, profit#149]
-
-(86) ReusedExchange [Reuses operator id: 75]
-Output [8]: [channel#40, id#41, sum#184, isEmpty#185, sum#186, isEmpty#187, sum#188, isEmpty#189]
-
-(87) HashAggregate [codegen id : 66]
-Input [8]: [channel#40, id#41, sum#184, isEmpty#185, sum#186, isEmpty#187, sum#188, isEmpty#189]
+(83) HashAggregate [codegen id : 64]
+Input [8]: [channel#40, id#41, sum#183, isEmpty#184, sum#185, isEmpty#186, sum#187, isEmpty#188]
 Keys [2]: [channel#40, id#41]
-Functions [3]: [sum(sales#42), sum(returns#43), sum(profit#190)]
-Aggregate Attributes [3]: [sum(sales#42)#191, sum(returns#43)#192, sum(profit#190)#193]
-Results [3]: [sum(sales#42)#191 AS sales#160, sum(returns#43)#192 AS returns#161, sum(profit#190)#193 AS profit#162]
+Functions [3]: [sum(sales#42), sum(returns#43), sum(profit#189)]
+Aggregate Attributes [3]: [sum(sales#42)#190, sum(returns#43)#191, sum(profit#189)#192]
+Results [3]: [sum(sales#42)#190 AS sales#160, sum(returns#43)#191 AS returns#161, sum(profit#189)#192 AS profit#162]
 
-(88) HashAggregate [codegen id : 66]
+(84) HashAggregate [codegen id : 64]
 Input [3]: [sales#160, returns#161, profit#162]
 Keys: []
 Functions [3]: [partial_sum(sales#160), partial_sum(returns#161), partial_sum(profit#162)]
-Aggregate Attributes [6]: [sum#194, isEmpty#195, sum#196, isEmpty#197, sum#198, isEmpty#199]
-Results [6]: [sum#200, isEmpty#201, sum#202, isEmpty#203, sum#204, isEmpty#205]
+Aggregate Attributes [6]: [sum#193, isEmpty#194, sum#195, isEmpty#196, sum#197, isEmpty#198]
+Results [6]: [sum#199, isEmpty#200, sum#201, isEmpty#202, sum#203, isEmpty#204]
 
-(89) Exchange
-Input [6]: [sum#200, isEmpty#201, sum#202, isEmpty#203, sum#204, isEmpty#205]
-Arguments: SinglePartition, true, [id=#206]
+(85) Exchange
+Input [6]: [sum#199, isEmpty#200, sum#201, isEmpty#202, sum#203, isEmpty#204]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#205]
 
-(90) HashAggregate [codegen id : 67]
-Input [6]: [sum#200, isEmpty#201, sum#202, isEmpty#203, sum#204, isEmpty#205]
+(86) HashAggregate [codegen id : 65]
+Input [6]: [sum#199, isEmpty#200, sum#201, isEmpty#202, sum#203, isEmpty#204]
 Keys: []
 Functions [3]: [sum(sales#160), sum(returns#161), sum(profit#162)]
-Aggregate Attributes [3]: [sum(sales#160)#207, sum(returns#161)#208, sum(profit#162)#209]
-Results [5]: [null AS channel#210, null AS id#211, sum(sales#160)#207 AS sum(sales)#212, sum(returns#161)#208 AS sum(returns)#213, sum(profit#162)#209 AS sum(profit)#214]
+Aggregate Attributes [3]: [sum(sales#160)#206, sum(returns#161)#207, sum(profit#162)#208]
+Results [5]: [null AS channel#209, null AS id#210, sum(sales#160)#206 AS sum(sales)#211, sum(returns#161)#207 AS sum(returns)#212, sum(profit#162)#208 AS sum(profit)#213]
 
-(91) Union
+(87) Union
 
-(92) HashAggregate [codegen id : 68]
+(88) HashAggregate [codegen id : 66]
 Input [5]: [channel#40, id#41, sales#147, returns#148, profit#149]
 Keys [5]: [channel#40, id#41, sales#147, returns#148, profit#149]
 Functions: []
 Aggregate Attributes: []
 Results [5]: [channel#40, id#41, sales#147, returns#148, profit#149]
 
-(93) Exchange
+(89) Exchange
 Input [5]: [channel#40, id#41, sales#147, returns#148, profit#149]
-Arguments: hashpartitioning(channel#40, id#41, sales#147, returns#148, profit#149, 5), true, [id=#215]
+Arguments: hashpartitioning(channel#40, id#41, sales#147, returns#148, profit#149, 5), ENSURE_REQUIREMENTS, [id=#214]
 
-(94) HashAggregate [codegen id : 69]
+(90) HashAggregate [codegen id : 67]
 Input [5]: [channel#40, id#41, sales#147, returns#148, profit#149]
 Keys [5]: [channel#40, id#41, sales#147, returns#148, profit#149]
 Functions: []
 Aggregate Attributes: []
 Results [5]: [channel#40, id#41, sales#147, returns#148, profit#149]
 
-(95) TakeOrderedAndProject
+(91) TakeOrderedAndProject
 Input [5]: [channel#40, id#41, sales#147, returns#148, profit#149]
 Arguments: 100, [channel#40 ASC NULLS FIRST, id#41 ASC NULLS FIRST], [channel#40, id#41, sales#147, returns#148, profit#149]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q5a/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q5a/simplified.txt
@@ -1,156 +1,148 @@
 TakeOrderedAndProject [channel,id,sales,returns,profit]
-  WholeStageCodegen (69)
+  WholeStageCodegen (67)
     HashAggregate [channel,id,sales,returns,profit]
       InputAdapter
         Exchange [channel,id,sales,returns,profit] #1
-          WholeStageCodegen (68)
+          WholeStageCodegen (66)
             HashAggregate [channel,id,sales,returns,profit]
               InputAdapter
                 Union
-                  WholeStageCodegen (45)
-                    HashAggregate [channel,id,sales,returns,profit]
+                  WholeStageCodegen (21)
+                    HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                       InputAdapter
-                        Exchange [channel,id,sales,returns,profit] #2
-                          WholeStageCodegen (44)
-                            HashAggregate [channel,id,sales,returns,profit]
+                        Exchange [channel,id] #2
+                          WholeStageCodegen (20)
+                            HashAggregate [channel,id,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                               InputAdapter
                                 Union
-                                  WholeStageCodegen (21)
-                                    HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                                  WholeStageCodegen (6)
+                                    HashAggregate [s_store_id,sum,sum,sum,sum] [sum(UnscaledValue(sales_price)),sum(UnscaledValue(return_amt)),sum(UnscaledValue(profit)),sum(UnscaledValue(net_loss)),channel,id,sales,returns,profit,sum,sum,sum,sum]
                                       InputAdapter
-                                        Exchange [channel,id] #3
-                                          WholeStageCodegen (20)
-                                            HashAggregate [channel,id,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
-                                              InputAdapter
-                                                Union
-                                                  WholeStageCodegen (6)
-                                                    HashAggregate [s_store_id,sum,sum,sum,sum] [sum(UnscaledValue(sales_price)),sum(UnscaledValue(return_amt)),sum(UnscaledValue(profit)),sum(UnscaledValue(net_loss)),channel,id,sales,returns,profit,sum,sum,sum,sum]
+                                        Exchange [s_store_id] #3
+                                          WholeStageCodegen (5)
+                                            HashAggregate [s_store_id,sales_price,return_amt,profit,net_loss] [sum,sum,sum,sum,sum,sum,sum,sum]
+                                              Project [sales_price,profit,return_amt,net_loss,s_store_id]
+                                                BroadcastHashJoin [store_sk,s_store_sk]
+                                                  Project [store_sk,sales_price,profit,return_amt,net_loss]
+                                                    BroadcastHashJoin [date_sk,d_date_sk]
                                                       InputAdapter
-                                                        Exchange [s_store_id] #4
-                                                          WholeStageCodegen (5)
-                                                            HashAggregate [s_store_id,sales_price,return_amt,profit,net_loss] [sum,sum,sum,sum,sum,sum,sum,sum]
-                                                              Project [sales_price,profit,return_amt,net_loss,s_store_id]
-                                                                BroadcastHashJoin [store_sk,s_store_sk]
-                                                                  Project [store_sk,sales_price,profit,return_amt,net_loss]
-                                                                    BroadcastHashJoin [date_sk,d_date_sk]
-                                                                      InputAdapter
-                                                                        Union
-                                                                          WholeStageCodegen (1)
-                                                                            Project [ss_store_sk,ss_sold_date_sk,ss_ext_sales_price,ss_net_profit]
-                                                                              Filter [ss_sold_date_sk,ss_store_sk]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet default.store_sales [ss_sold_date_sk,ss_store_sk,ss_ext_sales_price,ss_net_profit]
-                                                                          WholeStageCodegen (2)
-                                                                            Project [sr_store_sk,sr_returned_date_sk,sr_return_amt,sr_net_loss]
-                                                                              Filter [sr_returned_date_sk,sr_store_sk]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet default.store_returns [sr_returned_date_sk,sr_store_sk,sr_return_amt,sr_net_loss]
-                                                                      InputAdapter
-                                                                        BroadcastExchange #5
-                                                                          WholeStageCodegen (3)
-                                                                            Project [d_date_sk]
-                                                                              Filter [d_date,d_date_sk]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet default.date_dim [d_date_sk,d_date]
+                                                        Union
+                                                          WholeStageCodegen (1)
+                                                            Project [ss_store_sk,ss_sold_date_sk,ss_ext_sales_price,ss_net_profit]
+                                                              Filter [ss_sold_date_sk,ss_store_sk]
+                                                                ColumnarToRow
                                                                   InputAdapter
-                                                                    BroadcastExchange #6
-                                                                      WholeStageCodegen (4)
-                                                                        Filter [s_store_sk]
-                                                                          ColumnarToRow
-                                                                            InputAdapter
-                                                                              Scan parquet default.store [s_store_sk,s_store_id]
-                                                  WholeStageCodegen (12)
-                                                    HashAggregate [cp_catalog_page_id,sum,sum,sum,sum] [sum(UnscaledValue(sales_price)),sum(UnscaledValue(return_amt)),sum(UnscaledValue(profit)),sum(UnscaledValue(net_loss)),channel,id,sales,returns,profit,sum,sum,sum,sum]
+                                                                    Scan parquet default.store_sales [ss_sold_date_sk,ss_store_sk,ss_ext_sales_price,ss_net_profit]
+                                                          WholeStageCodegen (2)
+                                                            Project [sr_store_sk,sr_returned_date_sk,sr_return_amt,sr_net_loss]
+                                                              Filter [sr_returned_date_sk,sr_store_sk]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet default.store_returns [sr_returned_date_sk,sr_store_sk,sr_return_amt,sr_net_loss]
                                                       InputAdapter
-                                                        Exchange [cp_catalog_page_id] #7
-                                                          WholeStageCodegen (11)
-                                                            HashAggregate [cp_catalog_page_id,sales_price,return_amt,profit,net_loss] [sum,sum,sum,sum,sum,sum,sum,sum]
-                                                              Project [sales_price,profit,return_amt,net_loss,cp_catalog_page_id]
-                                                                BroadcastHashJoin [page_sk,cp_catalog_page_sk]
-                                                                  Project [page_sk,sales_price,profit,return_amt,net_loss]
-                                                                    BroadcastHashJoin [date_sk,d_date_sk]
-                                                                      InputAdapter
-                                                                        Union
-                                                                          WholeStageCodegen (7)
-                                                                            Project [cs_catalog_page_sk,cs_sold_date_sk,cs_ext_sales_price,cs_net_profit]
-                                                                              Filter [cs_sold_date_sk,cs_catalog_page_sk]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet default.catalog_sales [cs_sold_date_sk,cs_catalog_page_sk,cs_ext_sales_price,cs_net_profit]
-                                                                          WholeStageCodegen (8)
-                                                                            Project [cr_catalog_page_sk,cr_returned_date_sk,cr_return_amount,cr_net_loss]
-                                                                              Filter [cr_returned_date_sk,cr_catalog_page_sk]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet default.catalog_returns [cr_returned_date_sk,cr_catalog_page_sk,cr_return_amount,cr_net_loss]
-                                                                      InputAdapter
-                                                                        ReusedExchange [d_date_sk] #5
+                                                        BroadcastExchange #4
+                                                          WholeStageCodegen (3)
+                                                            Project [d_date_sk]
+                                                              Filter [d_date,d_date_sk]
+                                                                ColumnarToRow
                                                                   InputAdapter
-                                                                    BroadcastExchange #8
-                                                                      WholeStageCodegen (10)
-                                                                        Filter [cp_catalog_page_sk]
-                                                                          ColumnarToRow
-                                                                            InputAdapter
-                                                                              Scan parquet default.catalog_page [cp_catalog_page_sk,cp_catalog_page_id]
-                                                  WholeStageCodegen (19)
-                                                    HashAggregate [web_site_id,sum,sum,sum,sum] [sum(UnscaledValue(sales_price)),sum(UnscaledValue(return_amt)),sum(UnscaledValue(profit)),sum(UnscaledValue(net_loss)),channel,id,sales,returns,profit,sum,sum,sum,sum]
-                                                      InputAdapter
-                                                        Exchange [web_site_id] #9
-                                                          WholeStageCodegen (18)
-                                                            HashAggregate [web_site_id,sales_price,return_amt,profit,net_loss] [sum,sum,sum,sum,sum,sum,sum,sum]
-                                                              Project [sales_price,profit,return_amt,net_loss,web_site_id]
-                                                                BroadcastHashJoin [wsr_web_site_sk,web_site_sk]
-                                                                  Project [wsr_web_site_sk,sales_price,profit,return_amt,net_loss]
-                                                                    BroadcastHashJoin [date_sk,d_date_sk]
-                                                                      InputAdapter
-                                                                        Union
-                                                                          WholeStageCodegen (13)
-                                                                            Project [ws_web_site_sk,ws_sold_date_sk,ws_ext_sales_price,ws_net_profit]
-                                                                              Filter [ws_sold_date_sk,ws_web_site_sk]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet default.web_sales [ws_sold_date_sk,ws_web_site_sk,ws_ext_sales_price,ws_net_profit]
-                                                                          WholeStageCodegen (15)
-                                                                            Project [ws_web_site_sk,wr_returned_date_sk,wr_return_amt,wr_net_loss]
-                                                                              BroadcastHashJoin [wr_item_sk,wr_order_number,ws_item_sk,ws_order_number]
-                                                                                Filter [wr_returned_date_sk]
-                                                                                  ColumnarToRow
-                                                                                    InputAdapter
-                                                                                      Scan parquet default.web_returns [wr_returned_date_sk,wr_item_sk,wr_order_number,wr_return_amt,wr_net_loss]
-                                                                                InputAdapter
-                                                                                  BroadcastExchange #10
-                                                                                    WholeStageCodegen (14)
-                                                                                      Filter [ws_item_sk,ws_order_number,ws_web_site_sk]
-                                                                                        ColumnarToRow
-                                                                                          InputAdapter
-                                                                                            Scan parquet default.web_sales [ws_item_sk,ws_web_site_sk,ws_order_number]
-                                                                      InputAdapter
-                                                                        ReusedExchange [d_date_sk] #5
-                                                                  InputAdapter
-                                                                    BroadcastExchange #11
-                                                                      WholeStageCodegen (17)
-                                                                        Filter [web_site_sk]
-                                                                          ColumnarToRow
-                                                                            InputAdapter
-                                                                              Scan parquet default.web_site [web_site_sk,web_site_id]
-                                  WholeStageCodegen (43)
-                                    HashAggregate [channel,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),id,sum(sales),sum(returns),sum(profit),sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                                                                    Scan parquet default.date_dim [d_date_sk,d_date]
+                                                  InputAdapter
+                                                    BroadcastExchange #5
+                                                      WholeStageCodegen (4)
+                                                        Filter [s_store_sk]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet default.store [s_store_sk,s_store_id]
+                                  WholeStageCodegen (12)
+                                    HashAggregate [cp_catalog_page_id,sum,sum,sum,sum] [sum(UnscaledValue(sales_price)),sum(UnscaledValue(return_amt)),sum(UnscaledValue(profit)),sum(UnscaledValue(net_loss)),channel,id,sales,returns,profit,sum,sum,sum,sum]
                                       InputAdapter
-                                        Exchange [channel] #12
-                                          WholeStageCodegen (42)
-                                            HashAggregate [channel,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
-                                              HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
-                                                InputAdapter
-                                                  ReusedExchange [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] #3
-                  WholeStageCodegen (67)
+                                        Exchange [cp_catalog_page_id] #6
+                                          WholeStageCodegen (11)
+                                            HashAggregate [cp_catalog_page_id,sales_price,return_amt,profit,net_loss] [sum,sum,sum,sum,sum,sum,sum,sum]
+                                              Project [sales_price,profit,return_amt,net_loss,cp_catalog_page_id]
+                                                BroadcastHashJoin [page_sk,cp_catalog_page_sk]
+                                                  Project [page_sk,sales_price,profit,return_amt,net_loss]
+                                                    BroadcastHashJoin [date_sk,d_date_sk]
+                                                      InputAdapter
+                                                        Union
+                                                          WholeStageCodegen (7)
+                                                            Project [cs_catalog_page_sk,cs_sold_date_sk,cs_ext_sales_price,cs_net_profit]
+                                                              Filter [cs_sold_date_sk,cs_catalog_page_sk]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet default.catalog_sales [cs_sold_date_sk,cs_catalog_page_sk,cs_ext_sales_price,cs_net_profit]
+                                                          WholeStageCodegen (8)
+                                                            Project [cr_catalog_page_sk,cr_returned_date_sk,cr_return_amount,cr_net_loss]
+                                                              Filter [cr_returned_date_sk,cr_catalog_page_sk]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet default.catalog_returns [cr_returned_date_sk,cr_catalog_page_sk,cr_return_amount,cr_net_loss]
+                                                      InputAdapter
+                                                        ReusedExchange [d_date_sk] #4
+                                                  InputAdapter
+                                                    BroadcastExchange #7
+                                                      WholeStageCodegen (10)
+                                                        Filter [cp_catalog_page_sk]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet default.catalog_page [cp_catalog_page_sk,cp_catalog_page_id]
+                                  WholeStageCodegen (19)
+                                    HashAggregate [web_site_id,sum,sum,sum,sum] [sum(UnscaledValue(sales_price)),sum(UnscaledValue(return_amt)),sum(UnscaledValue(profit)),sum(UnscaledValue(net_loss)),channel,id,sales,returns,profit,sum,sum,sum,sum]
+                                      InputAdapter
+                                        Exchange [web_site_id] #8
+                                          WholeStageCodegen (18)
+                                            HashAggregate [web_site_id,sales_price,return_amt,profit,net_loss] [sum,sum,sum,sum,sum,sum,sum,sum]
+                                              Project [sales_price,profit,return_amt,net_loss,web_site_id]
+                                                BroadcastHashJoin [wsr_web_site_sk,web_site_sk]
+                                                  Project [wsr_web_site_sk,sales_price,profit,return_amt,net_loss]
+                                                    BroadcastHashJoin [date_sk,d_date_sk]
+                                                      InputAdapter
+                                                        Union
+                                                          WholeStageCodegen (13)
+                                                            Project [ws_web_site_sk,ws_sold_date_sk,ws_ext_sales_price,ws_net_profit]
+                                                              Filter [ws_sold_date_sk,ws_web_site_sk]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet default.web_sales [ws_sold_date_sk,ws_web_site_sk,ws_ext_sales_price,ws_net_profit]
+                                                          WholeStageCodegen (15)
+                                                            Project [ws_web_site_sk,wr_returned_date_sk,wr_return_amt,wr_net_loss]
+                                                              BroadcastHashJoin [wr_item_sk,wr_order_number,ws_item_sk,ws_order_number]
+                                                                Filter [wr_returned_date_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet default.web_returns [wr_returned_date_sk,wr_item_sk,wr_order_number,wr_return_amt,wr_net_loss]
+                                                                InputAdapter
+                                                                  BroadcastExchange #9
+                                                                    WholeStageCodegen (14)
+                                                                      Filter [ws_item_sk,ws_order_number,ws_web_site_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet default.web_sales [ws_item_sk,ws_web_site_sk,ws_order_number]
+                                                      InputAdapter
+                                                        ReusedExchange [d_date_sk] #4
+                                                  InputAdapter
+                                                    BroadcastExchange #10
+                                                      WholeStageCodegen (17)
+                                                        Filter [web_site_sk]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet default.web_site [web_site_sk,web_site_id]
+                  WholeStageCodegen (43)
+                    HashAggregate [channel,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),id,sum(sales),sum(returns),sum(profit),sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                      InputAdapter
+                        Exchange [channel] #11
+                          WholeStageCodegen (42)
+                            HashAggregate [channel,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                              HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                                InputAdapter
+                                  ReusedExchange [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] #2
+                  WholeStageCodegen (65)
                     HashAggregate [sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),channel,id,sum(sales),sum(returns),sum(profit),sum,isEmpty,sum,isEmpty,sum,isEmpty]
                       InputAdapter
-                        Exchange #13
-                          WholeStageCodegen (66)
+                        Exchange #12
+                          WholeStageCodegen (64)
                             HashAggregate [sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                               HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                                 InputAdapter
-                                  ReusedExchange [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] #3
+                                  ReusedExchange [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] #2

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a.sf100/explain.txt
@@ -1,68 +1,64 @@
 == Physical Plan ==
-TakeOrderedAndProject (64)
-+- * Project (63)
-   +- Window (62)
-      +- * Sort (61)
-         +- Exchange (60)
-            +- * HashAggregate (59)
-               +- Exchange (58)
-                  +- * HashAggregate (57)
-                     +- Union (56)
-                        :- * HashAggregate (50)
-                        :  +- Exchange (49)
-                        :     +- * HashAggregate (48)
-                        :        +- Union (47)
-                        :           :- * HashAggregate (41)
-                        :           :  +- Exchange (40)
-                        :           :     +- * HashAggregate (39)
-                        :           :        +- * Project (38)
-                        :           :           +- * BroadcastHashJoin Inner BuildRight (37)
-                        :           :              :- * Project (10)
-                        :           :              :  +- * BroadcastHashJoin Inner BuildRight (9)
-                        :           :              :     :- * Filter (3)
-                        :           :              :     :  +- * ColumnarToRow (2)
-                        :           :              :     :     +- Scan parquet default.store_sales (1)
-                        :           :              :     +- BroadcastExchange (8)
-                        :           :              :        +- * Project (7)
-                        :           :              :           +- * Filter (6)
-                        :           :              :              +- * ColumnarToRow (5)
-                        :           :              :                 +- Scan parquet default.date_dim (4)
-                        :           :              +- BroadcastExchange (36)
-                        :           :                 +- * BroadcastHashJoin LeftSemi BuildRight (35)
-                        :           :                    :- * Filter (13)
-                        :           :                    :  +- * ColumnarToRow (12)
-                        :           :                    :     +- Scan parquet default.store (11)
-                        :           :                    +- BroadcastExchange (34)
-                        :           :                       +- * Project (33)
-                        :           :                          +- * Filter (32)
-                        :           :                             +- Window (31)
-                        :           :                                +- * Sort (30)
-                        :           :                                   +- Exchange (29)
-                        :           :                                      +- * HashAggregate (28)
-                        :           :                                         +- Exchange (27)
-                        :           :                                            +- * HashAggregate (26)
-                        :           :                                               +- * Project (25)
-                        :           :                                                  +- * BroadcastHashJoin Inner BuildRight (24)
-                        :           :                                                     :- * Project (19)
-                        :           :                                                     :  +- * BroadcastHashJoin Inner BuildRight (18)
-                        :           :                                                     :     :- * Filter (16)
-                        :           :                                                     :     :  +- * ColumnarToRow (15)
-                        :           :                                                     :     :     +- Scan parquet default.store_sales (14)
-                        :           :                                                     :     +- ReusedExchange (17)
-                        :           :                                                     +- BroadcastExchange (23)
-                        :           :                                                        +- * Filter (22)
-                        :           :                                                           +- * ColumnarToRow (21)
-                        :           :                                                              +- Scan parquet default.store (20)
-                        :           +- * HashAggregate (46)
-                        :              +- Exchange (45)
-                        :                 +- * HashAggregate (44)
-                        :                    +- * HashAggregate (43)
-                        :                       +- ReusedExchange (42)
-                        +- * HashAggregate (55)
-                           +- Exchange (54)
-                              +- * HashAggregate (53)
-                                 +- * HashAggregate (52)
-                                    +- ReusedExchange (51)
+TakeOrderedAndProject (60)
++- * Project (59)
+   +- Window (58)
+      +- * Sort (57)
+         +- Exchange (56)
+            +- * HashAggregate (55)
+               +- Exchange (54)
+                  +- * HashAggregate (53)
+                     +- Union (52)
+                        :- * HashAggregate (41)
+                        :  +- Exchange (40)
+                        :     +- * HashAggregate (39)
+                        :        +- * Project (38)
+                        :           +- * BroadcastHashJoin Inner BuildRight (37)
+                        :              :- * Project (10)
+                        :              :  +- * BroadcastHashJoin Inner BuildRight (9)
+                        :              :     :- * Filter (3)
+                        :              :     :  +- * ColumnarToRow (2)
+                        :              :     :     +- Scan parquet default.store_sales (1)
+                        :              :     +- BroadcastExchange (8)
+                        :              :        +- * Project (7)
+                        :              :           +- * Filter (6)
+                        :              :              +- * ColumnarToRow (5)
+                        :              :                 +- Scan parquet default.date_dim (4)
+                        :              +- BroadcastExchange (36)
+                        :                 +- * BroadcastHashJoin LeftSemi BuildRight (35)
+                        :                    :- * Filter (13)
+                        :                    :  +- * ColumnarToRow (12)
+                        :                    :     +- Scan parquet default.store (11)
+                        :                    +- BroadcastExchange (34)
+                        :                       +- * Project (33)
+                        :                          +- * Filter (32)
+                        :                             +- Window (31)
+                        :                                +- * Sort (30)
+                        :                                   +- Exchange (29)
+                        :                                      +- * HashAggregate (28)
+                        :                                         +- Exchange (27)
+                        :                                            +- * HashAggregate (26)
+                        :                                               +- * Project (25)
+                        :                                                  +- * BroadcastHashJoin Inner BuildRight (24)
+                        :                                                     :- * Project (19)
+                        :                                                     :  +- * BroadcastHashJoin Inner BuildRight (18)
+                        :                                                     :     :- * Filter (16)
+                        :                                                     :     :  +- * ColumnarToRow (15)
+                        :                                                     :     :     +- Scan parquet default.store_sales (14)
+                        :                                                     :     +- ReusedExchange (17)
+                        :                                                     +- BroadcastExchange (23)
+                        :                                                        +- * Filter (22)
+                        :                                                           +- * ColumnarToRow (21)
+                        :                                                              +- Scan parquet default.store (20)
+                        :- * HashAggregate (46)
+                        :  +- Exchange (45)
+                        :     +- * HashAggregate (44)
+                        :        +- * HashAggregate (43)
+                        :           +- ReusedExchange (42)
+                        +- * HashAggregate (51)
+                           +- Exchange (50)
+                              +- * HashAggregate (49)
+                                 +- * HashAggregate (48)
+                                    +- ReusedExchange (47)
 
 
 (1) Scan parquet default.store_sales
@@ -186,7 +182,7 @@ Results [2]: [s_state#9, sum#12]
 
 (27) Exchange
 Input [2]: [s_state#9, sum#12]
-Arguments: hashpartitioning(s_state#9, 5), true, [id=#13]
+Arguments: hashpartitioning(s_state#9, 5), ENSURE_REQUIREMENTS, [id=#13]
 
 (28) HashAggregate [codegen id : 5]
 Input [2]: [s_state#9, sum#12]
@@ -197,7 +193,7 @@ Results [3]: [s_state#9 AS s_state#15, s_state#9, MakeDecimal(sum(UnscaledValue(
 
 (29) Exchange
 Input [3]: [s_state#15, s_state#9, _w2#16]
-Arguments: hashpartitioning(s_state#9, 5), true, [id=#17]
+Arguments: hashpartitioning(s_state#9, 5), ENSURE_REQUIREMENTS, [id=#17]
 
 (30) Sort [codegen id : 6]
 Input [3]: [s_state#15, s_state#9, _w2#16]
@@ -246,7 +242,7 @@ Results [3]: [s_state#9, s_county#8, sum#22]
 
 (40) Exchange
 Input [3]: [s_state#9, s_county#8, sum#22]
-Arguments: hashpartitioning(s_state#9, s_county#8, 5), true, [id=#23]
+Arguments: hashpartitioning(s_state#9, s_county#8, 5), ENSURE_REQUIREMENTS, [id=#23]
 
 (41) HashAggregate [codegen id : 10]
 Input [3]: [s_state#9, s_county#8, sum#22]
@@ -274,7 +270,7 @@ Results [3]: [s_state#9, sum#34, isEmpty#35]
 
 (45) Exchange
 Input [3]: [s_state#9, sum#34, isEmpty#35]
-Arguments: hashpartitioning(s_state#9, 5), true, [id=#36]
+Arguments: hashpartitioning(s_state#9, 5), ENSURE_REQUIREMENTS, [id=#36]
 
 (46) HashAggregate [codegen id : 21]
 Input [3]: [s_state#9, sum#34, isEmpty#35]
@@ -283,91 +279,71 @@ Functions [1]: [sum(total_sum#31)]
 Aggregate Attributes [1]: [sum(total_sum#31)#37]
 Results [6]: [sum(total_sum#31)#37 AS total_sum#38, s_state#9, null AS s_county#39, 0 AS g_state#40, 1 AS g_county#41, 1 AS lochierarchy#42]
 
-(47) Union
+(47) ReusedExchange [Reuses operator id: 40]
+Output [3]: [s_state#9, s_county#8, sum#43]
 
-(48) HashAggregate [codegen id : 22]
-Input [6]: [total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28]
-Keys [6]: [total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28]
-Functions: []
-Aggregate Attributes: []
-Results [6]: [total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28]
-
-(49) Exchange
-Input [6]: [total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28]
-Arguments: hashpartitioning(total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28, 5), true, [id=#43]
-
-(50) HashAggregate [codegen id : 23]
-Input [6]: [total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28]
-Keys [6]: [total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28]
-Functions: []
-Aggregate Attributes: []
-Results [6]: [total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28]
-
-(51) ReusedExchange [Reuses operator id: 40]
-Output [3]: [s_state#9, s_county#8, sum#44]
-
-(52) HashAggregate [codegen id : 33]
-Input [3]: [s_state#9, s_county#8, sum#44]
+(48) HashAggregate [codegen id : 31]
+Input [3]: [s_state#9, s_county#8, sum#43]
 Keys [2]: [s_state#9, s_county#8]
 Functions [1]: [sum(UnscaledValue(ss_net_profit#3))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_profit#3))#45]
-Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_profit#3))#45,17,2) AS total_sum#31]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_profit#3))#44]
+Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_profit#3))#44,17,2) AS total_sum#31]
 
-(53) HashAggregate [codegen id : 33]
+(49) HashAggregate [codegen id : 31]
 Input [1]: [total_sum#31]
 Keys: []
 Functions [1]: [partial_sum(total_sum#31)]
-Aggregate Attributes [2]: [sum#46, isEmpty#47]
-Results [2]: [sum#48, isEmpty#49]
+Aggregate Attributes [2]: [sum#45, isEmpty#46]
+Results [2]: [sum#47, isEmpty#48]
 
-(54) Exchange
-Input [2]: [sum#48, isEmpty#49]
-Arguments: SinglePartition, true, [id=#50]
+(50) Exchange
+Input [2]: [sum#47, isEmpty#48]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#49]
 
-(55) HashAggregate [codegen id : 34]
-Input [2]: [sum#48, isEmpty#49]
+(51) HashAggregate [codegen id : 32]
+Input [2]: [sum#47, isEmpty#48]
 Keys: []
 Functions [1]: [sum(total_sum#31)]
-Aggregate Attributes [1]: [sum(total_sum#31)#51]
-Results [6]: [sum(total_sum#31)#51 AS total_sum#52, null AS s_state#53, null AS s_county#54, 1 AS g_state#55, 1 AS g_county#56, 2 AS lochierarchy#57]
+Aggregate Attributes [1]: [sum(total_sum#31)#50]
+Results [6]: [sum(total_sum#31)#50 AS total_sum#51, null AS s_state#52, null AS s_county#53, 1 AS g_state#54, 1 AS g_county#55, 2 AS lochierarchy#56]
 
-(56) Union
+(52) Union
 
-(57) HashAggregate [codegen id : 35]
+(53) HashAggregate [codegen id : 33]
 Input [6]: [total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28]
 Keys [6]: [total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28]
 Functions: []
 Aggregate Attributes: []
 Results [6]: [total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28]
 
-(58) Exchange
+(54) Exchange
 Input [6]: [total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28]
-Arguments: hashpartitioning(total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28, 5), true, [id=#58]
+Arguments: hashpartitioning(total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28, 5), ENSURE_REQUIREMENTS, [id=#57]
 
-(59) HashAggregate [codegen id : 36]
+(55) HashAggregate [codegen id : 34]
 Input [6]: [total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28]
 Keys [6]: [total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28]
 Functions: []
 Aggregate Attributes: []
-Results [5]: [total_sum#25, s_state#9, s_county#8, lochierarchy#28, CASE WHEN (g_county#27 = 0) THEN s_state#9 END AS _w0#59]
+Results [5]: [total_sum#25, s_state#9, s_county#8, lochierarchy#28, CASE WHEN (g_county#27 = 0) THEN s_state#9 END AS _w0#58]
 
-(60) Exchange
-Input [5]: [total_sum#25, s_state#9, s_county#8, lochierarchy#28, _w0#59]
-Arguments: hashpartitioning(lochierarchy#28, _w0#59, 5), true, [id=#60]
+(56) Exchange
+Input [5]: [total_sum#25, s_state#9, s_county#8, lochierarchy#28, _w0#58]
+Arguments: hashpartitioning(lochierarchy#28, _w0#58, 5), ENSURE_REQUIREMENTS, [id=#59]
 
-(61) Sort [codegen id : 37]
-Input [5]: [total_sum#25, s_state#9, s_county#8, lochierarchy#28, _w0#59]
-Arguments: [lochierarchy#28 ASC NULLS FIRST, _w0#59 ASC NULLS FIRST, total_sum#25 DESC NULLS LAST], false, 0
+(57) Sort [codegen id : 35]
+Input [5]: [total_sum#25, s_state#9, s_county#8, lochierarchy#28, _w0#58]
+Arguments: [lochierarchy#28 ASC NULLS FIRST, _w0#58 ASC NULLS FIRST, total_sum#25 DESC NULLS LAST], false, 0
 
-(62) Window
-Input [5]: [total_sum#25, s_state#9, s_county#8, lochierarchy#28, _w0#59]
-Arguments: [rank(total_sum#25) windowspecdefinition(lochierarchy#28, _w0#59, total_sum#25 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank_within_parent#61], [lochierarchy#28, _w0#59], [total_sum#25 DESC NULLS LAST]
+(58) Window
+Input [5]: [total_sum#25, s_state#9, s_county#8, lochierarchy#28, _w0#58]
+Arguments: [rank(total_sum#25) windowspecdefinition(lochierarchy#28, _w0#58, total_sum#25 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank_within_parent#60], [lochierarchy#28, _w0#58], [total_sum#25 DESC NULLS LAST]
 
-(63) Project [codegen id : 38]
-Output [5]: [total_sum#25, s_state#9, s_county#8, lochierarchy#28, rank_within_parent#61]
-Input [6]: [total_sum#25, s_state#9, s_county#8, lochierarchy#28, _w0#59, rank_within_parent#61]
+(59) Project [codegen id : 36]
+Output [5]: [total_sum#25, s_state#9, s_county#8, lochierarchy#28, rank_within_parent#60]
+Input [6]: [total_sum#25, s_state#9, s_county#8, lochierarchy#28, _w0#58, rank_within_parent#60]
 
-(64) TakeOrderedAndProject
-Input [5]: [total_sum#25, s_state#9, s_county#8, lochierarchy#28, rank_within_parent#61]
-Arguments: 100, [lochierarchy#28 DESC NULLS LAST, CASE WHEN (lochierarchy#28 = 0) THEN s_state#9 END ASC NULLS FIRST, rank_within_parent#61 ASC NULLS FIRST], [total_sum#25, s_state#9, s_county#8, lochierarchy#28, rank_within_parent#61]
+(60) TakeOrderedAndProject
+Input [5]: [total_sum#25, s_state#9, s_county#8, lochierarchy#28, rank_within_parent#60]
+Arguments: 100, [lochierarchy#28 DESC NULLS LAST, CASE WHEN (lochierarchy#28 = 0) THEN s_state#9 END ASC NULLS FIRST, rank_within_parent#60 ASC NULLS FIRST], [total_sum#25, s_state#9, s_county#8, lochierarchy#28, rank_within_parent#60]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a.sf100/simplified.txt
@@ -1,107 +1,99 @@
 TakeOrderedAndProject [lochierarchy,s_state,rank_within_parent,total_sum,s_county]
-  WholeStageCodegen (38)
+  WholeStageCodegen (36)
     Project [total_sum,s_state,s_county,lochierarchy,rank_within_parent]
       InputAdapter
         Window [total_sum,lochierarchy,_w0]
-          WholeStageCodegen (37)
+          WholeStageCodegen (35)
             Sort [lochierarchy,_w0,total_sum]
               InputAdapter
                 Exchange [lochierarchy,_w0] #1
-                  WholeStageCodegen (36)
+                  WholeStageCodegen (34)
                     HashAggregate [total_sum,s_state,s_county,g_state,g_county,lochierarchy] [_w0]
                       InputAdapter
                         Exchange [total_sum,s_state,s_county,g_state,g_county,lochierarchy] #2
-                          WholeStageCodegen (35)
+                          WholeStageCodegen (33)
                             HashAggregate [total_sum,s_state,s_county,g_state,g_county,lochierarchy]
                               InputAdapter
                                 Union
-                                  WholeStageCodegen (23)
-                                    HashAggregate [total_sum,s_state,s_county,g_state,g_county,lochierarchy]
+                                  WholeStageCodegen (10)
+                                    HashAggregate [s_state,s_county,sum] [sum(UnscaledValue(ss_net_profit)),total_sum,g_state,g_county,lochierarchy,sum]
                                       InputAdapter
-                                        Exchange [total_sum,s_state,s_county,g_state,g_county,lochierarchy] #3
-                                          WholeStageCodegen (22)
-                                            HashAggregate [total_sum,s_state,s_county,g_state,g_county,lochierarchy]
-                                              InputAdapter
-                                                Union
-                                                  WholeStageCodegen (10)
-                                                    HashAggregate [s_state,s_county,sum] [sum(UnscaledValue(ss_net_profit)),total_sum,g_state,g_county,lochierarchy,sum]
+                                        Exchange [s_state,s_county] #3
+                                          WholeStageCodegen (9)
+                                            HashAggregate [s_state,s_county,ss_net_profit] [sum,sum]
+                                              Project [ss_net_profit,s_county,s_state]
+                                                BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                                  Project [ss_store_sk,ss_net_profit]
+                                                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                      Filter [ss_sold_date_sk,ss_store_sk]
+                                                        ColumnarToRow
+                                                          InputAdapter
+                                                            Scan parquet default.store_sales [ss_sold_date_sk,ss_store_sk,ss_net_profit]
                                                       InputAdapter
-                                                        Exchange [s_state,s_county] #4
-                                                          WholeStageCodegen (9)
-                                                            HashAggregate [s_state,s_county,ss_net_profit] [sum,sum]
-                                                              Project [ss_net_profit,s_county,s_state]
-                                                                BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                                  Project [ss_store_sk,ss_net_profit]
-                                                                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                      Filter [ss_sold_date_sk,ss_store_sk]
-                                                                        ColumnarToRow
-                                                                          InputAdapter
-                                                                            Scan parquet default.store_sales [ss_sold_date_sk,ss_store_sk,ss_net_profit]
-                                                                      InputAdapter
-                                                                        BroadcastExchange #5
-                                                                          WholeStageCodegen (1)
-                                                                            Project [d_date_sk]
-                                                                              Filter [d_month_seq,d_date_sk]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet default.date_dim [d_date_sk,d_month_seq]
+                                                        BroadcastExchange #4
+                                                          WholeStageCodegen (1)
+                                                            Project [d_date_sk]
+                                                              Filter [d_month_seq,d_date_sk]
+                                                                ColumnarToRow
                                                                   InputAdapter
-                                                                    BroadcastExchange #6
-                                                                      WholeStageCodegen (8)
-                                                                        BroadcastHashJoin [s_state,s_state]
-                                                                          Filter [s_store_sk]
-                                                                            ColumnarToRow
-                                                                              InputAdapter
-                                                                                Scan parquet default.store [s_store_sk,s_county,s_state]
-                                                                          InputAdapter
-                                                                            BroadcastExchange #7
-                                                                              WholeStageCodegen (7)
-                                                                                Project [s_state]
-                                                                                  Filter [ranking]
+                                                                    Scan parquet default.date_dim [d_date_sk,d_month_seq]
+                                                  InputAdapter
+                                                    BroadcastExchange #5
+                                                      WholeStageCodegen (8)
+                                                        BroadcastHashJoin [s_state,s_state]
+                                                          Filter [s_store_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet default.store [s_store_sk,s_county,s_state]
+                                                          InputAdapter
+                                                            BroadcastExchange #6
+                                                              WholeStageCodegen (7)
+                                                                Project [s_state]
+                                                                  Filter [ranking]
+                                                                    InputAdapter
+                                                                      Window [_w2,s_state]
+                                                                        WholeStageCodegen (6)
+                                                                          Sort [s_state,_w2]
+                                                                            InputAdapter
+                                                                              Exchange [s_state] #7
+                                                                                WholeStageCodegen (5)
+                                                                                  HashAggregate [s_state,sum] [sum(UnscaledValue(ss_net_profit)),s_state,_w2,sum]
                                                                                     InputAdapter
-                                                                                      Window [_w2,s_state]
-                                                                                        WholeStageCodegen (6)
-                                                                                          Sort [s_state,_w2]
-                                                                                            InputAdapter
-                                                                                              Exchange [s_state] #8
-                                                                                                WholeStageCodegen (5)
-                                                                                                  HashAggregate [s_state,sum] [sum(UnscaledValue(ss_net_profit)),s_state,_w2,sum]
+                                                                                      Exchange [s_state] #8
+                                                                                        WholeStageCodegen (4)
+                                                                                          HashAggregate [s_state,ss_net_profit] [sum,sum]
+                                                                                            Project [ss_net_profit,s_state]
+                                                                                              BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                                                                                Project [ss_store_sk,ss_net_profit]
+                                                                                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                                                                    Filter [ss_store_sk,ss_sold_date_sk]
+                                                                                                      ColumnarToRow
+                                                                                                        InputAdapter
+                                                                                                          Scan parquet default.store_sales [ss_sold_date_sk,ss_store_sk,ss_net_profit]
                                                                                                     InputAdapter
-                                                                                                      Exchange [s_state] #9
-                                                                                                        WholeStageCodegen (4)
-                                                                                                          HashAggregate [s_state,ss_net_profit] [sum,sum]
-                                                                                                            Project [ss_net_profit,s_state]
-                                                                                                              BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                                                                                Project [ss_store_sk,ss_net_profit]
-                                                                                                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                                                                    Filter [ss_store_sk,ss_sold_date_sk]
-                                                                                                                      ColumnarToRow
-                                                                                                                        InputAdapter
-                                                                                                                          Scan parquet default.store_sales [ss_sold_date_sk,ss_store_sk,ss_net_profit]
-                                                                                                                    InputAdapter
-                                                                                                                      ReusedExchange [d_date_sk] #5
-                                                                                                                InputAdapter
-                                                                                                                  BroadcastExchange #10
-                                                                                                                    WholeStageCodegen (3)
-                                                                                                                      Filter [s_store_sk]
-                                                                                                                        ColumnarToRow
-                                                                                                                          InputAdapter
-                                                                                                                            Scan parquet default.store [s_store_sk,s_state]
-                                                  WholeStageCodegen (21)
-                                                    HashAggregate [s_state,sum,isEmpty] [sum(total_sum),total_sum,s_county,g_state,g_county,lochierarchy,sum,isEmpty]
-                                                      InputAdapter
-                                                        Exchange [s_state] #11
-                                                          WholeStageCodegen (20)
-                                                            HashAggregate [s_state,total_sum] [sum,isEmpty,sum,isEmpty]
-                                                              HashAggregate [s_state,s_county,sum] [sum(UnscaledValue(ss_net_profit)),total_sum,sum]
-                                                                InputAdapter
-                                                                  ReusedExchange [s_state,s_county,sum] #4
-                                  WholeStageCodegen (34)
+                                                                                                      ReusedExchange [d_date_sk] #4
+                                                                                                InputAdapter
+                                                                                                  BroadcastExchange #9
+                                                                                                    WholeStageCodegen (3)
+                                                                                                      Filter [s_store_sk]
+                                                                                                        ColumnarToRow
+                                                                                                          InputAdapter
+                                                                                                            Scan parquet default.store [s_store_sk,s_state]
+                                  WholeStageCodegen (21)
+                                    HashAggregate [s_state,sum,isEmpty] [sum(total_sum),total_sum,s_county,g_state,g_county,lochierarchy,sum,isEmpty]
+                                      InputAdapter
+                                        Exchange [s_state] #10
+                                          WholeStageCodegen (20)
+                                            HashAggregate [s_state,total_sum] [sum,isEmpty,sum,isEmpty]
+                                              HashAggregate [s_state,s_county,sum] [sum(UnscaledValue(ss_net_profit)),total_sum,sum]
+                                                InputAdapter
+                                                  ReusedExchange [s_state,s_county,sum] #3
+                                  WholeStageCodegen (32)
                                     HashAggregate [sum,isEmpty] [sum(total_sum),total_sum,s_state,s_county,g_state,g_county,lochierarchy,sum,isEmpty]
                                       InputAdapter
-                                        Exchange #12
-                                          WholeStageCodegen (33)
+                                        Exchange #11
+                                          WholeStageCodegen (31)
                                             HashAggregate [total_sum] [sum,isEmpty,sum,isEmpty]
                                               HashAggregate [s_state,s_county,sum] [sum(UnscaledValue(ss_net_profit)),total_sum,sum]
                                                 InputAdapter
-                                                  ReusedExchange [s_state,s_county,sum] #4
+                                                  ReusedExchange [s_state,s_county,sum] #3

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a/explain.txt
@@ -1,68 +1,64 @@
 == Physical Plan ==
-TakeOrderedAndProject (64)
-+- * Project (63)
-   +- Window (62)
-      +- * Sort (61)
-         +- Exchange (60)
-            +- * HashAggregate (59)
-               +- Exchange (58)
-                  +- * HashAggregate (57)
-                     +- Union (56)
-                        :- * HashAggregate (50)
-                        :  +- Exchange (49)
-                        :     +- * HashAggregate (48)
-                        :        +- Union (47)
-                        :           :- * HashAggregate (41)
-                        :           :  +- Exchange (40)
-                        :           :     +- * HashAggregate (39)
-                        :           :        +- * Project (38)
-                        :           :           +- * BroadcastHashJoin Inner BuildRight (37)
-                        :           :              :- * Project (10)
-                        :           :              :  +- * BroadcastHashJoin Inner BuildRight (9)
-                        :           :              :     :- * Filter (3)
-                        :           :              :     :  +- * ColumnarToRow (2)
-                        :           :              :     :     +- Scan parquet default.store_sales (1)
-                        :           :              :     +- BroadcastExchange (8)
-                        :           :              :        +- * Project (7)
-                        :           :              :           +- * Filter (6)
-                        :           :              :              +- * ColumnarToRow (5)
-                        :           :              :                 +- Scan parquet default.date_dim (4)
-                        :           :              +- BroadcastExchange (36)
-                        :           :                 +- * BroadcastHashJoin LeftSemi BuildRight (35)
-                        :           :                    :- * Filter (13)
-                        :           :                    :  +- * ColumnarToRow (12)
-                        :           :                    :     +- Scan parquet default.store (11)
-                        :           :                    +- BroadcastExchange (34)
-                        :           :                       +- * Project (33)
-                        :           :                          +- * Filter (32)
-                        :           :                             +- Window (31)
-                        :           :                                +- * Sort (30)
-                        :           :                                   +- Exchange (29)
-                        :           :                                      +- * HashAggregate (28)
-                        :           :                                         +- Exchange (27)
-                        :           :                                            +- * HashAggregate (26)
-                        :           :                                               +- * Project (25)
-                        :           :                                                  +- * BroadcastHashJoin Inner BuildRight (24)
-                        :           :                                                     :- * Project (22)
-                        :           :                                                     :  +- * BroadcastHashJoin Inner BuildRight (21)
-                        :           :                                                     :     :- * Filter (16)
-                        :           :                                                     :     :  +- * ColumnarToRow (15)
-                        :           :                                                     :     :     +- Scan parquet default.store_sales (14)
-                        :           :                                                     :     +- BroadcastExchange (20)
-                        :           :                                                     :        +- * Filter (19)
-                        :           :                                                     :           +- * ColumnarToRow (18)
-                        :           :                                                     :              +- Scan parquet default.store (17)
-                        :           :                                                     +- ReusedExchange (23)
-                        :           +- * HashAggregate (46)
-                        :              +- Exchange (45)
-                        :                 +- * HashAggregate (44)
-                        :                    +- * HashAggregate (43)
-                        :                       +- ReusedExchange (42)
-                        +- * HashAggregate (55)
-                           +- Exchange (54)
-                              +- * HashAggregate (53)
-                                 +- * HashAggregate (52)
-                                    +- ReusedExchange (51)
+TakeOrderedAndProject (60)
++- * Project (59)
+   +- Window (58)
+      +- * Sort (57)
+         +- Exchange (56)
+            +- * HashAggregate (55)
+               +- Exchange (54)
+                  +- * HashAggregate (53)
+                     +- Union (52)
+                        :- * HashAggregate (41)
+                        :  +- Exchange (40)
+                        :     +- * HashAggregate (39)
+                        :        +- * Project (38)
+                        :           +- * BroadcastHashJoin Inner BuildRight (37)
+                        :              :- * Project (10)
+                        :              :  +- * BroadcastHashJoin Inner BuildRight (9)
+                        :              :     :- * Filter (3)
+                        :              :     :  +- * ColumnarToRow (2)
+                        :              :     :     +- Scan parquet default.store_sales (1)
+                        :              :     +- BroadcastExchange (8)
+                        :              :        +- * Project (7)
+                        :              :           +- * Filter (6)
+                        :              :              +- * ColumnarToRow (5)
+                        :              :                 +- Scan parquet default.date_dim (4)
+                        :              +- BroadcastExchange (36)
+                        :                 +- * BroadcastHashJoin LeftSemi BuildRight (35)
+                        :                    :- * Filter (13)
+                        :                    :  +- * ColumnarToRow (12)
+                        :                    :     +- Scan parquet default.store (11)
+                        :                    +- BroadcastExchange (34)
+                        :                       +- * Project (33)
+                        :                          +- * Filter (32)
+                        :                             +- Window (31)
+                        :                                +- * Sort (30)
+                        :                                   +- Exchange (29)
+                        :                                      +- * HashAggregate (28)
+                        :                                         +- Exchange (27)
+                        :                                            +- * HashAggregate (26)
+                        :                                               +- * Project (25)
+                        :                                                  +- * BroadcastHashJoin Inner BuildRight (24)
+                        :                                                     :- * Project (22)
+                        :                                                     :  +- * BroadcastHashJoin Inner BuildRight (21)
+                        :                                                     :     :- * Filter (16)
+                        :                                                     :     :  +- * ColumnarToRow (15)
+                        :                                                     :     :     +- Scan parquet default.store_sales (14)
+                        :                                                     :     +- BroadcastExchange (20)
+                        :                                                     :        +- * Filter (19)
+                        :                                                     :           +- * ColumnarToRow (18)
+                        :                                                     :              +- Scan parquet default.store (17)
+                        :                                                     +- ReusedExchange (23)
+                        :- * HashAggregate (46)
+                        :  +- Exchange (45)
+                        :     +- * HashAggregate (44)
+                        :        +- * HashAggregate (43)
+                        :           +- ReusedExchange (42)
+                        +- * HashAggregate (51)
+                           +- Exchange (50)
+                              +- * HashAggregate (49)
+                                 +- * HashAggregate (48)
+                                    +- ReusedExchange (47)
 
 
 (1) Scan parquet default.store_sales
@@ -186,7 +182,7 @@ Results [2]: [s_state#9, sum#12]
 
 (27) Exchange
 Input [2]: [s_state#9, sum#12]
-Arguments: hashpartitioning(s_state#9, 5), true, [id=#13]
+Arguments: hashpartitioning(s_state#9, 5), ENSURE_REQUIREMENTS, [id=#13]
 
 (28) HashAggregate [codegen id : 5]
 Input [2]: [s_state#9, sum#12]
@@ -197,7 +193,7 @@ Results [3]: [s_state#9 AS s_state#15, s_state#9, MakeDecimal(sum(UnscaledValue(
 
 (29) Exchange
 Input [3]: [s_state#15, s_state#9, _w2#16]
-Arguments: hashpartitioning(s_state#9, 5), true, [id=#17]
+Arguments: hashpartitioning(s_state#9, 5), ENSURE_REQUIREMENTS, [id=#17]
 
 (30) Sort [codegen id : 6]
 Input [3]: [s_state#15, s_state#9, _w2#16]
@@ -246,7 +242,7 @@ Results [3]: [s_state#9, s_county#8, sum#22]
 
 (40) Exchange
 Input [3]: [s_state#9, s_county#8, sum#22]
-Arguments: hashpartitioning(s_state#9, s_county#8, 5), true, [id=#23]
+Arguments: hashpartitioning(s_state#9, s_county#8, 5), ENSURE_REQUIREMENTS, [id=#23]
 
 (41) HashAggregate [codegen id : 10]
 Input [3]: [s_state#9, s_county#8, sum#22]
@@ -274,7 +270,7 @@ Results [3]: [s_state#9, sum#34, isEmpty#35]
 
 (45) Exchange
 Input [3]: [s_state#9, sum#34, isEmpty#35]
-Arguments: hashpartitioning(s_state#9, 5), true, [id=#36]
+Arguments: hashpartitioning(s_state#9, 5), ENSURE_REQUIREMENTS, [id=#36]
 
 (46) HashAggregate [codegen id : 21]
 Input [3]: [s_state#9, sum#34, isEmpty#35]
@@ -283,91 +279,71 @@ Functions [1]: [sum(total_sum#31)]
 Aggregate Attributes [1]: [sum(total_sum#31)#37]
 Results [6]: [sum(total_sum#31)#37 AS total_sum#38, s_state#9, null AS s_county#39, 0 AS g_state#40, 1 AS g_county#41, 1 AS lochierarchy#42]
 
-(47) Union
+(47) ReusedExchange [Reuses operator id: 40]
+Output [3]: [s_state#9, s_county#8, sum#43]
 
-(48) HashAggregate [codegen id : 22]
-Input [6]: [total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28]
-Keys [6]: [total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28]
-Functions: []
-Aggregate Attributes: []
-Results [6]: [total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28]
-
-(49) Exchange
-Input [6]: [total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28]
-Arguments: hashpartitioning(total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28, 5), true, [id=#43]
-
-(50) HashAggregate [codegen id : 23]
-Input [6]: [total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28]
-Keys [6]: [total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28]
-Functions: []
-Aggregate Attributes: []
-Results [6]: [total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28]
-
-(51) ReusedExchange [Reuses operator id: 40]
-Output [3]: [s_state#9, s_county#8, sum#44]
-
-(52) HashAggregate [codegen id : 33]
-Input [3]: [s_state#9, s_county#8, sum#44]
+(48) HashAggregate [codegen id : 31]
+Input [3]: [s_state#9, s_county#8, sum#43]
 Keys [2]: [s_state#9, s_county#8]
 Functions [1]: [sum(UnscaledValue(ss_net_profit#3))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_profit#3))#45]
-Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_profit#3))#45,17,2) AS total_sum#31]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_profit#3))#44]
+Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_profit#3))#44,17,2) AS total_sum#31]
 
-(53) HashAggregate [codegen id : 33]
+(49) HashAggregate [codegen id : 31]
 Input [1]: [total_sum#31]
 Keys: []
 Functions [1]: [partial_sum(total_sum#31)]
-Aggregate Attributes [2]: [sum#46, isEmpty#47]
-Results [2]: [sum#48, isEmpty#49]
+Aggregate Attributes [2]: [sum#45, isEmpty#46]
+Results [2]: [sum#47, isEmpty#48]
 
-(54) Exchange
-Input [2]: [sum#48, isEmpty#49]
-Arguments: SinglePartition, true, [id=#50]
+(50) Exchange
+Input [2]: [sum#47, isEmpty#48]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#49]
 
-(55) HashAggregate [codegen id : 34]
-Input [2]: [sum#48, isEmpty#49]
+(51) HashAggregate [codegen id : 32]
+Input [2]: [sum#47, isEmpty#48]
 Keys: []
 Functions [1]: [sum(total_sum#31)]
-Aggregate Attributes [1]: [sum(total_sum#31)#51]
-Results [6]: [sum(total_sum#31)#51 AS total_sum#52, null AS s_state#53, null AS s_county#54, 1 AS g_state#55, 1 AS g_county#56, 2 AS lochierarchy#57]
+Aggregate Attributes [1]: [sum(total_sum#31)#50]
+Results [6]: [sum(total_sum#31)#50 AS total_sum#51, null AS s_state#52, null AS s_county#53, 1 AS g_state#54, 1 AS g_county#55, 2 AS lochierarchy#56]
 
-(56) Union
+(52) Union
 
-(57) HashAggregate [codegen id : 35]
+(53) HashAggregate [codegen id : 33]
 Input [6]: [total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28]
 Keys [6]: [total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28]
 Functions: []
 Aggregate Attributes: []
 Results [6]: [total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28]
 
-(58) Exchange
+(54) Exchange
 Input [6]: [total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28]
-Arguments: hashpartitioning(total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28, 5), true, [id=#58]
+Arguments: hashpartitioning(total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28, 5), ENSURE_REQUIREMENTS, [id=#57]
 
-(59) HashAggregate [codegen id : 36]
+(55) HashAggregate [codegen id : 34]
 Input [6]: [total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28]
 Keys [6]: [total_sum#25, s_state#9, s_county#8, g_state#26, g_county#27, lochierarchy#28]
 Functions: []
 Aggregate Attributes: []
-Results [5]: [total_sum#25, s_state#9, s_county#8, lochierarchy#28, CASE WHEN (g_county#27 = 0) THEN s_state#9 END AS _w0#59]
+Results [5]: [total_sum#25, s_state#9, s_county#8, lochierarchy#28, CASE WHEN (g_county#27 = 0) THEN s_state#9 END AS _w0#58]
 
-(60) Exchange
-Input [5]: [total_sum#25, s_state#9, s_county#8, lochierarchy#28, _w0#59]
-Arguments: hashpartitioning(lochierarchy#28, _w0#59, 5), true, [id=#60]
+(56) Exchange
+Input [5]: [total_sum#25, s_state#9, s_county#8, lochierarchy#28, _w0#58]
+Arguments: hashpartitioning(lochierarchy#28, _w0#58, 5), ENSURE_REQUIREMENTS, [id=#59]
 
-(61) Sort [codegen id : 37]
-Input [5]: [total_sum#25, s_state#9, s_county#8, lochierarchy#28, _w0#59]
-Arguments: [lochierarchy#28 ASC NULLS FIRST, _w0#59 ASC NULLS FIRST, total_sum#25 DESC NULLS LAST], false, 0
+(57) Sort [codegen id : 35]
+Input [5]: [total_sum#25, s_state#9, s_county#8, lochierarchy#28, _w0#58]
+Arguments: [lochierarchy#28 ASC NULLS FIRST, _w0#58 ASC NULLS FIRST, total_sum#25 DESC NULLS LAST], false, 0
 
-(62) Window
-Input [5]: [total_sum#25, s_state#9, s_county#8, lochierarchy#28, _w0#59]
-Arguments: [rank(total_sum#25) windowspecdefinition(lochierarchy#28, _w0#59, total_sum#25 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank_within_parent#61], [lochierarchy#28, _w0#59], [total_sum#25 DESC NULLS LAST]
+(58) Window
+Input [5]: [total_sum#25, s_state#9, s_county#8, lochierarchy#28, _w0#58]
+Arguments: [rank(total_sum#25) windowspecdefinition(lochierarchy#28, _w0#58, total_sum#25 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank_within_parent#60], [lochierarchy#28, _w0#58], [total_sum#25 DESC NULLS LAST]
 
-(63) Project [codegen id : 38]
-Output [5]: [total_sum#25, s_state#9, s_county#8, lochierarchy#28, rank_within_parent#61]
-Input [6]: [total_sum#25, s_state#9, s_county#8, lochierarchy#28, _w0#59, rank_within_parent#61]
+(59) Project [codegen id : 36]
+Output [5]: [total_sum#25, s_state#9, s_county#8, lochierarchy#28, rank_within_parent#60]
+Input [6]: [total_sum#25, s_state#9, s_county#8, lochierarchy#28, _w0#58, rank_within_parent#60]
 
-(64) TakeOrderedAndProject
-Input [5]: [total_sum#25, s_state#9, s_county#8, lochierarchy#28, rank_within_parent#61]
-Arguments: 100, [lochierarchy#28 DESC NULLS LAST, CASE WHEN (lochierarchy#28 = 0) THEN s_state#9 END ASC NULLS FIRST, rank_within_parent#61 ASC NULLS FIRST], [total_sum#25, s_state#9, s_county#8, lochierarchy#28, rank_within_parent#61]
+(60) TakeOrderedAndProject
+Input [5]: [total_sum#25, s_state#9, s_county#8, lochierarchy#28, rank_within_parent#60]
+Arguments: 100, [lochierarchy#28 DESC NULLS LAST, CASE WHEN (lochierarchy#28 = 0) THEN s_state#9 END ASC NULLS FIRST, rank_within_parent#60 ASC NULLS FIRST], [total_sum#25, s_state#9, s_county#8, lochierarchy#28, rank_within_parent#60]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a/simplified.txt
@@ -1,107 +1,99 @@
 TakeOrderedAndProject [lochierarchy,s_state,rank_within_parent,total_sum,s_county]
-  WholeStageCodegen (38)
+  WholeStageCodegen (36)
     Project [total_sum,s_state,s_county,lochierarchy,rank_within_parent]
       InputAdapter
         Window [total_sum,lochierarchy,_w0]
-          WholeStageCodegen (37)
+          WholeStageCodegen (35)
             Sort [lochierarchy,_w0,total_sum]
               InputAdapter
                 Exchange [lochierarchy,_w0] #1
-                  WholeStageCodegen (36)
+                  WholeStageCodegen (34)
                     HashAggregate [total_sum,s_state,s_county,g_state,g_county,lochierarchy] [_w0]
                       InputAdapter
                         Exchange [total_sum,s_state,s_county,g_state,g_county,lochierarchy] #2
-                          WholeStageCodegen (35)
+                          WholeStageCodegen (33)
                             HashAggregate [total_sum,s_state,s_county,g_state,g_county,lochierarchy]
                               InputAdapter
                                 Union
-                                  WholeStageCodegen (23)
-                                    HashAggregate [total_sum,s_state,s_county,g_state,g_county,lochierarchy]
+                                  WholeStageCodegen (10)
+                                    HashAggregate [s_state,s_county,sum] [sum(UnscaledValue(ss_net_profit)),total_sum,g_state,g_county,lochierarchy,sum]
                                       InputAdapter
-                                        Exchange [total_sum,s_state,s_county,g_state,g_county,lochierarchy] #3
-                                          WholeStageCodegen (22)
-                                            HashAggregate [total_sum,s_state,s_county,g_state,g_county,lochierarchy]
-                                              InputAdapter
-                                                Union
-                                                  WholeStageCodegen (10)
-                                                    HashAggregate [s_state,s_county,sum] [sum(UnscaledValue(ss_net_profit)),total_sum,g_state,g_county,lochierarchy,sum]
+                                        Exchange [s_state,s_county] #3
+                                          WholeStageCodegen (9)
+                                            HashAggregate [s_state,s_county,ss_net_profit] [sum,sum]
+                                              Project [ss_net_profit,s_county,s_state]
+                                                BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                                  Project [ss_store_sk,ss_net_profit]
+                                                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                      Filter [ss_sold_date_sk,ss_store_sk]
+                                                        ColumnarToRow
+                                                          InputAdapter
+                                                            Scan parquet default.store_sales [ss_sold_date_sk,ss_store_sk,ss_net_profit]
                                                       InputAdapter
-                                                        Exchange [s_state,s_county] #4
-                                                          WholeStageCodegen (9)
-                                                            HashAggregate [s_state,s_county,ss_net_profit] [sum,sum]
-                                                              Project [ss_net_profit,s_county,s_state]
-                                                                BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                                  Project [ss_store_sk,ss_net_profit]
-                                                                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                      Filter [ss_sold_date_sk,ss_store_sk]
-                                                                        ColumnarToRow
-                                                                          InputAdapter
-                                                                            Scan parquet default.store_sales [ss_sold_date_sk,ss_store_sk,ss_net_profit]
-                                                                      InputAdapter
-                                                                        BroadcastExchange #5
-                                                                          WholeStageCodegen (1)
-                                                                            Project [d_date_sk]
-                                                                              Filter [d_month_seq,d_date_sk]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet default.date_dim [d_date_sk,d_month_seq]
+                                                        BroadcastExchange #4
+                                                          WholeStageCodegen (1)
+                                                            Project [d_date_sk]
+                                                              Filter [d_month_seq,d_date_sk]
+                                                                ColumnarToRow
                                                                   InputAdapter
-                                                                    BroadcastExchange #6
-                                                                      WholeStageCodegen (8)
-                                                                        BroadcastHashJoin [s_state,s_state]
-                                                                          Filter [s_store_sk]
-                                                                            ColumnarToRow
-                                                                              InputAdapter
-                                                                                Scan parquet default.store [s_store_sk,s_county,s_state]
-                                                                          InputAdapter
-                                                                            BroadcastExchange #7
-                                                                              WholeStageCodegen (7)
-                                                                                Project [s_state]
-                                                                                  Filter [ranking]
+                                                                    Scan parquet default.date_dim [d_date_sk,d_month_seq]
+                                                  InputAdapter
+                                                    BroadcastExchange #5
+                                                      WholeStageCodegen (8)
+                                                        BroadcastHashJoin [s_state,s_state]
+                                                          Filter [s_store_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet default.store [s_store_sk,s_county,s_state]
+                                                          InputAdapter
+                                                            BroadcastExchange #6
+                                                              WholeStageCodegen (7)
+                                                                Project [s_state]
+                                                                  Filter [ranking]
+                                                                    InputAdapter
+                                                                      Window [_w2,s_state]
+                                                                        WholeStageCodegen (6)
+                                                                          Sort [s_state,_w2]
+                                                                            InputAdapter
+                                                                              Exchange [s_state] #7
+                                                                                WholeStageCodegen (5)
+                                                                                  HashAggregate [s_state,sum] [sum(UnscaledValue(ss_net_profit)),s_state,_w2,sum]
                                                                                     InputAdapter
-                                                                                      Window [_w2,s_state]
-                                                                                        WholeStageCodegen (6)
-                                                                                          Sort [s_state,_w2]
-                                                                                            InputAdapter
-                                                                                              Exchange [s_state] #8
-                                                                                                WholeStageCodegen (5)
-                                                                                                  HashAggregate [s_state,sum] [sum(UnscaledValue(ss_net_profit)),s_state,_w2,sum]
+                                                                                      Exchange [s_state] #8
+                                                                                        WholeStageCodegen (4)
+                                                                                          HashAggregate [s_state,ss_net_profit] [sum,sum]
+                                                                                            Project [ss_net_profit,s_state]
+                                                                                              BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                                                                Project [ss_sold_date_sk,ss_net_profit,s_state]
+                                                                                                  BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                                                                                    Filter [ss_store_sk,ss_sold_date_sk]
+                                                                                                      ColumnarToRow
+                                                                                                        InputAdapter
+                                                                                                          Scan parquet default.store_sales [ss_sold_date_sk,ss_store_sk,ss_net_profit]
                                                                                                     InputAdapter
-                                                                                                      Exchange [s_state] #9
-                                                                                                        WholeStageCodegen (4)
-                                                                                                          HashAggregate [s_state,ss_net_profit] [sum,sum]
-                                                                                                            Project [ss_net_profit,s_state]
-                                                                                                              BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                                                                Project [ss_sold_date_sk,ss_net_profit,s_state]
-                                                                                                                  BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                                                                                    Filter [ss_store_sk,ss_sold_date_sk]
-                                                                                                                      ColumnarToRow
-                                                                                                                        InputAdapter
-                                                                                                                          Scan parquet default.store_sales [ss_sold_date_sk,ss_store_sk,ss_net_profit]
-                                                                                                                    InputAdapter
-                                                                                                                      BroadcastExchange #10
-                                                                                                                        WholeStageCodegen (2)
-                                                                                                                          Filter [s_store_sk]
-                                                                                                                            ColumnarToRow
-                                                                                                                              InputAdapter
-                                                                                                                                Scan parquet default.store [s_store_sk,s_state]
-                                                                                                                InputAdapter
-                                                                                                                  ReusedExchange [d_date_sk] #5
-                                                  WholeStageCodegen (21)
-                                                    HashAggregate [s_state,sum,isEmpty] [sum(total_sum),total_sum,s_county,g_state,g_county,lochierarchy,sum,isEmpty]
-                                                      InputAdapter
-                                                        Exchange [s_state] #11
-                                                          WholeStageCodegen (20)
-                                                            HashAggregate [s_state,total_sum] [sum,isEmpty,sum,isEmpty]
-                                                              HashAggregate [s_state,s_county,sum] [sum(UnscaledValue(ss_net_profit)),total_sum,sum]
-                                                                InputAdapter
-                                                                  ReusedExchange [s_state,s_county,sum] #4
-                                  WholeStageCodegen (34)
+                                                                                                      BroadcastExchange #9
+                                                                                                        WholeStageCodegen (2)
+                                                                                                          Filter [s_store_sk]
+                                                                                                            ColumnarToRow
+                                                                                                              InputAdapter
+                                                                                                                Scan parquet default.store [s_store_sk,s_state]
+                                                                                                InputAdapter
+                                                                                                  ReusedExchange [d_date_sk] #4
+                                  WholeStageCodegen (21)
+                                    HashAggregate [s_state,sum,isEmpty] [sum(total_sum),total_sum,s_county,g_state,g_county,lochierarchy,sum,isEmpty]
+                                      InputAdapter
+                                        Exchange [s_state] #10
+                                          WholeStageCodegen (20)
+                                            HashAggregate [s_state,total_sum] [sum,isEmpty,sum,isEmpty]
+                                              HashAggregate [s_state,s_county,sum] [sum(UnscaledValue(ss_net_profit)),total_sum,sum]
+                                                InputAdapter
+                                                  ReusedExchange [s_state,s_county,sum] #3
+                                  WholeStageCodegen (32)
                                     HashAggregate [sum,isEmpty] [sum(total_sum),total_sum,s_state,s_county,g_state,g_county,lochierarchy,sum,isEmpty]
                                       InputAdapter
-                                        Exchange #12
-                                          WholeStageCodegen (33)
+                                        Exchange #11
+                                          WholeStageCodegen (31)
                                             HashAggregate [total_sum] [sum,isEmpty,sum,isEmpty]
                                               HashAggregate [s_state,s_county,sum] [sum(UnscaledValue(ss_net_profit)),total_sum,sum]
                                                 InputAdapter
-                                                  ReusedExchange [s_state,s_county,sum] #4
+                                                  ReusedExchange [s_state,s_county,sum] #3

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75.sf100/explain.txt
@@ -1,142 +1,134 @@
 == Physical Plan ==
-TakeOrderedAndProject (138)
-+- * Project (137)
-   +- * SortMergeJoin Inner (136)
-      :- * Sort (74)
-      :  +- Exchange (73)
-      :     +- * HashAggregate (72)
-      :        +- Exchange (71)
-      :           +- * HashAggregate (70)
-      :              +- * HashAggregate (69)
-      :                 +- Exchange (68)
-      :                    +- * HashAggregate (67)
-      :                       +- Union (66)
-      :                          :- * HashAggregate (47)
-      :                          :  +- Exchange (46)
-      :                          :     +- * HashAggregate (45)
-      :                          :        +- Union (44)
-      :                          :           :- * Project (25)
-      :                          :           :  +- SortMergeJoin LeftOuter (24)
-      :                          :           :     :- * Sort (18)
-      :                          :           :     :  +- Exchange (17)
-      :                          :           :     :     +- * Project (16)
-      :                          :           :     :        +- * BroadcastHashJoin Inner BuildRight (15)
-      :                          :           :     :           :- * Project (10)
-      :                          :           :     :           :  +- * BroadcastHashJoin Inner BuildRight (9)
-      :                          :           :     :           :     :- * Filter (3)
-      :                          :           :     :           :     :  +- * ColumnarToRow (2)
-      :                          :           :     :           :     :     +- Scan parquet default.catalog_sales (1)
-      :                          :           :     :           :     +- BroadcastExchange (8)
-      :                          :           :     :           :        +- * Project (7)
-      :                          :           :     :           :           +- * Filter (6)
-      :                          :           :     :           :              +- * ColumnarToRow (5)
-      :                          :           :     :           :                 +- Scan parquet default.item (4)
-      :                          :           :     :           +- BroadcastExchange (14)
-      :                          :           :     :              +- * Filter (13)
-      :                          :           :     :                 +- * ColumnarToRow (12)
-      :                          :           :     :                    +- Scan parquet default.date_dim (11)
-      :                          :           :     +- * Sort (23)
-      :                          :           :        +- Exchange (22)
-      :                          :           :           +- * Filter (21)
-      :                          :           :              +- * ColumnarToRow (20)
-      :                          :           :                 +- Scan parquet default.catalog_returns (19)
-      :                          :           +- * Project (43)
-      :                          :              +- SortMergeJoin LeftOuter (42)
-      :                          :                 :- * Sort (36)
-      :                          :                 :  +- Exchange (35)
-      :                          :                 :     +- * Project (34)
-      :                          :                 :        +- * BroadcastHashJoin Inner BuildRight (33)
-      :                          :                 :           :- * Project (31)
-      :                          :                 :           :  +- * BroadcastHashJoin Inner BuildRight (30)
-      :                          :                 :           :     :- * Filter (28)
-      :                          :                 :           :     :  +- * ColumnarToRow (27)
-      :                          :                 :           :     :     +- Scan parquet default.store_sales (26)
-      :                          :                 :           :     +- ReusedExchange (29)
-      :                          :                 :           +- ReusedExchange (32)
-      :                          :                 +- * Sort (41)
-      :                          :                    +- Exchange (40)
-      :                          :                       +- * Filter (39)
-      :                          :                          +- * ColumnarToRow (38)
-      :                          :                             +- Scan parquet default.store_returns (37)
-      :                          +- * Project (65)
-      :                             +- SortMergeJoin LeftOuter (64)
-      :                                :- * Sort (58)
-      :                                :  +- Exchange (57)
-      :                                :     +- * Project (56)
-      :                                :        +- * BroadcastHashJoin Inner BuildRight (55)
-      :                                :           :- * Project (53)
-      :                                :           :  +- * BroadcastHashJoin Inner BuildRight (52)
-      :                                :           :     :- * Filter (50)
-      :                                :           :     :  +- * ColumnarToRow (49)
-      :                                :           :     :     +- Scan parquet default.web_sales (48)
-      :                                :           :     +- ReusedExchange (51)
-      :                                :           +- ReusedExchange (54)
-      :                                +- * Sort (63)
-      :                                   +- Exchange (62)
-      :                                      +- * Filter (61)
-      :                                         +- * ColumnarToRow (60)
-      :                                            +- Scan parquet default.web_returns (59)
-      +- * Sort (135)
-         +- Exchange (134)
-            +- * HashAggregate (133)
-               +- Exchange (132)
-                  +- * HashAggregate (131)
-                     +- * HashAggregate (130)
-                        +- Exchange (129)
-                           +- * HashAggregate (128)
-                              +- Union (127)
-                                 :- * HashAggregate (111)
-                                 :  +- Exchange (110)
-                                 :     +- * HashAggregate (109)
-                                 :        +- Union (108)
-                                 :           :- * Project (92)
-                                 :           :  +- SortMergeJoin LeftOuter (91)
-                                 :           :     :- * Sort (88)
-                                 :           :     :  +- Exchange (87)
-                                 :           :     :     +- * Project (86)
-                                 :           :     :        +- * BroadcastHashJoin Inner BuildRight (85)
-                                 :           :     :           :- * Project (80)
-                                 :           :     :           :  +- * BroadcastHashJoin Inner BuildRight (79)
-                                 :           :     :           :     :- * Filter (77)
-                                 :           :     :           :     :  +- * ColumnarToRow (76)
-                                 :           :     :           :     :     +- Scan parquet default.catalog_sales (75)
-                                 :           :     :           :     +- ReusedExchange (78)
-                                 :           :     :           +- BroadcastExchange (84)
-                                 :           :     :              +- * Filter (83)
-                                 :           :     :                 +- * ColumnarToRow (82)
-                                 :           :     :                    +- Scan parquet default.date_dim (81)
-                                 :           :     +- * Sort (90)
-                                 :           :        +- ReusedExchange (89)
-                                 :           +- * Project (107)
-                                 :              +- SortMergeJoin LeftOuter (106)
-                                 :                 :- * Sort (103)
-                                 :                 :  +- Exchange (102)
-                                 :                 :     +- * Project (101)
-                                 :                 :        +- * BroadcastHashJoin Inner BuildRight (100)
-                                 :                 :           :- * Project (98)
-                                 :                 :           :  +- * BroadcastHashJoin Inner BuildRight (97)
-                                 :                 :           :     :- * Filter (95)
-                                 :                 :           :     :  +- * ColumnarToRow (94)
-                                 :                 :           :     :     +- Scan parquet default.store_sales (93)
-                                 :                 :           :     +- ReusedExchange (96)
-                                 :                 :           +- ReusedExchange (99)
-                                 :                 +- * Sort (105)
-                                 :                    +- ReusedExchange (104)
-                                 +- * Project (126)
-                                    +- SortMergeJoin LeftOuter (125)
-                                       :- * Sort (122)
-                                       :  +- Exchange (121)
-                                       :     +- * Project (120)
-                                       :        +- * BroadcastHashJoin Inner BuildRight (119)
-                                       :           :- * Project (117)
-                                       :           :  +- * BroadcastHashJoin Inner BuildRight (116)
-                                       :           :     :- * Filter (114)
-                                       :           :     :  +- * ColumnarToRow (113)
-                                       :           :     :     +- Scan parquet default.web_sales (112)
-                                       :           :     +- ReusedExchange (115)
-                                       :           +- ReusedExchange (118)
-                                       +- * Sort (124)
-                                          +- ReusedExchange (123)
+TakeOrderedAndProject (130)
++- * Project (129)
+   +- * SortMergeJoin Inner (128)
+      :- * Sort (70)
+      :  +- Exchange (69)
+      :     +- * HashAggregate (68)
+      :        +- Exchange (67)
+      :           +- * HashAggregate (66)
+      :              +- * HashAggregate (65)
+      :                 +- Exchange (64)
+      :                    +- * HashAggregate (63)
+      :                       +- Union (62)
+      :                          :- * Project (25)
+      :                          :  +- SortMergeJoin LeftOuter (24)
+      :                          :     :- * Sort (18)
+      :                          :     :  +- Exchange (17)
+      :                          :     :     +- * Project (16)
+      :                          :     :        +- * BroadcastHashJoin Inner BuildRight (15)
+      :                          :     :           :- * Project (10)
+      :                          :     :           :  +- * BroadcastHashJoin Inner BuildRight (9)
+      :                          :     :           :     :- * Filter (3)
+      :                          :     :           :     :  +- * ColumnarToRow (2)
+      :                          :     :           :     :     +- Scan parquet default.catalog_sales (1)
+      :                          :     :           :     +- BroadcastExchange (8)
+      :                          :     :           :        +- * Project (7)
+      :                          :     :           :           +- * Filter (6)
+      :                          :     :           :              +- * ColumnarToRow (5)
+      :                          :     :           :                 +- Scan parquet default.item (4)
+      :                          :     :           +- BroadcastExchange (14)
+      :                          :     :              +- * Filter (13)
+      :                          :     :                 +- * ColumnarToRow (12)
+      :                          :     :                    +- Scan parquet default.date_dim (11)
+      :                          :     +- * Sort (23)
+      :                          :        +- Exchange (22)
+      :                          :           +- * Filter (21)
+      :                          :              +- * ColumnarToRow (20)
+      :                          :                 +- Scan parquet default.catalog_returns (19)
+      :                          :- * Project (43)
+      :                          :  +- SortMergeJoin LeftOuter (42)
+      :                          :     :- * Sort (36)
+      :                          :     :  +- Exchange (35)
+      :                          :     :     +- * Project (34)
+      :                          :     :        +- * BroadcastHashJoin Inner BuildRight (33)
+      :                          :     :           :- * Project (31)
+      :                          :     :           :  +- * BroadcastHashJoin Inner BuildRight (30)
+      :                          :     :           :     :- * Filter (28)
+      :                          :     :           :     :  +- * ColumnarToRow (27)
+      :                          :     :           :     :     +- Scan parquet default.store_sales (26)
+      :                          :     :           :     +- ReusedExchange (29)
+      :                          :     :           +- ReusedExchange (32)
+      :                          :     +- * Sort (41)
+      :                          :        +- Exchange (40)
+      :                          :           +- * Filter (39)
+      :                          :              +- * ColumnarToRow (38)
+      :                          :                 +- Scan parquet default.store_returns (37)
+      :                          +- * Project (61)
+      :                             +- SortMergeJoin LeftOuter (60)
+      :                                :- * Sort (54)
+      :                                :  +- Exchange (53)
+      :                                :     +- * Project (52)
+      :                                :        +- * BroadcastHashJoin Inner BuildRight (51)
+      :                                :           :- * Project (49)
+      :                                :           :  +- * BroadcastHashJoin Inner BuildRight (48)
+      :                                :           :     :- * Filter (46)
+      :                                :           :     :  +- * ColumnarToRow (45)
+      :                                :           :     :     +- Scan parquet default.web_sales (44)
+      :                                :           :     +- ReusedExchange (47)
+      :                                :           +- ReusedExchange (50)
+      :                                +- * Sort (59)
+      :                                   +- Exchange (58)
+      :                                      +- * Filter (57)
+      :                                         +- * ColumnarToRow (56)
+      :                                            +- Scan parquet default.web_returns (55)
+      +- * Sort (127)
+         +- Exchange (126)
+            +- * HashAggregate (125)
+               +- Exchange (124)
+                  +- * HashAggregate (123)
+                     +- * HashAggregate (122)
+                        +- Exchange (121)
+                           +- * HashAggregate (120)
+                              +- Union (119)
+                                 :- * Project (88)
+                                 :  +- SortMergeJoin LeftOuter (87)
+                                 :     :- * Sort (84)
+                                 :     :  +- Exchange (83)
+                                 :     :     +- * Project (82)
+                                 :     :        +- * BroadcastHashJoin Inner BuildRight (81)
+                                 :     :           :- * Project (76)
+                                 :     :           :  +- * BroadcastHashJoin Inner BuildRight (75)
+                                 :     :           :     :- * Filter (73)
+                                 :     :           :     :  +- * ColumnarToRow (72)
+                                 :     :           :     :     +- Scan parquet default.catalog_sales (71)
+                                 :     :           :     +- ReusedExchange (74)
+                                 :     :           +- BroadcastExchange (80)
+                                 :     :              +- * Filter (79)
+                                 :     :                 +- * ColumnarToRow (78)
+                                 :     :                    +- Scan parquet default.date_dim (77)
+                                 :     +- * Sort (86)
+                                 :        +- ReusedExchange (85)
+                                 :- * Project (103)
+                                 :  +- SortMergeJoin LeftOuter (102)
+                                 :     :- * Sort (99)
+                                 :     :  +- Exchange (98)
+                                 :     :     +- * Project (97)
+                                 :     :        +- * BroadcastHashJoin Inner BuildRight (96)
+                                 :     :           :- * Project (94)
+                                 :     :           :  +- * BroadcastHashJoin Inner BuildRight (93)
+                                 :     :           :     :- * Filter (91)
+                                 :     :           :     :  +- * ColumnarToRow (90)
+                                 :     :           :     :     +- Scan parquet default.store_sales (89)
+                                 :     :           :     +- ReusedExchange (92)
+                                 :     :           +- ReusedExchange (95)
+                                 :     +- * Sort (101)
+                                 :        +- ReusedExchange (100)
+                                 +- * Project (118)
+                                    +- SortMergeJoin LeftOuter (117)
+                                       :- * Sort (114)
+                                       :  +- Exchange (113)
+                                       :     +- * Project (112)
+                                       :        +- * BroadcastHashJoin Inner BuildRight (111)
+                                       :           :- * Project (109)
+                                       :           :  +- * BroadcastHashJoin Inner BuildRight (108)
+                                       :           :     :- * Filter (106)
+                                       :           :     :  +- * ColumnarToRow (105)
+                                       :           :     :     +- Scan parquet default.web_sales (104)
+                                       :           :     +- ReusedExchange (107)
+                                       :           +- ReusedExchange (110)
+                                       +- * Sort (116)
+                                          +- ReusedExchange (115)
 
 
 (1) Scan parquet default.catalog_sales
@@ -213,7 +205,7 @@ Input [11]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, 
 
 (17) Exchange
 Input [9]: [cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14]
-Arguments: hashpartitioning(cs_order_number#3, cs_item_sk#2, 5), true, [id=#16]
+Arguments: hashpartitioning(cs_order_number#3, cs_item_sk#2, 5), ENSURE_REQUIREMENTS, [id=#16]
 
 (18) Sort [codegen id : 4]
 Input [9]: [cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14]
@@ -235,7 +227,7 @@ Condition : (isnotnull(cr_order_number#18) AND isnotnull(cr_item_sk#17))
 
 (22) Exchange
 Input [4]: [cr_item_sk#17, cr_order_number#18, cr_return_quantity#19, cr_return_amount#20]
-Arguments: hashpartitioning(cr_order_number#18, cr_item_sk#17, 5), true, [id=#21]
+Arguments: hashpartitioning(cr_order_number#18, cr_item_sk#17, 5), ENSURE_REQUIREMENTS, [id=#21]
 
 (23) Sort [codegen id : 6]
 Input [4]: [cr_item_sk#17, cr_order_number#18, cr_return_quantity#19, cr_return_amount#20]
@@ -290,7 +282,7 @@ Input [11]: [ss_sold_date_sk#24, ss_item_sk#25, ss_ticket_number#26, ss_quantity
 
 (35) Exchange
 Input [9]: [ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14]
-Arguments: hashpartitioning(cast(ss_ticket_number#26 as bigint), cast(ss_item_sk#25 as bigint), 5), true, [id=#29]
+Arguments: hashpartitioning(cast(ss_ticket_number#26 as bigint), cast(ss_item_sk#25 as bigint), 5), ENSURE_REQUIREMENTS, [id=#29]
 
 (36) Sort [codegen id : 11]
 Input [9]: [ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14]
@@ -312,7 +304,7 @@ Condition : (isnotnull(sr_ticket_number#31) AND isnotnull(sr_item_sk#30))
 
 (40) Exchange
 Input [4]: [sr_item_sk#30, sr_ticket_number#31, sr_return_quantity#32, sr_return_amt#33]
-Arguments: hashpartitioning(sr_ticket_number#31, sr_item_sk#30, 5), true, [id=#34]
+Arguments: hashpartitioning(sr_ticket_number#31, sr_item_sk#30, 5), ENSURE_REQUIREMENTS, [id=#34]
 
 (41) Sort [codegen id : 13]
 Input [4]: [sr_item_sk#30, sr_ticket_number#31, sr_return_quantity#32, sr_return_amt#33]
@@ -327,426 +319,386 @@ Join condition: None
 Output [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, (ss_quantity#27 - coalesce(sr_return_quantity#32, 0)) AS sales_cnt#35, CheckOverflow((promote_precision(cast(ss_ext_sales_price#28 as decimal(8,2))) - promote_precision(cast(coalesce(sr_return_amt#33, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#36]
 Input [13]: [ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14, sr_item_sk#30, sr_ticket_number#31, sr_return_quantity#32, sr_return_amt#33]
 
-(44) Union
-
-(45) HashAggregate [codegen id : 15]
-Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23]
-Keys [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23]
-Functions: []
-Aggregate Attributes: []
-Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23]
-
-(46) Exchange
-Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23]
-Arguments: hashpartitioning(d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23, 5), true, [id=#37]
-
-(47) HashAggregate [codegen id : 16]
-Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23]
-Keys [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23]
-Functions: []
-Aggregate Attributes: []
-Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23]
-
-(48) Scan parquet default.web_sales
-Output [5]: [ws_sold_date_sk#38, ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42]
+(44) Scan parquet default.web_sales
+Output [5]: [ws_sold_date_sk#37, ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_sales]
 PushedFilters: [IsNotNull(ws_item_sk), IsNotNull(ws_sold_date_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_item_sk:int,ws_order_number:int,ws_quantity:int,ws_ext_sales_price:decimal(7,2)>
 
-(49) ColumnarToRow [codegen id : 19]
-Input [5]: [ws_sold_date_sk#38, ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42]
+(45) ColumnarToRow [codegen id : 17]
+Input [5]: [ws_sold_date_sk#37, ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41]
 
-(50) Filter [codegen id : 19]
-Input [5]: [ws_sold_date_sk#38, ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42]
-Condition : (isnotnull(ws_item_sk#39) AND isnotnull(ws_sold_date_sk#38))
+(46) Filter [codegen id : 17]
+Input [5]: [ws_sold_date_sk#37, ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41]
+Condition : (isnotnull(ws_item_sk#38) AND isnotnull(ws_sold_date_sk#37))
 
-(51) ReusedExchange [Reuses operator id: 8]
+(47) ReusedExchange [Reuses operator id: 8]
 Output [5]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
 
-(52) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [ws_item_sk#39]
+(48) BroadcastHashJoin [codegen id : 17]
+Left keys [1]: [ws_item_sk#38]
 Right keys [1]: [i_item_sk#6]
 Join condition: None
 
-(53) Project [codegen id : 19]
-Output [9]: [ws_sold_date_sk#38, ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
-Input [10]: [ws_sold_date_sk#38, ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42, i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
+(49) Project [codegen id : 17]
+Output [9]: [ws_sold_date_sk#37, ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
+Input [10]: [ws_sold_date_sk#37, ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41, i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
 
-(54) ReusedExchange [Reuses operator id: 14]
+(50) ReusedExchange [Reuses operator id: 14]
 Output [2]: [d_date_sk#13, d_year#14]
 
-(55) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [ws_sold_date_sk#38]
+(51) BroadcastHashJoin [codegen id : 17]
+Left keys [1]: [ws_sold_date_sk#37]
 Right keys [1]: [d_date_sk#13]
 Join condition: None
 
-(56) Project [codegen id : 19]
-Output [9]: [ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14]
-Input [11]: [ws_sold_date_sk#38, ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_date_sk#13, d_year#14]
+(52) Project [codegen id : 17]
+Output [9]: [ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14]
+Input [11]: [ws_sold_date_sk#37, ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_date_sk#13, d_year#14]
 
-(57) Exchange
-Input [9]: [ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14]
-Arguments: hashpartitioning(cast(ws_order_number#40 as bigint), cast(ws_item_sk#39 as bigint), 5), true, [id=#43]
+(53) Exchange
+Input [9]: [ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14]
+Arguments: hashpartitioning(cast(ws_order_number#39 as bigint), cast(ws_item_sk#38 as bigint), 5), ENSURE_REQUIREMENTS, [id=#42]
 
-(58) Sort [codegen id : 20]
-Input [9]: [ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14]
-Arguments: [cast(ws_order_number#40 as bigint) ASC NULLS FIRST, cast(ws_item_sk#39 as bigint) ASC NULLS FIRST], false, 0
+(54) Sort [codegen id : 18]
+Input [9]: [ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14]
+Arguments: [cast(ws_order_number#39 as bigint) ASC NULLS FIRST, cast(ws_item_sk#38 as bigint) ASC NULLS FIRST], false, 0
 
-(59) Scan parquet default.web_returns
-Output [4]: [wr_item_sk#44, wr_order_number#45, wr_return_quantity#46, wr_return_amt#47]
+(55) Scan parquet default.web_returns
+Output [4]: [wr_item_sk#43, wr_order_number#44, wr_return_quantity#45, wr_return_amt#46]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_returns]
 PushedFilters: [IsNotNull(wr_order_number), IsNotNull(wr_item_sk)]
 ReadSchema: struct<wr_item_sk:bigint,wr_order_number:bigint,wr_return_quantity:int,wr_return_amt:decimal(7,2)>
 
-(60) ColumnarToRow [codegen id : 21]
-Input [4]: [wr_item_sk#44, wr_order_number#45, wr_return_quantity#46, wr_return_amt#47]
+(56) ColumnarToRow [codegen id : 19]
+Input [4]: [wr_item_sk#43, wr_order_number#44, wr_return_quantity#45, wr_return_amt#46]
 
-(61) Filter [codegen id : 21]
-Input [4]: [wr_item_sk#44, wr_order_number#45, wr_return_quantity#46, wr_return_amt#47]
-Condition : (isnotnull(wr_order_number#45) AND isnotnull(wr_item_sk#44))
+(57) Filter [codegen id : 19]
+Input [4]: [wr_item_sk#43, wr_order_number#44, wr_return_quantity#45, wr_return_amt#46]
+Condition : (isnotnull(wr_order_number#44) AND isnotnull(wr_item_sk#43))
 
-(62) Exchange
-Input [4]: [wr_item_sk#44, wr_order_number#45, wr_return_quantity#46, wr_return_amt#47]
-Arguments: hashpartitioning(wr_order_number#45, wr_item_sk#44, 5), true, [id=#48]
+(58) Exchange
+Input [4]: [wr_item_sk#43, wr_order_number#44, wr_return_quantity#45, wr_return_amt#46]
+Arguments: hashpartitioning(wr_order_number#44, wr_item_sk#43, 5), ENSURE_REQUIREMENTS, [id=#47]
 
-(63) Sort [codegen id : 22]
-Input [4]: [wr_item_sk#44, wr_order_number#45, wr_return_quantity#46, wr_return_amt#47]
-Arguments: [wr_order_number#45 ASC NULLS FIRST, wr_item_sk#44 ASC NULLS FIRST], false, 0
+(59) Sort [codegen id : 20]
+Input [4]: [wr_item_sk#43, wr_order_number#44, wr_return_quantity#45, wr_return_amt#46]
+Arguments: [wr_order_number#44 ASC NULLS FIRST, wr_item_sk#43 ASC NULLS FIRST], false, 0
 
-(64) SortMergeJoin
-Left keys [2]: [cast(ws_order_number#40 as bigint), cast(ws_item_sk#39 as bigint)]
-Right keys [2]: [wr_order_number#45, wr_item_sk#44]
+(60) SortMergeJoin
+Left keys [2]: [cast(ws_order_number#39 as bigint), cast(ws_item_sk#38 as bigint)]
+Right keys [2]: [wr_order_number#44, wr_item_sk#43]
 Join condition: None
 
-(65) Project [codegen id : 23]
-Output [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, (ws_quantity#41 - coalesce(wr_return_quantity#46, 0)) AS sales_cnt#49, CheckOverflow((promote_precision(cast(ws_ext_sales_price#42 as decimal(8,2))) - promote_precision(cast(coalesce(wr_return_amt#47, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#50]
-Input [13]: [ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14, wr_item_sk#44, wr_order_number#45, wr_return_quantity#46, wr_return_amt#47]
+(61) Project [codegen id : 21]
+Output [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, (ws_quantity#40 - coalesce(wr_return_quantity#45, 0)) AS sales_cnt#48, CheckOverflow((promote_precision(cast(ws_ext_sales_price#41 as decimal(8,2))) - promote_precision(cast(coalesce(wr_return_amt#46, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#49]
+Input [13]: [ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14, wr_item_sk#43, wr_order_number#44, wr_return_quantity#45, wr_return_amt#46]
 
-(66) Union
+(62) Union
 
-(67) HashAggregate [codegen id : 24]
+(63) HashAggregate [codegen id : 22]
 Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23]
 Keys [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23]
 Functions: []
 Aggregate Attributes: []
 Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23]
 
-(68) Exchange
+(64) Exchange
 Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23]
-Arguments: hashpartitioning(d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23, 5), true, [id=#51]
+Arguments: hashpartitioning(d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23, 5), ENSURE_REQUIREMENTS, [id=#50]
 
-(69) HashAggregate [codegen id : 25]
+(65) HashAggregate [codegen id : 23]
 Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23]
 Keys [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23]
 Functions: []
 Aggregate Attributes: []
 Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23]
 
-(70) HashAggregate [codegen id : 25]
+(66) HashAggregate [codegen id : 23]
 Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#22, sales_amt#23]
 Keys [5]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
 Functions [2]: [partial_sum(cast(sales_cnt#22 as bigint)), partial_sum(UnscaledValue(sales_amt#23))]
-Aggregate Attributes [2]: [sum#52, sum#53]
-Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum#54, sum#55]
+Aggregate Attributes [2]: [sum#51, sum#52]
+Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum#53, sum#54]
 
-(71) Exchange
-Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum#54, sum#55]
-Arguments: hashpartitioning(d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, 5), true, [id=#56]
+(67) Exchange
+Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum#53, sum#54]
+Arguments: hashpartitioning(d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, 5), ENSURE_REQUIREMENTS, [id=#55]
 
-(72) HashAggregate [codegen id : 26]
-Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum#54, sum#55]
+(68) HashAggregate [codegen id : 24]
+Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum#53, sum#54]
 Keys [5]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
 Functions [2]: [sum(cast(sales_cnt#22 as bigint)), sum(UnscaledValue(sales_amt#23))]
-Aggregate Attributes [2]: [sum(cast(sales_cnt#22 as bigint))#57, sum(UnscaledValue(sales_amt#23))#58]
-Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum(cast(sales_cnt#22 as bigint))#57 AS sales_cnt#59, MakeDecimal(sum(UnscaledValue(sales_amt#23))#58,18,2) AS sales_amt#60]
+Aggregate Attributes [2]: [sum(cast(sales_cnt#22 as bigint))#56, sum(UnscaledValue(sales_amt#23))#57]
+Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum(cast(sales_cnt#22 as bigint))#56 AS sales_cnt#58, MakeDecimal(sum(UnscaledValue(sales_amt#23))#57,18,2) AS sales_amt#59]
 
-(73) Exchange
-Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#59, sales_amt#60]
-Arguments: hashpartitioning(i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, 5), true, [id=#61]
+(69) Exchange
+Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#58, sales_amt#59]
+Arguments: hashpartitioning(i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, 5), ENSURE_REQUIREMENTS, [id=#60]
 
-(74) Sort [codegen id : 27]
-Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#59, sales_amt#60]
+(70) Sort [codegen id : 25]
+Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#58, sales_amt#59]
 Arguments: [i_brand_id#7 ASC NULLS FIRST, i_class_id#8 ASC NULLS FIRST, i_category_id#9 ASC NULLS FIRST, i_manufact_id#11 ASC NULLS FIRST], false, 0
 
-(75) Scan parquet default.catalog_sales
+(71) Scan parquet default.catalog_sales
 Output [5]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_sales]
 PushedFilters: [IsNotNull(cs_item_sk), IsNotNull(cs_sold_date_sk)]
 ReadSchema: struct<cs_sold_date_sk:int,cs_item_sk:int,cs_order_number:int,cs_quantity:int,cs_ext_sales_price:decimal(7,2)>
 
-(76) ColumnarToRow [codegen id : 30]
+(72) ColumnarToRow [codegen id : 28]
 Input [5]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5]
 
-(77) Filter [codegen id : 30]
+(73) Filter [codegen id : 28]
 Input [5]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5]
 Condition : (isnotnull(cs_item_sk#2) AND isnotnull(cs_sold_date_sk#1))
 
-(78) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#62, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66]
+(74) ReusedExchange [Reuses operator id: 8]
+Output [5]: [i_item_sk#61, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65]
 
-(79) BroadcastHashJoin [codegen id : 30]
+(75) BroadcastHashJoin [codegen id : 28]
 Left keys [1]: [cs_item_sk#2]
-Right keys [1]: [i_item_sk#62]
+Right keys [1]: [i_item_sk#61]
 Join condition: None
 
-(80) Project [codegen id : 30]
-Output [9]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66]
-Input [10]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_item_sk#62, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66]
+(76) Project [codegen id : 28]
+Output [9]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65]
+Input [10]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_item_sk#61, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65]
 
-(81) Scan parquet default.date_dim
-Output [2]: [d_date_sk#67, d_year#68]
+(77) Scan parquet default.date_dim
+Output [2]: [d_date_sk#66, d_year#67]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(82) ColumnarToRow [codegen id : 29]
-Input [2]: [d_date_sk#67, d_year#68]
+(78) ColumnarToRow [codegen id : 27]
+Input [2]: [d_date_sk#66, d_year#67]
 
-(83) Filter [codegen id : 29]
-Input [2]: [d_date_sk#67, d_year#68]
-Condition : ((isnotnull(d_year#68) AND (d_year#68 = 2001)) AND isnotnull(d_date_sk#67))
+(79) Filter [codegen id : 27]
+Input [2]: [d_date_sk#66, d_year#67]
+Condition : ((isnotnull(d_year#67) AND (d_year#67 = 2001)) AND isnotnull(d_date_sk#66))
 
-(84) BroadcastExchange
-Input [2]: [d_date_sk#67, d_year#68]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#69]
+(80) BroadcastExchange
+Input [2]: [d_date_sk#66, d_year#67]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#68]
 
-(85) BroadcastHashJoin [codegen id : 30]
+(81) BroadcastHashJoin [codegen id : 28]
 Left keys [1]: [cs_sold_date_sk#1]
-Right keys [1]: [d_date_sk#67]
+Right keys [1]: [d_date_sk#66]
 Join condition: None
 
-(86) Project [codegen id : 30]
-Output [9]: [cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, d_year#68]
-Input [11]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, d_date_sk#67, d_year#68]
+(82) Project [codegen id : 28]
+Output [9]: [cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, d_year#67]
+Input [11]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, d_date_sk#66, d_year#67]
 
-(87) Exchange
-Input [9]: [cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, d_year#68]
-Arguments: hashpartitioning(cs_order_number#3, cs_item_sk#2, 5), true, [id=#70]
+(83) Exchange
+Input [9]: [cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, d_year#67]
+Arguments: hashpartitioning(cs_order_number#3, cs_item_sk#2, 5), ENSURE_REQUIREMENTS, [id=#69]
 
-(88) Sort [codegen id : 31]
-Input [9]: [cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, d_year#68]
+(84) Sort [codegen id : 29]
+Input [9]: [cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, d_year#67]
 Arguments: [cs_order_number#3 ASC NULLS FIRST, cs_item_sk#2 ASC NULLS FIRST], false, 0
 
-(89) ReusedExchange [Reuses operator id: 22]
+(85) ReusedExchange [Reuses operator id: 22]
 Output [4]: [cr_item_sk#17, cr_order_number#18, cr_return_quantity#19, cr_return_amount#20]
 
-(90) Sort [codegen id : 33]
+(86) Sort [codegen id : 31]
 Input [4]: [cr_item_sk#17, cr_order_number#18, cr_return_quantity#19, cr_return_amount#20]
 Arguments: [cr_order_number#18 ASC NULLS FIRST, cr_item_sk#17 ASC NULLS FIRST], false, 0
 
-(91) SortMergeJoin
+(87) SortMergeJoin
 Left keys [2]: [cs_order_number#3, cs_item_sk#2]
 Right keys [2]: [cr_order_number#18, cr_item_sk#17]
 Join condition: None
 
-(92) Project [codegen id : 34]
-Output [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, (cs_quantity#4 - coalesce(cr_return_quantity#19, 0)) AS sales_cnt#22, CheckOverflow((promote_precision(cast(cs_ext_sales_price#5 as decimal(8,2))) - promote_precision(cast(coalesce(cr_return_amount#20, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#23]
-Input [13]: [cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, d_year#68, cr_item_sk#17, cr_order_number#18, cr_return_quantity#19, cr_return_amount#20]
+(88) Project [codegen id : 32]
+Output [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, (cs_quantity#4 - coalesce(cr_return_quantity#19, 0)) AS sales_cnt#22, CheckOverflow((promote_precision(cast(cs_ext_sales_price#5 as decimal(8,2))) - promote_precision(cast(coalesce(cr_return_amount#20, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#23]
+Input [13]: [cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, d_year#67, cr_item_sk#17, cr_order_number#18, cr_return_quantity#19, cr_return_amount#20]
 
-(93) Scan parquet default.store_sales
+(89) Scan parquet default.store_sales
 Output [5]: [ss_sold_date_sk#24, ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_sold_date_sk)]
 ReadSchema: struct<ss_sold_date_sk:int,ss_item_sk:int,ss_ticket_number:int,ss_quantity:int,ss_ext_sales_price:decimal(7,2)>
 
-(94) ColumnarToRow [codegen id : 37]
+(90) ColumnarToRow [codegen id : 35]
 Input [5]: [ss_sold_date_sk#24, ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28]
 
-(95) Filter [codegen id : 37]
+(91) Filter [codegen id : 35]
 Input [5]: [ss_sold_date_sk#24, ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28]
 Condition : (isnotnull(ss_item_sk#25) AND isnotnull(ss_sold_date_sk#24))
 
-(96) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#62, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66]
+(92) ReusedExchange [Reuses operator id: 8]
+Output [5]: [i_item_sk#61, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65]
 
-(97) BroadcastHashJoin [codegen id : 37]
+(93) BroadcastHashJoin [codegen id : 35]
 Left keys [1]: [ss_item_sk#25]
-Right keys [1]: [i_item_sk#62]
+Right keys [1]: [i_item_sk#61]
 Join condition: None
 
-(98) Project [codegen id : 37]
-Output [9]: [ss_sold_date_sk#24, ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66]
-Input [10]: [ss_sold_date_sk#24, ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_item_sk#62, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66]
+(94) Project [codegen id : 35]
+Output [9]: [ss_sold_date_sk#24, ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65]
+Input [10]: [ss_sold_date_sk#24, ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_item_sk#61, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65]
 
-(99) ReusedExchange [Reuses operator id: 84]
-Output [2]: [d_date_sk#67, d_year#68]
+(95) ReusedExchange [Reuses operator id: 80]
+Output [2]: [d_date_sk#66, d_year#67]
 
-(100) BroadcastHashJoin [codegen id : 37]
+(96) BroadcastHashJoin [codegen id : 35]
 Left keys [1]: [ss_sold_date_sk#24]
-Right keys [1]: [d_date_sk#67]
+Right keys [1]: [d_date_sk#66]
 Join condition: None
 
-(101) Project [codegen id : 37]
-Output [9]: [ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, d_year#68]
-Input [11]: [ss_sold_date_sk#24, ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, d_date_sk#67, d_year#68]
+(97) Project [codegen id : 35]
+Output [9]: [ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, d_year#67]
+Input [11]: [ss_sold_date_sk#24, ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, d_date_sk#66, d_year#67]
 
-(102) Exchange
-Input [9]: [ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, d_year#68]
-Arguments: hashpartitioning(cast(ss_ticket_number#26 as bigint), cast(ss_item_sk#25 as bigint), 5), true, [id=#71]
+(98) Exchange
+Input [9]: [ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, d_year#67]
+Arguments: hashpartitioning(cast(ss_ticket_number#26 as bigint), cast(ss_item_sk#25 as bigint), 5), ENSURE_REQUIREMENTS, [id=#70]
 
-(103) Sort [codegen id : 38]
-Input [9]: [ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, d_year#68]
+(99) Sort [codegen id : 36]
+Input [9]: [ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, d_year#67]
 Arguments: [cast(ss_ticket_number#26 as bigint) ASC NULLS FIRST, cast(ss_item_sk#25 as bigint) ASC NULLS FIRST], false, 0
 
-(104) ReusedExchange [Reuses operator id: 40]
+(100) ReusedExchange [Reuses operator id: 40]
 Output [4]: [sr_item_sk#30, sr_ticket_number#31, sr_return_quantity#32, sr_return_amt#33]
 
-(105) Sort [codegen id : 40]
+(101) Sort [codegen id : 38]
 Input [4]: [sr_item_sk#30, sr_ticket_number#31, sr_return_quantity#32, sr_return_amt#33]
 Arguments: [sr_ticket_number#31 ASC NULLS FIRST, sr_item_sk#30 ASC NULLS FIRST], false, 0
 
-(106) SortMergeJoin
+(102) SortMergeJoin
 Left keys [2]: [cast(ss_ticket_number#26 as bigint), cast(ss_item_sk#25 as bigint)]
 Right keys [2]: [sr_ticket_number#31, sr_item_sk#30]
 Join condition: None
 
-(107) Project [codegen id : 41]
-Output [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, (ss_quantity#27 - coalesce(sr_return_quantity#32, 0)) AS sales_cnt#72, CheckOverflow((promote_precision(cast(ss_ext_sales_price#28 as decimal(8,2))) - promote_precision(cast(coalesce(sr_return_amt#33, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#73]
-Input [13]: [ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, d_year#68, sr_item_sk#30, sr_ticket_number#31, sr_return_quantity#32, sr_return_amt#33]
+(103) Project [codegen id : 39]
+Output [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, (ss_quantity#27 - coalesce(sr_return_quantity#32, 0)) AS sales_cnt#71, CheckOverflow((promote_precision(cast(ss_ext_sales_price#28 as decimal(8,2))) - promote_precision(cast(coalesce(sr_return_amt#33, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#72]
+Input [13]: [ss_item_sk#25, ss_ticket_number#26, ss_quantity#27, ss_ext_sales_price#28, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, d_year#67, sr_item_sk#30, sr_ticket_number#31, sr_return_quantity#32, sr_return_amt#33]
 
-(108) Union
-
-(109) HashAggregate [codegen id : 42]
-Input [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23]
-Keys [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23]
-Functions: []
-Aggregate Attributes: []
-Results [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23]
-
-(110) Exchange
-Input [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23]
-Arguments: hashpartitioning(d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23, 5), true, [id=#74]
-
-(111) HashAggregate [codegen id : 43]
-Input [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23]
-Keys [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23]
-Functions: []
-Aggregate Attributes: []
-Results [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23]
-
-(112) Scan parquet default.web_sales
-Output [5]: [ws_sold_date_sk#38, ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42]
+(104) Scan parquet default.web_sales
+Output [5]: [ws_sold_date_sk#37, ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_sales]
 PushedFilters: [IsNotNull(ws_item_sk), IsNotNull(ws_sold_date_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_item_sk:int,ws_order_number:int,ws_quantity:int,ws_ext_sales_price:decimal(7,2)>
 
-(113) ColumnarToRow [codegen id : 46]
-Input [5]: [ws_sold_date_sk#38, ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42]
+(105) ColumnarToRow [codegen id : 42]
+Input [5]: [ws_sold_date_sk#37, ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41]
 
-(114) Filter [codegen id : 46]
-Input [5]: [ws_sold_date_sk#38, ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42]
-Condition : (isnotnull(ws_item_sk#39) AND isnotnull(ws_sold_date_sk#38))
+(106) Filter [codegen id : 42]
+Input [5]: [ws_sold_date_sk#37, ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41]
+Condition : (isnotnull(ws_item_sk#38) AND isnotnull(ws_sold_date_sk#37))
 
-(115) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#62, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66]
+(107) ReusedExchange [Reuses operator id: 8]
+Output [5]: [i_item_sk#61, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65]
 
-(116) BroadcastHashJoin [codegen id : 46]
-Left keys [1]: [ws_item_sk#39]
-Right keys [1]: [i_item_sk#62]
+(108) BroadcastHashJoin [codegen id : 42]
+Left keys [1]: [ws_item_sk#38]
+Right keys [1]: [i_item_sk#61]
 Join condition: None
 
-(117) Project [codegen id : 46]
-Output [9]: [ws_sold_date_sk#38, ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66]
-Input [10]: [ws_sold_date_sk#38, ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42, i_item_sk#62, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66]
+(109) Project [codegen id : 42]
+Output [9]: [ws_sold_date_sk#37, ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65]
+Input [10]: [ws_sold_date_sk#37, ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41, i_item_sk#61, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65]
 
-(118) ReusedExchange [Reuses operator id: 84]
-Output [2]: [d_date_sk#67, d_year#68]
+(110) ReusedExchange [Reuses operator id: 80]
+Output [2]: [d_date_sk#66, d_year#67]
 
-(119) BroadcastHashJoin [codegen id : 46]
-Left keys [1]: [ws_sold_date_sk#38]
-Right keys [1]: [d_date_sk#67]
+(111) BroadcastHashJoin [codegen id : 42]
+Left keys [1]: [ws_sold_date_sk#37]
+Right keys [1]: [d_date_sk#66]
 Join condition: None
 
-(120) Project [codegen id : 46]
-Output [9]: [ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, d_year#68]
-Input [11]: [ws_sold_date_sk#38, ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, d_date_sk#67, d_year#68]
+(112) Project [codegen id : 42]
+Output [9]: [ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, d_year#67]
+Input [11]: [ws_sold_date_sk#37, ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, d_date_sk#66, d_year#67]
+
+(113) Exchange
+Input [9]: [ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, d_year#67]
+Arguments: hashpartitioning(cast(ws_order_number#39 as bigint), cast(ws_item_sk#38 as bigint), 5), ENSURE_REQUIREMENTS, [id=#73]
+
+(114) Sort [codegen id : 43]
+Input [9]: [ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, d_year#67]
+Arguments: [cast(ws_order_number#39 as bigint) ASC NULLS FIRST, cast(ws_item_sk#38 as bigint) ASC NULLS FIRST], false, 0
+
+(115) ReusedExchange [Reuses operator id: 58]
+Output [4]: [wr_item_sk#43, wr_order_number#44, wr_return_quantity#45, wr_return_amt#46]
+
+(116) Sort [codegen id : 45]
+Input [4]: [wr_item_sk#43, wr_order_number#44, wr_return_quantity#45, wr_return_amt#46]
+Arguments: [wr_order_number#44 ASC NULLS FIRST, wr_item_sk#43 ASC NULLS FIRST], false, 0
+
+(117) SortMergeJoin
+Left keys [2]: [cast(ws_order_number#39 as bigint), cast(ws_item_sk#38 as bigint)]
+Right keys [2]: [wr_order_number#44, wr_item_sk#43]
+Join condition: None
+
+(118) Project [codegen id : 46]
+Output [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, (ws_quantity#40 - coalesce(wr_return_quantity#45, 0)) AS sales_cnt#74, CheckOverflow((promote_precision(cast(ws_ext_sales_price#41 as decimal(8,2))) - promote_precision(cast(coalesce(wr_return_amt#46, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#75]
+Input [13]: [ws_item_sk#38, ws_order_number#39, ws_quantity#40, ws_ext_sales_price#41, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, d_year#67, wr_item_sk#43, wr_order_number#44, wr_return_quantity#45, wr_return_amt#46]
+
+(119) Union
+
+(120) HashAggregate [codegen id : 47]
+Input [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sales_cnt#22, sales_amt#23]
+Keys [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sales_cnt#22, sales_amt#23]
+Functions: []
+Aggregate Attributes: []
+Results [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sales_cnt#22, sales_amt#23]
 
 (121) Exchange
-Input [9]: [ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, d_year#68]
-Arguments: hashpartitioning(cast(ws_order_number#40 as bigint), cast(ws_item_sk#39 as bigint), 5), true, [id=#75]
+Input [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sales_cnt#22, sales_amt#23]
+Arguments: hashpartitioning(d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sales_cnt#22, sales_amt#23, 5), ENSURE_REQUIREMENTS, [id=#76]
 
-(122) Sort [codegen id : 47]
-Input [9]: [ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, d_year#68]
-Arguments: [cast(ws_order_number#40 as bigint) ASC NULLS FIRST, cast(ws_item_sk#39 as bigint) ASC NULLS FIRST], false, 0
-
-(123) ReusedExchange [Reuses operator id: 62]
-Output [4]: [wr_item_sk#44, wr_order_number#45, wr_return_quantity#46, wr_return_amt#47]
-
-(124) Sort [codegen id : 49]
-Input [4]: [wr_item_sk#44, wr_order_number#45, wr_return_quantity#46, wr_return_amt#47]
-Arguments: [wr_order_number#45 ASC NULLS FIRST, wr_item_sk#44 ASC NULLS FIRST], false, 0
-
-(125) SortMergeJoin
-Left keys [2]: [cast(ws_order_number#40 as bigint), cast(ws_item_sk#39 as bigint)]
-Right keys [2]: [wr_order_number#45, wr_item_sk#44]
-Join condition: None
-
-(126) Project [codegen id : 50]
-Output [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, (ws_quantity#41 - coalesce(wr_return_quantity#46, 0)) AS sales_cnt#76, CheckOverflow((promote_precision(cast(ws_ext_sales_price#42 as decimal(8,2))) - promote_precision(cast(coalesce(wr_return_amt#47, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#77]
-Input [13]: [ws_item_sk#39, ws_order_number#40, ws_quantity#41, ws_ext_sales_price#42, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, d_year#68, wr_item_sk#44, wr_order_number#45, wr_return_quantity#46, wr_return_amt#47]
-
-(127) Union
-
-(128) HashAggregate [codegen id : 51]
-Input [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23]
-Keys [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23]
+(122) HashAggregate [codegen id : 48]
+Input [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sales_cnt#22, sales_amt#23]
+Keys [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sales_cnt#22, sales_amt#23]
 Functions: []
 Aggregate Attributes: []
-Results [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23]
+Results [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sales_cnt#22, sales_amt#23]
 
-(129) Exchange
-Input [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23]
-Arguments: hashpartitioning(d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23, 5), true, [id=#78]
-
-(130) HashAggregate [codegen id : 52]
-Input [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23]
-Keys [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23]
-Functions: []
-Aggregate Attributes: []
-Results [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23]
-
-(131) HashAggregate [codegen id : 52]
-Input [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#22, sales_amt#23]
-Keys [5]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66]
+(123) HashAggregate [codegen id : 48]
+Input [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sales_cnt#22, sales_amt#23]
+Keys [5]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65]
 Functions [2]: [partial_sum(cast(sales_cnt#22 as bigint)), partial_sum(UnscaledValue(sales_amt#23))]
-Aggregate Attributes [2]: [sum#79, sum#80]
-Results [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sum#81, sum#82]
+Aggregate Attributes [2]: [sum#77, sum#78]
+Results [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sum#79, sum#80]
 
-(132) Exchange
-Input [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sum#81, sum#82]
-Arguments: hashpartitioning(d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, 5), true, [id=#83]
+(124) Exchange
+Input [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sum#79, sum#80]
+Arguments: hashpartitioning(d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, 5), ENSURE_REQUIREMENTS, [id=#81]
 
-(133) HashAggregate [codegen id : 53]
-Input [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sum#81, sum#82]
-Keys [5]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66]
+(125) HashAggregate [codegen id : 49]
+Input [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sum#79, sum#80]
+Keys [5]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65]
 Functions [2]: [sum(cast(sales_cnt#22 as bigint)), sum(UnscaledValue(sales_amt#23))]
-Aggregate Attributes [2]: [sum(cast(sales_cnt#22 as bigint))#84, sum(UnscaledValue(sales_amt#23))#85]
-Results [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sum(cast(sales_cnt#22 as bigint))#84 AS sales_cnt#86, MakeDecimal(sum(UnscaledValue(sales_amt#23))#85,18,2) AS sales_amt#87]
+Aggregate Attributes [2]: [sum(cast(sales_cnt#22 as bigint))#82, sum(UnscaledValue(sales_amt#23))#83]
+Results [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sum(cast(sales_cnt#22 as bigint))#82 AS sales_cnt#84, MakeDecimal(sum(UnscaledValue(sales_amt#23))#83,18,2) AS sales_amt#85]
 
-(134) Exchange
-Input [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#86, sales_amt#87]
-Arguments: hashpartitioning(i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, 5), true, [id=#88]
+(126) Exchange
+Input [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sales_cnt#84, sales_amt#85]
+Arguments: hashpartitioning(i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, 5), ENSURE_REQUIREMENTS, [id=#86]
 
-(135) Sort [codegen id : 54]
-Input [7]: [d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#86, sales_amt#87]
-Arguments: [i_brand_id#63 ASC NULLS FIRST, i_class_id#64 ASC NULLS FIRST, i_category_id#65 ASC NULLS FIRST, i_manufact_id#66 ASC NULLS FIRST], false, 0
+(127) Sort [codegen id : 50]
+Input [7]: [d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sales_cnt#84, sales_amt#85]
+Arguments: [i_brand_id#62 ASC NULLS FIRST, i_class_id#63 ASC NULLS FIRST, i_category_id#64 ASC NULLS FIRST, i_manufact_id#65 ASC NULLS FIRST], false, 0
 
-(136) SortMergeJoin [codegen id : 55]
+(128) SortMergeJoin [codegen id : 51]
 Left keys [4]: [i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
-Right keys [4]: [i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66]
-Join condition: (CheckOverflow((promote_precision(cast(sales_cnt#59 as decimal(17,2))) / promote_precision(cast(sales_cnt#86 as decimal(17,2)))), DecimalType(37,20), true) < 0.90000000000000000000)
+Right keys [4]: [i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65]
+Join condition: (CheckOverflow((promote_precision(cast(sales_cnt#58 as decimal(17,2))) / promote_precision(cast(sales_cnt#84 as decimal(17,2)))), DecimalType(37,20), true) < 0.90000000000000000000)
 
-(137) Project [codegen id : 55]
-Output [10]: [d_year#68 AS prev_year#89, d_year#14 AS year#90, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#86 AS prev_yr_cnt#91, sales_cnt#59 AS curr_yr_cnt#92, (sales_cnt#59 - sales_cnt#86) AS sales_cnt_diff#93, CheckOverflow((promote_precision(cast(sales_amt#60 as decimal(19,2))) - promote_precision(cast(sales_amt#87 as decimal(19,2)))), DecimalType(19,2), true) AS sales_amt_diff#94]
-Input [14]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#59, sales_amt#60, d_year#68, i_brand_id#63, i_class_id#64, i_category_id#65, i_manufact_id#66, sales_cnt#86, sales_amt#87]
+(129) Project [codegen id : 51]
+Output [10]: [d_year#67 AS prev_year#87, d_year#14 AS year#88, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#84 AS prev_yr_cnt#89, sales_cnt#58 AS curr_yr_cnt#90, (sales_cnt#58 - sales_cnt#84) AS sales_cnt_diff#91, CheckOverflow((promote_precision(cast(sales_amt#59 as decimal(19,2))) - promote_precision(cast(sales_amt#85 as decimal(19,2)))), DecimalType(19,2), true) AS sales_amt_diff#92]
+Input [14]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#58, sales_amt#59, d_year#67, i_brand_id#62, i_class_id#63, i_category_id#64, i_manufact_id#65, sales_cnt#84, sales_amt#85]
 
-(138) TakeOrderedAndProject
-Input [10]: [prev_year#89, year#90, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, prev_yr_cnt#91, curr_yr_cnt#92, sales_cnt_diff#93, sales_amt_diff#94]
-Arguments: 100, [sales_cnt_diff#93 ASC NULLS FIRST, sales_amt_diff#94 ASC NULLS FIRST], [prev_year#89, year#90, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, prev_yr_cnt#91, curr_yr_cnt#92, sales_cnt_diff#93, sales_amt_diff#94]
+(130) TakeOrderedAndProject
+Input [10]: [prev_year#87, year#88, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, prev_yr_cnt#89, curr_yr_cnt#90, sales_cnt_diff#91, sales_amt_diff#92]
+Arguments: 100, [sales_cnt_diff#91 ASC NULLS FIRST, sales_amt_diff#92 ASC NULLS FIRST], [prev_year#87, year#88, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, prev_yr_cnt#89, curr_yr_cnt#90, sales_cnt_diff#91, sales_amt_diff#92]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75.sf100/simplified.txt
@@ -1,113 +1,105 @@
 TakeOrderedAndProject [sales_cnt_diff,sales_amt_diff,prev_year,year,i_brand_id,i_class_id,i_category_id,i_manufact_id,prev_yr_cnt,curr_yr_cnt]
-  WholeStageCodegen (55)
+  WholeStageCodegen (51)
     Project [d_year,d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_cnt,sales_amt,sales_amt]
       SortMergeJoin [i_brand_id,i_class_id,i_category_id,i_manufact_id,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_cnt]
         InputAdapter
-          WholeStageCodegen (27)
+          WholeStageCodegen (25)
             Sort [i_brand_id,i_class_id,i_category_id,i_manufact_id]
               InputAdapter
                 Exchange [i_brand_id,i_class_id,i_category_id,i_manufact_id] #1
-                  WholeStageCodegen (26)
+                  WholeStageCodegen (24)
                     HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sum,sum] [sum(cast(sales_cnt as bigint)),sum(UnscaledValue(sales_amt)),sales_cnt,sales_amt,sum,sum]
                       InputAdapter
                         Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id] #2
-                          WholeStageCodegen (25)
+                          WholeStageCodegen (23)
                             HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] [sum,sum,sum,sum]
                               HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
                                 InputAdapter
                                   Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #3
-                                    WholeStageCodegen (24)
+                                    WholeStageCodegen (22)
                                       HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
                                         InputAdapter
                                           Union
-                                            WholeStageCodegen (16)
-                                              HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
+                                            WholeStageCodegen (7)
+                                              Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,cs_quantity,cr_return_quantity,cs_ext_sales_price,cr_return_amount]
                                                 InputAdapter
-                                                  Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #4
-                                                    WholeStageCodegen (15)
-                                                      HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
+                                                  SortMergeJoin [cs_order_number,cs_item_sk,cr_order_number,cr_item_sk]
+                                                    WholeStageCodegen (4)
+                                                      Sort [cs_order_number,cs_item_sk]
                                                         InputAdapter
-                                                          Union
-                                                            WholeStageCodegen (7)
-                                                              Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,cs_quantity,cr_return_quantity,cs_ext_sales_price,cr_return_amount]
-                                                                InputAdapter
-                                                                  SortMergeJoin [cs_order_number,cs_item_sk,cr_order_number,cr_item_sk]
-                                                                    WholeStageCodegen (4)
-                                                                      Sort [cs_order_number,cs_item_sk]
-                                                                        InputAdapter
-                                                                          Exchange [cs_order_number,cs_item_sk] #5
-                                                                            WholeStageCodegen (3)
-                                                                              Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                                                BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                                  Project [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                                    BroadcastHashJoin [cs_item_sk,i_item_sk]
-                                                                                      Filter [cs_item_sk,cs_sold_date_sk]
-                                                                                        ColumnarToRow
-                                                                                          InputAdapter
-                                                                                            Scan parquet default.catalog_sales [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price]
-                                                                                      InputAdapter
-                                                                                        BroadcastExchange #6
-                                                                                          WholeStageCodegen (1)
-                                                                                            Project [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                                              Filter [i_category,i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                                                ColumnarToRow
-                                                                                                  InputAdapter
-                                                                                                    Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id,i_category,i_manufact_id]
-                                                                                  InputAdapter
-                                                                                    BroadcastExchange #7
-                                                                                      WholeStageCodegen (2)
-                                                                                        Filter [d_year,d_date_sk]
-                                                                                          ColumnarToRow
-                                                                                            InputAdapter
-                                                                                              Scan parquet default.date_dim [d_date_sk,d_year]
-                                                                    WholeStageCodegen (6)
-                                                                      Sort [cr_order_number,cr_item_sk]
-                                                                        InputAdapter
-                                                                          Exchange [cr_order_number,cr_item_sk] #8
-                                                                            WholeStageCodegen (5)
-                                                                              Filter [cr_order_number,cr_item_sk]
+                                                          Exchange [cs_order_number,cs_item_sk] #4
+                                                            WholeStageCodegen (3)
+                                                              Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
+                                                                BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                                  Project [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                                    BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                                      Filter [cs_item_sk,cs_sold_date_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet default.catalog_sales [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price]
+                                                                      InputAdapter
+                                                                        BroadcastExchange #5
+                                                                          WholeStageCodegen (1)
+                                                                            Project [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                                              Filter [i_category,i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
                                                                                 ColumnarToRow
                                                                                   InputAdapter
-                                                                                    Scan parquet default.catalog_returns [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount]
-                                                            WholeStageCodegen (14)
-                                                              Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ss_quantity,sr_return_quantity,ss_ext_sales_price,sr_return_amt]
-                                                                InputAdapter
-                                                                  SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
-                                                                    WholeStageCodegen (11)
-                                                                      Sort [ss_ticket_number,ss_item_sk]
-                                                                        InputAdapter
-                                                                          Exchange [ss_ticket_number,ss_item_sk] #9
-                                                                            WholeStageCodegen (10)
-                                                                              Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                                                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                                  Project [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                                    BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                                                      Filter [ss_item_sk,ss_sold_date_sk]
-                                                                                        ColumnarToRow
-                                                                                          InputAdapter
-                                                                                            Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price]
-                                                                                      InputAdapter
-                                                                                        ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
-                                                                                  InputAdapter
-                                                                                    ReusedExchange [d_date_sk,d_year] #7
-                                                                    WholeStageCodegen (13)
-                                                                      Sort [sr_ticket_number,sr_item_sk]
-                                                                        InputAdapter
-                                                                          Exchange [sr_ticket_number,sr_item_sk] #10
-                                                                            WholeStageCodegen (12)
-                                                                              Filter [sr_ticket_number,sr_item_sk]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet default.store_returns [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt]
-                                            WholeStageCodegen (23)
+                                                                                    Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id,i_category,i_manufact_id]
+                                                                  InputAdapter
+                                                                    BroadcastExchange #6
+                                                                      WholeStageCodegen (2)
+                                                                        Filter [d_year,d_date_sk]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet default.date_dim [d_date_sk,d_year]
+                                                    WholeStageCodegen (6)
+                                                      Sort [cr_order_number,cr_item_sk]
+                                                        InputAdapter
+                                                          Exchange [cr_order_number,cr_item_sk] #7
+                                                            WholeStageCodegen (5)
+                                                              Filter [cr_order_number,cr_item_sk]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet default.catalog_returns [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount]
+                                            WholeStageCodegen (14)
+                                              Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ss_quantity,sr_return_quantity,ss_ext_sales_price,sr_return_amt]
+                                                InputAdapter
+                                                  SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
+                                                    WholeStageCodegen (11)
+                                                      Sort [ss_ticket_number,ss_item_sk]
+                                                        InputAdapter
+                                                          Exchange [ss_ticket_number,ss_item_sk] #8
+                                                            WholeStageCodegen (10)
+                                                              Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
+                                                                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                                  Project [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                                    BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                                      Filter [ss_item_sk,ss_sold_date_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price]
+                                                                      InputAdapter
+                                                                        ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #5
+                                                                  InputAdapter
+                                                                    ReusedExchange [d_date_sk,d_year] #6
+                                                    WholeStageCodegen (13)
+                                                      Sort [sr_ticket_number,sr_item_sk]
+                                                        InputAdapter
+                                                          Exchange [sr_ticket_number,sr_item_sk] #9
+                                                            WholeStageCodegen (12)
+                                                              Filter [sr_ticket_number,sr_item_sk]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet default.store_returns [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt]
+                                            WholeStageCodegen (21)
                                               Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ws_quantity,wr_return_quantity,ws_ext_sales_price,wr_return_amt]
                                                 InputAdapter
                                                   SortMergeJoin [ws_order_number,ws_item_sk,wr_order_number,wr_item_sk]
-                                                    WholeStageCodegen (20)
+                                                    WholeStageCodegen (18)
                                                       Sort [ws_order_number,ws_item_sk]
                                                         InputAdapter
-                                                          Exchange [ws_order_number,ws_item_sk] #11
-                                                            WholeStageCodegen (19)
+                                                          Exchange [ws_order_number,ws_item_sk] #10
+                                                            WholeStageCodegen (17)
                                                               Project [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
                                                                 BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                                   Project [ws_sold_date_sk,ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
@@ -117,108 +109,100 @@ TakeOrderedAndProject [sales_cnt_diff,sales_amt_diff,prev_year,year,i_brand_id,i
                                                                           InputAdapter
                                                                             Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price]
                                                                       InputAdapter
-                                                                        ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
+                                                                        ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #5
                                                                   InputAdapter
-                                                                    ReusedExchange [d_date_sk,d_year] #7
-                                                    WholeStageCodegen (22)
+                                                                    ReusedExchange [d_date_sk,d_year] #6
+                                                    WholeStageCodegen (20)
                                                       Sort [wr_order_number,wr_item_sk]
                                                         InputAdapter
-                                                          Exchange [wr_order_number,wr_item_sk] #12
-                                                            WholeStageCodegen (21)
+                                                          Exchange [wr_order_number,wr_item_sk] #11
+                                                            WholeStageCodegen (19)
                                                               Filter [wr_order_number,wr_item_sk]
                                                                 ColumnarToRow
                                                                   InputAdapter
                                                                     Scan parquet default.web_returns [wr_item_sk,wr_order_number,wr_return_quantity,wr_return_amt]
         InputAdapter
-          WholeStageCodegen (54)
+          WholeStageCodegen (50)
             Sort [i_brand_id,i_class_id,i_category_id,i_manufact_id]
               InputAdapter
-                Exchange [i_brand_id,i_class_id,i_category_id,i_manufact_id] #13
-                  WholeStageCodegen (53)
+                Exchange [i_brand_id,i_class_id,i_category_id,i_manufact_id] #12
+                  WholeStageCodegen (49)
                     HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sum,sum] [sum(cast(sales_cnt as bigint)),sum(UnscaledValue(sales_amt)),sales_cnt,sales_amt,sum,sum]
                       InputAdapter
-                        Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id] #14
-                          WholeStageCodegen (52)
+                        Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id] #13
+                          WholeStageCodegen (48)
                             HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] [sum,sum,sum,sum]
                               HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
                                 InputAdapter
-                                  Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #15
-                                    WholeStageCodegen (51)
+                                  Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #14
+                                    WholeStageCodegen (47)
                                       HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
                                         InputAdapter
                                           Union
-                                            WholeStageCodegen (43)
-                                              HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
+                                            WholeStageCodegen (32)
+                                              Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,cs_quantity,cr_return_quantity,cs_ext_sales_price,cr_return_amount]
                                                 InputAdapter
-                                                  Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #16
-                                                    WholeStageCodegen (42)
-                                                      HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
+                                                  SortMergeJoin [cs_order_number,cs_item_sk,cr_order_number,cr_item_sk]
+                                                    WholeStageCodegen (29)
+                                                      Sort [cs_order_number,cs_item_sk]
                                                         InputAdapter
-                                                          Union
-                                                            WholeStageCodegen (34)
-                                                              Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,cs_quantity,cr_return_quantity,cs_ext_sales_price,cr_return_amount]
-                                                                InputAdapter
-                                                                  SortMergeJoin [cs_order_number,cs_item_sk,cr_order_number,cr_item_sk]
-                                                                    WholeStageCodegen (31)
-                                                                      Sort [cs_order_number,cs_item_sk]
-                                                                        InputAdapter
-                                                                          Exchange [cs_order_number,cs_item_sk] #17
-                                                                            WholeStageCodegen (30)
-                                                                              Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                                                BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                                  Project [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                                    BroadcastHashJoin [cs_item_sk,i_item_sk]
-                                                                                      Filter [cs_item_sk,cs_sold_date_sk]
-                                                                                        ColumnarToRow
-                                                                                          InputAdapter
-                                                                                            Scan parquet default.catalog_sales [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price]
-                                                                                      InputAdapter
-                                                                                        ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
-                                                                                  InputAdapter
-                                                                                    BroadcastExchange #18
-                                                                                      WholeStageCodegen (29)
-                                                                                        Filter [d_year,d_date_sk]
-                                                                                          ColumnarToRow
-                                                                                            InputAdapter
-                                                                                              Scan parquet default.date_dim [d_date_sk,d_year]
-                                                                    WholeStageCodegen (33)
-                                                                      Sort [cr_order_number,cr_item_sk]
-                                                                        InputAdapter
-                                                                          ReusedExchange [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount] #8
-                                                            WholeStageCodegen (41)
-                                                              Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ss_quantity,sr_return_quantity,ss_ext_sales_price,sr_return_amt]
-                                                                InputAdapter
-                                                                  SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
-                                                                    WholeStageCodegen (38)
-                                                                      Sort [ss_ticket_number,ss_item_sk]
-                                                                        InputAdapter
-                                                                          Exchange [ss_ticket_number,ss_item_sk] #19
-                                                                            WholeStageCodegen (37)
-                                                                              Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                                                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                                  Project [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                                    BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                                                      Filter [ss_item_sk,ss_sold_date_sk]
-                                                                                        ColumnarToRow
-                                                                                          InputAdapter
-                                                                                            Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price]
-                                                                                      InputAdapter
-                                                                                        ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
-                                                                                  InputAdapter
-                                                                                    ReusedExchange [d_date_sk,d_year] #18
-                                                                    WholeStageCodegen (40)
-                                                                      Sort [sr_ticket_number,sr_item_sk]
-                                                                        InputAdapter
-                                                                          ReusedExchange [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt] #10
-                                            WholeStageCodegen (50)
+                                                          Exchange [cs_order_number,cs_item_sk] #15
+                                                            WholeStageCodegen (28)
+                                                              Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
+                                                                BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                                  Project [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                                    BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                                      Filter [cs_item_sk,cs_sold_date_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet default.catalog_sales [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price]
+                                                                      InputAdapter
+                                                                        ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #5
+                                                                  InputAdapter
+                                                                    BroadcastExchange #16
+                                                                      WholeStageCodegen (27)
+                                                                        Filter [d_year,d_date_sk]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet default.date_dim [d_date_sk,d_year]
+                                                    WholeStageCodegen (31)
+                                                      Sort [cr_order_number,cr_item_sk]
+                                                        InputAdapter
+                                                          ReusedExchange [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount] #7
+                                            WholeStageCodegen (39)
+                                              Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ss_quantity,sr_return_quantity,ss_ext_sales_price,sr_return_amt]
+                                                InputAdapter
+                                                  SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
+                                                    WholeStageCodegen (36)
+                                                      Sort [ss_ticket_number,ss_item_sk]
+                                                        InputAdapter
+                                                          Exchange [ss_ticket_number,ss_item_sk] #17
+                                                            WholeStageCodegen (35)
+                                                              Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
+                                                                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                                  Project [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                                    BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                                      Filter [ss_item_sk,ss_sold_date_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price]
+                                                                      InputAdapter
+                                                                        ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #5
+                                                                  InputAdapter
+                                                                    ReusedExchange [d_date_sk,d_year] #16
+                                                    WholeStageCodegen (38)
+                                                      Sort [sr_ticket_number,sr_item_sk]
+                                                        InputAdapter
+                                                          ReusedExchange [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt] #9
+                                            WholeStageCodegen (46)
                                               Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ws_quantity,wr_return_quantity,ws_ext_sales_price,wr_return_amt]
                                                 InputAdapter
                                                   SortMergeJoin [ws_order_number,ws_item_sk,wr_order_number,wr_item_sk]
-                                                    WholeStageCodegen (47)
+                                                    WholeStageCodegen (43)
                                                       Sort [ws_order_number,ws_item_sk]
                                                         InputAdapter
-                                                          Exchange [ws_order_number,ws_item_sk] #20
-                                                            WholeStageCodegen (46)
+                                                          Exchange [ws_order_number,ws_item_sk] #18
+                                                            WholeStageCodegen (42)
                                                               Project [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
                                                                 BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                                   Project [ws_sold_date_sk,ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
@@ -228,10 +212,10 @@ TakeOrderedAndProject [sales_cnt_diff,sales_amt_diff,prev_year,year,i_brand_id,i
                                                                           InputAdapter
                                                                             Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price]
                                                                       InputAdapter
-                                                                        ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
+                                                                        ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #5
                                                                   InputAdapter
-                                                                    ReusedExchange [d_date_sk,d_year] #18
-                                                    WholeStageCodegen (49)
+                                                                    ReusedExchange [d_date_sk,d_year] #16
+                                                    WholeStageCodegen (45)
                                                       Sort [wr_order_number,wr_item_sk]
                                                         InputAdapter
-                                                          ReusedExchange [wr_item_sk,wr_order_number,wr_return_quantity,wr_return_amt] #12
+                                                          ReusedExchange [wr_item_sk,wr_order_number,wr_return_quantity,wr_return_amt] #11

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75/explain.txt
@@ -1,121 +1,113 @@
 == Physical Plan ==
-TakeOrderedAndProject (117)
-+- * Project (116)
-   +- * BroadcastHashJoin Inner BuildRight (115)
-      :- * HashAggregate (63)
-      :  +- Exchange (62)
-      :     +- * HashAggregate (61)
-      :        +- * HashAggregate (60)
-      :           +- Exchange (59)
-      :              +- * HashAggregate (58)
-      :                 +- Union (57)
-      :                    :- * HashAggregate (41)
-      :                    :  +- Exchange (40)
-      :                    :     +- * HashAggregate (39)
-      :                    :        +- Union (38)
-      :                    :           :- * Project (22)
-      :                    :           :  +- * BroadcastHashJoin LeftOuter BuildRight (21)
-      :                    :           :     :- * Project (16)
-      :                    :           :     :  +- * BroadcastHashJoin Inner BuildRight (15)
-      :                    :           :     :     :- * Project (10)
-      :                    :           :     :     :  +- * BroadcastHashJoin Inner BuildRight (9)
-      :                    :           :     :     :     :- * Filter (3)
-      :                    :           :     :     :     :  +- * ColumnarToRow (2)
-      :                    :           :     :     :     :     +- Scan parquet default.catalog_sales (1)
-      :                    :           :     :     :     +- BroadcastExchange (8)
-      :                    :           :     :     :        +- * Project (7)
-      :                    :           :     :     :           +- * Filter (6)
-      :                    :           :     :     :              +- * ColumnarToRow (5)
-      :                    :           :     :     :                 +- Scan parquet default.item (4)
-      :                    :           :     :     +- BroadcastExchange (14)
-      :                    :           :     :        +- * Filter (13)
-      :                    :           :     :           +- * ColumnarToRow (12)
-      :                    :           :     :              +- Scan parquet default.date_dim (11)
-      :                    :           :     +- BroadcastExchange (20)
-      :                    :           :        +- * Filter (19)
-      :                    :           :           +- * ColumnarToRow (18)
-      :                    :           :              +- Scan parquet default.catalog_returns (17)
-      :                    :           +- * Project (37)
-      :                    :              +- * BroadcastHashJoin LeftOuter BuildRight (36)
-      :                    :                 :- * Project (31)
-      :                    :                 :  +- * BroadcastHashJoin Inner BuildRight (30)
-      :                    :                 :     :- * Project (28)
-      :                    :                 :     :  +- * BroadcastHashJoin Inner BuildRight (27)
-      :                    :                 :     :     :- * Filter (25)
-      :                    :                 :     :     :  +- * ColumnarToRow (24)
-      :                    :                 :     :     :     +- Scan parquet default.store_sales (23)
-      :                    :                 :     :     +- ReusedExchange (26)
-      :                    :                 :     +- ReusedExchange (29)
-      :                    :                 +- BroadcastExchange (35)
-      :                    :                    +- * Filter (34)
-      :                    :                       +- * ColumnarToRow (33)
-      :                    :                          +- Scan parquet default.store_returns (32)
-      :                    +- * Project (56)
-      :                       +- * BroadcastHashJoin LeftOuter BuildRight (55)
-      :                          :- * Project (50)
-      :                          :  +- * BroadcastHashJoin Inner BuildRight (49)
-      :                          :     :- * Project (47)
-      :                          :     :  +- * BroadcastHashJoin Inner BuildRight (46)
-      :                          :     :     :- * Filter (44)
-      :                          :     :     :  +- * ColumnarToRow (43)
-      :                          :     :     :     +- Scan parquet default.web_sales (42)
-      :                          :     :     +- ReusedExchange (45)
-      :                          :     +- ReusedExchange (48)
-      :                          +- BroadcastExchange (54)
-      :                             +- * Filter (53)
-      :                                +- * ColumnarToRow (52)
-      :                                   +- Scan parquet default.web_returns (51)
-      +- BroadcastExchange (114)
-         +- * HashAggregate (113)
-            +- Exchange (112)
-               +- * HashAggregate (111)
-                  +- * HashAggregate (110)
-                     +- Exchange (109)
-                        +- * HashAggregate (108)
-                           +- Union (107)
-                              :- * HashAggregate (94)
-                              :  +- Exchange (93)
-                              :     +- * HashAggregate (92)
-                              :        +- Union (91)
-                              :           :- * Project (78)
-                              :           :  +- * BroadcastHashJoin LeftOuter BuildRight (77)
-                              :           :     :- * Project (75)
-                              :           :     :  +- * BroadcastHashJoin Inner BuildRight (74)
-                              :           :     :     :- * Project (69)
-                              :           :     :     :  +- * BroadcastHashJoin Inner BuildRight (68)
-                              :           :     :     :     :- * Filter (66)
-                              :           :     :     :     :  +- * ColumnarToRow (65)
-                              :           :     :     :     :     +- Scan parquet default.catalog_sales (64)
-                              :           :     :     :     +- ReusedExchange (67)
-                              :           :     :     +- BroadcastExchange (73)
-                              :           :     :        +- * Filter (72)
-                              :           :     :           +- * ColumnarToRow (71)
-                              :           :     :              +- Scan parquet default.date_dim (70)
-                              :           :     +- ReusedExchange (76)
-                              :           +- * Project (90)
-                              :              +- * BroadcastHashJoin LeftOuter BuildRight (89)
-                              :                 :- * Project (87)
-                              :                 :  +- * BroadcastHashJoin Inner BuildRight (86)
-                              :                 :     :- * Project (84)
-                              :                 :     :  +- * BroadcastHashJoin Inner BuildRight (83)
-                              :                 :     :     :- * Filter (81)
-                              :                 :     :     :  +- * ColumnarToRow (80)
-                              :                 :     :     :     +- Scan parquet default.store_sales (79)
-                              :                 :     :     +- ReusedExchange (82)
-                              :                 :     +- ReusedExchange (85)
-                              :                 +- ReusedExchange (88)
-                              +- * Project (106)
-                                 +- * BroadcastHashJoin LeftOuter BuildRight (105)
-                                    :- * Project (103)
-                                    :  +- * BroadcastHashJoin Inner BuildRight (102)
-                                    :     :- * Project (100)
-                                    :     :  +- * BroadcastHashJoin Inner BuildRight (99)
-                                    :     :     :- * Filter (97)
-                                    :     :     :  +- * ColumnarToRow (96)
-                                    :     :     :     +- Scan parquet default.web_sales (95)
-                                    :     :     +- ReusedExchange (98)
-                                    :     +- ReusedExchange (101)
-                                    +- ReusedExchange (104)
+TakeOrderedAndProject (109)
++- * Project (108)
+   +- * BroadcastHashJoin Inner BuildRight (107)
+      :- * HashAggregate (59)
+      :  +- Exchange (58)
+      :     +- * HashAggregate (57)
+      :        +- * HashAggregate (56)
+      :           +- Exchange (55)
+      :              +- * HashAggregate (54)
+      :                 +- Union (53)
+      :                    :- * Project (22)
+      :                    :  +- * BroadcastHashJoin LeftOuter BuildRight (21)
+      :                    :     :- * Project (16)
+      :                    :     :  +- * BroadcastHashJoin Inner BuildRight (15)
+      :                    :     :     :- * Project (10)
+      :                    :     :     :  +- * BroadcastHashJoin Inner BuildRight (9)
+      :                    :     :     :     :- * Filter (3)
+      :                    :     :     :     :  +- * ColumnarToRow (2)
+      :                    :     :     :     :     +- Scan parquet default.catalog_sales (1)
+      :                    :     :     :     +- BroadcastExchange (8)
+      :                    :     :     :        +- * Project (7)
+      :                    :     :     :           +- * Filter (6)
+      :                    :     :     :              +- * ColumnarToRow (5)
+      :                    :     :     :                 +- Scan parquet default.item (4)
+      :                    :     :     +- BroadcastExchange (14)
+      :                    :     :        +- * Filter (13)
+      :                    :     :           +- * ColumnarToRow (12)
+      :                    :     :              +- Scan parquet default.date_dim (11)
+      :                    :     +- BroadcastExchange (20)
+      :                    :        +- * Filter (19)
+      :                    :           +- * ColumnarToRow (18)
+      :                    :              +- Scan parquet default.catalog_returns (17)
+      :                    :- * Project (37)
+      :                    :  +- * BroadcastHashJoin LeftOuter BuildRight (36)
+      :                    :     :- * Project (31)
+      :                    :     :  +- * BroadcastHashJoin Inner BuildRight (30)
+      :                    :     :     :- * Project (28)
+      :                    :     :     :  +- * BroadcastHashJoin Inner BuildRight (27)
+      :                    :     :     :     :- * Filter (25)
+      :                    :     :     :     :  +- * ColumnarToRow (24)
+      :                    :     :     :     :     +- Scan parquet default.store_sales (23)
+      :                    :     :     :     +- ReusedExchange (26)
+      :                    :     :     +- ReusedExchange (29)
+      :                    :     +- BroadcastExchange (35)
+      :                    :        +- * Filter (34)
+      :                    :           +- * ColumnarToRow (33)
+      :                    :              +- Scan parquet default.store_returns (32)
+      :                    +- * Project (52)
+      :                       +- * BroadcastHashJoin LeftOuter BuildRight (51)
+      :                          :- * Project (46)
+      :                          :  +- * BroadcastHashJoin Inner BuildRight (45)
+      :                          :     :- * Project (43)
+      :                          :     :  +- * BroadcastHashJoin Inner BuildRight (42)
+      :                          :     :     :- * Filter (40)
+      :                          :     :     :  +- * ColumnarToRow (39)
+      :                          :     :     :     +- Scan parquet default.web_sales (38)
+      :                          :     :     +- ReusedExchange (41)
+      :                          :     +- ReusedExchange (44)
+      :                          +- BroadcastExchange (50)
+      :                             +- * Filter (49)
+      :                                +- * ColumnarToRow (48)
+      :                                   +- Scan parquet default.web_returns (47)
+      +- BroadcastExchange (106)
+         +- * HashAggregate (105)
+            +- Exchange (104)
+               +- * HashAggregate (103)
+                  +- * HashAggregate (102)
+                     +- Exchange (101)
+                        +- * HashAggregate (100)
+                           +- Union (99)
+                              :- * Project (74)
+                              :  +- * BroadcastHashJoin LeftOuter BuildRight (73)
+                              :     :- * Project (71)
+                              :     :  +- * BroadcastHashJoin Inner BuildRight (70)
+                              :     :     :- * Project (65)
+                              :     :     :  +- * BroadcastHashJoin Inner BuildRight (64)
+                              :     :     :     :- * Filter (62)
+                              :     :     :     :  +- * ColumnarToRow (61)
+                              :     :     :     :     +- Scan parquet default.catalog_sales (60)
+                              :     :     :     +- ReusedExchange (63)
+                              :     :     +- BroadcastExchange (69)
+                              :     :        +- * Filter (68)
+                              :     :           +- * ColumnarToRow (67)
+                              :     :              +- Scan parquet default.date_dim (66)
+                              :     +- ReusedExchange (72)
+                              :- * Project (86)
+                              :  +- * BroadcastHashJoin LeftOuter BuildRight (85)
+                              :     :- * Project (83)
+                              :     :  +- * BroadcastHashJoin Inner BuildRight (82)
+                              :     :     :- * Project (80)
+                              :     :     :  +- * BroadcastHashJoin Inner BuildRight (79)
+                              :     :     :     :- * Filter (77)
+                              :     :     :     :  +- * ColumnarToRow (76)
+                              :     :     :     :     +- Scan parquet default.store_sales (75)
+                              :     :     :     +- ReusedExchange (78)
+                              :     :     +- ReusedExchange (81)
+                              :     +- ReusedExchange (84)
+                              +- * Project (98)
+                                 +- * BroadcastHashJoin LeftOuter BuildRight (97)
+                                    :- * Project (95)
+                                    :  +- * BroadcastHashJoin Inner BuildRight (94)
+                                    :     :- * Project (92)
+                                    :     :  +- * BroadcastHashJoin Inner BuildRight (91)
+                                    :     :     :- * Filter (89)
+                                    :     :     :  +- * ColumnarToRow (88)
+                                    :     :     :     +- Scan parquet default.web_sales (87)
+                                    :     :     +- ReusedExchange (90)
+                                    :     +- ReusedExchange (93)
+                                    +- ReusedExchange (96)
 
 
 (1) Scan parquet default.catalog_sales
@@ -282,366 +274,326 @@ Join condition: None
 Output [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, (ss_quantity#26 - coalesce(sr_return_quantity#30, 0)) AS sales_cnt#33, CheckOverflow((promote_precision(cast(ss_ext_sales_price#27 as decimal(8,2))) - promote_precision(cast(coalesce(sr_return_amt#31, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#34]
 Input [13]: [ss_item_sk#24, ss_ticket_number#25, ss_quantity#26, ss_ext_sales_price#27, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14, sr_item_sk#28, sr_ticket_number#29, sr_return_quantity#30, sr_return_amt#31]
 
-(38) Union
-
-(39) HashAggregate [codegen id : 9]
-Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22]
-Keys [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22]
-Functions: []
-Aggregate Attributes: []
-Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22]
-
-(40) Exchange
-Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22]
-Arguments: hashpartitioning(d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22, 5), true, [id=#35]
-
-(41) HashAggregate [codegen id : 10]
-Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22]
-Keys [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22]
-Functions: []
-Aggregate Attributes: []
-Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22]
-
-(42) Scan parquet default.web_sales
-Output [5]: [ws_sold_date_sk#36, ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40]
+(38) Scan parquet default.web_sales
+Output [5]: [ws_sold_date_sk#35, ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_sales]
 PushedFilters: [IsNotNull(ws_item_sk), IsNotNull(ws_sold_date_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_item_sk:int,ws_order_number:int,ws_quantity:int,ws_ext_sales_price:decimal(7,2)>
 
-(43) ColumnarToRow [codegen id : 14]
-Input [5]: [ws_sold_date_sk#36, ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40]
+(39) ColumnarToRow [codegen id : 12]
+Input [5]: [ws_sold_date_sk#35, ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39]
 
-(44) Filter [codegen id : 14]
-Input [5]: [ws_sold_date_sk#36, ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40]
-Condition : (isnotnull(ws_item_sk#37) AND isnotnull(ws_sold_date_sk#36))
+(40) Filter [codegen id : 12]
+Input [5]: [ws_sold_date_sk#35, ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39]
+Condition : (isnotnull(ws_item_sk#36) AND isnotnull(ws_sold_date_sk#35))
 
-(45) ReusedExchange [Reuses operator id: 8]
+(41) ReusedExchange [Reuses operator id: 8]
 Output [5]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
 
-(46) BroadcastHashJoin [codegen id : 14]
-Left keys [1]: [ws_item_sk#37]
+(42) BroadcastHashJoin [codegen id : 12]
+Left keys [1]: [ws_item_sk#36]
 Right keys [1]: [i_item_sk#6]
 Join condition: None
 
-(47) Project [codegen id : 14]
-Output [9]: [ws_sold_date_sk#36, ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
-Input [10]: [ws_sold_date_sk#36, ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40, i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
+(43) Project [codegen id : 12]
+Output [9]: [ws_sold_date_sk#35, ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
+Input [10]: [ws_sold_date_sk#35, ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39, i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
 
-(48) ReusedExchange [Reuses operator id: 14]
+(44) ReusedExchange [Reuses operator id: 14]
 Output [2]: [d_date_sk#13, d_year#14]
 
-(49) BroadcastHashJoin [codegen id : 14]
-Left keys [1]: [ws_sold_date_sk#36]
+(45) BroadcastHashJoin [codegen id : 12]
+Left keys [1]: [ws_sold_date_sk#35]
 Right keys [1]: [d_date_sk#13]
 Join condition: None
 
-(50) Project [codegen id : 14]
-Output [9]: [ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14]
-Input [11]: [ws_sold_date_sk#36, ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_date_sk#13, d_year#14]
+(46) Project [codegen id : 12]
+Output [9]: [ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14]
+Input [11]: [ws_sold_date_sk#35, ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_date_sk#13, d_year#14]
 
-(51) Scan parquet default.web_returns
-Output [4]: [wr_item_sk#41, wr_order_number#42, wr_return_quantity#43, wr_return_amt#44]
+(47) Scan parquet default.web_returns
+Output [4]: [wr_item_sk#40, wr_order_number#41, wr_return_quantity#42, wr_return_amt#43]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_returns]
 PushedFilters: [IsNotNull(wr_order_number), IsNotNull(wr_item_sk)]
 ReadSchema: struct<wr_item_sk:bigint,wr_order_number:bigint,wr_return_quantity:int,wr_return_amt:decimal(7,2)>
 
-(52) ColumnarToRow [codegen id : 13]
-Input [4]: [wr_item_sk#41, wr_order_number#42, wr_return_quantity#43, wr_return_amt#44]
+(48) ColumnarToRow [codegen id : 11]
+Input [4]: [wr_item_sk#40, wr_order_number#41, wr_return_quantity#42, wr_return_amt#43]
 
-(53) Filter [codegen id : 13]
-Input [4]: [wr_item_sk#41, wr_order_number#42, wr_return_quantity#43, wr_return_amt#44]
-Condition : (isnotnull(wr_order_number#42) AND isnotnull(wr_item_sk#41))
+(49) Filter [codegen id : 11]
+Input [4]: [wr_item_sk#40, wr_order_number#41, wr_return_quantity#42, wr_return_amt#43]
+Condition : (isnotnull(wr_order_number#41) AND isnotnull(wr_item_sk#40))
 
-(54) BroadcastExchange
-Input [4]: [wr_item_sk#41, wr_order_number#42, wr_return_quantity#43, wr_return_amt#44]
-Arguments: HashedRelationBroadcastMode(List(input[1, bigint, false], input[0, bigint, false]),false), [id=#45]
+(50) BroadcastExchange
+Input [4]: [wr_item_sk#40, wr_order_number#41, wr_return_quantity#42, wr_return_amt#43]
+Arguments: HashedRelationBroadcastMode(List(input[1, bigint, false], input[0, bigint, false]),false), [id=#44]
 
-(55) BroadcastHashJoin [codegen id : 14]
-Left keys [2]: [cast(ws_order_number#38 as bigint), cast(ws_item_sk#37 as bigint)]
-Right keys [2]: [wr_order_number#42, wr_item_sk#41]
+(51) BroadcastHashJoin [codegen id : 12]
+Left keys [2]: [cast(ws_order_number#37 as bigint), cast(ws_item_sk#36 as bigint)]
+Right keys [2]: [wr_order_number#41, wr_item_sk#40]
 Join condition: None
 
-(56) Project [codegen id : 14]
-Output [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, (ws_quantity#39 - coalesce(wr_return_quantity#43, 0)) AS sales_cnt#46, CheckOverflow((promote_precision(cast(ws_ext_sales_price#40 as decimal(8,2))) - promote_precision(cast(coalesce(wr_return_amt#44, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#47]
-Input [13]: [ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14, wr_item_sk#41, wr_order_number#42, wr_return_quantity#43, wr_return_amt#44]
+(52) Project [codegen id : 12]
+Output [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, (ws_quantity#38 - coalesce(wr_return_quantity#42, 0)) AS sales_cnt#45, CheckOverflow((promote_precision(cast(ws_ext_sales_price#39 as decimal(8,2))) - promote_precision(cast(coalesce(wr_return_amt#43, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#46]
+Input [13]: [ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, d_year#14, wr_item_sk#40, wr_order_number#41, wr_return_quantity#42, wr_return_amt#43]
 
-(57) Union
+(53) Union
 
-(58) HashAggregate [codegen id : 15]
+(54) HashAggregate [codegen id : 13]
 Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22]
 Keys [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22]
 Functions: []
 Aggregate Attributes: []
 Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22]
 
-(59) Exchange
+(55) Exchange
 Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22]
-Arguments: hashpartitioning(d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22, 5), true, [id=#48]
+Arguments: hashpartitioning(d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22, 5), ENSURE_REQUIREMENTS, [id=#47]
 
-(60) HashAggregate [codegen id : 16]
+(56) HashAggregate [codegen id : 14]
 Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22]
 Keys [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22]
 Functions: []
 Aggregate Attributes: []
 Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22]
 
-(61) HashAggregate [codegen id : 16]
+(57) HashAggregate [codegen id : 14]
 Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#21, sales_amt#22]
 Keys [5]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
 Functions [2]: [partial_sum(cast(sales_cnt#21 as bigint)), partial_sum(UnscaledValue(sales_amt#22))]
-Aggregate Attributes [2]: [sum#49, sum#50]
-Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum#51, sum#52]
+Aggregate Attributes [2]: [sum#48, sum#49]
+Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum#50, sum#51]
 
-(62) Exchange
-Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum#51, sum#52]
-Arguments: hashpartitioning(d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, 5), true, [id=#53]
+(58) Exchange
+Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum#50, sum#51]
+Arguments: hashpartitioning(d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, 5), ENSURE_REQUIREMENTS, [id=#52]
 
-(63) HashAggregate [codegen id : 34]
-Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum#51, sum#52]
+(59) HashAggregate [codegen id : 30]
+Input [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum#50, sum#51]
 Keys [5]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
 Functions [2]: [sum(cast(sales_cnt#21 as bigint)), sum(UnscaledValue(sales_amt#22))]
-Aggregate Attributes [2]: [sum(cast(sales_cnt#21 as bigint))#54, sum(UnscaledValue(sales_amt#22))#55]
-Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum(cast(sales_cnt#21 as bigint))#54 AS sales_cnt#56, MakeDecimal(sum(UnscaledValue(sales_amt#22))#55,18,2) AS sales_amt#57]
+Aggregate Attributes [2]: [sum(cast(sales_cnt#21 as bigint))#53, sum(UnscaledValue(sales_amt#22))#54]
+Results [7]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sum(cast(sales_cnt#21 as bigint))#53 AS sales_cnt#55, MakeDecimal(sum(UnscaledValue(sales_amt#22))#54,18,2) AS sales_amt#56]
 
-(64) Scan parquet default.catalog_sales
+(60) Scan parquet default.catalog_sales
 Output [5]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_sales]
 PushedFilters: [IsNotNull(cs_item_sk), IsNotNull(cs_sold_date_sk)]
 ReadSchema: struct<cs_sold_date_sk:int,cs_item_sk:int,cs_order_number:int,cs_quantity:int,cs_ext_sales_price:decimal(7,2)>
 
-(65) ColumnarToRow [codegen id : 20]
+(61) ColumnarToRow [codegen id : 18]
 Input [5]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5]
 
-(66) Filter [codegen id : 20]
+(62) Filter [codegen id : 18]
 Input [5]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5]
 Condition : (isnotnull(cs_item_sk#2) AND isnotnull(cs_sold_date_sk#1))
 
-(67) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#58, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62]
+(63) ReusedExchange [Reuses operator id: 8]
+Output [5]: [i_item_sk#57, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61]
 
-(68) BroadcastHashJoin [codegen id : 20]
+(64) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [cs_item_sk#2]
-Right keys [1]: [i_item_sk#58]
+Right keys [1]: [i_item_sk#57]
 Join condition: None
 
-(69) Project [codegen id : 20]
-Output [9]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62]
-Input [10]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_item_sk#58, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62]
+(65) Project [codegen id : 18]
+Output [9]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61]
+Input [10]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_item_sk#57, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61]
 
-(70) Scan parquet default.date_dim
-Output [2]: [d_date_sk#63, d_year#64]
+(66) Scan parquet default.date_dim
+Output [2]: [d_date_sk#62, d_year#63]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(71) ColumnarToRow [codegen id : 18]
-Input [2]: [d_date_sk#63, d_year#64]
+(67) ColumnarToRow [codegen id : 16]
+Input [2]: [d_date_sk#62, d_year#63]
 
-(72) Filter [codegen id : 18]
-Input [2]: [d_date_sk#63, d_year#64]
-Condition : ((isnotnull(d_year#64) AND (d_year#64 = 2001)) AND isnotnull(d_date_sk#63))
+(68) Filter [codegen id : 16]
+Input [2]: [d_date_sk#62, d_year#63]
+Condition : ((isnotnull(d_year#63) AND (d_year#63 = 2001)) AND isnotnull(d_date_sk#62))
 
-(73) BroadcastExchange
-Input [2]: [d_date_sk#63, d_year#64]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#65]
+(69) BroadcastExchange
+Input [2]: [d_date_sk#62, d_year#63]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#64]
 
-(74) BroadcastHashJoin [codegen id : 20]
+(70) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [cs_sold_date_sk#1]
-Right keys [1]: [d_date_sk#63]
+Right keys [1]: [d_date_sk#62]
 Join condition: None
 
-(75) Project [codegen id : 20]
-Output [9]: [cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, d_year#64]
-Input [11]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, d_date_sk#63, d_year#64]
+(71) Project [codegen id : 18]
+Output [9]: [cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, d_year#63]
+Input [11]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, d_date_sk#62, d_year#63]
 
-(76) ReusedExchange [Reuses operator id: 20]
+(72) ReusedExchange [Reuses operator id: 20]
 Output [4]: [cr_item_sk#16, cr_order_number#17, cr_return_quantity#18, cr_return_amount#19]
 
-(77) BroadcastHashJoin [codegen id : 20]
+(73) BroadcastHashJoin [codegen id : 18]
 Left keys [2]: [cs_order_number#3, cs_item_sk#2]
 Right keys [2]: [cr_order_number#17, cr_item_sk#16]
 Join condition: None
 
-(78) Project [codegen id : 20]
-Output [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, (cs_quantity#4 - coalesce(cr_return_quantity#18, 0)) AS sales_cnt#21, CheckOverflow((promote_precision(cast(cs_ext_sales_price#5 as decimal(8,2))) - promote_precision(cast(coalesce(cr_return_amount#19, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#22]
-Input [13]: [cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, d_year#64, cr_item_sk#16, cr_order_number#17, cr_return_quantity#18, cr_return_amount#19]
+(74) Project [codegen id : 18]
+Output [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, (cs_quantity#4 - coalesce(cr_return_quantity#18, 0)) AS sales_cnt#21, CheckOverflow((promote_precision(cast(cs_ext_sales_price#5 as decimal(8,2))) - promote_precision(cast(coalesce(cr_return_amount#19, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#22]
+Input [13]: [cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, d_year#63, cr_item_sk#16, cr_order_number#17, cr_return_quantity#18, cr_return_amount#19]
 
-(79) Scan parquet default.store_sales
+(75) Scan parquet default.store_sales
 Output [5]: [ss_sold_date_sk#23, ss_item_sk#24, ss_ticket_number#25, ss_quantity#26, ss_ext_sales_price#27]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_sold_date_sk)]
 ReadSchema: struct<ss_sold_date_sk:int,ss_item_sk:int,ss_ticket_number:int,ss_quantity:int,ss_ext_sales_price:decimal(7,2)>
 
-(80) ColumnarToRow [codegen id : 24]
+(76) ColumnarToRow [codegen id : 22]
 Input [5]: [ss_sold_date_sk#23, ss_item_sk#24, ss_ticket_number#25, ss_quantity#26, ss_ext_sales_price#27]
 
-(81) Filter [codegen id : 24]
+(77) Filter [codegen id : 22]
 Input [5]: [ss_sold_date_sk#23, ss_item_sk#24, ss_ticket_number#25, ss_quantity#26, ss_ext_sales_price#27]
 Condition : (isnotnull(ss_item_sk#24) AND isnotnull(ss_sold_date_sk#23))
 
-(82) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#58, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62]
+(78) ReusedExchange [Reuses operator id: 8]
+Output [5]: [i_item_sk#57, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61]
 
-(83) BroadcastHashJoin [codegen id : 24]
+(79) BroadcastHashJoin [codegen id : 22]
 Left keys [1]: [ss_item_sk#24]
-Right keys [1]: [i_item_sk#58]
+Right keys [1]: [i_item_sk#57]
 Join condition: None
 
-(84) Project [codegen id : 24]
-Output [9]: [ss_sold_date_sk#23, ss_item_sk#24, ss_ticket_number#25, ss_quantity#26, ss_ext_sales_price#27, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62]
-Input [10]: [ss_sold_date_sk#23, ss_item_sk#24, ss_ticket_number#25, ss_quantity#26, ss_ext_sales_price#27, i_item_sk#58, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62]
+(80) Project [codegen id : 22]
+Output [9]: [ss_sold_date_sk#23, ss_item_sk#24, ss_ticket_number#25, ss_quantity#26, ss_ext_sales_price#27, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61]
+Input [10]: [ss_sold_date_sk#23, ss_item_sk#24, ss_ticket_number#25, ss_quantity#26, ss_ext_sales_price#27, i_item_sk#57, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61]
 
-(85) ReusedExchange [Reuses operator id: 73]
-Output [2]: [d_date_sk#63, d_year#64]
+(81) ReusedExchange [Reuses operator id: 69]
+Output [2]: [d_date_sk#62, d_year#63]
 
-(86) BroadcastHashJoin [codegen id : 24]
+(82) BroadcastHashJoin [codegen id : 22]
 Left keys [1]: [ss_sold_date_sk#23]
-Right keys [1]: [d_date_sk#63]
+Right keys [1]: [d_date_sk#62]
 Join condition: None
 
-(87) Project [codegen id : 24]
-Output [9]: [ss_item_sk#24, ss_ticket_number#25, ss_quantity#26, ss_ext_sales_price#27, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, d_year#64]
-Input [11]: [ss_sold_date_sk#23, ss_item_sk#24, ss_ticket_number#25, ss_quantity#26, ss_ext_sales_price#27, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, d_date_sk#63, d_year#64]
+(83) Project [codegen id : 22]
+Output [9]: [ss_item_sk#24, ss_ticket_number#25, ss_quantity#26, ss_ext_sales_price#27, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, d_year#63]
+Input [11]: [ss_sold_date_sk#23, ss_item_sk#24, ss_ticket_number#25, ss_quantity#26, ss_ext_sales_price#27, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, d_date_sk#62, d_year#63]
 
-(88) ReusedExchange [Reuses operator id: 35]
+(84) ReusedExchange [Reuses operator id: 35]
 Output [4]: [sr_item_sk#28, sr_ticket_number#29, sr_return_quantity#30, sr_return_amt#31]
 
-(89) BroadcastHashJoin [codegen id : 24]
+(85) BroadcastHashJoin [codegen id : 22]
 Left keys [2]: [cast(ss_ticket_number#25 as bigint), cast(ss_item_sk#24 as bigint)]
 Right keys [2]: [sr_ticket_number#29, sr_item_sk#28]
 Join condition: None
 
-(90) Project [codegen id : 24]
-Output [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, (ss_quantity#26 - coalesce(sr_return_quantity#30, 0)) AS sales_cnt#66, CheckOverflow((promote_precision(cast(ss_ext_sales_price#27 as decimal(8,2))) - promote_precision(cast(coalesce(sr_return_amt#31, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#67]
-Input [13]: [ss_item_sk#24, ss_ticket_number#25, ss_quantity#26, ss_ext_sales_price#27, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, d_year#64, sr_item_sk#28, sr_ticket_number#29, sr_return_quantity#30, sr_return_amt#31]
+(86) Project [codegen id : 22]
+Output [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, (ss_quantity#26 - coalesce(sr_return_quantity#30, 0)) AS sales_cnt#65, CheckOverflow((promote_precision(cast(ss_ext_sales_price#27 as decimal(8,2))) - promote_precision(cast(coalesce(sr_return_amt#31, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#66]
+Input [13]: [ss_item_sk#24, ss_ticket_number#25, ss_quantity#26, ss_ext_sales_price#27, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, d_year#63, sr_item_sk#28, sr_ticket_number#29, sr_return_quantity#30, sr_return_amt#31]
 
-(91) Union
-
-(92) HashAggregate [codegen id : 25]
-Input [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22]
-Keys [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22]
-Functions: []
-Aggregate Attributes: []
-Results [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22]
-
-(93) Exchange
-Input [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22]
-Arguments: hashpartitioning(d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22, 5), true, [id=#68]
-
-(94) HashAggregate [codegen id : 26]
-Input [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22]
-Keys [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22]
-Functions: []
-Aggregate Attributes: []
-Results [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22]
-
-(95) Scan parquet default.web_sales
-Output [5]: [ws_sold_date_sk#36, ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40]
+(87) Scan parquet default.web_sales
+Output [5]: [ws_sold_date_sk#35, ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_sales]
 PushedFilters: [IsNotNull(ws_item_sk), IsNotNull(ws_sold_date_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_item_sk:int,ws_order_number:int,ws_quantity:int,ws_ext_sales_price:decimal(7,2)>
 
-(96) ColumnarToRow [codegen id : 30]
-Input [5]: [ws_sold_date_sk#36, ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40]
+(88) ColumnarToRow [codegen id : 26]
+Input [5]: [ws_sold_date_sk#35, ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39]
 
-(97) Filter [codegen id : 30]
-Input [5]: [ws_sold_date_sk#36, ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40]
-Condition : (isnotnull(ws_item_sk#37) AND isnotnull(ws_sold_date_sk#36))
+(89) Filter [codegen id : 26]
+Input [5]: [ws_sold_date_sk#35, ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39]
+Condition : (isnotnull(ws_item_sk#36) AND isnotnull(ws_sold_date_sk#35))
 
-(98) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#58, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62]
+(90) ReusedExchange [Reuses operator id: 8]
+Output [5]: [i_item_sk#57, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61]
 
-(99) BroadcastHashJoin [codegen id : 30]
-Left keys [1]: [ws_item_sk#37]
-Right keys [1]: [i_item_sk#58]
+(91) BroadcastHashJoin [codegen id : 26]
+Left keys [1]: [ws_item_sk#36]
+Right keys [1]: [i_item_sk#57]
 Join condition: None
 
-(100) Project [codegen id : 30]
-Output [9]: [ws_sold_date_sk#36, ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62]
-Input [10]: [ws_sold_date_sk#36, ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40, i_item_sk#58, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62]
+(92) Project [codegen id : 26]
+Output [9]: [ws_sold_date_sk#35, ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61]
+Input [10]: [ws_sold_date_sk#35, ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39, i_item_sk#57, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61]
 
-(101) ReusedExchange [Reuses operator id: 73]
-Output [2]: [d_date_sk#63, d_year#64]
+(93) ReusedExchange [Reuses operator id: 69]
+Output [2]: [d_date_sk#62, d_year#63]
 
-(102) BroadcastHashJoin [codegen id : 30]
-Left keys [1]: [ws_sold_date_sk#36]
-Right keys [1]: [d_date_sk#63]
+(94) BroadcastHashJoin [codegen id : 26]
+Left keys [1]: [ws_sold_date_sk#35]
+Right keys [1]: [d_date_sk#62]
 Join condition: None
 
-(103) Project [codegen id : 30]
-Output [9]: [ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, d_year#64]
-Input [11]: [ws_sold_date_sk#36, ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, d_date_sk#63, d_year#64]
+(95) Project [codegen id : 26]
+Output [9]: [ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, d_year#63]
+Input [11]: [ws_sold_date_sk#35, ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, d_date_sk#62, d_year#63]
 
-(104) ReusedExchange [Reuses operator id: 54]
-Output [4]: [wr_item_sk#41, wr_order_number#42, wr_return_quantity#43, wr_return_amt#44]
+(96) ReusedExchange [Reuses operator id: 50]
+Output [4]: [wr_item_sk#40, wr_order_number#41, wr_return_quantity#42, wr_return_amt#43]
 
-(105) BroadcastHashJoin [codegen id : 30]
-Left keys [2]: [cast(ws_order_number#38 as bigint), cast(ws_item_sk#37 as bigint)]
-Right keys [2]: [wr_order_number#42, wr_item_sk#41]
+(97) BroadcastHashJoin [codegen id : 26]
+Left keys [2]: [cast(ws_order_number#37 as bigint), cast(ws_item_sk#36 as bigint)]
+Right keys [2]: [wr_order_number#41, wr_item_sk#40]
 Join condition: None
 
-(106) Project [codegen id : 30]
-Output [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, (ws_quantity#39 - coalesce(wr_return_quantity#43, 0)) AS sales_cnt#69, CheckOverflow((promote_precision(cast(ws_ext_sales_price#40 as decimal(8,2))) - promote_precision(cast(coalesce(wr_return_amt#44, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#70]
-Input [13]: [ws_item_sk#37, ws_order_number#38, ws_quantity#39, ws_ext_sales_price#40, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, d_year#64, wr_item_sk#41, wr_order_number#42, wr_return_quantity#43, wr_return_amt#44]
+(98) Project [codegen id : 26]
+Output [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, (ws_quantity#38 - coalesce(wr_return_quantity#42, 0)) AS sales_cnt#67, CheckOverflow((promote_precision(cast(ws_ext_sales_price#39 as decimal(8,2))) - promote_precision(cast(coalesce(wr_return_amt#43, 0.00) as decimal(8,2)))), DecimalType(8,2), true) AS sales_amt#68]
+Input [13]: [ws_item_sk#36, ws_order_number#37, ws_quantity#38, ws_ext_sales_price#39, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, d_year#63, wr_item_sk#40, wr_order_number#41, wr_return_quantity#42, wr_return_amt#43]
 
-(107) Union
+(99) Union
 
-(108) HashAggregate [codegen id : 31]
-Input [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22]
-Keys [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22]
+(100) HashAggregate [codegen id : 27]
+Input [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, sales_cnt#21, sales_amt#22]
+Keys [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, sales_cnt#21, sales_amt#22]
 Functions: []
 Aggregate Attributes: []
-Results [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22]
+Results [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, sales_cnt#21, sales_amt#22]
 
-(109) Exchange
-Input [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22]
-Arguments: hashpartitioning(d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22, 5), true, [id=#71]
+(101) Exchange
+Input [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, sales_cnt#21, sales_amt#22]
+Arguments: hashpartitioning(d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, sales_cnt#21, sales_amt#22, 5), ENSURE_REQUIREMENTS, [id=#69]
 
-(110) HashAggregate [codegen id : 32]
-Input [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22]
-Keys [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22]
+(102) HashAggregate [codegen id : 28]
+Input [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, sales_cnt#21, sales_amt#22]
+Keys [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, sales_cnt#21, sales_amt#22]
 Functions: []
 Aggregate Attributes: []
-Results [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22]
+Results [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, sales_cnt#21, sales_amt#22]
 
-(111) HashAggregate [codegen id : 32]
-Input [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#21, sales_amt#22]
-Keys [5]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62]
+(103) HashAggregate [codegen id : 28]
+Input [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, sales_cnt#21, sales_amt#22]
+Keys [5]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61]
 Functions [2]: [partial_sum(cast(sales_cnt#21 as bigint)), partial_sum(UnscaledValue(sales_amt#22))]
-Aggregate Attributes [2]: [sum#72, sum#73]
-Results [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sum#74, sum#75]
+Aggregate Attributes [2]: [sum#70, sum#71]
+Results [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, sum#72, sum#73]
 
-(112) Exchange
-Input [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sum#74, sum#75]
-Arguments: hashpartitioning(d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, 5), true, [id=#76]
+(104) Exchange
+Input [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, sum#72, sum#73]
+Arguments: hashpartitioning(d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, 5), ENSURE_REQUIREMENTS, [id=#74]
 
-(113) HashAggregate [codegen id : 33]
-Input [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sum#74, sum#75]
-Keys [5]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62]
+(105) HashAggregate [codegen id : 29]
+Input [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, sum#72, sum#73]
+Keys [5]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61]
 Functions [2]: [sum(cast(sales_cnt#21 as bigint)), sum(UnscaledValue(sales_amt#22))]
-Aggregate Attributes [2]: [sum(cast(sales_cnt#21 as bigint))#77, sum(UnscaledValue(sales_amt#22))#78]
-Results [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sum(cast(sales_cnt#21 as bigint))#77 AS sales_cnt#79, MakeDecimal(sum(UnscaledValue(sales_amt#22))#78,18,2) AS sales_amt#80]
+Aggregate Attributes [2]: [sum(cast(sales_cnt#21 as bigint))#75, sum(UnscaledValue(sales_amt#22))#76]
+Results [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, sum(cast(sales_cnt#21 as bigint))#75 AS sales_cnt#77, MakeDecimal(sum(UnscaledValue(sales_amt#22))#76,18,2) AS sales_amt#78]
 
-(114) BroadcastExchange
-Input [7]: [d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#79, sales_amt#80]
-Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, true], input[3, int, true], input[4, int, true]),false), [id=#81]
+(106) BroadcastExchange
+Input [7]: [d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, sales_cnt#77, sales_amt#78]
+Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, true], input[3, int, true], input[4, int, true]),false), [id=#79]
 
-(115) BroadcastHashJoin [codegen id : 34]
+(107) BroadcastHashJoin [codegen id : 30]
 Left keys [4]: [i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
-Right keys [4]: [i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62]
-Join condition: (CheckOverflow((promote_precision(cast(sales_cnt#56 as decimal(17,2))) / promote_precision(cast(sales_cnt#79 as decimal(17,2)))), DecimalType(37,20), true) < 0.90000000000000000000)
+Right keys [4]: [i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61]
+Join condition: (CheckOverflow((promote_precision(cast(sales_cnt#55 as decimal(17,2))) / promote_precision(cast(sales_cnt#77 as decimal(17,2)))), DecimalType(37,20), true) < 0.90000000000000000000)
 
-(116) Project [codegen id : 34]
-Output [10]: [d_year#64 AS prev_year#82, d_year#14 AS year#83, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#79 AS prev_yr_cnt#84, sales_cnt#56 AS curr_yr_cnt#85, (sales_cnt#56 - sales_cnt#79) AS sales_cnt_diff#86, CheckOverflow((promote_precision(cast(sales_amt#57 as decimal(19,2))) - promote_precision(cast(sales_amt#80 as decimal(19,2)))), DecimalType(19,2), true) AS sales_amt_diff#87]
-Input [14]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#56, sales_amt#57, d_year#64, i_brand_id#59, i_class_id#60, i_category_id#61, i_manufact_id#62, sales_cnt#79, sales_amt#80]
+(108) Project [codegen id : 30]
+Output [10]: [d_year#63 AS prev_year#80, d_year#14 AS year#81, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#77 AS prev_yr_cnt#82, sales_cnt#55 AS curr_yr_cnt#83, (sales_cnt#55 - sales_cnt#77) AS sales_cnt_diff#84, CheckOverflow((promote_precision(cast(sales_amt#56 as decimal(19,2))) - promote_precision(cast(sales_amt#78 as decimal(19,2)))), DecimalType(19,2), true) AS sales_amt_diff#85]
+Input [14]: [d_year#14, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#55, sales_amt#56, d_year#63, i_brand_id#58, i_class_id#59, i_category_id#60, i_manufact_id#61, sales_cnt#77, sales_amt#78]
 
-(117) TakeOrderedAndProject
-Input [10]: [prev_year#82, year#83, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, prev_yr_cnt#84, curr_yr_cnt#85, sales_cnt_diff#86, sales_amt_diff#87]
-Arguments: 100, [sales_cnt_diff#86 ASC NULLS FIRST, sales_amt_diff#87 ASC NULLS FIRST], [prev_year#82, year#83, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, prev_yr_cnt#84, curr_yr_cnt#85, sales_cnt_diff#86, sales_amt_diff#87]
+(109) TakeOrderedAndProject
+Input [10]: [prev_year#80, year#81, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, prev_yr_cnt#82, curr_yr_cnt#83, sales_cnt_diff#84, sales_amt_diff#85]
+Arguments: 100, [sales_cnt_diff#84 ASC NULLS FIRST, sales_amt_diff#85 ASC NULLS FIRST], [prev_year#80, year#81, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, prev_yr_cnt#82, curr_yr_cnt#83, sales_cnt_diff#84, sales_amt_diff#85]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75/simplified.txt
@@ -1,83 +1,75 @@
 TakeOrderedAndProject [sales_cnt_diff,sales_amt_diff,prev_year,year,i_brand_id,i_class_id,i_category_id,i_manufact_id,prev_yr_cnt,curr_yr_cnt]
-  WholeStageCodegen (34)
+  WholeStageCodegen (30)
     Project [d_year,d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_cnt,sales_amt,sales_amt]
       BroadcastHashJoin [i_brand_id,i_class_id,i_category_id,i_manufact_id,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_cnt]
         HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sum,sum] [sum(cast(sales_cnt as bigint)),sum(UnscaledValue(sales_amt)),sales_cnt,sales_amt,sum,sum]
           InputAdapter
             Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id] #1
-              WholeStageCodegen (16)
+              WholeStageCodegen (14)
                 HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] [sum,sum,sum,sum]
                   HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
                     InputAdapter
                       Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #2
-                        WholeStageCodegen (15)
+                        WholeStageCodegen (13)
                           HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
                             InputAdapter
                               Union
-                                WholeStageCodegen (10)
-                                  HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
-                                    InputAdapter
-                                      Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #3
-                                        WholeStageCodegen (9)
-                                          HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
-                                            InputAdapter
-                                              Union
-                                                WholeStageCodegen (4)
-                                                  Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,cs_quantity,cr_return_quantity,cs_ext_sales_price,cr_return_amount]
-                                                    BroadcastHashJoin [cs_order_number,cs_item_sk,cr_order_number,cr_item_sk]
-                                                      Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                        BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                          Project [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                            BroadcastHashJoin [cs_item_sk,i_item_sk]
-                                                              Filter [cs_item_sk,cs_sold_date_sk]
-                                                                ColumnarToRow
-                                                                  InputAdapter
-                                                                    Scan parquet default.catalog_sales [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price]
-                                                              InputAdapter
-                                                                BroadcastExchange #4
-                                                                  WholeStageCodegen (1)
-                                                                    Project [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                      Filter [i_category,i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                        ColumnarToRow
-                                                                          InputAdapter
-                                                                            Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id,i_category,i_manufact_id]
+                                WholeStageCodegen (4)
+                                  Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,cs_quantity,cr_return_quantity,cs_ext_sales_price,cr_return_amount]
+                                    BroadcastHashJoin [cs_order_number,cs_item_sk,cr_order_number,cr_item_sk]
+                                      Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
+                                        BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                          Project [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                            BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                              Filter [cs_item_sk,cs_sold_date_sk]
+                                                ColumnarToRow
+                                                  InputAdapter
+                                                    Scan parquet default.catalog_sales [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price]
+                                              InputAdapter
+                                                BroadcastExchange #3
+                                                  WholeStageCodegen (1)
+                                                    Project [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                      Filter [i_category,i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                        ColumnarToRow
                                                           InputAdapter
-                                                            BroadcastExchange #5
-                                                              WholeStageCodegen (2)
-                                                                Filter [d_year,d_date_sk]
-                                                                  ColumnarToRow
-                                                                    InputAdapter
-                                                                      Scan parquet default.date_dim [d_date_sk,d_year]
-                                                      InputAdapter
-                                                        BroadcastExchange #6
-                                                          WholeStageCodegen (3)
-                                                            Filter [cr_order_number,cr_item_sk]
-                                                              ColumnarToRow
-                                                                InputAdapter
-                                                                  Scan parquet default.catalog_returns [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount]
-                                                WholeStageCodegen (8)
-                                                  Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ss_quantity,sr_return_quantity,ss_ext_sales_price,sr_return_amt]
-                                                    BroadcastHashJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
-                                                      Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                        BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                          Project [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                            BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                              Filter [ss_item_sk,ss_sold_date_sk]
-                                                                ColumnarToRow
-                                                                  InputAdapter
-                                                                    Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price]
-                                                              InputAdapter
-                                                                ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #4
-                                                          InputAdapter
-                                                            ReusedExchange [d_date_sk,d_year] #5
-                                                      InputAdapter
-                                                        BroadcastExchange #7
-                                                          WholeStageCodegen (7)
-                                                            Filter [sr_ticket_number,sr_item_sk]
-                                                              ColumnarToRow
-                                                                InputAdapter
-                                                                  Scan parquet default.store_returns [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt]
-                                WholeStageCodegen (14)
+                                                            Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id,i_category,i_manufact_id]
+                                          InputAdapter
+                                            BroadcastExchange #4
+                                              WholeStageCodegen (2)
+                                                Filter [d_year,d_date_sk]
+                                                  ColumnarToRow
+                                                    InputAdapter
+                                                      Scan parquet default.date_dim [d_date_sk,d_year]
+                                      InputAdapter
+                                        BroadcastExchange #5
+                                          WholeStageCodegen (3)
+                                            Filter [cr_order_number,cr_item_sk]
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet default.catalog_returns [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount]
+                                WholeStageCodegen (8)
+                                  Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ss_quantity,sr_return_quantity,ss_ext_sales_price,sr_return_amt]
+                                    BroadcastHashJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
+                                      Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
+                                        BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                          Project [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                            BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                              Filter [ss_item_sk,ss_sold_date_sk]
+                                                ColumnarToRow
+                                                  InputAdapter
+                                                    Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price]
+                                              InputAdapter
+                                                ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #3
+                                          InputAdapter
+                                            ReusedExchange [d_date_sk,d_year] #4
+                                      InputAdapter
+                                        BroadcastExchange #6
+                                          WholeStageCodegen (7)
+                                            Filter [sr_ticket_number,sr_item_sk]
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet default.store_returns [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt]
+                                WholeStageCodegen (12)
                                   Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ws_quantity,wr_return_quantity,ws_ext_sales_price,wr_return_amt]
                                     BroadcastHashJoin [ws_order_number,ws_item_sk,wr_order_number,wr_item_sk]
                                       Project [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
@@ -89,79 +81,71 @@ TakeOrderedAndProject [sales_cnt_diff,sales_amt_diff,prev_year,year,i_brand_id,i
                                                   InputAdapter
                                                     Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price]
                                               InputAdapter
-                                                ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #4
+                                                ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #3
                                           InputAdapter
-                                            ReusedExchange [d_date_sk,d_year] #5
+                                            ReusedExchange [d_date_sk,d_year] #4
                                       InputAdapter
-                                        BroadcastExchange #8
-                                          WholeStageCodegen (13)
+                                        BroadcastExchange #7
+                                          WholeStageCodegen (11)
                                             Filter [wr_order_number,wr_item_sk]
                                               ColumnarToRow
                                                 InputAdapter
                                                   Scan parquet default.web_returns [wr_item_sk,wr_order_number,wr_return_quantity,wr_return_amt]
         InputAdapter
-          BroadcastExchange #9
-            WholeStageCodegen (33)
+          BroadcastExchange #8
+            WholeStageCodegen (29)
               HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sum,sum] [sum(cast(sales_cnt as bigint)),sum(UnscaledValue(sales_amt)),sales_cnt,sales_amt,sum,sum]
                 InputAdapter
-                  Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id] #10
-                    WholeStageCodegen (32)
+                  Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id] #9
+                    WholeStageCodegen (28)
                       HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] [sum,sum,sum,sum]
                         HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
                           InputAdapter
-                            Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #11
-                              WholeStageCodegen (31)
+                            Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #10
+                              WholeStageCodegen (27)
                                 HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
                                   InputAdapter
                                     Union
+                                      WholeStageCodegen (18)
+                                        Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,cs_quantity,cr_return_quantity,cs_ext_sales_price,cr_return_amount]
+                                          BroadcastHashJoin [cs_order_number,cs_item_sk,cr_order_number,cr_item_sk]
+                                            Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
+                                              BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                Project [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                  BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                    Filter [cs_item_sk,cs_sold_date_sk]
+                                                      ColumnarToRow
+                                                        InputAdapter
+                                                          Scan parquet default.catalog_sales [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price]
+                                                    InputAdapter
+                                                      ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #3
+                                                InputAdapter
+                                                  BroadcastExchange #11
+                                                    WholeStageCodegen (16)
+                                                      Filter [d_year,d_date_sk]
+                                                        ColumnarToRow
+                                                          InputAdapter
+                                                            Scan parquet default.date_dim [d_date_sk,d_year]
+                                            InputAdapter
+                                              ReusedExchange [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount] #5
+                                      WholeStageCodegen (22)
+                                        Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ss_quantity,sr_return_quantity,ss_ext_sales_price,sr_return_amt]
+                                          BroadcastHashJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
+                                            Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
+                                              BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                Project [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                  BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                    Filter [ss_item_sk,ss_sold_date_sk]
+                                                      ColumnarToRow
+                                                        InputAdapter
+                                                          Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price]
+                                                    InputAdapter
+                                                      ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #3
+                                                InputAdapter
+                                                  ReusedExchange [d_date_sk,d_year] #11
+                                            InputAdapter
+                                              ReusedExchange [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt] #6
                                       WholeStageCodegen (26)
-                                        HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
-                                          InputAdapter
-                                            Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #12
-                                              WholeStageCodegen (25)
-                                                HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
-                                                  InputAdapter
-                                                    Union
-                                                      WholeStageCodegen (20)
-                                                        Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,cs_quantity,cr_return_quantity,cs_ext_sales_price,cr_return_amount]
-                                                          BroadcastHashJoin [cs_order_number,cs_item_sk,cr_order_number,cr_item_sk]
-                                                            Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                              BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                Project [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                  BroadcastHashJoin [cs_item_sk,i_item_sk]
-                                                                    Filter [cs_item_sk,cs_sold_date_sk]
-                                                                      ColumnarToRow
-                                                                        InputAdapter
-                                                                          Scan parquet default.catalog_sales [cs_sold_date_sk,cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price]
-                                                                    InputAdapter
-                                                                      ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #4
-                                                                InputAdapter
-                                                                  BroadcastExchange #13
-                                                                    WholeStageCodegen (18)
-                                                                      Filter [d_year,d_date_sk]
-                                                                        ColumnarToRow
-                                                                          InputAdapter
-                                                                            Scan parquet default.date_dim [d_date_sk,d_year]
-                                                            InputAdapter
-                                                              ReusedExchange [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount] #6
-                                                      WholeStageCodegen (24)
-                                                        Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ss_quantity,sr_return_quantity,ss_ext_sales_price,sr_return_amt]
-                                                          BroadcastHashJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
-                                                            Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                              BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                Project [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                  BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                                    Filter [ss_item_sk,ss_sold_date_sk]
-                                                                      ColumnarToRow
-                                                                        InputAdapter
-                                                                          Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price]
-                                                                    InputAdapter
-                                                                      ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #4
-                                                                InputAdapter
-                                                                  ReusedExchange [d_date_sk,d_year] #13
-                                                            InputAdapter
-                                                              ReusedExchange [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt] #7
-                                      WholeStageCodegen (30)
                                         Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ws_quantity,wr_return_quantity,ws_ext_sales_price,wr_return_amt]
                                           BroadcastHashJoin [ws_order_number,ws_item_sk,wr_order_number,wr_item_sk]
                                             Project [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
@@ -173,8 +157,8 @@ TakeOrderedAndProject [sales_cnt_diff,sales_amt_diff,prev_year,year,i_brand_id,i
                                                         InputAdapter
                                                           Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price]
                                                     InputAdapter
-                                                      ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #4
+                                                      ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #3
                                                 InputAdapter
-                                                  ReusedExchange [d_date_sk,d_year] #13
+                                                  ReusedExchange [d_date_sk,d_year] #11
                                             InputAdapter
-                                              ReusedExchange [wr_item_sk,wr_order_number,wr_return_quantity,wr_return_amt] #8
+                                              ReusedExchange [wr_item_sk,wr_order_number,wr_return_quantity,wr_return_amt] #7

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a.sf100/explain.txt
@@ -1,112 +1,108 @@
 == Physical Plan ==
-TakeOrderedAndProject (108)
-+- * HashAggregate (107)
-   +- Exchange (106)
-      +- * HashAggregate (105)
-         +- Union (104)
-            :- * HashAggregate (98)
-            :  +- Exchange (97)
-            :     +- * HashAggregate (96)
-            :        +- Union (95)
-            :           :- * HashAggregate (89)
-            :           :  +- Exchange (88)
-            :           :     +- * HashAggregate (87)
-            :           :        +- Union (86)
-            :           :           :- * Project (34)
-            :           :           :  +- * BroadcastHashJoin LeftOuter BuildRight (33)
-            :           :           :     :- * HashAggregate (19)
-            :           :           :     :  +- Exchange (18)
-            :           :           :     :     +- * HashAggregate (17)
-            :           :           :     :        +- * Project (16)
-            :           :           :     :           +- * BroadcastHashJoin Inner BuildRight (15)
-            :           :           :     :              :- * Project (10)
-            :           :           :     :              :  +- * BroadcastHashJoin Inner BuildRight (9)
-            :           :           :     :              :     :- * Filter (3)
-            :           :           :     :              :     :  +- * ColumnarToRow (2)
-            :           :           :     :              :     :     +- Scan parquet default.store_sales (1)
-            :           :           :     :              :     +- BroadcastExchange (8)
-            :           :           :     :              :        +- * Project (7)
-            :           :           :     :              :           +- * Filter (6)
-            :           :           :     :              :              +- * ColumnarToRow (5)
-            :           :           :     :              :                 +- Scan parquet default.date_dim (4)
-            :           :           :     :              +- BroadcastExchange (14)
-            :           :           :     :                 +- * Filter (13)
-            :           :           :     :                    +- * ColumnarToRow (12)
-            :           :           :     :                       +- Scan parquet default.store (11)
-            :           :           :     +- BroadcastExchange (32)
-            :           :           :        +- * HashAggregate (31)
-            :           :           :           +- Exchange (30)
-            :           :           :              +- * HashAggregate (29)
-            :           :           :                 +- * Project (28)
-            :           :           :                    +- * BroadcastHashJoin Inner BuildRight (27)
-            :           :           :                       :- * Project (25)
-            :           :           :                       :  +- * BroadcastHashJoin Inner BuildRight (24)
-            :           :           :                       :     :- * Filter (22)
-            :           :           :                       :     :  +- * ColumnarToRow (21)
-            :           :           :                       :     :     +- Scan parquet default.store_returns (20)
-            :           :           :                       :     +- ReusedExchange (23)
-            :           :           :                       +- ReusedExchange (26)
-            :           :           :- * Project (55)
-            :           :           :  +- BroadcastNestedLoopJoin Inner BuildRight (54)
-            :           :           :     :- * HashAggregate (43)
-            :           :           :     :  +- Exchange (42)
-            :           :           :     :     +- * HashAggregate (41)
-            :           :           :     :        +- * Project (40)
-            :           :           :     :           +- * BroadcastHashJoin Inner BuildRight (39)
-            :           :           :     :              :- * Filter (37)
-            :           :           :     :              :  +- * ColumnarToRow (36)
-            :           :           :     :              :     +- Scan parquet default.catalog_sales (35)
-            :           :           :     :              +- ReusedExchange (38)
-            :           :           :     +- BroadcastExchange (53)
-            :           :           :        +- * HashAggregate (52)
-            :           :           :           +- Exchange (51)
-            :           :           :              +- * HashAggregate (50)
-            :           :           :                 +- * Project (49)
-            :           :           :                    +- * BroadcastHashJoin Inner BuildRight (48)
-            :           :           :                       :- * Filter (46)
-            :           :           :                       :  +- * ColumnarToRow (45)
-            :           :           :                       :     +- Scan parquet default.catalog_returns (44)
-            :           :           :                       +- ReusedExchange (47)
-            :           :           +- * Project (85)
-            :           :              +- * BroadcastHashJoin LeftOuter BuildRight (84)
-            :           :                 :- * HashAggregate (70)
-            :           :                 :  +- Exchange (69)
-            :           :                 :     +- * HashAggregate (68)
-            :           :                 :        +- * Project (67)
-            :           :                 :           +- * BroadcastHashJoin Inner BuildRight (66)
-            :           :                 :              :- * Project (61)
-            :           :                 :              :  +- * BroadcastHashJoin Inner BuildRight (60)
-            :           :                 :              :     :- * Filter (58)
-            :           :                 :              :     :  +- * ColumnarToRow (57)
-            :           :                 :              :     :     +- Scan parquet default.web_sales (56)
-            :           :                 :              :     +- ReusedExchange (59)
-            :           :                 :              +- BroadcastExchange (65)
-            :           :                 :                 +- * Filter (64)
-            :           :                 :                    +- * ColumnarToRow (63)
-            :           :                 :                       +- Scan parquet default.web_page (62)
-            :           :                 +- BroadcastExchange (83)
-            :           :                    +- * HashAggregate (82)
-            :           :                       +- Exchange (81)
-            :           :                          +- * HashAggregate (80)
-            :           :                             +- * Project (79)
-            :           :                                +- * BroadcastHashJoin Inner BuildRight (78)
-            :           :                                   :- * Project (76)
-            :           :                                   :  +- * BroadcastHashJoin Inner BuildRight (75)
-            :           :                                   :     :- * Filter (73)
-            :           :                                   :     :  +- * ColumnarToRow (72)
-            :           :                                   :     :     +- Scan parquet default.web_returns (71)
-            :           :                                   :     +- ReusedExchange (74)
-            :           :                                   +- ReusedExchange (77)
-            :           +- * HashAggregate (94)
-            :              +- Exchange (93)
-            :                 +- * HashAggregate (92)
-            :                    +- * HashAggregate (91)
-            :                       +- ReusedExchange (90)
-            +- * HashAggregate (103)
-               +- Exchange (102)
-                  +- * HashAggregate (101)
-                     +- * HashAggregate (100)
-                        +- ReusedExchange (99)
+TakeOrderedAndProject (104)
++- * HashAggregate (103)
+   +- Exchange (102)
+      +- * HashAggregate (101)
+         +- Union (100)
+            :- * HashAggregate (89)
+            :  +- Exchange (88)
+            :     +- * HashAggregate (87)
+            :        +- Union (86)
+            :           :- * Project (34)
+            :           :  +- * BroadcastHashJoin LeftOuter BuildRight (33)
+            :           :     :- * HashAggregate (19)
+            :           :     :  +- Exchange (18)
+            :           :     :     +- * HashAggregate (17)
+            :           :     :        +- * Project (16)
+            :           :     :           +- * BroadcastHashJoin Inner BuildRight (15)
+            :           :     :              :- * Project (10)
+            :           :     :              :  +- * BroadcastHashJoin Inner BuildRight (9)
+            :           :     :              :     :- * Filter (3)
+            :           :     :              :     :  +- * ColumnarToRow (2)
+            :           :     :              :     :     +- Scan parquet default.store_sales (1)
+            :           :     :              :     +- BroadcastExchange (8)
+            :           :     :              :        +- * Project (7)
+            :           :     :              :           +- * Filter (6)
+            :           :     :              :              +- * ColumnarToRow (5)
+            :           :     :              :                 +- Scan parquet default.date_dim (4)
+            :           :     :              +- BroadcastExchange (14)
+            :           :     :                 +- * Filter (13)
+            :           :     :                    +- * ColumnarToRow (12)
+            :           :     :                       +- Scan parquet default.store (11)
+            :           :     +- BroadcastExchange (32)
+            :           :        +- * HashAggregate (31)
+            :           :           +- Exchange (30)
+            :           :              +- * HashAggregate (29)
+            :           :                 +- * Project (28)
+            :           :                    +- * BroadcastHashJoin Inner BuildRight (27)
+            :           :                       :- * Project (25)
+            :           :                       :  +- * BroadcastHashJoin Inner BuildRight (24)
+            :           :                       :     :- * Filter (22)
+            :           :                       :     :  +- * ColumnarToRow (21)
+            :           :                       :     :     +- Scan parquet default.store_returns (20)
+            :           :                       :     +- ReusedExchange (23)
+            :           :                       +- ReusedExchange (26)
+            :           :- * Project (55)
+            :           :  +- BroadcastNestedLoopJoin Inner BuildRight (54)
+            :           :     :- * HashAggregate (43)
+            :           :     :  +- Exchange (42)
+            :           :     :     +- * HashAggregate (41)
+            :           :     :        +- * Project (40)
+            :           :     :           +- * BroadcastHashJoin Inner BuildRight (39)
+            :           :     :              :- * Filter (37)
+            :           :     :              :  +- * ColumnarToRow (36)
+            :           :     :              :     +- Scan parquet default.catalog_sales (35)
+            :           :     :              +- ReusedExchange (38)
+            :           :     +- BroadcastExchange (53)
+            :           :        +- * HashAggregate (52)
+            :           :           +- Exchange (51)
+            :           :              +- * HashAggregate (50)
+            :           :                 +- * Project (49)
+            :           :                    +- * BroadcastHashJoin Inner BuildRight (48)
+            :           :                       :- * Filter (46)
+            :           :                       :  +- * ColumnarToRow (45)
+            :           :                       :     +- Scan parquet default.catalog_returns (44)
+            :           :                       +- ReusedExchange (47)
+            :           +- * Project (85)
+            :              +- * BroadcastHashJoin LeftOuter BuildRight (84)
+            :                 :- * HashAggregate (70)
+            :                 :  +- Exchange (69)
+            :                 :     +- * HashAggregate (68)
+            :                 :        +- * Project (67)
+            :                 :           +- * BroadcastHashJoin Inner BuildRight (66)
+            :                 :              :- * Project (61)
+            :                 :              :  +- * BroadcastHashJoin Inner BuildRight (60)
+            :                 :              :     :- * Filter (58)
+            :                 :              :     :  +- * ColumnarToRow (57)
+            :                 :              :     :     +- Scan parquet default.web_sales (56)
+            :                 :              :     +- ReusedExchange (59)
+            :                 :              +- BroadcastExchange (65)
+            :                 :                 +- * Filter (64)
+            :                 :                    +- * ColumnarToRow (63)
+            :                 :                       +- Scan parquet default.web_page (62)
+            :                 +- BroadcastExchange (83)
+            :                    +- * HashAggregate (82)
+            :                       +- Exchange (81)
+            :                          +- * HashAggregate (80)
+            :                             +- * Project (79)
+            :                                +- * BroadcastHashJoin Inner BuildRight (78)
+            :                                   :- * Project (76)
+            :                                   :  +- * BroadcastHashJoin Inner BuildRight (75)
+            :                                   :     :- * Filter (73)
+            :                                   :     :  +- * ColumnarToRow (72)
+            :                                   :     :     +- Scan parquet default.web_returns (71)
+            :                                   :     +- ReusedExchange (74)
+            :                                   +- ReusedExchange (77)
+            :- * HashAggregate (94)
+            :  +- Exchange (93)
+            :     +- * HashAggregate (92)
+            :        +- * HashAggregate (91)
+            :           +- ReusedExchange (90)
+            +- * HashAggregate (99)
+               +- Exchange (98)
+                  +- * HashAggregate (97)
+                     +- * HashAggregate (96)
+                        +- ReusedExchange (95)
 
 
 (1) Scan parquet default.store_sales
@@ -190,7 +186,7 @@ Results [3]: [s_store_sk#8, sum#12, sum#13]
 
 (18) Exchange
 Input [3]: [s_store_sk#8, sum#12, sum#13]
-Arguments: hashpartitioning(s_store_sk#8, 5), true, [id=#14]
+Arguments: hashpartitioning(s_store_sk#8, 5), ENSURE_REQUIREMENTS, [id=#14]
 
 (19) HashAggregate [codegen id : 8]
 Input [3]: [s_store_sk#8, sum#12, sum#13]
@@ -246,7 +242,7 @@ Results [3]: [s_store_sk#23, sum#26, sum#27]
 
 (30) Exchange
 Input [3]: [s_store_sk#23, sum#26, sum#27]
-Arguments: hashpartitioning(s_store_sk#23, 5), true, [id=#28]
+Arguments: hashpartitioning(s_store_sk#23, 5), ENSURE_REQUIREMENTS, [id=#28]
 
 (31) HashAggregate [codegen id : 7]
 Input [3]: [s_store_sk#23, sum#26, sum#27]
@@ -303,7 +299,7 @@ Results [3]: [cs_call_center_sk#39, sum#44, sum#45]
 
 (42) Exchange
 Input [3]: [cs_call_center_sk#39, sum#44, sum#45]
-Arguments: hashpartitioning(cs_call_center_sk#39, 5), true, [id=#46]
+Arguments: hashpartitioning(cs_call_center_sk#39, 5), ENSURE_REQUIREMENTS, [id=#46]
 
 (43) HashAggregate [codegen id : 11]
 Input [3]: [cs_call_center_sk#39, sum#44, sum#45]
@@ -347,7 +343,7 @@ Results [2]: [sum#56, sum#57]
 
 (51) Exchange
 Input [2]: [sum#56, sum#57]
-Arguments: SinglePartition, true, [id=#58]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#58]
 
 (52) HashAggregate [codegen id : 14]
 Input [2]: [sum#56, sum#57]
@@ -429,7 +425,7 @@ Results [3]: [wp_web_page_sk#71, sum#75, sum#76]
 
 (69) Exchange
 Input [3]: [wp_web_page_sk#71, sum#75, sum#76]
-Arguments: hashpartitioning(wp_web_page_sk#71, 5), true, [id=#77]
+Arguments: hashpartitioning(wp_web_page_sk#71, 5), ENSURE_REQUIREMENTS, [id=#77]
 
 (70) HashAggregate [codegen id : 23]
 Input [3]: [wp_web_page_sk#71, sum#75, sum#76]
@@ -485,7 +481,7 @@ Results [3]: [wp_web_page_sk#86, sum#89, sum#90]
 
 (81) Exchange
 Input [3]: [wp_web_page_sk#86, sum#89, sum#90]
-Arguments: hashpartitioning(wp_web_page_sk#86, 5), true, [id=#91]
+Arguments: hashpartitioning(wp_web_page_sk#86, 5), ENSURE_REQUIREMENTS, [id=#91]
 
 (82) HashAggregate [codegen id : 22]
 Input [3]: [wp_web_page_sk#86, sum#89, sum#90]
@@ -518,7 +514,7 @@ Results [8]: [channel#34, id#35, sum#107, isEmpty#108, sum#109, isEmpty#110, sum
 
 (88) Exchange
 Input [8]: [channel#34, id#35, sum#107, isEmpty#108, sum#109, isEmpty#110, sum#111, isEmpty#112]
-Arguments: hashpartitioning(channel#34, id#35, 5), true, [id=#113]
+Arguments: hashpartitioning(channel#34, id#35, 5), ENSURE_REQUIREMENTS, [id=#113]
 
 (89) HashAggregate [codegen id : 25]
 Input [8]: [channel#34, id#35, sum#107, isEmpty#108, sum#109, isEmpty#110, sum#111, isEmpty#112]
@@ -546,7 +542,7 @@ Results [7]: [channel#34, sum#139, isEmpty#140, sum#141, isEmpty#142, sum#143, i
 
 (93) Exchange
 Input [7]: [channel#34, sum#139, isEmpty#140, sum#141, isEmpty#142, sum#143, isEmpty#144]
-Arguments: hashpartitioning(channel#34, 5), true, [id=#145]
+Arguments: hashpartitioning(channel#34, 5), ENSURE_REQUIREMENTS, [id=#145]
 
 (94) HashAggregate [codegen id : 51]
 Input [7]: [channel#34, sum#139, isEmpty#140, sum#141, isEmpty#142, sum#143, isEmpty#144]
@@ -555,75 +551,55 @@ Functions [3]: [sum(sales#130), sum(returns#131), sum(profit#132)]
 Aggregate Attributes [3]: [sum(sales#130)#146, sum(returns#131)#147, sum(profit#132)#148]
 Results [5]: [channel#34, null AS id#149, sum(sales#130)#146 AS sales#150, sum(returns#131)#147 AS returns#151, sum(profit#132)#148 AS profit#152]
 
-(95) Union
+(95) ReusedExchange [Reuses operator id: 88]
+Output [8]: [channel#34, id#35, sum#153, isEmpty#154, sum#155, isEmpty#156, sum#157, isEmpty#158]
 
-(96) HashAggregate [codegen id : 52]
-Input [5]: [channel#34, id#35, sales#117, returns#118, profit#119]
-Keys [5]: [channel#34, id#35, sales#117, returns#118, profit#119]
-Functions: []
-Aggregate Attributes: []
-Results [5]: [channel#34, id#35, sales#117, returns#118, profit#119]
-
-(97) Exchange
-Input [5]: [channel#34, id#35, sales#117, returns#118, profit#119]
-Arguments: hashpartitioning(channel#34, id#35, sales#117, returns#118, profit#119, 5), true, [id=#153]
-
-(98) HashAggregate [codegen id : 53]
-Input [5]: [channel#34, id#35, sales#117, returns#118, profit#119]
-Keys [5]: [channel#34, id#35, sales#117, returns#118, profit#119]
-Functions: []
-Aggregate Attributes: []
-Results [5]: [channel#34, id#35, sales#117, returns#118, profit#119]
-
-(99) ReusedExchange [Reuses operator id: 88]
-Output [8]: [channel#34, id#35, sum#154, isEmpty#155, sum#156, isEmpty#157, sum#158, isEmpty#159]
-
-(100) HashAggregate [codegen id : 78]
-Input [8]: [channel#34, id#35, sum#154, isEmpty#155, sum#156, isEmpty#157, sum#158, isEmpty#159]
+(96) HashAggregate [codegen id : 76]
+Input [8]: [channel#34, id#35, sum#153, isEmpty#154, sum#155, isEmpty#156, sum#157, isEmpty#158]
 Keys [2]: [channel#34, id#35]
-Functions [3]: [sum(sales#17), sum(returns#36), sum(profit#160)]
-Aggregate Attributes [3]: [sum(sales#17)#161, sum(returns#36)#162, sum(profit#160)#163]
-Results [3]: [sum(sales#17)#161 AS sales#130, sum(returns#36)#162 AS returns#131, sum(profit#160)#163 AS profit#132]
+Functions [3]: [sum(sales#17), sum(returns#36), sum(profit#159)]
+Aggregate Attributes [3]: [sum(sales#17)#160, sum(returns#36)#161, sum(profit#159)#162]
+Results [3]: [sum(sales#17)#160 AS sales#130, sum(returns#36)#161 AS returns#131, sum(profit#159)#162 AS profit#132]
 
-(101) HashAggregate [codegen id : 78]
+(97) HashAggregate [codegen id : 76]
 Input [3]: [sales#130, returns#131, profit#132]
 Keys: []
 Functions [3]: [partial_sum(sales#130), partial_sum(returns#131), partial_sum(profit#132)]
-Aggregate Attributes [6]: [sum#164, isEmpty#165, sum#166, isEmpty#167, sum#168, isEmpty#169]
-Results [6]: [sum#170, isEmpty#171, sum#172, isEmpty#173, sum#174, isEmpty#175]
+Aggregate Attributes [6]: [sum#163, isEmpty#164, sum#165, isEmpty#166, sum#167, isEmpty#168]
+Results [6]: [sum#169, isEmpty#170, sum#171, isEmpty#172, sum#173, isEmpty#174]
 
-(102) Exchange
-Input [6]: [sum#170, isEmpty#171, sum#172, isEmpty#173, sum#174, isEmpty#175]
-Arguments: SinglePartition, true, [id=#176]
+(98) Exchange
+Input [6]: [sum#169, isEmpty#170, sum#171, isEmpty#172, sum#173, isEmpty#174]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#175]
 
-(103) HashAggregate [codegen id : 79]
-Input [6]: [sum#170, isEmpty#171, sum#172, isEmpty#173, sum#174, isEmpty#175]
+(99) HashAggregate [codegen id : 77]
+Input [6]: [sum#169, isEmpty#170, sum#171, isEmpty#172, sum#173, isEmpty#174]
 Keys: []
 Functions [3]: [sum(sales#130), sum(returns#131), sum(profit#132)]
-Aggregate Attributes [3]: [sum(sales#130)#177, sum(returns#131)#178, sum(profit#132)#179]
-Results [5]: [null AS channel#180, null AS id#181, sum(sales#130)#177 AS sales#182, sum(returns#131)#178 AS returns#183, sum(profit#132)#179 AS profit#184]
+Aggregate Attributes [3]: [sum(sales#130)#176, sum(returns#131)#177, sum(profit#132)#178]
+Results [5]: [null AS channel#179, null AS id#180, sum(sales#130)#176 AS sales#181, sum(returns#131)#177 AS returns#182, sum(profit#132)#178 AS profit#183]
 
-(104) Union
+(100) Union
 
-(105) HashAggregate [codegen id : 80]
+(101) HashAggregate [codegen id : 78]
 Input [5]: [channel#34, id#35, sales#117, returns#118, profit#119]
 Keys [5]: [channel#34, id#35, sales#117, returns#118, profit#119]
 Functions: []
 Aggregate Attributes: []
 Results [5]: [channel#34, id#35, sales#117, returns#118, profit#119]
 
-(106) Exchange
+(102) Exchange
 Input [5]: [channel#34, id#35, sales#117, returns#118, profit#119]
-Arguments: hashpartitioning(channel#34, id#35, sales#117, returns#118, profit#119, 5), true, [id=#185]
+Arguments: hashpartitioning(channel#34, id#35, sales#117, returns#118, profit#119, 5), ENSURE_REQUIREMENTS, [id=#184]
 
-(107) HashAggregate [codegen id : 81]
+(103) HashAggregate [codegen id : 79]
 Input [5]: [channel#34, id#35, sales#117, returns#118, profit#119]
 Keys [5]: [channel#34, id#35, sales#117, returns#118, profit#119]
 Functions: []
 Aggregate Attributes: []
 Results [5]: [channel#34, id#35, sales#117, returns#118, profit#119]
 
-(108) TakeOrderedAndProject
+(104) TakeOrderedAndProject
 Input [5]: [channel#34, id#35, sales#117, returns#118, profit#119]
 Arguments: 100, [channel#34 ASC NULLS FIRST, id#35 ASC NULLS FIRST], [channel#34, id#35, sales#117, returns#118, profit#119]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a.sf100/simplified.txt
@@ -1,172 +1,164 @@
 TakeOrderedAndProject [channel,id,sales,returns,profit]
-  WholeStageCodegen (81)
+  WholeStageCodegen (79)
     HashAggregate [channel,id,sales,returns,profit]
       InputAdapter
         Exchange [channel,id,sales,returns,profit] #1
-          WholeStageCodegen (80)
+          WholeStageCodegen (78)
             HashAggregate [channel,id,sales,returns,profit]
               InputAdapter
                 Union
-                  WholeStageCodegen (53)
-                    HashAggregate [channel,id,sales,returns,profit]
+                  WholeStageCodegen (25)
+                    HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                       InputAdapter
-                        Exchange [channel,id,sales,returns,profit] #2
-                          WholeStageCodegen (52)
-                            HashAggregate [channel,id,sales,returns,profit]
+                        Exchange [channel,id] #2
+                          WholeStageCodegen (24)
+                            HashAggregate [channel,id,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                               InputAdapter
                                 Union
-                                  WholeStageCodegen (25)
-                                    HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
-                                      InputAdapter
-                                        Exchange [channel,id] #3
-                                          WholeStageCodegen (24)
-                                            HashAggregate [channel,id,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
-                                              InputAdapter
-                                                Union
-                                                  WholeStageCodegen (8)
-                                                    Project [s_store_sk,sales,returns,profit,profit_loss]
-                                                      BroadcastHashJoin [s_store_sk,s_store_sk]
-                                                        HashAggregate [s_store_sk,sum,sum] [sum(UnscaledValue(ss_ext_sales_price)),sum(UnscaledValue(ss_net_profit)),sales,profit,sum,sum]
-                                                          InputAdapter
-                                                            Exchange [s_store_sk] #4
-                                                              WholeStageCodegen (3)
-                                                                HashAggregate [s_store_sk,ss_ext_sales_price,ss_net_profit] [sum,sum,sum,sum]
-                                                                  Project [ss_ext_sales_price,ss_net_profit,s_store_sk]
-                                                                    BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                                      Project [ss_store_sk,ss_ext_sales_price,ss_net_profit]
-                                                                        BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                          Filter [ss_sold_date_sk,ss_store_sk]
-                                                                            ColumnarToRow
-                                                                              InputAdapter
-                                                                                Scan parquet default.store_sales [ss_sold_date_sk,ss_store_sk,ss_ext_sales_price,ss_net_profit]
-                                                                          InputAdapter
-                                                                            BroadcastExchange #5
-                                                                              WholeStageCodegen (1)
-                                                                                Project [d_date_sk]
-                                                                                  Filter [d_date,d_date_sk]
-                                                                                    ColumnarToRow
-                                                                                      InputAdapter
-                                                                                        Scan parquet default.date_dim [d_date_sk,d_date]
-                                                                      InputAdapter
-                                                                        BroadcastExchange #6
-                                                                          WholeStageCodegen (2)
-                                                                            Filter [s_store_sk]
-                                                                              ColumnarToRow
-                                                                                InputAdapter
-                                                                                  Scan parquet default.store [s_store_sk]
-                                                        InputAdapter
-                                                          BroadcastExchange #7
-                                                            WholeStageCodegen (7)
-                                                              HashAggregate [s_store_sk,sum,sum] [sum(UnscaledValue(sr_return_amt)),sum(UnscaledValue(sr_net_loss)),returns,profit_loss,sum,sum]
-                                                                InputAdapter
-                                                                  Exchange [s_store_sk] #8
-                                                                    WholeStageCodegen (6)
-                                                                      HashAggregate [s_store_sk,sr_return_amt,sr_net_loss] [sum,sum,sum,sum]
-                                                                        Project [sr_return_amt,sr_net_loss,s_store_sk]
-                                                                          BroadcastHashJoin [sr_returned_date_sk,d_date_sk]
-                                                                            Project [sr_returned_date_sk,sr_return_amt,sr_net_loss,s_store_sk]
-                                                                              BroadcastHashJoin [sr_store_sk,s_store_sk]
-                                                                                Filter [sr_returned_date_sk,sr_store_sk]
-                                                                                  ColumnarToRow
-                                                                                    InputAdapter
-                                                                                      Scan parquet default.store_returns [sr_returned_date_sk,sr_store_sk,sr_return_amt,sr_net_loss]
-                                                                                InputAdapter
-                                                                                  ReusedExchange [s_store_sk] #6
-                                                                            InputAdapter
-                                                                              ReusedExchange [d_date_sk] #5
-                                                  WholeStageCodegen (15)
-                                                    Project [cs_call_center_sk,sales,returns,profit,profit_loss]
-                                                      InputAdapter
-                                                        BroadcastNestedLoopJoin
-                                                          WholeStageCodegen (11)
-                                                            HashAggregate [cs_call_center_sk,sum,sum] [sum(UnscaledValue(cs_ext_sales_price)),sum(UnscaledValue(cs_net_profit)),sales,profit,sum,sum]
+                                  WholeStageCodegen (8)
+                                    Project [s_store_sk,sales,returns,profit,profit_loss]
+                                      BroadcastHashJoin [s_store_sk,s_store_sk]
+                                        HashAggregate [s_store_sk,sum,sum] [sum(UnscaledValue(ss_ext_sales_price)),sum(UnscaledValue(ss_net_profit)),sales,profit,sum,sum]
+                                          InputAdapter
+                                            Exchange [s_store_sk] #3
+                                              WholeStageCodegen (3)
+                                                HashAggregate [s_store_sk,ss_ext_sales_price,ss_net_profit] [sum,sum,sum,sum]
+                                                  Project [ss_ext_sales_price,ss_net_profit,s_store_sk]
+                                                    BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                                      Project [ss_store_sk,ss_ext_sales_price,ss_net_profit]
+                                                        BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                          Filter [ss_sold_date_sk,ss_store_sk]
+                                                            ColumnarToRow
                                                               InputAdapter
-                                                                Exchange [cs_call_center_sk] #9
-                                                                  WholeStageCodegen (10)
-                                                                    HashAggregate [cs_call_center_sk,cs_ext_sales_price,cs_net_profit] [sum,sum,sum,sum]
-                                                                      Project [cs_call_center_sk,cs_ext_sales_price,cs_net_profit]
-                                                                        BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                          Filter [cs_sold_date_sk]
-                                                                            ColumnarToRow
-                                                                              InputAdapter
-                                                                                Scan parquet default.catalog_sales [cs_sold_date_sk,cs_call_center_sk,cs_ext_sales_price,cs_net_profit]
-                                                                          InputAdapter
-                                                                            ReusedExchange [d_date_sk] #5
-                                                          BroadcastExchange #10
-                                                            WholeStageCodegen (14)
-                                                              HashAggregate [sum,sum] [sum(UnscaledValue(cr_return_amount)),sum(UnscaledValue(cr_net_loss)),returns,profit_loss,sum,sum]
-                                                                InputAdapter
-                                                                  Exchange #11
-                                                                    WholeStageCodegen (13)
-                                                                      HashAggregate [cr_return_amount,cr_net_loss] [sum,sum,sum,sum]
-                                                                        Project [cr_return_amount,cr_net_loss]
-                                                                          BroadcastHashJoin [cr_returned_date_sk,d_date_sk]
-                                                                            Filter [cr_returned_date_sk]
-                                                                              ColumnarToRow
-                                                                                InputAdapter
-                                                                                  Scan parquet default.catalog_returns [cr_returned_date_sk,cr_return_amount,cr_net_loss]
-                                                                            InputAdapter
-                                                                              ReusedExchange [d_date_sk] #5
-                                                  WholeStageCodegen (23)
-                                                    Project [wp_web_page_sk,sales,returns,profit,profit_loss]
-                                                      BroadcastHashJoin [wp_web_page_sk,wp_web_page_sk]
-                                                        HashAggregate [wp_web_page_sk,sum,sum] [sum(UnscaledValue(ws_ext_sales_price)),sum(UnscaledValue(ws_net_profit)),sales,profit,sum,sum]
+                                                                Scan parquet default.store_sales [ss_sold_date_sk,ss_store_sk,ss_ext_sales_price,ss_net_profit]
                                                           InputAdapter
-                                                            Exchange [wp_web_page_sk] #12
-                                                              WholeStageCodegen (18)
-                                                                HashAggregate [wp_web_page_sk,ws_ext_sales_price,ws_net_profit] [sum,sum,sum,sum]
-                                                                  Project [ws_ext_sales_price,ws_net_profit,wp_web_page_sk]
-                                                                    BroadcastHashJoin [ws_web_page_sk,wp_web_page_sk]
-                                                                      Project [ws_web_page_sk,ws_ext_sales_price,ws_net_profit]
-                                                                        BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                          Filter [ws_sold_date_sk,ws_web_page_sk]
-                                                                            ColumnarToRow
-                                                                              InputAdapter
-                                                                                Scan parquet default.web_sales [ws_sold_date_sk,ws_web_page_sk,ws_ext_sales_price,ws_net_profit]
-                                                                          InputAdapter
-                                                                            ReusedExchange [d_date_sk] #5
+                                                            BroadcastExchange #4
+                                                              WholeStageCodegen (1)
+                                                                Project [d_date_sk]
+                                                                  Filter [d_date,d_date_sk]
+                                                                    ColumnarToRow
                                                                       InputAdapter
-                                                                        BroadcastExchange #13
-                                                                          WholeStageCodegen (17)
-                                                                            Filter [wp_web_page_sk]
-                                                                              ColumnarToRow
-                                                                                InputAdapter
-                                                                                  Scan parquet default.web_page [wp_web_page_sk]
-                                                        InputAdapter
-                                                          BroadcastExchange #14
-                                                            WholeStageCodegen (22)
-                                                              HashAggregate [wp_web_page_sk,sum,sum] [sum(UnscaledValue(wr_return_amt)),sum(UnscaledValue(wr_net_loss)),returns,profit_loss,sum,sum]
+                                                                        Scan parquet default.date_dim [d_date_sk,d_date]
+                                                      InputAdapter
+                                                        BroadcastExchange #5
+                                                          WholeStageCodegen (2)
+                                                            Filter [s_store_sk]
+                                                              ColumnarToRow
                                                                 InputAdapter
-                                                                  Exchange [wp_web_page_sk] #15
-                                                                    WholeStageCodegen (21)
-                                                                      HashAggregate [wp_web_page_sk,wr_return_amt,wr_net_loss] [sum,sum,sum,sum]
-                                                                        Project [wr_return_amt,wr_net_loss,wp_web_page_sk]
-                                                                          BroadcastHashJoin [wr_returned_date_sk,d_date_sk]
-                                                                            Project [wr_returned_date_sk,wr_return_amt,wr_net_loss,wp_web_page_sk]
-                                                                              BroadcastHashJoin [wr_web_page_sk,wp_web_page_sk]
-                                                                                Filter [wr_returned_date_sk,wr_web_page_sk]
-                                                                                  ColumnarToRow
-                                                                                    InputAdapter
-                                                                                      Scan parquet default.web_returns [wr_returned_date_sk,wr_web_page_sk,wr_return_amt,wr_net_loss]
-                                                                                InputAdapter
-                                                                                  ReusedExchange [wp_web_page_sk] #13
-                                                                            InputAdapter
-                                                                              ReusedExchange [d_date_sk] #5
-                                  WholeStageCodegen (51)
-                                    HashAggregate [channel,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),id,sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
-                                      InputAdapter
-                                        Exchange [channel] #16
-                                          WholeStageCodegen (50)
-                                            HashAggregate [channel,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
-                                              HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                                                                  Scan parquet default.store [s_store_sk]
+                                        InputAdapter
+                                          BroadcastExchange #6
+                                            WholeStageCodegen (7)
+                                              HashAggregate [s_store_sk,sum,sum] [sum(UnscaledValue(sr_return_amt)),sum(UnscaledValue(sr_net_loss)),returns,profit_loss,sum,sum]
                                                 InputAdapter
-                                                  ReusedExchange [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] #3
-                  WholeStageCodegen (79)
+                                                  Exchange [s_store_sk] #7
+                                                    WholeStageCodegen (6)
+                                                      HashAggregate [s_store_sk,sr_return_amt,sr_net_loss] [sum,sum,sum,sum]
+                                                        Project [sr_return_amt,sr_net_loss,s_store_sk]
+                                                          BroadcastHashJoin [sr_returned_date_sk,d_date_sk]
+                                                            Project [sr_returned_date_sk,sr_return_amt,sr_net_loss,s_store_sk]
+                                                              BroadcastHashJoin [sr_store_sk,s_store_sk]
+                                                                Filter [sr_returned_date_sk,sr_store_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet default.store_returns [sr_returned_date_sk,sr_store_sk,sr_return_amt,sr_net_loss]
+                                                                InputAdapter
+                                                                  ReusedExchange [s_store_sk] #5
+                                                            InputAdapter
+                                                              ReusedExchange [d_date_sk] #4
+                                  WholeStageCodegen (15)
+                                    Project [cs_call_center_sk,sales,returns,profit,profit_loss]
+                                      InputAdapter
+                                        BroadcastNestedLoopJoin
+                                          WholeStageCodegen (11)
+                                            HashAggregate [cs_call_center_sk,sum,sum] [sum(UnscaledValue(cs_ext_sales_price)),sum(UnscaledValue(cs_net_profit)),sales,profit,sum,sum]
+                                              InputAdapter
+                                                Exchange [cs_call_center_sk] #8
+                                                  WholeStageCodegen (10)
+                                                    HashAggregate [cs_call_center_sk,cs_ext_sales_price,cs_net_profit] [sum,sum,sum,sum]
+                                                      Project [cs_call_center_sk,cs_ext_sales_price,cs_net_profit]
+                                                        BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                          Filter [cs_sold_date_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet default.catalog_sales [cs_sold_date_sk,cs_call_center_sk,cs_ext_sales_price,cs_net_profit]
+                                                          InputAdapter
+                                                            ReusedExchange [d_date_sk] #4
+                                          BroadcastExchange #9
+                                            WholeStageCodegen (14)
+                                              HashAggregate [sum,sum] [sum(UnscaledValue(cr_return_amount)),sum(UnscaledValue(cr_net_loss)),returns,profit_loss,sum,sum]
+                                                InputAdapter
+                                                  Exchange #10
+                                                    WholeStageCodegen (13)
+                                                      HashAggregate [cr_return_amount,cr_net_loss] [sum,sum,sum,sum]
+                                                        Project [cr_return_amount,cr_net_loss]
+                                                          BroadcastHashJoin [cr_returned_date_sk,d_date_sk]
+                                                            Filter [cr_returned_date_sk]
+                                                              ColumnarToRow
+                                                                InputAdapter
+                                                                  Scan parquet default.catalog_returns [cr_returned_date_sk,cr_return_amount,cr_net_loss]
+                                                            InputAdapter
+                                                              ReusedExchange [d_date_sk] #4
+                                  WholeStageCodegen (23)
+                                    Project [wp_web_page_sk,sales,returns,profit,profit_loss]
+                                      BroadcastHashJoin [wp_web_page_sk,wp_web_page_sk]
+                                        HashAggregate [wp_web_page_sk,sum,sum] [sum(UnscaledValue(ws_ext_sales_price)),sum(UnscaledValue(ws_net_profit)),sales,profit,sum,sum]
+                                          InputAdapter
+                                            Exchange [wp_web_page_sk] #11
+                                              WholeStageCodegen (18)
+                                                HashAggregate [wp_web_page_sk,ws_ext_sales_price,ws_net_profit] [sum,sum,sum,sum]
+                                                  Project [ws_ext_sales_price,ws_net_profit,wp_web_page_sk]
+                                                    BroadcastHashJoin [ws_web_page_sk,wp_web_page_sk]
+                                                      Project [ws_web_page_sk,ws_ext_sales_price,ws_net_profit]
+                                                        BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                          Filter [ws_sold_date_sk,ws_web_page_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet default.web_sales [ws_sold_date_sk,ws_web_page_sk,ws_ext_sales_price,ws_net_profit]
+                                                          InputAdapter
+                                                            ReusedExchange [d_date_sk] #4
+                                                      InputAdapter
+                                                        BroadcastExchange #12
+                                                          WholeStageCodegen (17)
+                                                            Filter [wp_web_page_sk]
+                                                              ColumnarToRow
+                                                                InputAdapter
+                                                                  Scan parquet default.web_page [wp_web_page_sk]
+                                        InputAdapter
+                                          BroadcastExchange #13
+                                            WholeStageCodegen (22)
+                                              HashAggregate [wp_web_page_sk,sum,sum] [sum(UnscaledValue(wr_return_amt)),sum(UnscaledValue(wr_net_loss)),returns,profit_loss,sum,sum]
+                                                InputAdapter
+                                                  Exchange [wp_web_page_sk] #14
+                                                    WholeStageCodegen (21)
+                                                      HashAggregate [wp_web_page_sk,wr_return_amt,wr_net_loss] [sum,sum,sum,sum]
+                                                        Project [wr_return_amt,wr_net_loss,wp_web_page_sk]
+                                                          BroadcastHashJoin [wr_returned_date_sk,d_date_sk]
+                                                            Project [wr_returned_date_sk,wr_return_amt,wr_net_loss,wp_web_page_sk]
+                                                              BroadcastHashJoin [wr_web_page_sk,wp_web_page_sk]
+                                                                Filter [wr_returned_date_sk,wr_web_page_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet default.web_returns [wr_returned_date_sk,wr_web_page_sk,wr_return_amt,wr_net_loss]
+                                                                InputAdapter
+                                                                  ReusedExchange [wp_web_page_sk] #12
+                                                            InputAdapter
+                                                              ReusedExchange [d_date_sk] #4
+                  WholeStageCodegen (51)
+                    HashAggregate [channel,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),id,sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                      InputAdapter
+                        Exchange [channel] #15
+                          WholeStageCodegen (50)
+                            HashAggregate [channel,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                              HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                                InputAdapter
+                                  ReusedExchange [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] #2
+                  WholeStageCodegen (77)
                     HashAggregate [sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),channel,id,sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                       InputAdapter
-                        Exchange #17
-                          WholeStageCodegen (78)
+                        Exchange #16
+                          WholeStageCodegen (76)
                             HashAggregate [sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                               HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                                 InputAdapter
-                                  ReusedExchange [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] #3
+                                  ReusedExchange [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] #2

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a/explain.txt
@@ -1,112 +1,108 @@
 == Physical Plan ==
-TakeOrderedAndProject (108)
-+- * HashAggregate (107)
-   +- Exchange (106)
-      +- * HashAggregate (105)
-         +- Union (104)
-            :- * HashAggregate (98)
-            :  +- Exchange (97)
-            :     +- * HashAggregate (96)
-            :        +- Union (95)
-            :           :- * HashAggregate (89)
-            :           :  +- Exchange (88)
-            :           :     +- * HashAggregate (87)
-            :           :        +- Union (86)
-            :           :           :- * Project (34)
-            :           :           :  +- * BroadcastHashJoin LeftOuter BuildRight (33)
-            :           :           :     :- * HashAggregate (19)
-            :           :           :     :  +- Exchange (18)
-            :           :           :     :     +- * HashAggregate (17)
-            :           :           :     :        +- * Project (16)
-            :           :           :     :           +- * BroadcastHashJoin Inner BuildRight (15)
-            :           :           :     :              :- * Project (10)
-            :           :           :     :              :  +- * BroadcastHashJoin Inner BuildRight (9)
-            :           :           :     :              :     :- * Filter (3)
-            :           :           :     :              :     :  +- * ColumnarToRow (2)
-            :           :           :     :              :     :     +- Scan parquet default.store_sales (1)
-            :           :           :     :              :     +- BroadcastExchange (8)
-            :           :           :     :              :        +- * Project (7)
-            :           :           :     :              :           +- * Filter (6)
-            :           :           :     :              :              +- * ColumnarToRow (5)
-            :           :           :     :              :                 +- Scan parquet default.date_dim (4)
-            :           :           :     :              +- BroadcastExchange (14)
-            :           :           :     :                 +- * Filter (13)
-            :           :           :     :                    +- * ColumnarToRow (12)
-            :           :           :     :                       +- Scan parquet default.store (11)
-            :           :           :     +- BroadcastExchange (32)
-            :           :           :        +- * HashAggregate (31)
-            :           :           :           +- Exchange (30)
-            :           :           :              +- * HashAggregate (29)
-            :           :           :                 +- * Project (28)
-            :           :           :                    +- * BroadcastHashJoin Inner BuildRight (27)
-            :           :           :                       :- * Project (25)
-            :           :           :                       :  +- * BroadcastHashJoin Inner BuildRight (24)
-            :           :           :                       :     :- * Filter (22)
-            :           :           :                       :     :  +- * ColumnarToRow (21)
-            :           :           :                       :     :     +- Scan parquet default.store_returns (20)
-            :           :           :                       :     +- ReusedExchange (23)
-            :           :           :                       +- ReusedExchange (26)
-            :           :           :- * Project (55)
-            :           :           :  +- BroadcastNestedLoopJoin Inner BuildLeft (54)
-            :           :           :     :- BroadcastExchange (44)
-            :           :           :     :  +- * HashAggregate (43)
-            :           :           :     :     +- Exchange (42)
-            :           :           :     :        +- * HashAggregate (41)
-            :           :           :     :           +- * Project (40)
-            :           :           :     :              +- * BroadcastHashJoin Inner BuildRight (39)
-            :           :           :     :                 :- * Filter (37)
-            :           :           :     :                 :  +- * ColumnarToRow (36)
-            :           :           :     :                 :     +- Scan parquet default.catalog_sales (35)
-            :           :           :     :                 +- ReusedExchange (38)
-            :           :           :     +- * HashAggregate (53)
-            :           :           :        +- Exchange (52)
-            :           :           :           +- * HashAggregate (51)
-            :           :           :              +- * Project (50)
-            :           :           :                 +- * BroadcastHashJoin Inner BuildRight (49)
-            :           :           :                    :- * Filter (47)
-            :           :           :                    :  +- * ColumnarToRow (46)
-            :           :           :                    :     +- Scan parquet default.catalog_returns (45)
-            :           :           :                    +- ReusedExchange (48)
-            :           :           +- * Project (85)
-            :           :              +- * BroadcastHashJoin LeftOuter BuildRight (84)
-            :           :                 :- * HashAggregate (70)
-            :           :                 :  +- Exchange (69)
-            :           :                 :     +- * HashAggregate (68)
-            :           :                 :        +- * Project (67)
-            :           :                 :           +- * BroadcastHashJoin Inner BuildRight (66)
-            :           :                 :              :- * Project (61)
-            :           :                 :              :  +- * BroadcastHashJoin Inner BuildRight (60)
-            :           :                 :              :     :- * Filter (58)
-            :           :                 :              :     :  +- * ColumnarToRow (57)
-            :           :                 :              :     :     +- Scan parquet default.web_sales (56)
-            :           :                 :              :     +- ReusedExchange (59)
-            :           :                 :              +- BroadcastExchange (65)
-            :           :                 :                 +- * Filter (64)
-            :           :                 :                    +- * ColumnarToRow (63)
-            :           :                 :                       +- Scan parquet default.web_page (62)
-            :           :                 +- BroadcastExchange (83)
-            :           :                    +- * HashAggregate (82)
-            :           :                       +- Exchange (81)
-            :           :                          +- * HashAggregate (80)
-            :           :                             +- * Project (79)
-            :           :                                +- * BroadcastHashJoin Inner BuildRight (78)
-            :           :                                   :- * Project (76)
-            :           :                                   :  +- * BroadcastHashJoin Inner BuildRight (75)
-            :           :                                   :     :- * Filter (73)
-            :           :                                   :     :  +- * ColumnarToRow (72)
-            :           :                                   :     :     +- Scan parquet default.web_returns (71)
-            :           :                                   :     +- ReusedExchange (74)
-            :           :                                   +- ReusedExchange (77)
-            :           +- * HashAggregate (94)
-            :              +- Exchange (93)
-            :                 +- * HashAggregate (92)
-            :                    +- * HashAggregate (91)
-            :                       +- ReusedExchange (90)
-            +- * HashAggregate (103)
-               +- Exchange (102)
-                  +- * HashAggregate (101)
-                     +- * HashAggregate (100)
-                        +- ReusedExchange (99)
+TakeOrderedAndProject (104)
++- * HashAggregate (103)
+   +- Exchange (102)
+      +- * HashAggregate (101)
+         +- Union (100)
+            :- * HashAggregate (89)
+            :  +- Exchange (88)
+            :     +- * HashAggregate (87)
+            :        +- Union (86)
+            :           :- * Project (34)
+            :           :  +- * BroadcastHashJoin LeftOuter BuildRight (33)
+            :           :     :- * HashAggregate (19)
+            :           :     :  +- Exchange (18)
+            :           :     :     +- * HashAggregate (17)
+            :           :     :        +- * Project (16)
+            :           :     :           +- * BroadcastHashJoin Inner BuildRight (15)
+            :           :     :              :- * Project (10)
+            :           :     :              :  +- * BroadcastHashJoin Inner BuildRight (9)
+            :           :     :              :     :- * Filter (3)
+            :           :     :              :     :  +- * ColumnarToRow (2)
+            :           :     :              :     :     +- Scan parquet default.store_sales (1)
+            :           :     :              :     +- BroadcastExchange (8)
+            :           :     :              :        +- * Project (7)
+            :           :     :              :           +- * Filter (6)
+            :           :     :              :              +- * ColumnarToRow (5)
+            :           :     :              :                 +- Scan parquet default.date_dim (4)
+            :           :     :              +- BroadcastExchange (14)
+            :           :     :                 +- * Filter (13)
+            :           :     :                    +- * ColumnarToRow (12)
+            :           :     :                       +- Scan parquet default.store (11)
+            :           :     +- BroadcastExchange (32)
+            :           :        +- * HashAggregate (31)
+            :           :           +- Exchange (30)
+            :           :              +- * HashAggregate (29)
+            :           :                 +- * Project (28)
+            :           :                    +- * BroadcastHashJoin Inner BuildRight (27)
+            :           :                       :- * Project (25)
+            :           :                       :  +- * BroadcastHashJoin Inner BuildRight (24)
+            :           :                       :     :- * Filter (22)
+            :           :                       :     :  +- * ColumnarToRow (21)
+            :           :                       :     :     +- Scan parquet default.store_returns (20)
+            :           :                       :     +- ReusedExchange (23)
+            :           :                       +- ReusedExchange (26)
+            :           :- * Project (55)
+            :           :  +- BroadcastNestedLoopJoin Inner BuildLeft (54)
+            :           :     :- BroadcastExchange (44)
+            :           :     :  +- * HashAggregate (43)
+            :           :     :     +- Exchange (42)
+            :           :     :        +- * HashAggregate (41)
+            :           :     :           +- * Project (40)
+            :           :     :              +- * BroadcastHashJoin Inner BuildRight (39)
+            :           :     :                 :- * Filter (37)
+            :           :     :                 :  +- * ColumnarToRow (36)
+            :           :     :                 :     +- Scan parquet default.catalog_sales (35)
+            :           :     :                 +- ReusedExchange (38)
+            :           :     +- * HashAggregate (53)
+            :           :        +- Exchange (52)
+            :           :           +- * HashAggregate (51)
+            :           :              +- * Project (50)
+            :           :                 +- * BroadcastHashJoin Inner BuildRight (49)
+            :           :                    :- * Filter (47)
+            :           :                    :  +- * ColumnarToRow (46)
+            :           :                    :     +- Scan parquet default.catalog_returns (45)
+            :           :                    +- ReusedExchange (48)
+            :           +- * Project (85)
+            :              +- * BroadcastHashJoin LeftOuter BuildRight (84)
+            :                 :- * HashAggregate (70)
+            :                 :  +- Exchange (69)
+            :                 :     +- * HashAggregate (68)
+            :                 :        +- * Project (67)
+            :                 :           +- * BroadcastHashJoin Inner BuildRight (66)
+            :                 :              :- * Project (61)
+            :                 :              :  +- * BroadcastHashJoin Inner BuildRight (60)
+            :                 :              :     :- * Filter (58)
+            :                 :              :     :  +- * ColumnarToRow (57)
+            :                 :              :     :     +- Scan parquet default.web_sales (56)
+            :                 :              :     +- ReusedExchange (59)
+            :                 :              +- BroadcastExchange (65)
+            :                 :                 +- * Filter (64)
+            :                 :                    +- * ColumnarToRow (63)
+            :                 :                       +- Scan parquet default.web_page (62)
+            :                 +- BroadcastExchange (83)
+            :                    +- * HashAggregate (82)
+            :                       +- Exchange (81)
+            :                          +- * HashAggregate (80)
+            :                             +- * Project (79)
+            :                                +- * BroadcastHashJoin Inner BuildRight (78)
+            :                                   :- * Project (76)
+            :                                   :  +- * BroadcastHashJoin Inner BuildRight (75)
+            :                                   :     :- * Filter (73)
+            :                                   :     :  +- * ColumnarToRow (72)
+            :                                   :     :     +- Scan parquet default.web_returns (71)
+            :                                   :     +- ReusedExchange (74)
+            :                                   +- ReusedExchange (77)
+            :- * HashAggregate (94)
+            :  +- Exchange (93)
+            :     +- * HashAggregate (92)
+            :        +- * HashAggregate (91)
+            :           +- ReusedExchange (90)
+            +- * HashAggregate (99)
+               +- Exchange (98)
+                  +- * HashAggregate (97)
+                     +- * HashAggregate (96)
+                        +- ReusedExchange (95)
 
 
 (1) Scan parquet default.store_sales
@@ -190,7 +186,7 @@ Results [3]: [s_store_sk#8, sum#12, sum#13]
 
 (18) Exchange
 Input [3]: [s_store_sk#8, sum#12, sum#13]
-Arguments: hashpartitioning(s_store_sk#8, 5), true, [id=#14]
+Arguments: hashpartitioning(s_store_sk#8, 5), ENSURE_REQUIREMENTS, [id=#14]
 
 (19) HashAggregate [codegen id : 8]
 Input [3]: [s_store_sk#8, sum#12, sum#13]
@@ -246,7 +242,7 @@ Results [3]: [s_store_sk#23, sum#26, sum#27]
 
 (30) Exchange
 Input [3]: [s_store_sk#23, sum#26, sum#27]
-Arguments: hashpartitioning(s_store_sk#23, 5), true, [id=#28]
+Arguments: hashpartitioning(s_store_sk#23, 5), ENSURE_REQUIREMENTS, [id=#28]
 
 (31) HashAggregate [codegen id : 7]
 Input [3]: [s_store_sk#23, sum#26, sum#27]
@@ -303,7 +299,7 @@ Results [3]: [cs_call_center_sk#39, sum#44, sum#45]
 
 (42) Exchange
 Input [3]: [cs_call_center_sk#39, sum#44, sum#45]
-Arguments: hashpartitioning(cs_call_center_sk#39, 5), true, [id=#46]
+Arguments: hashpartitioning(cs_call_center_sk#39, 5), ENSURE_REQUIREMENTS, [id=#46]
 
 (43) HashAggregate [codegen id : 11]
 Input [3]: [cs_call_center_sk#39, sum#44, sum#45]
@@ -351,7 +347,7 @@ Results [2]: [sum#57, sum#58]
 
 (52) Exchange
 Input [2]: [sum#57, sum#58]
-Arguments: SinglePartition, true, [id=#59]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#59]
 
 (53) HashAggregate [codegen id : 14]
 Input [2]: [sum#57, sum#58]
@@ -429,7 +425,7 @@ Results [3]: [wp_web_page_sk#71, sum#75, sum#76]
 
 (69) Exchange
 Input [3]: [wp_web_page_sk#71, sum#75, sum#76]
-Arguments: hashpartitioning(wp_web_page_sk#71, 5), true, [id=#77]
+Arguments: hashpartitioning(wp_web_page_sk#71, 5), ENSURE_REQUIREMENTS, [id=#77]
 
 (70) HashAggregate [codegen id : 23]
 Input [3]: [wp_web_page_sk#71, sum#75, sum#76]
@@ -485,7 +481,7 @@ Results [3]: [wp_web_page_sk#86, sum#89, sum#90]
 
 (81) Exchange
 Input [3]: [wp_web_page_sk#86, sum#89, sum#90]
-Arguments: hashpartitioning(wp_web_page_sk#86, 5), true, [id=#91]
+Arguments: hashpartitioning(wp_web_page_sk#86, 5), ENSURE_REQUIREMENTS, [id=#91]
 
 (82) HashAggregate [codegen id : 22]
 Input [3]: [wp_web_page_sk#86, sum#89, sum#90]
@@ -518,7 +514,7 @@ Results [8]: [channel#34, id#35, sum#107, isEmpty#108, sum#109, isEmpty#110, sum
 
 (88) Exchange
 Input [8]: [channel#34, id#35, sum#107, isEmpty#108, sum#109, isEmpty#110, sum#111, isEmpty#112]
-Arguments: hashpartitioning(channel#34, id#35, 5), true, [id=#113]
+Arguments: hashpartitioning(channel#34, id#35, 5), ENSURE_REQUIREMENTS, [id=#113]
 
 (89) HashAggregate [codegen id : 25]
 Input [8]: [channel#34, id#35, sum#107, isEmpty#108, sum#109, isEmpty#110, sum#111, isEmpty#112]
@@ -546,7 +542,7 @@ Results [7]: [channel#34, sum#139, isEmpty#140, sum#141, isEmpty#142, sum#143, i
 
 (93) Exchange
 Input [7]: [channel#34, sum#139, isEmpty#140, sum#141, isEmpty#142, sum#143, isEmpty#144]
-Arguments: hashpartitioning(channel#34, 5), true, [id=#145]
+Arguments: hashpartitioning(channel#34, 5), ENSURE_REQUIREMENTS, [id=#145]
 
 (94) HashAggregate [codegen id : 51]
 Input [7]: [channel#34, sum#139, isEmpty#140, sum#141, isEmpty#142, sum#143, isEmpty#144]
@@ -555,75 +551,55 @@ Functions [3]: [sum(sales#130), sum(returns#131), sum(profit#132)]
 Aggregate Attributes [3]: [sum(sales#130)#146, sum(returns#131)#147, sum(profit#132)#148]
 Results [5]: [channel#34, null AS id#149, sum(sales#130)#146 AS sales#150, sum(returns#131)#147 AS returns#151, sum(profit#132)#148 AS profit#152]
 
-(95) Union
+(95) ReusedExchange [Reuses operator id: 88]
+Output [8]: [channel#34, id#35, sum#153, isEmpty#154, sum#155, isEmpty#156, sum#157, isEmpty#158]
 
-(96) HashAggregate [codegen id : 52]
-Input [5]: [channel#34, id#35, sales#117, returns#118, profit#119]
-Keys [5]: [channel#34, id#35, sales#117, returns#118, profit#119]
-Functions: []
-Aggregate Attributes: []
-Results [5]: [channel#34, id#35, sales#117, returns#118, profit#119]
-
-(97) Exchange
-Input [5]: [channel#34, id#35, sales#117, returns#118, profit#119]
-Arguments: hashpartitioning(channel#34, id#35, sales#117, returns#118, profit#119, 5), true, [id=#153]
-
-(98) HashAggregate [codegen id : 53]
-Input [5]: [channel#34, id#35, sales#117, returns#118, profit#119]
-Keys [5]: [channel#34, id#35, sales#117, returns#118, profit#119]
-Functions: []
-Aggregate Attributes: []
-Results [5]: [channel#34, id#35, sales#117, returns#118, profit#119]
-
-(99) ReusedExchange [Reuses operator id: 88]
-Output [8]: [channel#34, id#35, sum#154, isEmpty#155, sum#156, isEmpty#157, sum#158, isEmpty#159]
-
-(100) HashAggregate [codegen id : 78]
-Input [8]: [channel#34, id#35, sum#154, isEmpty#155, sum#156, isEmpty#157, sum#158, isEmpty#159]
+(96) HashAggregate [codegen id : 76]
+Input [8]: [channel#34, id#35, sum#153, isEmpty#154, sum#155, isEmpty#156, sum#157, isEmpty#158]
 Keys [2]: [channel#34, id#35]
-Functions [3]: [sum(sales#17), sum(returns#36), sum(profit#160)]
-Aggregate Attributes [3]: [sum(sales#17)#161, sum(returns#36)#162, sum(profit#160)#163]
-Results [3]: [sum(sales#17)#161 AS sales#130, sum(returns#36)#162 AS returns#131, sum(profit#160)#163 AS profit#132]
+Functions [3]: [sum(sales#17), sum(returns#36), sum(profit#159)]
+Aggregate Attributes [3]: [sum(sales#17)#160, sum(returns#36)#161, sum(profit#159)#162]
+Results [3]: [sum(sales#17)#160 AS sales#130, sum(returns#36)#161 AS returns#131, sum(profit#159)#162 AS profit#132]
 
-(101) HashAggregate [codegen id : 78]
+(97) HashAggregate [codegen id : 76]
 Input [3]: [sales#130, returns#131, profit#132]
 Keys: []
 Functions [3]: [partial_sum(sales#130), partial_sum(returns#131), partial_sum(profit#132)]
-Aggregate Attributes [6]: [sum#164, isEmpty#165, sum#166, isEmpty#167, sum#168, isEmpty#169]
-Results [6]: [sum#170, isEmpty#171, sum#172, isEmpty#173, sum#174, isEmpty#175]
+Aggregate Attributes [6]: [sum#163, isEmpty#164, sum#165, isEmpty#166, sum#167, isEmpty#168]
+Results [6]: [sum#169, isEmpty#170, sum#171, isEmpty#172, sum#173, isEmpty#174]
 
-(102) Exchange
-Input [6]: [sum#170, isEmpty#171, sum#172, isEmpty#173, sum#174, isEmpty#175]
-Arguments: SinglePartition, true, [id=#176]
+(98) Exchange
+Input [6]: [sum#169, isEmpty#170, sum#171, isEmpty#172, sum#173, isEmpty#174]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#175]
 
-(103) HashAggregate [codegen id : 79]
-Input [6]: [sum#170, isEmpty#171, sum#172, isEmpty#173, sum#174, isEmpty#175]
+(99) HashAggregate [codegen id : 77]
+Input [6]: [sum#169, isEmpty#170, sum#171, isEmpty#172, sum#173, isEmpty#174]
 Keys: []
 Functions [3]: [sum(sales#130), sum(returns#131), sum(profit#132)]
-Aggregate Attributes [3]: [sum(sales#130)#177, sum(returns#131)#178, sum(profit#132)#179]
-Results [5]: [null AS channel#180, null AS id#181, sum(sales#130)#177 AS sales#182, sum(returns#131)#178 AS returns#183, sum(profit#132)#179 AS profit#184]
+Aggregate Attributes [3]: [sum(sales#130)#176, sum(returns#131)#177, sum(profit#132)#178]
+Results [5]: [null AS channel#179, null AS id#180, sum(sales#130)#176 AS sales#181, sum(returns#131)#177 AS returns#182, sum(profit#132)#178 AS profit#183]
 
-(104) Union
+(100) Union
 
-(105) HashAggregate [codegen id : 80]
+(101) HashAggregate [codegen id : 78]
 Input [5]: [channel#34, id#35, sales#117, returns#118, profit#119]
 Keys [5]: [channel#34, id#35, sales#117, returns#118, profit#119]
 Functions: []
 Aggregate Attributes: []
 Results [5]: [channel#34, id#35, sales#117, returns#118, profit#119]
 
-(106) Exchange
+(102) Exchange
 Input [5]: [channel#34, id#35, sales#117, returns#118, profit#119]
-Arguments: hashpartitioning(channel#34, id#35, sales#117, returns#118, profit#119, 5), true, [id=#185]
+Arguments: hashpartitioning(channel#34, id#35, sales#117, returns#118, profit#119, 5), ENSURE_REQUIREMENTS, [id=#184]
 
-(107) HashAggregate [codegen id : 81]
+(103) HashAggregate [codegen id : 79]
 Input [5]: [channel#34, id#35, sales#117, returns#118, profit#119]
 Keys [5]: [channel#34, id#35, sales#117, returns#118, profit#119]
 Functions: []
 Aggregate Attributes: []
 Results [5]: [channel#34, id#35, sales#117, returns#118, profit#119]
 
-(108) TakeOrderedAndProject
+(104) TakeOrderedAndProject
 Input [5]: [channel#34, id#35, sales#117, returns#118, profit#119]
 Arguments: 100, [channel#34 ASC NULLS FIRST, id#35 ASC NULLS FIRST], [channel#34, id#35, sales#117, returns#118, profit#119]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a/simplified.txt
@@ -1,172 +1,164 @@
 TakeOrderedAndProject [channel,id,sales,returns,profit]
-  WholeStageCodegen (81)
+  WholeStageCodegen (79)
     HashAggregate [channel,id,sales,returns,profit]
       InputAdapter
         Exchange [channel,id,sales,returns,profit] #1
-          WholeStageCodegen (80)
+          WholeStageCodegen (78)
             HashAggregate [channel,id,sales,returns,profit]
               InputAdapter
                 Union
-                  WholeStageCodegen (53)
-                    HashAggregate [channel,id,sales,returns,profit]
+                  WholeStageCodegen (25)
+                    HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                       InputAdapter
-                        Exchange [channel,id,sales,returns,profit] #2
-                          WholeStageCodegen (52)
-                            HashAggregate [channel,id,sales,returns,profit]
+                        Exchange [channel,id] #2
+                          WholeStageCodegen (24)
+                            HashAggregate [channel,id,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                               InputAdapter
                                 Union
-                                  WholeStageCodegen (25)
-                                    HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
-                                      InputAdapter
-                                        Exchange [channel,id] #3
-                                          WholeStageCodegen (24)
-                                            HashAggregate [channel,id,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
-                                              InputAdapter
-                                                Union
-                                                  WholeStageCodegen (8)
-                                                    Project [s_store_sk,sales,returns,profit,profit_loss]
-                                                      BroadcastHashJoin [s_store_sk,s_store_sk]
-                                                        HashAggregate [s_store_sk,sum,sum] [sum(UnscaledValue(ss_ext_sales_price)),sum(UnscaledValue(ss_net_profit)),sales,profit,sum,sum]
-                                                          InputAdapter
-                                                            Exchange [s_store_sk] #4
-                                                              WholeStageCodegen (3)
-                                                                HashAggregate [s_store_sk,ss_ext_sales_price,ss_net_profit] [sum,sum,sum,sum]
-                                                                  Project [ss_ext_sales_price,ss_net_profit,s_store_sk]
-                                                                    BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                                      Project [ss_store_sk,ss_ext_sales_price,ss_net_profit]
-                                                                        BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                          Filter [ss_sold_date_sk,ss_store_sk]
-                                                                            ColumnarToRow
-                                                                              InputAdapter
-                                                                                Scan parquet default.store_sales [ss_sold_date_sk,ss_store_sk,ss_ext_sales_price,ss_net_profit]
-                                                                          InputAdapter
-                                                                            BroadcastExchange #5
-                                                                              WholeStageCodegen (1)
-                                                                                Project [d_date_sk]
-                                                                                  Filter [d_date,d_date_sk]
-                                                                                    ColumnarToRow
-                                                                                      InputAdapter
-                                                                                        Scan parquet default.date_dim [d_date_sk,d_date]
-                                                                      InputAdapter
-                                                                        BroadcastExchange #6
-                                                                          WholeStageCodegen (2)
-                                                                            Filter [s_store_sk]
-                                                                              ColumnarToRow
-                                                                                InputAdapter
-                                                                                  Scan parquet default.store [s_store_sk]
-                                                        InputAdapter
-                                                          BroadcastExchange #7
-                                                            WholeStageCodegen (7)
-                                                              HashAggregate [s_store_sk,sum,sum] [sum(UnscaledValue(sr_return_amt)),sum(UnscaledValue(sr_net_loss)),returns,profit_loss,sum,sum]
-                                                                InputAdapter
-                                                                  Exchange [s_store_sk] #8
-                                                                    WholeStageCodegen (6)
-                                                                      HashAggregate [s_store_sk,sr_return_amt,sr_net_loss] [sum,sum,sum,sum]
-                                                                        Project [sr_return_amt,sr_net_loss,s_store_sk]
-                                                                          BroadcastHashJoin [sr_store_sk,s_store_sk]
-                                                                            Project [sr_store_sk,sr_return_amt,sr_net_loss]
-                                                                              BroadcastHashJoin [sr_returned_date_sk,d_date_sk]
-                                                                                Filter [sr_returned_date_sk,sr_store_sk]
-                                                                                  ColumnarToRow
-                                                                                    InputAdapter
-                                                                                      Scan parquet default.store_returns [sr_returned_date_sk,sr_store_sk,sr_return_amt,sr_net_loss]
-                                                                                InputAdapter
-                                                                                  ReusedExchange [d_date_sk] #5
-                                                                            InputAdapter
-                                                                              ReusedExchange [s_store_sk] #6
-                                                  WholeStageCodegen (15)
-                                                    Project [cs_call_center_sk,sales,returns,profit,profit_loss]
-                                                      InputAdapter
-                                                        BroadcastNestedLoopJoin
-                                                          BroadcastExchange #9
-                                                            WholeStageCodegen (11)
-                                                              HashAggregate [cs_call_center_sk,sum,sum] [sum(UnscaledValue(cs_ext_sales_price)),sum(UnscaledValue(cs_net_profit)),sales,profit,sum,sum]
-                                                                InputAdapter
-                                                                  Exchange [cs_call_center_sk] #10
-                                                                    WholeStageCodegen (10)
-                                                                      HashAggregate [cs_call_center_sk,cs_ext_sales_price,cs_net_profit] [sum,sum,sum,sum]
-                                                                        Project [cs_call_center_sk,cs_ext_sales_price,cs_net_profit]
-                                                                          BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                            Filter [cs_sold_date_sk]
-                                                                              ColumnarToRow
-                                                                                InputAdapter
-                                                                                  Scan parquet default.catalog_sales [cs_sold_date_sk,cs_call_center_sk,cs_ext_sales_price,cs_net_profit]
-                                                                            InputAdapter
-                                                                              ReusedExchange [d_date_sk] #5
-                                                          WholeStageCodegen (14)
-                                                            HashAggregate [sum,sum] [sum(UnscaledValue(cr_return_amount)),sum(UnscaledValue(cr_net_loss)),returns,profit_loss,sum,sum]
+                                  WholeStageCodegen (8)
+                                    Project [s_store_sk,sales,returns,profit,profit_loss]
+                                      BroadcastHashJoin [s_store_sk,s_store_sk]
+                                        HashAggregate [s_store_sk,sum,sum] [sum(UnscaledValue(ss_ext_sales_price)),sum(UnscaledValue(ss_net_profit)),sales,profit,sum,sum]
+                                          InputAdapter
+                                            Exchange [s_store_sk] #3
+                                              WholeStageCodegen (3)
+                                                HashAggregate [s_store_sk,ss_ext_sales_price,ss_net_profit] [sum,sum,sum,sum]
+                                                  Project [ss_ext_sales_price,ss_net_profit,s_store_sk]
+                                                    BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                                      Project [ss_store_sk,ss_ext_sales_price,ss_net_profit]
+                                                        BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                          Filter [ss_sold_date_sk,ss_store_sk]
+                                                            ColumnarToRow
                                                               InputAdapter
-                                                                Exchange #11
-                                                                  WholeStageCodegen (13)
-                                                                    HashAggregate [cr_return_amount,cr_net_loss] [sum,sum,sum,sum]
-                                                                      Project [cr_return_amount,cr_net_loss]
-                                                                        BroadcastHashJoin [cr_returned_date_sk,d_date_sk]
-                                                                          Filter [cr_returned_date_sk]
-                                                                            ColumnarToRow
-                                                                              InputAdapter
-                                                                                Scan parquet default.catalog_returns [cr_returned_date_sk,cr_return_amount,cr_net_loss]
-                                                                          InputAdapter
-                                                                            ReusedExchange [d_date_sk] #5
-                                                  WholeStageCodegen (23)
-                                                    Project [wp_web_page_sk,sales,returns,profit,profit_loss]
-                                                      BroadcastHashJoin [wp_web_page_sk,wp_web_page_sk]
-                                                        HashAggregate [wp_web_page_sk,sum,sum] [sum(UnscaledValue(ws_ext_sales_price)),sum(UnscaledValue(ws_net_profit)),sales,profit,sum,sum]
+                                                                Scan parquet default.store_sales [ss_sold_date_sk,ss_store_sk,ss_ext_sales_price,ss_net_profit]
                                                           InputAdapter
-                                                            Exchange [wp_web_page_sk] #12
-                                                              WholeStageCodegen (18)
-                                                                HashAggregate [wp_web_page_sk,ws_ext_sales_price,ws_net_profit] [sum,sum,sum,sum]
-                                                                  Project [ws_ext_sales_price,ws_net_profit,wp_web_page_sk]
-                                                                    BroadcastHashJoin [ws_web_page_sk,wp_web_page_sk]
-                                                                      Project [ws_web_page_sk,ws_ext_sales_price,ws_net_profit]
-                                                                        BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                          Filter [ws_sold_date_sk,ws_web_page_sk]
-                                                                            ColumnarToRow
-                                                                              InputAdapter
-                                                                                Scan parquet default.web_sales [ws_sold_date_sk,ws_web_page_sk,ws_ext_sales_price,ws_net_profit]
-                                                                          InputAdapter
-                                                                            ReusedExchange [d_date_sk] #5
+                                                            BroadcastExchange #4
+                                                              WholeStageCodegen (1)
+                                                                Project [d_date_sk]
+                                                                  Filter [d_date,d_date_sk]
+                                                                    ColumnarToRow
                                                                       InputAdapter
-                                                                        BroadcastExchange #13
-                                                                          WholeStageCodegen (17)
-                                                                            Filter [wp_web_page_sk]
-                                                                              ColumnarToRow
-                                                                                InputAdapter
-                                                                                  Scan parquet default.web_page [wp_web_page_sk]
-                                                        InputAdapter
-                                                          BroadcastExchange #14
-                                                            WholeStageCodegen (22)
-                                                              HashAggregate [wp_web_page_sk,sum,sum] [sum(UnscaledValue(wr_return_amt)),sum(UnscaledValue(wr_net_loss)),returns,profit_loss,sum,sum]
+                                                                        Scan parquet default.date_dim [d_date_sk,d_date]
+                                                      InputAdapter
+                                                        BroadcastExchange #5
+                                                          WholeStageCodegen (2)
+                                                            Filter [s_store_sk]
+                                                              ColumnarToRow
                                                                 InputAdapter
-                                                                  Exchange [wp_web_page_sk] #15
-                                                                    WholeStageCodegen (21)
-                                                                      HashAggregate [wp_web_page_sk,wr_return_amt,wr_net_loss] [sum,sum,sum,sum]
-                                                                        Project [wr_return_amt,wr_net_loss,wp_web_page_sk]
-                                                                          BroadcastHashJoin [wr_web_page_sk,wp_web_page_sk]
-                                                                            Project [wr_web_page_sk,wr_return_amt,wr_net_loss]
-                                                                              BroadcastHashJoin [wr_returned_date_sk,d_date_sk]
-                                                                                Filter [wr_returned_date_sk,wr_web_page_sk]
-                                                                                  ColumnarToRow
-                                                                                    InputAdapter
-                                                                                      Scan parquet default.web_returns [wr_returned_date_sk,wr_web_page_sk,wr_return_amt,wr_net_loss]
-                                                                                InputAdapter
-                                                                                  ReusedExchange [d_date_sk] #5
-                                                                            InputAdapter
-                                                                              ReusedExchange [wp_web_page_sk] #13
-                                  WholeStageCodegen (51)
-                                    HashAggregate [channel,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),id,sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
-                                      InputAdapter
-                                        Exchange [channel] #16
-                                          WholeStageCodegen (50)
-                                            HashAggregate [channel,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
-                                              HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                                                                  Scan parquet default.store [s_store_sk]
+                                        InputAdapter
+                                          BroadcastExchange #6
+                                            WholeStageCodegen (7)
+                                              HashAggregate [s_store_sk,sum,sum] [sum(UnscaledValue(sr_return_amt)),sum(UnscaledValue(sr_net_loss)),returns,profit_loss,sum,sum]
                                                 InputAdapter
-                                                  ReusedExchange [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] #3
-                  WholeStageCodegen (79)
+                                                  Exchange [s_store_sk] #7
+                                                    WholeStageCodegen (6)
+                                                      HashAggregate [s_store_sk,sr_return_amt,sr_net_loss] [sum,sum,sum,sum]
+                                                        Project [sr_return_amt,sr_net_loss,s_store_sk]
+                                                          BroadcastHashJoin [sr_store_sk,s_store_sk]
+                                                            Project [sr_store_sk,sr_return_amt,sr_net_loss]
+                                                              BroadcastHashJoin [sr_returned_date_sk,d_date_sk]
+                                                                Filter [sr_returned_date_sk,sr_store_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet default.store_returns [sr_returned_date_sk,sr_store_sk,sr_return_amt,sr_net_loss]
+                                                                InputAdapter
+                                                                  ReusedExchange [d_date_sk] #4
+                                                            InputAdapter
+                                                              ReusedExchange [s_store_sk] #5
+                                  WholeStageCodegen (15)
+                                    Project [cs_call_center_sk,sales,returns,profit,profit_loss]
+                                      InputAdapter
+                                        BroadcastNestedLoopJoin
+                                          BroadcastExchange #8
+                                            WholeStageCodegen (11)
+                                              HashAggregate [cs_call_center_sk,sum,sum] [sum(UnscaledValue(cs_ext_sales_price)),sum(UnscaledValue(cs_net_profit)),sales,profit,sum,sum]
+                                                InputAdapter
+                                                  Exchange [cs_call_center_sk] #9
+                                                    WholeStageCodegen (10)
+                                                      HashAggregate [cs_call_center_sk,cs_ext_sales_price,cs_net_profit] [sum,sum,sum,sum]
+                                                        Project [cs_call_center_sk,cs_ext_sales_price,cs_net_profit]
+                                                          BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                            Filter [cs_sold_date_sk]
+                                                              ColumnarToRow
+                                                                InputAdapter
+                                                                  Scan parquet default.catalog_sales [cs_sold_date_sk,cs_call_center_sk,cs_ext_sales_price,cs_net_profit]
+                                                            InputAdapter
+                                                              ReusedExchange [d_date_sk] #4
+                                          WholeStageCodegen (14)
+                                            HashAggregate [sum,sum] [sum(UnscaledValue(cr_return_amount)),sum(UnscaledValue(cr_net_loss)),returns,profit_loss,sum,sum]
+                                              InputAdapter
+                                                Exchange #10
+                                                  WholeStageCodegen (13)
+                                                    HashAggregate [cr_return_amount,cr_net_loss] [sum,sum,sum,sum]
+                                                      Project [cr_return_amount,cr_net_loss]
+                                                        BroadcastHashJoin [cr_returned_date_sk,d_date_sk]
+                                                          Filter [cr_returned_date_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet default.catalog_returns [cr_returned_date_sk,cr_return_amount,cr_net_loss]
+                                                          InputAdapter
+                                                            ReusedExchange [d_date_sk] #4
+                                  WholeStageCodegen (23)
+                                    Project [wp_web_page_sk,sales,returns,profit,profit_loss]
+                                      BroadcastHashJoin [wp_web_page_sk,wp_web_page_sk]
+                                        HashAggregate [wp_web_page_sk,sum,sum] [sum(UnscaledValue(ws_ext_sales_price)),sum(UnscaledValue(ws_net_profit)),sales,profit,sum,sum]
+                                          InputAdapter
+                                            Exchange [wp_web_page_sk] #11
+                                              WholeStageCodegen (18)
+                                                HashAggregate [wp_web_page_sk,ws_ext_sales_price,ws_net_profit] [sum,sum,sum,sum]
+                                                  Project [ws_ext_sales_price,ws_net_profit,wp_web_page_sk]
+                                                    BroadcastHashJoin [ws_web_page_sk,wp_web_page_sk]
+                                                      Project [ws_web_page_sk,ws_ext_sales_price,ws_net_profit]
+                                                        BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                          Filter [ws_sold_date_sk,ws_web_page_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet default.web_sales [ws_sold_date_sk,ws_web_page_sk,ws_ext_sales_price,ws_net_profit]
+                                                          InputAdapter
+                                                            ReusedExchange [d_date_sk] #4
+                                                      InputAdapter
+                                                        BroadcastExchange #12
+                                                          WholeStageCodegen (17)
+                                                            Filter [wp_web_page_sk]
+                                                              ColumnarToRow
+                                                                InputAdapter
+                                                                  Scan parquet default.web_page [wp_web_page_sk]
+                                        InputAdapter
+                                          BroadcastExchange #13
+                                            WholeStageCodegen (22)
+                                              HashAggregate [wp_web_page_sk,sum,sum] [sum(UnscaledValue(wr_return_amt)),sum(UnscaledValue(wr_net_loss)),returns,profit_loss,sum,sum]
+                                                InputAdapter
+                                                  Exchange [wp_web_page_sk] #14
+                                                    WholeStageCodegen (21)
+                                                      HashAggregate [wp_web_page_sk,wr_return_amt,wr_net_loss] [sum,sum,sum,sum]
+                                                        Project [wr_return_amt,wr_net_loss,wp_web_page_sk]
+                                                          BroadcastHashJoin [wr_web_page_sk,wp_web_page_sk]
+                                                            Project [wr_web_page_sk,wr_return_amt,wr_net_loss]
+                                                              BroadcastHashJoin [wr_returned_date_sk,d_date_sk]
+                                                                Filter [wr_returned_date_sk,wr_web_page_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet default.web_returns [wr_returned_date_sk,wr_web_page_sk,wr_return_amt,wr_net_loss]
+                                                                InputAdapter
+                                                                  ReusedExchange [d_date_sk] #4
+                                                            InputAdapter
+                                                              ReusedExchange [wp_web_page_sk] #12
+                  WholeStageCodegen (51)
+                    HashAggregate [channel,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),id,sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                      InputAdapter
+                        Exchange [channel] #15
+                          WholeStageCodegen (50)
+                            HashAggregate [channel,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                              HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                                InputAdapter
+                                  ReusedExchange [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] #2
+                  WholeStageCodegen (77)
                     HashAggregate [sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),channel,id,sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                       InputAdapter
-                        Exchange #17
-                          WholeStageCodegen (78)
+                        Exchange #16
+                          WholeStageCodegen (76)
                             HashAggregate [sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                               HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                                 InputAdapter
-                                  ReusedExchange [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] #3
+                                  ReusedExchange [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] #2

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q80a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q80a.sf100/explain.txt
@@ -1,129 +1,125 @@
 == Physical Plan ==
-TakeOrderedAndProject (125)
-+- * HashAggregate (124)
-   +- Exchange (123)
-      +- * HashAggregate (122)
-         +- Union (121)
-            :- * HashAggregate (115)
-            :  +- Exchange (114)
-            :     +- * HashAggregate (113)
-            :        +- Union (112)
-            :           :- * HashAggregate (106)
-            :           :  +- Exchange (105)
-            :           :     +- * HashAggregate (104)
-            :           :        +- Union (103)
-            :           :           :- * HashAggregate (42)
-            :           :           :  +- Exchange (41)
-            :           :           :     +- * HashAggregate (40)
-            :           :           :        +- * Project (39)
-            :           :           :           +- * BroadcastHashJoin Inner BuildRight (38)
-            :           :           :              :- * Project (33)
-            :           :           :              :  +- * BroadcastHashJoin Inner BuildRight (32)
-            :           :           :              :     :- * Project (26)
-            :           :           :              :     :  +- * BroadcastHashJoin Inner BuildRight (25)
-            :           :           :              :     :     :- * Project (19)
-            :           :           :              :     :     :  +- * BroadcastHashJoin Inner BuildRight (18)
-            :           :           :              :     :     :     :- * Project (12)
-            :           :           :              :     :     :     :  +- SortMergeJoin LeftOuter (11)
-            :           :           :              :     :     :     :     :- * Sort (5)
-            :           :           :              :     :     :     :     :  +- Exchange (4)
-            :           :           :              :     :     :     :     :     +- * Filter (3)
-            :           :           :              :     :     :     :     :        +- * ColumnarToRow (2)
-            :           :           :              :     :     :     :     :           +- Scan parquet default.store_sales (1)
-            :           :           :              :     :     :     :     +- * Sort (10)
-            :           :           :              :     :     :     :        +- Exchange (9)
-            :           :           :              :     :     :     :           +- * Filter (8)
-            :           :           :              :     :     :     :              +- * ColumnarToRow (7)
-            :           :           :              :     :     :     :                 +- Scan parquet default.store_returns (6)
-            :           :           :              :     :     :     +- BroadcastExchange (17)
-            :           :           :              :     :     :        +- * Project (16)
-            :           :           :              :     :     :           +- * Filter (15)
-            :           :           :              :     :     :              +- * ColumnarToRow (14)
-            :           :           :              :     :     :                 +- Scan parquet default.item (13)
-            :           :           :              :     :     +- BroadcastExchange (24)
-            :           :           :              :     :        +- * Project (23)
-            :           :           :              :     :           +- * Filter (22)
-            :           :           :              :     :              +- * ColumnarToRow (21)
-            :           :           :              :     :                 +- Scan parquet default.promotion (20)
-            :           :           :              :     +- BroadcastExchange (31)
-            :           :           :              :        +- * Project (30)
-            :           :           :              :           +- * Filter (29)
-            :           :           :              :              +- * ColumnarToRow (28)
-            :           :           :              :                 +- Scan parquet default.date_dim (27)
-            :           :           :              +- BroadcastExchange (37)
-            :           :           :                 +- * Filter (36)
-            :           :           :                    +- * ColumnarToRow (35)
-            :           :           :                       +- Scan parquet default.store (34)
-            :           :           :- * HashAggregate (72)
-            :           :           :  +- Exchange (71)
-            :           :           :     +- * HashAggregate (70)
-            :           :           :        +- * Project (69)
-            :           :           :           +- * BroadcastHashJoin Inner BuildRight (68)
-            :           :           :              :- * Project (63)
-            :           :           :              :  +- * BroadcastHashJoin Inner BuildRight (62)
-            :           :           :              :     :- * Project (60)
-            :           :           :              :     :  +- * BroadcastHashJoin Inner BuildRight (59)
-            :           :           :              :     :     :- * Project (57)
-            :           :           :              :     :     :  +- * BroadcastHashJoin Inner BuildRight (56)
-            :           :           :              :     :     :     :- * Project (54)
-            :           :           :              :     :     :     :  +- SortMergeJoin LeftOuter (53)
-            :           :           :              :     :     :     :     :- * Sort (47)
-            :           :           :              :     :     :     :     :  +- Exchange (46)
-            :           :           :              :     :     :     :     :     +- * Filter (45)
-            :           :           :              :     :     :     :     :        +- * ColumnarToRow (44)
-            :           :           :              :     :     :     :     :           +- Scan parquet default.catalog_sales (43)
-            :           :           :              :     :     :     :     +- * Sort (52)
-            :           :           :              :     :     :     :        +- Exchange (51)
-            :           :           :              :     :     :     :           +- * Filter (50)
-            :           :           :              :     :     :     :              +- * ColumnarToRow (49)
-            :           :           :              :     :     :     :                 +- Scan parquet default.catalog_returns (48)
-            :           :           :              :     :     :     +- ReusedExchange (55)
-            :           :           :              :     :     +- ReusedExchange (58)
-            :           :           :              :     +- ReusedExchange (61)
-            :           :           :              +- BroadcastExchange (67)
-            :           :           :                 +- * Filter (66)
-            :           :           :                    +- * ColumnarToRow (65)
-            :           :           :                       +- Scan parquet default.catalog_page (64)
-            :           :           +- * HashAggregate (102)
-            :           :              +- Exchange (101)
-            :           :                 +- * HashAggregate (100)
-            :           :                    +- * Project (99)
-            :           :                       +- * BroadcastHashJoin Inner BuildRight (98)
-            :           :                          :- * Project (93)
-            :           :                          :  +- * BroadcastHashJoin Inner BuildRight (92)
-            :           :                          :     :- * Project (90)
-            :           :                          :     :  +- * BroadcastHashJoin Inner BuildRight (89)
-            :           :                          :     :     :- * Project (87)
-            :           :                          :     :     :  +- * BroadcastHashJoin Inner BuildRight (86)
-            :           :                          :     :     :     :- * Project (84)
-            :           :                          :     :     :     :  +- SortMergeJoin LeftOuter (83)
-            :           :                          :     :     :     :     :- * Sort (77)
-            :           :                          :     :     :     :     :  +- Exchange (76)
-            :           :                          :     :     :     :     :     +- * Filter (75)
-            :           :                          :     :     :     :     :        +- * ColumnarToRow (74)
-            :           :                          :     :     :     :     :           +- Scan parquet default.web_sales (73)
-            :           :                          :     :     :     :     +- * Sort (82)
-            :           :                          :     :     :     :        +- Exchange (81)
-            :           :                          :     :     :     :           +- * Filter (80)
-            :           :                          :     :     :     :              +- * ColumnarToRow (79)
-            :           :                          :     :     :     :                 +- Scan parquet default.web_returns (78)
-            :           :                          :     :     :     +- ReusedExchange (85)
-            :           :                          :     :     +- ReusedExchange (88)
-            :           :                          :     +- ReusedExchange (91)
-            :           :                          +- BroadcastExchange (97)
-            :           :                             +- * Filter (96)
-            :           :                                +- * ColumnarToRow (95)
-            :           :                                   +- Scan parquet default.web_site (94)
-            :           +- * HashAggregate (111)
-            :              +- Exchange (110)
-            :                 +- * HashAggregate (109)
-            :                    +- * HashAggregate (108)
-            :                       +- ReusedExchange (107)
-            +- * HashAggregate (120)
-               +- Exchange (119)
-                  +- * HashAggregate (118)
-                     +- * HashAggregate (117)
-                        +- ReusedExchange (116)
+TakeOrderedAndProject (121)
++- * HashAggregate (120)
+   +- Exchange (119)
+      +- * HashAggregate (118)
+         +- Union (117)
+            :- * HashAggregate (106)
+            :  +- Exchange (105)
+            :     +- * HashAggregate (104)
+            :        +- Union (103)
+            :           :- * HashAggregate (42)
+            :           :  +- Exchange (41)
+            :           :     +- * HashAggregate (40)
+            :           :        +- * Project (39)
+            :           :           +- * BroadcastHashJoin Inner BuildRight (38)
+            :           :              :- * Project (33)
+            :           :              :  +- * BroadcastHashJoin Inner BuildRight (32)
+            :           :              :     :- * Project (26)
+            :           :              :     :  +- * BroadcastHashJoin Inner BuildRight (25)
+            :           :              :     :     :- * Project (19)
+            :           :              :     :     :  +- * BroadcastHashJoin Inner BuildRight (18)
+            :           :              :     :     :     :- * Project (12)
+            :           :              :     :     :     :  +- SortMergeJoin LeftOuter (11)
+            :           :              :     :     :     :     :- * Sort (5)
+            :           :              :     :     :     :     :  +- Exchange (4)
+            :           :              :     :     :     :     :     +- * Filter (3)
+            :           :              :     :     :     :     :        +- * ColumnarToRow (2)
+            :           :              :     :     :     :     :           +- Scan parquet default.store_sales (1)
+            :           :              :     :     :     :     +- * Sort (10)
+            :           :              :     :     :     :        +- Exchange (9)
+            :           :              :     :     :     :           +- * Filter (8)
+            :           :              :     :     :     :              +- * ColumnarToRow (7)
+            :           :              :     :     :     :                 +- Scan parquet default.store_returns (6)
+            :           :              :     :     :     +- BroadcastExchange (17)
+            :           :              :     :     :        +- * Project (16)
+            :           :              :     :     :           +- * Filter (15)
+            :           :              :     :     :              +- * ColumnarToRow (14)
+            :           :              :     :     :                 +- Scan parquet default.item (13)
+            :           :              :     :     +- BroadcastExchange (24)
+            :           :              :     :        +- * Project (23)
+            :           :              :     :           +- * Filter (22)
+            :           :              :     :              +- * ColumnarToRow (21)
+            :           :              :     :                 +- Scan parquet default.promotion (20)
+            :           :              :     +- BroadcastExchange (31)
+            :           :              :        +- * Project (30)
+            :           :              :           +- * Filter (29)
+            :           :              :              +- * ColumnarToRow (28)
+            :           :              :                 +- Scan parquet default.date_dim (27)
+            :           :              +- BroadcastExchange (37)
+            :           :                 +- * Filter (36)
+            :           :                    +- * ColumnarToRow (35)
+            :           :                       +- Scan parquet default.store (34)
+            :           :- * HashAggregate (72)
+            :           :  +- Exchange (71)
+            :           :     +- * HashAggregate (70)
+            :           :        +- * Project (69)
+            :           :           +- * BroadcastHashJoin Inner BuildRight (68)
+            :           :              :- * Project (63)
+            :           :              :  +- * BroadcastHashJoin Inner BuildRight (62)
+            :           :              :     :- * Project (60)
+            :           :              :     :  +- * BroadcastHashJoin Inner BuildRight (59)
+            :           :              :     :     :- * Project (57)
+            :           :              :     :     :  +- * BroadcastHashJoin Inner BuildRight (56)
+            :           :              :     :     :     :- * Project (54)
+            :           :              :     :     :     :  +- SortMergeJoin LeftOuter (53)
+            :           :              :     :     :     :     :- * Sort (47)
+            :           :              :     :     :     :     :  +- Exchange (46)
+            :           :              :     :     :     :     :     +- * Filter (45)
+            :           :              :     :     :     :     :        +- * ColumnarToRow (44)
+            :           :              :     :     :     :     :           +- Scan parquet default.catalog_sales (43)
+            :           :              :     :     :     :     +- * Sort (52)
+            :           :              :     :     :     :        +- Exchange (51)
+            :           :              :     :     :     :           +- * Filter (50)
+            :           :              :     :     :     :              +- * ColumnarToRow (49)
+            :           :              :     :     :     :                 +- Scan parquet default.catalog_returns (48)
+            :           :              :     :     :     +- ReusedExchange (55)
+            :           :              :     :     +- ReusedExchange (58)
+            :           :              :     +- ReusedExchange (61)
+            :           :              +- BroadcastExchange (67)
+            :           :                 +- * Filter (66)
+            :           :                    +- * ColumnarToRow (65)
+            :           :                       +- Scan parquet default.catalog_page (64)
+            :           +- * HashAggregate (102)
+            :              +- Exchange (101)
+            :                 +- * HashAggregate (100)
+            :                    +- * Project (99)
+            :                       +- * BroadcastHashJoin Inner BuildRight (98)
+            :                          :- * Project (93)
+            :                          :  +- * BroadcastHashJoin Inner BuildRight (92)
+            :                          :     :- * Project (90)
+            :                          :     :  +- * BroadcastHashJoin Inner BuildRight (89)
+            :                          :     :     :- * Project (87)
+            :                          :     :     :  +- * BroadcastHashJoin Inner BuildRight (86)
+            :                          :     :     :     :- * Project (84)
+            :                          :     :     :     :  +- SortMergeJoin LeftOuter (83)
+            :                          :     :     :     :     :- * Sort (77)
+            :                          :     :     :     :     :  +- Exchange (76)
+            :                          :     :     :     :     :     +- * Filter (75)
+            :                          :     :     :     :     :        +- * ColumnarToRow (74)
+            :                          :     :     :     :     :           +- Scan parquet default.web_sales (73)
+            :                          :     :     :     :     +- * Sort (82)
+            :                          :     :     :     :        +- Exchange (81)
+            :                          :     :     :     :           +- * Filter (80)
+            :                          :     :     :     :              +- * ColumnarToRow (79)
+            :                          :     :     :     :                 +- Scan parquet default.web_returns (78)
+            :                          :     :     :     +- ReusedExchange (85)
+            :                          :     :     +- ReusedExchange (88)
+            :                          :     +- ReusedExchange (91)
+            :                          +- BroadcastExchange (97)
+            :                             +- * Filter (96)
+            :                                +- * ColumnarToRow (95)
+            :                                   +- Scan parquet default.web_site (94)
+            :- * HashAggregate (111)
+            :  +- Exchange (110)
+            :     +- * HashAggregate (109)
+            :        +- * HashAggregate (108)
+            :           +- ReusedExchange (107)
+            +- * HashAggregate (116)
+               +- Exchange (115)
+                  +- * HashAggregate (114)
+                     +- * HashAggregate (113)
+                        +- ReusedExchange (112)
 
 
 (1) Scan parquet default.store_sales
@@ -142,7 +138,7 @@ Condition : (((isnotnull(ss_sold_date_sk#1) AND isnotnull(ss_store_sk#3)) AND is
 
 (4) Exchange
 Input [7]: [ss_sold_date_sk#1, ss_item_sk#2, ss_store_sk#3, ss_promo_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_net_profit#7]
-Arguments: hashpartitioning(cast(ss_item_sk#2 as bigint), cast(ss_ticket_number#5 as bigint), 5), true, [id=#8]
+Arguments: hashpartitioning(cast(ss_item_sk#2 as bigint), cast(ss_ticket_number#5 as bigint), 5), ENSURE_REQUIREMENTS, [id=#8]
 
 (5) Sort [codegen id : 2]
 Input [7]: [ss_sold_date_sk#1, ss_item_sk#2, ss_store_sk#3, ss_promo_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_net_profit#7]
@@ -164,7 +160,7 @@ Condition : (isnotnull(sr_item_sk#9) AND isnotnull(sr_ticket_number#10))
 
 (9) Exchange
 Input [4]: [sr_item_sk#9, sr_ticket_number#10, sr_return_amt#11, sr_net_loss#12]
-Arguments: hashpartitioning(sr_item_sk#9, sr_ticket_number#10, 5), true, [id=#13]
+Arguments: hashpartitioning(sr_item_sk#9, sr_ticket_number#10, 5), ENSURE_REQUIREMENTS, [id=#13]
 
 (10) Sort [codegen id : 4]
 Input [4]: [sr_item_sk#9, sr_ticket_number#10, sr_return_amt#11, sr_net_loss#12]
@@ -308,7 +304,7 @@ Results [6]: [s_store_id#24, sum#31, sum#32, isEmpty#33, sum#34, isEmpty#35]
 
 (41) Exchange
 Input [6]: [s_store_id#24, sum#31, sum#32, isEmpty#33, sum#34, isEmpty#35]
-Arguments: hashpartitioning(s_store_id#24, 5), true, [id=#36]
+Arguments: hashpartitioning(s_store_id#24, 5), ENSURE_REQUIREMENTS, [id=#36]
 
 (42) HashAggregate [codegen id : 10]
 Input [6]: [s_store_id#24, sum#31, sum#32, isEmpty#33, sum#34, isEmpty#35]
@@ -333,7 +329,7 @@ Condition : (((isnotnull(cs_sold_date_sk#45) AND isnotnull(cs_catalog_page_sk#46
 
 (46) Exchange
 Input [7]: [cs_sold_date_sk#45, cs_catalog_page_sk#46, cs_item_sk#47, cs_promo_sk#48, cs_order_number#49, cs_ext_sales_price#50, cs_net_profit#51]
-Arguments: hashpartitioning(cs_item_sk#47, cs_order_number#49, 5), true, [id=#52]
+Arguments: hashpartitioning(cs_item_sk#47, cs_order_number#49, 5), ENSURE_REQUIREMENTS, [id=#52]
 
 (47) Sort [codegen id : 12]
 Input [7]: [cs_sold_date_sk#45, cs_catalog_page_sk#46, cs_item_sk#47, cs_promo_sk#48, cs_order_number#49, cs_ext_sales_price#50, cs_net_profit#51]
@@ -355,7 +351,7 @@ Condition : (isnotnull(cr_item_sk#53) AND isnotnull(cr_order_number#54))
 
 (51) Exchange
 Input [4]: [cr_item_sk#53, cr_order_number#54, cr_return_amount#55, cr_net_loss#56]
-Arguments: hashpartitioning(cr_item_sk#53, cr_order_number#54, 5), true, [id=#57]
+Arguments: hashpartitioning(cr_item_sk#53, cr_order_number#54, 5), ENSURE_REQUIREMENTS, [id=#57]
 
 (52) Sort [codegen id : 14]
 Input [4]: [cr_item_sk#53, cr_order_number#54, cr_return_amount#55, cr_net_loss#56]
@@ -442,7 +438,7 @@ Results [6]: [cp_catalog_page_id#59, sum#66, sum#67, isEmpty#68, sum#69, isEmpty
 
 (71) Exchange
 Input [6]: [cp_catalog_page_id#59, sum#66, sum#67, isEmpty#68, sum#69, isEmpty#70]
-Arguments: hashpartitioning(cp_catalog_page_id#59, 5), true, [id=#71]
+Arguments: hashpartitioning(cp_catalog_page_id#59, 5), ENSURE_REQUIREMENTS, [id=#71]
 
 (72) HashAggregate [codegen id : 20]
 Input [6]: [cp_catalog_page_id#59, sum#66, sum#67, isEmpty#68, sum#69, isEmpty#70]
@@ -467,7 +463,7 @@ Condition : (((isnotnull(ws_sold_date_sk#80) AND isnotnull(ws_web_site_sk#82)) A
 
 (76) Exchange
 Input [7]: [ws_sold_date_sk#80, ws_item_sk#81, ws_web_site_sk#82, ws_promo_sk#83, ws_order_number#84, ws_ext_sales_price#85, ws_net_profit#86]
-Arguments: hashpartitioning(cast(ws_item_sk#81 as bigint), cast(ws_order_number#84 as bigint), 5), true, [id=#87]
+Arguments: hashpartitioning(cast(ws_item_sk#81 as bigint), cast(ws_order_number#84 as bigint), 5), ENSURE_REQUIREMENTS, [id=#87]
 
 (77) Sort [codegen id : 22]
 Input [7]: [ws_sold_date_sk#80, ws_item_sk#81, ws_web_site_sk#82, ws_promo_sk#83, ws_order_number#84, ws_ext_sales_price#85, ws_net_profit#86]
@@ -489,7 +485,7 @@ Condition : (isnotnull(wr_item_sk#88) AND isnotnull(wr_order_number#89))
 
 (81) Exchange
 Input [4]: [wr_item_sk#88, wr_order_number#89, wr_return_amt#90, wr_net_loss#91]
-Arguments: hashpartitioning(wr_item_sk#88, wr_order_number#89, 5), true, [id=#92]
+Arguments: hashpartitioning(wr_item_sk#88, wr_order_number#89, 5), ENSURE_REQUIREMENTS, [id=#92]
 
 (82) Sort [codegen id : 24]
 Input [4]: [wr_item_sk#88, wr_order_number#89, wr_return_amt#90, wr_net_loss#91]
@@ -576,7 +572,7 @@ Results [6]: [web_site_id#94, sum#101, sum#102, isEmpty#103, sum#104, isEmpty#10
 
 (101) Exchange
 Input [6]: [web_site_id#94, sum#101, sum#102, isEmpty#103, sum#104, isEmpty#105]
-Arguments: hashpartitioning(web_site_id#94, 5), true, [id=#106]
+Arguments: hashpartitioning(web_site_id#94, 5), ENSURE_REQUIREMENTS, [id=#106]
 
 (102) HashAggregate [codegen id : 30]
 Input [6]: [web_site_id#94, sum#101, sum#102, isEmpty#103, sum#104, isEmpty#105]
@@ -596,7 +592,7 @@ Results [8]: [channel#40, id#41, sum#121, isEmpty#122, sum#123, isEmpty#124, sum
 
 (105) Exchange
 Input [8]: [channel#40, id#41, sum#121, isEmpty#122, sum#123, isEmpty#124, sum#125, isEmpty#126]
-Arguments: hashpartitioning(channel#40, id#41, 5), true, [id=#127]
+Arguments: hashpartitioning(channel#40, id#41, 5), ENSURE_REQUIREMENTS, [id=#127]
 
 (106) HashAggregate [codegen id : 32]
 Input [8]: [channel#40, id#41, sum#121, isEmpty#122, sum#123, isEmpty#124, sum#125, isEmpty#126]
@@ -624,7 +620,7 @@ Results [7]: [channel#40, sum#152, isEmpty#153, sum#154, isEmpty#155, sum#156, i
 
 (110) Exchange
 Input [7]: [channel#40, sum#152, isEmpty#153, sum#154, isEmpty#155, sum#156, isEmpty#157]
-Arguments: hashpartitioning(channel#40, 5), true, [id=#158]
+Arguments: hashpartitioning(channel#40, 5), ENSURE_REQUIREMENTS, [id=#158]
 
 (111) HashAggregate [codegen id : 65]
 Input [7]: [channel#40, sum#152, isEmpty#153, sum#154, isEmpty#155, sum#156, isEmpty#157]
@@ -633,75 +629,55 @@ Functions [3]: [sum(sales#143), sum(returns#144), sum(profit#145)]
 Aggregate Attributes [3]: [sum(sales#143)#159, sum(returns#144)#160, sum(profit#145)#161]
 Results [5]: [channel#40, null AS id#162, sum(sales#143)#159 AS sales#163, sum(returns#144)#160 AS returns#164, sum(profit#145)#161 AS profit#165]
 
-(112) Union
+(112) ReusedExchange [Reuses operator id: 105]
+Output [8]: [channel#40, id#41, sum#166, isEmpty#167, sum#168, isEmpty#169, sum#170, isEmpty#171]
 
-(113) HashAggregate [codegen id : 66]
-Input [5]: [channel#40, id#41, sales#131, returns#132, profit#133]
-Keys [5]: [channel#40, id#41, sales#131, returns#132, profit#133]
-Functions: []
-Aggregate Attributes: []
-Results [5]: [channel#40, id#41, sales#131, returns#132, profit#133]
-
-(114) Exchange
-Input [5]: [channel#40, id#41, sales#131, returns#132, profit#133]
-Arguments: hashpartitioning(channel#40, id#41, sales#131, returns#132, profit#133, 5), true, [id=#166]
-
-(115) HashAggregate [codegen id : 67]
-Input [5]: [channel#40, id#41, sales#131, returns#132, profit#133]
-Keys [5]: [channel#40, id#41, sales#131, returns#132, profit#133]
-Functions: []
-Aggregate Attributes: []
-Results [5]: [channel#40, id#41, sales#131, returns#132, profit#133]
-
-(116) ReusedExchange [Reuses operator id: 105]
-Output [8]: [channel#40, id#41, sum#167, isEmpty#168, sum#169, isEmpty#170, sum#171, isEmpty#172]
-
-(117) HashAggregate [codegen id : 99]
-Input [8]: [channel#40, id#41, sum#167, isEmpty#168, sum#169, isEmpty#170, sum#171, isEmpty#172]
+(113) HashAggregate [codegen id : 97]
+Input [8]: [channel#40, id#41, sum#166, isEmpty#167, sum#168, isEmpty#169, sum#170, isEmpty#171]
 Keys [2]: [channel#40, id#41]
 Functions [3]: [sum(sales#42), sum(returns#43), sum(profit#44)]
-Aggregate Attributes [3]: [sum(sales#42)#173, sum(returns#43)#174, sum(profit#44)#175]
-Results [3]: [sum(sales#42)#173 AS sales#143, sum(returns#43)#174 AS returns#144, sum(profit#44)#175 AS profit#145]
+Aggregate Attributes [3]: [sum(sales#42)#172, sum(returns#43)#173, sum(profit#44)#174]
+Results [3]: [sum(sales#42)#172 AS sales#143, sum(returns#43)#173 AS returns#144, sum(profit#44)#174 AS profit#145]
 
-(118) HashAggregate [codegen id : 99]
+(114) HashAggregate [codegen id : 97]
 Input [3]: [sales#143, returns#144, profit#145]
 Keys: []
 Functions [3]: [partial_sum(sales#143), partial_sum(returns#144), partial_sum(profit#145)]
-Aggregate Attributes [6]: [sum#176, isEmpty#177, sum#178, isEmpty#179, sum#180, isEmpty#181]
-Results [6]: [sum#182, isEmpty#183, sum#184, isEmpty#185, sum#186, isEmpty#187]
+Aggregate Attributes [6]: [sum#175, isEmpty#176, sum#177, isEmpty#178, sum#179, isEmpty#180]
+Results [6]: [sum#181, isEmpty#182, sum#183, isEmpty#184, sum#185, isEmpty#186]
 
-(119) Exchange
-Input [6]: [sum#182, isEmpty#183, sum#184, isEmpty#185, sum#186, isEmpty#187]
-Arguments: SinglePartition, true, [id=#188]
+(115) Exchange
+Input [6]: [sum#181, isEmpty#182, sum#183, isEmpty#184, sum#185, isEmpty#186]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#187]
 
-(120) HashAggregate [codegen id : 100]
-Input [6]: [sum#182, isEmpty#183, sum#184, isEmpty#185, sum#186, isEmpty#187]
+(116) HashAggregate [codegen id : 98]
+Input [6]: [sum#181, isEmpty#182, sum#183, isEmpty#184, sum#185, isEmpty#186]
 Keys: []
 Functions [3]: [sum(sales#143), sum(returns#144), sum(profit#145)]
-Aggregate Attributes [3]: [sum(sales#143)#189, sum(returns#144)#190, sum(profit#145)#191]
-Results [5]: [null AS channel#192, null AS id#193, sum(sales#143)#189 AS sales#194, sum(returns#144)#190 AS returns#195, sum(profit#145)#191 AS profit#196]
+Aggregate Attributes [3]: [sum(sales#143)#188, sum(returns#144)#189, sum(profit#145)#190]
+Results [5]: [null AS channel#191, null AS id#192, sum(sales#143)#188 AS sales#193, sum(returns#144)#189 AS returns#194, sum(profit#145)#190 AS profit#195]
 
-(121) Union
+(117) Union
 
-(122) HashAggregate [codegen id : 101]
+(118) HashAggregate [codegen id : 99]
 Input [5]: [channel#40, id#41, sales#131, returns#132, profit#133]
 Keys [5]: [channel#40, id#41, sales#131, returns#132, profit#133]
 Functions: []
 Aggregate Attributes: []
 Results [5]: [channel#40, id#41, sales#131, returns#132, profit#133]
 
-(123) Exchange
+(119) Exchange
 Input [5]: [channel#40, id#41, sales#131, returns#132, profit#133]
-Arguments: hashpartitioning(channel#40, id#41, sales#131, returns#132, profit#133, 5), true, [id=#197]
+Arguments: hashpartitioning(channel#40, id#41, sales#131, returns#132, profit#133, 5), ENSURE_REQUIREMENTS, [id=#196]
 
-(124) HashAggregate [codegen id : 102]
+(120) HashAggregate [codegen id : 100]
 Input [5]: [channel#40, id#41, sales#131, returns#132, profit#133]
 Keys [5]: [channel#40, id#41, sales#131, returns#132, profit#133]
 Functions: []
 Aggregate Attributes: []
 Results [5]: [channel#40, id#41, sales#131, returns#132, profit#133]
 
-(125) TakeOrderedAndProject
+(121) TakeOrderedAndProject
 Input [5]: [channel#40, id#41, sales#131, returns#132, profit#133]
 Arguments: 100, [channel#40 ASC NULLS FIRST, id#41 ASC NULLS FIRST], [channel#40, id#41, sales#131, returns#132, profit#133]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q80a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q80a.sf100/simplified.txt
@@ -1,205 +1,197 @@
 TakeOrderedAndProject [channel,id,sales,returns,profit]
-  WholeStageCodegen (102)
+  WholeStageCodegen (100)
     HashAggregate [channel,id,sales,returns,profit]
       InputAdapter
         Exchange [channel,id,sales,returns,profit] #1
-          WholeStageCodegen (101)
+          WholeStageCodegen (99)
             HashAggregate [channel,id,sales,returns,profit]
               InputAdapter
                 Union
-                  WholeStageCodegen (67)
-                    HashAggregate [channel,id,sales,returns,profit]
+                  WholeStageCodegen (32)
+                    HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                       InputAdapter
-                        Exchange [channel,id,sales,returns,profit] #2
-                          WholeStageCodegen (66)
-                            HashAggregate [channel,id,sales,returns,profit]
+                        Exchange [channel,id] #2
+                          WholeStageCodegen (31)
+                            HashAggregate [channel,id,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                               InputAdapter
                                 Union
-                                  WholeStageCodegen (32)
-                                    HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                                  WholeStageCodegen (10)
+                                    HashAggregate [s_store_id,sum,sum,isEmpty,sum,isEmpty] [sum(UnscaledValue(ss_ext_sales_price)),sum(coalesce(cast(sr_return_amt as decimal(12,2)), 0.00)),sum(CheckOverflow((promote_precision(cast(ss_net_profit as decimal(13,2))) - promote_precision(cast(coalesce(cast(sr_net_loss as decimal(12,2)), 0.00) as decimal(13,2)))), DecimalType(13,2), true)),channel,id,sales,returns,profit,sum,sum,isEmpty,sum,isEmpty]
                                       InputAdapter
-                                        Exchange [channel,id] #3
-                                          WholeStageCodegen (31)
-                                            HashAggregate [channel,id,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
-                                              InputAdapter
-                                                Union
-                                                  WholeStageCodegen (10)
-                                                    HashAggregate [s_store_id,sum,sum,isEmpty,sum,isEmpty] [sum(UnscaledValue(ss_ext_sales_price)),sum(coalesce(cast(sr_return_amt as decimal(12,2)), 0.00)),sum(CheckOverflow((promote_precision(cast(ss_net_profit as decimal(13,2))) - promote_precision(cast(coalesce(cast(sr_net_loss as decimal(12,2)), 0.00) as decimal(13,2)))), DecimalType(13,2), true)),channel,id,sales,returns,profit,sum,sum,isEmpty,sum,isEmpty]
-                                                      InputAdapter
-                                                        Exchange [s_store_id] #4
-                                                          WholeStageCodegen (9)
-                                                            HashAggregate [s_store_id,ss_ext_sales_price,sr_return_amt,ss_net_profit,sr_net_loss] [sum,sum,isEmpty,sum,isEmpty,sum,sum,isEmpty,sum,isEmpty]
-                                                              Project [ss_ext_sales_price,ss_net_profit,sr_return_amt,sr_net_loss,s_store_id]
-                                                                BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                                  Project [ss_store_sk,ss_ext_sales_price,ss_net_profit,sr_return_amt,sr_net_loss]
-                                                                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                      Project [ss_sold_date_sk,ss_store_sk,ss_ext_sales_price,ss_net_profit,sr_return_amt,sr_net_loss]
-                                                                        BroadcastHashJoin [ss_promo_sk,p_promo_sk]
-                                                                          Project [ss_sold_date_sk,ss_store_sk,ss_promo_sk,ss_ext_sales_price,ss_net_profit,sr_return_amt,sr_net_loss]
-                                                                            BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                                              Project [ss_sold_date_sk,ss_item_sk,ss_store_sk,ss_promo_sk,ss_ext_sales_price,ss_net_profit,sr_return_amt,sr_net_loss]
-                                                                                InputAdapter
-                                                                                  SortMergeJoin [ss_item_sk,ss_ticket_number,sr_item_sk,sr_ticket_number]
-                                                                                    WholeStageCodegen (2)
-                                                                                      Sort [ss_item_sk,ss_ticket_number]
-                                                                                        InputAdapter
-                                                                                          Exchange [ss_item_sk,ss_ticket_number] #5
-                                                                                            WholeStageCodegen (1)
-                                                                                              Filter [ss_sold_date_sk,ss_store_sk,ss_item_sk,ss_promo_sk]
-                                                                                                ColumnarToRow
-                                                                                                  InputAdapter
-                                                                                                    Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk,ss_store_sk,ss_promo_sk,ss_ticket_number,ss_ext_sales_price,ss_net_profit]
-                                                                                    WholeStageCodegen (4)
-                                                                                      Sort [sr_item_sk,sr_ticket_number]
-                                                                                        InputAdapter
-                                                                                          Exchange [sr_item_sk,sr_ticket_number] #6
-                                                                                            WholeStageCodegen (3)
-                                                                                              Filter [sr_item_sk,sr_ticket_number]
-                                                                                                ColumnarToRow
-                                                                                                  InputAdapter
-                                                                                                    Scan parquet default.store_returns [sr_item_sk,sr_ticket_number,sr_return_amt,sr_net_loss]
-                                                                              InputAdapter
-                                                                                BroadcastExchange #7
-                                                                                  WholeStageCodegen (5)
-                                                                                    Project [i_item_sk]
-                                                                                      Filter [i_current_price,i_item_sk]
-                                                                                        ColumnarToRow
-                                                                                          InputAdapter
-                                                                                            Scan parquet default.item [i_item_sk,i_current_price]
-                                                                          InputAdapter
-                                                                            BroadcastExchange #8
-                                                                              WholeStageCodegen (6)
-                                                                                Project [p_promo_sk]
-                                                                                  Filter [p_channel_tv,p_promo_sk]
-                                                                                    ColumnarToRow
-                                                                                      InputAdapter
-                                                                                        Scan parquet default.promotion [p_promo_sk,p_channel_tv]
-                                                                      InputAdapter
-                                                                        BroadcastExchange #9
-                                                                          WholeStageCodegen (7)
-                                                                            Project [d_date_sk]
-                                                                              Filter [d_date,d_date_sk]
+                                        Exchange [s_store_id] #3
+                                          WholeStageCodegen (9)
+                                            HashAggregate [s_store_id,ss_ext_sales_price,sr_return_amt,ss_net_profit,sr_net_loss] [sum,sum,isEmpty,sum,isEmpty,sum,sum,isEmpty,sum,isEmpty]
+                                              Project [ss_ext_sales_price,ss_net_profit,sr_return_amt,sr_net_loss,s_store_id]
+                                                BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                                  Project [ss_store_sk,ss_ext_sales_price,ss_net_profit,sr_return_amt,sr_net_loss]
+                                                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                      Project [ss_sold_date_sk,ss_store_sk,ss_ext_sales_price,ss_net_profit,sr_return_amt,sr_net_loss]
+                                                        BroadcastHashJoin [ss_promo_sk,p_promo_sk]
+                                                          Project [ss_sold_date_sk,ss_store_sk,ss_promo_sk,ss_ext_sales_price,ss_net_profit,sr_return_amt,sr_net_loss]
+                                                            BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                              Project [ss_sold_date_sk,ss_item_sk,ss_store_sk,ss_promo_sk,ss_ext_sales_price,ss_net_profit,sr_return_amt,sr_net_loss]
+                                                                InputAdapter
+                                                                  SortMergeJoin [ss_item_sk,ss_ticket_number,sr_item_sk,sr_ticket_number]
+                                                                    WholeStageCodegen (2)
+                                                                      Sort [ss_item_sk,ss_ticket_number]
+                                                                        InputAdapter
+                                                                          Exchange [ss_item_sk,ss_ticket_number] #4
+                                                                            WholeStageCodegen (1)
+                                                                              Filter [ss_sold_date_sk,ss_store_sk,ss_item_sk,ss_promo_sk]
                                                                                 ColumnarToRow
                                                                                   InputAdapter
-                                                                                    Scan parquet default.date_dim [d_date_sk,d_date]
-                                                                  InputAdapter
-                                                                    BroadcastExchange #10
-                                                                      WholeStageCodegen (8)
-                                                                        Filter [s_store_sk]
-                                                                          ColumnarToRow
-                                                                            InputAdapter
-                                                                              Scan parquet default.store [s_store_sk,s_store_id]
-                                                  WholeStageCodegen (20)
-                                                    HashAggregate [cp_catalog_page_id,sum,sum,isEmpty,sum,isEmpty] [sum(UnscaledValue(cs_ext_sales_price)),sum(coalesce(cast(cr_return_amount as decimal(12,2)), 0.00)),sum(CheckOverflow((promote_precision(cast(cs_net_profit as decimal(13,2))) - promote_precision(cast(coalesce(cast(cr_net_loss as decimal(12,2)), 0.00) as decimal(13,2)))), DecimalType(13,2), true)),channel,id,sales,returns,profit,sum,sum,isEmpty,sum,isEmpty]
-                                                      InputAdapter
-                                                        Exchange [cp_catalog_page_id] #11
-                                                          WholeStageCodegen (19)
-                                                            HashAggregate [cp_catalog_page_id,cs_ext_sales_price,cr_return_amount,cs_net_profit,cr_net_loss] [sum,sum,isEmpty,sum,isEmpty,sum,sum,isEmpty,sum,isEmpty]
-                                                              Project [cs_ext_sales_price,cs_net_profit,cr_return_amount,cr_net_loss,cp_catalog_page_id]
-                                                                BroadcastHashJoin [cs_catalog_page_sk,cp_catalog_page_sk]
-                                                                  Project [cs_catalog_page_sk,cs_ext_sales_price,cs_net_profit,cr_return_amount,cr_net_loss]
-                                                                    BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                      Project [cs_sold_date_sk,cs_catalog_page_sk,cs_ext_sales_price,cs_net_profit,cr_return_amount,cr_net_loss]
-                                                                        BroadcastHashJoin [cs_promo_sk,p_promo_sk]
-                                                                          Project [cs_sold_date_sk,cs_catalog_page_sk,cs_promo_sk,cs_ext_sales_price,cs_net_profit,cr_return_amount,cr_net_loss]
-                                                                            BroadcastHashJoin [cs_item_sk,i_item_sk]
-                                                                              Project [cs_sold_date_sk,cs_catalog_page_sk,cs_item_sk,cs_promo_sk,cs_ext_sales_price,cs_net_profit,cr_return_amount,cr_net_loss]
-                                                                                InputAdapter
-                                                                                  SortMergeJoin [cs_item_sk,cs_order_number,cr_item_sk,cr_order_number]
-                                                                                    WholeStageCodegen (12)
-                                                                                      Sort [cs_item_sk,cs_order_number]
-                                                                                        InputAdapter
-                                                                                          Exchange [cs_item_sk,cs_order_number] #12
-                                                                                            WholeStageCodegen (11)
-                                                                                              Filter [cs_sold_date_sk,cs_catalog_page_sk,cs_item_sk,cs_promo_sk]
-                                                                                                ColumnarToRow
-                                                                                                  InputAdapter
-                                                                                                    Scan parquet default.catalog_sales [cs_sold_date_sk,cs_catalog_page_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_ext_sales_price,cs_net_profit]
-                                                                                    WholeStageCodegen (14)
-                                                                                      Sort [cr_item_sk,cr_order_number]
-                                                                                        InputAdapter
-                                                                                          Exchange [cr_item_sk,cr_order_number] #13
-                                                                                            WholeStageCodegen (13)
-                                                                                              Filter [cr_item_sk,cr_order_number]
-                                                                                                ColumnarToRow
-                                                                                                  InputAdapter
-                                                                                                    Scan parquet default.catalog_returns [cr_item_sk,cr_order_number,cr_return_amount,cr_net_loss]
-                                                                              InputAdapter
-                                                                                ReusedExchange [i_item_sk] #7
+                                                                                    Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk,ss_store_sk,ss_promo_sk,ss_ticket_number,ss_ext_sales_price,ss_net_profit]
+                                                                    WholeStageCodegen (4)
+                                                                      Sort [sr_item_sk,sr_ticket_number]
+                                                                        InputAdapter
+                                                                          Exchange [sr_item_sk,sr_ticket_number] #5
+                                                                            WholeStageCodegen (3)
+                                                                              Filter [sr_item_sk,sr_ticket_number]
+                                                                                ColumnarToRow
+                                                                                  InputAdapter
+                                                                                    Scan parquet default.store_returns [sr_item_sk,sr_ticket_number,sr_return_amt,sr_net_loss]
+                                                              InputAdapter
+                                                                BroadcastExchange #6
+                                                                  WholeStageCodegen (5)
+                                                                    Project [i_item_sk]
+                                                                      Filter [i_current_price,i_item_sk]
+                                                                        ColumnarToRow
                                                                           InputAdapter
-                                                                            ReusedExchange [p_promo_sk] #8
+                                                                            Scan parquet default.item [i_item_sk,i_current_price]
+                                                          InputAdapter
+                                                            BroadcastExchange #7
+                                                              WholeStageCodegen (6)
+                                                                Project [p_promo_sk]
+                                                                  Filter [p_channel_tv,p_promo_sk]
+                                                                    ColumnarToRow
                                                                       InputAdapter
-                                                                        ReusedExchange [d_date_sk] #9
-                                                                  InputAdapter
-                                                                    BroadcastExchange #14
-                                                                      WholeStageCodegen (18)
-                                                                        Filter [cp_catalog_page_sk]
-                                                                          ColumnarToRow
-                                                                            InputAdapter
-                                                                              Scan parquet default.catalog_page [cp_catalog_page_sk,cp_catalog_page_id]
-                                                  WholeStageCodegen (30)
-                                                    HashAggregate [web_site_id,sum,sum,isEmpty,sum,isEmpty] [sum(UnscaledValue(ws_ext_sales_price)),sum(coalesce(cast(wr_return_amt as decimal(12,2)), 0.00)),sum(CheckOverflow((promote_precision(cast(ws_net_profit as decimal(13,2))) - promote_precision(cast(coalesce(cast(wr_net_loss as decimal(12,2)), 0.00) as decimal(13,2)))), DecimalType(13,2), true)),channel,id,sales,returns,profit,sum,sum,isEmpty,sum,isEmpty]
+                                                                        Scan parquet default.promotion [p_promo_sk,p_channel_tv]
                                                       InputAdapter
-                                                        Exchange [web_site_id] #15
-                                                          WholeStageCodegen (29)
-                                                            HashAggregate [web_site_id,ws_ext_sales_price,wr_return_amt,ws_net_profit,wr_net_loss] [sum,sum,isEmpty,sum,isEmpty,sum,sum,isEmpty,sum,isEmpty]
-                                                              Project [ws_ext_sales_price,ws_net_profit,wr_return_amt,wr_net_loss,web_site_id]
-                                                                BroadcastHashJoin [ws_web_site_sk,web_site_sk]
-                                                                  Project [ws_web_site_sk,ws_ext_sales_price,ws_net_profit,wr_return_amt,wr_net_loss]
-                                                                    BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                      Project [ws_sold_date_sk,ws_web_site_sk,ws_ext_sales_price,ws_net_profit,wr_return_amt,wr_net_loss]
-                                                                        BroadcastHashJoin [ws_promo_sk,p_promo_sk]
-                                                                          Project [ws_sold_date_sk,ws_web_site_sk,ws_promo_sk,ws_ext_sales_price,ws_net_profit,wr_return_amt,wr_net_loss]
-                                                                            BroadcastHashJoin [ws_item_sk,i_item_sk]
-                                                                              Project [ws_sold_date_sk,ws_item_sk,ws_web_site_sk,ws_promo_sk,ws_ext_sales_price,ws_net_profit,wr_return_amt,wr_net_loss]
-                                                                                InputAdapter
-                                                                                  SortMergeJoin [ws_item_sk,ws_order_number,wr_item_sk,wr_order_number]
-                                                                                    WholeStageCodegen (22)
-                                                                                      Sort [ws_item_sk,ws_order_number]
-                                                                                        InputAdapter
-                                                                                          Exchange [ws_item_sk,ws_order_number] #16
-                                                                                            WholeStageCodegen (21)
-                                                                                              Filter [ws_sold_date_sk,ws_web_site_sk,ws_item_sk,ws_promo_sk]
-                                                                                                ColumnarToRow
-                                                                                                  InputAdapter
-                                                                                                    Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk,ws_web_site_sk,ws_promo_sk,ws_order_number,ws_ext_sales_price,ws_net_profit]
-                                                                                    WholeStageCodegen (24)
-                                                                                      Sort [wr_item_sk,wr_order_number]
-                                                                                        InputAdapter
-                                                                                          Exchange [wr_item_sk,wr_order_number] #17
-                                                                                            WholeStageCodegen (23)
-                                                                                              Filter [wr_item_sk,wr_order_number]
-                                                                                                ColumnarToRow
-                                                                                                  InputAdapter
-                                                                                                    Scan parquet default.web_returns [wr_item_sk,wr_order_number,wr_return_amt,wr_net_loss]
-                                                                              InputAdapter
-                                                                                ReusedExchange [i_item_sk] #7
-                                                                          InputAdapter
-                                                                            ReusedExchange [p_promo_sk] #8
-                                                                      InputAdapter
-                                                                        ReusedExchange [d_date_sk] #9
+                                                        BroadcastExchange #8
+                                                          WholeStageCodegen (7)
+                                                            Project [d_date_sk]
+                                                              Filter [d_date,d_date_sk]
+                                                                ColumnarToRow
                                                                   InputAdapter
-                                                                    BroadcastExchange #18
-                                                                      WholeStageCodegen (28)
-                                                                        Filter [web_site_sk]
-                                                                          ColumnarToRow
-                                                                            InputAdapter
-                                                                              Scan parquet default.web_site [web_site_sk,web_site_id]
-                                  WholeStageCodegen (65)
-                                    HashAggregate [channel,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),id,sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                                                                    Scan parquet default.date_dim [d_date_sk,d_date]
+                                                  InputAdapter
+                                                    BroadcastExchange #9
+                                                      WholeStageCodegen (8)
+                                                        Filter [s_store_sk]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet default.store [s_store_sk,s_store_id]
+                                  WholeStageCodegen (20)
+                                    HashAggregate [cp_catalog_page_id,sum,sum,isEmpty,sum,isEmpty] [sum(UnscaledValue(cs_ext_sales_price)),sum(coalesce(cast(cr_return_amount as decimal(12,2)), 0.00)),sum(CheckOverflow((promote_precision(cast(cs_net_profit as decimal(13,2))) - promote_precision(cast(coalesce(cast(cr_net_loss as decimal(12,2)), 0.00) as decimal(13,2)))), DecimalType(13,2), true)),channel,id,sales,returns,profit,sum,sum,isEmpty,sum,isEmpty]
                                       InputAdapter
-                                        Exchange [channel] #19
-                                          WholeStageCodegen (64)
-                                            HashAggregate [channel,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
-                                              HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
-                                                InputAdapter
-                                                  ReusedExchange [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] #3
-                  WholeStageCodegen (100)
+                                        Exchange [cp_catalog_page_id] #10
+                                          WholeStageCodegen (19)
+                                            HashAggregate [cp_catalog_page_id,cs_ext_sales_price,cr_return_amount,cs_net_profit,cr_net_loss] [sum,sum,isEmpty,sum,isEmpty,sum,sum,isEmpty,sum,isEmpty]
+                                              Project [cs_ext_sales_price,cs_net_profit,cr_return_amount,cr_net_loss,cp_catalog_page_id]
+                                                BroadcastHashJoin [cs_catalog_page_sk,cp_catalog_page_sk]
+                                                  Project [cs_catalog_page_sk,cs_ext_sales_price,cs_net_profit,cr_return_amount,cr_net_loss]
+                                                    BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                      Project [cs_sold_date_sk,cs_catalog_page_sk,cs_ext_sales_price,cs_net_profit,cr_return_amount,cr_net_loss]
+                                                        BroadcastHashJoin [cs_promo_sk,p_promo_sk]
+                                                          Project [cs_sold_date_sk,cs_catalog_page_sk,cs_promo_sk,cs_ext_sales_price,cs_net_profit,cr_return_amount,cr_net_loss]
+                                                            BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                              Project [cs_sold_date_sk,cs_catalog_page_sk,cs_item_sk,cs_promo_sk,cs_ext_sales_price,cs_net_profit,cr_return_amount,cr_net_loss]
+                                                                InputAdapter
+                                                                  SortMergeJoin [cs_item_sk,cs_order_number,cr_item_sk,cr_order_number]
+                                                                    WholeStageCodegen (12)
+                                                                      Sort [cs_item_sk,cs_order_number]
+                                                                        InputAdapter
+                                                                          Exchange [cs_item_sk,cs_order_number] #11
+                                                                            WholeStageCodegen (11)
+                                                                              Filter [cs_sold_date_sk,cs_catalog_page_sk,cs_item_sk,cs_promo_sk]
+                                                                                ColumnarToRow
+                                                                                  InputAdapter
+                                                                                    Scan parquet default.catalog_sales [cs_sold_date_sk,cs_catalog_page_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_ext_sales_price,cs_net_profit]
+                                                                    WholeStageCodegen (14)
+                                                                      Sort [cr_item_sk,cr_order_number]
+                                                                        InputAdapter
+                                                                          Exchange [cr_item_sk,cr_order_number] #12
+                                                                            WholeStageCodegen (13)
+                                                                              Filter [cr_item_sk,cr_order_number]
+                                                                                ColumnarToRow
+                                                                                  InputAdapter
+                                                                                    Scan parquet default.catalog_returns [cr_item_sk,cr_order_number,cr_return_amount,cr_net_loss]
+                                                              InputAdapter
+                                                                ReusedExchange [i_item_sk] #6
+                                                          InputAdapter
+                                                            ReusedExchange [p_promo_sk] #7
+                                                      InputAdapter
+                                                        ReusedExchange [d_date_sk] #8
+                                                  InputAdapter
+                                                    BroadcastExchange #13
+                                                      WholeStageCodegen (18)
+                                                        Filter [cp_catalog_page_sk]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet default.catalog_page [cp_catalog_page_sk,cp_catalog_page_id]
+                                  WholeStageCodegen (30)
+                                    HashAggregate [web_site_id,sum,sum,isEmpty,sum,isEmpty] [sum(UnscaledValue(ws_ext_sales_price)),sum(coalesce(cast(wr_return_amt as decimal(12,2)), 0.00)),sum(CheckOverflow((promote_precision(cast(ws_net_profit as decimal(13,2))) - promote_precision(cast(coalesce(cast(wr_net_loss as decimal(12,2)), 0.00) as decimal(13,2)))), DecimalType(13,2), true)),channel,id,sales,returns,profit,sum,sum,isEmpty,sum,isEmpty]
+                                      InputAdapter
+                                        Exchange [web_site_id] #14
+                                          WholeStageCodegen (29)
+                                            HashAggregate [web_site_id,ws_ext_sales_price,wr_return_amt,ws_net_profit,wr_net_loss] [sum,sum,isEmpty,sum,isEmpty,sum,sum,isEmpty,sum,isEmpty]
+                                              Project [ws_ext_sales_price,ws_net_profit,wr_return_amt,wr_net_loss,web_site_id]
+                                                BroadcastHashJoin [ws_web_site_sk,web_site_sk]
+                                                  Project [ws_web_site_sk,ws_ext_sales_price,ws_net_profit,wr_return_amt,wr_net_loss]
+                                                    BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                      Project [ws_sold_date_sk,ws_web_site_sk,ws_ext_sales_price,ws_net_profit,wr_return_amt,wr_net_loss]
+                                                        BroadcastHashJoin [ws_promo_sk,p_promo_sk]
+                                                          Project [ws_sold_date_sk,ws_web_site_sk,ws_promo_sk,ws_ext_sales_price,ws_net_profit,wr_return_amt,wr_net_loss]
+                                                            BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                              Project [ws_sold_date_sk,ws_item_sk,ws_web_site_sk,ws_promo_sk,ws_ext_sales_price,ws_net_profit,wr_return_amt,wr_net_loss]
+                                                                InputAdapter
+                                                                  SortMergeJoin [ws_item_sk,ws_order_number,wr_item_sk,wr_order_number]
+                                                                    WholeStageCodegen (22)
+                                                                      Sort [ws_item_sk,ws_order_number]
+                                                                        InputAdapter
+                                                                          Exchange [ws_item_sk,ws_order_number] #15
+                                                                            WholeStageCodegen (21)
+                                                                              Filter [ws_sold_date_sk,ws_web_site_sk,ws_item_sk,ws_promo_sk]
+                                                                                ColumnarToRow
+                                                                                  InputAdapter
+                                                                                    Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk,ws_web_site_sk,ws_promo_sk,ws_order_number,ws_ext_sales_price,ws_net_profit]
+                                                                    WholeStageCodegen (24)
+                                                                      Sort [wr_item_sk,wr_order_number]
+                                                                        InputAdapter
+                                                                          Exchange [wr_item_sk,wr_order_number] #16
+                                                                            WholeStageCodegen (23)
+                                                                              Filter [wr_item_sk,wr_order_number]
+                                                                                ColumnarToRow
+                                                                                  InputAdapter
+                                                                                    Scan parquet default.web_returns [wr_item_sk,wr_order_number,wr_return_amt,wr_net_loss]
+                                                              InputAdapter
+                                                                ReusedExchange [i_item_sk] #6
+                                                          InputAdapter
+                                                            ReusedExchange [p_promo_sk] #7
+                                                      InputAdapter
+                                                        ReusedExchange [d_date_sk] #8
+                                                  InputAdapter
+                                                    BroadcastExchange #17
+                                                      WholeStageCodegen (28)
+                                                        Filter [web_site_sk]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet default.web_site [web_site_sk,web_site_id]
+                  WholeStageCodegen (65)
+                    HashAggregate [channel,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),id,sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                      InputAdapter
+                        Exchange [channel] #18
+                          WholeStageCodegen (64)
+                            HashAggregate [channel,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                              HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                                InputAdapter
+                                  ReusedExchange [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] #2
+                  WholeStageCodegen (98)
                     HashAggregate [sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),channel,id,sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                       InputAdapter
-                        Exchange #20
-                          WholeStageCodegen (99)
+                        Exchange #19
+                          WholeStageCodegen (97)
                             HashAggregate [sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                               HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                                 InputAdapter
-                                  ReusedExchange [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] #3
+                                  ReusedExchange [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] #2

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q80a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q80a/explain.txt
@@ -1,120 +1,116 @@
 == Physical Plan ==
-TakeOrderedAndProject (116)
-+- * HashAggregate (115)
-   +- Exchange (114)
-      +- * HashAggregate (113)
-         +- Union (112)
-            :- * HashAggregate (106)
-            :  +- Exchange (105)
-            :     +- * HashAggregate (104)
-            :        +- Union (103)
-            :           :- * HashAggregate (97)
-            :           :  +- Exchange (96)
-            :           :     +- * HashAggregate (95)
-            :           :        +- Union (94)
-            :           :           :- * HashAggregate (39)
-            :           :           :  +- Exchange (38)
-            :           :           :     +- * HashAggregate (37)
-            :           :           :        +- * Project (36)
-            :           :           :           +- * BroadcastHashJoin Inner BuildRight (35)
-            :           :           :              :- * Project (29)
-            :           :           :              :  +- * BroadcastHashJoin Inner BuildRight (28)
-            :           :           :              :     :- * Project (22)
-            :           :           :              :     :  +- * BroadcastHashJoin Inner BuildRight (21)
-            :           :           :              :     :     :- * Project (16)
-            :           :           :              :     :     :  +- * BroadcastHashJoin Inner BuildRight (15)
-            :           :           :              :     :     :     :- * Project (9)
-            :           :           :              :     :     :     :  +- * BroadcastHashJoin LeftOuter BuildRight (8)
-            :           :           :              :     :     :     :     :- * Filter (3)
-            :           :           :              :     :     :     :     :  +- * ColumnarToRow (2)
-            :           :           :              :     :     :     :     :     +- Scan parquet default.store_sales (1)
-            :           :           :              :     :     :     :     +- BroadcastExchange (7)
-            :           :           :              :     :     :     :        +- * Filter (6)
-            :           :           :              :     :     :     :           +- * ColumnarToRow (5)
-            :           :           :              :     :     :     :              +- Scan parquet default.store_returns (4)
-            :           :           :              :     :     :     +- BroadcastExchange (14)
-            :           :           :              :     :     :        +- * Project (13)
-            :           :           :              :     :     :           +- * Filter (12)
-            :           :           :              :     :     :              +- * ColumnarToRow (11)
-            :           :           :              :     :     :                 +- Scan parquet default.date_dim (10)
-            :           :           :              :     :     +- BroadcastExchange (20)
-            :           :           :              :     :        +- * Filter (19)
-            :           :           :              :     :           +- * ColumnarToRow (18)
-            :           :           :              :     :              +- Scan parquet default.store (17)
-            :           :           :              :     +- BroadcastExchange (27)
-            :           :           :              :        +- * Project (26)
-            :           :           :              :           +- * Filter (25)
-            :           :           :              :              +- * ColumnarToRow (24)
-            :           :           :              :                 +- Scan parquet default.item (23)
-            :           :           :              +- BroadcastExchange (34)
-            :           :           :                 +- * Project (33)
-            :           :           :                    +- * Filter (32)
-            :           :           :                       +- * ColumnarToRow (31)
-            :           :           :                          +- Scan parquet default.promotion (30)
-            :           :           :- * HashAggregate (66)
-            :           :           :  +- Exchange (65)
-            :           :           :     +- * HashAggregate (64)
-            :           :           :        +- * Project (63)
-            :           :           :           +- * BroadcastHashJoin Inner BuildRight (62)
-            :           :           :              :- * Project (60)
-            :           :           :              :  +- * BroadcastHashJoin Inner BuildRight (59)
-            :           :           :              :     :- * Project (57)
-            :           :           :              :     :  +- * BroadcastHashJoin Inner BuildRight (56)
-            :           :           :              :     :     :- * Project (51)
-            :           :           :              :     :     :  +- * BroadcastHashJoin Inner BuildRight (50)
-            :           :           :              :     :     :     :- * Project (48)
-            :           :           :              :     :     :     :  +- * BroadcastHashJoin LeftOuter BuildRight (47)
-            :           :           :              :     :     :     :     :- * Filter (42)
-            :           :           :              :     :     :     :     :  +- * ColumnarToRow (41)
-            :           :           :              :     :     :     :     :     +- Scan parquet default.catalog_sales (40)
-            :           :           :              :     :     :     :     +- BroadcastExchange (46)
-            :           :           :              :     :     :     :        +- * Filter (45)
-            :           :           :              :     :     :     :           +- * ColumnarToRow (44)
-            :           :           :              :     :     :     :              +- Scan parquet default.catalog_returns (43)
-            :           :           :              :     :     :     +- ReusedExchange (49)
-            :           :           :              :     :     +- BroadcastExchange (55)
-            :           :           :              :     :        +- * Filter (54)
-            :           :           :              :     :           +- * ColumnarToRow (53)
-            :           :           :              :     :              +- Scan parquet default.catalog_page (52)
-            :           :           :              :     +- ReusedExchange (58)
-            :           :           :              +- ReusedExchange (61)
-            :           :           +- * HashAggregate (93)
-            :           :              +- Exchange (92)
-            :           :                 +- * HashAggregate (91)
-            :           :                    +- * Project (90)
-            :           :                       +- * BroadcastHashJoin Inner BuildRight (89)
-            :           :                          :- * Project (87)
-            :           :                          :  +- * BroadcastHashJoin Inner BuildRight (86)
-            :           :                          :     :- * Project (84)
-            :           :                          :     :  +- * BroadcastHashJoin Inner BuildRight (83)
-            :           :                          :     :     :- * Project (78)
-            :           :                          :     :     :  +- * BroadcastHashJoin Inner BuildRight (77)
-            :           :                          :     :     :     :- * Project (75)
-            :           :                          :     :     :     :  +- * BroadcastHashJoin LeftOuter BuildRight (74)
-            :           :                          :     :     :     :     :- * Filter (69)
-            :           :                          :     :     :     :     :  +- * ColumnarToRow (68)
-            :           :                          :     :     :     :     :     +- Scan parquet default.web_sales (67)
-            :           :                          :     :     :     :     +- BroadcastExchange (73)
-            :           :                          :     :     :     :        +- * Filter (72)
-            :           :                          :     :     :     :           +- * ColumnarToRow (71)
-            :           :                          :     :     :     :              +- Scan parquet default.web_returns (70)
-            :           :                          :     :     :     +- ReusedExchange (76)
-            :           :                          :     :     +- BroadcastExchange (82)
-            :           :                          :     :        +- * Filter (81)
-            :           :                          :     :           +- * ColumnarToRow (80)
-            :           :                          :     :              +- Scan parquet default.web_site (79)
-            :           :                          :     +- ReusedExchange (85)
-            :           :                          +- ReusedExchange (88)
-            :           +- * HashAggregate (102)
-            :              +- Exchange (101)
-            :                 +- * HashAggregate (100)
-            :                    +- * HashAggregate (99)
-            :                       +- ReusedExchange (98)
-            +- * HashAggregate (111)
-               +- Exchange (110)
-                  +- * HashAggregate (109)
-                     +- * HashAggregate (108)
-                        +- ReusedExchange (107)
+TakeOrderedAndProject (112)
++- * HashAggregate (111)
+   +- Exchange (110)
+      +- * HashAggregate (109)
+         +- Union (108)
+            :- * HashAggregate (97)
+            :  +- Exchange (96)
+            :     +- * HashAggregate (95)
+            :        +- Union (94)
+            :           :- * HashAggregate (39)
+            :           :  +- Exchange (38)
+            :           :     +- * HashAggregate (37)
+            :           :        +- * Project (36)
+            :           :           +- * BroadcastHashJoin Inner BuildRight (35)
+            :           :              :- * Project (29)
+            :           :              :  +- * BroadcastHashJoin Inner BuildRight (28)
+            :           :              :     :- * Project (22)
+            :           :              :     :  +- * BroadcastHashJoin Inner BuildRight (21)
+            :           :              :     :     :- * Project (16)
+            :           :              :     :     :  +- * BroadcastHashJoin Inner BuildRight (15)
+            :           :              :     :     :     :- * Project (9)
+            :           :              :     :     :     :  +- * BroadcastHashJoin LeftOuter BuildRight (8)
+            :           :              :     :     :     :     :- * Filter (3)
+            :           :              :     :     :     :     :  +- * ColumnarToRow (2)
+            :           :              :     :     :     :     :     +- Scan parquet default.store_sales (1)
+            :           :              :     :     :     :     +- BroadcastExchange (7)
+            :           :              :     :     :     :        +- * Filter (6)
+            :           :              :     :     :     :           +- * ColumnarToRow (5)
+            :           :              :     :     :     :              +- Scan parquet default.store_returns (4)
+            :           :              :     :     :     +- BroadcastExchange (14)
+            :           :              :     :     :        +- * Project (13)
+            :           :              :     :     :           +- * Filter (12)
+            :           :              :     :     :              +- * ColumnarToRow (11)
+            :           :              :     :     :                 +- Scan parquet default.date_dim (10)
+            :           :              :     :     +- BroadcastExchange (20)
+            :           :              :     :        +- * Filter (19)
+            :           :              :     :           +- * ColumnarToRow (18)
+            :           :              :     :              +- Scan parquet default.store (17)
+            :           :              :     +- BroadcastExchange (27)
+            :           :              :        +- * Project (26)
+            :           :              :           +- * Filter (25)
+            :           :              :              +- * ColumnarToRow (24)
+            :           :              :                 +- Scan parquet default.item (23)
+            :           :              +- BroadcastExchange (34)
+            :           :                 +- * Project (33)
+            :           :                    +- * Filter (32)
+            :           :                       +- * ColumnarToRow (31)
+            :           :                          +- Scan parquet default.promotion (30)
+            :           :- * HashAggregate (66)
+            :           :  +- Exchange (65)
+            :           :     +- * HashAggregate (64)
+            :           :        +- * Project (63)
+            :           :           +- * BroadcastHashJoin Inner BuildRight (62)
+            :           :              :- * Project (60)
+            :           :              :  +- * BroadcastHashJoin Inner BuildRight (59)
+            :           :              :     :- * Project (57)
+            :           :              :     :  +- * BroadcastHashJoin Inner BuildRight (56)
+            :           :              :     :     :- * Project (51)
+            :           :              :     :     :  +- * BroadcastHashJoin Inner BuildRight (50)
+            :           :              :     :     :     :- * Project (48)
+            :           :              :     :     :     :  +- * BroadcastHashJoin LeftOuter BuildRight (47)
+            :           :              :     :     :     :     :- * Filter (42)
+            :           :              :     :     :     :     :  +- * ColumnarToRow (41)
+            :           :              :     :     :     :     :     +- Scan parquet default.catalog_sales (40)
+            :           :              :     :     :     :     +- BroadcastExchange (46)
+            :           :              :     :     :     :        +- * Filter (45)
+            :           :              :     :     :     :           +- * ColumnarToRow (44)
+            :           :              :     :     :     :              +- Scan parquet default.catalog_returns (43)
+            :           :              :     :     :     +- ReusedExchange (49)
+            :           :              :     :     +- BroadcastExchange (55)
+            :           :              :     :        +- * Filter (54)
+            :           :              :     :           +- * ColumnarToRow (53)
+            :           :              :     :              +- Scan parquet default.catalog_page (52)
+            :           :              :     +- ReusedExchange (58)
+            :           :              +- ReusedExchange (61)
+            :           +- * HashAggregate (93)
+            :              +- Exchange (92)
+            :                 +- * HashAggregate (91)
+            :                    +- * Project (90)
+            :                       +- * BroadcastHashJoin Inner BuildRight (89)
+            :                          :- * Project (87)
+            :                          :  +- * BroadcastHashJoin Inner BuildRight (86)
+            :                          :     :- * Project (84)
+            :                          :     :  +- * BroadcastHashJoin Inner BuildRight (83)
+            :                          :     :     :- * Project (78)
+            :                          :     :     :  +- * BroadcastHashJoin Inner BuildRight (77)
+            :                          :     :     :     :- * Project (75)
+            :                          :     :     :     :  +- * BroadcastHashJoin LeftOuter BuildRight (74)
+            :                          :     :     :     :     :- * Filter (69)
+            :                          :     :     :     :     :  +- * ColumnarToRow (68)
+            :                          :     :     :     :     :     +- Scan parquet default.web_sales (67)
+            :                          :     :     :     :     +- BroadcastExchange (73)
+            :                          :     :     :     :        +- * Filter (72)
+            :                          :     :     :     :           +- * ColumnarToRow (71)
+            :                          :     :     :     :              +- Scan parquet default.web_returns (70)
+            :                          :     :     :     +- ReusedExchange (76)
+            :                          :     :     +- BroadcastExchange (82)
+            :                          :     :        +- * Filter (81)
+            :                          :     :           +- * ColumnarToRow (80)
+            :                          :     :              +- Scan parquet default.web_site (79)
+            :                          :     +- ReusedExchange (85)
+            :                          +- ReusedExchange (88)
+            :- * HashAggregate (102)
+            :  +- Exchange (101)
+            :     +- * HashAggregate (100)
+            :        +- * HashAggregate (99)
+            :           +- ReusedExchange (98)
+            +- * HashAggregate (107)
+               +- Exchange (106)
+                  +- * HashAggregate (105)
+                     +- * HashAggregate (104)
+                        +- ReusedExchange (103)
 
 
 (1) Scan parquet default.store_sales
@@ -287,7 +283,7 @@ Results [6]: [s_store_id#17, sum#30, sum#31, isEmpty#32, sum#33, isEmpty#34]
 
 (38) Exchange
 Input [6]: [s_store_id#17, sum#30, sum#31, isEmpty#32, sum#33, isEmpty#34]
-Arguments: hashpartitioning(s_store_id#17, 5), true, [id=#35]
+Arguments: hashpartitioning(s_store_id#17, 5), ENSURE_REQUIREMENTS, [id=#35]
 
 (39) HashAggregate [codegen id : 7]
 Input [6]: [s_store_id#17, sum#30, sum#31, isEmpty#32, sum#33, isEmpty#34]
@@ -409,7 +405,7 @@ Results [6]: [cp_catalog_page_id#57, sum#64, sum#65, isEmpty#66, sum#67, isEmpty
 
 (65) Exchange
 Input [6]: [cp_catalog_page_id#57, sum#64, sum#65, isEmpty#66, sum#67, isEmpty#68]
-Arguments: hashpartitioning(cp_catalog_page_id#57, 5), true, [id=#69]
+Arguments: hashpartitioning(cp_catalog_page_id#57, 5), ENSURE_REQUIREMENTS, [id=#69]
 
 (66) HashAggregate [codegen id : 14]
 Input [6]: [cp_catalog_page_id#57, sum#64, sum#65, isEmpty#66, sum#67, isEmpty#68]
@@ -531,7 +527,7 @@ Results [6]: [web_site_id#91, sum#98, sum#99, isEmpty#100, sum#101, isEmpty#102]
 
 (92) Exchange
 Input [6]: [web_site_id#91, sum#98, sum#99, isEmpty#100, sum#101, isEmpty#102]
-Arguments: hashpartitioning(web_site_id#91, 5), true, [id=#103]
+Arguments: hashpartitioning(web_site_id#91, 5), ENSURE_REQUIREMENTS, [id=#103]
 
 (93) HashAggregate [codegen id : 21]
 Input [6]: [web_site_id#91, sum#98, sum#99, isEmpty#100, sum#101, isEmpty#102]
@@ -551,7 +547,7 @@ Results [8]: [channel#39, id#40, sum#118, isEmpty#119, sum#120, isEmpty#121, sum
 
 (96) Exchange
 Input [8]: [channel#39, id#40, sum#118, isEmpty#119, sum#120, isEmpty#121, sum#122, isEmpty#123]
-Arguments: hashpartitioning(channel#39, id#40, 5), true, [id=#124]
+Arguments: hashpartitioning(channel#39, id#40, 5), ENSURE_REQUIREMENTS, [id=#124]
 
 (97) HashAggregate [codegen id : 23]
 Input [8]: [channel#39, id#40, sum#118, isEmpty#119, sum#120, isEmpty#121, sum#122, isEmpty#123]
@@ -579,7 +575,7 @@ Results [7]: [channel#39, sum#149, isEmpty#150, sum#151, isEmpty#152, sum#153, i
 
 (101) Exchange
 Input [7]: [channel#39, sum#149, isEmpty#150, sum#151, isEmpty#152, sum#153, isEmpty#154]
-Arguments: hashpartitioning(channel#39, 5), true, [id=#155]
+Arguments: hashpartitioning(channel#39, 5), ENSURE_REQUIREMENTS, [id=#155]
 
 (102) HashAggregate [codegen id : 47]
 Input [7]: [channel#39, sum#149, isEmpty#150, sum#151, isEmpty#152, sum#153, isEmpty#154]
@@ -588,75 +584,55 @@ Functions [3]: [sum(sales#140), sum(returns#141), sum(profit#142)]
 Aggregate Attributes [3]: [sum(sales#140)#156, sum(returns#141)#157, sum(profit#142)#158]
 Results [5]: [channel#39, null AS id#159, sum(sales#140)#156 AS sales#160, sum(returns#141)#157 AS returns#161, sum(profit#142)#158 AS profit#162]
 
-(103) Union
+(103) ReusedExchange [Reuses operator id: 96]
+Output [8]: [channel#39, id#40, sum#163, isEmpty#164, sum#165, isEmpty#166, sum#167, isEmpty#168]
 
-(104) HashAggregate [codegen id : 48]
-Input [5]: [channel#39, id#40, sales#128, returns#129, profit#130]
-Keys [5]: [channel#39, id#40, sales#128, returns#129, profit#130]
-Functions: []
-Aggregate Attributes: []
-Results [5]: [channel#39, id#40, sales#128, returns#129, profit#130]
-
-(105) Exchange
-Input [5]: [channel#39, id#40, sales#128, returns#129, profit#130]
-Arguments: hashpartitioning(channel#39, id#40, sales#128, returns#129, profit#130, 5), true, [id=#163]
-
-(106) HashAggregate [codegen id : 49]
-Input [5]: [channel#39, id#40, sales#128, returns#129, profit#130]
-Keys [5]: [channel#39, id#40, sales#128, returns#129, profit#130]
-Functions: []
-Aggregate Attributes: []
-Results [5]: [channel#39, id#40, sales#128, returns#129, profit#130]
-
-(107) ReusedExchange [Reuses operator id: 96]
-Output [8]: [channel#39, id#40, sum#164, isEmpty#165, sum#166, isEmpty#167, sum#168, isEmpty#169]
-
-(108) HashAggregate [codegen id : 72]
-Input [8]: [channel#39, id#40, sum#164, isEmpty#165, sum#166, isEmpty#167, sum#168, isEmpty#169]
+(104) HashAggregate [codegen id : 70]
+Input [8]: [channel#39, id#40, sum#163, isEmpty#164, sum#165, isEmpty#166, sum#167, isEmpty#168]
 Keys [2]: [channel#39, id#40]
 Functions [3]: [sum(sales#41), sum(returns#42), sum(profit#43)]
-Aggregate Attributes [3]: [sum(sales#41)#170, sum(returns#42)#171, sum(profit#43)#172]
-Results [3]: [sum(sales#41)#170 AS sales#140, sum(returns#42)#171 AS returns#141, sum(profit#43)#172 AS profit#142]
+Aggregate Attributes [3]: [sum(sales#41)#169, sum(returns#42)#170, sum(profit#43)#171]
+Results [3]: [sum(sales#41)#169 AS sales#140, sum(returns#42)#170 AS returns#141, sum(profit#43)#171 AS profit#142]
 
-(109) HashAggregate [codegen id : 72]
+(105) HashAggregate [codegen id : 70]
 Input [3]: [sales#140, returns#141, profit#142]
 Keys: []
 Functions [3]: [partial_sum(sales#140), partial_sum(returns#141), partial_sum(profit#142)]
-Aggregate Attributes [6]: [sum#173, isEmpty#174, sum#175, isEmpty#176, sum#177, isEmpty#178]
-Results [6]: [sum#179, isEmpty#180, sum#181, isEmpty#182, sum#183, isEmpty#184]
+Aggregate Attributes [6]: [sum#172, isEmpty#173, sum#174, isEmpty#175, sum#176, isEmpty#177]
+Results [6]: [sum#178, isEmpty#179, sum#180, isEmpty#181, sum#182, isEmpty#183]
 
-(110) Exchange
-Input [6]: [sum#179, isEmpty#180, sum#181, isEmpty#182, sum#183, isEmpty#184]
-Arguments: SinglePartition, true, [id=#185]
+(106) Exchange
+Input [6]: [sum#178, isEmpty#179, sum#180, isEmpty#181, sum#182, isEmpty#183]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#184]
 
-(111) HashAggregate [codegen id : 73]
-Input [6]: [sum#179, isEmpty#180, sum#181, isEmpty#182, sum#183, isEmpty#184]
+(107) HashAggregate [codegen id : 71]
+Input [6]: [sum#178, isEmpty#179, sum#180, isEmpty#181, sum#182, isEmpty#183]
 Keys: []
 Functions [3]: [sum(sales#140), sum(returns#141), sum(profit#142)]
-Aggregate Attributes [3]: [sum(sales#140)#186, sum(returns#141)#187, sum(profit#142)#188]
-Results [5]: [null AS channel#189, null AS id#190, sum(sales#140)#186 AS sales#191, sum(returns#141)#187 AS returns#192, sum(profit#142)#188 AS profit#193]
+Aggregate Attributes [3]: [sum(sales#140)#185, sum(returns#141)#186, sum(profit#142)#187]
+Results [5]: [null AS channel#188, null AS id#189, sum(sales#140)#185 AS sales#190, sum(returns#141)#186 AS returns#191, sum(profit#142)#187 AS profit#192]
 
-(112) Union
+(108) Union
 
-(113) HashAggregate [codegen id : 74]
+(109) HashAggregate [codegen id : 72]
 Input [5]: [channel#39, id#40, sales#128, returns#129, profit#130]
 Keys [5]: [channel#39, id#40, sales#128, returns#129, profit#130]
 Functions: []
 Aggregate Attributes: []
 Results [5]: [channel#39, id#40, sales#128, returns#129, profit#130]
 
-(114) Exchange
+(110) Exchange
 Input [5]: [channel#39, id#40, sales#128, returns#129, profit#130]
-Arguments: hashpartitioning(channel#39, id#40, sales#128, returns#129, profit#130, 5), true, [id=#194]
+Arguments: hashpartitioning(channel#39, id#40, sales#128, returns#129, profit#130, 5), ENSURE_REQUIREMENTS, [id=#193]
 
-(115) HashAggregate [codegen id : 75]
+(111) HashAggregate [codegen id : 73]
 Input [5]: [channel#39, id#40, sales#128, returns#129, profit#130]
 Keys [5]: [channel#39, id#40, sales#128, returns#129, profit#130]
 Functions: []
 Aggregate Attributes: []
 Results [5]: [channel#39, id#40, sales#128, returns#129, profit#130]
 
-(116) TakeOrderedAndProject
+(112) TakeOrderedAndProject
 Input [5]: [channel#39, id#40, sales#128, returns#129, profit#130]
 Arguments: 100, [channel#39 ASC NULLS FIRST, id#40 ASC NULLS FIRST], [channel#39, id#40, sales#128, returns#129, profit#130]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q80a/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q80a/simplified.txt
@@ -1,181 +1,173 @@
 TakeOrderedAndProject [channel,id,sales,returns,profit]
-  WholeStageCodegen (75)
+  WholeStageCodegen (73)
     HashAggregate [channel,id,sales,returns,profit]
       InputAdapter
         Exchange [channel,id,sales,returns,profit] #1
-          WholeStageCodegen (74)
+          WholeStageCodegen (72)
             HashAggregate [channel,id,sales,returns,profit]
               InputAdapter
                 Union
-                  WholeStageCodegen (49)
-                    HashAggregate [channel,id,sales,returns,profit]
+                  WholeStageCodegen (23)
+                    HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                       InputAdapter
-                        Exchange [channel,id,sales,returns,profit] #2
-                          WholeStageCodegen (48)
-                            HashAggregate [channel,id,sales,returns,profit]
+                        Exchange [channel,id] #2
+                          WholeStageCodegen (22)
+                            HashAggregate [channel,id,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                               InputAdapter
                                 Union
-                                  WholeStageCodegen (23)
-                                    HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                                  WholeStageCodegen (7)
+                                    HashAggregate [s_store_id,sum,sum,isEmpty,sum,isEmpty] [sum(UnscaledValue(ss_ext_sales_price)),sum(coalesce(cast(sr_return_amt as decimal(12,2)), 0.00)),sum(CheckOverflow((promote_precision(cast(ss_net_profit as decimal(13,2))) - promote_precision(cast(coalesce(cast(sr_net_loss as decimal(12,2)), 0.00) as decimal(13,2)))), DecimalType(13,2), true)),channel,id,sales,returns,profit,sum,sum,isEmpty,sum,isEmpty]
                                       InputAdapter
-                                        Exchange [channel,id] #3
-                                          WholeStageCodegen (22)
-                                            HashAggregate [channel,id,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
-                                              InputAdapter
-                                                Union
-                                                  WholeStageCodegen (7)
-                                                    HashAggregate [s_store_id,sum,sum,isEmpty,sum,isEmpty] [sum(UnscaledValue(ss_ext_sales_price)),sum(coalesce(cast(sr_return_amt as decimal(12,2)), 0.00)),sum(CheckOverflow((promote_precision(cast(ss_net_profit as decimal(13,2))) - promote_precision(cast(coalesce(cast(sr_net_loss as decimal(12,2)), 0.00) as decimal(13,2)))), DecimalType(13,2), true)),channel,id,sales,returns,profit,sum,sum,isEmpty,sum,isEmpty]
-                                                      InputAdapter
-                                                        Exchange [s_store_id] #4
-                                                          WholeStageCodegen (6)
-                                                            HashAggregate [s_store_id,ss_ext_sales_price,sr_return_amt,ss_net_profit,sr_net_loss] [sum,sum,isEmpty,sum,isEmpty,sum,sum,isEmpty,sum,isEmpty]
-                                                              Project [ss_ext_sales_price,ss_net_profit,sr_return_amt,sr_net_loss,s_store_id]
-                                                                BroadcastHashJoin [ss_promo_sk,p_promo_sk]
-                                                                  Project [ss_promo_sk,ss_ext_sales_price,ss_net_profit,sr_return_amt,sr_net_loss,s_store_id]
-                                                                    BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                                      Project [ss_item_sk,ss_promo_sk,ss_ext_sales_price,ss_net_profit,sr_return_amt,sr_net_loss,s_store_id]
-                                                                        BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                                          Project [ss_item_sk,ss_store_sk,ss_promo_sk,ss_ext_sales_price,ss_net_profit,sr_return_amt,sr_net_loss]
-                                                                            BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                              Project [ss_sold_date_sk,ss_item_sk,ss_store_sk,ss_promo_sk,ss_ext_sales_price,ss_net_profit,sr_return_amt,sr_net_loss]
-                                                                                BroadcastHashJoin [ss_item_sk,ss_ticket_number,sr_item_sk,sr_ticket_number]
-                                                                                  Filter [ss_sold_date_sk,ss_store_sk,ss_item_sk,ss_promo_sk]
-                                                                                    ColumnarToRow
-                                                                                      InputAdapter
-                                                                                        Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk,ss_store_sk,ss_promo_sk,ss_ticket_number,ss_ext_sales_price,ss_net_profit]
-                                                                                  InputAdapter
-                                                                                    BroadcastExchange #5
-                                                                                      WholeStageCodegen (1)
-                                                                                        Filter [sr_item_sk,sr_ticket_number]
-                                                                                          ColumnarToRow
-                                                                                            InputAdapter
-                                                                                              Scan parquet default.store_returns [sr_item_sk,sr_ticket_number,sr_return_amt,sr_net_loss]
-                                                                              InputAdapter
-                                                                                BroadcastExchange #6
-                                                                                  WholeStageCodegen (2)
-                                                                                    Project [d_date_sk]
-                                                                                      Filter [d_date,d_date_sk]
-                                                                                        ColumnarToRow
-                                                                                          InputAdapter
-                                                                                            Scan parquet default.date_dim [d_date_sk,d_date]
-                                                                          InputAdapter
-                                                                            BroadcastExchange #7
-                                                                              WholeStageCodegen (3)
-                                                                                Filter [s_store_sk]
-                                                                                  ColumnarToRow
-                                                                                    InputAdapter
-                                                                                      Scan parquet default.store [s_store_sk,s_store_id]
+                                        Exchange [s_store_id] #3
+                                          WholeStageCodegen (6)
+                                            HashAggregate [s_store_id,ss_ext_sales_price,sr_return_amt,ss_net_profit,sr_net_loss] [sum,sum,isEmpty,sum,isEmpty,sum,sum,isEmpty,sum,isEmpty]
+                                              Project [ss_ext_sales_price,ss_net_profit,sr_return_amt,sr_net_loss,s_store_id]
+                                                BroadcastHashJoin [ss_promo_sk,p_promo_sk]
+                                                  Project [ss_promo_sk,ss_ext_sales_price,ss_net_profit,sr_return_amt,sr_net_loss,s_store_id]
+                                                    BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                      Project [ss_item_sk,ss_promo_sk,ss_ext_sales_price,ss_net_profit,sr_return_amt,sr_net_loss,s_store_id]
+                                                        BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                                          Project [ss_item_sk,ss_store_sk,ss_promo_sk,ss_ext_sales_price,ss_net_profit,sr_return_amt,sr_net_loss]
+                                                            BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                              Project [ss_sold_date_sk,ss_item_sk,ss_store_sk,ss_promo_sk,ss_ext_sales_price,ss_net_profit,sr_return_amt,sr_net_loss]
+                                                                BroadcastHashJoin [ss_item_sk,ss_ticket_number,sr_item_sk,sr_ticket_number]
+                                                                  Filter [ss_sold_date_sk,ss_store_sk,ss_item_sk,ss_promo_sk]
+                                                                    ColumnarToRow
                                                                       InputAdapter
-                                                                        BroadcastExchange #8
-                                                                          WholeStageCodegen (4)
-                                                                            Project [i_item_sk]
-                                                                              Filter [i_current_price,i_item_sk]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet default.item [i_item_sk,i_current_price]
+                                                                        Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk,ss_store_sk,ss_promo_sk,ss_ticket_number,ss_ext_sales_price,ss_net_profit]
                                                                   InputAdapter
-                                                                    BroadcastExchange #9
-                                                                      WholeStageCodegen (5)
-                                                                        Project [p_promo_sk]
-                                                                          Filter [p_channel_tv,p_promo_sk]
-                                                                            ColumnarToRow
-                                                                              InputAdapter
-                                                                                Scan parquet default.promotion [p_promo_sk,p_channel_tv]
-                                                  WholeStageCodegen (14)
-                                                    HashAggregate [cp_catalog_page_id,sum,sum,isEmpty,sum,isEmpty] [sum(UnscaledValue(cs_ext_sales_price)),sum(coalesce(cast(cr_return_amount as decimal(12,2)), 0.00)),sum(CheckOverflow((promote_precision(cast(cs_net_profit as decimal(13,2))) - promote_precision(cast(coalesce(cast(cr_net_loss as decimal(12,2)), 0.00) as decimal(13,2)))), DecimalType(13,2), true)),channel,id,sales,returns,profit,sum,sum,isEmpty,sum,isEmpty]
-                                                      InputAdapter
-                                                        Exchange [cp_catalog_page_id] #10
-                                                          WholeStageCodegen (13)
-                                                            HashAggregate [cp_catalog_page_id,cs_ext_sales_price,cr_return_amount,cs_net_profit,cr_net_loss] [sum,sum,isEmpty,sum,isEmpty,sum,sum,isEmpty,sum,isEmpty]
-                                                              Project [cs_ext_sales_price,cs_net_profit,cr_return_amount,cr_net_loss,cp_catalog_page_id]
-                                                                BroadcastHashJoin [cs_promo_sk,p_promo_sk]
-                                                                  Project [cs_promo_sk,cs_ext_sales_price,cs_net_profit,cr_return_amount,cr_net_loss,cp_catalog_page_id]
-                                                                    BroadcastHashJoin [cs_item_sk,i_item_sk]
-                                                                      Project [cs_item_sk,cs_promo_sk,cs_ext_sales_price,cs_net_profit,cr_return_amount,cr_net_loss,cp_catalog_page_id]
-                                                                        BroadcastHashJoin [cs_catalog_page_sk,cp_catalog_page_sk]
-                                                                          Project [cs_catalog_page_sk,cs_item_sk,cs_promo_sk,cs_ext_sales_price,cs_net_profit,cr_return_amount,cr_net_loss]
-                                                                            BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                              Project [cs_sold_date_sk,cs_catalog_page_sk,cs_item_sk,cs_promo_sk,cs_ext_sales_price,cs_net_profit,cr_return_amount,cr_net_loss]
-                                                                                BroadcastHashJoin [cs_item_sk,cs_order_number,cr_item_sk,cr_order_number]
-                                                                                  Filter [cs_sold_date_sk,cs_catalog_page_sk,cs_item_sk,cs_promo_sk]
-                                                                                    ColumnarToRow
-                                                                                      InputAdapter
-                                                                                        Scan parquet default.catalog_sales [cs_sold_date_sk,cs_catalog_page_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_ext_sales_price,cs_net_profit]
-                                                                                  InputAdapter
-                                                                                    BroadcastExchange #11
-                                                                                      WholeStageCodegen (8)
-                                                                                        Filter [cr_item_sk,cr_order_number]
-                                                                                          ColumnarToRow
-                                                                                            InputAdapter
-                                                                                              Scan parquet default.catalog_returns [cr_item_sk,cr_order_number,cr_return_amount,cr_net_loss]
-                                                                              InputAdapter
-                                                                                ReusedExchange [d_date_sk] #6
+                                                                    BroadcastExchange #4
+                                                                      WholeStageCodegen (1)
+                                                                        Filter [sr_item_sk,sr_ticket_number]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet default.store_returns [sr_item_sk,sr_ticket_number,sr_return_amt,sr_net_loss]
+                                                              InputAdapter
+                                                                BroadcastExchange #5
+                                                                  WholeStageCodegen (2)
+                                                                    Project [d_date_sk]
+                                                                      Filter [d_date,d_date_sk]
+                                                                        ColumnarToRow
                                                                           InputAdapter
-                                                                            BroadcastExchange #12
-                                                                              WholeStageCodegen (10)
-                                                                                Filter [cp_catalog_page_sk]
-                                                                                  ColumnarToRow
-                                                                                    InputAdapter
-                                                                                      Scan parquet default.catalog_page [cp_catalog_page_sk,cp_catalog_page_id]
-                                                                      InputAdapter
-                                                                        ReusedExchange [i_item_sk] #8
-                                                                  InputAdapter
-                                                                    ReusedExchange [p_promo_sk] #9
-                                                  WholeStageCodegen (21)
-                                                    HashAggregate [web_site_id,sum,sum,isEmpty,sum,isEmpty] [sum(UnscaledValue(ws_ext_sales_price)),sum(coalesce(cast(wr_return_amt as decimal(12,2)), 0.00)),sum(CheckOverflow((promote_precision(cast(ws_net_profit as decimal(13,2))) - promote_precision(cast(coalesce(cast(wr_net_loss as decimal(12,2)), 0.00) as decimal(13,2)))), DecimalType(13,2), true)),channel,id,sales,returns,profit,sum,sum,isEmpty,sum,isEmpty]
+                                                                            Scan parquet default.date_dim [d_date_sk,d_date]
+                                                          InputAdapter
+                                                            BroadcastExchange #6
+                                                              WholeStageCodegen (3)
+                                                                Filter [s_store_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet default.store [s_store_sk,s_store_id]
                                                       InputAdapter
-                                                        Exchange [web_site_id] #13
-                                                          WholeStageCodegen (20)
-                                                            HashAggregate [web_site_id,ws_ext_sales_price,wr_return_amt,ws_net_profit,wr_net_loss] [sum,sum,isEmpty,sum,isEmpty,sum,sum,isEmpty,sum,isEmpty]
-                                                              Project [ws_ext_sales_price,ws_net_profit,wr_return_amt,wr_net_loss,web_site_id]
-                                                                BroadcastHashJoin [ws_promo_sk,p_promo_sk]
-                                                                  Project [ws_promo_sk,ws_ext_sales_price,ws_net_profit,wr_return_amt,wr_net_loss,web_site_id]
-                                                                    BroadcastHashJoin [ws_item_sk,i_item_sk]
-                                                                      Project [ws_item_sk,ws_promo_sk,ws_ext_sales_price,ws_net_profit,wr_return_amt,wr_net_loss,web_site_id]
-                                                                        BroadcastHashJoin [ws_web_site_sk,web_site_sk]
-                                                                          Project [ws_item_sk,ws_web_site_sk,ws_promo_sk,ws_ext_sales_price,ws_net_profit,wr_return_amt,wr_net_loss]
-                                                                            BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                              Project [ws_sold_date_sk,ws_item_sk,ws_web_site_sk,ws_promo_sk,ws_ext_sales_price,ws_net_profit,wr_return_amt,wr_net_loss]
-                                                                                BroadcastHashJoin [ws_item_sk,ws_order_number,wr_item_sk,wr_order_number]
-                                                                                  Filter [ws_sold_date_sk,ws_web_site_sk,ws_item_sk,ws_promo_sk]
-                                                                                    ColumnarToRow
-                                                                                      InputAdapter
-                                                                                        Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk,ws_web_site_sk,ws_promo_sk,ws_order_number,ws_ext_sales_price,ws_net_profit]
-                                                                                  InputAdapter
-                                                                                    BroadcastExchange #14
-                                                                                      WholeStageCodegen (15)
-                                                                                        Filter [wr_item_sk,wr_order_number]
-                                                                                          ColumnarToRow
-                                                                                            InputAdapter
-                                                                                              Scan parquet default.web_returns [wr_item_sk,wr_order_number,wr_return_amt,wr_net_loss]
-                                                                              InputAdapter
-                                                                                ReusedExchange [d_date_sk] #6
-                                                                          InputAdapter
-                                                                            BroadcastExchange #15
-                                                                              WholeStageCodegen (17)
-                                                                                Filter [web_site_sk]
-                                                                                  ColumnarToRow
-                                                                                    InputAdapter
-                                                                                      Scan parquet default.web_site [web_site_sk,web_site_id]
-                                                                      InputAdapter
-                                                                        ReusedExchange [i_item_sk] #8
+                                                        BroadcastExchange #7
+                                                          WholeStageCodegen (4)
+                                                            Project [i_item_sk]
+                                                              Filter [i_current_price,i_item_sk]
+                                                                ColumnarToRow
                                                                   InputAdapter
-                                                                    ReusedExchange [p_promo_sk] #9
-                                  WholeStageCodegen (47)
-                                    HashAggregate [channel,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),id,sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                                                                    Scan parquet default.item [i_item_sk,i_current_price]
+                                                  InputAdapter
+                                                    BroadcastExchange #8
+                                                      WholeStageCodegen (5)
+                                                        Project [p_promo_sk]
+                                                          Filter [p_channel_tv,p_promo_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet default.promotion [p_promo_sk,p_channel_tv]
+                                  WholeStageCodegen (14)
+                                    HashAggregate [cp_catalog_page_id,sum,sum,isEmpty,sum,isEmpty] [sum(UnscaledValue(cs_ext_sales_price)),sum(coalesce(cast(cr_return_amount as decimal(12,2)), 0.00)),sum(CheckOverflow((promote_precision(cast(cs_net_profit as decimal(13,2))) - promote_precision(cast(coalesce(cast(cr_net_loss as decimal(12,2)), 0.00) as decimal(13,2)))), DecimalType(13,2), true)),channel,id,sales,returns,profit,sum,sum,isEmpty,sum,isEmpty]
                                       InputAdapter
-                                        Exchange [channel] #16
-                                          WholeStageCodegen (46)
-                                            HashAggregate [channel,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
-                                              HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
-                                                InputAdapter
-                                                  ReusedExchange [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] #3
-                  WholeStageCodegen (73)
+                                        Exchange [cp_catalog_page_id] #9
+                                          WholeStageCodegen (13)
+                                            HashAggregate [cp_catalog_page_id,cs_ext_sales_price,cr_return_amount,cs_net_profit,cr_net_loss] [sum,sum,isEmpty,sum,isEmpty,sum,sum,isEmpty,sum,isEmpty]
+                                              Project [cs_ext_sales_price,cs_net_profit,cr_return_amount,cr_net_loss,cp_catalog_page_id]
+                                                BroadcastHashJoin [cs_promo_sk,p_promo_sk]
+                                                  Project [cs_promo_sk,cs_ext_sales_price,cs_net_profit,cr_return_amount,cr_net_loss,cp_catalog_page_id]
+                                                    BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                      Project [cs_item_sk,cs_promo_sk,cs_ext_sales_price,cs_net_profit,cr_return_amount,cr_net_loss,cp_catalog_page_id]
+                                                        BroadcastHashJoin [cs_catalog_page_sk,cp_catalog_page_sk]
+                                                          Project [cs_catalog_page_sk,cs_item_sk,cs_promo_sk,cs_ext_sales_price,cs_net_profit,cr_return_amount,cr_net_loss]
+                                                            BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                              Project [cs_sold_date_sk,cs_catalog_page_sk,cs_item_sk,cs_promo_sk,cs_ext_sales_price,cs_net_profit,cr_return_amount,cr_net_loss]
+                                                                BroadcastHashJoin [cs_item_sk,cs_order_number,cr_item_sk,cr_order_number]
+                                                                  Filter [cs_sold_date_sk,cs_catalog_page_sk,cs_item_sk,cs_promo_sk]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet default.catalog_sales [cs_sold_date_sk,cs_catalog_page_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_ext_sales_price,cs_net_profit]
+                                                                  InputAdapter
+                                                                    BroadcastExchange #10
+                                                                      WholeStageCodegen (8)
+                                                                        Filter [cr_item_sk,cr_order_number]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet default.catalog_returns [cr_item_sk,cr_order_number,cr_return_amount,cr_net_loss]
+                                                              InputAdapter
+                                                                ReusedExchange [d_date_sk] #5
+                                                          InputAdapter
+                                                            BroadcastExchange #11
+                                                              WholeStageCodegen (10)
+                                                                Filter [cp_catalog_page_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet default.catalog_page [cp_catalog_page_sk,cp_catalog_page_id]
+                                                      InputAdapter
+                                                        ReusedExchange [i_item_sk] #7
+                                                  InputAdapter
+                                                    ReusedExchange [p_promo_sk] #8
+                                  WholeStageCodegen (21)
+                                    HashAggregate [web_site_id,sum,sum,isEmpty,sum,isEmpty] [sum(UnscaledValue(ws_ext_sales_price)),sum(coalesce(cast(wr_return_amt as decimal(12,2)), 0.00)),sum(CheckOverflow((promote_precision(cast(ws_net_profit as decimal(13,2))) - promote_precision(cast(coalesce(cast(wr_net_loss as decimal(12,2)), 0.00) as decimal(13,2)))), DecimalType(13,2), true)),channel,id,sales,returns,profit,sum,sum,isEmpty,sum,isEmpty]
+                                      InputAdapter
+                                        Exchange [web_site_id] #12
+                                          WholeStageCodegen (20)
+                                            HashAggregate [web_site_id,ws_ext_sales_price,wr_return_amt,ws_net_profit,wr_net_loss] [sum,sum,isEmpty,sum,isEmpty,sum,sum,isEmpty,sum,isEmpty]
+                                              Project [ws_ext_sales_price,ws_net_profit,wr_return_amt,wr_net_loss,web_site_id]
+                                                BroadcastHashJoin [ws_promo_sk,p_promo_sk]
+                                                  Project [ws_promo_sk,ws_ext_sales_price,ws_net_profit,wr_return_amt,wr_net_loss,web_site_id]
+                                                    BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                      Project [ws_item_sk,ws_promo_sk,ws_ext_sales_price,ws_net_profit,wr_return_amt,wr_net_loss,web_site_id]
+                                                        BroadcastHashJoin [ws_web_site_sk,web_site_sk]
+                                                          Project [ws_item_sk,ws_web_site_sk,ws_promo_sk,ws_ext_sales_price,ws_net_profit,wr_return_amt,wr_net_loss]
+                                                            BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                              Project [ws_sold_date_sk,ws_item_sk,ws_web_site_sk,ws_promo_sk,ws_ext_sales_price,ws_net_profit,wr_return_amt,wr_net_loss]
+                                                                BroadcastHashJoin [ws_item_sk,ws_order_number,wr_item_sk,wr_order_number]
+                                                                  Filter [ws_sold_date_sk,ws_web_site_sk,ws_item_sk,ws_promo_sk]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk,ws_web_site_sk,ws_promo_sk,ws_order_number,ws_ext_sales_price,ws_net_profit]
+                                                                  InputAdapter
+                                                                    BroadcastExchange #13
+                                                                      WholeStageCodegen (15)
+                                                                        Filter [wr_item_sk,wr_order_number]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet default.web_returns [wr_item_sk,wr_order_number,wr_return_amt,wr_net_loss]
+                                                              InputAdapter
+                                                                ReusedExchange [d_date_sk] #5
+                                                          InputAdapter
+                                                            BroadcastExchange #14
+                                                              WholeStageCodegen (17)
+                                                                Filter [web_site_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet default.web_site [web_site_sk,web_site_id]
+                                                      InputAdapter
+                                                        ReusedExchange [i_item_sk] #7
+                                                  InputAdapter
+                                                    ReusedExchange [p_promo_sk] #8
+                  WholeStageCodegen (47)
+                    HashAggregate [channel,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),id,sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                      InputAdapter
+                        Exchange [channel] #15
+                          WholeStageCodegen (46)
+                            HashAggregate [channel,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                              HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                                InputAdapter
+                                  ReusedExchange [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] #2
+                  WholeStageCodegen (71)
                     HashAggregate [sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),channel,id,sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                       InputAdapter
-                        Exchange #17
-                          WholeStageCodegen (72)
+                        Exchange #16
+                          WholeStageCodegen (70)
                             HashAggregate [sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                               HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                                 InputAdapter
-                                  ReusedExchange [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] #3
+                                  ReusedExchange [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] #2

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a.sf100/explain.txt
@@ -1,46 +1,42 @@
 == Physical Plan ==
-TakeOrderedAndProject (42)
-+- * Project (41)
-   +- Window (40)
-      +- * Sort (39)
-         +- Exchange (38)
-            +- * HashAggregate (37)
-               +- Exchange (36)
-                  +- * HashAggregate (35)
-                     +- Union (34)
-                        :- * HashAggregate (28)
-                        :  +- Exchange (27)
-                        :     +- * HashAggregate (26)
-                        :        +- Union (25)
-                        :           :- * HashAggregate (19)
-                        :           :  +- Exchange (18)
-                        :           :     +- * HashAggregate (17)
-                        :           :        +- * Project (16)
-                        :           :           +- * BroadcastHashJoin Inner BuildRight (15)
-                        :           :              :- * Project (10)
-                        :           :              :  +- * BroadcastHashJoin Inner BuildRight (9)
-                        :           :              :     :- * Filter (3)
-                        :           :              :     :  +- * ColumnarToRow (2)
-                        :           :              :     :     +- Scan parquet default.web_sales (1)
-                        :           :              :     +- BroadcastExchange (8)
-                        :           :              :        +- * Project (7)
-                        :           :              :           +- * Filter (6)
-                        :           :              :              +- * ColumnarToRow (5)
-                        :           :              :                 +- Scan parquet default.date_dim (4)
-                        :           :              +- BroadcastExchange (14)
-                        :           :                 +- * Filter (13)
-                        :           :                    +- * ColumnarToRow (12)
-                        :           :                       +- Scan parquet default.item (11)
-                        :           +- * HashAggregate (24)
-                        :              +- Exchange (23)
-                        :                 +- * HashAggregate (22)
-                        :                    +- * HashAggregate (21)
-                        :                       +- ReusedExchange (20)
-                        +- * HashAggregate (33)
-                           +- Exchange (32)
-                              +- * HashAggregate (31)
-                                 +- * HashAggregate (30)
-                                    +- ReusedExchange (29)
+TakeOrderedAndProject (38)
++- * Project (37)
+   +- Window (36)
+      +- * Sort (35)
+         +- Exchange (34)
+            +- * HashAggregate (33)
+               +- Exchange (32)
+                  +- * HashAggregate (31)
+                     +- Union (30)
+                        :- * HashAggregate (19)
+                        :  +- Exchange (18)
+                        :     +- * HashAggregate (17)
+                        :        +- * Project (16)
+                        :           +- * BroadcastHashJoin Inner BuildRight (15)
+                        :              :- * Project (10)
+                        :              :  +- * BroadcastHashJoin Inner BuildRight (9)
+                        :              :     :- * Filter (3)
+                        :              :     :  +- * ColumnarToRow (2)
+                        :              :     :     +- Scan parquet default.web_sales (1)
+                        :              :     +- BroadcastExchange (8)
+                        :              :        +- * Project (7)
+                        :              :           +- * Filter (6)
+                        :              :              +- * ColumnarToRow (5)
+                        :              :                 +- Scan parquet default.date_dim (4)
+                        :              +- BroadcastExchange (14)
+                        :                 +- * Filter (13)
+                        :                    +- * ColumnarToRow (12)
+                        :                       +- Scan parquet default.item (11)
+                        :- * HashAggregate (24)
+                        :  +- Exchange (23)
+                        :     +- * HashAggregate (22)
+                        :        +- * HashAggregate (21)
+                        :           +- ReusedExchange (20)
+                        +- * HashAggregate (29)
+                           +- Exchange (28)
+                              +- * HashAggregate (27)
+                                 +- * HashAggregate (26)
+                                    +- ReusedExchange (25)
 
 
 (1) Scan parquet default.web_sales
@@ -124,7 +120,7 @@ Results [3]: [i_category#9, i_class#8, sum#12]
 
 (18) Exchange
 Input [3]: [i_category#9, i_class#8, sum#12]
-Arguments: hashpartitioning(i_category#9, i_class#8, 5), true, [id=#13]
+Arguments: hashpartitioning(i_category#9, i_class#8, 5), ENSURE_REQUIREMENTS, [id=#13]
 
 (19) HashAggregate [codegen id : 4]
 Input [3]: [i_category#9, i_class#8, sum#12]
@@ -152,7 +148,7 @@ Results [3]: [i_category#9, sum#24, isEmpty#25]
 
 (23) Exchange
 Input [3]: [i_category#9, sum#24, isEmpty#25]
-Arguments: hashpartitioning(i_category#9, 5), true, [id=#26]
+Arguments: hashpartitioning(i_category#9, 5), ENSURE_REQUIREMENTS, [id=#26]
 
 (24) HashAggregate [codegen id : 9]
 Input [3]: [i_category#9, sum#24, isEmpty#25]
@@ -161,91 +157,71 @@ Functions [1]: [sum(total_sum#21)]
 Aggregate Attributes [1]: [sum(total_sum#21)#27]
 Results [6]: [sum(total_sum#21)#27 AS total_sum#28, i_category#9, null AS i_class#29, 0 AS g_category#30, 1 AS g_class#31, 1 AS lochierarchy#32]
 
-(25) Union
+(25) ReusedExchange [Reuses operator id: 18]
+Output [3]: [i_category#9, i_class#8, sum#33]
 
-(26) HashAggregate [codegen id : 10]
-Input [6]: [total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18]
-Keys [6]: [total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18]
-Functions: []
-Aggregate Attributes: []
-Results [6]: [total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18]
-
-(27) Exchange
-Input [6]: [total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18]
-Arguments: hashpartitioning(total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18, 5), true, [id=#33]
-
-(28) HashAggregate [codegen id : 11]
-Input [6]: [total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18]
-Keys [6]: [total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18]
-Functions: []
-Aggregate Attributes: []
-Results [6]: [total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18]
-
-(29) ReusedExchange [Reuses operator id: 18]
-Output [3]: [i_category#9, i_class#8, sum#34]
-
-(30) HashAggregate [codegen id : 15]
-Input [3]: [i_category#9, i_class#8, sum#34]
+(26) HashAggregate [codegen id : 13]
+Input [3]: [i_category#9, i_class#8, sum#33]
 Keys [2]: [i_category#9, i_class#8]
 Functions [1]: [sum(UnscaledValue(ws_net_paid#3))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ws_net_paid#3))#35]
-Results [1]: [MakeDecimal(sum(UnscaledValue(ws_net_paid#3))#35,17,2) AS total_sum#21]
+Aggregate Attributes [1]: [sum(UnscaledValue(ws_net_paid#3))#34]
+Results [1]: [MakeDecimal(sum(UnscaledValue(ws_net_paid#3))#34,17,2) AS total_sum#21]
 
-(31) HashAggregate [codegen id : 15]
+(27) HashAggregate [codegen id : 13]
 Input [1]: [total_sum#21]
 Keys: []
 Functions [1]: [partial_sum(total_sum#21)]
-Aggregate Attributes [2]: [sum#36, isEmpty#37]
-Results [2]: [sum#38, isEmpty#39]
+Aggregate Attributes [2]: [sum#35, isEmpty#36]
+Results [2]: [sum#37, isEmpty#38]
 
-(32) Exchange
-Input [2]: [sum#38, isEmpty#39]
-Arguments: SinglePartition, true, [id=#40]
+(28) Exchange
+Input [2]: [sum#37, isEmpty#38]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#39]
 
-(33) HashAggregate [codegen id : 16]
-Input [2]: [sum#38, isEmpty#39]
+(29) HashAggregate [codegen id : 14]
+Input [2]: [sum#37, isEmpty#38]
 Keys: []
 Functions [1]: [sum(total_sum#21)]
-Aggregate Attributes [1]: [sum(total_sum#21)#41]
-Results [6]: [sum(total_sum#21)#41 AS total_sum#42, null AS i_category#43, null AS i_class#44, 1 AS g_category#45, 1 AS g_class#46, 2 AS lochierarchy#47]
+Aggregate Attributes [1]: [sum(total_sum#21)#40]
+Results [6]: [sum(total_sum#21)#40 AS total_sum#41, null AS i_category#42, null AS i_class#43, 1 AS g_category#44, 1 AS g_class#45, 2 AS lochierarchy#46]
 
-(34) Union
+(30) Union
 
-(35) HashAggregate [codegen id : 17]
+(31) HashAggregate [codegen id : 15]
 Input [6]: [total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18]
 Keys [6]: [total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18]
 Functions: []
 Aggregate Attributes: []
 Results [6]: [total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18]
 
-(36) Exchange
+(32) Exchange
 Input [6]: [total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18]
-Arguments: hashpartitioning(total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18, 5), true, [id=#48]
+Arguments: hashpartitioning(total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18, 5), ENSURE_REQUIREMENTS, [id=#47]
 
-(37) HashAggregate [codegen id : 18]
+(33) HashAggregate [codegen id : 16]
 Input [6]: [total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18]
 Keys [6]: [total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18]
 Functions: []
 Aggregate Attributes: []
-Results [5]: [total_sum#15, i_category#9, i_class#8, lochierarchy#18, CASE WHEN (g_class#17 = 0) THEN i_category#9 END AS _w0#49]
+Results [5]: [total_sum#15, i_category#9, i_class#8, lochierarchy#18, CASE WHEN (g_class#17 = 0) THEN i_category#9 END AS _w0#48]
 
-(38) Exchange
-Input [5]: [total_sum#15, i_category#9, i_class#8, lochierarchy#18, _w0#49]
-Arguments: hashpartitioning(lochierarchy#18, _w0#49, 5), true, [id=#50]
+(34) Exchange
+Input [5]: [total_sum#15, i_category#9, i_class#8, lochierarchy#18, _w0#48]
+Arguments: hashpartitioning(lochierarchy#18, _w0#48, 5), ENSURE_REQUIREMENTS, [id=#49]
 
-(39) Sort [codegen id : 19]
-Input [5]: [total_sum#15, i_category#9, i_class#8, lochierarchy#18, _w0#49]
-Arguments: [lochierarchy#18 ASC NULLS FIRST, _w0#49 ASC NULLS FIRST, total_sum#15 DESC NULLS LAST], false, 0
+(35) Sort [codegen id : 17]
+Input [5]: [total_sum#15, i_category#9, i_class#8, lochierarchy#18, _w0#48]
+Arguments: [lochierarchy#18 ASC NULLS FIRST, _w0#48 ASC NULLS FIRST, total_sum#15 DESC NULLS LAST], false, 0
 
-(40) Window
-Input [5]: [total_sum#15, i_category#9, i_class#8, lochierarchy#18, _w0#49]
-Arguments: [rank(total_sum#15) windowspecdefinition(lochierarchy#18, _w0#49, total_sum#15 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank_within_parent#51], [lochierarchy#18, _w0#49], [total_sum#15 DESC NULLS LAST]
+(36) Window
+Input [5]: [total_sum#15, i_category#9, i_class#8, lochierarchy#18, _w0#48]
+Arguments: [rank(total_sum#15) windowspecdefinition(lochierarchy#18, _w0#48, total_sum#15 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank_within_parent#50], [lochierarchy#18, _w0#48], [total_sum#15 DESC NULLS LAST]
 
-(41) Project [codegen id : 20]
-Output [5]: [total_sum#15, i_category#9, i_class#8, lochierarchy#18, rank_within_parent#51]
-Input [6]: [total_sum#15, i_category#9, i_class#8, lochierarchy#18, _w0#49, rank_within_parent#51]
+(37) Project [codegen id : 18]
+Output [5]: [total_sum#15, i_category#9, i_class#8, lochierarchy#18, rank_within_parent#50]
+Input [6]: [total_sum#15, i_category#9, i_class#8, lochierarchy#18, _w0#48, rank_within_parent#50]
 
-(42) TakeOrderedAndProject
-Input [5]: [total_sum#15, i_category#9, i_class#8, lochierarchy#18, rank_within_parent#51]
-Arguments: 100, [lochierarchy#18 DESC NULLS LAST, CASE WHEN (lochierarchy#18 = 0) THEN i_category#9 END ASC NULLS FIRST, rank_within_parent#51 ASC NULLS FIRST], [total_sum#15, i_category#9, i_class#8, lochierarchy#18, rank_within_parent#51]
+(38) TakeOrderedAndProject
+Input [5]: [total_sum#15, i_category#9, i_class#8, lochierarchy#18, rank_within_parent#50]
+Arguments: 100, [lochierarchy#18 DESC NULLS LAST, CASE WHEN (lochierarchy#18 = 0) THEN i_category#9 END ASC NULLS FIRST, rank_within_parent#50 ASC NULLS FIRST], [total_sum#15, i_category#9, i_class#8, lochierarchy#18, rank_within_parent#50]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a.sf100/simplified.txt
@@ -1,72 +1,64 @@
 TakeOrderedAndProject [lochierarchy,i_category,rank_within_parent,total_sum,i_class]
-  WholeStageCodegen (20)
+  WholeStageCodegen (18)
     Project [total_sum,i_category,i_class,lochierarchy,rank_within_parent]
       InputAdapter
         Window [total_sum,lochierarchy,_w0]
-          WholeStageCodegen (19)
+          WholeStageCodegen (17)
             Sort [lochierarchy,_w0,total_sum]
               InputAdapter
                 Exchange [lochierarchy,_w0] #1
-                  WholeStageCodegen (18)
+                  WholeStageCodegen (16)
                     HashAggregate [total_sum,i_category,i_class,g_category,g_class,lochierarchy] [_w0]
                       InputAdapter
                         Exchange [total_sum,i_category,i_class,g_category,g_class,lochierarchy] #2
-                          WholeStageCodegen (17)
+                          WholeStageCodegen (15)
                             HashAggregate [total_sum,i_category,i_class,g_category,g_class,lochierarchy]
                               InputAdapter
                                 Union
-                                  WholeStageCodegen (11)
-                                    HashAggregate [total_sum,i_category,i_class,g_category,g_class,lochierarchy]
+                                  WholeStageCodegen (4)
+                                    HashAggregate [i_category,i_class,sum] [sum(UnscaledValue(ws_net_paid)),total_sum,g_category,g_class,lochierarchy,sum]
                                       InputAdapter
-                                        Exchange [total_sum,i_category,i_class,g_category,g_class,lochierarchy] #3
-                                          WholeStageCodegen (10)
-                                            HashAggregate [total_sum,i_category,i_class,g_category,g_class,lochierarchy]
-                                              InputAdapter
-                                                Union
-                                                  WholeStageCodegen (4)
-                                                    HashAggregate [i_category,i_class,sum] [sum(UnscaledValue(ws_net_paid)),total_sum,g_category,g_class,lochierarchy,sum]
+                                        Exchange [i_category,i_class] #3
+                                          WholeStageCodegen (3)
+                                            HashAggregate [i_category,i_class,ws_net_paid] [sum,sum]
+                                              Project [ws_net_paid,i_class,i_category]
+                                                BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                  Project [ws_item_sk,ws_net_paid]
+                                                    BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                      Filter [ws_sold_date_sk,ws_item_sk]
+                                                        ColumnarToRow
+                                                          InputAdapter
+                                                            Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk,ws_net_paid]
                                                       InputAdapter
-                                                        Exchange [i_category,i_class] #4
-                                                          WholeStageCodegen (3)
-                                                            HashAggregate [i_category,i_class,ws_net_paid] [sum,sum]
-                                                              Project [ws_net_paid,i_class,i_category]
-                                                                BroadcastHashJoin [ws_item_sk,i_item_sk]
-                                                                  Project [ws_item_sk,ws_net_paid]
-                                                                    BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                      Filter [ws_sold_date_sk,ws_item_sk]
-                                                                        ColumnarToRow
-                                                                          InputAdapter
-                                                                            Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk,ws_net_paid]
-                                                                      InputAdapter
-                                                                        BroadcastExchange #5
-                                                                          WholeStageCodegen (1)
-                                                                            Project [d_date_sk]
-                                                                              Filter [d_month_seq,d_date_sk]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet default.date_dim [d_date_sk,d_month_seq]
+                                                        BroadcastExchange #4
+                                                          WholeStageCodegen (1)
+                                                            Project [d_date_sk]
+                                                              Filter [d_month_seq,d_date_sk]
+                                                                ColumnarToRow
                                                                   InputAdapter
-                                                                    BroadcastExchange #6
-                                                                      WholeStageCodegen (2)
-                                                                        Filter [i_item_sk]
-                                                                          ColumnarToRow
-                                                                            InputAdapter
-                                                                              Scan parquet default.item [i_item_sk,i_class,i_category]
-                                                  WholeStageCodegen (9)
-                                                    HashAggregate [i_category,sum,isEmpty] [sum(total_sum),total_sum,i_class,g_category,g_class,lochierarchy,sum,isEmpty]
-                                                      InputAdapter
-                                                        Exchange [i_category] #7
-                                                          WholeStageCodegen (8)
-                                                            HashAggregate [i_category,total_sum] [sum,isEmpty,sum,isEmpty]
-                                                              HashAggregate [i_category,i_class,sum] [sum(UnscaledValue(ws_net_paid)),total_sum,sum]
-                                                                InputAdapter
-                                                                  ReusedExchange [i_category,i_class,sum] #4
-                                  WholeStageCodegen (16)
+                                                                    Scan parquet default.date_dim [d_date_sk,d_month_seq]
+                                                  InputAdapter
+                                                    BroadcastExchange #5
+                                                      WholeStageCodegen (2)
+                                                        Filter [i_item_sk]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet default.item [i_item_sk,i_class,i_category]
+                                  WholeStageCodegen (9)
+                                    HashAggregate [i_category,sum,isEmpty] [sum(total_sum),total_sum,i_class,g_category,g_class,lochierarchy,sum,isEmpty]
+                                      InputAdapter
+                                        Exchange [i_category] #6
+                                          WholeStageCodegen (8)
+                                            HashAggregate [i_category,total_sum] [sum,isEmpty,sum,isEmpty]
+                                              HashAggregate [i_category,i_class,sum] [sum(UnscaledValue(ws_net_paid)),total_sum,sum]
+                                                InputAdapter
+                                                  ReusedExchange [i_category,i_class,sum] #3
+                                  WholeStageCodegen (14)
                                     HashAggregate [sum,isEmpty] [sum(total_sum),total_sum,i_category,i_class,g_category,g_class,lochierarchy,sum,isEmpty]
                                       InputAdapter
-                                        Exchange #8
-                                          WholeStageCodegen (15)
+                                        Exchange #7
+                                          WholeStageCodegen (13)
                                             HashAggregate [total_sum] [sum,isEmpty,sum,isEmpty]
                                               HashAggregate [i_category,i_class,sum] [sum(UnscaledValue(ws_net_paid)),total_sum,sum]
                                                 InputAdapter
-                                                  ReusedExchange [i_category,i_class,sum] #4
+                                                  ReusedExchange [i_category,i_class,sum] #3

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a/explain.txt
@@ -1,46 +1,42 @@
 == Physical Plan ==
-TakeOrderedAndProject (42)
-+- * Project (41)
-   +- Window (40)
-      +- * Sort (39)
-         +- Exchange (38)
-            +- * HashAggregate (37)
-               +- Exchange (36)
-                  +- * HashAggregate (35)
-                     +- Union (34)
-                        :- * HashAggregate (28)
-                        :  +- Exchange (27)
-                        :     +- * HashAggregate (26)
-                        :        +- Union (25)
-                        :           :- * HashAggregate (19)
-                        :           :  +- Exchange (18)
-                        :           :     +- * HashAggregate (17)
-                        :           :        +- * Project (16)
-                        :           :           +- * BroadcastHashJoin Inner BuildRight (15)
-                        :           :              :- * Project (10)
-                        :           :              :  +- * BroadcastHashJoin Inner BuildRight (9)
-                        :           :              :     :- * Filter (3)
-                        :           :              :     :  +- * ColumnarToRow (2)
-                        :           :              :     :     +- Scan parquet default.web_sales (1)
-                        :           :              :     +- BroadcastExchange (8)
-                        :           :              :        +- * Project (7)
-                        :           :              :           +- * Filter (6)
-                        :           :              :              +- * ColumnarToRow (5)
-                        :           :              :                 +- Scan parquet default.date_dim (4)
-                        :           :              +- BroadcastExchange (14)
-                        :           :                 +- * Filter (13)
-                        :           :                    +- * ColumnarToRow (12)
-                        :           :                       +- Scan parquet default.item (11)
-                        :           +- * HashAggregate (24)
-                        :              +- Exchange (23)
-                        :                 +- * HashAggregate (22)
-                        :                    +- * HashAggregate (21)
-                        :                       +- ReusedExchange (20)
-                        +- * HashAggregate (33)
-                           +- Exchange (32)
-                              +- * HashAggregate (31)
-                                 +- * HashAggregate (30)
-                                    +- ReusedExchange (29)
+TakeOrderedAndProject (38)
++- * Project (37)
+   +- Window (36)
+      +- * Sort (35)
+         +- Exchange (34)
+            +- * HashAggregate (33)
+               +- Exchange (32)
+                  +- * HashAggregate (31)
+                     +- Union (30)
+                        :- * HashAggregate (19)
+                        :  +- Exchange (18)
+                        :     +- * HashAggregate (17)
+                        :        +- * Project (16)
+                        :           +- * BroadcastHashJoin Inner BuildRight (15)
+                        :              :- * Project (10)
+                        :              :  +- * BroadcastHashJoin Inner BuildRight (9)
+                        :              :     :- * Filter (3)
+                        :              :     :  +- * ColumnarToRow (2)
+                        :              :     :     +- Scan parquet default.web_sales (1)
+                        :              :     +- BroadcastExchange (8)
+                        :              :        +- * Project (7)
+                        :              :           +- * Filter (6)
+                        :              :              +- * ColumnarToRow (5)
+                        :              :                 +- Scan parquet default.date_dim (4)
+                        :              +- BroadcastExchange (14)
+                        :                 +- * Filter (13)
+                        :                    +- * ColumnarToRow (12)
+                        :                       +- Scan parquet default.item (11)
+                        :- * HashAggregate (24)
+                        :  +- Exchange (23)
+                        :     +- * HashAggregate (22)
+                        :        +- * HashAggregate (21)
+                        :           +- ReusedExchange (20)
+                        +- * HashAggregate (29)
+                           +- Exchange (28)
+                              +- * HashAggregate (27)
+                                 +- * HashAggregate (26)
+                                    +- ReusedExchange (25)
 
 
 (1) Scan parquet default.web_sales
@@ -124,7 +120,7 @@ Results [3]: [i_category#9, i_class#8, sum#12]
 
 (18) Exchange
 Input [3]: [i_category#9, i_class#8, sum#12]
-Arguments: hashpartitioning(i_category#9, i_class#8, 5), true, [id=#13]
+Arguments: hashpartitioning(i_category#9, i_class#8, 5), ENSURE_REQUIREMENTS, [id=#13]
 
 (19) HashAggregate [codegen id : 4]
 Input [3]: [i_category#9, i_class#8, sum#12]
@@ -152,7 +148,7 @@ Results [3]: [i_category#9, sum#24, isEmpty#25]
 
 (23) Exchange
 Input [3]: [i_category#9, sum#24, isEmpty#25]
-Arguments: hashpartitioning(i_category#9, 5), true, [id=#26]
+Arguments: hashpartitioning(i_category#9, 5), ENSURE_REQUIREMENTS, [id=#26]
 
 (24) HashAggregate [codegen id : 9]
 Input [3]: [i_category#9, sum#24, isEmpty#25]
@@ -161,91 +157,71 @@ Functions [1]: [sum(total_sum#21)]
 Aggregate Attributes [1]: [sum(total_sum#21)#27]
 Results [6]: [sum(total_sum#21)#27 AS total_sum#28, i_category#9, null AS i_class#29, 0 AS g_category#30, 1 AS g_class#31, 1 AS lochierarchy#32]
 
-(25) Union
+(25) ReusedExchange [Reuses operator id: 18]
+Output [3]: [i_category#9, i_class#8, sum#33]
 
-(26) HashAggregate [codegen id : 10]
-Input [6]: [total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18]
-Keys [6]: [total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18]
-Functions: []
-Aggregate Attributes: []
-Results [6]: [total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18]
-
-(27) Exchange
-Input [6]: [total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18]
-Arguments: hashpartitioning(total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18, 5), true, [id=#33]
-
-(28) HashAggregate [codegen id : 11]
-Input [6]: [total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18]
-Keys [6]: [total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18]
-Functions: []
-Aggregate Attributes: []
-Results [6]: [total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18]
-
-(29) ReusedExchange [Reuses operator id: 18]
-Output [3]: [i_category#9, i_class#8, sum#34]
-
-(30) HashAggregate [codegen id : 15]
-Input [3]: [i_category#9, i_class#8, sum#34]
+(26) HashAggregate [codegen id : 13]
+Input [3]: [i_category#9, i_class#8, sum#33]
 Keys [2]: [i_category#9, i_class#8]
 Functions [1]: [sum(UnscaledValue(ws_net_paid#3))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ws_net_paid#3))#35]
-Results [1]: [MakeDecimal(sum(UnscaledValue(ws_net_paid#3))#35,17,2) AS total_sum#21]
+Aggregate Attributes [1]: [sum(UnscaledValue(ws_net_paid#3))#34]
+Results [1]: [MakeDecimal(sum(UnscaledValue(ws_net_paid#3))#34,17,2) AS total_sum#21]
 
-(31) HashAggregate [codegen id : 15]
+(27) HashAggregate [codegen id : 13]
 Input [1]: [total_sum#21]
 Keys: []
 Functions [1]: [partial_sum(total_sum#21)]
-Aggregate Attributes [2]: [sum#36, isEmpty#37]
-Results [2]: [sum#38, isEmpty#39]
+Aggregate Attributes [2]: [sum#35, isEmpty#36]
+Results [2]: [sum#37, isEmpty#38]
 
-(32) Exchange
-Input [2]: [sum#38, isEmpty#39]
-Arguments: SinglePartition, true, [id=#40]
+(28) Exchange
+Input [2]: [sum#37, isEmpty#38]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#39]
 
-(33) HashAggregate [codegen id : 16]
-Input [2]: [sum#38, isEmpty#39]
+(29) HashAggregate [codegen id : 14]
+Input [2]: [sum#37, isEmpty#38]
 Keys: []
 Functions [1]: [sum(total_sum#21)]
-Aggregate Attributes [1]: [sum(total_sum#21)#41]
-Results [6]: [sum(total_sum#21)#41 AS total_sum#42, null AS i_category#43, null AS i_class#44, 1 AS g_category#45, 1 AS g_class#46, 2 AS lochierarchy#47]
+Aggregate Attributes [1]: [sum(total_sum#21)#40]
+Results [6]: [sum(total_sum#21)#40 AS total_sum#41, null AS i_category#42, null AS i_class#43, 1 AS g_category#44, 1 AS g_class#45, 2 AS lochierarchy#46]
 
-(34) Union
+(30) Union
 
-(35) HashAggregate [codegen id : 17]
+(31) HashAggregate [codegen id : 15]
 Input [6]: [total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18]
 Keys [6]: [total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18]
 Functions: []
 Aggregate Attributes: []
 Results [6]: [total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18]
 
-(36) Exchange
+(32) Exchange
 Input [6]: [total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18]
-Arguments: hashpartitioning(total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18, 5), true, [id=#48]
+Arguments: hashpartitioning(total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18, 5), ENSURE_REQUIREMENTS, [id=#47]
 
-(37) HashAggregate [codegen id : 18]
+(33) HashAggregate [codegen id : 16]
 Input [6]: [total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18]
 Keys [6]: [total_sum#15, i_category#9, i_class#8, g_category#16, g_class#17, lochierarchy#18]
 Functions: []
 Aggregate Attributes: []
-Results [5]: [total_sum#15, i_category#9, i_class#8, lochierarchy#18, CASE WHEN (g_class#17 = 0) THEN i_category#9 END AS _w0#49]
+Results [5]: [total_sum#15, i_category#9, i_class#8, lochierarchy#18, CASE WHEN (g_class#17 = 0) THEN i_category#9 END AS _w0#48]
 
-(38) Exchange
-Input [5]: [total_sum#15, i_category#9, i_class#8, lochierarchy#18, _w0#49]
-Arguments: hashpartitioning(lochierarchy#18, _w0#49, 5), true, [id=#50]
+(34) Exchange
+Input [5]: [total_sum#15, i_category#9, i_class#8, lochierarchy#18, _w0#48]
+Arguments: hashpartitioning(lochierarchy#18, _w0#48, 5), ENSURE_REQUIREMENTS, [id=#49]
 
-(39) Sort [codegen id : 19]
-Input [5]: [total_sum#15, i_category#9, i_class#8, lochierarchy#18, _w0#49]
-Arguments: [lochierarchy#18 ASC NULLS FIRST, _w0#49 ASC NULLS FIRST, total_sum#15 DESC NULLS LAST], false, 0
+(35) Sort [codegen id : 17]
+Input [5]: [total_sum#15, i_category#9, i_class#8, lochierarchy#18, _w0#48]
+Arguments: [lochierarchy#18 ASC NULLS FIRST, _w0#48 ASC NULLS FIRST, total_sum#15 DESC NULLS LAST], false, 0
 
-(40) Window
-Input [5]: [total_sum#15, i_category#9, i_class#8, lochierarchy#18, _w0#49]
-Arguments: [rank(total_sum#15) windowspecdefinition(lochierarchy#18, _w0#49, total_sum#15 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank_within_parent#51], [lochierarchy#18, _w0#49], [total_sum#15 DESC NULLS LAST]
+(36) Window
+Input [5]: [total_sum#15, i_category#9, i_class#8, lochierarchy#18, _w0#48]
+Arguments: [rank(total_sum#15) windowspecdefinition(lochierarchy#18, _w0#48, total_sum#15 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank_within_parent#50], [lochierarchy#18, _w0#48], [total_sum#15 DESC NULLS LAST]
 
-(41) Project [codegen id : 20]
-Output [5]: [total_sum#15, i_category#9, i_class#8, lochierarchy#18, rank_within_parent#51]
-Input [6]: [total_sum#15, i_category#9, i_class#8, lochierarchy#18, _w0#49, rank_within_parent#51]
+(37) Project [codegen id : 18]
+Output [5]: [total_sum#15, i_category#9, i_class#8, lochierarchy#18, rank_within_parent#50]
+Input [6]: [total_sum#15, i_category#9, i_class#8, lochierarchy#18, _w0#48, rank_within_parent#50]
 
-(42) TakeOrderedAndProject
-Input [5]: [total_sum#15, i_category#9, i_class#8, lochierarchy#18, rank_within_parent#51]
-Arguments: 100, [lochierarchy#18 DESC NULLS LAST, CASE WHEN (lochierarchy#18 = 0) THEN i_category#9 END ASC NULLS FIRST, rank_within_parent#51 ASC NULLS FIRST], [total_sum#15, i_category#9, i_class#8, lochierarchy#18, rank_within_parent#51]
+(38) TakeOrderedAndProject
+Input [5]: [total_sum#15, i_category#9, i_class#8, lochierarchy#18, rank_within_parent#50]
+Arguments: 100, [lochierarchy#18 DESC NULLS LAST, CASE WHEN (lochierarchy#18 = 0) THEN i_category#9 END ASC NULLS FIRST, rank_within_parent#50 ASC NULLS FIRST], [total_sum#15, i_category#9, i_class#8, lochierarchy#18, rank_within_parent#50]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a/simplified.txt
@@ -1,72 +1,64 @@
 TakeOrderedAndProject [lochierarchy,i_category,rank_within_parent,total_sum,i_class]
-  WholeStageCodegen (20)
+  WholeStageCodegen (18)
     Project [total_sum,i_category,i_class,lochierarchy,rank_within_parent]
       InputAdapter
         Window [total_sum,lochierarchy,_w0]
-          WholeStageCodegen (19)
+          WholeStageCodegen (17)
             Sort [lochierarchy,_w0,total_sum]
               InputAdapter
                 Exchange [lochierarchy,_w0] #1
-                  WholeStageCodegen (18)
+                  WholeStageCodegen (16)
                     HashAggregate [total_sum,i_category,i_class,g_category,g_class,lochierarchy] [_w0]
                       InputAdapter
                         Exchange [total_sum,i_category,i_class,g_category,g_class,lochierarchy] #2
-                          WholeStageCodegen (17)
+                          WholeStageCodegen (15)
                             HashAggregate [total_sum,i_category,i_class,g_category,g_class,lochierarchy]
                               InputAdapter
                                 Union
-                                  WholeStageCodegen (11)
-                                    HashAggregate [total_sum,i_category,i_class,g_category,g_class,lochierarchy]
+                                  WholeStageCodegen (4)
+                                    HashAggregate [i_category,i_class,sum] [sum(UnscaledValue(ws_net_paid)),total_sum,g_category,g_class,lochierarchy,sum]
                                       InputAdapter
-                                        Exchange [total_sum,i_category,i_class,g_category,g_class,lochierarchy] #3
-                                          WholeStageCodegen (10)
-                                            HashAggregate [total_sum,i_category,i_class,g_category,g_class,lochierarchy]
-                                              InputAdapter
-                                                Union
-                                                  WholeStageCodegen (4)
-                                                    HashAggregate [i_category,i_class,sum] [sum(UnscaledValue(ws_net_paid)),total_sum,g_category,g_class,lochierarchy,sum]
+                                        Exchange [i_category,i_class] #3
+                                          WholeStageCodegen (3)
+                                            HashAggregate [i_category,i_class,ws_net_paid] [sum,sum]
+                                              Project [ws_net_paid,i_class,i_category]
+                                                BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                  Project [ws_item_sk,ws_net_paid]
+                                                    BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                      Filter [ws_sold_date_sk,ws_item_sk]
+                                                        ColumnarToRow
+                                                          InputAdapter
+                                                            Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk,ws_net_paid]
                                                       InputAdapter
-                                                        Exchange [i_category,i_class] #4
-                                                          WholeStageCodegen (3)
-                                                            HashAggregate [i_category,i_class,ws_net_paid] [sum,sum]
-                                                              Project [ws_net_paid,i_class,i_category]
-                                                                BroadcastHashJoin [ws_item_sk,i_item_sk]
-                                                                  Project [ws_item_sk,ws_net_paid]
-                                                                    BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                      Filter [ws_sold_date_sk,ws_item_sk]
-                                                                        ColumnarToRow
-                                                                          InputAdapter
-                                                                            Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk,ws_net_paid]
-                                                                      InputAdapter
-                                                                        BroadcastExchange #5
-                                                                          WholeStageCodegen (1)
-                                                                            Project [d_date_sk]
-                                                                              Filter [d_month_seq,d_date_sk]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet default.date_dim [d_date_sk,d_month_seq]
+                                                        BroadcastExchange #4
+                                                          WholeStageCodegen (1)
+                                                            Project [d_date_sk]
+                                                              Filter [d_month_seq,d_date_sk]
+                                                                ColumnarToRow
                                                                   InputAdapter
-                                                                    BroadcastExchange #6
-                                                                      WholeStageCodegen (2)
-                                                                        Filter [i_item_sk]
-                                                                          ColumnarToRow
-                                                                            InputAdapter
-                                                                              Scan parquet default.item [i_item_sk,i_class,i_category]
-                                                  WholeStageCodegen (9)
-                                                    HashAggregate [i_category,sum,isEmpty] [sum(total_sum),total_sum,i_class,g_category,g_class,lochierarchy,sum,isEmpty]
-                                                      InputAdapter
-                                                        Exchange [i_category] #7
-                                                          WholeStageCodegen (8)
-                                                            HashAggregate [i_category,total_sum] [sum,isEmpty,sum,isEmpty]
-                                                              HashAggregate [i_category,i_class,sum] [sum(UnscaledValue(ws_net_paid)),total_sum,sum]
-                                                                InputAdapter
-                                                                  ReusedExchange [i_category,i_class,sum] #4
-                                  WholeStageCodegen (16)
+                                                                    Scan parquet default.date_dim [d_date_sk,d_month_seq]
+                                                  InputAdapter
+                                                    BroadcastExchange #5
+                                                      WholeStageCodegen (2)
+                                                        Filter [i_item_sk]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet default.item [i_item_sk,i_class,i_category]
+                                  WholeStageCodegen (9)
+                                    HashAggregate [i_category,sum,isEmpty] [sum(total_sum),total_sum,i_class,g_category,g_class,lochierarchy,sum,isEmpty]
+                                      InputAdapter
+                                        Exchange [i_category] #6
+                                          WholeStageCodegen (8)
+                                            HashAggregate [i_category,total_sum] [sum,isEmpty,sum,isEmpty]
+                                              HashAggregate [i_category,i_class,sum] [sum(UnscaledValue(ws_net_paid)),total_sum,sum]
+                                                InputAdapter
+                                                  ReusedExchange [i_category,i_class,sum] #3
+                                  WholeStageCodegen (14)
                                     HashAggregate [sum,isEmpty] [sum(total_sum),total_sum,i_category,i_class,g_category,g_class,lochierarchy,sum,isEmpty]
                                       InputAdapter
-                                        Exchange #8
-                                          WholeStageCodegen (15)
+                                        Exchange #7
+                                          WholeStageCodegen (13)
                                             HashAggregate [total_sum] [sum,isEmpty,sum,isEmpty]
                                               HashAggregate [i_category,i_class,sum] [sum(UnscaledValue(ws_net_paid)),total_sum,sum]
                                                 InputAdapter
-                                                  ReusedExchange [i_category,i_class,sum] #4
+                                                  ReusedExchange [i_category,i_class,sum] #3

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.catalyst.expressions.aggregate.{Complete, Partial}
 import org.apache.spark.sql.catalyst.optimizer.{ConvertToLocalRelation, NestedColumnAliasingSuite}
 import org.apache.spark.sql.catalyst.plans.logical.{Project, RepartitionByExpression}
 import org.apache.spark.sql.catalyst.util.StringUtils
+import org.apache.spark.sql.execution.UnionExec
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
 import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
@@ -3824,6 +3825,23 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
       }
       System.clearProperty("ivy.home")
     }
+  }
+
+  test("SPARK-xxxxx: Combine distinct unions that have noop project between them") {
+    val df = sql("""
+      |SELECT a, b FROM (
+      |  SELECT a, b FROM testData2
+      |  UNION
+      |  SELECT a, sum(b) FROM testData2 GROUP BY a
+      |  UNION
+      |  SELECT null AS a, sum(b) FROM testData2
+      |)""".stripMargin)
+
+    val unions = df.queryExecution.sparkPlan.collect {
+      case u: UnionExec => u
+    }
+
+    assert(unions.size == 1)
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3827,7 +3827,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     }
   }
 
-  test("SPARK-xxxxx: Combine distinct unions that have noop project between them") {
+  test("SPARK-33964: Combine distinct unions that have noop project between them") {
     val df = sql("""
       |SELECT a, b FROM (
       |  SELECT a, b FROM testData2


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Added the `RemoveNoopOperators` rule to optimization batch `Union`.  Also made sure that the `RemoveNoopOperators` would be idempotent. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
In several TPCDS queries the `CombineUnions` rule does not manage to combine unions, because they have noop `Project`s between them.
The `Project`s will be removed by `RemoveNoopOperators`, but by then `ReplaceDistinctWithAggregate` has been applied and there are aggregates between the unions. Adding a copy of `RemoveNoopOperators` earlier in the optimization chain allows `CombineUnions` to work on more queries.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
New UTs and the output of `PlanStabilitySuite`