### PR TITLE
[SPARK-33975][SQL] Include add_hours function

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -390,6 +390,7 @@ object FunctionRegistry {
     expression[XPathString]("xpath_string"),
 
     // datetime functions
+    expression[AddHours]("add_hours"),
     expression[AddMonths]("add_months"),
     expression[CurrentDate]("current_date"),
     expression[CurrentTimestamp]("current_timestamp"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -1445,8 +1445,9 @@ case class ToUTCTimestamp(left: Expression, right: Expression) extends UTCTimest
   override val prettyName: String = "to_utc_timestamp"
 }
 
-
-
+/**
+ * Returns the time that is numHours after startTime
+ */
 case class AddHours(startTime: Expression, numHours: Expression, timeZoneId: Option[String] = None)
   extends BinaryExpression with ImplicitCastInputTypes with NullIntolerant
     with TimeZoneAwareExpression {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -575,6 +575,21 @@ object DateTimeUtils {
   }
 
   /**
+   * Adds hours to a timestamp represented as the number of
+   * microseconds since 1970-01-01 00:00:00Z.
+   * @return A timestamp value, expressed in microseconds since 1970-01-01 00:00:00Z.
+   */
+  def timestampAddHours(
+    start: Long,
+    hours: Int,
+    zoneId: ZoneId): Long = {
+    val resultTimestamp = microsToInstant(start)
+      .atZone(zoneId)
+      .plusHours(hours)
+    instantToMicros(resultTimestamp.toInstant)
+  }
+
+  /**
    * Adds a full interval (months, days, microseconds) a timestamp represented as the number of
    * microseconds since 1970-01-01 00:00:00Z.
    * @return A timestamp value, expressed in microseconds since 1970-01-01 00:00:00Z.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -580,9 +580,9 @@ object DateTimeUtils {
    * @return A timestamp value, expressed in microseconds since 1970-01-01 00:00:00Z.
    */
   def timestampAddHours(
-    start: Long,
-    hours: Int,
-    zoneId: ZoneId): Long = {
+      start: Long,
+      hours: Int,
+      zoneId: ZoneId): Long = {
     val resultTimestamp = microsToInstant(start)
       .atZone(zoneId)
       .plusHours(hours)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -401,6 +401,16 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
     intercept[IllegalArgumentException](dateAddInterval(input, new CalendarInterval(36, 47, 1)))
   }
 
+  test("timestamp add hours") {
+    val ts1 = date(1997, 2, 28, 10, 30, 0)
+    val ts2 = date(1997, 2, 28, 14, 30, 0)
+    assert(timestampAddHours(ts1, 4, defaultZoneId) === ts2)
+
+    val ts3 = date(1997, 2, 27, 16, 0, 0, 0, LA)
+    val ts4 = date(1997, 2, 27, 12, 0, 0, 0, LA)
+    assert(timestampAddHours(ts3, -4, LA) === ts4)
+  }
+
   test("timestamp add months") {
     val ts1 = date(1997, 2, 28, 10, 30, 0)
     val ts2 = date(2000, 2, 28, 10, 30, 0, 123000)

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -2842,6 +2842,20 @@ object functions {
   //////////////////////////////////////////////////////////////////////////////////////////////
 
   /**
+   * Returns the timestamp that is `numHours` after `startTime`.
+   *
+   * @param startTime A date, timestamp or string. If a string, the data must be in a format that
+   *                  can be cast to a date, such as `yyyy-MM-dd` or `yyyy-MM-dd HH:mm:ss.SSSS`
+   * @param numHours The number of hours to add to `startTime`, can be negative to subtract hours
+   * @return A timestamp, or null if `startTime` was a string that could not be cast to a timestamp
+   * @group datetime_funcs
+   * @since TBD
+   */
+  def add_hours(startTime: Column, numHours: Column): Column = withExpr {
+    AddHours(startTime.expr, numHours.expr)
+  }
+
+  /**
    * Returns the date that is `numMonths` after `startDate`.
    *
    * @param startDate A date, timestamp or string. If a string, the data must be in a format that

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -2849,7 +2849,7 @@ object functions {
    * @param numHours The number of hours to add to `startTime`, can be negative to subtract hours
    * @return A timestamp, or null if `startTime` was a string that could not be cast to a timestamp
    * @group datetime_funcs
-   * @since TBD
+   * @since 3.2.0
    */
   def add_hours(startTime: Column, numHours: Column): Column = withExpr {
     AddHours(startTime.expr, numHours.expr)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
@@ -326,7 +326,7 @@ class DateFunctionsSuite extends QueryTest with SharedSparkSession {
   test("function add_hours") {
     val t1 = Timestamp.valueOf("2015-10-01 00:00:01")
     val t2 = Timestamp.valueOf("2016-02-29 00:00:02")
-    val df = Seq((1, t1), (2, t2)).toDF("n", "t")
+    val df = Seq((t1), (t2)).toDF("t")
     checkAnswer(
       df.select(add_hours(col("t"), lit(2))),
       Seq(Row(Timestamp.valueOf("2015-10-01 02:00:01")),
@@ -349,7 +349,7 @@ class DateFunctionsSuite extends QueryTest with SharedSparkSession {
         Row(Timestamp.valueOf("2016-02-29 02:00:02"))))
     val d1 = Date.valueOf("2015-08-31")
     val d2 = Date.valueOf("2015-02-28")
-    val df2 = Seq((1, d1), (2, d2)).toDF("n", "d")
+    val df2 = Seq((d1), (d2)).toDF("d")
     checkAnswer(
       df2.select(add_hours(col("d"), lit(1))),
       Seq(Row(Timestamp.valueOf("2015-08-31 01:00:00")),

--- a/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
@@ -323,6 +323,39 @@ class DateFunctionsSuite extends QueryTest with SharedSparkSession {
         Row(Timestamp.valueOf("2015-12-27 00:00:00"))))
   }
 
+  test("function add_hours") {
+    val t1 = Timestamp.valueOf("2015-10-01 00:00:01")
+    val t2 = Timestamp.valueOf("2016-02-29 00:00:02")
+    val df = Seq((1, t1), (2, t2)).toDF("n", "t")
+    checkAnswer(
+      df.select(add_hours(col("t"), lit(2))),
+      Seq(Row(Timestamp.valueOf("2015-10-01 02:00:01")),
+        Row(Timestamp.valueOf("2016-02-29 02:00:02"))))
+    checkAnswer(
+      df.select(add_hours(col("t"), lit(-2))),
+      Seq(Row(Timestamp.valueOf("2015-09-30 22:00:01")),
+        Row(Timestamp.valueOf("2016-02-28 22:00:02"))))
+    checkAnswer(
+      df.selectExpr("add_hours(t, 2)"),
+      Seq(Row(Timestamp.valueOf("2015-10-01 02:00:01")),
+        Row(Timestamp.valueOf("2016-02-29 02:00:02"))))
+    checkAnswer(
+      df.selectExpr("add_hours(t, -2)"),
+      Seq(Row(Timestamp.valueOf("2015-09-30 22:00:01")),
+        Row(Timestamp.valueOf("2016-02-28 22:00:02"))))
+    checkAnswer(
+      df.withColumn("x", lit(2)).select(add_hours(col("t"), col("x"))),
+      Seq(Row(Timestamp.valueOf("2015-10-01 02:00:01")),
+        Row(Timestamp.valueOf("2016-02-29 02:00:02"))))
+    val d1 = Date.valueOf("2015-08-31")
+    val d2 = Date.valueOf("2015-02-28")
+    val df2 = Seq((1, d1), (2, d2)).toDF("n", "d")
+    checkAnswer(
+      df2.select(add_hours(col("d"), lit(1))),
+      Seq(Row(Timestamp.valueOf("2015-08-31 01:00:00")),
+        Row(Timestamp.valueOf("2015-02-28 01:00:00"))))
+  }
+
   test("function add_months") {
     val d1 = Date.valueOf("2015-08-31")
     val d2 = Date.valueOf("2015-02-28")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR add an `add_hours` function.  Here's how users currently need to add hours to a time column:

```scala
df.withColumn("plus_2_hours", expr("first_datetime + INTERVAL 2 hours"))
```

We don't want to make users manipulate strings in their Scala code.  We also don't want to force users to pass around column names when they should be passing around Column objects.

The `add_hours` function will make this logic a lot more intuitive and consistent with the rest of the API:

```scala
df.withColumn("plus_2_hours", add_hours(col("first_datetime"), lit(2)))
```

The [Stackoverflow question on this issue](https://stackoverflow.com/questions/40883084/adding-12-hours-to-datetime-column-in-spark) has 21,000 views, so this feature will be useful for a lot of users.

[Spark 3 made some awesome improvements to the dates / times APIs](https://databricks.com/blog/2020/07/22/a-comprehensive-look-at-dates-and-timestamps-in-apache-spark-3-0.html) and this PR is one example of an improvement that'll continue making these APIs easier to use.

### Why are the changes needed?

There are the `INTERVAL` and UDF work-arounds, so this isn't strictly needed, but it makes the API a lot easier to work with when performing hour-based computations.  It'll also make the answer easier to find.  It's not easy to find the `INTERVAL` solution in [the docs](https://spark.apache.org/docs/latest/api/scala/org/apache/spark/sql/functions$.html).

### Does this PR introduce _any_ user-facing change?

Yes, this adds the `add_hours` function to the `org.apache.spark.sql.functions` object which is a public facing API.  The `@since` function annotation will need to be updated with the right version if this ends up getting merged in.

### How was this patch tested?

Function was unit tested.  The unit tests follow the testing patterns of similar SQL functions.