### PR TITLE
[SPARK-34009][BUILD] To activate profile 'aarch64' based on OS settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3371,6 +3371,12 @@
       <properties>
         <leveldbjni.group>org.openlabtesting.leveldbjni</leveldbjni.group>
       </properties>
+      <activation>
+        <os>
+          <family>linux</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
Instead of taking parameter '-Paarch64' when maven build
to activate the profile based on OS settings automatically,
than we can use same command to build on aarch64.

### What changes were proposed in this pull request?
Activate profile 'aarch64' based on OS


### Why are the changes needed?
After this change, we build spark using the same command for aarch64 as x86. 


### Does this PR introduce _any_ user-facing change?
No.
After this change, no need to taking parameter '-Paarch64' when build, but take the parameter works also.


### How was this patch tested?
ARM daily CI.
