### PR TITLE
[SPARK-33874][K8S][FOLLOWUP] Handle long lived sidecars - clean up logging

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsSnapshot.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsSnapshot.scala
@@ -93,9 +93,10 @@ object ExecutorPodsSnapshot extends Logging {
                   case _ =>
                     PodRunning(pod)
                 }
-              // If we can't find the Spark container status, fall back to the pod status
+              // If we can't find the Spark container status, fall back to the pod status. This is
+              // expected to occur during pod startup and other situations.
               case _ =>
-                logWarning(s"Unable to find container ${sparkContainerName} in pod ${pod} " +
+                logDebug(s"Unable to find container ${sparkContainerName} in pod ${pod} " +
                   "defaulting to entire pod status (running).")
                 PodRunning(pod)
             }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Switch log level from warn to debug when the spark container is not present in the pod's container statuses.

### Why are the changes needed?

There are many non-critical situations where the Spark container may not be present, and the warning log level is too high.

### Does this PR introduce _any_ user-facing change?

Log message change.

### How was this patch tested?

N/A