### PR TITLE
[SPARK-30681][PYTHON][FOLLOW-UP] Keep the name similar with Scala side in higher order functions

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -4355,7 +4355,7 @@ def filter(col, f):
     return _invoke_higher_order_function("ArrayFilter", [col], [f])
 
 
-def aggregate(col, zero, merge, finish=None):
+def aggregate(col, initialValue, merge, finish=None):
     """
     Applies a binary operator to an initial state and all elements in the array,
     and reduces this to a single state. The final state is converted into the final result
@@ -4372,7 +4372,7 @@ def aggregate(col, zero, merge, finish=None):
     ----------
     col : :class:`Column` or str
         name of column or expression
-    zero : :class:`Column` or str
+    initialValue : :class:`Column` or str
         initial value. Name of column or expression
     merge : function
         a binary function ``(acc: Column, x: Column) -> Column...`` returning expression
@@ -4416,19 +4416,19 @@ def aggregate(col, zero, merge, finish=None):
     if finish is not None:
         return _invoke_higher_order_function(
             "ArrayAggregate",
-            [col, zero],
+            [col, initialValue],
             [merge, finish]
         )
 
     else:
         return _invoke_higher_order_function(
             "ArrayAggregate",
-            [col, zero],
+            [col, initialValue],
             [merge]
         )
 
 
-def zip_with(col1, col2, f):
+def zip_with(left, right, f):
     """
     Merge two given arrays, element-wise, into a single array using a function.
     If one array is shorter, nulls are appended at the end to match the length of the longer
@@ -4438,9 +4438,9 @@ def zip_with(col1, col2, f):
 
     Parameters
     ----------
-    col1 : :class:`Column` or str
+    left : :class:`Column` or str
         name of the first column or expression
-    col2 : :class:`Column` or str
+    right : :class:`Column` or str
         name of the second column or expression
     f : function
         a binary function ``(x1: Column, x2: Column) -> Column...``
@@ -4471,7 +4471,7 @@ def zip_with(col1, col2, f):
     |[foo_1, bar_2, 3]|
     +-----------------+
     """
-    return _invoke_higher_order_function("ZipWith", [col1, col2], [f])
+    return _invoke_higher_order_function("ZipWith", [left, right], [f])
 
 
 def transform_keys(col, f):

--- a/python/pyspark/sql/functions.pyi
+++ b/python/pyspark/sql/functions.pyi
@@ -237,13 +237,13 @@ def filter(col: ColumnOrName, f: Callable[[Column], Column]) -> Column: ...
 def filter(col: ColumnOrName, f: Callable[[Column, Column], Column]) -> Column: ...
 def aggregate(
     col: ColumnOrName,
-    zero: ColumnOrName,
+    initialValue: ColumnOrName,
     merge: Callable[[Column, Column], Column],
     finish: Optional[Callable[[Column], Column]] = ...,
 ) -> Column: ...
 def zip_with(
-    col1: ColumnOrName,
-    ColumnOrName: ColumnOrName,
+    left: ColumnOrName,
+    right: ColumnOrName,
     f: Callable[[Column, Column], Column],
 ) -> Column: ...
 def transform_keys(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/27406. It fixes the naming to match with Scala side.

Note that there are a bit of inconsistency already e.g.) `col`, `e`, `expr` and `column`. This part I did not change but other names like `zero` vs `initialValue` or `col1`/`col2` vs `left`/`right` looks unnecessary.

### Why are the changes needed?

To make the usage similar with Scala side, and for consistency.

### Does this PR introduce _any_ user-facing change?

No, this is not released yet.

### How was this patch tested?

GitHub Actions and Jenkins build will test it out.
