### PR TITLE
[SPARK-33995][SQL] Expose make_interval as a Scala function

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -2842,7 +2842,7 @@ object functions {
   //////////////////////////////////////////////////////////////////////////////////////////////
 
   /**
-   * Creates a datetime interval
+   * (Scala-specific) Creates a datetime interval
    *
    * @param years Number of years
    * @param months Number of months

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -2842,6 +2842,31 @@ object functions {
   //////////////////////////////////////////////////////////////////////////////////////////////
 
   /**
+   * Creates a datetime interval
+   *
+   * @param years Number of years
+   * @param months Number of months
+   * @param weeks Number of weeks
+   * @param days Number of days
+   * @param hours Number of hours
+   * @param mins Number of mins
+   * @param secs Number of secs
+   * @return A datetime interval
+   * @group datetime_funcs
+   * @since 3.2.0
+   */
+  def make_interval(
+      years: Column = lit(0),
+      months: Column = lit(0),
+      weeks: Column = lit(0),
+      days: Column = lit(0),
+      hours: Column = lit(0),
+      mins: Column = lit(0),
+      secs: Column = lit(0)): Column = withExpr {
+    MakeInterval(years.expr, months.expr, weeks.expr, days.expr, hours.expr, mins.expr, secs.expr)
+  }
+
+  /**
    * Returns the date that is `numMonths` after `startDate`.
    *
    * @param startDate A date, timestamp or string. If a string, the data must be in a format that

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDateFunctionsSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDateFunctionsSuite.java
@@ -41,7 +41,8 @@ public class JavaDateFunctionsSuite {
     StructType schema = createStructType(Arrays.asList(
       createStructField("some_date", DateType, false),
       createStructField("expected", DateType, false)));
-    Dataset<Row> df = spark.createDataFrame(rows, schema).withColumn("plus_two_years", col("some_date").plus(twoYears));
+    Dataset<Row> df = spark.createDataFrame(rows, schema)
+            .withColumn("plus_two_years", col("some_date").plus(twoYears));
     Assert.assertTrue(Arrays.equals(
       (Row[]) df.select(df.col("plus_two_years")).collect(),
       (Row[]) df.select(df.col("expected")).collect()));

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDateFunctionsSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDateFunctionsSuite.java
@@ -1,0 +1,50 @@
+package test.org.apache.spark.sql;
+
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.test.TestSparkSession;
+import org.apache.spark.sql.types.StructType;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.Date;
+import java.util.*;
+
+import static org.apache.spark.sql.types.DataTypes.*;
+import static org.apache.spark.sql.functions.*;
+
+public class JavaDateFunctionsSuite {
+    private transient TestSparkSession spark;
+
+    @Before
+    public void setUp() {
+        spark = new TestSparkSession();
+    }
+
+    @After
+    public void tearDown() {
+        spark.stop();
+        spark = null;
+    }
+
+    @Test
+    public void makeIntervalWorksWithJava() {
+        Column twoYears = make_interval(lit(2), lit(0), lit(0), lit(0), lit(0), lit(0), lit(0));
+        List<Row> rows = Arrays.asList(
+                RowFactory.create(Date.valueOf("2014-06-30"), Date.valueOf("2016-06-30")),
+                RowFactory.create(Date.valueOf("2015-05-01"), Date.valueOf("2017-05-01")),
+                RowFactory.create(Date.valueOf("2018-12-30"), Date.valueOf("2020-12-30")));
+        StructType schema = createStructType(Arrays.asList(
+                createStructField("some_date", DateType, false),
+                createStructField("expected", DateType, false)));
+        Dataset<Row> df = spark.createDataFrame(rows, schema).withColumn("plus_two_years", col("some_date").plus(twoYears));
+        Assert.assertTrue(Arrays.equals(
+                (Row[]) df.select(df.col("plus_two_years")).collect(),
+                (Row[]) df.select(df.col("expected")).collect()));
+    }
+
+}

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDateFunctionsSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDateFunctionsSuite.java
@@ -18,33 +18,33 @@ import static org.apache.spark.sql.types.DataTypes.*;
 import static org.apache.spark.sql.functions.*;
 
 public class JavaDateFunctionsSuite {
-    private transient TestSparkSession spark;
+  private transient TestSparkSession spark;
 
-    @Before
-    public void setUp() {
+  @Before
+  public void setUp() {
         spark = new TestSparkSession();
     }
 
-    @After
-    public void tearDown() {
-        spark.stop();
-        spark = null;
-    }
+  @After
+  public void tearDown() {
+    spark.stop();
+    spark = null;
+  }
 
-    @Test
-    public void makeIntervalWorksWithJava() {
-        Column twoYears = make_interval(lit(2), lit(0), lit(0), lit(0), lit(0), lit(0), lit(0));
-        List<Row> rows = Arrays.asList(
-                RowFactory.create(Date.valueOf("2014-06-30"), Date.valueOf("2016-06-30")),
-                RowFactory.create(Date.valueOf("2015-05-01"), Date.valueOf("2017-05-01")),
-                RowFactory.create(Date.valueOf("2018-12-30"), Date.valueOf("2020-12-30")));
-        StructType schema = createStructType(Arrays.asList(
-                createStructField("some_date", DateType, false),
-                createStructField("expected", DateType, false)));
-        Dataset<Row> df = spark.createDataFrame(rows, schema).withColumn("plus_two_years", col("some_date").plus(twoYears));
-        Assert.assertTrue(Arrays.equals(
-                (Row[]) df.select(df.col("plus_two_years")).collect(),
-                (Row[]) df.select(df.col("expected")).collect()));
-    }
+  @Test
+  public void makeIntervalWorksWithJava() {
+    Column twoYears = make_interval(lit(2), lit(0), lit(0), lit(0), lit(0), lit(0), lit(0));
+    List<Row> rows = Arrays.asList(
+      RowFactory.create(Date.valueOf("2014-06-30"), Date.valueOf("2016-06-30")),
+      RowFactory.create(Date.valueOf("2015-05-01"), Date.valueOf("2017-05-01")),
+      RowFactory.create(Date.valueOf("2018-12-30"), Date.valueOf("2020-12-30")));
+    StructType schema = createStructType(Arrays.asList(
+      createStructField("some_date", DateType, false),
+      createStructField("expected", DateType, false)));
+    Dataset<Row> df = spark.createDataFrame(rows, schema).withColumn("plus_two_years", col("some_date").plus(twoYears));
+    Assert.assertTrue(Arrays.equals(
+      (Row[]) df.select(df.col("plus_two_years")).collect(),
+      (Row[]) df.select(df.col("expected")).collect()));
+  }
 
 }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDateFunctionsSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDateFunctionsSuite.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package test.org.apache.spark.sql;
 
 import org.apache.spark.sql.Column;

--- a/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
@@ -323,6 +323,46 @@ class DateFunctionsSuite extends QueryTest with SharedSparkSession {
         Row(Timestamp.valueOf("2015-12-27 00:00:00"))))
   }
 
+  test("function make_interval") {
+    val t1 = Timestamp.valueOf("2015-10-01 00:00:01")
+    val t2 = Timestamp.valueOf("2016-02-29 00:00:02")
+    val df = Seq((t1), (t2)).toDF("t")
+    // adds two hours to times
+    checkAnswer(
+      df.select(col("t") + make_interval(hours = lit(2))),
+      Seq(Row(Timestamp.valueOf("2015-10-01 02:00:01")),
+        Row(Timestamp.valueOf("2016-02-29 02:00:02"))))
+    // adds four days and two hours to times
+    checkAnswer(
+      df.select(col("t") + make_interval(hours = lit(2), days = lit(4))),
+      Seq(Row(Timestamp.valueOf("2015-10-05 02:00:01")),
+        Row(Timestamp.valueOf("2016-03-04 02:00:02"))))
+    // subtracts two hours from times
+    checkAnswer(
+      df.select(col("t") + make_interval(hours = lit(-2))),
+      Seq(Row(Timestamp.valueOf("2015-09-30 22:00:01")),
+        Row(Timestamp.valueOf("2016-02-28 22:00:02"))))
+
+    val d1 = Date.valueOf("2015-08-31")
+    val d2 = Date.valueOf("2015-02-28")
+    val df2 = Seq((d1), (d2)).toDF("d")
+    // adding an hour to a date does nothing
+    checkAnswer(
+      df2.select(col("d") + make_interval(hours = lit(1))),
+      Seq(Row(Date.valueOf("2015-08-31")),
+        Row(Date.valueOf("2015-02-28"))))
+    // adds three years to date
+    checkAnswer(
+      df2.select(col("d") + make_interval(years = lit(3))),
+      Seq(Row(Date.valueOf("2018-08-31")),
+        Row(Date.valueOf("2018-02-28"))))
+    // subtracts 1 week, one day from date
+    checkAnswer(
+      df2.select(col("d") - make_interval(weeks = lit(1), days = lit(1))),
+      Seq(Row(Date.valueOf("2015-08-23")),
+        Row(Date.valueOf("2015-02-20"))))
+  }
+
   test("function add_months") {
     val d1 = Date.valueOf("2015-08-31")
     val d2 = Date.valueOf("2015-02-28")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pull request exposes the `make_interval` function, [as suggested here](https://github.com/apache/spark/pull/31000#pullrequestreview-560812433), and as agreed to [here](https://github.com/apache/spark/pull/31000#issuecomment-754856820) and [here](https://github.com/apache/spark/pull/31000#issuecomment-755040234).

This powerful little function allows for idiomatic datetime arithmetic via the Scala API:

```scala
// add two hours
df.withColumn("plus_2_hours", col("first_datetime") + make_interval(hours = lit(2)))

// subtract one week and 30 seconds
col("d") - make_interval(weeks = lit(1), secs = lit(30))
```

The `make_interval` [SQL function](https://github.com/apache/spark/pull/26446) already exists.

Here is [the JIRA ticket](https://issues.apache.org/jira/browse/SPARK-33995) for this PR.

### Why are the changes needed?

The Spark API makes it easy to perform datetime addition / subtraction with months (`add_months`) and days (`date_add`).  Users need to write code like this to perform datetime addition with years, weeks, hours, minutes, or seconds:

```scala
df.withColumn("plus_2_hours", expr("first_datetime + INTERVAL 2 hours"))
```

We don't want to force users to manipulate SQL strings when they're using the Scala API.

### Does this PR introduce _any_ user-facing change?

Yes, this PR adds `make_interval` to the `org.apache.spark.sql.functions` API.  

This single function will benefit a lot of users.  It's a small increase in the surface of the API for a big gain.

### How was this patch tested?

This was tested via unit tests.

cc: @MaxGekk 