### PR TITLE
[SPARK-34026][SQL] Inject repartition and sort nodes to satisfy required distribution and ordering

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/InMemoryTable.scala
@@ -30,7 +30,8 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, JoinedRow}
 import org.apache.spark.sql.catalyst.util.{CharVarcharUtils, DateTimeUtils}
 import org.apache.spark.sql.connector.catalog._
-import org.apache.spark.sql.connector.expressions.{BucketTransform, DaysTransform, HoursTransform, IdentityTransform, MonthsTransform, Transform, YearsTransform}
+import org.apache.spark.sql.connector.distributions.{Distribution, Distributions}
+import org.apache.spark.sql.connector.expressions.{BucketTransform, DaysTransform, HoursTransform, IdentityTransform, MonthsTransform, SortOrder, Transform, YearsTransform}
 import org.apache.spark.sql.connector.read._
 import org.apache.spark.sql.connector.write._
 import org.apache.spark.sql.connector.write.streaming.{StreamingDataWriterFactory, StreamingWrite}
@@ -46,7 +47,9 @@ class InMemoryTable(
     val name: String,
     val schema: StructType,
     override val partitioning: Array[Transform],
-    override val properties: util.Map[String, String])
+    override val properties: util.Map[String, String],
+    val distribution: Distribution = Distributions.unspecified(),
+    val ordering: Array[SortOrder] = Array.empty)
   extends Table with SupportsRead with SupportsWrite with SupportsDelete
       with SupportsMetadataColumns {
 
@@ -274,7 +277,11 @@ class InMemoryTable(
         this
       }
 
-      override def build(): Write = new Write {
+      override def build(): Write = new Write with RequiresDistributionAndOrdering {
+        override def requiredDistribution: Distribution = distribution
+
+        override def requiredOrdering: Array[SortOrder] = ordering
+
         override def toBatch: BatchWrite = writer
 
         override def toStreaming: StreamingWrite = streamingWriter match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DistributionAndOrderingUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DistributionAndOrderingUtils.scala
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.spark.sql.{catalyst, AnalysisException}
+import org.apache.spark.sql.catalyst.analysis.Resolver
+import org.apache.spark.sql.catalyst.expressions.{NamedExpression, SortOrder}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, RepartitionByExpression, Sort}
+import org.apache.spark.sql.connector.distributions.{ClusteredDistribution, OrderedDistribution, UnspecifiedDistribution}
+import org.apache.spark.sql.connector.expressions.{Expression, FieldReference, IdentityTransform, NullOrdering, SortDirection, SortValue}
+import org.apache.spark.sql.connector.write.{RequiresDistributionAndOrdering, Write}
+import org.apache.spark.sql.internal.SQLConf
+
+object DistributionAndOrderingUtils {
+
+  def prepareQuery(write: Write, query: LogicalPlan, conf: SQLConf): LogicalPlan = write match {
+    case write: RequiresDistributionAndOrdering =>
+      val resolver = conf.resolver
+
+      val distribution = write.requiredDistribution match {
+        case d: OrderedDistribution =>
+          d.ordering.map(e => toCatalyst(e, query, resolver))
+        case d: ClusteredDistribution =>
+          d.clustering.map(e => toCatalyst(e, query, resolver))
+        case _: UnspecifiedDistribution =>
+          Array.empty[catalyst.expressions.Expression]
+      }
+
+      val queryWithDistribution = if (distribution.nonEmpty) {
+        val numShufflePartitions = conf.numShufflePartitions
+        // the conversion to catalyst expressions above produces SortOrder expressions
+        // for OrderedDistribution and generic expressions for ClusteredDistribution
+        // this allows RepartitionByExpression to pick either range or hash partitioning
+        RepartitionByExpression(distribution, query, numShufflePartitions)
+      } else {
+        query
+      }
+
+      val ordering = write.requiredOrdering.toSeq
+        .map(e => toCatalyst(e, query, resolver))
+        .asInstanceOf[Seq[catalyst.expressions.SortOrder]]
+
+      val queryWithDistributionAndOrdering = if (ordering.nonEmpty) {
+        Sort(ordering, global = false, queryWithDistribution)
+      } else {
+        queryWithDistribution
+      }
+
+      queryWithDistributionAndOrdering
+
+    case _ =>
+      query
+  }
+
+  private def toCatalyst(
+      expr: Expression,
+      query: LogicalPlan,
+      resolver: Resolver): catalyst.expressions.Expression = {
+
+    // we cannot perform the resolution in the analyzer since we need to optimize expressions
+    // in nodes like OverwriteByExpression before constructing a logical write
+    def resolve(ref: FieldReference): NamedExpression = {
+      query.resolve(ref.parts, resolver) match {
+        case Some(attr) => attr
+        case None => throw new AnalysisException(s"Cannot resolve '$ref' using ${query.output}")
+      }
+    }
+
+    expr match {
+      case SortValue(child, direction, nullOrdering) =>
+        val catalystChild = toCatalyst(child, query, resolver)
+        SortOrder(catalystChild, toCatalyst(direction), toCatalyst(nullOrdering), Seq.empty)
+      case IdentityTransform(ref) =>
+        resolve(ref)
+      case ref: FieldReference =>
+        resolve(ref)
+      case _ =>
+        throw new AnalysisException(s"$expr is not currently supported")
+    }
+  }
+
+  private def toCatalyst(direction: SortDirection): catalyst.expressions.SortDirection = {
+    direction match {
+      case SortDirection.ASCENDING => catalyst.expressions.Ascending
+      case SortDirection.DESCENDING => catalyst.expressions.Descending
+    }
+  }
+
+  private def toCatalyst(nullOrdering: NullOrdering): catalyst.expressions.NullOrdering = {
+    nullOrdering match {
+      case NullOrdering.NULLS_FIRST => catalyst.expressions.NullsFirst
+      case NullOrdering.NULLS_LAST => catalyst.expressions.NullsLast
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/WriteDistributionAndOrderingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/WriteDistributionAndOrderingSuite.scala
@@ -1,0 +1,619 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector
+
+import java.util.Collections
+
+import org.scalatest.BeforeAndAfter
+
+import org.apache.spark.sql.{catalyst, DataFrame, QueryTest}
+import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.catalyst.plans.physical
+import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, RangePartitioning, UnknownPartitioning}
+import org.apache.spark.sql.connector.catalog.Identifier
+import org.apache.spark.sql.connector.distributions.{Distribution, Distributions}
+import org.apache.spark.sql.connector.expressions.{Expression, FieldReference, NullOrdering, SortDirection, SortOrder}
+import org.apache.spark.sql.connector.expressions.LogicalExpressions._
+import org.apache.spark.sql.execution.{QueryExecution, SortExec, SparkPlan}
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
+import org.apache.spark.sql.execution.datasources.v2.V2TableWriteExec
+import org.apache.spark.sql.execution.exchange.ShuffleExchangeLike
+import org.apache.spark.sql.functions.lit
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
+import org.apache.spark.sql.util.QueryExecutionListener
+
+class WriteDistributionAndOrderingSuite
+  extends QueryTest with SharedSparkSession with BeforeAndAfter {
+
+  import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+  before {
+    spark.conf.set("spark.sql.catalog.testcat", classOf[InMemoryTableCatalog].getName)
+  }
+
+  after {
+    spark.sessionState.catalogManager.reset()
+    spark.sessionState.conf.clear()
+  }
+
+  private val namespace = Array("ns1")
+  private val ident = Identifier.of(namespace, "test_table")
+  private val tableNameAsString = "testcat." + ident.toString
+  private val emptyProps = Collections.emptyMap[String, String]
+  private val schema = new StructType()
+    .add("id", IntegerType)
+    .add("data", StringType)
+
+  private val resolver = conf.resolver
+
+  test("ordered distribution and sort with same exprs: append") {
+    checkOrderedDistributionAndSortWithSameExprs("append")
+  }
+
+  test("ordered distribution and sort with same exprs: overwrite") {
+    checkOrderedDistributionAndSortWithSameExprs("overwrite")
+  }
+
+  test("ordered distribution and sort with same exprs: overwriteDynamic") {
+    checkOrderedDistributionAndSortWithSameExprs("overwriteDynamic")
+  }
+
+  private def checkOrderedDistributionAndSortWithSameExprs(command: String): Unit = {
+    val tableOrdering = Array[SortOrder](
+      sort(FieldReference("data"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST)
+    )
+    val tableDistribution = Distributions.ordered(tableOrdering)
+
+    val writeOrdering = Seq(
+      catalyst.expressions.SortOrder(
+        attr("data"),
+        catalyst.expressions.Ascending,
+        catalyst.expressions.NullsFirst,
+        Seq.empty
+      )
+    )
+    val writePartitioning = RangePartitioning(writeOrdering, conf.numShufflePartitions)
+
+    checkWriteRequirements(
+      tableDistribution,
+      tableOrdering,
+      expectedWritePartitioning = writePartitioning,
+      expectedWriteOrdering = writeOrdering,
+      writeCommand = command)
+  }
+
+  test("clustered distribution and sort with same exprs: append") {
+    checkClusteredDistributionAndSortWithSameExprs("append")
+  }
+
+  test("clustered distribution and sort with same exprs: overwrite") {
+    checkClusteredDistributionAndSortWithSameExprs("overwrite")
+  }
+
+  test("clustered distribution and sort with same exprs: overwriteDynamic") {
+    checkClusteredDistributionAndSortWithSameExprs("overwriteDynamic")
+  }
+
+  private def checkClusteredDistributionAndSortWithSameExprs(command: String): Unit = {
+    val tableOrdering = Array[SortOrder](
+      sort(FieldReference("data"), SortDirection.DESCENDING, NullOrdering.NULLS_FIRST),
+      sort(FieldReference("id"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST)
+    )
+    val clustering = Array[Expression](FieldReference("data"), FieldReference("id"))
+    val tableDistribution = Distributions.clustered(clustering)
+
+    val writeOrdering = Seq(
+      catalyst.expressions.SortOrder(
+        attr("data"),
+        catalyst.expressions.Descending,
+        catalyst.expressions.NullsFirst,
+        Seq.empty
+      ),
+      catalyst.expressions.SortOrder(
+        attr("id"),
+        catalyst.expressions.Ascending,
+        catalyst.expressions.NullsFirst,
+        Seq.empty
+      )
+    )
+    val writePartitioningExprs = Seq(attr("data"), attr("id"))
+    val writePartitioning = HashPartitioning(writePartitioningExprs, conf.numShufflePartitions)
+
+    checkWriteRequirements(
+      tableDistribution,
+      tableOrdering,
+      expectedWritePartitioning = writePartitioning,
+      expectedWriteOrdering = writeOrdering,
+      writeCommand = command)
+  }
+
+  test("clustered distribution and sort with extended exprs: append") {
+    checkClusteredDistributionAndSortWithExtendedExprs("append")
+  }
+
+  test("clustered distribution and sort with extended exprs: overwrite") {
+    checkClusteredDistributionAndSortWithExtendedExprs("overwrite")
+  }
+
+  test("clustered distribution and sort with extended exprs: overwriteDynamic") {
+    checkClusteredDistributionAndSortWithExtendedExprs("overwriteDynamic")
+  }
+
+  private def checkClusteredDistributionAndSortWithExtendedExprs(command: String): Unit = {
+    val tableOrdering = Array[SortOrder](
+      sort(FieldReference("data"), SortDirection.DESCENDING, NullOrdering.NULLS_FIRST),
+      sort(FieldReference("id"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST)
+    )
+    val clustering = Array[Expression](FieldReference("data"))
+    val tableDistribution = Distributions.clustered(clustering)
+
+    val writeOrdering = Seq(
+      catalyst.expressions.SortOrder(
+        attr("data"),
+        catalyst.expressions.Descending,
+        catalyst.expressions.NullsFirst,
+        Seq.empty
+      ),
+      catalyst.expressions.SortOrder(
+        attr("id"),
+        catalyst.expressions.Ascending,
+        catalyst.expressions.NullsFirst,
+        Seq.empty
+      )
+    )
+    val writePartitioningExprs = Seq(attr("data"))
+    val writePartitioning = HashPartitioning(writePartitioningExprs, conf.numShufflePartitions)
+
+    checkWriteRequirements(
+      tableDistribution,
+      tableOrdering,
+      expectedWritePartitioning = writePartitioning,
+      expectedWriteOrdering = writeOrdering,
+      writeCommand = command)
+  }
+
+  test("unspecified distribution and local sort: append") {
+    checkUnspecifiedDistributionAndLocalSort("append")
+  }
+
+  test("unspecified distribution and local sort: overwrite") {
+    checkUnspecifiedDistributionAndLocalSort("overwrite")
+  }
+
+  test("unspecified distribution and local sort: overwriteDynamic") {
+    checkUnspecifiedDistributionAndLocalSort("overwriteDynamic")
+  }
+
+  private def checkUnspecifiedDistributionAndLocalSort(command: String): Unit = {
+    val tableOrdering = Array[SortOrder](
+      sort(FieldReference("data"), SortDirection.DESCENDING, NullOrdering.NULLS_FIRST)
+    )
+    val tableDistribution = Distributions.unspecified()
+
+    val writeOrdering = Seq(
+      catalyst.expressions.SortOrder(
+        attr("data"),
+        catalyst.expressions.Descending,
+        catalyst.expressions.NullsFirst,
+        Seq.empty
+      )
+    )
+    val writePartitioning = UnknownPartitioning(0)
+
+    checkWriteRequirements(
+      tableDistribution,
+      tableOrdering,
+      expectedWritePartitioning = writePartitioning,
+      expectedWriteOrdering = writeOrdering,
+      writeCommand = command)
+  }
+
+  test("unspecified distribution and no sort: append") {
+    checkUnspecifiedDistributionAndNoSort("append")
+  }
+
+  test("unspecified distribution and no sort: overwrite") {
+    checkUnspecifiedDistributionAndNoSort("overwrite")
+  }
+
+  test("unspecified distribution and no sort: overwriteDynamic") {
+    checkUnspecifiedDistributionAndNoSort("overwriteDynamic")
+  }
+
+  private def checkUnspecifiedDistributionAndNoSort(command: String): Unit = {
+    val tableOrdering = Array.empty[SortOrder]
+    val tableDistribution = Distributions.unspecified()
+
+    val writeOrdering = Seq.empty[catalyst.expressions.SortOrder]
+    val writePartitioning = UnknownPartitioning(0)
+
+    checkWriteRequirements(
+      tableDistribution,
+      tableOrdering,
+      expectedWritePartitioning = writePartitioning,
+      expectedWriteOrdering = writeOrdering,
+      writeCommand = command)
+  }
+
+  test("ordered distribution and sort with manual global sort: append") {
+    checkOrderedDistributionAndSortWithManualGlobalSort("append")
+  }
+
+  test("ordered distribution and sort with manual global sort: overwrite") {
+    checkOrderedDistributionAndSortWithManualGlobalSort("overwrite")
+  }
+
+  test("ordered distribution and sort with manual global sort: overwriteDynamic") {
+    checkOrderedDistributionAndSortWithManualGlobalSort("overwriteDynamic")
+  }
+
+  private def checkOrderedDistributionAndSortWithManualGlobalSort(command: String): Unit = {
+    val tableOrdering = Array[SortOrder](
+      sort(FieldReference("data"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST),
+      sort(FieldReference("id"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST)
+    )
+    val tableDistribution = Distributions.ordered(tableOrdering)
+
+    val writeOrdering = Seq(
+      catalyst.expressions.SortOrder(
+        attr("data"),
+        catalyst.expressions.Ascending,
+        catalyst.expressions.NullsFirst,
+        Seq.empty
+      ),
+      catalyst.expressions.SortOrder(
+        attr("id"),
+        catalyst.expressions.Ascending,
+        catalyst.expressions.NullsFirst,
+        Seq.empty
+      )
+    )
+    val writePartitioning = RangePartitioning(writeOrdering, conf.numShufflePartitions)
+
+    checkWriteRequirements(
+      tableDistribution,
+      tableOrdering,
+      expectedWritePartitioning = writePartitioning,
+      expectedWriteOrdering = writeOrdering,
+      writeTransform = df => df.orderBy("data", "id"),
+      writeCommand = command)
+  }
+
+  test("ordered distribution and sort with incompatible global sort: append") {
+    checkOrderedDistributionAndSortWithIncompatibleGlobalSort("append")
+  }
+
+  test("ordered distribution and sort with incompatible global sort: overwrite") {
+    checkOrderedDistributionAndSortWithIncompatibleGlobalSort("overwrite")
+  }
+
+  test("ordered distribution and sort with incompatible global sort: overwriteDynamic") {
+    checkOrderedDistributionAndSortWithIncompatibleGlobalSort("overwriteDynamic")
+  }
+
+  private def checkOrderedDistributionAndSortWithIncompatibleGlobalSort(command: String): Unit = {
+    val tableOrdering = Array[SortOrder](
+      sort(FieldReference("data"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST),
+      sort(FieldReference("id"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST)
+    )
+    val tableDistribution = Distributions.ordered(tableOrdering)
+
+    val writeOrdering = Seq(
+      catalyst.expressions.SortOrder(
+        attr("data"),
+        catalyst.expressions.Ascending,
+        catalyst.expressions.NullsFirst,
+        Seq.empty
+      ),
+      catalyst.expressions.SortOrder(
+        attr("id"),
+        catalyst.expressions.Ascending,
+        catalyst.expressions.NullsFirst,
+        Seq.empty
+      )
+    )
+    val writePartitioning = RangePartitioning(writeOrdering, conf.numShufflePartitions)
+
+    checkWriteRequirements(
+      tableDistribution,
+      tableOrdering,
+      expectedWritePartitioning = writePartitioning,
+      expectedWriteOrdering = writeOrdering,
+      writeTransform = df => df.orderBy(df("data").desc, df("id").asc),
+      writeCommand = command)
+  }
+
+  test("ordered distribution and sort with manual local sort: append") {
+    checkOrderedDistributionAndSortWithManualLocalSort("append")
+  }
+
+  test("ordered distribution and sort with manual local sort: overwrite") {
+    checkOrderedDistributionAndSortWithManualLocalSort("overwrite")
+  }
+
+  test("ordered distribution and sort with manual local sort: overwriteDynamic") {
+    checkOrderedDistributionAndSortWithManualLocalSort("overwriteDynamic")
+  }
+
+  private def checkOrderedDistributionAndSortWithManualLocalSort(command: String): Unit = {
+    val tableOrdering = Array[SortOrder](
+      sort(FieldReference("data"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST),
+      sort(FieldReference("id"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST)
+    )
+    val tableDistribution = Distributions.ordered(tableOrdering)
+
+    val writeOrdering = Seq(
+      catalyst.expressions.SortOrder(
+        attr("data"),
+        catalyst.expressions.Ascending,
+        catalyst.expressions.NullsFirst,
+        Seq.empty
+      ),
+      catalyst.expressions.SortOrder(
+        attr("id"),
+        catalyst.expressions.Ascending,
+        catalyst.expressions.NullsFirst,
+        Seq.empty
+      )
+    )
+    val writePartitioning = RangePartitioning(writeOrdering, conf.numShufflePartitions)
+
+    checkWriteRequirements(
+      tableDistribution,
+      tableOrdering,
+      expectedWritePartitioning = writePartitioning,
+      expectedWriteOrdering = writeOrdering,
+      writeTransform = df => df.sortWithinPartitions("data", "id"),
+      writeCommand = command)
+  }
+
+  ignore("ordered distribution and sort with manual repartition: append") {
+    checkOrderedDistributionAndSortWithManualRepartition("append")
+  }
+
+  ignore("ordered distribution and sort with manual repartition: overwrite") {
+    checkOrderedDistributionAndSortWithManualRepartition("overwrite")
+  }
+
+  ignore("ordered distribution and sort with manual repartition: overwriteDynamic") {
+    checkOrderedDistributionAndSortWithManualRepartition("overwriteDynamic")
+  }
+
+  private def checkOrderedDistributionAndSortWithManualRepartition(command: String): Unit = {
+    val tableOrdering = Array[SortOrder](
+      sort(FieldReference("data"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST),
+      sort(FieldReference("id"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST)
+    )
+    val tableDistribution = Distributions.ordered(tableOrdering)
+
+    val writeOrdering = Seq(
+      catalyst.expressions.SortOrder(
+        attr("data"),
+        catalyst.expressions.Ascending,
+        catalyst.expressions.NullsFirst,
+        Seq.empty
+      ),
+      catalyst.expressions.SortOrder(
+        attr("id"),
+        catalyst.expressions.Ascending,
+        catalyst.expressions.NullsFirst,
+        Seq.empty
+      )
+    )
+    val writePartitioning = RangePartitioning(writeOrdering, conf.numShufflePartitions)
+
+    checkWriteRequirements(
+      tableDistribution,
+      tableOrdering,
+      expectedWritePartitioning = writePartitioning,
+      expectedWriteOrdering = writeOrdering,
+      writeTransform = df => df.repartitionByRange(df("data"), df("id")),
+      writeCommand = command)
+  }
+
+  test("clustered distribution and local sort with manual global sort: append") {
+    checkClusteredDistributionAndLocalSortWithManualGlobalSort("append")
+  }
+
+  test("clustered distribution and local sort with manual global sort: overwrite") {
+    checkClusteredDistributionAndLocalSortWithManualGlobalSort("overwrite")
+  }
+
+  test("clustered distribution and local sort with manual global sort: overwriteDynamic") {
+    checkClusteredDistributionAndLocalSortWithManualGlobalSort("overwriteDynamic")
+  }
+
+  private def checkClusteredDistributionAndLocalSortWithManualGlobalSort(command: String): Unit = {
+    val tableOrdering = Array[SortOrder](
+      sort(FieldReference("data"), SortDirection.DESCENDING, NullOrdering.NULLS_FIRST),
+      sort(FieldReference("id"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST)
+    )
+    val tableDistribution = Distributions.clustered(Array(FieldReference("data")))
+
+    val writeOrdering = Seq(
+      catalyst.expressions.SortOrder(
+        attr("data"),
+        catalyst.expressions.Descending,
+        catalyst.expressions.NullsFirst,
+        Seq.empty
+      ),
+      catalyst.expressions.SortOrder(
+        attr("id"),
+        catalyst.expressions.Ascending,
+        catalyst.expressions.NullsFirst,
+        Seq.empty
+      )
+    )
+    val writePartitioningExprs = Seq(attr("data"))
+    val writePartitioning = HashPartitioning(writePartitioningExprs, conf.numShufflePartitions)
+
+    checkWriteRequirements(
+      tableDistribution,
+      tableOrdering,
+      expectedWritePartitioning = writePartitioning,
+      expectedWriteOrdering = writeOrdering,
+      writeTransform = df => df.orderBy("data", "id"),
+      writeCommand = command)
+  }
+
+  test("clustered distribution and local sort with manual local sort: append") {
+    checkClusteredDistributionAndLocalSortWithManualLocalSort("append")
+  }
+
+  test("clustered distribution and local sort with manual local sort: overwrite") {
+    checkClusteredDistributionAndLocalSortWithManualLocalSort("overwrite")
+  }
+
+  test("clustered distribution and local sort with manual local sort: overwriteDynamic") {
+    checkClusteredDistributionAndLocalSortWithManualLocalSort("overwriteDynamic")
+  }
+
+  private def checkClusteredDistributionAndLocalSortWithManualLocalSort(command: String): Unit = {
+    val tableOrdering = Array[SortOrder](
+      sort(FieldReference("data"), SortDirection.DESCENDING, NullOrdering.NULLS_FIRST),
+      sort(FieldReference("id"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST)
+    )
+    val tableDistribution = Distributions.clustered(Array(FieldReference("data")))
+
+    val writeOrdering = Seq(
+      catalyst.expressions.SortOrder(
+        attr("data"),
+        catalyst.expressions.Descending,
+        catalyst.expressions.NullsFirst,
+        Seq.empty
+      ),
+      catalyst.expressions.SortOrder(
+        attr("id"),
+        catalyst.expressions.Ascending,
+        catalyst.expressions.NullsFirst,
+        Seq.empty
+      )
+    )
+    val writePartitioningExprs = Seq(attr("data"))
+    val writePartitioning = HashPartitioning(writePartitioningExprs, conf.numShufflePartitions)
+
+    checkWriteRequirements(
+      tableDistribution,
+      tableOrdering,
+      expectedWritePartitioning = writePartitioning,
+      expectedWriteOrdering = writeOrdering,
+      writeTransform = df => df.orderBy("data", "id"),
+      writeCommand = command)
+  }
+
+  private def checkWriteRequirements(
+      tableDistribution: Distribution,
+      tableOrdering: Array[SortOrder],
+      expectedWritePartitioning: physical.Partitioning,
+      expectedWriteOrdering: Seq[catalyst.expressions.SortOrder],
+      writeTransform: DataFrame => DataFrame = df => df,
+      writeCommand: String = "append"): Unit = {
+
+    catalog.createTable(ident, schema, Array.empty, emptyProps, tableDistribution, tableOrdering)
+
+    val df = spark.createDataFrame(Seq((1, "a"), (2, "b"), (3, "c"))).toDF("id", "data")
+    val writer = writeTransform(df).writeTo(tableNameAsString)
+    val executedPlan = writeCommand match {
+      case "append" => execute(writer.append())
+      case "overwrite" => execute(writer.overwrite(lit(true)))
+      case "overwriteDynamic" => execute(writer.overwritePartitions())
+    }
+
+    checkPartitioningAndOrdering(executedPlan, expectedWritePartitioning, expectedWriteOrdering)
+
+    checkAnswer(spark.table(tableNameAsString), df)
+  }
+
+  private def checkPartitioningAndOrdering(
+      plan: SparkPlan,
+      partitioning: physical.Partitioning,
+      ordering: Seq[catalyst.expressions.SortOrder]): Unit = {
+
+    val sorts = plan.collect { case s: SortExec => s }
+    assert(sorts.size <= 1, "must be at most one sort")
+    val shuffles = plan.collect { case s: ShuffleExchangeLike => s }
+    assert(shuffles.size <= 1, "must be at most one shuffle")
+
+    val actualPartitioning = plan.outputPartitioning
+    val expectedPartitioning = partitioning match {
+      case p: physical.RangePartitioning =>
+        val resolvedOrdering = p.ordering.map(resolveAttrs(_, plan))
+        p.copy(ordering = resolvedOrdering.asInstanceOf[Seq[catalyst.expressions.SortOrder]])
+      case p: physical.HashPartitioning =>
+        val resolvedExprs = p.expressions.map(resolveAttrs(_, plan))
+        p.copy(expressions = resolvedExprs)
+      case other => other
+    }
+    assert(actualPartitioning == expectedPartitioning, "partitioning must match")
+
+    val actualOrdering = plan.outputOrdering
+    val expectedOrdering = ordering.map(resolveAttrs(_, plan))
+    assert(actualOrdering == expectedOrdering, "ordering must match")
+  }
+
+  private def resolveAttrs(
+      expr: catalyst.expressions.Expression,
+      plan: SparkPlan): catalyst.expressions.Expression = {
+
+    expr.transform {
+      case UnresolvedAttribute(Seq(attrName)) =>
+        plan.output.find(attr => resolver(attr.name, attrName)).get
+      case UnresolvedAttribute(nameParts) =>
+        val attrName = nameParts.mkString(".")
+        fail(s"cannot resolve a nested attr: $attrName")
+    }
+  }
+
+  private def attr(name: String): UnresolvedAttribute = {
+    UnresolvedAttribute(name)
+  }
+
+  private def catalog: InMemoryTableCatalog = {
+    val catalog = spark.sessionState.catalogManager.catalog("testcat")
+    catalog.asTableCatalog.asInstanceOf[InMemoryTableCatalog]
+  }
+
+  // executes a write operation and keeps the executed physical plan
+  private def execute(writeFunc: => Unit): SparkPlan = {
+    var executedPlan: SparkPlan = null
+
+    val listener = new QueryExecutionListener {
+      override def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit = {
+        executedPlan = qe.executedPlan
+      }
+      override def onFailure(funcName: String, qe: QueryExecution, exception: Exception): Unit = {
+      }
+    }
+    spark.listenerManager.register(listener)
+
+    writeFunc
+
+    sparkContext.listenerBus.waitUntilEmpty()
+
+    executedPlan match {
+      case w: V2TableWriteExec =>
+        w.query match {
+          case p: AdaptiveSparkPlanExec => p.inputPlan
+          case p => p
+        }
+      case _ =>
+        fail("expected V2TableWriteExec")
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/WriteDistributionAndOrderingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/WriteDistributionAndOrderingSuite.scala
@@ -49,7 +49,7 @@ class WriteDistributionAndOrderingSuite
 
   after {
     spark.sessionState.catalogManager.reset()
-    spark.sessionState.conf.clear()
+    spark.sessionState.conf.unsetConf("spark.sql.catalog.testcat")
   }
 
   private val namespace = Array("ns1")
@@ -380,50 +380,6 @@ class WriteDistributionAndOrderingSuite
       expectedWritePartitioning = writePartitioning,
       expectedWriteOrdering = writeOrdering,
       writeTransform = df => df.sortWithinPartitions("data", "id"),
-      writeCommand = command)
-  }
-
-  ignore("ordered distribution and sort with manual repartition: append") {
-    checkOrderedDistributionAndSortWithManualRepartition("append")
-  }
-
-  ignore("ordered distribution and sort with manual repartition: overwrite") {
-    checkOrderedDistributionAndSortWithManualRepartition("overwrite")
-  }
-
-  ignore("ordered distribution and sort with manual repartition: overwriteDynamic") {
-    checkOrderedDistributionAndSortWithManualRepartition("overwriteDynamic")
-  }
-
-  private def checkOrderedDistributionAndSortWithManualRepartition(command: String): Unit = {
-    val tableOrdering = Array[SortOrder](
-      sort(FieldReference("data"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST),
-      sort(FieldReference("id"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST)
-    )
-    val tableDistribution = Distributions.ordered(tableOrdering)
-
-    val writeOrdering = Seq(
-      catalyst.expressions.SortOrder(
-        attr("data"),
-        catalyst.expressions.Ascending,
-        catalyst.expressions.NullsFirst,
-        Seq.empty
-      ),
-      catalyst.expressions.SortOrder(
-        attr("id"),
-        catalyst.expressions.Ascending,
-        catalyst.expressions.NullsFirst,
-        Seq.empty
-      )
-    )
-    val writePartitioning = RangePartitioning(writeOrdering, conf.numShufflePartitions)
-
-    checkWriteRequirements(
-      tableDistribution,
-      tableOrdering,
-      expectedWritePartitioning = writePartitioning,
-      expectedWriteOrdering = writeOrdering,
-      writeTransform = df => df.repartitionByRange(df("data"), df("id")),
       writeCommand = command)
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds repartition and sort nodes to satisfy the required distribution and ordering introduced in SPARK-33779.

Note: This PR contains the final part of changes discussed in PR #29066.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

These changes are the next step as discussed in the [design doc](https://docs.google.com/document/d/1X0NsQSryvNmXBY9kcvfINeYyKC-AahZarUqg3nS1GQs/edit#) for SPARK-23889.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

This PR comes with a new test suite.