### PR TITLE
[SPARK-34045][ML] OneVsRestModel.transform should not call setter of submodels

### DIFF
--- a/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
@@ -210,6 +210,19 @@ class OneVsRestSuite extends MLTest with DefaultReadWriteTest {
     assert(ova2.fit(dataset2) !== null)
   }
 
+  test("SPARK-34045: OneVsRestModel.transform should not call setter of submodels") {
+    val logReg = new LogisticRegression().setMaxIter(1)
+    val ovr = new OneVsRest().setClassifier(logReg)
+    val ovrm = ovr.fit(dataset)
+    val dataset2 = dataset.withColumnRenamed("features", "features2")
+    ovrm.setFeaturesCol("features2")
+
+    val oldCols = ovrm.models.map(_.getFeaturesCol)
+    ovrm.transform(dataset2)
+    val newCols = ovrm.models.map(_.getFeaturesCol)
+    assert(oldCols === newCols)
+  }
+
   test("OneVsRest.copy and OneVsRestModel.copy") {
     val lr = new LogisticRegression()
       .setMaxIter(1)


### PR DESCRIPTION
### What changes were proposed in this pull request?
use a tmp model in OneVsRestModel.transform, to avoid calling directly setter of model


### Why are the changes needed?
params of model (submodels) should not be changed in transform


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
added testsuite