### PR TITLE
[SPARK-34048][SQL][TESTS] Check the amount of calls to Hive external catalog

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/AlterTableAddPartitionSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/AlterTableAddPartitionSuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.hive.execution.command
 
-import org.apache.spark.metrics.source.HiveCatalogMetrics
 import org.apache.spark.sql.execution.command.v1
 
 /**
@@ -33,17 +32,13 @@ class AlterTableAddPartitionSuite
       sql(s"CREATE TABLE $t (id int, part int) $defaultUsing PARTITIONED BY (part)")
       sql(s"INSERT INTO $t PARTITION (part=0) SELECT 0")
 
-      val callsAmount = 14
-      HiveCatalogMetrics.reset()
-      assert(HiveCatalogMetrics.METRIC_HIVE_CLIENT_CALLS.getCount === 0)
-      sql(s"ALTER TABLE $t ADD PARTITION (part=1)")
-      assert(HiveCatalogMetrics.METRIC_HIVE_CLIENT_CALLS.getCount === callsAmount)
-
+      checkHiveClientCalls(expected = 14) {
+        sql(s"ALTER TABLE $t ADD PARTITION (part=1)")
+      }
       sql(s"CACHE TABLE $t")
-      HiveCatalogMetrics.reset()
-      assert(HiveCatalogMetrics.METRIC_HIVE_CLIENT_CALLS.getCount === 0)
-      sql(s"ALTER TABLE $t ADD PARTITION (part=2)")
-      assert(HiveCatalogMetrics.METRIC_HIVE_CLIENT_CALLS.getCount === callsAmount)
+      checkHiveClientCalls(expected = 14) {
+        sql(s"ALTER TABLE $t ADD PARTITION (part=2)")
+      }
     }
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/AlterTableDropPartitionSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/AlterTableDropPartitionSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.hive.execution.command
 
+import org.apache.spark.metrics.source.HiveCatalogMetrics
 import org.apache.spark.sql.execution.command.v1
 
 /**
@@ -25,4 +26,24 @@ import org.apache.spark.sql.execution.command.v1
  */
 class AlterTableDropPartitionSuite
   extends v1.AlterTableDropPartitionSuiteBase
-  with CommandSuiteBase
+  with CommandSuiteBase {
+
+  test("hive client calls") {
+    withNamespaceAndTable("ns", "tbl") { t =>
+      sql(s"CREATE TABLE $t (id int, part int) $defaultUsing PARTITIONED BY (part)")
+      sql(s"INSERT INTO $t PARTITION (part=0) SELECT 0")
+      sql(s"INSERT INTO $t PARTITION (part=1) SELECT 1")
+      val callsAmount = 19
+      HiveCatalogMetrics.reset()
+      assert(HiveCatalogMetrics.METRIC_HIVE_CLIENT_CALLS.getCount === 0)
+      sql(s"ALTER TABLE $t DROP PARTITION (part=0)")
+      assert(HiveCatalogMetrics.METRIC_HIVE_CLIENT_CALLS.getCount === callsAmount)
+
+      sql(s"CACHE TABLE $t")
+      HiveCatalogMetrics.reset()
+      assert(HiveCatalogMetrics.METRIC_HIVE_CLIENT_CALLS.getCount === 0)
+      sql(s"ALTER TABLE $t DROP PARTITION (part=1)")
+      assert(HiveCatalogMetrics.METRIC_HIVE_CLIENT_CALLS.getCount === callsAmount + 3)
+    }
+  }
+}

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/AlterTableDropPartitionSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/AlterTableDropPartitionSuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.hive.execution.command
 
-import org.apache.spark.metrics.source.HiveCatalogMetrics
 import org.apache.spark.sql.execution.command.v1
 
 /**
@@ -34,17 +33,13 @@ class AlterTableDropPartitionSuite
       sql(s"INSERT INTO $t PARTITION (part=0) SELECT 0")
       sql(s"INSERT INTO $t PARTITION (part=1) SELECT 1")
 
-      val callsAmount = 19
-      HiveCatalogMetrics.reset()
-      assert(HiveCatalogMetrics.METRIC_HIVE_CLIENT_CALLS.getCount === 0)
-      sql(s"ALTER TABLE $t DROP PARTITION (part=0)")
-      assert(HiveCatalogMetrics.METRIC_HIVE_CLIENT_CALLS.getCount === callsAmount)
-
+      checkHiveClientCalls(expected = 19) {
+        sql(s"ALTER TABLE $t DROP PARTITION (part=0)")
+      }
       sql(s"CACHE TABLE $t")
-      HiveCatalogMetrics.reset()
-      assert(HiveCatalogMetrics.METRIC_HIVE_CLIENT_CALLS.getCount === 0)
-      sql(s"ALTER TABLE $t DROP PARTITION (part=1)")
-      assert(HiveCatalogMetrics.METRIC_HIVE_CLIENT_CALLS.getCount === callsAmount + 3)
+      checkHiveClientCalls(expected = 22) {
+        sql(s"ALTER TABLE $t DROP PARTITION (part=1)")
+      }
     }
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/AlterTableDropPartitionSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/AlterTableDropPartitionSuite.scala
@@ -33,6 +33,7 @@ class AlterTableDropPartitionSuite
       sql(s"CREATE TABLE $t (id int, part int) $defaultUsing PARTITIONED BY (part)")
       sql(s"INSERT INTO $t PARTITION (part=0) SELECT 0")
       sql(s"INSERT INTO $t PARTITION (part=1) SELECT 1")
+
       val callsAmount = 19
       HiveCatalogMetrics.reset()
       assert(HiveCatalogMetrics.METRIC_HIVE_CLIENT_CALLS.getCount === 0)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/AlterTableRenamePartitionSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/AlterTableRenamePartitionSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.hive.execution.command
 
+import org.apache.spark.metrics.source.HiveCatalogMetrics
 import org.apache.spark.sql.execution.command.v1
 
 /**
@@ -25,4 +26,24 @@ import org.apache.spark.sql.execution.command.v1
  */
 class AlterTableRenamePartitionSuite
   extends v1.AlterTableRenamePartitionSuiteBase
-  with CommandSuiteBase
+  with CommandSuiteBase {
+
+  test("hive client calls") {
+    withNamespaceAndTable("ns", "tbl") { t =>
+      sql(s"CREATE TABLE $t (id int, part int) $defaultUsing PARTITIONED BY (part)")
+      sql(s"INSERT INTO $t PARTITION (part=0) SELECT 0")
+
+      val callsAmount = 21
+      HiveCatalogMetrics.reset()
+      assert(HiveCatalogMetrics.METRIC_HIVE_CLIENT_CALLS.getCount === 0)
+      sql(s"ALTER TABLE $t PARTITION (part=0) RENAME TO PARTITION (part=1)")
+      assert(HiveCatalogMetrics.METRIC_HIVE_CLIENT_CALLS.getCount === callsAmount)
+
+      sql(s"CACHE TABLE $t")
+      HiveCatalogMetrics.reset()
+      assert(HiveCatalogMetrics.METRIC_HIVE_CLIENT_CALLS.getCount === 0)
+      sql(s"ALTER TABLE $t PARTITION (part=1) RENAME TO PARTITION (part=2)")
+      assert(HiveCatalogMetrics.METRIC_HIVE_CLIENT_CALLS.getCount === callsAmount + 3)
+    }
+  }
+}

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/AlterTableRenamePartitionSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/AlterTableRenamePartitionSuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.hive.execution.command
 
-import org.apache.spark.metrics.source.HiveCatalogMetrics
 import org.apache.spark.sql.execution.command.v1
 
 /**
@@ -33,17 +32,13 @@ class AlterTableRenamePartitionSuite
       sql(s"CREATE TABLE $t (id int, part int) $defaultUsing PARTITIONED BY (part)")
       sql(s"INSERT INTO $t PARTITION (part=0) SELECT 0")
 
-      val callsAmount = 21
-      HiveCatalogMetrics.reset()
-      assert(HiveCatalogMetrics.METRIC_HIVE_CLIENT_CALLS.getCount === 0)
-      sql(s"ALTER TABLE $t PARTITION (part=0) RENAME TO PARTITION (part=1)")
-      assert(HiveCatalogMetrics.METRIC_HIVE_CLIENT_CALLS.getCount === callsAmount)
-
+      checkHiveClientCalls(expected = 21) {
+        sql(s"ALTER TABLE $t PARTITION (part=0) RENAME TO PARTITION (part=1)")
+      }
       sql(s"CACHE TABLE $t")
-      HiveCatalogMetrics.reset()
-      assert(HiveCatalogMetrics.METRIC_HIVE_CLIENT_CALLS.getCount === 0)
-      sql(s"ALTER TABLE $t PARTITION (part=1) RENAME TO PARTITION (part=2)")
-      assert(HiveCatalogMetrics.METRIC_HIVE_CLIENT_CALLS.getCount === callsAmount + 3)
+      checkHiveClientCalls(expected = 24) {
+        sql(s"ALTER TABLE $t PARTITION (part=1) RENAME TO PARTITION (part=2)")
+      }
     }
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/CommandSuiteBase.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/CommandSuiteBase.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.hive.execution.command
 
+import org.apache.spark.metrics.source.HiveCatalogMetrics
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.hive.test.TestHiveSingleton
@@ -46,5 +47,12 @@ trait CommandSuiteBase extends TestHiveSingleton {
         .first().getString(0)
     val location = information.split("\\r?\\n").filter(_.startsWith("Location:")).head
     assert(location.endsWith(expected))
+  }
+
+  def checkHiveClientCalls[T](expected: Int)(f: => T): Unit = {
+    HiveCatalogMetrics.reset()
+    assert(HiveCatalogMetrics.METRIC_HIVE_CLIENT_CALLS.getCount === 0)
+    f
+    assert(HiveCatalogMetrics.METRIC_HIVE_CLIENT_CALLS.getCount === expected)
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/DropTableSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/DropTableSuite.scala
@@ -22,4 +22,13 @@ import org.apache.spark.sql.execution.command.v1
 /**
  * The class contains tests for the `DROP TABLE` command to check V1 Hive external table catalog.
  */
-class DropTableSuite extends v1.DropTableSuiteBase with CommandSuiteBase
+class DropTableSuite extends v1.DropTableSuiteBase with CommandSuiteBase {
+  test("hive client calls") {
+    withNamespaceAndTable("ns", "tbl") { t =>
+      sql(s"CREATE TABLE $t (id int) $defaultUsing")
+      checkHiveClientCalls(expected = 15) {
+        sql(s"DROP TABLE $t")
+      }
+    }
+  }
+}

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowNamespacesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowNamespacesSuite.scala
@@ -40,4 +40,15 @@ class ShowNamespacesSuite extends v1.ShowNamespacesSuiteBase with CommandSuiteBa
       }
     }
   }
+
+  test("hive client calls") {
+    withNamespace(s"$catalog.ns1", s"$catalog.ns2") {
+      sql(s"CREATE NAMESPACE $catalog.ns1")
+      sql(s"CREATE NAMESPACE $catalog.ns2")
+
+      checkHiveClientCalls(expected = 1) {
+        sql(s"SHOW NAMESPACES IN $catalog")
+      }
+    }
+  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowPartitionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowPartitionsSuite.scala
@@ -38,4 +38,13 @@ class ShowPartitionsSuite extends v1.ShowPartitionsSuiteBase with CommandSuiteBa
       }
     }
   }
+
+  test("hive client calls") {
+    withNamespaceAndTable("ns", "dateTable") { t =>
+      createDateTable(t)
+      checkHiveClientCalls(expected = 10) {
+        sql(s"SHOW PARTITIONS $t")
+      }
+    }
+  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowTablesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowTablesSuite.scala
@@ -22,4 +22,13 @@ import org.apache.spark.sql.execution.command.v1
 /**
  * The class contains tests for the `SHOW TABLES` command to check V1 Hive external table catalog.
  */
-class ShowTablesSuite extends v1.ShowTablesSuiteBase with CommandSuiteBase
+class ShowTablesSuite extends v1.ShowTablesSuiteBase with CommandSuiteBase {
+  test("hive client calls") {
+    withNamespaceAndTable("ns", "tbl") { t =>
+      sql(s"CREATE TABLE $t (id int) $defaultUsing")
+      checkHiveClientCalls(expected = 3) {
+        sql(s"SHOW TABLES IN $catalog.ns")
+      }
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add new tests to unified test suites to check the total amount of calls via the Hive client.

### Why are the changes needed?
1. To improve test coverage
2. To make foundation for future optimizations

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
By running the affected test suites like:
```
$ build/sbt -Phive-2.3 -Phive-thriftserver "test:testOnly *AlterTableDropPartitionSuite"
```