### PR TITLE
[SPARK-31891][SQL] Recover tables with non-existing partition locations

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -808,7 +808,12 @@ case class AlterTableRecoverPartitionsCommand(
         if (fs.exists(new Path(uri))) None else Some(partition.spec)
       }
     }.flatten
-    catalog.dropPartitions(tableName, dropPartSpecs, true, false, false)
+    catalog.dropPartitions(
+      tableName,
+      dropPartSpecs,
+      ignoreIfNotExists = true,
+      purge = false,
+      retainData = true)
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -1235,12 +1235,18 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
     fs.createNewFile(new Path(new Path(root, "A=2/B=6/C=31"), ".hiddenFile"))  // file
     fs.mkdirs(new Path(new Path(root, "A=2/B=6/C=31"), "_temporary"))
 
-    val parts = (10 to 100).map { a =>
+    val parts = (10 to 100).flatMap { a =>
       val part = Map("a" -> a.toString, "b" -> "5", "c" -> "42")
-      fs.mkdirs(new Path(new Path(new Path(root, s"a=$a"), "b=5"), "c=42"))
+      val partPath = new Path(new Path(new Path(root, s"a=$a"), "b=5"), "c=42")
+      fs.mkdirs(partPath)
       fs.createNewFile(new Path(new Path(root, s"a=$a/b=5/c=42"), "a.csv"))  // file
       createTablePartition(catalog, part, tableIdent)
-      part
+      if (a >= 90) {
+        fs.delete(partPath, true)
+        None
+      } else {
+        Some (part)
+      }
     }
 
     // invalid


### PR DESCRIPTION
### What changes were proposed in this pull request?
List all table partitions in v1 `ALTER TABLE .. RECOVER PARTITIONS` (and in `MSCK REPAIR TABLE ..`), check partition locations, and drop the partitions if their location doesn't exist in the filesystem.

### Why are the changes needed?
The changes allow to recover tables with removed partitions. The example below portraits the problem:
```sql
spark-sql> create table tbl2 (col int, part int) partitioned by (part);
spark-sql> insert into tbl2 partition (part=1) select 1;
spark-sql> insert into tbl2 partition (part=0) select 0;
spark-sql> show table extended like 'tbl2' partition (part = 0);
default	tbl2	false	Partition Values: [part=0]
Location: file:/Users/maximgekk/proj/apache-spark/spark-warehouse/tbl2/part=0
...
```
Remove the partition (part = 0) from the filesystem:
```
$ rm -rf /Users/maximgekk/proj/apache-spark/spark-warehouse/tbl2/part=0
```
Even after recovering, we cannot query the table:
```sql
spark-sql> alter table tbl2 recover partitions;
spark-sql> select * from tbl2;
21/01/08 22:49:13 ERROR SparkSQLDriver: Failed in [select * from tbl2]
org.apache.hadoop.mapred.InvalidInputException: Input path does not exist: file:/Users/maximgekk/proj/apache-spark/spark-warehouse/tbl2/part=0
```

### Does this PR introduce _any_ user-facing change?
Yes. After the changes, we can query recovered table:
```sql
spark-sql> alter table tbl2 recover partitions;
spark-sql> select * from tbl2;
1	1
spark-sql> show partitions tbl2;
part=1
```

### How was this patch tested?
By running the modified test suite:
```
$ build/sbt -Phive -Phive-thriftserver "test:testOnly *CatalogedDDLSuite"
```