### PR TITLE
[SPARK-34058][UI] Add button to show/hide all stage details

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/table.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/table.js
@@ -103,3 +103,14 @@ function onSearchStringChange() {
         });
     }
 }
+
+function toggleStagesDetail(obj) {
+  if (obj.innerHTML.indexOf("Show ") == 0) {
+    obj.innerHTML = "Hide All Stages Details"
+  } else {
+    obj.innerHTML = "Show All Stages Details"
+  }
+  obj.parentNode.querySelectorAll('.stage-details').forEach(function (item) {
+    item.classList.toggle('collapsed')
+  })
+}

--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllStagesPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllStagesPage.scala
@@ -154,6 +154,7 @@ private[ui] class AllStagesPage(parent: StagesTab) extends WebUIPage("") {
       </h4>
     </span> ++
       <div class={s"aggregated-all$classSuffix collapsible-table"}>
+        <button class="btn btn-spark" onclick="toggleStagesDetail(this)">Show All Stages Details</button>
         {stagesTable.toNodeSeq}
       </div>
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
Currently there is no way to expand all stages details all in once. It is hard if you want to navigate to search for specific stages details.

Proposed to add a UI elements to collapse/expand all stages detail in stages tab. 
![image](https://user-images.githubusercontent.com/20021316/104113468-03f9b280-5335-11eb-8c96-7e8a00d2f668.png)

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Currently there is no way to expand all stages details all in once. It is hard if you want to navigate to search for specific stages details.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
There is no button to cexpand/collapse all stages detail all in once
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
manual tested
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
