### PR TITLE
[SPARK-34055][SQL][TESTS][FOLLOWUP] Increase the expected number of calls to Hive external catalog in partition adding

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/AlterTableAddPartitionSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/AlterTableAddPartitionSuite.scala
@@ -32,11 +32,11 @@ class AlterTableAddPartitionSuite
       sql(s"CREATE TABLE $t (id int, part int) $defaultUsing PARTITIONED BY (part)")
       sql(s"INSERT INTO $t PARTITION (part=0) SELECT 0")
 
-      checkHiveClientCalls(expected = 14) {
+      checkHiveClientCalls(expected = 20) {
         sql(s"ALTER TABLE $t ADD PARTITION (part=1)")
       }
       sql(s"CACHE TABLE $t")
-      checkHiveClientCalls(expected = 14) {
+      checkHiveClientCalls(expected = 23) {
         sql(s"ALTER TABLE $t ADD PARTITION (part=2)")
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Increase the number of calls to Hive external catalog in the test for `ALTER TABLE .. ADD PARTITION`.

### Why are the changes needed?
There is a logical conflict between https://github.com/apache/spark/pull/31101 and https://github.com/apache/spark/pull/31092. The first one fixes a caching issue and increases the number of calls to Hive external catalog.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
By running the modified test:
```
$ build/sbt -Phive-2.3 -Phive-thriftserver "test:testOnly *.AlterTableAddPartitionSuite"
```