### PR TITLE
[SPARK-34062][SQL] Call `updateTableStats()` from `AlterTableAddPartitionCommand`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -486,18 +486,8 @@ case class AlterTableAddPartitionCommand(
     }
 
     sparkSession.catalog.refreshTable(table.identifier.quotedString)
-    if (table.stats.nonEmpty) {
-      if (sparkSession.sessionState.conf.autoSizeUpdateEnabled) {
-        val addedSize = CommandUtils.calculateMultipleLocationSizes(sparkSession, table.identifier,
-          parts.map(_.storage.locationUri)).sum
-        if (addedSize > 0) {
-          val newStats = CatalogStatistics(sizeInBytes = table.stats.get.sizeInBytes + addedSize)
-          catalog.alterTableStats(table.identifier, Some(newStats))
-        }
-      } else {
-        catalog.alterTableStats(table.identifier, None)
-      }
-    }
+    CommandUtils.updateTableStats(sparkSession, table)
+
     Seq.empty[Row]
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Replace the code for updating of table stats by `updateTableStats()` in `AlterTableAddPartitionCommand.run()`. This follows the same approach as in `AlterTableDropPartitionCommand.run()`

### Why are the changes needed?
To improve code maintenance.

### Does this PR introduce _any_ user-facing change?
Should not.

### How was this patch tested?
By running unified tests for `ALTER TABLE .. ADD PARTITION`:
```
$ build/sbt -Phive-2.3 -Phive-thriftserver "test:testOnly *.AlterTableAddPartitionSuite"
```
