### PR TITLE
[SPARK-34055][SQL][TESTS][FOLLOWUP] Check partition adding to cached Hive table

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/AlterTableAddPartitionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/AlterTableAddPartitionSuite.scala
@@ -48,7 +48,7 @@ trait AlterTableAddPartitionSuiteBase extends command.AlterTableAddPartitionSuit
 
   test("SPARK-34055: refresh cache in partition adding") {
     withTable("t") {
-      sql("CREATE TABLE t (id int, part int) USING parquet PARTITIONED BY (part)")
+      sql(s"CREATE TABLE t (id int, part int) $defaultUsing PARTITIONED BY (part)")
       sql("INSERT INTO t PARTITION (part=0) SELECT 0")
       assert(!spark.catalog.isCached("t"))
       sql("CACHE TABLE t")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Replace `USING parquet` by `$defaultUsing` which is `USING parquet` for v1 In-Memory catalog and `USING hive` for v1 Hive external catalog.

### Why are the changes needed?
The PR https://github.com/apache/spark/pull/31101 added UT test but it checks only v1 In-Memory catalog. This PR runs this test for Hive external catalog as well to improve test coverage. 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
By running the affected test suites:
```
$ build/sbt -Phive-2.3 -Phive-thriftserver "test:testOnly *.AlterTableAddPartitionSuite"
```