### PR TITLE
[SPARK-33084][CORE][SQL] Rename Unit test file and use fake ivy link

### DIFF
--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -1067,17 +1067,17 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
       dependencyJars.foreach(jar => assert(sc.listJars().exists(_.contains(jar))))
 
       assert(logAppender.loggingEvents.count(_.getRenderedMessage.contains(
-        "Added dependency jars of Ivy URI" +
-          " ivy://org.apache.hive:hive-storage-api:2.7.0?transitive=true")) == 1)
+        "Added dependency jars of Ivy URI " +
+          "ivy://org.apache.hive:hive-storage-api:2.7.0?transitive=true")) == 1)
 
       // test dependency jars exist
       sc.addJar("ivy://org.apache.hive:hive-storage-api:2.7.0?transitive=true")
       assert(logAppender.loggingEvents.count(_.getRenderedMessage.contains(
-        "The dependency jars of Ivy URI" +
-          " ivy://org.apache.hive:hive-storage-api:2.7.0?transitive=true")) == 1)
+        "The dependency jars of Ivy URI " +
+          "ivy://org.apache.hive:hive-storage-api:2.7.0?transitive=true")) == 1)
       val existMsg = logAppender.loggingEvents.filter(_.getRenderedMessage.contains(
-        "The dependency jars of Ivy URI" +
-          " ivy://org.apache.hive:hive-storage-api:2.7.0?transitive=true"))
+        "The dependency jars of Ivy URI " +
+          "ivy://org.apache.hive:hive-storage-api:2.7.0?transitive=true"))
         .head.getRenderedMessage
       dependencyJars.foreach(jar => assert(existMsg.contains(jar)))
     }
@@ -1109,8 +1109,8 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
         "invalidParam1=foo&invalidParam2=boo")
       assert(sc.listJars().exists(_.contains("org.apache.hive_hive-storage-api-2.7.0.jar")))
       assert(logAppender.loggingEvents.exists(_.getRenderedMessage.contains(
-        "Invalid parameters `invalidParam1,invalidParam2` found in Ivy URI query" +
-          " `invalidParam1=foo&invalidParam2=boo`.")))
+        "Invalid parameters `invalidParam1,invalidParam2` found in Ivy URI query " +
+          "`invalidParam1=foo&invalidParam2=boo`.")))
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/util/DependencyUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/DependencyUtilsSuite.scala
@@ -32,29 +32,29 @@ class DependencyUtilsSuite extends SparkFunSuite {
     val e2 = intercept[IllegalArgumentException] {
       DependencyUtils.resolveMavenDependencies(URI.create("ivy://org.apache.test:test-test"))
     }.getMessage
-    assert(e2.contains("Invalid Ivy URI authority in uri ivy://org.apache.test:test-test:" +
-      " Expected 'org:module:version', found org.apache.test:test-test."))
+    assert(e2.contains("Invalid Ivy URI authority in uri ivy://org.apache.test:test-test: " +
+      "Expected 'org:module:version', found org.apache.test:test-test."))
 
     val e3 = intercept[IllegalArgumentException] {
       DependencyUtils.resolveMavenDependencies(
         URI.create("ivy://org.apache.test:test-test:1.0.0?foo="))
     }.getMessage
-    assert(e3.contains("Invalid query string in Ivy URI" +
-      " ivy://org.apache.test:test-test:1.0.0?foo=:"))
+    assert(e3.contains("Invalid query string in Ivy URI " +
+      "ivy://org.apache.test:test-test:1.0.0?foo=:"))
 
     val e4 = intercept[IllegalArgumentException] {
       DependencyUtils.resolveMavenDependencies(
         URI.create("ivy://org.apache.test:test-test:1.0.0?bar=&baz=foo"))
     }.getMessage
-    assert(e4.contains("Invalid query string in Ivy URI" +
-      " ivy://org.apache.test:test-test:1.0.0?bar=&baz=foo: bar=&baz=foo"))
+    assert(e4.contains("Invalid query string in Ivy URI " +
+      "ivy://org.apache.test:test-test:1.0.0?bar=&baz=foo: bar=&baz=foo"))
 
     val e5 = intercept[IllegalArgumentException] {
       DependencyUtils.resolveMavenDependencies(
         URI.create("ivy://org.apache.test:test-test:1.0.0?exclude=org.apache"))
     }.getMessage
-    assert(e5.contains("Invalid exclude string in Ivy URI" +
-      " ivy://org.apache.test:test-test:1.0.0?exclude=org.apache:" +
-      " expected 'org:module,org:module,..', found org.apache"))
+    assert(e5.contains("Invalid exclude string in Ivy URI " +
+      "ivy://org.apache.test:test-test:1.0.0?exclude=org.apache: " +
+      "expected 'org:module,org:module,..', found org.apache"))
   }
 }

--- a/core/src/test/scala/org/apache/spark/util/DependencyUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/DependencyUtilsSuite.scala
@@ -30,31 +30,31 @@ class DependencyUtilsSuite extends SparkFunSuite {
     assert(e1.contains("Expected authority at index 6: ivy://"))
 
     val e2 = intercept[IllegalArgumentException] {
-      DependencyUtils.resolveMavenDependencies(URI.create("ivy://org.apache.hive:hive-contrib"))
+      DependencyUtils.resolveMavenDependencies(URI.create("ivy://org.apache.test:test-test"))
     }.getMessage
-    assert(e2.contains("Invalid Ivy URI authority in uri ivy://org.apache.hive:hive-contrib:" +
-      " Expected 'org:module:version', found org.apache.hive:hive-contrib."))
+    assert(e2.contains("Invalid Ivy URI authority in uri ivy://org.apache.test:test-test:" +
+      " Expected 'org:module:version', found org.apache.test:test-test."))
 
     val e3 = intercept[IllegalArgumentException] {
       DependencyUtils.resolveMavenDependencies(
-        URI.create("ivy://org.apache.hive:hive-contrib:2.3.7?foo="))
+        URI.create("ivy://org.apache.test:test-test:1.0.0?foo="))
     }.getMessage
     assert(e3.contains("Invalid query string in Ivy URI" +
-      " ivy://org.apache.hive:hive-contrib:2.3.7?foo=:"))
+      " ivy://org.apache.test:test-test:1.0.0?foo=:"))
 
     val e4 = intercept[IllegalArgumentException] {
       DependencyUtils.resolveMavenDependencies(
-        URI.create("ivy://org.apache.hive:hive-contrib:2.3.7?bar=&baz=foo"))
+        URI.create("ivy://org.apache.test:test-test:1.0.0?bar=&baz=foo"))
     }.getMessage
     assert(e4.contains("Invalid query string in Ivy URI" +
-      " ivy://org.apache.hive:hive-contrib:2.3.7?bar=&baz=foo: bar=&baz=foo"))
+      " ivy://org.apache.test:test-test:1.0.0?bar=&baz=foo: bar=&baz=foo"))
 
     val e5 = intercept[IllegalArgumentException] {
       DependencyUtils.resolveMavenDependencies(
-        URI.create("ivy://org.apache.hive:hive-contrib:2.3.7?exclude=org.pentaho"))
+        URI.create("ivy://org.apache.test:test-test:1.0.0?exclude=org.apache"))
     }.getMessage
     assert(e5.contains("Invalid exclude string in Ivy URI" +
-      " ivy://org.apache.hive:hive-contrib:2.3.7?exclude=org.pentaho:" +
-      " expected 'org:module,org:module,..', found org.pentaho"))
+      " ivy://org.apache.test:test-test:1.0.0?exclude=org.apache:" +
+      " expected 'org:module,org:module,..', found org.apache"))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
According to https://github.com/apache/spark/pull/29966#discussion_r554514344
Use wrong name about suite file, this pr to fix this problem.
And change to use some fake ivy link for this test


### Why are the changes needed?
Follow file name rule


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
No
