### PR TITLE
[34066][SQL] Fix misleading  json function `from_json` 's example result

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -509,9 +509,9 @@ case class JsonTuple(children: Seq[Expression])
   examples = """
     Examples:
       > SELECT _FUNC_('{"a":1, "b":0.8}', 'a INT, b DOUBLE');
-       {"a":1,"b":0.8}
+       {1, 0.8}
       > SELECT _FUNC_('{"time":"26/08/2015"}', 'time Timestamp', map('timestampFormat', 'dd/MM/yyyy'));
-       {"time":2015-08-26 00:00:00}
+       {2015-08-26 00:00:00}
   """,
   group = "json_funcs",
   since = "2.2.0")


### PR DESCRIPTION

### What changes were proposed in this pull request?
Fix misleading json function example result, the true result is 
```
+---------------------------+
|from_json({"a":1, "b":0.8})|
+---------------------------+
|                   {1, 0.8}|
+---------------------------+
+--------------------------------+
|from_json({"time":"26/08/2015"})|
+--------------------------------+
|            {2015-08-26 00:00...|
+--------------------------------+
```


### Why are the changes needed?
Fix misleading information


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Not need
