### PR TITLE
[SPARK-34065][INFRA] Cancel the duplicated jobs only in PRs at GitHub Actions

### DIFF
--- a/.github/workflows/cancel_duplicate_workflow_runs.yml
+++ b/.github/workflows/cancel_duplicate_workflow_runs.yml
@@ -7,8 +7,7 @@ on:
 
 jobs:
   cancel-duplicate-workflow-runs:
-    # Trigger iif workflows are running in pull requests.
-    if: github.event.workflow_run.head_repository.full_name != 'apache/spark'
+    if: github.event.workflow_run.event == 'pull_request'
     name: "Cancel duplicate workflow runs"
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cancel_duplicate_workflow_runs.yml
+++ b/.github/workflows/cancel_duplicate_workflow_runs.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   cancel-duplicate-workflow-runs:
+    # Trigger iif workflows are running in pull requests.
+    if: github.event.workflow_run.head_repository.full_name != 'apache/spark'
     name: "Cancel duplicate workflow runs"
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is kind of a followup of https://github.com/apache/spark/pull/31104 but I decided to track it separately with a separate JIRA.

Currently the jobs are being canceled in main repo branches. If a commit is merged, for example, to master branch before the test finishes, it cancels the previous builds. This is a problem because we cannot, for example, detect logical conflict properly. We should only cancel the jobs in PRs:

![Screen Shot 2021-01-11 at 3 22 24 PM](https://user-images.githubusercontent.com/6477701/104152015-c7f04b80-5421-11eb-9e40-6b0a0e5b8442.png)

This PR proposes to don't do this in the main repo branch commits but only do it in PRs.

### Why are the changes needed?

- To keep the test coverage
- To run the test in the synced master branch instead of relying on the builds made in each PR with an outdated master branch
- To detect test failures from logical conflicts from merging two conflicting PRs at the same time.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

I manually tested in
- https://github.com/HyukjinKwon/spark/pull/27
- https://github.com/HyukjinKwon/spark/pull/28

I added Yi Wu as a co-author since he helped verifying the current fix in the PR above.

I checked that it does not cancel in the main repo branch:

![Screen Shot 2021-01-11 at 3 58 52 PM](https://user-images.githubusercontent.com/6477701/104153656-3afbc100-5426-11eb-9309-85f6f4fd9ff3.png)

I checked it cancels in PRs:

![Screen Shot 2021-01-11 at 3 58 45 PM](https://user-images.githubusercontent.com/6477701/104153658-3d5e1b00-5426-11eb-89f7-786c3ae6849a.png)
