### PR TITLE
[SPARK-34070][CORE][SQL] Replaces find and emptiness check with exists

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
@@ -272,7 +272,7 @@ private[storage] class BlockManagerDecommissioner(
         migrationPeers.get(peer).foreach(_.running = false)
     }
     // If we don't have anyone to migrate to give up
-    if (!migrationPeers.values.exists(_.running == true)) {
+    if (!migrationPeers.values.exists(_.running)) {
       stoppedShuffle = true
     }
     // If we found any new shuffles to migrate or otherwise have not migrated everything.

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
@@ -272,7 +272,7 @@ private[storage] class BlockManagerDecommissioner(
         migrationPeers.get(peer).foreach(_.running = false)
     }
     // If we don't have anyone to migrate to give up
-    if (migrationPeers.values.find(_.running == true).isEmpty) {
+    if (!migrationPeers.values.exists(_.running == true)) {
       stoppedShuffle = true
     }
     // If we found any new shuffles to migrate or otherwise have not migrated everything.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -572,7 +572,7 @@ class Analyzer(override val catalogManager: CatalogManager)
           // Only unique expressions are included in the group by expressions and is determined
           // based on their semantic equality. Example. grouping sets ((a * b), (b * a)) results
           // in grouping expression (a * b)
-          if (result.find(_.semanticEquals(currentExpr)).isDefined) {
+          if (result.exists(_.semanticEquals(currentExpr))) {
             result
           } else {
             result :+ currentExpr

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -844,10 +844,10 @@ object DataSource extends Logging {
    */
   def validateSchema(schema: StructType): Unit = {
     def hasEmptySchema(schema: StructType): Boolean = {
-      schema.size == 0 || schema.find {
+      schema.size == 0 || schema.exists {
         case StructField(_, b: StructType, _, _) => hasEmptySchema(b)
         case _ => false
-      }.isDefined
+      }
     }
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr use `exists` to simplify `find + emptiness check`, it's semantically consistent, but looks simpler.

**Before**

```
seq.find(p).isDefined

or

seq.find(p).isEmpty
```

**After**

```
seq.exists(p)

or

!seq.exists(p)
```
### Why are the changes needed?
Code Simpilefications.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass the Jenkins or GitHub Action
