### PR TITLE
[SPARK-33970][SQL][TEST][FOLLOWUP] Use String comparision

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HivePartitionFilteringSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HivePartitionFilteringSuite.scala
@@ -41,7 +41,7 @@ class HivePartitionFilteringSuite(version: String)
   private val tryDirectSqlKey = HiveConf.ConfVars.METASTORE_TRY_DIRECT_SQL.varname
 
   // Support default partition in metastoredirectsql since HIVE-11898(Hive 2.0.0).
-  private val defaultPartition = if (version >= "2.0.0") Some(DEFAULT_PARTITION_NAME) else None
+  private val defaultPartition = if (version >= "2.0") Some(DEFAULT_PARTITION_NAME) else None
 
   private val dsValue = 20170101 to 20170103
   private val hValue = 0 to 4

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HivePartitionFilteringSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HivePartitionFilteringSuite.scala
@@ -41,7 +41,7 @@ class HivePartitionFilteringSuite(version: String)
   private val tryDirectSqlKey = HiveConf.ConfVars.METASTORE_TRY_DIRECT_SQL.varname
 
   // Support default partition in metastoredirectsql since HIVE-11898(Hive 2.0.0).
-  private val defaultPartition = if (version.toDouble >= 2) Some(DEFAULT_PARTITION_NAME) else None
+  private val defaultPartition = if (version >= "2.0.0") Some(DEFAULT_PARTITION_NAME) else None
 
   private val dsValue = 20170101 to 20170103
   private val hValue = 0 to 4


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up to replace `version.toDouble > 2` with `version >= "2.0"`

### Why are the changes needed?

`toDouble` has some assumption and can cause `java.lang.NumberFormatException`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.