### PR TITLE
[SPARK-34074][SQL] Update stats only when table size changes

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
@@ -57,8 +57,11 @@ object CommandUtils extends Logging {
     if (sparkSession.sessionState.conf.autoSizeUpdateEnabled) {
       val newTable = catalog.getTableMetadata(table.identifier)
       val newSize = CommandUtils.calculateTotalSize(sparkSession, newTable)
-      val newStats = CatalogStatistics(sizeInBytes = newSize)
-      catalog.alterTableStats(table.identifier, Some(newStats))
+      val isNewStats = newTable.stats.map(newSize != _.sizeInBytes).getOrElse(true)
+      if (isNewStats) {
+        val newStats = CatalogStatistics(sizeInBytes = newSize)
+        catalog.alterTableStats(table.identifier, Some(newStats))
+      }
     } else if (table.stats.nonEmpty) {
       catalog.alterTableStats(table.identifier, None)
     } else {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLCommandTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLCommandTestUtils.scala
@@ -91,4 +91,20 @@ trait DDLCommandTestUtils extends SQLTestUtils {
   }
 
   protected def checkLocation(t: String, spec: TablePartitionSpec, expected: String): Unit
+
+  // Getting the total table size in the filesystem in bytes
+  def getTableSize(tableName: String): Int = {
+    val stats =
+      sql(s"DESCRIBE TABLE EXTENDED $tableName")
+        .select("data_type")
+        .where("col_name = 'Statistics'")
+        .first()
+        .getString(0)
+    val tableSizeInStats = ".*(\\d) bytes.*".r
+    val size = stats match {
+      case tableSizeInStats(s) => s.toInt
+      case _ => throw new IllegalArgumentException("Not found table size in stats")
+    }
+    size
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Do not alter table stats if they are the same as in the catalog (at least since the recent retrieve).

### Why are the changes needed?
The changes reduce the number of calls to Hive external catalog.

### Does this PR introduce _any_ user-facing change?
Should not.

### How was this patch tested?
By running the modified test suites:
```
$ build/sbt -Phive-2.3 -Phive-thriftserver "test:testOnly *AlterTableAddPartitionSuite"
$ build/sbt -Phive-2.3 -Phive-thriftserver "test:testOnly *AlterTableDropPartitionSuite"
```