### PR TITLE
[WIP][SPARK-34082][SQL] Window expressions with alias inside WHERE and HAVING clauses fail with explicit exceptions

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
@@ -915,6 +915,8 @@ class DataFrameWindowFunctionsSuite extends QueryTest
     checkAnalysisError(
       sql("SELECT * FROM testData2 WHERE b = 2 AND RANK() OVER(ORDER BY b) = 1"), "WHERE")
     checkAnalysisError(
+      sql("SELECT a, RANK() OVER(ORDER BY b) AS s FROM testData2 WHERE b = 2 AND s = 1"), "WHERE")
+    checkAnalysisError(
       sql("SELECT * FROM testData2 GROUP BY a HAVING a > AVG(b) AND RANK() OVER(ORDER BY a) = 1"),
       "HAVING")
     checkAnalysisError(
@@ -926,6 +928,13 @@ class DataFrameWindowFunctionsSuite extends QueryTest
            |FROM testData2
            |GROUP BY a
            |HAVING SUM(b) = 5 AND RANK() OVER(ORDER BY a) = 1""".stripMargin),
+      "HAVING")
+    checkAnalysisError(
+      sql(
+        s"""SELECT a, MAX(b), RANK() OVER(ORDER BY a) AS s
+           |FROM testData2
+           |GROUP BY a
+           |HAVING SUM(b) = 5 AND s = 1""".stripMargin),
       "HAVING")
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
#21580 prohibits window expressions inside WHERE and HAVING clauses. But if the window expressions with alias inside WHERE and HAVING clauses, Spark does not handle this explicitly and will fail with non-descriptive exceptions.
```
SELECT a, RANK() OVER(ORDER BY b) AS s FROM testData2 WHERE b = 2 AND s = 1
```
> cannot resolve '`s`' given input columns: [testdata2.a, testdata2.b]

```
SELECT a, MAX(b), RANK() OVER(ORDER BY a) AS s
FROM testData2
GROUP BY a
HAVING SUM(b) = 5 AND s = 1
```
> cannot resolve '`b`' given input columns: [testdata2.a, max(b)]


### Why are the changes needed?
Correct the exception message to `It is not allowed to use window functions inside $clauseName clause`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add unit test cases
