### PR TITLE
[SPARK-32380][SQL]fixed spark3.0 access hive table while data in hbase problem

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -299,7 +299,7 @@ class HadoopTableReader(
    */
   private def createHadoopRDD(localTableDesc: TableDesc, inputPathStr: String): RDD[Writable] = {
     val inputFormatClazz = localTableDesc.getInputFileFormatClass
-    if (classOf[newInputClass[_, _]].isAssignableFrom(inputFormatClazz)) {
+    if (classOf[oldInputClass[_, _]].isAssignableFrom(inputFormatClazz)) {
       createNewHadoopRDD(localTableDesc, inputPathStr)
     } else {
       createOldHadoopRDD(localTableDesc, inputPathStr)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -300,9 +300,9 @@ class HadoopTableReader(
   private def createHadoopRDD(localTableDesc: TableDesc, inputPathStr: String): RDD[Writable] = {
     val inputFormatClazz = localTableDesc.getInputFileFormatClass
     if (classOf[oldInputClass[_, _]].isAssignableFrom(inputFormatClazz)) {
-      createNewHadoopRDD(localTableDesc, inputPathStr)
-    } else {
       createOldHadoopRDD(localTableDesc, inputPathStr)
+    } else {
+      createNewHadoopRDD(localTableDesc, inputPathStr)
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->
fixed spark3.0 access hive table while data in hbase problem

### What changes were proposed in this pull request?
The PR modify TableReader.scala to create OldHadoopRDD when inputformat is 'org.apache.hadoop.hive.hbase.HiveHBaseTableInputFormat', beacuse NewHadoopRDD uses the new MapReduce API (org.apache.hadoop.mapreduce),but some initialization operations for hbase are implemented using the older MapReduce API (org.apache.hadoop.mapred),this makes the default NewHadoopRDD can not access hbase table.Therefore, in order to be compatible with implementation classes similar to 'org.apache.hadoop.hive.hbase.HiveHBaseTableInputFormat' that uses the old API and the new API, it should be prioritized whether to create OldHadoopRDD.
This PR is similar to https://github.com/apache/spark/pull/29178

Reference link： https://issues.apache.org/jira/browse/SPARK-32380
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Sparksql cannot access hive table while data in hbase, want to fixed this bug.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
- step 1 create hbase table

> hbase(main):001:0>create 'hive_hbase_test', 'f' <br>
hbase(main):001:0> put 'hive_hbase_test', 'r1', 'f:c1', '123' <br>

- step 2 create hive table mapping to hbase table

> CREATE EXTERNAL TABLE `test.hbase_test`(<br>
  `key` string COMMENT '', <br>
  `value` string COMMENT '')<br>
STORED BY<br>
'org.apache.hadoop.hive.hbase.HBaseStorageHandler' <br>
WITH SERDEPROPERTIES ( <br>
  'hbase.columns.mapping'=':key,f:c1', <br>
  'serialization.format'='1')<br>
TBLPROPERTIES (<br>
  'hbase.table.name'='hive_hbase_test')

- step 3 using spark-sql cli to query data in hive

> spark-sql> select * from test.hbase_test limit 1;

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
