### PR TITLE
[SPARK-34088][CORE] Rename all decommission configurations to use the same namespace "spark.decommission.*"

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Worker.scala
@@ -84,7 +84,7 @@ private[spark] object Worker {
       .createWithDefault(100)
 
   val WORKER_DECOMMISSION_SIGNAL =
-    ConfigBuilder("spark.worker.decommission.signal")
+    ConfigBuilder("spark.decommission.worker.signal")
       .doc("The signal that used to trigger the worker to start decommission.")
       .version("3.2.0")
       .stringConf

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -472,7 +472,7 @@ package object config {
       .createWithDefaultString("30s")
 
   private[spark] val STORAGE_DECOMMISSION_FALLBACK_STORAGE_PATH =
-    ConfigBuilder("spark.decommission.storage.fallbackStorage.path")
+    ConfigBuilder("spark.decommission.storage.fallbackStoragePath")
       .doc("The location for fallback storage during block manager decommissioning. " +
         "For example, `s3a://spark-storage/`. In case of empty, fallback storage is disabled. " +
         "The storage should be managed by TTL because Spark will not clean it up.")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -421,14 +421,14 @@ package object config {
       .createWithDefault(1)
 
   private[spark] val STORAGE_DECOMMISSION_ENABLED =
-    ConfigBuilder("spark.storage.decommission.enabled")
+    ConfigBuilder("spark.decommission.storage.enabled")
       .doc("Whether to decommission the block manager when decommissioning executor")
       .version("3.1.0")
       .booleanConf
       .createWithDefault(false)
 
   private[spark] val STORAGE_DECOMMISSION_SHUFFLE_BLOCKS_ENABLED =
-    ConfigBuilder("spark.storage.decommission.shuffleBlocks.enabled")
+    ConfigBuilder("spark.decommission.storage.shuffleBlocks.enabled")
       .doc("Whether to transfer shuffle blocks during block manager decommissioning. Requires " +
         "a migratable shuffle resolver (like sort based shuffle)")
       .version("3.1.0")
@@ -436,7 +436,7 @@ package object config {
       .createWithDefault(false)
 
   private[spark] val STORAGE_DECOMMISSION_SHUFFLE_MAX_THREADS =
-    ConfigBuilder("spark.storage.decommission.shuffleBlocks.maxThreads")
+    ConfigBuilder("spark.decommission.storage.shuffleBlocks.maxThreads")
       .doc("Maximum number of threads to use in migrating shuffle files.")
       .version("3.1.0")
       .intConf
@@ -444,14 +444,14 @@ package object config {
       .createWithDefault(8)
 
   private[spark] val STORAGE_DECOMMISSION_RDD_BLOCKS_ENABLED =
-    ConfigBuilder("spark.storage.decommission.rddBlocks.enabled")
+    ConfigBuilder("spark.decommission.storage.rddBlocks.enabled")
       .doc("Whether to transfer RDD blocks during block manager decommissioning.")
       .version("3.1.0")
       .booleanConf
       .createWithDefault(false)
 
   private[spark] val STORAGE_DECOMMISSION_MAX_REPLICATION_FAILURE_PER_BLOCK =
-    ConfigBuilder("spark.storage.decommission.maxReplicationFailuresPerBlock")
+    ConfigBuilder("spark.decommission.storage.maxReplicationFailuresPerBlock")
       .internal()
       .doc("Maximum number of failures which can be handled for the replication of " +
         "one RDD block when block manager is decommissioning and trying to move its " +
@@ -461,7 +461,7 @@ package object config {
       .createWithDefault(3)
 
   private[spark] val STORAGE_DECOMMISSION_REPLICATION_REATTEMPT_INTERVAL =
-    ConfigBuilder("spark.storage.decommission.replicationReattemptInterval")
+    ConfigBuilder("spark.decommission.storage.replicationReattemptInterval")
       .internal()
       .doc("The interval of time between consecutive cache block replication reattempts " +
         "happening on each decommissioning executor (due to storage decommissioning).")
@@ -472,7 +472,7 @@ package object config {
       .createWithDefaultString("30s")
 
   private[spark] val STORAGE_DECOMMISSION_FALLBACK_STORAGE_PATH =
-    ConfigBuilder("spark.storage.decommission.fallbackStorage.path")
+    ConfigBuilder("spark.decommission.storage.fallbackStorage.path")
       .doc("The location for fallback storage during block manager decommissioning. " +
         "For example, `s3a://spark-storage/`. In case of empty, fallback storage is disabled. " +
         "The storage should be managed by TTL because Spark will not clean it up.")
@@ -1917,7 +1917,7 @@ package object config {
       .createWithDefault(false)
 
   private[spark] val EXECUTOR_DECOMMISSION_KILL_INTERVAL =
-    ConfigBuilder("spark.executor.decommission.killInterval")
+    ConfigBuilder("spark.decommission.executor.killInterval")
       .doc("Duration after which a decommissioned executor will be killed forcefully." +
         "This config is useful for cloud environments where we know in advance when " +
         "an executor is going to go down after decommissioning signal i.e. around 2 mins " +
@@ -1928,7 +1928,7 @@ package object config {
       .createOptional
 
   private[spark] val EXECUTOR_DECOMMISSION_SIGNAL =
-    ConfigBuilder("spark.executor.decommission.signal")
+    ConfigBuilder("spark.decommission.executor.signal")
       .doc("The signal that used to trigger the executor to start decommission.")
       .version("3.2.0")
       .stringConf


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR supposes to rename all decommission configurations to use the same namespace "spark.decommission.*".

Besides, it also refines the config "spark.decommission.storage.fallbackStorage.path" to "spark.decommission.storage.fallbackStoragePath".




### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Currently, decommission configurations are using difference namespaces, e.g., 

```scala
spark.decommission.*
spark.storage.decommission.*
spark.executor.decommission.*
```
which may introduce unnecessary overhead for end-users. It's better to keep them under the same namespace. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No, since Spark 3.1 hasn't officially released.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Pass existing tests.
