### PR TITLE
[SPARK-34033][R] SparkR Daemon Initialization

### DIFF
--- a/R/pkg/inst/worker/daemon.R
+++ b/R/pkg/inst/worker/daemon.R
@@ -32,6 +32,10 @@ inputCon <- socketConnection(
 
 SparkR:::doServerAuth(inputCon, Sys.getenv("SPARKR_WORKER_SECRET"))
 
+# Application-specific daemon initialization. Typical use is loading libraries.
+DaemonInit <- Sys.getenv("SPARKR_DAEMON_INIT")
+if (DaemonInit != "NULL") eval(parse(text = DaemonInit))
+
 # Waits indefinitely for a socket connection by default.
 selectTimeout <- NULL
 

--- a/R/pkg/inst/worker/daemon.R
+++ b/R/pkg/inst/worker/daemon.R
@@ -33,8 +33,7 @@ inputCon <- socketConnection(
 SparkR:::doServerAuth(inputCon, Sys.getenv("SPARKR_WORKER_SECRET"))
 
 # Application-specific daemon initialization. Typical use is loading libraries.
-DaemonInit <- Sys.getenv("SPARKR_DAEMON_INIT")
-if (DaemonInit != "NULL") eval(parse(text = DaemonInit))
+eval(parse(text = Sys.getenv("SPARKR_DAEMON_INIT")))
 
 # Waits indefinitely for a socket connection by default.
 selectTimeout <- NULL

--- a/R/pkg/tests/fulltests/test_daemon_initialization.R
+++ b/R/pkg/tests/fulltests/test_daemon_initialization.R
@@ -1,0 +1,51 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+library(testthat)
+context("Daemon Initialization")
+test_that("Daemon Initialization", {
+  if (is_windows()) {
+    skip("Can't test daemon initialization if you don't use daemons.")
+  }
+  sparkR.stop()
+  sparkR.session(
+    spark.r.daemonInit =
+      'message("Initting the Daemon ..."); testInit <- "wow"'
+  )
+  data <-
+    list(list(1L, 1, "1", 0.1), list(1L, 2, "1", 0.2), list(3L, 3, "3", 0.3))
+  inputColumnNames <- c("a", "b", "c", "d")
+  groupingColumnNames <- c("a", "c")
+  workerFunction <- function(key, x) {
+    if (!exists("testInit")) {
+      warning("daemon did not initialize")
+      quit(status = 1, save = "no")
+    }
+    data.frame(key, mean(x$b), stringsAsFactors = FALSE)
+  }
+  outputSchema <-
+    structType(
+      structField("a", "integer"),
+      structField("c", "string"),
+      structField("avg", "double")
+    )
+  df <- createDataFrame(data, inputColumnNames)
+  resultDF <-
+    gapply(df, groupingColumnNames, workerFunction, outputSchema)
+  result <- collect(resultDF)
+  expect_equal(max(result$avg), 3)
+  sparkR.stop()
+})

--- a/R/run-tests.sh
+++ b/R/run-tests.sh
@@ -30,10 +30,21 @@ if [[ $(echo $SPARK_AVRO_JAR_PATH | wc -l) -eq 1 ]]; then
 fi
 
 if [ -z "$SPARK_JARS" ]; then
-  SPARK_TESTING=1 NOT_CRAN=true $FWDIR/../bin/spark-submit --driver-java-options "-Dlog4j.configuration=file:$FWDIR/log4j.properties" --conf spark.hadoop.fs.defaultFS="file:///" --conf spark.driver.extraJavaOptions="-Dio.netty.tryReflectionSetAccessible=true" --conf spark.executor.extraJavaOptions="-Dio.netty.tryReflectionSetAccessible=true" $FWDIR/pkg/tests/run-all.R 2>&1 | tee -a $LOGFILE
+  JARS=""
 else
-  SPARK_TESTING=1 NOT_CRAN=true $FWDIR/../bin/spark-submit --jars $SPARK_JARS --driver-java-options "-Dlog4j.configuration=file:$FWDIR/log4j.properties" --conf spark.hadoop.fs.defaultFS="file:///" --conf spark.driver.extraJavaOptions="-Dio.netty.tryReflectionSetAccessible=true" --conf spark.executor.extraJavaOptions="-Dio.netty.tryReflectionSetAccessible=true" $FWDIR/pkg/tests/run-all.R 2>&1 | tee -a $LOGFILE
+  JARS="--jars $SPARK_JARS"
 fi
+
+NOT_CRAN=true \
+SPARK_TESTING=1 \
+$FWDIR/../bin/spark-submit \
+--conf spark.driver.extraJavaOptions="-Dio.netty.tryReflectionSetAccessible=true" \
+--conf spark.executor.extraJavaOptions="-Dio.netty.tryReflectionSetAccessible=true" \
+--conf spark.hadoop.fs.defaultFS="file:///" \
+--conf spark.r.daemonInit='testInit <- "wow"' \
+--driver-java-options "-Dlog4j.configuration=file:$FWDIR/log4j.properties" \
+$JARS \
+$FWDIR/pkg/tests/run-all.R 2>&1 | tee -a $LOGFILE
 
 FAILED=$((PIPESTATUS[0]||$FAILED))
 

--- a/core/src/main/scala/org/apache/spark/api/r/BaseRRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/BaseRRunner.scala
@@ -24,9 +24,6 @@ import java.util.Arrays
 import scala.io.Source
 import scala.util.Try
 
-import org.apache.log4j.Level.INFO
-import org.apache.log4j.Logger.getRootLogger
-
 import org.apache.spark._
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.Logging
@@ -322,14 +319,6 @@ private[r] object BaseRRunner {
           // we expect one connections
           val serverSocket = new ServerSocket(0, 1, InetAddress.getByName("localhost"))
           val daemonPort = serverSocket.getLocalPort
-
-          // Ensure daemon initialization is logged by ensuring
-          // org.apache.spark.api.r.BufferedStreamThread is at INFO level
-          val rootLogger = getRootLogger
-          val logLevel = rootLogger.getLevel
-          val raiseLogging = logLevel.getSyslogEquivalent < INFO.getSyslogEquivalent
-          if(raiseLogging) rootLogger.setLevel(INFO)
-
           errThread = createRProcess(daemonPort, "daemon.R")
           // the socket used to send out the input of task
           serverSocket.setSoTimeout(SparkEnv.get.conf.get(R_DAEMON_TIMEOUT))
@@ -339,7 +328,6 @@ private[r] object BaseRRunner {
             daemonChannel = new DataOutputStream(new BufferedOutputStream(sock.getOutputStream))
           } finally {
             serverSocket.close()
-            if(raiseLogging) rootLogger.setLevel(logLevel)
           }
         }
         try {

--- a/core/src/main/scala/org/apache/spark/api/r/BaseRRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/BaseRRunner.scala
@@ -24,6 +24,9 @@ import java.util.Arrays
 import scala.io.Source
 import scala.util.Try
 
+import org.apache.log4j.Level.INFO
+import org.apache.log4j.Logger.getRootLogger
+
 import org.apache.spark._
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.Logging
@@ -301,6 +304,7 @@ private[r] object BaseRRunner {
     pb.environment().put("SPARKR_SPARKFILES_ROOT_DIR", SparkFiles.getRootDirectory())
     pb.environment().put("SPARKR_IS_RUNNING_ON_WORKER", "TRUE")
     pb.environment().put("SPARKR_WORKER_SECRET", authHelper.secret)
+    pb.environment().put("SPARKR_DAEMON_INIT", sparkConf.get(R_DAEMON_INIT))
     pb.redirectErrorStream(true)  // redirect stderr into stdout
     val proc = pb.start()
     val errThread = startStdoutThread(proc)
@@ -318,15 +322,24 @@ private[r] object BaseRRunner {
           // we expect one connections
           val serverSocket = new ServerSocket(0, 1, InetAddress.getByName("localhost"))
           val daemonPort = serverSocket.getLocalPort
+
+          // Ensure daemon initialization is logged by ensuring
+          // org.apache.spark.api.r.BufferedStreamThread is at INFO level
+          val rootLogger = getRootLogger
+          val logLevel = rootLogger.getLevel
+          val raiseLogging = logLevel.getSyslogEquivalent < INFO.getSyslogEquivalent
+          if(raiseLogging) rootLogger.setLevel(INFO)
+
           errThread = createRProcess(daemonPort, "daemon.R")
           // the socket used to send out the input of task
-          serverSocket.setSoTimeout(10000)
+          serverSocket.setSoTimeout(SparkEnv.get.conf.get(R_DAEMON_TIMEOUT))
           val sock = serverSocket.accept()
           try {
             authHelper.authClient(sock)
             daemonChannel = new DataOutputStream(new BufferedOutputStream(sock.getOutputStream))
           } finally {
             serverSocket.close()
+            if(raiseLogging) rootLogger.setLevel(logLevel)
           }
         }
         try {

--- a/core/src/main/scala/org/apache/spark/internal/config/R.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/R.scala
@@ -42,4 +42,16 @@ private[spark] object R {
     .version("1.5.3")
     .stringConf
     .createOptional
+
+  /** The SparkR daemon will evaluate this before forking. */
+  val R_DAEMON_INIT = ConfigBuilder("spark.r.daemonInit")
+    .version("3.2.0")
+    .stringConf
+    .createWithDefault("NULL")
+
+  /** milliseconds to wait until we give up launching the daemon */
+  val R_DAEMON_TIMEOUT = ConfigBuilder("spark.r.daemonTimeout")
+    .version("3.2.0")
+    .intConf
+    .createWithDefault(10000)
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2825,6 +2825,28 @@ External users can query the static sql config values via `SparkSession.conf` or
   <td>1.5.3</td>
 </tr>
 <tr>
+  <td><code>spark.r.daemonInit</code></td>
+  <td>NULL</td>
+  <td>
+    R code you would like executed <b>before</b> the daemon starts
+    processing groups. See
+    <a href="sparkr.md#daemon-initialization">Daemon Initialization</a>.
+    Increase spark.r.daemonTimeout if your initialization takes longer
+    than the default.
+    </td>
+    <td>3.2.0</td>
+</tr>
+<tr>
+  <td><code>spark.r.daemonTimeout</code></td>
+  <td>10000</td>
+  <td>
+    What is the upper limit in milliseconds that we allow for daemon
+    initialization? In other words, how long should the spark executor
+    wait until it decides that it can't launch the SparkR daemon?
+  </td>
+  <td>3.2.0</td>
+</tr>
+<tr>
   <td><code>spark.r.driver.command</code></td>
   <td>spark.r.command</td>
   <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2833,8 +2833,8 @@ External users can query the static sql config values via `SparkSession.conf` or
     <a href="sparkr.md#daemon-initialization">Daemon Initialization</a>.
     Increase spark.r.daemonTimeout if your initialization takes longer
     than the default.
-    </td>
-    <td>3.2.0</td>
+  </td>
+  <td>3.2.0</td>
 </tr>
 <tr>
   <td><code>spark.r.daemonTimeout</code></td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2825,6 +2825,7 @@ External users can query the static sql config values via `SparkSession.conf` or
   <td>1.5.3</td>
 </tr>
 <tr>
+  <a name="daemonInit">
   <td><code>spark.r.daemonInit</code></td>
   <td>NULL</td>
   <td>
@@ -2837,6 +2838,7 @@ External users can query the static sql config values via `SparkSession.conf` or
   <td>3.2.0</td>
 </tr>
 <tr>
+  <a name="daemonTimeout">
   <td><code>spark.r.daemonTimeout</code></td>
   <td>10000</td>
   <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2825,7 +2825,6 @@ External users can query the static sql config values via `SparkSession.conf` or
   <td>1.5.3</td>
 </tr>
 <tr>
-  <a name="daemonInit">
   <td><code>spark.r.daemonInit</code></td>
   <td>NULL</td>
   <td>
@@ -2838,7 +2837,6 @@ External users can query the static sql config values via `SparkSession.conf` or
   <td>3.2.0</td>
 </tr>
 <tr>
-  <a name="daemonTimeout">
   <td><code>spark.r.daemonTimeout</code></td>
   <td>10000</td>
   <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2825,7 +2825,7 @@ External users can query the static sql config values via `SparkSession.conf` or
   <td>1.5.3</td>
 </tr>
 <tr>
-  <td><code>spark.r.daemonInit</code></td>
+  <td><code>spark.r.daemonInit</code><a name="spark.r.daemonInit"></td>
   <td>NULL</td>
   <td>
     R code you would like executed <b>before</b> the daemon starts
@@ -2837,7 +2837,7 @@ External users can query the static sql config values via `SparkSession.conf` or
   <td>3.2.0</td>
 </tr>
 <tr>
-  <td><code>spark.r.daemonTimeout</code></td>
+  <td><code>spark.r.daemonTimeout</code><a name="spark.r.daemonTimeout"></a></td>
   <td>10000</td>
   <td>
     What is the upper limit in milliseconds that we allow for daemon

--- a/docs/sparkr.md
+++ b/docs/sparkr.md
@@ -764,9 +764,10 @@ of compute time repeatedly doing something that should have taken a few
 seconds during daemon initialization.
 
 Every Spark executor spawns a process running an R daemon. The daemon
-"forks a copy" of itself whenever Spark finds work for it to do. It may
-be applying a predefined method such as "max", or it may be applying
-your worker function. SparkR::gapply arranges things so that your worker
+["forks a copy"](https://stat.ethz.ch/R-manual/R-devel/library/parallel/html/mcfork.html)
+of itself whenever Spark finds work for it to do. It may be applying a
+predefined method such as "max", or it may be applying your worker
+function. [SparkR::gapply](#gapply) arranges things so that your worker
 function will be called with each group. A group is the pair
 Key-Seq[Row]. In the absence of partitioning, the daemon will fork for
 every group found. With partitioning, the daemon will fork for every
@@ -776,10 +777,10 @@ All the initializations and library loading your worker function manages
 is thrown away when the fork concludes. Every fork has to be
 initialized.
 
-The configuration spark.r.daemonInit provides a way to avoid reloading
-packages every time the daemon forks by having the daemon pre-load
-packages. You do this by providing R code to initialize the daemon for
-your application.
+The configuration [spark.r.daemonInit](configuration.md#daemonInit)
+provides a way to avoid reloading packages every time the daemon forks
+by having the daemon pre-load packages. You do this by providing R code
+to initialize the daemon for your application.
 
 ## Examples
 
@@ -808,4 +809,5 @@ library(wow) from the newly created wowTarget.
 
 
 Warning: if your initialization takes longer than 10 seconds, consider
-increasing the configuration [spark.r.daemonTimeout](configuration.md#sparkr).
+increasing the configuration
+[spark.r.daemonTimeout](configuration.md#daemonTimeout).

--- a/docs/sparkr.md
+++ b/docs/sparkr.md
@@ -777,10 +777,10 @@ All the initializations and library loading your worker function manages
 is thrown away when the fork concludes. Every fork has to be
 initialized.
 
-The configuration [spark.r.daemonInit](configuration.md#daemonInit)
-provides a way to avoid reloading packages every time the daemon forks
-by having the daemon pre-load packages. You do this by providing R code
-to initialize the daemon for your application.
+The configuration spark.r.daemonInit provides a way to avoid reloading
+packages every time the daemon forks by having the daemon pre-load
+packages. You do this by providing R code to initialize the daemon for
+your application.
 
 ## Examples
 
@@ -809,5 +809,4 @@ library(wow) from the newly created wowTarget.
 
 
 Warning: if your initialization takes longer than 10 seconds, consider
-increasing the configuration
-[spark.r.daemonTimeout](configuration.md#daemonTimeout).
+increasing the configuration spark.r.daemonTimeout.

--- a/docs/sparkr.md
+++ b/docs/sparkr.md
@@ -777,10 +777,11 @@ All the initializations and library loading your worker function manages
 is thrown away when the fork concludes. Every fork has to be
 initialized.
 
-The configuration spark.r.daemonInit provides a way to avoid reloading
-packages every time the daemon forks by having the daemon pre-load
-packages. You do this by providing R code to initialize the daemon for
-your application.
+The configuration
+[spark.r.daemonInit](./configuration.md#spark.r.daemonInit) provides a
+way to avoid reloading packages every time the daemon forks by having
+the daemon pre-load packages. You do this by providing R code to
+initialize the daemon for your application.
 
 
 ## Time Saved
@@ -798,7 +799,8 @@ A real-world example:
 ## Warning
 
 If your initialization takes longer than 10 seconds, consider increasing
-the configuration spark.r.daemonTimeout.
+the configuration
+[spark.r.daemonTimeout](./configuration.md#spark.r.daemonTimeout).
 
 
 ## Examples

--- a/docs/sparkr.md
+++ b/docs/sparkr.md
@@ -782,6 +782,25 @@ packages every time the daemon forks by having the daemon pre-load
 packages. You do this by providing R code to initialize the daemon for
 your application.
 
+
+## Time Saved
+
+The amount of time saved per call to gapply is thus
+
+yourInitialization * (partitions - executors)
+
+A real-world example:
+
+(5 seconds to load libraries) * ( (40,000 partitions) - (700 executors) ) / 60 / 60
+
+55 hours saved in total. 55 hours / 700 executors ~= 5 minutes per executor.
+
+## Warning
+
+If your initialization takes longer than 10 seconds, consider increasing
+the configuration spark.r.daemonTimeout.
+
+
 ## Examples
 
 Suppose we want library(wow) to be pre-loaded for our workers.
@@ -806,7 +825,3 @@ YARN creates a directory for the new executor, unzips 'wow.zip' in some
 other directory, and then provides a symlink to it called
 ./wowTarget. When the executor starts the daemon, the daemon loads
 library(wow) from the newly created wowTarget.
-
-
-Warning: if your initialization takes longer than 10 seconds, consider
-increasing the configuration spark.r.daemonTimeout.


### PR DESCRIPTION
### What changes were proposed in this pull request?

A way of letting sparkR users preload libraries and other initialization
in the daemon before it starts forking. A full description can be found
in [docs/sparkr.md#daemon-initialization](/WamBamBoozle/spark/blob/daemon_init/docs/sparkr.md#daemon-initialization).

### Why are the changes needed?

Performance

### Does this PR introduce _any_ user-facing change?

Yes. It introduces two new sparkR session parameters,
spark.r.daemonInit and spark.r.daemonTimeout, as described in
[docs/configuration.md#sparkr](/WamBamBoozle/spark/blob/daemon_init/docs/configuration.md#sparkr).

### How was this patch tested?

added pkg/tests/fulltests/test_daemon_initialization.R
