### PR TITLE
[SPARK-34093][ML] param maxDepth should check upper bound

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
@@ -61,7 +61,7 @@ private[ml] trait DecisionTreeParams extends PredictorParams
   final val maxDepth: IntParam =
     new IntParam(this, "maxDepth", "Maximum depth of the tree. (Nonnegative)" +
       " E.g., depth 0 means 1 leaf node; depth 1 means 1 internal node + 2 leaf nodes.",
-      ParamValidators.gtEq(0))
+      ParamValidators.inRange(0, 30))
 
   /**
    * Maximum number of bins used for discretizing continuous features and for choosing how to split

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
@@ -60,7 +60,8 @@ private[ml] trait DecisionTreeParams extends PredictorParams
    */
   final val maxDepth: IntParam =
     new IntParam(this, "maxDepth", "Maximum depth of the tree. (Nonnegative)" +
-      " E.g., depth 0 means 1 leaf node; depth 1 means 1 internal node + 2 leaf nodes.",
+      " E.g., depth 0 means 1 leaf node; depth 1 means 1 internal node + 2 leaf nodes." +
+      " Must be in range [0, 30].",
       ParamValidators.inRange(0, 30))
 
   /**

--- a/python/pyspark/ml/tree.py
+++ b/python/pyspark/ml/tree.py
@@ -67,7 +67,8 @@ class _DecisionTreeParams(HasCheckpointInterval, HasSeed, HasWeightCol):
                     typeConverter=TypeConverters.toString)
 
     maxDepth = Param(Params._dummy(), "maxDepth", "Maximum depth of the tree. (>= 0) E.g., " +
-                     "depth 0 means 1 leaf node; depth 1 means 1 internal node + 2 leaf nodes.",
+                     "depth 0 means 1 leaf node; depth 1 means 1 internal node + 2 leaf nodes. " +
+                     "Must be in range [0, 30].",
                      typeConverter=TypeConverters.toInt)
 
     maxBins = Param(Params._dummy(), "maxBins", "Max number of bins for discretizing continuous " +


### PR DESCRIPTION
### What changes were proposed in this pull request?
update the ParamValidators of `maxDepth`


### Why are the changes needed?
current impl of tree models only support maxDepth<=30

### Does this PR introduce _any_ user-facing change?
If `maxDepth`>30, fail quickly


### How was this patch tested?
existing testsuites
