### PR TITLE
[SPARK-33933][SQL] Materialize BroadcastQueryStage first to avoid broadcast timeout in AQE

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -215,7 +215,7 @@ case class AdaptiveSparkPlanExec(
             future
           }
 
-          // Wait the all the materialization of broadcast stages finish
+          // Wait for the materialization of all broadcast stages finish
           broadcastMaterializationFutures.foreach(ThreadUtils.awaitReady(_, Duration.Inf))
 
           // Start materialization of non-broadcast stages

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -22,7 +22,7 @@ import java.net.URI
 
 import org.apache.log4j.Level
 
-import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent, SparkListenerJobStart}
+import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent, SparkListenerJobStart, SparkListenerStageSubmitted, StageInfo}
 import org.apache.spark.sql.{Dataset, QueryTest, Row, SparkSession, Strategy}
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight}
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LogicalPlan}
@@ -1459,5 +1459,43 @@ class AdaptiveQueryExecSuite
         }
       }
     }
+  }
+
+  test("SPARK-33933: AQE broadcast should not timeout with slow map tasks") {
+
+    val broadcastTimeoutInSec = 2
+    val shuffleMapTaskParallsm = 100
+
+    val input = spark.sparkContext.parallelize(Range(0, 100), shuffleMapTaskParallsm)
+      .flatMap(x => {
+        Thread.sleep(50)
+        for (i <- Range(0, 100)) yield (x % 26, x % 10)
+      }).toDF("index", "pv")
+    val dim = Range(0, 26)
+      .map(x => (x, ('a' + x).toChar.toString))
+      .toDF("index", "name")
+      .coalesce(1)
+    val testDf = input.groupBy("index")
+      .agg(sum($"pv").alias("pv"))
+      .join(dim, Seq("index"))
+
+    val stageInfos = scala.collection.mutable.ArrayBuffer[StageInfo]()
+    val listener = new SparkListener {
+      override def onStageSubmitted(stageSubmitted: SparkListenerStageSubmitted): Unit = {
+        stageInfos += stageSubmitted.stageInfo
+      }
+    }
+    spark.sparkContext.addSparkListener(listener)
+
+    withSQLConf(SQLConf.BROADCAST_TIMEOUT.key -> broadcastTimeoutInSec.toString,
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true") {
+      val result = testDf.collect()
+      assert(result.length == 26)
+      val sortedStageInfos = stageInfos.sortBy(_.submissionTime)
+      assert(sortedStageInfos.size > 2)
+      assert(sortedStageInfos(0).numTasks == 1)
+      assert(sortedStageInfos(1).numTasks == shuffleMapTaskParallsm)
+    }
+
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In AdaptiveSparkPlanExec.getFinalPhysicalPlan, when newStages are generated, materialize BroadcastQueryStage first and wait the materialization finish before materialize other (ShuffleQueryStage) stages.
It can make sure the broadcast job are scheduled and finished before map jobs to avoid waiting for job schedule and cause broadcast timeout. This is the same behavior with non-AQE queries.
Actually, we want to only control the schedule for broadcast job is before map jobs. However, it is difficult to control and may have large changes to spark-core. So the trade off is wait broadcast job finish before materialize ShuffleQueryStage.

Consider the case, a is a large table, b and c are very small in-memory dimension tables.
```
SELECT a.id, a.name, b.name, c.name, count(a.value) 
FROM a 
JOIN b on a.id = b.id 
JOIN c on a.name = c.name 
GROUP BY a.id, a.name
```
For non-AQE: 
1. run collect b, then broadcast b 
2. run collect c, then broadcast c
3. submit job which contains 2 stage

For current AQE: 
1. submit 3 job( shuffle map stage for a, collect b and broadcast b, collect c broadcast c ) almost at the same time
2. when all finished, run result stage

For AQE with this PR:
1. submit 2 job(collect b and broadcast b, collect c broadcast c) at the same time
2. wait broadcast of b and c finish
3. run shuffle map stage
2. run result stage

### Why are the changes needed?
In non-AQE, we always wait the broadcast finish before submit shuffle map tasks.

When enable AQE, in getFinalPhysicalPlan, spark traversal the physical plan bottom up and create query stage for materialized part by createQueryStages and materialize those new created query stages to submit map stages or broadcasting. When ShuffleQueryStage are materializing before BroadcastQueryStage, the map stage(job) and broadcast job are submitted almost at the same time, but map stage will hold all the computing resources. If the map stage runs slow (when lots of data needs to process and the resource is limited), the broadcast job cannot be started(and finished) before spark.sql.broadcastTimeout, thus cause whole job failed (introduced in SPARK-31475).

The workaround to increase spark.sql.broadcastTimeout doesn't make sense and graceful, because the data to broadcast is very small.

https://github.com/apache/spark/pull/30998 give a solution by sort the new stages by class type to make sure the calling of materialize() for BroadcastQueryState precede others. However, the solution is not perfect and because of the flaky of UT, it is revered. The order of calling materialize can guarantee that the order of task to be scheduled in normal circumstances, but, the guarantee is not strict since the submit of broadcast job and shuffle map job are in different thread.
1. for broadcast job, call doPrepare() in main thread, and then start the real materialization in "broadcast-exchange-0" thread pool: calling getByteArrayRdd().collect() to submit collect job
2. for shuffle map job, call ShuffleExchangeExec.mapOutputStatisticsFuture() which call sparkContext.submitMapStage() directly in main thread to submit map stage

1 is trigger before 2, so in normal cases, the broadcast job will be submit first.
However, we can not control how fast the two thread runs, so the "broadcast-exchange-0" thread could run a little bit slower than main thread, result in map stage submit first So there's still risk for the shuffle map job schedule earlier before broadcast job.

### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
1. Add UT
2. Test the code using dev environment in https://issues.apache.org/jira/browse/SPARK-33933