### PR TITLE
[SPARK-34096][SQL] Improve performance for nth_value ignore nulls over offset window

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowExecBase.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowExecBase.scala
@@ -126,9 +126,10 @@ trait WindowExecBase extends UnaryExecNode {
     // Add a function and its function to the map for a given frame.
     def collect(tpe: String, fr: SpecifiedWindowFrame, e: Expression, fn: Expression): Unit = {
       val key = fn match {
-        // This branch is used for Lead/Lag to support ignoring null.
-        // All window frames move in rows. If there are multiple Leads or Lags acting on a row
-        // and operating on different input expressions, they should not be moved uniformly
+        // This branch is used for Lead/Lag to support ignoring null and optimize the performance
+        // for NthValue ignoring null.
+        // All window frames move in rows. If there are multiple Leads, Lags or NthValues acting on
+        // a row and operating on different input expressions, they should not be moved uniformly
         // by row. Therefore, we put these functions in different window frames.
         case f: OffsetWindowFunction if f.ignoreNulls =>
           (tpe, fr.frameType, fr.lower, fr.upper, f.children.map(_.canonicalized))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowFunctionFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowFunctionFrame.scala
@@ -364,24 +364,15 @@ class UnboundedPrecedingOffsetWindowFunctionFrame(
       findNextRowWithNonNullInput()
       selectedRow = nextSelectedRow.asInstanceOf[UnsafeRow]
     } else {
-      while (inputIndex < offset - 1) {
-        if (inputIterator.hasNext) inputIterator.next()
-        inputIndex += 1
-      }
-      if (inputIndex < input.length) {
+      while (inputIndex < offset) {
         selectedRow = WindowFunctionFrame.getNextOrNull(inputIterator)
+        inputIndex += 1
       }
     }
   }
 
-  lazy val boundary = if (ignoreNulls) {
-    inputIndex - 1
-  } else {
-    inputIndex
-  }
-
   override def write(index: Int, current: InternalRow): Unit = {
-    if (index >= boundary && selectedRow != null) {
+    if (index >= inputIndex - 1 && selectedRow != null) {
       projection(selectedRow)
     } else {
       fillDefaultValue(EmptyRow)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowFunctionFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowFunctionFrame.scala
@@ -130,6 +130,31 @@ abstract class OffsetWindowFunctionFrameBase(
     newMutableProjection(boundExpressions, Nil).target(target)
   }
 
+  /** Holder the UnsafeRow where the input operator by function is not null. */
+  protected var nextSelectedRow = EmptyRow
+
+  // The number of rows skipped to get the next UnsafeRow where the input operator by function
+  // is not null.
+  protected var skippedNonNullCount = 0
+
+  /** Create the projection to determine whether input is null. */
+  protected val project = UnsafeProjection.create(Seq(IsNull(expressions.head.input)), inputSchema)
+
+  /** Check if the output value of the first index is null. */
+  protected def nullCheck(row: InternalRow): Boolean = project(row).getBoolean(0)
+
+  /** find the offset row whose input is not null */
+  protected def findNextRowWithNonNullInput(): Unit = {
+    while (skippedNonNullCount < offset && inputIndex < input.length) {
+      val r = WindowFunctionFrame.getNextOrNull(inputIterator)
+      if (!nullCheck(r)) {
+        nextSelectedRow = r
+        skippedNonNullCount += 1
+      }
+      inputIndex += 1
+    }
+  }
+
   override def currentLowerBound(): Int = throw new UnsupportedOperationException()
 
   override def currentUpperBound(): Int = throw new UnsupportedOperationException()
@@ -152,31 +177,6 @@ class FrameLessOffsetWindowFunctionFrame(
     ignoreNulls: Boolean = false)
   extends OffsetWindowFunctionFrameBase(
     target, ordinal, expressions, inputSchema, newMutableProjection, offset) {
-
-  /** Holder the UnsafeRow where the input operator by function is not null. */
-  private var nextSelectedRow = EmptyRow
-
-  // The number of rows skipped to get the next UnsafeRow where the input operator by function
-  // is not null.
-  private var skippedNonNullCount = 0
-
-  /** Create the projection to determine whether input is null. */
-  private val project = UnsafeProjection.create(Seq(IsNull(expressions.head.input)), inputSchema)
-
-  /** Check if the output value of the first index is null. */
-  private def nullCheck(row: InternalRow): Boolean = project(row).getBoolean(0)
-
-  /** find the offset row whose input is not null */
-  private def findNextRowWithNonNullInput(): Unit = {
-    while (skippedNonNullCount < offset && inputIndex < input.length) {
-      val r = WindowFunctionFrame.getNextOrNull(inputIterator)
-      if (!nullCheck(r)) {
-        nextSelectedRow = r
-        skippedNonNullCount += 1
-      }
-      inputIndex += 1
-    }
-  }
 
   override def prepare(rows: ExternalAppendOnlyUnsafeRowArray): Unit = {
     input = rows
@@ -292,7 +292,8 @@ class UnboundedOffsetWindowFunctionFrame(
     expressions: Array[OffsetWindowFunction],
     inputSchema: Seq[Attribute],
     newMutableProjection: (Seq[Expression], Seq[Attribute]) => MutableProjection,
-    offset: Int)
+    offset: Int,
+    ignoreNulls: Boolean = false)
   extends OffsetWindowFunctionFrameBase(
     target, ordinal, expressions, inputSchema, newMutableProjection, offset) {
   assert(offset > 0)
@@ -305,12 +306,22 @@ class UnboundedOffsetWindowFunctionFrame(
       inputIterator = input.generateIterator()
       // drain the first few rows if offset is larger than one
       inputIndex = 0
-      while (inputIndex < offset - 1) {
-        if (inputIterator.hasNext) inputIterator.next()
-        inputIndex += 1
+      if (ignoreNulls) {
+        findNextRowWithNonNullInput()
+        if (nextSelectedRow == EmptyRow) {
+          // Use default values since the offset row whose input value is not null does not exist.
+          fillDefaultValue(EmptyRow)
+        } else {
+          projection(nextSelectedRow)
+        }
+      } else {
+        while (inputIndex < offset - 1) {
+          if (inputIterator.hasNext) inputIterator.next()
+          inputIndex += 1
+        }
+        val r = WindowFunctionFrame.getNextOrNull(inputIterator)
+        projection(r)
       }
-      val r = WindowFunctionFrame.getNextOrNull(inputIterator)
-      projection(r)
     }
   }
 
@@ -336,7 +347,8 @@ class UnboundedPrecedingOffsetWindowFunctionFrame(
     expressions: Array[OffsetWindowFunction],
     inputSchema: Seq[Attribute],
     newMutableProjection: (Seq[Expression], Seq[Attribute]) => MutableProjection,
-    offset: Int)
+    offset: Int,
+    ignoreNulls: Boolean = false)
   extends OffsetWindowFunctionFrameBase(
     target, ordinal, expressions, inputSchema, newMutableProjection, offset) {
   assert(offset > 0)
@@ -348,17 +360,28 @@ class UnboundedPrecedingOffsetWindowFunctionFrame(
     inputIterator = input.generateIterator()
     // drain the first few rows if offset is larger than one
     inputIndex = 0
-    while (inputIndex < offset - 1) {
-      if (inputIterator.hasNext) inputIterator.next()
-      inputIndex += 1
-    }
-    if (inputIndex < input.length) {
-      selectedRow = WindowFunctionFrame.getNextOrNull(inputIterator)
+    if (ignoreNulls) {
+      findNextRowWithNonNullInput()
+      selectedRow = nextSelectedRow.asInstanceOf[UnsafeRow]
+    } else {
+      while (inputIndex < offset - 1) {
+        if (inputIterator.hasNext) inputIterator.next()
+        inputIndex += 1
+      }
+      if (inputIndex < input.length) {
+        selectedRow = WindowFunctionFrame.getNextOrNull(inputIterator)
+      }
     }
   }
 
+  lazy val boundary = if (ignoreNulls) {
+    inputIndex - 1
+  } else {
+    inputIndex
+  }
+
   override def write(index: Int, current: InternalRow): Unit = {
-    if (index >= inputIndex && selectedRow != null) {
+    if (index >= boundary && selectedRow != null) {
       projection(selectedRow)
     } else {
       fillDefaultValue(EmptyRow)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowFunctionFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowFunctionFrame.scala
@@ -130,8 +130,6 @@ abstract class OffsetWindowFunctionFrameBase(
     newMutableProjection(boundExpressions, Nil).target(target)
   }
 
-  var selectedRow: UnsafeRow = null
-
   /** Holder the UnsafeRow where the input operator by function is not null. */
   protected var nextSelectedRow = EmptyRow
 
@@ -317,6 +315,7 @@ class UnboundedOffsetWindowFunctionFrame(
           projection(nextSelectedRow)
         }
       } else {
+        var selectedRow: UnsafeRow = null
         while (inputIndex < offset) {
           selectedRow = WindowFunctionFrame.getNextOrNull(inputIterator)
           inputIndex += 1
@@ -353,6 +352,8 @@ class UnboundedPrecedingOffsetWindowFunctionFrame(
   extends OffsetWindowFunctionFrameBase(
     target, ordinal, expressions, inputSchema, newMutableProjection, offset) {
   assert(offset > 0)
+
+  var selectedRow: UnsafeRow = null
 
   override def prepare(rows: ExternalAppendOnlyUnsafeRowArray): Unit = {
     input = rows


### PR DESCRIPTION
### What changes were proposed in this pull request?
The current implement of `UnboundedOffsetWindowFunctionFrame` and `UnboundedPrecedingOffsetWindowFunctionFrame` only support `nth_value` that respect nulls. So nth_value will execute with `UnboundedWindowFunctionFrame` and `UnboundedPrecedingWindowFunctionFrame`.
`UnboundedWindowFunctionFrame` and `UnboundedPrecedingWindowFunctionFrame` will call `updateExpressions` of `nth_value` multiple times.


### Why are the changes needed?
Improve performance for nth_value ignore nulls over offset window


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Jenkins test
