### PR TITLE
[SPARK-33354][FOLLOWUP][DOC] Shorten the table width of ANSI compliance casting document

### DIFF
--- a/docs/sql-ref-ansi-compliance.md
+++ b/docs/sql-ref-ansi-compliance.md
@@ -69,19 +69,19 @@ The type conversion of Spark ANSI mode follows the syntax rules of section 6.13 
 
  The valid combinations of target data type and source data type in a `CAST` expression are given by the following table.
 “Y” indicates that the combination is syntactically valid without restriction and “N” indicates that the combination is not valid.
-    
-| From\To   | NumericType | StringType | DateType | TimestampType | IntervalType | BooleanType | BinaryType | ArrayType | MapType | StructType |
+
+| Source\Target | Numeric | String | Date | Timestamp | Interval | Boolean | Binary | Array | Map | Struct |
 |-----------|---------|--------|------|-----------|----------|---------|--------|-------|-----|--------|
-| NumericType   | Y       | Y      | N    | N         | N        | Y       | N      | N     | N   | N      |
-| StringType    | Y       | Y      | Y    | Y         | Y        | Y       | Y      | N     | N   | N      |
-| DateType      | N       | Y      | Y    | Y         | N        | N       | N      | N     | N   | N      |
-| TimestampType | N       | Y      | Y    | Y         | N        | N       | N      | N     | N   | N      |
-| IntervalType  | N       | Y      | N    | N         | Y        | N       | N      | N     | N   | N      |
-| BooleanType   | Y       | Y      | N    | N         | N        | Y       | N      | N     | N   | N      |
-| BinaryType    | Y       | N      | N    | N         | N        | N       | Y      | N     | N   | N      |
-| ArrayType     | N       | N      | N    | N         | N        | N       | N      | Y     | N   | N      |
-| MapType       | N       | N      | N    | N         | N        | N       | N      | N     | Y   | N      |
-| StructType    | N       | N      | N    | N         | N        | N       | N      | N     | N   | Y      |
+| Numeric   | Y       | Y      | N    | N         | N        | Y       | N      | N     | N   | N      |
+| String    | Y       | Y      | Y    | Y         | Y        | Y       | Y      | N     | N   | N      |
+| Date      | N       | Y      | Y    | Y         | N        | N       | N      | N     | N   | N      |
+| Timestamp | N       | Y      | Y    | Y         | N        | N       | N      | N     | N   | N      |
+| Interval  | N       | Y      | N    | N         | Y        | N       | N      | N     | N   | N      |
+| Boolean   | Y       | Y      | N    | N         | N        | Y       | N      | N     | N   | N      |
+| Binary    | Y       | N      | N    | N         | N        | N       | Y      | N     | N   | N      |
+| Array     | N       | N      | N    | N         | N        | N       | N      | Y     | N   | N      |
+| Map       | N       | N      | N    | N         | N        | N       | N      | N     | Y   | N      |
+| Struct    | N       | N      | N    | N         | N        | N       | N      | N     | N   | Y      |
 
 Currently, the ANSI mode affects explicit casting and assignment casting only.
 In future releases, the behaviour of type coercion might change along with the other two type conversion rules.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This is a follow-up of https://github.com/apache/spark/pull/30260
It shortens the table width of ANSI compliance casting document.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The table is too wide and the UI of doc site is broken if we scroll the page to right side.
![Screen Shot 2021-01-14 at 3 04 57 PM](https://user-images.githubusercontent.com/1097932/104565897-d2693b80-5601-11eb-9f93-5f603cfc94c1.png)



### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Minor document change

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Build doc site locally and preview:
![Screen Shot 2021-01-14 at 4 44 30 PM](https://user-images.githubusercontent.com/1097932/104565814-b2d21300-5601-11eb-94c4-78c785cda8ed.png)
