### PR TITLE
[SPARK-34114][SQL] should not trim right for read-side char length check and padding

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/CharVarcharUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/CharVarcharUtils.scala
@@ -160,9 +160,10 @@ object CharVarcharUtils extends Logging {
   }
 
   private def paddingWithLengthCheck(expr: Expression, dt: DataType): Expression = dt match {
-    case CharType(length) => StringRPad(stringLengthCheck(expr, dt), Literal(length))
+    case CharType(length) =>
+      StringRPad(stringLengthCheck(expr, dt, needTrim = false), Literal(length))
 
-    case VarcharType(_) => stringLengthCheck(expr, dt)
+    case VarcharType(_) => stringLengthCheck(expr, dt, needTrim = false)
 
     case StructType(fields) =>
       val struct = CreateNamedStruct(fields.zipWithIndex.flatMap { case (f, i) =>
@@ -199,7 +200,7 @@ object CharVarcharUtils extends Logging {
    */
   def stringLengthCheck(expr: Expression, targetAttr: Attribute): Expression = {
     getRawType(targetAttr.metadata).map { rawType =>
-      stringLengthCheck(expr, rawType)
+      stringLengthCheck(expr, rawType, needTrim = true)
     }.getOrElse(expr)
   }
 
@@ -208,53 +209,56 @@ object CharVarcharUtils extends Logging {
     RaiseError(Literal(errMsg, StringType), StringType)
   }
 
-  private def stringLengthCheck(expr: Expression, dt: DataType): Expression = dt match {
-    case CharType(length) =>
-      val trimmed = StringTrimRight(expr)
-      // Trailing spaces do not count in the length check. We don't need to retain the trailing
-      // spaces, as we will pad char type columns/fields at read time.
-      If(
-        GreaterThan(Length(trimmed), Literal(length)),
-        raiseError("char", length),
-        trimmed)
-
-    case VarcharType(length) =>
-      val trimmed = StringTrimRight(expr)
-      // Trailing spaces do not count in the length check. We need to retain the trailing spaces
-      // (truncate to length N), as there is no read-time padding for varchar type.
-      // TODO: create a special TrimRight function that can trim to a certain length.
-      If(
-        LessThanOrEqual(Length(expr), Literal(length)),
-        expr,
+  private def stringLengthCheck(expr: Expression, dt: DataType, needTrim: Boolean): Expression = {
+    dt match {
+      case CharType(length) =>
+        val trimmed = if (needTrim) StringTrimRight(expr) else expr
+        // Trailing spaces do not count in the length check. We don't need to retain the trailing
+        // spaces, as we will pad char type columns/fields at read time.
         If(
           GreaterThan(Length(trimmed), Literal(length)),
-          raiseError("varchar", length),
-          StringRPad(trimmed, Literal(length))))
+          raiseError("char", length),
+          trimmed)
 
-    case StructType(fields) =>
-      val struct = CreateNamedStruct(fields.zipWithIndex.flatMap { case (f, i) =>
-        Seq(Literal(f.name), stringLengthCheck(GetStructField(expr, i, Some(f.name)), f.dataType))
-      })
-      if (expr.nullable) {
-        If(IsNull(expr), Literal(null, struct.dataType), struct)
-      } else {
-        struct
-      }
+      case VarcharType(length) =>
+        val trimmed = if (needTrim) StringTrimRight(expr) else expr
+        // Trailing spaces do not count in the length check. We need to retain the trailing spaces
+        // (truncate to length N), as there is no read-time padding for varchar type.
+        // TODO: create a special TrimRight function that can trim to a certain length.
+        If(
+          LessThanOrEqual(Length(expr), Literal(length)),
+          expr,
+          If(
+            GreaterThan(Length(trimmed), Literal(length)),
+            raiseError("varchar", length),
+            StringRPad(trimmed, Literal(length))))
 
-    case ArrayType(et, containsNull) => stringLengthCheckInArray(expr, et, containsNull)
+      case StructType(fields) =>
+        val struct = CreateNamedStruct(fields.zipWithIndex.flatMap { case (f, i) =>
+          Seq(Literal(f.name),
+            stringLengthCheck(GetStructField(expr, i, Some(f.name)), f.dataType, needTrim))
+        })
+        if (expr.nullable) {
+          If(IsNull(expr), Literal(null, struct.dataType), struct)
+        } else {
+          struct
+        }
 
-    case MapType(kt, vt, valueContainsNull) =>
-      val newKeys = stringLengthCheckInArray(MapKeys(expr), kt, containsNull = false)
-      val newValues = stringLengthCheckInArray(MapValues(expr), vt, valueContainsNull)
-      MapFromArrays(newKeys, newValues)
+      case ArrayType(et, containsNull) => stringLengthCheckInArray(expr, et, containsNull, needTrim)
 
-    case _ => expr
+      case MapType(kt, vt, valueContainsNull) =>
+        val newKeys = stringLengthCheckInArray(MapKeys(expr), kt, containsNull = false, needTrim)
+        val newValues = stringLengthCheckInArray(MapValues(expr), vt, valueContainsNull, needTrim)
+        MapFromArrays(newKeys, newValues)
+
+      case _ => expr
+    }
   }
 
   private def stringLengthCheckInArray(
-      arr: Expression, et: DataType, containsNull: Boolean): Expression = {
+      arr: Expression, et: DataType, containsNull: Boolean, needTrim: Boolean): Expression = {
     val param = NamedLambdaVariable("x", replaceCharVarcharWithString(et), containsNull)
-    val func = LambdaFunction(stringLengthCheck(param, et), Seq(param))
+    val func = LambdaFunction(stringLengthCheck(param, et, needTrim), Seq(param))
     ArrayTransform(arr, func)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/CharVarcharUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/CharVarcharUtils.scala
@@ -21,7 +21,7 @@ import scala.collection.mutable
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.catalyst.expressions.{StringTrimRight, _}
+import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._

--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -667,7 +667,7 @@ class FileSourceCharVarcharTestSuite extends CharVarcharTestSuite with SharedSpa
     }
   }
 
-  test("should not trim right for read-side length check and char padding") {
+  test("SPARK-34114: should not trim right for read-side length check and char padding") {
     Seq("char", "varchar").foreach { typ =>
       withTempPath { dir =>
         withTable("t") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -472,6 +472,22 @@ trait CharVarcharTestSuite extends QueryTest with SQLTestUtils {
         Row(1))
     }
   }
+
+  test("SPARK-34114: varchar type will strip tailing spaces to certain length at write time") {
+    withTable("t") {
+      sql(s"CREATE TABLE t(v VARCHAR(3)) USING $format")
+      sql("INSERT INTO t VALUES ('c      ')")
+      checkAnswer(spark.table("t"), Row("c  "))
+    }
+  }
+
+  test("SPARK-34114: varchar type will remain the value length with spaces at read time") {
+    withTable("t") {
+      sql(s"CREATE TABLE t(v VARCHAR(3)) USING $format")
+      sql("INSERT INTO t VALUES ('c ')")
+      checkAnswer(spark.table("t"), Row("c "))
+    }
+  }
 }
 
 // Some basic char/varchar tests which doesn't rely on table implementation.


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

On the read-side, we should respect the original data instead of trimming it first.

It brings extra overhead on the code-gen code side, trimming and padding for the same field, and it's also unnecessary and a bug

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

bugfix and perf regression

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

no
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
new tests