### PR TITLE
[SPARK-34269][SQL][TESTS][FOLLOWUP] Add test cases for cache lookup and project removal

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -1316,26 +1316,16 @@ class CachedTableSuite extends QueryTest with SQLTestUtils
     }
   }
 
-  test("SPARK-34269: cache lookup with ORDER BY clause") {
-    withTable("t") {
-      withTempView("v1") {
-        sql("CREATE TABLE t (key bigint, value string) USING parquet")
-        sql("CACHE TABLE v1 AS SELECT * FROM t ORDER BY key")
+  test("SPARK-34269: cache lookup with ORDER BY / LIMIT clause") {
+    Seq("ORDER BY key", "LIMIT 10").foreach { clause =>
+      withTable("t") {
+        withTempView("v1") {
+          sql("CREATE TABLE t (key bigint, value string) USING parquet")
+          sql(s"CACHE TABLE v1 AS SELECT * FROM t $clause")
 
-        val query = sql("SELECT * FROM t ORDER BY key")
-        assert(spark.sharedState.cacheManager.lookupCachedData(query).isDefined)
-      }
-    }
-  }
-
-  test("SPARK-34269: cache lookup with LIMIT clause") {
-    withTable("t") {
-      withTempView("v1") {
-        sql("CREATE TABLE t (key bigint, value string) USING parquet")
-        sql("CACHE TABLE v1 AS SELECT * FROM t LIMIT 10")
-
-        val query = sql("SELECT * FROM t LIMIT 10")
-        assert(spark.sharedState.cacheManager.lookupCachedData(query).isDefined)
+          val query = sql(s"SELECT * FROM t $clause")
+          assert(spark.sharedState.cacheManager.lookupCachedData(query).isDefined)
+        }
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -1316,6 +1316,30 @@ class CachedTableSuite extends QueryTest with SQLTestUtils
     }
   }
 
+  test("SPARK-34269: cache lookup with ORDER BY clause") {
+    withTable("t") {
+      withTempView("v1") {
+        sql("CREATE TABLE t (key bigint, value string) USING parquet")
+        sql("CACHE TABLE v1 AS SELECT * FROM t ORDER BY key")
+
+        val query = sql("SELECT * FROM t ORDER BY key")
+        assert(spark.sharedState.cacheManager.lookupCachedData(query).isDefined)
+      }
+    }
+  }
+
+  test("SPARK-34269: cache lookup with LIMIT clause") {
+    withTable("t") {
+      withTempView("v1") {
+        sql("CREATE TABLE t (key bigint, value string) USING parquet")
+        sql("CACHE TABLE v1 AS SELECT * FROM t LIMIT 10")
+
+        val query = sql("SELECT * FROM t LIMIT 10")
+        assert(spark.sharedState.cacheManager.lookupCachedData(query).isDefined)
+      }
+    }
+  }
+
   test("SPARK-33786: Cache's storage level should be respected when a table name is altered.") {
     withTable("old", "new") {
       withTempPath { path =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This adds a few test cases for looking up cached temporary/permanent view created using clauses such as `ORDER BY` or `LIMIT`. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Due to `EliminateView` and how canonization is done for `View`, which inserts an extra project operator, cache lookup could fail in the following simple example:
```sql
> CREATE TABLE t (key bigint, value string) USING parquet
> CACHE TABLE v1 AS SELECT * FROM t ORDER BY key
> SELECT * FROM t ORDER BY key
```

#31368 addresses this issue by removing the project operator if `canRemoveProject` check is successful. This PR adds a few tests.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

NO

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

This PR just adds unit tests.