### PR TITLE
[SPARK-34123][Web UI] optimize spark history summary page loading

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/historypage-template.html
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage-template.html
@@ -75,26 +75,6 @@
       </th>
   </thead>
   <tbody>
-  {{#applications}}
-    <tr>
-      {{#attempts}}
-      <td {{#hasMultipleAttempts}}style="background-color:#fff"{{/hasMultipleAttempts}}>{{version}}</td>
-      <td {{#hasMultipleAttempts}}style="background-color:#fff"{{/hasMultipleAttempts}}><span title="{{id}}"><a href="{{uiroot}}/history/{{id}}{{#hasAttemptId}}/{{attemptId}}{{/hasAttemptId}}/jobs/">{{id}}</a></span></td>
-      <td {{#hasMultipleAttempts}}style="background-color:#fff"{{/hasMultipleAttempts}}>{{name}}</td>
-      {{#hasMultipleAttempts}}
-      <td><a href="{{uiroot}}/history/{{id}}{{#hasAttemptId}}/{{attemptId}}{{/hasAttemptId}}/jobs/">{{attemptId}}</a></td>
-      {{/hasMultipleAttempts}}
-      <td>{{startTime}}</td>
-      {{#showCompletedColumns}}
-      <td>{{endTime}}</td>
-      <td><span title="{{durationMillisec}}">{{duration}}</span></td>
-      {{/showCompletedColumns}}
-      <td>{{sparkUser}}</td>
-      <td>{{lastUpdated}}</td>
-      <td><a href="{{log}}" class="btn btn-info btn-mini">Download</a></td>
-      {{/attempts}}
-    </tr>
-  {{/applications}}
   </tbody>
 </table>
 </script>

--- a/core/src/main/resources/org/apache/spark/ui/static/historypage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage.js
@@ -195,6 +195,16 @@ $(document).ready(function() {
               render: (log, type, row) => `<a href="${log}" class="btn btn-info btn-mini">Download</a>` 
             },
           ],
+          "aoColumnDefs": [
+            {
+              aTargets: [0, 1, 2],
+              fnCreatedCell: (nTd, sData, oData, iRow, iCol) => {
+                if (hasMultipleAttempts) { 
+                  $(nTd).css('background-color', '#fff');
+                } 
+              }
+            },
+          ],
           "autoWidth": false,
           "deferRender": true
         };

--- a/core/src/main/resources/org/apache/spark/ui/static/historypage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage.js
@@ -140,9 +140,13 @@ $(document).ready(function() {
             (attempt.hasOwnProperty("attemptId") ? attempt["attemptId"] + "/" : "") + "logs";
           attempt["durationMillisec"] = attempt["duration"];
           attempt["duration"] = formatDuration(attempt["duration"]);
-          var hasAttemptId = attempt.hasOwnProperty("attemptId");
-          var app_clone = {"id" : id, "name" : name, "version": version, "hasAttemptId" : hasAttemptId, "attempts" : [attempt]};
-          array.push(app_clone);
+          attempt["id"] = id;
+          attempt["name"] = name;
+          attempt["version"] = version;
+          attempt["attemptUrl"] = uiRoot + "/history/" + id + "/" +
+            (attempt.hasOwnProperty("attemptId") ? attempt["attemptId"] + "/" : "") + "jobs/";
+
+          array.push(attempt);
         }
       }
       if(array.length < 20) {
@@ -165,17 +169,31 @@ $(document).ready(function() {
         var completedColumnName = 'completed';
         var durationColumnName = 'duration';
         var conf = {
+          "data": array,
           "columns": [
-            {name: 'version'},
-            {name: 'appId', type: "appid-numeric"},
-            {name: 'appName'},
-            {name: attemptIdColumnName},
-            {name: startedColumnName},
-            {name: completedColumnName},
-            {name: durationColumnName, type: "title-numeric"},
-            {name: 'user'},
-            {name: 'lastUpdated'},
-            {name: 'eventLog'},
+            {name: 'version', data: 'version' },
+            {
+              name: 'appId', 
+              type: "appid-numeric", 
+              data: 'id',
+              render:  (id, type, row) => `<span title="${id}"><a href="${row.attemptUrl}">${id}</a></span>`
+            },
+            {name: 'appName', data: 'name' },
+            {
+              name: attemptIdColumnName, 
+              data: 'attemptId',
+              render: (attemptId, type, row) => (attemptId ? `<a href="${row.attemptUrl}">${attemptId}</a>` : '')
+            },
+            {name: startedColumnName, data: 'startTime' },
+            {name: completedColumnName, data: 'endTime' },
+            {name: durationColumnName, type: "title-numeric", data: 'duration' },
+            {name: 'user', data: 'sparkUser' },
+            {name: 'lastUpdated', data: 'lastUpdated' },
+            {
+              name: 'eventLog', 
+              data: 'log', 
+              render: (log, type, row) => `<a href="${log}" class="btn btn-info btn-mini">Download</a>` 
+            },
           ],
           "autoWidth": false,
           "deferRender": true


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
Display history server entries using datatables instead of Mustache + Datatables which proved to be faster and non-blocking for the webpage while searching (using search bar in the page)


### Why are the changes needed?
Small changes in the attempts (entries) and removed part of HTML (Mustache template).


### Does this PR introduce _any_ user-facing change?
Not very sure, but it's not supposed to change the way the page looks rather it changes how entries are displayed.


### How was this patch tested?
Running test, since it's not adding new functionality.
