### PR TITLE
[SPARK-34117][SQL] Disable LeftSemi/LeftAnti push down over Aggregate

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -307,13 +307,6 @@ trait JoinSelectionHelper {
     }
   }
 
-  def canPlanAsBroadcastHashJoin(join: Join, conf: SQLConf): Boolean = {
-    getBroadcastBuildSide(join.left, join.right, join.joinType,
-      join.hint, hintOnly = true, conf).isDefined ||
-      getBroadcastBuildSide(join.left, join.right, join.joinType,
-        join.hint, hintOnly = false, conf).isDefined
-  }
-
   def hintToBroadcastLeft(hint: JoinHint): Boolean = {
     hint.leftHint.exists(_.strategy.contains(BROADCAST))
   }

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a/explain.txt
@@ -27,50 +27,50 @@ TakeOrderedAndProject (115)
                :                    :     :           +- BroadcastExchange (53)
                :                    :     :              +- * HashAggregate (52)
                :                    :     :                 +- * HashAggregate (51)
-               :                    :     :                    +- * HashAggregate (50)
-               :                    :     :                       +- Exchange (49)
-               :                    :     :                          +- * HashAggregate (48)
-               :                    :     :                             +- * BroadcastHashJoin LeftSemi BuildRight (47)
-               :                    :     :                                :- * BroadcastHashJoin LeftSemi BuildRight (36)
-               :                    :     :                                :  :- * Project (22)
-               :                    :     :                                :  :  +- * BroadcastHashJoin Inner BuildRight (21)
-               :                    :     :                                :  :     :- * Project (15)
-               :                    :     :                                :  :     :  +- * BroadcastHashJoin Inner BuildRight (14)
-               :                    :     :                                :  :     :     :- * Filter (9)
-               :                    :     :                                :  :     :     :  +- * ColumnarToRow (8)
-               :                    :     :                                :  :     :     :     +- Scan parquet default.store_sales (7)
-               :                    :     :                                :  :     :     +- BroadcastExchange (13)
-               :                    :     :                                :  :     :        +- * Filter (12)
-               :                    :     :                                :  :     :           +- * ColumnarToRow (11)
-               :                    :     :                                :  :     :              +- Scan parquet default.item (10)
-               :                    :     :                                :  :     +- BroadcastExchange (20)
-               :                    :     :                                :  :        +- * Project (19)
-               :                    :     :                                :  :           +- * Filter (18)
-               :                    :     :                                :  :              +- * ColumnarToRow (17)
-               :                    :     :                                :  :                 +- Scan parquet default.date_dim (16)
-               :                    :     :                                :  +- BroadcastExchange (35)
-               :                    :     :                                :     +- * Project (34)
-               :                    :     :                                :        +- * BroadcastHashJoin Inner BuildRight (33)
-               :                    :     :                                :           :- * Project (31)
-               :                    :     :                                :           :  +- * BroadcastHashJoin Inner BuildRight (30)
-               :                    :     :                                :           :     :- * Filter (25)
-               :                    :     :                                :           :     :  +- * ColumnarToRow (24)
-               :                    :     :                                :           :     :     +- Scan parquet default.catalog_sales (23)
-               :                    :     :                                :           :     +- BroadcastExchange (29)
-               :                    :     :                                :           :        +- * Filter (28)
-               :                    :     :                                :           :           +- * ColumnarToRow (27)
-               :                    :     :                                :           :              +- Scan parquet default.item (26)
-               :                    :     :                                :           +- ReusedExchange (32)
-               :                    :     :                                +- BroadcastExchange (46)
-               :                    :     :                                   +- * Project (45)
-               :                    :     :                                      +- * BroadcastHashJoin Inner BuildRight (44)
-               :                    :     :                                         :- * Project (42)
-               :                    :     :                                         :  +- * BroadcastHashJoin Inner BuildRight (41)
-               :                    :     :                                         :     :- * Filter (39)
-               :                    :     :                                         :     :  +- * ColumnarToRow (38)
-               :                    :     :                                         :     :     +- Scan parquet default.web_sales (37)
-               :                    :     :                                         :     +- ReusedExchange (40)
-               :                    :     :                                         +- ReusedExchange (43)
+               :                    :     :                    +- * BroadcastHashJoin LeftSemi BuildRight (50)
+               :                    :     :                       :- * HashAggregate (39)
+               :                    :     :                       :  +- Exchange (38)
+               :                    :     :                       :     +- * HashAggregate (37)
+               :                    :     :                       :        +- * BroadcastHashJoin LeftSemi BuildRight (36)
+               :                    :     :                       :           :- * Project (22)
+               :                    :     :                       :           :  +- * BroadcastHashJoin Inner BuildRight (21)
+               :                    :     :                       :           :     :- * Project (15)
+               :                    :     :                       :           :     :  +- * BroadcastHashJoin Inner BuildRight (14)
+               :                    :     :                       :           :     :     :- * Filter (9)
+               :                    :     :                       :           :     :     :  +- * ColumnarToRow (8)
+               :                    :     :                       :           :     :     :     +- Scan parquet default.store_sales (7)
+               :                    :     :                       :           :     :     +- BroadcastExchange (13)
+               :                    :     :                       :           :     :        +- * Filter (12)
+               :                    :     :                       :           :     :           +- * ColumnarToRow (11)
+               :                    :     :                       :           :     :              +- Scan parquet default.item (10)
+               :                    :     :                       :           :     +- BroadcastExchange (20)
+               :                    :     :                       :           :        +- * Project (19)
+               :                    :     :                       :           :           +- * Filter (18)
+               :                    :     :                       :           :              +- * ColumnarToRow (17)
+               :                    :     :                       :           :                 +- Scan parquet default.date_dim (16)
+               :                    :     :                       :           +- BroadcastExchange (35)
+               :                    :     :                       :              +- * Project (34)
+               :                    :     :                       :                 +- * BroadcastHashJoin Inner BuildRight (33)
+               :                    :     :                       :                    :- * Project (31)
+               :                    :     :                       :                    :  +- * BroadcastHashJoin Inner BuildRight (30)
+               :                    :     :                       :                    :     :- * Filter (25)
+               :                    :     :                       :                    :     :  +- * ColumnarToRow (24)
+               :                    :     :                       :                    :     :     +- Scan parquet default.catalog_sales (23)
+               :                    :     :                       :                    :     +- BroadcastExchange (29)
+               :                    :     :                       :                    :        +- * Filter (28)
+               :                    :     :                       :                    :           +- * ColumnarToRow (27)
+               :                    :     :                       :                    :              +- Scan parquet default.item (26)
+               :                    :     :                       :                    +- ReusedExchange (32)
+               :                    :     :                       +- BroadcastExchange (49)
+               :                    :     :                          +- * Project (48)
+               :                    :     :                             +- * BroadcastHashJoin Inner BuildRight (47)
+               :                    :     :                                :- * Project (45)
+               :                    :     :                                :  +- * BroadcastHashJoin Inner BuildRight (44)
+               :                    :     :                                :     :- * Filter (42)
+               :                    :     :                                :     :  +- * ColumnarToRow (41)
+               :                    :     :                                :     :     +- Scan parquet default.web_sales (40)
+               :                    :     :                                :     +- ReusedExchange (43)
+               :                    :     :                                +- ReusedExchange (46)
                :                    :     +- BroadcastExchange (63)
                :                    :        +- * BroadcastHashJoin LeftSemi BuildRight (62)
                :                    :           :- * Filter (60)
@@ -151,10 +151,10 @@ Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_sold_date_sk)]
 ReadSchema: struct<ss_sold_date_sk:int,ss_item_sk:int>
 
-(8) ColumnarToRow [codegen id : 9]
+(8) ColumnarToRow [codegen id : 6]
 Input [2]: [ss_sold_date_sk#1, ss_item_sk#2]
 
-(9) Filter [codegen id : 9]
+(9) Filter [codegen id : 6]
 Input [2]: [ss_sold_date_sk#1, ss_item_sk#2]
 Condition : (isnotnull(ss_item_sk#2) AND isnotnull(ss_sold_date_sk#1))
 
@@ -176,12 +176,12 @@ Condition : (((isnotnull(i_item_sk#5) AND isnotnull(i_brand_id#6)) AND isnotnull
 Input [4]: [i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#9]
 
-(14) BroadcastHashJoin [codegen id : 9]
+(14) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_item_sk#2]
 Right keys [1]: [i_item_sk#5]
 Join condition: None
 
-(15) Project [codegen id : 9]
+(15) Project [codegen id : 6]
 Output [4]: [ss_sold_date_sk#1, i_brand_id#6, i_class_id#7, i_category_id#8]
 Input [6]: [ss_sold_date_sk#1, ss_item_sk#2, i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
 
@@ -207,12 +207,12 @@ Input [2]: [d_date_sk#10, d_year#11]
 Input [1]: [d_date_sk#10]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#12]
 
-(21) BroadcastHashJoin [codegen id : 9]
+(21) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_sold_date_sk#1]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
-(22) Project [codegen id : 9]
+(22) Project [codegen id : 6]
 Output [3]: [i_brand_id#6 AS brand_id#13, i_class_id#7 AS class_id#14, i_category_id#8 AS category_id#15]
 Input [5]: [ss_sold_date_sk#1, i_brand_id#6, i_class_id#7, i_category_id#8, d_date_sk#10]
 
@@ -273,75 +273,75 @@ Input [5]: [cs_sold_date_sk#16, i_brand_id#6, i_class_id#7, i_category_id#8, d_d
 Input [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
 Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true]), coalesce(input[1, int, true], 0), isnull(input[1, int, true]), coalesce(input[2, int, true], 0), isnull(input[2, int, true])),false), [id=#19]
 
-(36) BroadcastHashJoin [codegen id : 9]
+(36) BroadcastHashJoin [codegen id : 6]
 Left keys [6]: [coalesce(brand_id#13, 0), isnull(brand_id#13), coalesce(class_id#14, 0), isnull(class_id#14), coalesce(category_id#15, 0), isnull(category_id#15)]
 Right keys [6]: [coalesce(i_brand_id#6, 0), isnull(i_brand_id#6), coalesce(i_class_id#7, 0), isnull(i_class_id#7), coalesce(i_category_id#8, 0), isnull(i_category_id#8)]
 Join condition: None
 
-(37) Scan parquet default.web_sales
-Output [2]: [ws_sold_date_sk#20, ws_item_sk#21]
+(37) HashAggregate [codegen id : 6]
+Input [3]: [brand_id#13, class_id#14, category_id#15]
+Keys [3]: [brand_id#13, class_id#14, category_id#15]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [brand_id#13, class_id#14, category_id#15]
+
+(38) Exchange
+Input [3]: [brand_id#13, class_id#14, category_id#15]
+Arguments: hashpartitioning(brand_id#13, class_id#14, category_id#15, 5), ENSURE_REQUIREMENTS, [id=#20]
+
+(39) HashAggregate [codegen id : 10]
+Input [3]: [brand_id#13, class_id#14, category_id#15]
+Keys [3]: [brand_id#13, class_id#14, category_id#15]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [brand_id#13, class_id#14, category_id#15]
+
+(40) Scan parquet default.web_sales
+Output [2]: [ws_sold_date_sk#21, ws_item_sk#22]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_sales]
 PushedFilters: [IsNotNull(ws_item_sk), IsNotNull(ws_sold_date_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_item_sk:int>
 
-(38) ColumnarToRow [codegen id : 8]
-Input [2]: [ws_sold_date_sk#20, ws_item_sk#21]
+(41) ColumnarToRow [codegen id : 9]
+Input [2]: [ws_sold_date_sk#21, ws_item_sk#22]
 
-(39) Filter [codegen id : 8]
-Input [2]: [ws_sold_date_sk#20, ws_item_sk#21]
-Condition : (isnotnull(ws_item_sk#21) AND isnotnull(ws_sold_date_sk#20))
+(42) Filter [codegen id : 9]
+Input [2]: [ws_sold_date_sk#21, ws_item_sk#22]
+Condition : (isnotnull(ws_item_sk#22) AND isnotnull(ws_sold_date_sk#21))
 
-(40) ReusedExchange [Reuses operator id: 29]
+(43) ReusedExchange [Reuses operator id: 29]
 Output [4]: [i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
 
-(41) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [ws_item_sk#21]
+(44) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [ws_item_sk#22]
 Right keys [1]: [i_item_sk#5]
 Join condition: None
 
-(42) Project [codegen id : 8]
-Output [4]: [ws_sold_date_sk#20, i_brand_id#6, i_class_id#7, i_category_id#8]
-Input [6]: [ws_sold_date_sk#20, ws_item_sk#21, i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
+(45) Project [codegen id : 9]
+Output [4]: [ws_sold_date_sk#21, i_brand_id#6, i_class_id#7, i_category_id#8]
+Input [6]: [ws_sold_date_sk#21, ws_item_sk#22, i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
 
-(43) ReusedExchange [Reuses operator id: 20]
+(46) ReusedExchange [Reuses operator id: 20]
 Output [1]: [d_date_sk#10]
 
-(44) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [ws_sold_date_sk#20]
+(47) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [ws_sold_date_sk#21]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
-(45) Project [codegen id : 8]
+(48) Project [codegen id : 9]
 Output [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
-Input [5]: [ws_sold_date_sk#20, i_brand_id#6, i_class_id#7, i_category_id#8, d_date_sk#10]
+Input [5]: [ws_sold_date_sk#21, i_brand_id#6, i_class_id#7, i_category_id#8, d_date_sk#10]
 
-(46) BroadcastExchange
+(49) BroadcastExchange
 Input [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
-Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true]), coalesce(input[1, int, true], 0), isnull(input[1, int, true]), coalesce(input[2, int, true], 0), isnull(input[2, int, true])),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true]), coalesce(input[1, int, true], 0), isnull(input[1, int, true]), coalesce(input[2, int, true], 0), isnull(input[2, int, true])),false), [id=#23]
 
-(47) BroadcastHashJoin [codegen id : 9]
+(50) BroadcastHashJoin [codegen id : 10]
 Left keys [6]: [coalesce(brand_id#13, 0), isnull(brand_id#13), coalesce(class_id#14, 0), isnull(class_id#14), coalesce(category_id#15, 0), isnull(category_id#15)]
 Right keys [6]: [coalesce(i_brand_id#6, 0), isnull(i_brand_id#6), coalesce(i_class_id#7, 0), isnull(i_class_id#7), coalesce(i_category_id#8, 0), isnull(i_category_id#8)]
 Join condition: None
-
-(48) HashAggregate [codegen id : 9]
-Input [3]: [brand_id#13, class_id#14, category_id#15]
-Keys [3]: [brand_id#13, class_id#14, category_id#15]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [brand_id#13, class_id#14, category_id#15]
-
-(49) Exchange
-Input [3]: [brand_id#13, class_id#14, category_id#15]
-Arguments: hashpartitioning(brand_id#13, class_id#14, category_id#15, 5), true, [id=#23]
-
-(50) HashAggregate [codegen id : 10]
-Input [3]: [brand_id#13, class_id#14, category_id#15]
-Keys [3]: [brand_id#13, class_id#14, category_id#15]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [brand_id#13, class_id#14, category_id#15]
 
 (51) HashAggregate [codegen id : 10]
 Input [3]: [brand_id#13, class_id#14, category_id#15]
@@ -454,7 +454,7 @@ Results [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#33, isEmpty#34, c
 
 (74) Exchange
 Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#33, isEmpty#34, count#35]
-Arguments: hashpartitioning(i_brand_id#6, i_class_id#7, i_category_id#8, 5), true, [id=#36]
+Arguments: hashpartitioning(i_brand_id#6, i_class_id#7, i_category_id#8, 5), ENSURE_REQUIREMENTS, [id=#36]
 
 (75) HashAggregate [codegen id : 26]
 Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#33, isEmpty#34, count#35]
@@ -526,7 +526,7 @@ Results [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#50, isEmpty#51, c
 
 (90) Exchange
 Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#50, isEmpty#51, count#52]
-Arguments: hashpartitioning(i_brand_id#6, i_class_id#7, i_category_id#8, 5), true, [id=#53]
+Arguments: hashpartitioning(i_brand_id#6, i_class_id#7, i_category_id#8, 5), ENSURE_REQUIREMENTS, [id=#53]
 
 (91) HashAggregate [codegen id : 52]
 Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#50, isEmpty#51, count#52]
@@ -544,24 +544,24 @@ Output [6]: [sales#56, number_sales#57, catalog AS channel#59, i_brand_id#6, i_c
 Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#56, number_sales#57, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#58]
 
 (94) Scan parquet default.web_sales
-Output [4]: [ws_sold_date_sk#20, ws_item_sk#21, ws_quantity#60, ws_list_price#61]
+Output [4]: [ws_sold_date_sk#21, ws_item_sk#22, ws_quantity#60, ws_list_price#61]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_sales]
 PushedFilters: [IsNotNull(ws_item_sk), IsNotNull(ws_sold_date_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_item_sk:int,ws_quantity:int,ws_list_price:decimal(7,2)>
 
 (95) ColumnarToRow [codegen id : 77]
-Input [4]: [ws_sold_date_sk#20, ws_item_sk#21, ws_quantity#60, ws_list_price#61]
+Input [4]: [ws_sold_date_sk#21, ws_item_sk#22, ws_quantity#60, ws_list_price#61]
 
 (96) Filter [codegen id : 77]
-Input [4]: [ws_sold_date_sk#20, ws_item_sk#21, ws_quantity#60, ws_list_price#61]
-Condition : (isnotnull(ws_item_sk#21) AND isnotnull(ws_sold_date_sk#20))
+Input [4]: [ws_sold_date_sk#21, ws_item_sk#22, ws_quantity#60, ws_list_price#61]
+Condition : (isnotnull(ws_item_sk#22) AND isnotnull(ws_sold_date_sk#21))
 
 (97) ReusedExchange [Reuses operator id: 56]
 Output [1]: [ss_item_sk#25]
 
 (98) BroadcastHashJoin [codegen id : 77]
-Left keys [1]: [ws_item_sk#21]
+Left keys [1]: [ws_item_sk#22]
 Right keys [1]: [ss_item_sk#25]
 Join condition: None
 
@@ -569,25 +569,25 @@ Join condition: None
 Output [4]: [i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
 
 (100) BroadcastHashJoin [codegen id : 77]
-Left keys [1]: [ws_item_sk#21]
+Left keys [1]: [ws_item_sk#22]
 Right keys [1]: [i_item_sk#5]
 Join condition: None
 
 (101) Project [codegen id : 77]
-Output [6]: [ws_sold_date_sk#20, ws_quantity#60, ws_list_price#61, i_brand_id#6, i_class_id#7, i_category_id#8]
-Input [8]: [ws_sold_date_sk#20, ws_item_sk#21, ws_quantity#60, ws_list_price#61, i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
+Output [6]: [ws_sold_date_sk#21, ws_quantity#60, ws_list_price#61, i_brand_id#6, i_class_id#7, i_category_id#8]
+Input [8]: [ws_sold_date_sk#21, ws_item_sk#22, ws_quantity#60, ws_list_price#61, i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
 
 (102) ReusedExchange [Reuses operator id: 70]
 Output [1]: [d_date_sk#10]
 
 (103) BroadcastHashJoin [codegen id : 77]
-Left keys [1]: [ws_sold_date_sk#20]
+Left keys [1]: [ws_sold_date_sk#21]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
 (104) Project [codegen id : 77]
 Output [5]: [ws_quantity#60, ws_list_price#61, i_brand_id#6, i_class_id#7, i_category_id#8]
-Input [7]: [ws_sold_date_sk#20, ws_quantity#60, ws_list_price#61, i_brand_id#6, i_class_id#7, i_category_id#8, d_date_sk#10]
+Input [7]: [ws_sold_date_sk#21, ws_quantity#60, ws_list_price#61, i_brand_id#6, i_class_id#7, i_category_id#8, d_date_sk#10]
 
 (105) HashAggregate [codegen id : 77]
 Input [5]: [ws_quantity#60, ws_list_price#61, i_brand_id#6, i_class_id#7, i_category_id#8]
@@ -598,7 +598,7 @@ Results [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#65, isEmpty#66, c
 
 (106) Exchange
 Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#65, isEmpty#66, count#67]
-Arguments: hashpartitioning(i_brand_id#6, i_class_id#7, i_category_id#8, 5), true, [id=#68]
+Arguments: hashpartitioning(i_brand_id#6, i_class_id#7, i_category_id#8, 5), ENSURE_REQUIREMENTS, [id=#68]
 
 (107) HashAggregate [codegen id : 78]
 Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#65, isEmpty#66, count#67]
@@ -630,7 +630,7 @@ Results [8]: [channel#75, i_brand_id#76, i_class_id#77, i_category_id#78, spark_
 
 (113) Exchange
 Input [8]: [channel#75, i_brand_id#76, i_class_id#77, i_category_id#78, spark_grouping_id#79, sum#83, isEmpty#84, sum#85]
-Arguments: hashpartitioning(channel#75, i_brand_id#76, i_class_id#77, i_category_id#78, spark_grouping_id#79, 5), true, [id=#86]
+Arguments: hashpartitioning(channel#75, i_brand_id#76, i_class_id#77, i_category_id#78, spark_grouping_id#79, 5), ENSURE_REQUIREMENTS, [id=#86]
 
 (114) HashAggregate [codegen id : 80]
 Input [8]: [channel#75, i_brand_id#76, i_class_id#77, i_category_id#78, spark_grouping_id#79, sum#83, isEmpty#84, sum#85]
@@ -746,30 +746,30 @@ Output [2]: [cs_quantity#45 AS quantity#94, cs_list_price#46 AS list_price#95]
 Input [4]: [cs_sold_date_sk#16, cs_quantity#45, cs_list_price#46, d_date_sk#10]
 
 (132) Scan parquet default.web_sales
-Output [3]: [ws_sold_date_sk#20, ws_quantity#60, ws_list_price#61]
+Output [3]: [ws_sold_date_sk#21, ws_quantity#60, ws_list_price#61]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_sales]
 PushedFilters: [IsNotNull(ws_sold_date_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_quantity:int,ws_list_price:decimal(7,2)>
 
 (133) ColumnarToRow [codegen id : 6]
-Input [3]: [ws_sold_date_sk#20, ws_quantity#60, ws_list_price#61]
+Input [3]: [ws_sold_date_sk#21, ws_quantity#60, ws_list_price#61]
 
 (134) Filter [codegen id : 6]
-Input [3]: [ws_sold_date_sk#20, ws_quantity#60, ws_list_price#61]
-Condition : isnotnull(ws_sold_date_sk#20)
+Input [3]: [ws_sold_date_sk#21, ws_quantity#60, ws_list_price#61]
+Condition : isnotnull(ws_sold_date_sk#21)
 
 (135) ReusedExchange [Reuses operator id: 123]
 Output [1]: [d_date_sk#10]
 
 (136) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ws_sold_date_sk#20]
+Left keys [1]: [ws_sold_date_sk#21]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
 (137) Project [codegen id : 6]
 Output [2]: [ws_quantity#60 AS quantity#96, ws_list_price#61 AS list_price#97]
-Input [4]: [ws_sold_date_sk#20, ws_quantity#60, ws_list_price#61, d_date_sk#10]
+Input [4]: [ws_sold_date_sk#21, ws_quantity#60, ws_list_price#61, d_date_sk#10]
 
 (138) Union
 
@@ -782,7 +782,7 @@ Results [2]: [sum#100, count#101]
 
 (140) Exchange
 Input [2]: [sum#100, count#101]
-Arguments: SinglePartition, true, [id=#102]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#102]
 
 (141) HashAggregate [codegen id : 8]
 Input [2]: [sum#100, count#101]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a/simplified.txt
@@ -81,12 +81,12 @@ TakeOrderedAndProject [channel,i_brand_id,i_class_id,i_category_id,sum(sales),su
                                                             WholeStageCodegen (10)
                                                               HashAggregate [brand_id,class_id,category_id]
                                                                 HashAggregate [brand_id,class_id,category_id]
-                                                                  HashAggregate [brand_id,class_id,category_id]
-                                                                    InputAdapter
-                                                                      Exchange [brand_id,class_id,category_id] #5
-                                                                        WholeStageCodegen (9)
-                                                                          HashAggregate [brand_id,class_id,category_id]
-                                                                            BroadcastHashJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
+                                                                  BroadcastHashJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
+                                                                    HashAggregate [brand_id,class_id,category_id]
+                                                                      InputAdapter
+                                                                        Exchange [brand_id,class_id,category_id] #5
+                                                                          WholeStageCodegen (6)
+                                                                            HashAggregate [brand_id,class_id,category_id]
                                                                               BroadcastHashJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
                                                                                 Project [i_brand_id,i_class_id,i_category_id]
                                                                                   BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
@@ -131,21 +131,21 @@ TakeOrderedAndProject [channel,i_brand_id,i_class_id,i_category_id,sum(sales),su
                                                                                                           Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
                                                                                           InputAdapter
                                                                                             ReusedExchange [d_date_sk] #7
+                                                                    InputAdapter
+                                                                      BroadcastExchange #10
+                                                                        WholeStageCodegen (9)
+                                                                          Project [i_brand_id,i_class_id,i_category_id]
+                                                                            BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                                              Project [ws_sold_date_sk,i_brand_id,i_class_id,i_category_id]
+                                                                                BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                                                  Filter [ws_item_sk,ws_sold_date_sk]
+                                                                                    ColumnarToRow
+                                                                                      InputAdapter
+                                                                                        Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk]
+                                                                                  InputAdapter
+                                                                                    ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #9
                                                                               InputAdapter
-                                                                                BroadcastExchange #10
-                                                                                  WholeStageCodegen (8)
-                                                                                    Project [i_brand_id,i_class_id,i_category_id]
-                                                                                      BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                                        Project [ws_sold_date_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                          BroadcastHashJoin [ws_item_sk,i_item_sk]
-                                                                                            Filter [ws_item_sk,ws_sold_date_sk]
-                                                                                              ColumnarToRow
-                                                                                                InputAdapter
-                                                                                                  Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk]
-                                                                                            InputAdapter
-                                                                                              ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #9
-                                                                                        InputAdapter
-                                                                                          ReusedExchange [d_date_sk] #7
+                                                                                ReusedExchange [d_date_sk] #7
                                             InputAdapter
                                               BroadcastExchange #11
                                                 WholeStageCodegen (23)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b.sf100/explain.txt
@@ -1,117 +1,118 @@
 == Physical Plan ==
-TakeOrderedAndProject (113)
-+- * BroadcastHashJoin Inner BuildRight (112)
-   :- * Project (90)
-   :  +- * Filter (89)
-   :     +- * HashAggregate (88)
-   :        +- Exchange (87)
-   :           +- * HashAggregate (86)
-   :              +- * Project (85)
-   :                 +- * BroadcastHashJoin Inner BuildRight (84)
-   :                    :- * Project (74)
-   :                    :  +- * BroadcastHashJoin Inner BuildRight (73)
-   :                    :     :- SortMergeJoin LeftSemi (67)
+TakeOrderedAndProject (114)
++- * BroadcastHashJoin Inner BuildRight (113)
+   :- * Project (91)
+   :  +- * Filter (90)
+   :     +- * HashAggregate (89)
+   :        +- Exchange (88)
+   :           +- * HashAggregate (87)
+   :              +- * Project (86)
+   :                 +- * BroadcastHashJoin Inner BuildRight (85)
+   :                    :- * Project (75)
+   :                    :  +- * BroadcastHashJoin Inner BuildRight (74)
+   :                    :     :- SortMergeJoin LeftSemi (68)
    :                    :     :  :- * Sort (5)
    :                    :     :  :  +- Exchange (4)
    :                    :     :  :     +- * Filter (3)
    :                    :     :  :        +- * ColumnarToRow (2)
    :                    :     :  :           +- Scan parquet default.store_sales (1)
-   :                    :     :  +- * Sort (66)
-   :                    :     :     +- Exchange (65)
-   :                    :     :        +- * Project (64)
-   :                    :     :           +- * BroadcastHashJoin Inner BuildRight (63)
+   :                    :     :  +- * Sort (67)
+   :                    :     :     +- Exchange (66)
+   :                    :     :        +- * Project (65)
+   :                    :     :           +- * BroadcastHashJoin Inner BuildRight (64)
    :                    :     :              :- * Filter (8)
    :                    :     :              :  +- * ColumnarToRow (7)
    :                    :     :              :     +- Scan parquet default.item (6)
-   :                    :     :              +- BroadcastExchange (62)
-   :                    :     :                 +- * HashAggregate (61)
-   :                    :     :                    +- Exchange (60)
-   :                    :     :                       +- * HashAggregate (59)
-   :                    :     :                          +- SortMergeJoin LeftSemi (58)
-   :                    :     :                             :- * Sort (46)
-   :                    :     :                             :  +- Exchange (45)
-   :                    :     :                             :     +- * HashAggregate (44)
-   :                    :     :                             :        +- Exchange (43)
-   :                    :     :                             :           +- * HashAggregate (42)
-   :                    :     :                             :              +- SortMergeJoin LeftSemi (41)
-   :                    :     :                             :                 :- * Sort (26)
-   :                    :     :                             :                 :  +- Exchange (25)
-   :                    :     :                             :                 :     +- * Project (24)
-   :                    :     :                             :                 :        +- * BroadcastHashJoin Inner BuildRight (23)
-   :                    :     :                             :                 :           :- * Project (18)
-   :                    :     :                             :                 :           :  +- * BroadcastHashJoin Inner BuildRight (17)
-   :                    :     :                             :                 :           :     :- * Filter (11)
-   :                    :     :                             :                 :           :     :  +- * ColumnarToRow (10)
-   :                    :     :                             :                 :           :     :     +- Scan parquet default.store_sales (9)
-   :                    :     :                             :                 :           :     +- BroadcastExchange (16)
-   :                    :     :                             :                 :           :        +- * Project (15)
-   :                    :     :                             :                 :           :           +- * Filter (14)
-   :                    :     :                             :                 :           :              +- * ColumnarToRow (13)
-   :                    :     :                             :                 :           :                 +- Scan parquet default.date_dim (12)
-   :                    :     :                             :                 :           +- BroadcastExchange (22)
-   :                    :     :                             :                 :              +- * Filter (21)
-   :                    :     :                             :                 :                 +- * ColumnarToRow (20)
-   :                    :     :                             :                 :                    +- Scan parquet default.item (19)
-   :                    :     :                             :                 +- * Sort (40)
-   :                    :     :                             :                    +- Exchange (39)
-   :                    :     :                             :                       +- * Project (38)
-   :                    :     :                             :                          +- * BroadcastHashJoin Inner BuildRight (37)
-   :                    :     :                             :                             :- * Project (32)
-   :                    :     :                             :                             :  +- * BroadcastHashJoin Inner BuildRight (31)
-   :                    :     :                             :                             :     :- * Filter (29)
-   :                    :     :                             :                             :     :  +- * ColumnarToRow (28)
-   :                    :     :                             :                             :     :     +- Scan parquet default.catalog_sales (27)
-   :                    :     :                             :                             :     +- ReusedExchange (30)
-   :                    :     :                             :                             +- BroadcastExchange (36)
-   :                    :     :                             :                                +- * Filter (35)
-   :                    :     :                             :                                   +- * ColumnarToRow (34)
-   :                    :     :                             :                                      +- Scan parquet default.item (33)
-   :                    :     :                             +- * Sort (57)
-   :                    :     :                                +- Exchange (56)
-   :                    :     :                                   +- * Project (55)
-   :                    :     :                                      +- * BroadcastHashJoin Inner BuildRight (54)
-   :                    :     :                                         :- * Project (52)
-   :                    :     :                                         :  +- * BroadcastHashJoin Inner BuildRight (51)
-   :                    :     :                                         :     :- * Filter (49)
-   :                    :     :                                         :     :  +- * ColumnarToRow (48)
-   :                    :     :                                         :     :     +- Scan parquet default.web_sales (47)
-   :                    :     :                                         :     +- ReusedExchange (50)
-   :                    :     :                                         +- ReusedExchange (53)
-   :                    :     +- BroadcastExchange (72)
-   :                    :        +- * Project (71)
-   :                    :           +- * Filter (70)
-   :                    :              +- * ColumnarToRow (69)
-   :                    :                 +- Scan parquet default.date_dim (68)
-   :                    +- BroadcastExchange (83)
-   :                       +- SortMergeJoin LeftSemi (82)
-   :                          :- * Sort (79)
-   :                          :  +- Exchange (78)
-   :                          :     +- * Filter (77)
-   :                          :        +- * ColumnarToRow (76)
-   :                          :           +- Scan parquet default.item (75)
-   :                          +- * Sort (81)
-   :                             +- ReusedExchange (80)
-   +- BroadcastExchange (111)
-      +- * Project (110)
-         +- * Filter (109)
-            +- * HashAggregate (108)
-               +- Exchange (107)
-                  +- * HashAggregate (106)
-                     +- * Project (105)
-                        +- * BroadcastHashJoin Inner BuildRight (104)
-                           :- * Project (102)
-                           :  +- * BroadcastHashJoin Inner BuildRight (101)
-                           :     :- SortMergeJoin LeftSemi (95)
-                           :     :  :- * Sort (92)
-                           :     :  :  +- ReusedExchange (91)
-                           :     :  +- * Sort (94)
-                           :     :     +- ReusedExchange (93)
-                           :     +- BroadcastExchange (100)
-                           :        +- * Project (99)
-                           :           +- * Filter (98)
-                           :              +- * ColumnarToRow (97)
-                           :                 +- Scan parquet default.date_dim (96)
-                           +- ReusedExchange (103)
+   :                    :     :              +- BroadcastExchange (63)
+   :                    :     :                 +- * HashAggregate (62)
+   :                    :     :                    +- * HashAggregate (61)
+   :                    :     :                       +- * BroadcastHashJoin LeftSemi BuildRight (60)
+   :                    :     :                          :- * HashAggregate (46)
+   :                    :     :                          :  +- * HashAggregate (45)
+   :                    :     :                          :     +- * BroadcastHashJoin LeftSemi BuildRight (44)
+   :                    :     :                          :        :- * HashAggregate (27)
+   :                    :     :                          :        :  +- Exchange (26)
+   :                    :     :                          :        :     +- * HashAggregate (25)
+   :                    :     :                          :        :        +- * Project (24)
+   :                    :     :                          :        :           +- * BroadcastHashJoin Inner BuildRight (23)
+   :                    :     :                          :        :              :- * Project (18)
+   :                    :     :                          :        :              :  +- * BroadcastHashJoin Inner BuildRight (17)
+   :                    :     :                          :        :              :     :- * Filter (11)
+   :                    :     :                          :        :              :     :  +- * ColumnarToRow (10)
+   :                    :     :                          :        :              :     :     +- Scan parquet default.store_sales (9)
+   :                    :     :                          :        :              :     +- BroadcastExchange (16)
+   :                    :     :                          :        :              :        +- * Project (15)
+   :                    :     :                          :        :              :           +- * Filter (14)
+   :                    :     :                          :        :              :              +- * ColumnarToRow (13)
+   :                    :     :                          :        :              :                 +- Scan parquet default.date_dim (12)
+   :                    :     :                          :        :              +- BroadcastExchange (22)
+   :                    :     :                          :        :                 +- * Filter (21)
+   :                    :     :                          :        :                    +- * ColumnarToRow (20)
+   :                    :     :                          :        :                       +- Scan parquet default.item (19)
+   :                    :     :                          :        +- BroadcastExchange (43)
+   :                    :     :                          :           +- * HashAggregate (42)
+   :                    :     :                          :              +- Exchange (41)
+   :                    :     :                          :                 +- * HashAggregate (40)
+   :                    :     :                          :                    +- * Project (39)
+   :                    :     :                          :                       +- * BroadcastHashJoin Inner BuildRight (38)
+   :                    :     :                          :                          :- * Project (33)
+   :                    :     :                          :                          :  +- * BroadcastHashJoin Inner BuildRight (32)
+   :                    :     :                          :                          :     :- * Filter (30)
+   :                    :     :                          :                          :     :  +- * ColumnarToRow (29)
+   :                    :     :                          :                          :     :     +- Scan parquet default.catalog_sales (28)
+   :                    :     :                          :                          :     +- ReusedExchange (31)
+   :                    :     :                          :                          +- BroadcastExchange (37)
+   :                    :     :                          :                             +- * Filter (36)
+   :                    :     :                          :                                +- * ColumnarToRow (35)
+   :                    :     :                          :                                   +- Scan parquet default.item (34)
+   :                    :     :                          +- BroadcastExchange (59)
+   :                    :     :                             +- * HashAggregate (58)
+   :                    :     :                                +- Exchange (57)
+   :                    :     :                                   +- * HashAggregate (56)
+   :                    :     :                                      +- * Project (55)
+   :                    :     :                                         +- * BroadcastHashJoin Inner BuildRight (54)
+   :                    :     :                                            :- * Project (52)
+   :                    :     :                                            :  +- * BroadcastHashJoin Inner BuildRight (51)
+   :                    :     :                                            :     :- * Filter (49)
+   :                    :     :                                            :     :  +- * ColumnarToRow (48)
+   :                    :     :                                            :     :     +- Scan parquet default.web_sales (47)
+   :                    :     :                                            :     +- ReusedExchange (50)
+   :                    :     :                                            +- ReusedExchange (53)
+   :                    :     +- BroadcastExchange (73)
+   :                    :        +- * Project (72)
+   :                    :           +- * Filter (71)
+   :                    :              +- * ColumnarToRow (70)
+   :                    :                 +- Scan parquet default.date_dim (69)
+   :                    +- BroadcastExchange (84)
+   :                       +- SortMergeJoin LeftSemi (83)
+   :                          :- * Sort (80)
+   :                          :  +- Exchange (79)
+   :                          :     +- * Filter (78)
+   :                          :        +- * ColumnarToRow (77)
+   :                          :           +- Scan parquet default.item (76)
+   :                          +- * Sort (82)
+   :                             +- ReusedExchange (81)
+   +- BroadcastExchange (112)
+      +- * Project (111)
+         +- * Filter (110)
+            +- * HashAggregate (109)
+               +- Exchange (108)
+                  +- * HashAggregate (107)
+                     +- * Project (106)
+                        +- * BroadcastHashJoin Inner BuildRight (105)
+                           :- * Project (103)
+                           :  +- * BroadcastHashJoin Inner BuildRight (102)
+                           :     :- SortMergeJoin LeftSemi (96)
+                           :     :  :- * Sort (93)
+                           :     :  :  +- ReusedExchange (92)
+                           :     :  +- * Sort (95)
+                           :     :     +- ReusedExchange (94)
+                           :     +- BroadcastExchange (101)
+                           :        +- * Project (100)
+                           :           +- * Filter (99)
+                           :              +- * ColumnarToRow (98)
+                           :                 +- Scan parquet default.date_dim (97)
+                           +- ReusedExchange (104)
 
 
 (1) Scan parquet default.store_sales
@@ -143,10 +144,10 @@ Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_brand_id), IsNotNull(i_class_id), IsNotNull(i_category_id)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(7) ColumnarToRow [codegen id : 20]
+(7) ColumnarToRow [codegen id : 15]
 Input [4]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
 
-(8) Filter [codegen id : 20]
+(8) Filter [codegen id : 15]
 Input [4]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
 Condition : ((isnotnull(i_brand_id#7) AND isnotnull(i_class_id#8)) AND isnotnull(i_category_id#9))
 
@@ -222,604 +223,626 @@ Join condition: None
 Output [3]: [i_brand_id#7 AS brand_id#14, i_class_id#8 AS class_id#15, i_category_id#9 AS category_id#16]
 Input [5]: [ss_item_sk#2, i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
 
-(25) Exchange
+(25) HashAggregate [codegen id : 5]
 Input [3]: [brand_id#14, class_id#15, category_id#16]
-Arguments: hashpartitioning(coalesce(brand_id#14, 0), isnull(brand_id#14), coalesce(class_id#15, 0), isnull(class_id#15), coalesce(category_id#16, 0), isnull(category_id#16), 5), ENSURE_REQUIREMENTS, [id=#17]
+Keys [3]: [brand_id#14, class_id#15, category_id#16]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [brand_id#14, class_id#15, category_id#16]
 
-(26) Sort [codegen id : 6]
+(26) Exchange
 Input [3]: [brand_id#14, class_id#15, category_id#16]
-Arguments: [coalesce(brand_id#14, 0) ASC NULLS FIRST, isnull(brand_id#14) ASC NULLS FIRST, coalesce(class_id#15, 0) ASC NULLS FIRST, isnull(class_id#15) ASC NULLS FIRST, coalesce(category_id#16, 0) ASC NULLS FIRST, isnull(category_id#16) ASC NULLS FIRST], false, 0
+Arguments: hashpartitioning(brand_id#14, class_id#15, category_id#16, 5), ENSURE_REQUIREMENTS, [id=#17]
 
-(27) Scan parquet default.catalog_sales
+(27) HashAggregate [codegen id : 14]
+Input [3]: [brand_id#14, class_id#15, category_id#16]
+Keys [3]: [brand_id#14, class_id#15, category_id#16]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [brand_id#14, class_id#15, category_id#16]
+
+(28) Scan parquet default.catalog_sales
 Output [2]: [cs_sold_date_sk#18, cs_item_sk#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_sales]
 PushedFilters: [IsNotNull(cs_item_sk), IsNotNull(cs_sold_date_sk)]
 ReadSchema: struct<cs_sold_date_sk:int,cs_item_sk:int>
 
-(28) ColumnarToRow [codegen id : 9]
+(29) ColumnarToRow [codegen id : 8]
 Input [2]: [cs_sold_date_sk#18, cs_item_sk#19]
 
-(29) Filter [codegen id : 9]
+(30) Filter [codegen id : 8]
 Input [2]: [cs_sold_date_sk#18, cs_item_sk#19]
 Condition : (isnotnull(cs_item_sk#19) AND isnotnull(cs_sold_date_sk#18))
 
-(30) ReusedExchange [Reuses operator id: 16]
+(31) ReusedExchange [Reuses operator id: 16]
 Output [1]: [d_date_sk#10]
 
-(31) BroadcastHashJoin [codegen id : 9]
+(32) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_sold_date_sk#18]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
-(32) Project [codegen id : 9]
+(33) Project [codegen id : 8]
 Output [1]: [cs_item_sk#19]
 Input [3]: [cs_sold_date_sk#18, cs_item_sk#19, d_date_sk#10]
 
-(33) Scan parquet default.item
+(34) Scan parquet default.item
 Output [4]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(34) ColumnarToRow [codegen id : 8]
+(35) ColumnarToRow [codegen id : 7]
 Input [4]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
 
-(35) Filter [codegen id : 8]
+(36) Filter [codegen id : 7]
 Input [4]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
 Condition : isnotnull(i_item_sk#6)
 
-(36) BroadcastExchange
+(37) BroadcastExchange
 Input [4]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#20]
 
-(37) BroadcastHashJoin [codegen id : 9]
+(38) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_item_sk#19]
 Right keys [1]: [i_item_sk#6]
 Join condition: None
 
-(38) Project [codegen id : 9]
+(39) Project [codegen id : 8]
 Output [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
 Input [5]: [cs_item_sk#19, i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
 
-(39) Exchange
+(40) HashAggregate [codegen id : 8]
 Input [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
-Arguments: hashpartitioning(coalesce(i_brand_id#7, 0), isnull(i_brand_id#7), coalesce(i_class_id#8, 0), isnull(i_class_id#8), coalesce(i_category_id#9, 0), isnull(i_category_id#9), 5), ENSURE_REQUIREMENTS, [id=#21]
+Keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
 
-(40) Sort [codegen id : 10]
+(41) Exchange
 Input [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
-Arguments: [coalesce(i_brand_id#7, 0) ASC NULLS FIRST, isnull(i_brand_id#7) ASC NULLS FIRST, coalesce(i_class_id#8, 0) ASC NULLS FIRST, isnull(i_class_id#8) ASC NULLS FIRST, coalesce(i_category_id#9, 0) ASC NULLS FIRST, isnull(i_category_id#9) ASC NULLS FIRST], false, 0
+Arguments: hashpartitioning(i_brand_id#7, i_class_id#8, i_category_id#9, 5), ENSURE_REQUIREMENTS, [id=#21]
 
-(41) SortMergeJoin
+(42) HashAggregate [codegen id : 9]
+Input [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
+Keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
+
+(43) BroadcastExchange
+Input [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
+Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true]), coalesce(input[1, int, true], 0), isnull(input[1, int, true]), coalesce(input[2, int, true], 0), isnull(input[2, int, true])),false), [id=#22]
+
+(44) BroadcastHashJoin [codegen id : 14]
 Left keys [6]: [coalesce(brand_id#14, 0), isnull(brand_id#14), coalesce(class_id#15, 0), isnull(class_id#15), coalesce(category_id#16, 0), isnull(category_id#16)]
 Right keys [6]: [coalesce(i_brand_id#7, 0), isnull(i_brand_id#7), coalesce(i_class_id#8, 0), isnull(i_class_id#8), coalesce(i_category_id#9, 0), isnull(i_category_id#9)]
 Join condition: None
 
-(42) HashAggregate [codegen id : 11]
+(45) HashAggregate [codegen id : 14]
 Input [3]: [brand_id#14, class_id#15, category_id#16]
 Keys [3]: [brand_id#14, class_id#15, category_id#16]
 Functions: []
 Aggregate Attributes: []
 Results [3]: [brand_id#14, class_id#15, category_id#16]
 
-(43) Exchange
-Input [3]: [brand_id#14, class_id#15, category_id#16]
-Arguments: hashpartitioning(brand_id#14, class_id#15, category_id#16, 5), ENSURE_REQUIREMENTS, [id=#22]
-
-(44) HashAggregate [codegen id : 12]
+(46) HashAggregate [codegen id : 14]
 Input [3]: [brand_id#14, class_id#15, category_id#16]
 Keys [3]: [brand_id#14, class_id#15, category_id#16]
 Functions: []
 Aggregate Attributes: []
 Results [3]: [brand_id#14, class_id#15, category_id#16]
-
-(45) Exchange
-Input [3]: [brand_id#14, class_id#15, category_id#16]
-Arguments: hashpartitioning(coalesce(brand_id#14, 0), isnull(brand_id#14), coalesce(class_id#15, 0), isnull(class_id#15), coalesce(category_id#16, 0), isnull(category_id#16), 5), ENSURE_REQUIREMENTS, [id=#23]
-
-(46) Sort [codegen id : 13]
-Input [3]: [brand_id#14, class_id#15, category_id#16]
-Arguments: [coalesce(brand_id#14, 0) ASC NULLS FIRST, isnull(brand_id#14) ASC NULLS FIRST, coalesce(class_id#15, 0) ASC NULLS FIRST, isnull(class_id#15) ASC NULLS FIRST, coalesce(category_id#16, 0) ASC NULLS FIRST, isnull(category_id#16) ASC NULLS FIRST], false, 0
 
 (47) Scan parquet default.web_sales
-Output [2]: [ws_sold_date_sk#24, ws_item_sk#25]
+Output [2]: [ws_sold_date_sk#23, ws_item_sk#24]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_sales]
 PushedFilters: [IsNotNull(ws_item_sk), IsNotNull(ws_sold_date_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_item_sk:int>
 
-(48) ColumnarToRow [codegen id : 16]
-Input [2]: [ws_sold_date_sk#24, ws_item_sk#25]
+(48) ColumnarToRow [codegen id : 12]
+Input [2]: [ws_sold_date_sk#23, ws_item_sk#24]
 
-(49) Filter [codegen id : 16]
-Input [2]: [ws_sold_date_sk#24, ws_item_sk#25]
-Condition : (isnotnull(ws_item_sk#25) AND isnotnull(ws_sold_date_sk#24))
+(49) Filter [codegen id : 12]
+Input [2]: [ws_sold_date_sk#23, ws_item_sk#24]
+Condition : (isnotnull(ws_item_sk#24) AND isnotnull(ws_sold_date_sk#23))
 
 (50) ReusedExchange [Reuses operator id: 16]
 Output [1]: [d_date_sk#10]
 
-(51) BroadcastHashJoin [codegen id : 16]
-Left keys [1]: [ws_sold_date_sk#24]
+(51) BroadcastHashJoin [codegen id : 12]
+Left keys [1]: [ws_sold_date_sk#23]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
-(52) Project [codegen id : 16]
-Output [1]: [ws_item_sk#25]
-Input [3]: [ws_sold_date_sk#24, ws_item_sk#25, d_date_sk#10]
+(52) Project [codegen id : 12]
+Output [1]: [ws_item_sk#24]
+Input [3]: [ws_sold_date_sk#23, ws_item_sk#24, d_date_sk#10]
 
-(53) ReusedExchange [Reuses operator id: 36]
+(53) ReusedExchange [Reuses operator id: 37]
 Output [4]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
 
-(54) BroadcastHashJoin [codegen id : 16]
-Left keys [1]: [ws_item_sk#25]
+(54) BroadcastHashJoin [codegen id : 12]
+Left keys [1]: [ws_item_sk#24]
 Right keys [1]: [i_item_sk#6]
 Join condition: None
 
-(55) Project [codegen id : 16]
+(55) Project [codegen id : 12]
 Output [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
-Input [5]: [ws_item_sk#25, i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
+Input [5]: [ws_item_sk#24, i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
 
-(56) Exchange
+(56) HashAggregate [codegen id : 12]
 Input [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
-Arguments: hashpartitioning(coalesce(i_brand_id#7, 0), isnull(i_brand_id#7), coalesce(i_class_id#8, 0), isnull(i_class_id#8), coalesce(i_category_id#9, 0), isnull(i_category_id#9), 5), ENSURE_REQUIREMENTS, [id=#26]
+Keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
 
-(57) Sort [codegen id : 17]
+(57) Exchange
 Input [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
-Arguments: [coalesce(i_brand_id#7, 0) ASC NULLS FIRST, isnull(i_brand_id#7) ASC NULLS FIRST, coalesce(i_class_id#8, 0) ASC NULLS FIRST, isnull(i_class_id#8) ASC NULLS FIRST, coalesce(i_category_id#9, 0) ASC NULLS FIRST, isnull(i_category_id#9) ASC NULLS FIRST], false, 0
+Arguments: hashpartitioning(i_brand_id#7, i_class_id#8, i_category_id#9, 5), ENSURE_REQUIREMENTS, [id=#25]
 
-(58) SortMergeJoin
+(58) HashAggregate [codegen id : 13]
+Input [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
+Keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
+
+(59) BroadcastExchange
+Input [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
+Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true]), coalesce(input[1, int, true], 0), isnull(input[1, int, true]), coalesce(input[2, int, true], 0), isnull(input[2, int, true])),false), [id=#26]
+
+(60) BroadcastHashJoin [codegen id : 14]
 Left keys [6]: [coalesce(brand_id#14, 0), isnull(brand_id#14), coalesce(class_id#15, 0), isnull(class_id#15), coalesce(category_id#16, 0), isnull(category_id#16)]
 Right keys [6]: [coalesce(i_brand_id#7, 0), isnull(i_brand_id#7), coalesce(i_class_id#8, 0), isnull(i_class_id#8), coalesce(i_category_id#9, 0), isnull(i_category_id#9)]
 Join condition: None
 
-(59) HashAggregate [codegen id : 18]
+(61) HashAggregate [codegen id : 14]
 Input [3]: [brand_id#14, class_id#15, category_id#16]
 Keys [3]: [brand_id#14, class_id#15, category_id#16]
 Functions: []
 Aggregate Attributes: []
 Results [3]: [brand_id#14, class_id#15, category_id#16]
 
-(60) Exchange
-Input [3]: [brand_id#14, class_id#15, category_id#16]
-Arguments: hashpartitioning(brand_id#14, class_id#15, category_id#16, 5), ENSURE_REQUIREMENTS, [id=#27]
-
-(61) HashAggregate [codegen id : 19]
+(62) HashAggregate [codegen id : 14]
 Input [3]: [brand_id#14, class_id#15, category_id#16]
 Keys [3]: [brand_id#14, class_id#15, category_id#16]
 Functions: []
 Aggregate Attributes: []
 Results [3]: [brand_id#14, class_id#15, category_id#16]
 
-(62) BroadcastExchange
+(63) BroadcastExchange
 Input [3]: [brand_id#14, class_id#15, category_id#16]
-Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false), [id=#28]
+Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false), [id=#27]
 
-(63) BroadcastHashJoin [codegen id : 20]
+(64) BroadcastHashJoin [codegen id : 15]
 Left keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
 Right keys [3]: [brand_id#14, class_id#15, category_id#16]
 Join condition: None
 
-(64) Project [codegen id : 20]
-Output [1]: [i_item_sk#6 AS ss_item_sk#29]
+(65) Project [codegen id : 15]
+Output [1]: [i_item_sk#6 AS ss_item_sk#28]
 Input [7]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9, brand_id#14, class_id#15, category_id#16]
 
-(65) Exchange
-Input [1]: [ss_item_sk#29]
-Arguments: hashpartitioning(ss_item_sk#29, 5), ENSURE_REQUIREMENTS, [id=#30]
+(66) Exchange
+Input [1]: [ss_item_sk#28]
+Arguments: hashpartitioning(ss_item_sk#28, 5), ENSURE_REQUIREMENTS, [id=#29]
 
-(66) Sort [codegen id : 21]
-Input [1]: [ss_item_sk#29]
-Arguments: [ss_item_sk#29 ASC NULLS FIRST], false, 0
+(67) Sort [codegen id : 16]
+Input [1]: [ss_item_sk#28]
+Arguments: [ss_item_sk#28 ASC NULLS FIRST], false, 0
 
-(67) SortMergeJoin
+(68) SortMergeJoin
 Left keys [1]: [ss_item_sk#2]
-Right keys [1]: [ss_item_sk#29]
+Right keys [1]: [ss_item_sk#28]
 Join condition: None
 
-(68) Scan parquet default.date_dim
-Output [2]: [d_date_sk#10, d_week_seq#31]
+(69) Scan parquet default.date_dim
+Output [2]: [d_date_sk#10, d_week_seq#30]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_week_seq), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int>
 
-(69) ColumnarToRow [codegen id : 22]
-Input [2]: [d_date_sk#10, d_week_seq#31]
+(70) ColumnarToRow [codegen id : 17]
+Input [2]: [d_date_sk#10, d_week_seq#30]
 
-(70) Filter [codegen id : 22]
-Input [2]: [d_date_sk#10, d_week_seq#31]
-Condition : ((isnotnull(d_week_seq#31) AND (d_week_seq#31 = Subquery scalar-subquery#32, [id=#33])) AND isnotnull(d_date_sk#10))
+(71) Filter [codegen id : 17]
+Input [2]: [d_date_sk#10, d_week_seq#30]
+Condition : ((isnotnull(d_week_seq#30) AND (d_week_seq#30 = Subquery scalar-subquery#31, [id=#32])) AND isnotnull(d_date_sk#10))
 
-(71) Project [codegen id : 22]
+(72) Project [codegen id : 17]
 Output [1]: [d_date_sk#10]
-Input [2]: [d_date_sk#10, d_week_seq#31]
+Input [2]: [d_date_sk#10, d_week_seq#30]
 
-(72) BroadcastExchange
+(73) BroadcastExchange
 Input [1]: [d_date_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#34]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#33]
 
-(73) BroadcastHashJoin [codegen id : 44]
+(74) BroadcastHashJoin [codegen id : 34]
 Left keys [1]: [ss_sold_date_sk#1]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
-(74) Project [codegen id : 44]
+(75) Project [codegen id : 34]
 Output [3]: [ss_item_sk#2, ss_quantity#3, ss_list_price#4]
 Input [5]: [ss_sold_date_sk#1, ss_item_sk#2, ss_quantity#3, ss_list_price#4, d_date_sk#10]
 
-(75) Scan parquet default.item
+(76) Scan parquet default.item
 Output [4]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk), IsNotNull(i_brand_id), IsNotNull(i_class_id), IsNotNull(i_category_id)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(76) ColumnarToRow [codegen id : 23]
+(77) ColumnarToRow [codegen id : 18]
 Input [4]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
 
-(77) Filter [codegen id : 23]
+(78) Filter [codegen id : 18]
 Input [4]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
 Condition : (((isnotnull(i_item_sk#6) AND isnotnull(i_brand_id#7)) AND isnotnull(i_class_id#8)) AND isnotnull(i_category_id#9))
 
-(78) Exchange
+(79) Exchange
 Input [4]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
-Arguments: hashpartitioning(i_item_sk#6, 5), ENSURE_REQUIREMENTS, [id=#35]
+Arguments: hashpartitioning(i_item_sk#6, 5), ENSURE_REQUIREMENTS, [id=#34]
 
-(79) Sort [codegen id : 24]
+(80) Sort [codegen id : 19]
 Input [4]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
 Arguments: [i_item_sk#6 ASC NULLS FIRST], false, 0
 
-(80) ReusedExchange [Reuses operator id: 65]
-Output [1]: [ss_item_sk#29]
+(81) ReusedExchange [Reuses operator id: 66]
+Output [1]: [ss_item_sk#28]
 
-(81) Sort [codegen id : 43]
-Input [1]: [ss_item_sk#29]
-Arguments: [ss_item_sk#29 ASC NULLS FIRST], false, 0
+(82) Sort [codegen id : 33]
+Input [1]: [ss_item_sk#28]
+Arguments: [ss_item_sk#28 ASC NULLS FIRST], false, 0
 
-(82) SortMergeJoin
+(83) SortMergeJoin
 Left keys [1]: [i_item_sk#6]
-Right keys [1]: [ss_item_sk#29]
+Right keys [1]: [ss_item_sk#28]
 Join condition: None
 
-(83) BroadcastExchange
+(84) BroadcastExchange
 Input [4]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#36]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#35]
 
-(84) BroadcastHashJoin [codegen id : 44]
+(85) BroadcastHashJoin [codegen id : 34]
 Left keys [1]: [ss_item_sk#2]
 Right keys [1]: [i_item_sk#6]
 Join condition: None
 
-(85) Project [codegen id : 44]
+(86) Project [codegen id : 34]
 Output [5]: [ss_quantity#3, ss_list_price#4, i_brand_id#7, i_class_id#8, i_category_id#9]
 Input [7]: [ss_item_sk#2, ss_quantity#3, ss_list_price#4, i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
 
-(86) HashAggregate [codegen id : 44]
+(87) HashAggregate [codegen id : 34]
 Input [5]: [ss_quantity#3, ss_list_price#4, i_brand_id#7, i_class_id#8, i_category_id#9]
 Keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
 Functions [2]: [partial_sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true)), partial_count(1)]
-Aggregate Attributes [3]: [sum#37, isEmpty#38, count#39]
-Results [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#40, isEmpty#41, count#42]
+Aggregate Attributes [3]: [sum#36, isEmpty#37, count#38]
+Results [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#39, isEmpty#40, count#41]
 
-(87) Exchange
-Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#40, isEmpty#41, count#42]
-Arguments: hashpartitioning(i_brand_id#7, i_class_id#8, i_category_id#9, 5), ENSURE_REQUIREMENTS, [id=#43]
+(88) Exchange
+Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#39, isEmpty#40, count#41]
+Arguments: hashpartitioning(i_brand_id#7, i_class_id#8, i_category_id#9, 5), ENSURE_REQUIREMENTS, [id=#42]
 
-(88) HashAggregate [codegen id : 90]
-Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#40, isEmpty#41, count#42]
+(89) HashAggregate [codegen id : 70]
+Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum#39, isEmpty#40, count#41]
 Keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
 Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#44, count(1)#45]
-Results [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#44 AS sales#46, count(1)#45 AS number_sales#47, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#44 AS sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#48]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#43, count(1)#44]
+Results [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#43 AS sales#45, count(1)#44 AS number_sales#46, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#43 AS sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#47]
 
-(89) Filter [codegen id : 90]
-Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#46, number_sales#47, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#48]
-Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#48) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#48 as decimal(32,6)) > cast(Subquery scalar-subquery#49, [id=#50] as decimal(32,6))))
+(90) Filter [codegen id : 70]
+Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#45, number_sales#46, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#47]
+Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#47) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#47 as decimal(32,6)) > cast(Subquery scalar-subquery#48, [id=#49] as decimal(32,6))))
 
-(90) Project [codegen id : 90]
-Output [6]: [store AS channel#51, i_brand_id#7, i_class_id#8, i_category_id#9, sales#46, number_sales#47]
-Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#46, number_sales#47, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#48]
+(91) Project [codegen id : 70]
+Output [6]: [store AS channel#50, i_brand_id#7, i_class_id#8, i_category_id#9, sales#45, number_sales#46]
+Input [6]: [i_brand_id#7, i_class_id#8, i_category_id#9, sales#45, number_sales#46, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#47]
 
-(91) ReusedExchange [Reuses operator id: 4]
+(92) ReusedExchange [Reuses operator id: 4]
 Output [4]: [ss_sold_date_sk#1, ss_item_sk#2, ss_quantity#3, ss_list_price#4]
 
-(92) Sort [codegen id : 46]
+(93) Sort [codegen id : 36]
 Input [4]: [ss_sold_date_sk#1, ss_item_sk#2, ss_quantity#3, ss_list_price#4]
 Arguments: [ss_item_sk#2 ASC NULLS FIRST], false, 0
 
-(93) ReusedExchange [Reuses operator id: 65]
-Output [1]: [ss_item_sk#29]
+(94) ReusedExchange [Reuses operator id: 66]
+Output [1]: [ss_item_sk#28]
 
-(94) Sort [codegen id : 65]
-Input [1]: [ss_item_sk#29]
-Arguments: [ss_item_sk#29 ASC NULLS FIRST], false, 0
+(95) Sort [codegen id : 50]
+Input [1]: [ss_item_sk#28]
+Arguments: [ss_item_sk#28 ASC NULLS FIRST], false, 0
 
-(95) SortMergeJoin
+(96) SortMergeJoin
 Left keys [1]: [ss_item_sk#2]
-Right keys [1]: [ss_item_sk#29]
+Right keys [1]: [ss_item_sk#28]
 Join condition: None
 
-(96) Scan parquet default.date_dim
-Output [2]: [d_date_sk#10, d_week_seq#31]
+(97) Scan parquet default.date_dim
+Output [2]: [d_date_sk#10, d_week_seq#30]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_week_seq), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int>
 
-(97) ColumnarToRow [codegen id : 66]
-Input [2]: [d_date_sk#10, d_week_seq#31]
+(98) ColumnarToRow [codegen id : 51]
+Input [2]: [d_date_sk#10, d_week_seq#30]
 
-(98) Filter [codegen id : 66]
-Input [2]: [d_date_sk#10, d_week_seq#31]
-Condition : ((isnotnull(d_week_seq#31) AND (d_week_seq#31 = Subquery scalar-subquery#52, [id=#53])) AND isnotnull(d_date_sk#10))
+(99) Filter [codegen id : 51]
+Input [2]: [d_date_sk#10, d_week_seq#30]
+Condition : ((isnotnull(d_week_seq#30) AND (d_week_seq#30 = Subquery scalar-subquery#51, [id=#52])) AND isnotnull(d_date_sk#10))
 
-(99) Project [codegen id : 66]
+(100) Project [codegen id : 51]
 Output [1]: [d_date_sk#10]
-Input [2]: [d_date_sk#10, d_week_seq#31]
+Input [2]: [d_date_sk#10, d_week_seq#30]
 
-(100) BroadcastExchange
+(101) BroadcastExchange
 Input [1]: [d_date_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#54]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#53]
 
-(101) BroadcastHashJoin [codegen id : 88]
+(102) BroadcastHashJoin [codegen id : 68]
 Left keys [1]: [ss_sold_date_sk#1]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
-(102) Project [codegen id : 88]
+(103) Project [codegen id : 68]
 Output [3]: [ss_item_sk#2, ss_quantity#3, ss_list_price#4]
 Input [5]: [ss_sold_date_sk#1, ss_item_sk#2, ss_quantity#3, ss_list_price#4, d_date_sk#10]
 
-(103) ReusedExchange [Reuses operator id: 83]
-Output [4]: [i_item_sk#55, i_brand_id#56, i_class_id#57, i_category_id#58]
+(104) ReusedExchange [Reuses operator id: 84]
+Output [4]: [i_item_sk#54, i_brand_id#55, i_class_id#56, i_category_id#57]
 
-(104) BroadcastHashJoin [codegen id : 88]
+(105) BroadcastHashJoin [codegen id : 68]
 Left keys [1]: [ss_item_sk#2]
-Right keys [1]: [i_item_sk#55]
+Right keys [1]: [i_item_sk#54]
 Join condition: None
 
-(105) Project [codegen id : 88]
-Output [5]: [ss_quantity#3, ss_list_price#4, i_brand_id#56, i_class_id#57, i_category_id#58]
-Input [7]: [ss_item_sk#2, ss_quantity#3, ss_list_price#4, i_item_sk#55, i_brand_id#56, i_class_id#57, i_category_id#58]
+(106) Project [codegen id : 68]
+Output [5]: [ss_quantity#3, ss_list_price#4, i_brand_id#55, i_class_id#56, i_category_id#57]
+Input [7]: [ss_item_sk#2, ss_quantity#3, ss_list_price#4, i_item_sk#54, i_brand_id#55, i_class_id#56, i_category_id#57]
 
-(106) HashAggregate [codegen id : 88]
-Input [5]: [ss_quantity#3, ss_list_price#4, i_brand_id#56, i_class_id#57, i_category_id#58]
-Keys [3]: [i_brand_id#56, i_class_id#57, i_category_id#58]
+(107) HashAggregate [codegen id : 68]
+Input [5]: [ss_quantity#3, ss_list_price#4, i_brand_id#55, i_class_id#56, i_category_id#57]
+Keys [3]: [i_brand_id#55, i_class_id#56, i_category_id#57]
 Functions [2]: [partial_sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true)), partial_count(1)]
-Aggregate Attributes [3]: [sum#59, isEmpty#60, count#61]
-Results [6]: [i_brand_id#56, i_class_id#57, i_category_id#58, sum#62, isEmpty#63, count#64]
+Aggregate Attributes [3]: [sum#58, isEmpty#59, count#60]
+Results [6]: [i_brand_id#55, i_class_id#56, i_category_id#57, sum#61, isEmpty#62, count#63]
 
-(107) Exchange
-Input [6]: [i_brand_id#56, i_class_id#57, i_category_id#58, sum#62, isEmpty#63, count#64]
-Arguments: hashpartitioning(i_brand_id#56, i_class_id#57, i_category_id#58, 5), ENSURE_REQUIREMENTS, [id=#65]
+(108) Exchange
+Input [6]: [i_brand_id#55, i_class_id#56, i_category_id#57, sum#61, isEmpty#62, count#63]
+Arguments: hashpartitioning(i_brand_id#55, i_class_id#56, i_category_id#57, 5), ENSURE_REQUIREMENTS, [id=#64]
 
-(108) HashAggregate [codegen id : 89]
-Input [6]: [i_brand_id#56, i_class_id#57, i_category_id#58, sum#62, isEmpty#63, count#64]
-Keys [3]: [i_brand_id#56, i_class_id#57, i_category_id#58]
+(109) HashAggregate [codegen id : 69]
+Input [6]: [i_brand_id#55, i_class_id#56, i_category_id#57, sum#61, isEmpty#62, count#63]
+Keys [3]: [i_brand_id#55, i_class_id#56, i_category_id#57]
 Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#66, count(1)#67]
-Results [6]: [i_brand_id#56, i_class_id#57, i_category_id#58, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#66 AS sales#68, count(1)#67 AS number_sales#69, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#66 AS sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#70]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#65, count(1)#66]
+Results [6]: [i_brand_id#55, i_class_id#56, i_category_id#57, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#65 AS sales#67, count(1)#66 AS number_sales#68, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#65 AS sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#69]
 
-(109) Filter [codegen id : 89]
-Input [6]: [i_brand_id#56, i_class_id#57, i_category_id#58, sales#68, number_sales#69, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#70]
-Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#70) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#70 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#49, [id=#50] as decimal(32,6))))
+(110) Filter [codegen id : 69]
+Input [6]: [i_brand_id#55, i_class_id#56, i_category_id#57, sales#67, number_sales#68, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#69]
+Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#69) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#69 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#48, [id=#49] as decimal(32,6))))
 
-(110) Project [codegen id : 89]
-Output [6]: [store AS channel#71, i_brand_id#56, i_class_id#57, i_category_id#58, sales#68, number_sales#69]
-Input [6]: [i_brand_id#56, i_class_id#57, i_category_id#58, sales#68, number_sales#69, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#70]
+(111) Project [codegen id : 69]
+Output [6]: [store AS channel#70, i_brand_id#55, i_class_id#56, i_category_id#57, sales#67, number_sales#68]
+Input [6]: [i_brand_id#55, i_class_id#56, i_category_id#57, sales#67, number_sales#68, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#69]
 
-(111) BroadcastExchange
-Input [6]: [channel#71, i_brand_id#56, i_class_id#57, i_category_id#58, sales#68, number_sales#69]
-Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, true], input[3, int, true]),false), [id=#72]
+(112) BroadcastExchange
+Input [6]: [channel#70, i_brand_id#55, i_class_id#56, i_category_id#57, sales#67, number_sales#68]
+Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, true], input[3, int, true]),false), [id=#71]
 
-(112) BroadcastHashJoin [codegen id : 90]
+(113) BroadcastHashJoin [codegen id : 70]
 Left keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
-Right keys [3]: [i_brand_id#56, i_class_id#57, i_category_id#58]
+Right keys [3]: [i_brand_id#55, i_class_id#56, i_category_id#57]
 Join condition: None
 
-(113) TakeOrderedAndProject
-Input [12]: [channel#51, i_brand_id#7, i_class_id#8, i_category_id#9, sales#46, number_sales#47, channel#71, i_brand_id#56, i_class_id#57, i_category_id#58, sales#68, number_sales#69]
-Arguments: 100, [i_brand_id#7 ASC NULLS FIRST, i_class_id#8 ASC NULLS FIRST, i_category_id#9 ASC NULLS FIRST], [channel#51, i_brand_id#7, i_class_id#8, i_category_id#9, sales#46, number_sales#47, channel#71, i_brand_id#56, i_class_id#57, i_category_id#58, sales#68, number_sales#69]
+(114) TakeOrderedAndProject
+Input [12]: [channel#50, i_brand_id#7, i_class_id#8, i_category_id#9, sales#45, number_sales#46, channel#70, i_brand_id#55, i_class_id#56, i_category_id#57, sales#67, number_sales#68]
+Arguments: 100, [i_brand_id#7 ASC NULLS FIRST, i_class_id#8 ASC NULLS FIRST, i_category_id#9 ASC NULLS FIRST], [channel#50, i_brand_id#7, i_class_id#8, i_category_id#9, sales#45, number_sales#46, channel#70, i_brand_id#55, i_class_id#56, i_category_id#57, sales#67, number_sales#68]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 89 Hosting Expression = Subquery scalar-subquery#49, [id=#50]
-* HashAggregate (139)
-+- Exchange (138)
-   +- * HashAggregate (137)
-      +- Union (136)
-         :- * Project (123)
-         :  +- * BroadcastHashJoin Inner BuildRight (122)
-         :     :- * Filter (116)
-         :     :  +- * ColumnarToRow (115)
-         :     :     +- Scan parquet default.store_sales (114)
-         :     +- BroadcastExchange (121)
-         :        +- * Project (120)
-         :           +- * Filter (119)
-         :              +- * ColumnarToRow (118)
-         :                 +- Scan parquet default.date_dim (117)
-         :- * Project (129)
-         :  +- * BroadcastHashJoin Inner BuildRight (128)
-         :     :- * Filter (126)
-         :     :  +- * ColumnarToRow (125)
-         :     :     +- Scan parquet default.catalog_sales (124)
-         :     +- ReusedExchange (127)
-         +- * Project (135)
-            +- * BroadcastHashJoin Inner BuildRight (134)
-               :- * Filter (132)
-               :  +- * ColumnarToRow (131)
-               :     +- Scan parquet default.web_sales (130)
-               +- ReusedExchange (133)
+Subquery:1 Hosting operator id = 90 Hosting Expression = Subquery scalar-subquery#48, [id=#49]
+* HashAggregate (140)
++- Exchange (139)
+   +- * HashAggregate (138)
+      +- Union (137)
+         :- * Project (124)
+         :  +- * BroadcastHashJoin Inner BuildRight (123)
+         :     :- * Filter (117)
+         :     :  +- * ColumnarToRow (116)
+         :     :     +- Scan parquet default.store_sales (115)
+         :     +- BroadcastExchange (122)
+         :        +- * Project (121)
+         :           +- * Filter (120)
+         :              +- * ColumnarToRow (119)
+         :                 +- Scan parquet default.date_dim (118)
+         :- * Project (130)
+         :  +- * BroadcastHashJoin Inner BuildRight (129)
+         :     :- * Filter (127)
+         :     :  +- * ColumnarToRow (126)
+         :     :     +- Scan parquet default.catalog_sales (125)
+         :     +- ReusedExchange (128)
+         +- * Project (136)
+            +- * BroadcastHashJoin Inner BuildRight (135)
+               :- * Filter (133)
+               :  +- * ColumnarToRow (132)
+               :     +- Scan parquet default.web_sales (131)
+               +- ReusedExchange (134)
 
 
-(114) Scan parquet default.store_sales
+(115) Scan parquet default.store_sales
 Output [3]: [ss_sold_date_sk#1, ss_quantity#3, ss_list_price#4]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_sold_date_sk)]
 ReadSchema: struct<ss_sold_date_sk:int,ss_quantity:int,ss_list_price:decimal(7,2)>
 
-(115) ColumnarToRow [codegen id : 2]
+(116) ColumnarToRow [codegen id : 2]
 Input [3]: [ss_sold_date_sk#1, ss_quantity#3, ss_list_price#4]
 
-(116) Filter [codegen id : 2]
+(117) Filter [codegen id : 2]
 Input [3]: [ss_sold_date_sk#1, ss_quantity#3, ss_list_price#4]
 Condition : isnotnull(ss_sold_date_sk#1)
 
-(117) Scan parquet default.date_dim
+(118) Scan parquet default.date_dim
 Output [2]: [d_date_sk#10, d_year#11]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), GreaterThanOrEqual(d_year,1999), LessThanOrEqual(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(118) ColumnarToRow [codegen id : 1]
+(119) ColumnarToRow [codegen id : 1]
 Input [2]: [d_date_sk#10, d_year#11]
 
-(119) Filter [codegen id : 1]
+(120) Filter [codegen id : 1]
 Input [2]: [d_date_sk#10, d_year#11]
 Condition : (((isnotnull(d_year#11) AND (d_year#11 >= 1999)) AND (d_year#11 <= 2001)) AND isnotnull(d_date_sk#10))
 
-(120) Project [codegen id : 1]
+(121) Project [codegen id : 1]
 Output [1]: [d_date_sk#10]
 Input [2]: [d_date_sk#10, d_year#11]
 
-(121) BroadcastExchange
+(122) BroadcastExchange
 Input [1]: [d_date_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#73]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#72]
 
-(122) BroadcastHashJoin [codegen id : 2]
+(123) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#1]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
-(123) Project [codegen id : 2]
-Output [2]: [ss_quantity#3 AS quantity#74, ss_list_price#4 AS list_price#75]
+(124) Project [codegen id : 2]
+Output [2]: [ss_quantity#3 AS quantity#73, ss_list_price#4 AS list_price#74]
 Input [4]: [ss_sold_date_sk#1, ss_quantity#3, ss_list_price#4, d_date_sk#10]
 
-(124) Scan parquet default.catalog_sales
-Output [3]: [cs_sold_date_sk#18, cs_quantity#76, cs_list_price#77]
+(125) Scan parquet default.catalog_sales
+Output [3]: [cs_sold_date_sk#18, cs_quantity#75, cs_list_price#76]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_sales]
 PushedFilters: [IsNotNull(cs_sold_date_sk)]
 ReadSchema: struct<cs_sold_date_sk:int,cs_quantity:int,cs_list_price:decimal(7,2)>
 
-(125) ColumnarToRow [codegen id : 4]
-Input [3]: [cs_sold_date_sk#18, cs_quantity#76, cs_list_price#77]
+(126) ColumnarToRow [codegen id : 4]
+Input [3]: [cs_sold_date_sk#18, cs_quantity#75, cs_list_price#76]
 
-(126) Filter [codegen id : 4]
-Input [3]: [cs_sold_date_sk#18, cs_quantity#76, cs_list_price#77]
+(127) Filter [codegen id : 4]
+Input [3]: [cs_sold_date_sk#18, cs_quantity#75, cs_list_price#76]
 Condition : isnotnull(cs_sold_date_sk#18)
 
-(127) ReusedExchange [Reuses operator id: 121]
+(128) ReusedExchange [Reuses operator id: 122]
 Output [1]: [d_date_sk#10]
 
-(128) BroadcastHashJoin [codegen id : 4]
+(129) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_sold_date_sk#18]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
-(129) Project [codegen id : 4]
-Output [2]: [cs_quantity#76 AS quantity#78, cs_list_price#77 AS list_price#79]
-Input [4]: [cs_sold_date_sk#18, cs_quantity#76, cs_list_price#77, d_date_sk#10]
+(130) Project [codegen id : 4]
+Output [2]: [cs_quantity#75 AS quantity#77, cs_list_price#76 AS list_price#78]
+Input [4]: [cs_sold_date_sk#18, cs_quantity#75, cs_list_price#76, d_date_sk#10]
 
-(130) Scan parquet default.web_sales
-Output [3]: [ws_sold_date_sk#24, ws_quantity#80, ws_list_price#81]
+(131) Scan parquet default.web_sales
+Output [3]: [ws_sold_date_sk#23, ws_quantity#79, ws_list_price#80]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_sales]
 PushedFilters: [IsNotNull(ws_sold_date_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_quantity:int,ws_list_price:decimal(7,2)>
 
-(131) ColumnarToRow [codegen id : 6]
-Input [3]: [ws_sold_date_sk#24, ws_quantity#80, ws_list_price#81]
+(132) ColumnarToRow [codegen id : 6]
+Input [3]: [ws_sold_date_sk#23, ws_quantity#79, ws_list_price#80]
 
-(132) Filter [codegen id : 6]
-Input [3]: [ws_sold_date_sk#24, ws_quantity#80, ws_list_price#81]
-Condition : isnotnull(ws_sold_date_sk#24)
+(133) Filter [codegen id : 6]
+Input [3]: [ws_sold_date_sk#23, ws_quantity#79, ws_list_price#80]
+Condition : isnotnull(ws_sold_date_sk#23)
 
-(133) ReusedExchange [Reuses operator id: 121]
+(134) ReusedExchange [Reuses operator id: 122]
 Output [1]: [d_date_sk#10]
 
-(134) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ws_sold_date_sk#24]
+(135) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [ws_sold_date_sk#23]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
-(135) Project [codegen id : 6]
-Output [2]: [ws_quantity#80 AS quantity#82, ws_list_price#81 AS list_price#83]
-Input [4]: [ws_sold_date_sk#24, ws_quantity#80, ws_list_price#81, d_date_sk#10]
+(136) Project [codegen id : 6]
+Output [2]: [ws_quantity#79 AS quantity#81, ws_list_price#80 AS list_price#82]
+Input [4]: [ws_sold_date_sk#23, ws_quantity#79, ws_list_price#80, d_date_sk#10]
 
-(136) Union
+(137) Union
 
-(137) HashAggregate [codegen id : 7]
-Input [2]: [quantity#74, list_price#75]
+(138) HashAggregate [codegen id : 7]
+Input [2]: [quantity#73, list_price#74]
 Keys: []
-Functions [1]: [partial_avg(CheckOverflow((promote_precision(cast(cast(quantity#74 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#75 as decimal(12,2)))), DecimalType(18,2), true))]
-Aggregate Attributes [2]: [sum#84, count#85]
-Results [2]: [sum#86, count#87]
+Functions [1]: [partial_avg(CheckOverflow((promote_precision(cast(cast(quantity#73 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#74 as decimal(12,2)))), DecimalType(18,2), true))]
+Aggregate Attributes [2]: [sum#83, count#84]
+Results [2]: [sum#85, count#86]
 
-(138) Exchange
-Input [2]: [sum#86, count#87]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#88]
+(139) Exchange
+Input [2]: [sum#85, count#86]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#87]
 
-(139) HashAggregate [codegen id : 8]
-Input [2]: [sum#86, count#87]
+(140) HashAggregate [codegen id : 8]
+Input [2]: [sum#85, count#86]
 Keys: []
-Functions [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#74 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#75 as decimal(12,2)))), DecimalType(18,2), true))]
-Aggregate Attributes [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#74 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#75 as decimal(12,2)))), DecimalType(18,2), true))#89]
-Results [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#74 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#75 as decimal(12,2)))), DecimalType(18,2), true))#89 AS average_sales#90]
+Functions [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#73 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#74 as decimal(12,2)))), DecimalType(18,2), true))]
+Aggregate Attributes [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#73 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#74 as decimal(12,2)))), DecimalType(18,2), true))#88]
+Results [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#73 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#74 as decimal(12,2)))), DecimalType(18,2), true))#88 AS average_sales#89]
 
-Subquery:2 Hosting operator id = 70 Hosting Expression = Subquery scalar-subquery#32, [id=#33]
-* Project (143)
-+- * Filter (142)
-   +- * ColumnarToRow (141)
-      +- Scan parquet default.date_dim (140)
+Subquery:2 Hosting operator id = 71 Hosting Expression = Subquery scalar-subquery#31, [id=#32]
+* Project (144)
++- * Filter (143)
+   +- * ColumnarToRow (142)
+      +- Scan parquet default.date_dim (141)
 
 
-(140) Scan parquet default.date_dim
-Output [4]: [d_week_seq#31, d_year#11, d_moy#91, d_dom#92]
+(141) Scan parquet default.date_dim
+Output [4]: [d_week_seq#30, d_year#11, d_moy#90, d_dom#91]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), IsNotNull(d_dom), EqualTo(d_year,2000), EqualTo(d_moy,12), EqualTo(d_dom,11)]
 ReadSchema: struct<d_week_seq:int,d_year:int,d_moy:int,d_dom:int>
 
-(141) ColumnarToRow [codegen id : 1]
-Input [4]: [d_week_seq#31, d_year#11, d_moy#91, d_dom#92]
+(142) ColumnarToRow [codegen id : 1]
+Input [4]: [d_week_seq#30, d_year#11, d_moy#90, d_dom#91]
 
-(142) Filter [codegen id : 1]
-Input [4]: [d_week_seq#31, d_year#11, d_moy#91, d_dom#92]
-Condition : (((((isnotnull(d_year#11) AND isnotnull(d_moy#91)) AND isnotnull(d_dom#92)) AND (d_year#11 = 2000)) AND (d_moy#91 = 12)) AND (d_dom#92 = 11))
+(143) Filter [codegen id : 1]
+Input [4]: [d_week_seq#30, d_year#11, d_moy#90, d_dom#91]
+Condition : (((((isnotnull(d_year#11) AND isnotnull(d_moy#90)) AND isnotnull(d_dom#91)) AND (d_year#11 = 2000)) AND (d_moy#90 = 12)) AND (d_dom#91 = 11))
 
-(143) Project [codegen id : 1]
-Output [1]: [d_week_seq#31]
-Input [4]: [d_week_seq#31, d_year#11, d_moy#91, d_dom#92]
+(144) Project [codegen id : 1]
+Output [1]: [d_week_seq#30]
+Input [4]: [d_week_seq#30, d_year#11, d_moy#90, d_dom#91]
 
-Subquery:3 Hosting operator id = 109 Hosting Expression = ReusedSubquery Subquery scalar-subquery#49, [id=#50]
+Subquery:3 Hosting operator id = 110 Hosting Expression = ReusedSubquery Subquery scalar-subquery#48, [id=#49]
 
-Subquery:4 Hosting operator id = 98 Hosting Expression = Subquery scalar-subquery#52, [id=#53]
-* Project (147)
-+- * Filter (146)
-   +- * ColumnarToRow (145)
-      +- Scan parquet default.date_dim (144)
+Subquery:4 Hosting operator id = 99 Hosting Expression = Subquery scalar-subquery#51, [id=#52]
+* Project (148)
++- * Filter (147)
+   +- * ColumnarToRow (146)
+      +- Scan parquet default.date_dim (145)
 
 
-(144) Scan parquet default.date_dim
-Output [4]: [d_week_seq#31, d_year#11, d_moy#91, d_dom#92]
+(145) Scan parquet default.date_dim
+Output [4]: [d_week_seq#30, d_year#11, d_moy#90, d_dom#91]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), IsNotNull(d_dom), EqualTo(d_year,1999), EqualTo(d_moy,12), EqualTo(d_dom,11)]
 ReadSchema: struct<d_week_seq:int,d_year:int,d_moy:int,d_dom:int>
 
-(145) ColumnarToRow [codegen id : 1]
-Input [4]: [d_week_seq#31, d_year#11, d_moy#91, d_dom#92]
+(146) ColumnarToRow [codegen id : 1]
+Input [4]: [d_week_seq#30, d_year#11, d_moy#90, d_dom#91]
 
-(146) Filter [codegen id : 1]
-Input [4]: [d_week_seq#31, d_year#11, d_moy#91, d_dom#92]
-Condition : (((((isnotnull(d_year#11) AND isnotnull(d_moy#91)) AND isnotnull(d_dom#92)) AND (d_year#11 = 1999)) AND (d_moy#91 = 12)) AND (d_dom#92 = 11))
+(147) Filter [codegen id : 1]
+Input [4]: [d_week_seq#30, d_year#11, d_moy#90, d_dom#91]
+Condition : (((((isnotnull(d_year#11) AND isnotnull(d_moy#90)) AND isnotnull(d_dom#91)) AND (d_year#11 = 1999)) AND (d_moy#90 = 12)) AND (d_dom#91 = 11))
 
-(147) Project [codegen id : 1]
-Output [1]: [d_week_seq#31]
-Input [4]: [d_week_seq#31, d_year#11, d_moy#91, d_dom#92]
+(148) Project [codegen id : 1]
+Output [1]: [d_week_seq#30]
+Input [4]: [d_week_seq#30, d_year#11, d_moy#90, d_dom#91]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b.sf100/simplified.txt
@@ -1,5 +1,5 @@
 TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_sales,channel,i_brand_id,i_class_id,i_category_id,sales,number_sales]
-  WholeStageCodegen (90)
+  WholeStageCodegen (70)
     BroadcastHashJoin [i_brand_id,i_class_id,i_category_id,i_brand_id,i_class_id,i_category_id]
       Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
         Filter [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true))]
@@ -7,7 +7,7 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
             WholeStageCodegen (8)
               HashAggregate [sum,count] [avg(CheckOverflow((promote_precision(cast(cast(quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price as decimal(12,2)))), DecimalType(18,2), true)),average_sales,sum,count]
                 InputAdapter
-                  Exchange #17
+                  Exchange #16
                     WholeStageCodegen (7)
                       HashAggregate [quantity,list_price] [sum,count,sum,count]
                         InputAdapter
@@ -20,7 +20,7 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                                       InputAdapter
                                         Scan parquet default.store_sales [ss_sold_date_sk,ss_quantity,ss_list_price]
                                   InputAdapter
-                                    BroadcastExchange #18
+                                    BroadcastExchange #17
                                       WholeStageCodegen (1)
                                         Project [d_date_sk]
                                           Filter [d_year,d_date_sk]
@@ -35,7 +35,7 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                                       InputAdapter
                                         Scan parquet default.catalog_sales [cs_sold_date_sk,cs_quantity,cs_list_price]
                                   InputAdapter
-                                    ReusedExchange [d_date_sk] #18
+                                    ReusedExchange [d_date_sk] #17
                             WholeStageCodegen (6)
                               Project [ws_quantity,ws_list_price]
                                 BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
@@ -44,11 +44,11 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                                       InputAdapter
                                         Scan parquet default.web_sales [ws_sold_date_sk,ws_quantity,ws_list_price]
                                   InputAdapter
-                                    ReusedExchange [d_date_sk] #18
+                                    ReusedExchange [d_date_sk] #17
           HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
             InputAdapter
               Exchange [i_brand_id,i_class_id,i_category_id] #1
-                WholeStageCodegen (44)
+                WholeStageCodegen (34)
                   HashAggregate [i_brand_id,i_class_id,i_category_id,ss_quantity,ss_list_price] [sum,isEmpty,count,sum,isEmpty,count]
                     Project [ss_quantity,ss_list_price,i_brand_id,i_class_id,i_category_id]
                       BroadcastHashJoin [ss_item_sk,i_item_sk]
@@ -65,11 +65,11 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                                             ColumnarToRow
                                               InputAdapter
                                                 Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk,ss_quantity,ss_list_price]
-                                WholeStageCodegen (21)
+                                WholeStageCodegen (16)
                                   Sort [ss_item_sk]
                                     InputAdapter
                                       Exchange [ss_item_sk] #3
-                                        WholeStageCodegen (20)
+                                        WholeStageCodegen (15)
                                           Project [i_item_sk]
                                             BroadcastHashJoin [i_brand_id,i_class_id,i_category_id,brand_id,class_id,category_id]
                                               Filter [i_brand_id,i_class_id,i_category_id]
@@ -78,96 +78,89 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                                                     Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
                                               InputAdapter
                                                 BroadcastExchange #4
-                                                  WholeStageCodegen (19)
+                                                  WholeStageCodegen (14)
                                                     HashAggregate [brand_id,class_id,category_id]
-                                                      InputAdapter
-                                                        Exchange [brand_id,class_id,category_id] #5
-                                                          WholeStageCodegen (18)
+                                                      HashAggregate [brand_id,class_id,category_id]
+                                                        BroadcastHashJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
+                                                          HashAggregate [brand_id,class_id,category_id]
                                                             HashAggregate [brand_id,class_id,category_id]
-                                                              InputAdapter
-                                                                SortMergeJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
-                                                                  WholeStageCodegen (13)
-                                                                    Sort [brand_id,class_id,category_id]
-                                                                      InputAdapter
-                                                                        Exchange [brand_id,class_id,category_id] #6
-                                                                          WholeStageCodegen (12)
-                                                                            HashAggregate [brand_id,class_id,category_id]
-                                                                              InputAdapter
-                                                                                Exchange [brand_id,class_id,category_id] #7
-                                                                                  WholeStageCodegen (11)
-                                                                                    HashAggregate [brand_id,class_id,category_id]
+                                                              BroadcastHashJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
+                                                                HashAggregate [brand_id,class_id,category_id]
+                                                                  InputAdapter
+                                                                    Exchange [brand_id,class_id,category_id] #5
+                                                                      WholeStageCodegen (5)
+                                                                        HashAggregate [brand_id,class_id,category_id]
+                                                                          Project [i_brand_id,i_class_id,i_category_id]
+                                                                            BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                                              Project [ss_item_sk]
+                                                                                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                                                  Filter [ss_item_sk,ss_sold_date_sk]
+                                                                                    ColumnarToRow
                                                                                       InputAdapter
-                                                                                        SortMergeJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
-                                                                                          WholeStageCodegen (6)
-                                                                                            Sort [brand_id,class_id,category_id]
+                                                                                        Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk]
+                                                                                  InputAdapter
+                                                                                    BroadcastExchange #6
+                                                                                      WholeStageCodegen (3)
+                                                                                        Project [d_date_sk]
+                                                                                          Filter [d_year,d_date_sk]
+                                                                                            ColumnarToRow
                                                                                               InputAdapter
-                                                                                                Exchange [brand_id,class_id,category_id] #8
-                                                                                                  WholeStageCodegen (5)
-                                                                                                    Project [i_brand_id,i_class_id,i_category_id]
-                                                                                                      BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                                                                        Project [ss_item_sk]
-                                                                                                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                                                            Filter [ss_item_sk,ss_sold_date_sk]
-                                                                                                              ColumnarToRow
-                                                                                                                InputAdapter
-                                                                                                                  Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk]
-                                                                                                            InputAdapter
-                                                                                                              BroadcastExchange #9
-                                                                                                                WholeStageCodegen (3)
-                                                                                                                  Project [d_date_sk]
-                                                                                                                    Filter [d_year,d_date_sk]
-                                                                                                                      ColumnarToRow
-                                                                                                                        InputAdapter
-                                                                                                                          Scan parquet default.date_dim [d_date_sk,d_year]
-                                                                                                        InputAdapter
-                                                                                                          BroadcastExchange #10
-                                                                                                            WholeStageCodegen (4)
-                                                                                                              Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                                                ColumnarToRow
-                                                                                                                  InputAdapter
-                                                                                                                    Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                          WholeStageCodegen (10)
-                                                                                            Sort [i_brand_id,i_class_id,i_category_id]
-                                                                                              InputAdapter
-                                                                                                Exchange [i_brand_id,i_class_id,i_category_id] #11
-                                                                                                  WholeStageCodegen (9)
-                                                                                                    Project [i_brand_id,i_class_id,i_category_id]
-                                                                                                      BroadcastHashJoin [cs_item_sk,i_item_sk]
-                                                                                                        Project [cs_item_sk]
-                                                                                                          BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                                                            Filter [cs_item_sk,cs_sold_date_sk]
-                                                                                                              ColumnarToRow
-                                                                                                                InputAdapter
-                                                                                                                  Scan parquet default.catalog_sales [cs_sold_date_sk,cs_item_sk]
-                                                                                                            InputAdapter
-                                                                                                              ReusedExchange [d_date_sk] #9
-                                                                                                        InputAdapter
-                                                                                                          BroadcastExchange #12
-                                                                                                            WholeStageCodegen (8)
-                                                                                                              Filter [i_item_sk]
-                                                                                                                ColumnarToRow
-                                                                                                                  InputAdapter
-                                                                                                                    Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                  WholeStageCodegen (17)
-                                                                    Sort [i_brand_id,i_class_id,i_category_id]
-                                                                      InputAdapter
-                                                                        Exchange [i_brand_id,i_class_id,i_category_id] #13
-                                                                          WholeStageCodegen (16)
-                                                                            Project [i_brand_id,i_class_id,i_category_id]
-                                                                              BroadcastHashJoin [ws_item_sk,i_item_sk]
-                                                                                Project [ws_item_sk]
-                                                                                  BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                                    Filter [ws_item_sk,ws_sold_date_sk]
+                                                                                                Scan parquet default.date_dim [d_date_sk,d_year]
+                                                                              InputAdapter
+                                                                                BroadcastExchange #7
+                                                                                  WholeStageCodegen (4)
+                                                                                    Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
                                                                                       ColumnarToRow
                                                                                         InputAdapter
-                                                                                          Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk]
+                                                                                          Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                InputAdapter
+                                                                  BroadcastExchange #8
+                                                                    WholeStageCodegen (9)
+                                                                      HashAggregate [i_brand_id,i_class_id,i_category_id]
+                                                                        InputAdapter
+                                                                          Exchange [i_brand_id,i_class_id,i_category_id] #9
+                                                                            WholeStageCodegen (8)
+                                                                              HashAggregate [i_brand_id,i_class_id,i_category_id]
+                                                                                Project [i_brand_id,i_class_id,i_category_id]
+                                                                                  BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                                                    Project [cs_item_sk]
+                                                                                      BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                                                        Filter [cs_item_sk,cs_sold_date_sk]
+                                                                                          ColumnarToRow
+                                                                                            InputAdapter
+                                                                                              Scan parquet default.catalog_sales [cs_sold_date_sk,cs_item_sk]
+                                                                                        InputAdapter
+                                                                                          ReusedExchange [d_date_sk] #6
                                                                                     InputAdapter
-                                                                                      ReusedExchange [d_date_sk] #9
-                                                                                InputAdapter
-                                                                                  ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #12
+                                                                                      BroadcastExchange #10
+                                                                                        WholeStageCodegen (7)
+                                                                                          Filter [i_item_sk]
+                                                                                            ColumnarToRow
+                                                                                              InputAdapter
+                                                                                                Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                          InputAdapter
+                                                            BroadcastExchange #11
+                                                              WholeStageCodegen (13)
+                                                                HashAggregate [i_brand_id,i_class_id,i_category_id]
+                                                                  InputAdapter
+                                                                    Exchange [i_brand_id,i_class_id,i_category_id] #12
+                                                                      WholeStageCodegen (12)
+                                                                        HashAggregate [i_brand_id,i_class_id,i_category_id]
+                                                                          Project [i_brand_id,i_class_id,i_category_id]
+                                                                            BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                                              Project [ws_item_sk]
+                                                                                BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                                                  Filter [ws_item_sk,ws_sold_date_sk]
+                                                                                    ColumnarToRow
+                                                                                      InputAdapter
+                                                                                        Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk]
+                                                                                  InputAdapter
+                                                                                    ReusedExchange [d_date_sk] #6
+                                                                              InputAdapter
+                                                                                ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #10
                             InputAdapter
-                              BroadcastExchange #14
-                                WholeStageCodegen (22)
+                              BroadcastExchange #13
+                                WholeStageCodegen (17)
                                   Project [d_date_sk]
                                     Filter [d_week_seq,d_date_sk]
                                       Subquery #1
@@ -181,31 +174,31 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                                         InputAdapter
                                           Scan parquet default.date_dim [d_date_sk,d_week_seq]
                         InputAdapter
-                          BroadcastExchange #15
+                          BroadcastExchange #14
                             SortMergeJoin [i_item_sk,ss_item_sk]
-                              WholeStageCodegen (24)
+                              WholeStageCodegen (19)
                                 Sort [i_item_sk]
                                   InputAdapter
-                                    Exchange [i_item_sk] #16
-                                      WholeStageCodegen (23)
+                                    Exchange [i_item_sk] #15
+                                      WholeStageCodegen (18)
                                         Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
                                           ColumnarToRow
                                             InputAdapter
                                               Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                              WholeStageCodegen (43)
+                              WholeStageCodegen (33)
                                 Sort [ss_item_sk]
                                   InputAdapter
                                     ReusedExchange [ss_item_sk] #3
       InputAdapter
-        BroadcastExchange #19
-          WholeStageCodegen (89)
+        BroadcastExchange #18
+          WholeStageCodegen (69)
             Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
               Filter [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true))]
                 ReusedSubquery [average_sales] #2
                 HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
                   InputAdapter
-                    Exchange [i_brand_id,i_class_id,i_category_id] #20
-                      WholeStageCodegen (88)
+                    Exchange [i_brand_id,i_class_id,i_category_id] #19
+                      WholeStageCodegen (68)
                         HashAggregate [i_brand_id,i_class_id,i_category_id,ss_quantity,ss_list_price] [sum,isEmpty,count,sum,isEmpty,count]
                           Project [ss_quantity,ss_list_price,i_brand_id,i_class_id,i_category_id]
                             BroadcastHashJoin [ss_item_sk,i_item_sk]
@@ -213,17 +206,17 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                                 BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                   InputAdapter
                                     SortMergeJoin [ss_item_sk,ss_item_sk]
-                                      WholeStageCodegen (46)
+                                      WholeStageCodegen (36)
                                         Sort [ss_item_sk]
                                           InputAdapter
                                             ReusedExchange [ss_sold_date_sk,ss_item_sk,ss_quantity,ss_list_price] #2
-                                      WholeStageCodegen (65)
+                                      WholeStageCodegen (50)
                                         Sort [ss_item_sk]
                                           InputAdapter
                                             ReusedExchange [ss_item_sk] #3
                                   InputAdapter
-                                    BroadcastExchange #21
-                                      WholeStageCodegen (66)
+                                    BroadcastExchange #20
+                                      WholeStageCodegen (51)
                                         Project [d_date_sk]
                                           Filter [d_week_seq,d_date_sk]
                                             Subquery #3
@@ -237,4 +230,4 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                                               InputAdapter
                                                 Scan parquet default.date_dim [d_date_sk,d_week_seq]
                               InputAdapter
-                                ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #15
+                                ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #14

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b/explain.txt
@@ -1,104 +1,112 @@
 == Physical Plan ==
-TakeOrderedAndProject (100)
-+- * BroadcastHashJoin Inner BuildRight (99)
-   :- * Project (77)
-   :  +- * Filter (76)
-   :     +- * HashAggregate (75)
-   :        +- Exchange (74)
-   :           +- * HashAggregate (73)
-   :              +- * Project (72)
-   :                 +- * BroadcastHashJoin Inner BuildRight (71)
-   :                    :- * Project (65)
-   :                    :  +- * BroadcastHashJoin Inner BuildRight (64)
-   :                    :     :- * BroadcastHashJoin LeftSemi BuildRight (57)
+TakeOrderedAndProject (108)
++- * BroadcastHashJoin Inner BuildRight (107)
+   :- * Project (85)
+   :  +- * Filter (84)
+   :     +- * HashAggregate (83)
+   :        +- Exchange (82)
+   :           +- * HashAggregate (81)
+   :              +- * Project (80)
+   :                 +- * BroadcastHashJoin Inner BuildRight (79)
+   :                    :- * Project (73)
+   :                    :  +- * BroadcastHashJoin Inner BuildRight (72)
+   :                    :     :- * BroadcastHashJoin LeftSemi BuildRight (65)
    :                    :     :  :- * Filter (3)
    :                    :     :  :  +- * ColumnarToRow (2)
    :                    :     :  :     +- Scan parquet default.store_sales (1)
-   :                    :     :  +- BroadcastExchange (56)
-   :                    :     :     +- * Project (55)
-   :                    :     :        +- * BroadcastHashJoin Inner BuildRight (54)
+   :                    :     :  +- BroadcastExchange (64)
+   :                    :     :     +- * Project (63)
+   :                    :     :        +- * BroadcastHashJoin Inner BuildRight (62)
    :                    :     :           :- * Filter (6)
    :                    :     :           :  +- * ColumnarToRow (5)
    :                    :     :           :     +- Scan parquet default.item (4)
-   :                    :     :           +- BroadcastExchange (53)
-   :                    :     :              +- * HashAggregate (52)
-   :                    :     :                 +- * HashAggregate (51)
-   :                    :     :                    +- * HashAggregate (50)
-   :                    :     :                       +- Exchange (49)
-   :                    :     :                          +- * HashAggregate (48)
-   :                    :     :                             +- * BroadcastHashJoin LeftSemi BuildRight (47)
-   :                    :     :                                :- * BroadcastHashJoin LeftSemi BuildRight (36)
-   :                    :     :                                :  :- * Project (22)
-   :                    :     :                                :  :  +- * BroadcastHashJoin Inner BuildRight (21)
-   :                    :     :                                :  :     :- * Project (15)
-   :                    :     :                                :  :     :  +- * BroadcastHashJoin Inner BuildRight (14)
-   :                    :     :                                :  :     :     :- * Filter (9)
-   :                    :     :                                :  :     :     :  +- * ColumnarToRow (8)
-   :                    :     :                                :  :     :     :     +- Scan parquet default.store_sales (7)
-   :                    :     :                                :  :     :     +- BroadcastExchange (13)
-   :                    :     :                                :  :     :        +- * Filter (12)
-   :                    :     :                                :  :     :           +- * ColumnarToRow (11)
-   :                    :     :                                :  :     :              +- Scan parquet default.item (10)
-   :                    :     :                                :  :     +- BroadcastExchange (20)
-   :                    :     :                                :  :        +- * Project (19)
-   :                    :     :                                :  :           +- * Filter (18)
-   :                    :     :                                :  :              +- * ColumnarToRow (17)
-   :                    :     :                                :  :                 +- Scan parquet default.date_dim (16)
-   :                    :     :                                :  +- BroadcastExchange (35)
-   :                    :     :                                :     +- * Project (34)
-   :                    :     :                                :        +- * BroadcastHashJoin Inner BuildRight (33)
-   :                    :     :                                :           :- * Project (31)
-   :                    :     :                                :           :  +- * BroadcastHashJoin Inner BuildRight (30)
-   :                    :     :                                :           :     :- * Filter (25)
-   :                    :     :                                :           :     :  +- * ColumnarToRow (24)
-   :                    :     :                                :           :     :     +- Scan parquet default.catalog_sales (23)
-   :                    :     :                                :           :     +- BroadcastExchange (29)
-   :                    :     :                                :           :        +- * Filter (28)
-   :                    :     :                                :           :           +- * ColumnarToRow (27)
-   :                    :     :                                :           :              +- Scan parquet default.item (26)
-   :                    :     :                                :           +- ReusedExchange (32)
-   :                    :     :                                +- BroadcastExchange (46)
-   :                    :     :                                   +- * Project (45)
-   :                    :     :                                      +- * BroadcastHashJoin Inner BuildRight (44)
-   :                    :     :                                         :- * Project (42)
-   :                    :     :                                         :  +- * BroadcastHashJoin Inner BuildRight (41)
-   :                    :     :                                         :     :- * Filter (39)
-   :                    :     :                                         :     :  +- * ColumnarToRow (38)
-   :                    :     :                                         :     :     +- Scan parquet default.web_sales (37)
-   :                    :     :                                         :     +- ReusedExchange (40)
-   :                    :     :                                         +- ReusedExchange (43)
-   :                    :     +- BroadcastExchange (63)
-   :                    :        +- * BroadcastHashJoin LeftSemi BuildRight (62)
-   :                    :           :- * Filter (60)
-   :                    :           :  +- * ColumnarToRow (59)
-   :                    :           :     +- Scan parquet default.item (58)
-   :                    :           +- ReusedExchange (61)
-   :                    +- BroadcastExchange (70)
-   :                       +- * Project (69)
-   :                          +- * Filter (68)
-   :                             +- * ColumnarToRow (67)
-   :                                +- Scan parquet default.date_dim (66)
-   +- BroadcastExchange (98)
-      +- * Project (97)
-         +- * Filter (96)
-            +- * HashAggregate (95)
-               +- Exchange (94)
-                  +- * HashAggregate (93)
-                     +- * Project (92)
-                        +- * BroadcastHashJoin Inner BuildRight (91)
-                           :- * Project (85)
-                           :  +- * BroadcastHashJoin Inner BuildRight (84)
-                           :     :- * BroadcastHashJoin LeftSemi BuildRight (82)
-                           :     :  :- * Filter (80)
-                           :     :  :  +- * ColumnarToRow (79)
-                           :     :  :     +- Scan parquet default.store_sales (78)
-                           :     :  +- ReusedExchange (81)
-                           :     +- ReusedExchange (83)
-                           +- BroadcastExchange (90)
-                              +- * Project (89)
-                                 +- * Filter (88)
-                                    +- * ColumnarToRow (87)
-                                       +- Scan parquet default.date_dim (86)
+   :                    :     :           +- BroadcastExchange (61)
+   :                    :     :              +- * HashAggregate (60)
+   :                    :     :                 +- * HashAggregate (59)
+   :                    :     :                    +- * BroadcastHashJoin LeftSemi BuildRight (58)
+   :                    :     :                       :- * HashAggregate (44)
+   :                    :     :                       :  +- * HashAggregate (43)
+   :                    :     :                       :     +- * BroadcastHashJoin LeftSemi BuildRight (42)
+   :                    :     :                       :        :- * HashAggregate (25)
+   :                    :     :                       :        :  +- Exchange (24)
+   :                    :     :                       :        :     +- * HashAggregate (23)
+   :                    :     :                       :        :        +- * Project (22)
+   :                    :     :                       :        :           +- * BroadcastHashJoin Inner BuildRight (21)
+   :                    :     :                       :        :              :- * Project (15)
+   :                    :     :                       :        :              :  +- * BroadcastHashJoin Inner BuildRight (14)
+   :                    :     :                       :        :              :     :- * Filter (9)
+   :                    :     :                       :        :              :     :  +- * ColumnarToRow (8)
+   :                    :     :                       :        :              :     :     +- Scan parquet default.store_sales (7)
+   :                    :     :                       :        :              :     +- BroadcastExchange (13)
+   :                    :     :                       :        :              :        +- * Filter (12)
+   :                    :     :                       :        :              :           +- * ColumnarToRow (11)
+   :                    :     :                       :        :              :              +- Scan parquet default.item (10)
+   :                    :     :                       :        :              +- BroadcastExchange (20)
+   :                    :     :                       :        :                 +- * Project (19)
+   :                    :     :                       :        :                    +- * Filter (18)
+   :                    :     :                       :        :                       +- * ColumnarToRow (17)
+   :                    :     :                       :        :                          +- Scan parquet default.date_dim (16)
+   :                    :     :                       :        +- BroadcastExchange (41)
+   :                    :     :                       :           +- * HashAggregate (40)
+   :                    :     :                       :              +- Exchange (39)
+   :                    :     :                       :                 +- * HashAggregate (38)
+   :                    :     :                       :                    +- * Project (37)
+   :                    :     :                       :                       +- * BroadcastHashJoin Inner BuildRight (36)
+   :                    :     :                       :                          :- * Project (34)
+   :                    :     :                       :                          :  +- * BroadcastHashJoin Inner BuildRight (33)
+   :                    :     :                       :                          :     :- * Filter (28)
+   :                    :     :                       :                          :     :  +- * ColumnarToRow (27)
+   :                    :     :                       :                          :     :     +- Scan parquet default.catalog_sales (26)
+   :                    :     :                       :                          :     +- BroadcastExchange (32)
+   :                    :     :                       :                          :        +- * Filter (31)
+   :                    :     :                       :                          :           +- * ColumnarToRow (30)
+   :                    :     :                       :                          :              +- Scan parquet default.item (29)
+   :                    :     :                       :                          +- ReusedExchange (35)
+   :                    :     :                       +- BroadcastExchange (57)
+   :                    :     :                          +- * HashAggregate (56)
+   :                    :     :                             +- Exchange (55)
+   :                    :     :                                +- * HashAggregate (54)
+   :                    :     :                                   +- * Project (53)
+   :                    :     :                                      +- * BroadcastHashJoin Inner BuildRight (52)
+   :                    :     :                                         :- * Project (50)
+   :                    :     :                                         :  +- * BroadcastHashJoin Inner BuildRight (49)
+   :                    :     :                                         :     :- * Filter (47)
+   :                    :     :                                         :     :  +- * ColumnarToRow (46)
+   :                    :     :                                         :     :     +- Scan parquet default.web_sales (45)
+   :                    :     :                                         :     +- ReusedExchange (48)
+   :                    :     :                                         +- ReusedExchange (51)
+   :                    :     +- BroadcastExchange (71)
+   :                    :        +- * BroadcastHashJoin LeftSemi BuildRight (70)
+   :                    :           :- * Filter (68)
+   :                    :           :  +- * ColumnarToRow (67)
+   :                    :           :     +- Scan parquet default.item (66)
+   :                    :           +- ReusedExchange (69)
+   :                    +- BroadcastExchange (78)
+   :                       +- * Project (77)
+   :                          +- * Filter (76)
+   :                             +- * ColumnarToRow (75)
+   :                                +- Scan parquet default.date_dim (74)
+   +- BroadcastExchange (106)
+      +- * Project (105)
+         +- * Filter (104)
+            +- * HashAggregate (103)
+               +- Exchange (102)
+                  +- * HashAggregate (101)
+                     +- * Project (100)
+                        +- * BroadcastHashJoin Inner BuildRight (99)
+                           :- * Project (93)
+                           :  +- * BroadcastHashJoin Inner BuildRight (92)
+                           :     :- * BroadcastHashJoin LeftSemi BuildRight (90)
+                           :     :  :- * Filter (88)
+                           :     :  :  +- * ColumnarToRow (87)
+                           :     :  :     +- Scan parquet default.store_sales (86)
+                           :     :  +- ReusedExchange (89)
+                           :     +- ReusedExchange (91)
+                           +- BroadcastExchange (98)
+                              +- * Project (97)
+                                 +- * Filter (96)
+                                    +- * ColumnarToRow (95)
+                                       +- Scan parquet default.date_dim (94)
 
 
 (1) Scan parquet default.store_sales
@@ -108,10 +116,10 @@ Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_sold_date_sk)]
 ReadSchema: struct<ss_sold_date_sk:int,ss_item_sk:int,ss_quantity:int,ss_list_price:decimal(7,2)>
 
-(2) ColumnarToRow [codegen id : 25]
+(2) ColumnarToRow [codegen id : 29]
 Input [4]: [ss_sold_date_sk#1, ss_item_sk#2, ss_quantity#3, ss_list_price#4]
 
-(3) Filter [codegen id : 25]
+(3) Filter [codegen id : 29]
 Input [4]: [ss_sold_date_sk#1, ss_item_sk#2, ss_quantity#3, ss_list_price#4]
 Condition : (isnotnull(ss_item_sk#2) AND isnotnull(ss_sold_date_sk#1))
 
@@ -122,10 +130,10 @@ Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_brand_id), IsNotNull(i_class_id), IsNotNull(i_category_id)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(5) ColumnarToRow [codegen id : 11]
+(5) ColumnarToRow [codegen id : 13]
 Input [4]: [i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
 
-(6) Filter [codegen id : 11]
+(6) Filter [codegen id : 13]
 Input [4]: [i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
 Condition : ((isnotnull(i_brand_id#6) AND isnotnull(i_class_id#7)) AND isnotnull(i_category_id#8))
 
@@ -136,10 +144,10 @@ Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_sold_date_sk)]
 ReadSchema: struct<ss_sold_date_sk:int,ss_item_sk:int>
 
-(8) ColumnarToRow [codegen id : 9]
+(8) ColumnarToRow [codegen id : 3]
 Input [2]: [ss_sold_date_sk#1, ss_item_sk#2]
 
-(9) Filter [codegen id : 9]
+(9) Filter [codegen id : 3]
 Input [2]: [ss_sold_date_sk#1, ss_item_sk#2]
 Condition : (isnotnull(ss_item_sk#2) AND isnotnull(ss_sold_date_sk#1))
 
@@ -161,12 +169,12 @@ Condition : (((isnotnull(i_item_sk#5) AND isnotnull(i_brand_id#6)) AND isnotnull
 Input [4]: [i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#9]
 
-(14) BroadcastHashJoin [codegen id : 9]
+(14) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#2]
 Right keys [1]: [i_item_sk#5]
 Join condition: None
 
-(15) Project [codegen id : 9]
+(15) Project [codegen id : 3]
 Output [4]: [ss_sold_date_sk#1, i_brand_id#6, i_class_id#7, i_category_id#8]
 Input [6]: [ss_sold_date_sk#1, ss_item_sk#2, i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
 
@@ -192,572 +200,622 @@ Input [2]: [d_date_sk#10, d_year#11]
 Input [1]: [d_date_sk#10]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#12]
 
-(21) BroadcastHashJoin [codegen id : 9]
+(21) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#1]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
-(22) Project [codegen id : 9]
+(22) Project [codegen id : 3]
 Output [3]: [i_brand_id#6 AS brand_id#13, i_class_id#7 AS class_id#14, i_category_id#8 AS category_id#15]
 Input [5]: [ss_sold_date_sk#1, i_brand_id#6, i_class_id#7, i_category_id#8, d_date_sk#10]
 
-(23) Scan parquet default.catalog_sales
-Output [2]: [cs_sold_date_sk#16, cs_item_sk#17]
+(23) HashAggregate [codegen id : 3]
+Input [3]: [brand_id#13, class_id#14, category_id#15]
+Keys [3]: [brand_id#13, class_id#14, category_id#15]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [brand_id#13, class_id#14, category_id#15]
+
+(24) Exchange
+Input [3]: [brand_id#13, class_id#14, category_id#15]
+Arguments: hashpartitioning(brand_id#13, class_id#14, category_id#15, 5), ENSURE_REQUIREMENTS, [id=#16]
+
+(25) HashAggregate [codegen id : 12]
+Input [3]: [brand_id#13, class_id#14, category_id#15]
+Keys [3]: [brand_id#13, class_id#14, category_id#15]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [brand_id#13, class_id#14, category_id#15]
+
+(26) Scan parquet default.catalog_sales
+Output [2]: [cs_sold_date_sk#17, cs_item_sk#18]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_sales]
 PushedFilters: [IsNotNull(cs_item_sk), IsNotNull(cs_sold_date_sk)]
 ReadSchema: struct<cs_sold_date_sk:int,cs_item_sk:int>
 
-(24) ColumnarToRow [codegen id : 5]
-Input [2]: [cs_sold_date_sk#16, cs_item_sk#17]
+(27) ColumnarToRow [codegen id : 6]
+Input [2]: [cs_sold_date_sk#17, cs_item_sk#18]
 
-(25) Filter [codegen id : 5]
-Input [2]: [cs_sold_date_sk#16, cs_item_sk#17]
-Condition : (isnotnull(cs_item_sk#17) AND isnotnull(cs_sold_date_sk#16))
+(28) Filter [codegen id : 6]
+Input [2]: [cs_sold_date_sk#17, cs_item_sk#18]
+Condition : (isnotnull(cs_item_sk#18) AND isnotnull(cs_sold_date_sk#17))
 
-(26) Scan parquet default.item
+(29) Scan parquet default.item
 Output [4]: [i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(27) ColumnarToRow [codegen id : 3]
+(30) ColumnarToRow [codegen id : 4]
 Input [4]: [i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
 
-(28) Filter [codegen id : 3]
+(31) Filter [codegen id : 4]
 Input [4]: [i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
 Condition : isnotnull(i_item_sk#5)
 
-(29) BroadcastExchange
+(32) BroadcastExchange
 Input [4]: [i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#19]
 
-(30) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [cs_item_sk#17]
+(33) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [cs_item_sk#18]
 Right keys [1]: [i_item_sk#5]
 Join condition: None
 
-(31) Project [codegen id : 5]
-Output [4]: [cs_sold_date_sk#16, i_brand_id#6, i_class_id#7, i_category_id#8]
-Input [6]: [cs_sold_date_sk#16, cs_item_sk#17, i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
+(34) Project [codegen id : 6]
+Output [4]: [cs_sold_date_sk#17, i_brand_id#6, i_class_id#7, i_category_id#8]
+Input [6]: [cs_sold_date_sk#17, cs_item_sk#18, i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
 
-(32) ReusedExchange [Reuses operator id: 20]
+(35) ReusedExchange [Reuses operator id: 20]
 Output [1]: [d_date_sk#10]
 
-(33) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [cs_sold_date_sk#16]
+(36) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [cs_sold_date_sk#17]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
-(34) Project [codegen id : 5]
+(37) Project [codegen id : 6]
 Output [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
-Input [5]: [cs_sold_date_sk#16, i_brand_id#6, i_class_id#7, i_category_id#8, d_date_sk#10]
+Input [5]: [cs_sold_date_sk#17, i_brand_id#6, i_class_id#7, i_category_id#8, d_date_sk#10]
 
-(35) BroadcastExchange
+(38) HashAggregate [codegen id : 6]
 Input [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
-Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true]), coalesce(input[1, int, true], 0), isnull(input[1, int, true]), coalesce(input[2, int, true], 0), isnull(input[2, int, true])),false), [id=#19]
+Keys [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
 
-(36) BroadcastHashJoin [codegen id : 9]
+(39) Exchange
+Input [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
+Arguments: hashpartitioning(i_brand_id#6, i_class_id#7, i_category_id#8, 5), ENSURE_REQUIREMENTS, [id=#20]
+
+(40) HashAggregate [codegen id : 7]
+Input [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
+Keys [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
+
+(41) BroadcastExchange
+Input [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
+Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true]), coalesce(input[1, int, true], 0), isnull(input[1, int, true]), coalesce(input[2, int, true], 0), isnull(input[2, int, true])),false), [id=#21]
+
+(42) BroadcastHashJoin [codegen id : 12]
 Left keys [6]: [coalesce(brand_id#13, 0), isnull(brand_id#13), coalesce(class_id#14, 0), isnull(class_id#14), coalesce(category_id#15, 0), isnull(category_id#15)]
 Right keys [6]: [coalesce(i_brand_id#6, 0), isnull(i_brand_id#6), coalesce(i_class_id#7, 0), isnull(i_class_id#7), coalesce(i_category_id#8, 0), isnull(i_category_id#8)]
 Join condition: None
 
-(37) Scan parquet default.web_sales
-Output [2]: [ws_sold_date_sk#20, ws_item_sk#21]
+(43) HashAggregate [codegen id : 12]
+Input [3]: [brand_id#13, class_id#14, category_id#15]
+Keys [3]: [brand_id#13, class_id#14, category_id#15]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [brand_id#13, class_id#14, category_id#15]
+
+(44) HashAggregate [codegen id : 12]
+Input [3]: [brand_id#13, class_id#14, category_id#15]
+Keys [3]: [brand_id#13, class_id#14, category_id#15]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [brand_id#13, class_id#14, category_id#15]
+
+(45) Scan parquet default.web_sales
+Output [2]: [ws_sold_date_sk#22, ws_item_sk#23]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_sales]
 PushedFilters: [IsNotNull(ws_item_sk), IsNotNull(ws_sold_date_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_item_sk:int>
 
-(38) ColumnarToRow [codegen id : 8]
-Input [2]: [ws_sold_date_sk#20, ws_item_sk#21]
+(46) ColumnarToRow [codegen id : 10]
+Input [2]: [ws_sold_date_sk#22, ws_item_sk#23]
 
-(39) Filter [codegen id : 8]
-Input [2]: [ws_sold_date_sk#20, ws_item_sk#21]
-Condition : (isnotnull(ws_item_sk#21) AND isnotnull(ws_sold_date_sk#20))
+(47) Filter [codegen id : 10]
+Input [2]: [ws_sold_date_sk#22, ws_item_sk#23]
+Condition : (isnotnull(ws_item_sk#23) AND isnotnull(ws_sold_date_sk#22))
 
-(40) ReusedExchange [Reuses operator id: 29]
+(48) ReusedExchange [Reuses operator id: 32]
 Output [4]: [i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
 
-(41) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [ws_item_sk#21]
+(49) BroadcastHashJoin [codegen id : 10]
+Left keys [1]: [ws_item_sk#23]
 Right keys [1]: [i_item_sk#5]
 Join condition: None
 
-(42) Project [codegen id : 8]
-Output [4]: [ws_sold_date_sk#20, i_brand_id#6, i_class_id#7, i_category_id#8]
-Input [6]: [ws_sold_date_sk#20, ws_item_sk#21, i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
+(50) Project [codegen id : 10]
+Output [4]: [ws_sold_date_sk#22, i_brand_id#6, i_class_id#7, i_category_id#8]
+Input [6]: [ws_sold_date_sk#22, ws_item_sk#23, i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
 
-(43) ReusedExchange [Reuses operator id: 20]
+(51) ReusedExchange [Reuses operator id: 20]
 Output [1]: [d_date_sk#10]
 
-(44) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [ws_sold_date_sk#20]
+(52) BroadcastHashJoin [codegen id : 10]
+Left keys [1]: [ws_sold_date_sk#22]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
-(45) Project [codegen id : 8]
+(53) Project [codegen id : 10]
 Output [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
-Input [5]: [ws_sold_date_sk#20, i_brand_id#6, i_class_id#7, i_category_id#8, d_date_sk#10]
+Input [5]: [ws_sold_date_sk#22, i_brand_id#6, i_class_id#7, i_category_id#8, d_date_sk#10]
 
-(46) BroadcastExchange
+(54) HashAggregate [codegen id : 10]
 Input [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
-Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true]), coalesce(input[1, int, true], 0), isnull(input[1, int, true]), coalesce(input[2, int, true], 0), isnull(input[2, int, true])),false), [id=#22]
+Keys [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
 
-(47) BroadcastHashJoin [codegen id : 9]
+(55) Exchange
+Input [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
+Arguments: hashpartitioning(i_brand_id#6, i_class_id#7, i_category_id#8, 5), ENSURE_REQUIREMENTS, [id=#24]
+
+(56) HashAggregate [codegen id : 11]
+Input [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
+Keys [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
+
+(57) BroadcastExchange
+Input [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
+Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true]), coalesce(input[1, int, true], 0), isnull(input[1, int, true]), coalesce(input[2, int, true], 0), isnull(input[2, int, true])),false), [id=#25]
+
+(58) BroadcastHashJoin [codegen id : 12]
 Left keys [6]: [coalesce(brand_id#13, 0), isnull(brand_id#13), coalesce(class_id#14, 0), isnull(class_id#14), coalesce(category_id#15, 0), isnull(category_id#15)]
 Right keys [6]: [coalesce(i_brand_id#6, 0), isnull(i_brand_id#6), coalesce(i_class_id#7, 0), isnull(i_class_id#7), coalesce(i_category_id#8, 0), isnull(i_category_id#8)]
 Join condition: None
 
-(48) HashAggregate [codegen id : 9]
+(59) HashAggregate [codegen id : 12]
 Input [3]: [brand_id#13, class_id#14, category_id#15]
 Keys [3]: [brand_id#13, class_id#14, category_id#15]
 Functions: []
 Aggregate Attributes: []
 Results [3]: [brand_id#13, class_id#14, category_id#15]
 
-(49) Exchange
-Input [3]: [brand_id#13, class_id#14, category_id#15]
-Arguments: hashpartitioning(brand_id#13, class_id#14, category_id#15, 5), true, [id=#23]
-
-(50) HashAggregate [codegen id : 10]
+(60) HashAggregate [codegen id : 12]
 Input [3]: [brand_id#13, class_id#14, category_id#15]
 Keys [3]: [brand_id#13, class_id#14, category_id#15]
 Functions: []
 Aggregate Attributes: []
 Results [3]: [brand_id#13, class_id#14, category_id#15]
 
-(51) HashAggregate [codegen id : 10]
+(61) BroadcastExchange
 Input [3]: [brand_id#13, class_id#14, category_id#15]
-Keys [3]: [brand_id#13, class_id#14, category_id#15]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [brand_id#13, class_id#14, category_id#15]
+Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false), [id=#26]
 
-(52) HashAggregate [codegen id : 10]
-Input [3]: [brand_id#13, class_id#14, category_id#15]
-Keys [3]: [brand_id#13, class_id#14, category_id#15]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [brand_id#13, class_id#14, category_id#15]
-
-(53) BroadcastExchange
-Input [3]: [brand_id#13, class_id#14, category_id#15]
-Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false), [id=#24]
-
-(54) BroadcastHashJoin [codegen id : 11]
+(62) BroadcastHashJoin [codegen id : 13]
 Left keys [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
 Right keys [3]: [brand_id#13, class_id#14, category_id#15]
 Join condition: None
 
-(55) Project [codegen id : 11]
-Output [1]: [i_item_sk#5 AS ss_item_sk#25]
+(63) Project [codegen id : 13]
+Output [1]: [i_item_sk#5 AS ss_item_sk#27]
 Input [7]: [i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8, brand_id#13, class_id#14, category_id#15]
 
-(56) BroadcastExchange
-Input [1]: [ss_item_sk#25]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#26]
+(64) BroadcastExchange
+Input [1]: [ss_item_sk#27]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#28]
 
-(57) BroadcastHashJoin [codegen id : 25]
+(65) BroadcastHashJoin [codegen id : 29]
 Left keys [1]: [ss_item_sk#2]
-Right keys [1]: [ss_item_sk#25]
+Right keys [1]: [ss_item_sk#27]
 Join condition: None
 
-(58) Scan parquet default.item
+(66) Scan parquet default.item
 Output [4]: [i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk), IsNotNull(i_brand_id), IsNotNull(i_class_id), IsNotNull(i_category_id)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(59) ColumnarToRow [codegen id : 23]
+(67) ColumnarToRow [codegen id : 27]
 Input [4]: [i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
 
-(60) Filter [codegen id : 23]
+(68) Filter [codegen id : 27]
 Input [4]: [i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
 Condition : (((isnotnull(i_item_sk#5) AND isnotnull(i_brand_id#6)) AND isnotnull(i_class_id#7)) AND isnotnull(i_category_id#8))
 
-(61) ReusedExchange [Reuses operator id: 56]
-Output [1]: [ss_item_sk#25]
+(69) ReusedExchange [Reuses operator id: 64]
+Output [1]: [ss_item_sk#27]
 
-(62) BroadcastHashJoin [codegen id : 23]
+(70) BroadcastHashJoin [codegen id : 27]
 Left keys [1]: [i_item_sk#5]
-Right keys [1]: [ss_item_sk#25]
+Right keys [1]: [ss_item_sk#27]
 Join condition: None
 
-(63) BroadcastExchange
+(71) BroadcastExchange
 Input [4]: [i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#27]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#29]
 
-(64) BroadcastHashJoin [codegen id : 25]
+(72) BroadcastHashJoin [codegen id : 29]
 Left keys [1]: [ss_item_sk#2]
 Right keys [1]: [i_item_sk#5]
 Join condition: None
 
-(65) Project [codegen id : 25]
+(73) Project [codegen id : 29]
 Output [6]: [ss_sold_date_sk#1, ss_quantity#3, ss_list_price#4, i_brand_id#6, i_class_id#7, i_category_id#8]
 Input [8]: [ss_sold_date_sk#1, ss_item_sk#2, ss_quantity#3, ss_list_price#4, i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
 
-(66) Scan parquet default.date_dim
-Output [2]: [d_date_sk#10, d_week_seq#28]
+(74) Scan parquet default.date_dim
+Output [2]: [d_date_sk#10, d_week_seq#30]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_week_seq), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int>
 
-(67) ColumnarToRow [codegen id : 24]
-Input [2]: [d_date_sk#10, d_week_seq#28]
+(75) ColumnarToRow [codegen id : 28]
+Input [2]: [d_date_sk#10, d_week_seq#30]
 
-(68) Filter [codegen id : 24]
-Input [2]: [d_date_sk#10, d_week_seq#28]
-Condition : ((isnotnull(d_week_seq#28) AND (d_week_seq#28 = Subquery scalar-subquery#29, [id=#30])) AND isnotnull(d_date_sk#10))
+(76) Filter [codegen id : 28]
+Input [2]: [d_date_sk#10, d_week_seq#30]
+Condition : ((isnotnull(d_week_seq#30) AND (d_week_seq#30 = Subquery scalar-subquery#31, [id=#32])) AND isnotnull(d_date_sk#10))
 
-(69) Project [codegen id : 24]
+(77) Project [codegen id : 28]
 Output [1]: [d_date_sk#10]
-Input [2]: [d_date_sk#10, d_week_seq#28]
+Input [2]: [d_date_sk#10, d_week_seq#30]
 
-(70) BroadcastExchange
+(78) BroadcastExchange
 Input [1]: [d_date_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#31]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#33]
 
-(71) BroadcastHashJoin [codegen id : 25]
+(79) BroadcastHashJoin [codegen id : 29]
 Left keys [1]: [ss_sold_date_sk#1]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
-(72) Project [codegen id : 25]
+(80) Project [codegen id : 29]
 Output [5]: [ss_quantity#3, ss_list_price#4, i_brand_id#6, i_class_id#7, i_category_id#8]
 Input [7]: [ss_sold_date_sk#1, ss_quantity#3, ss_list_price#4, i_brand_id#6, i_class_id#7, i_category_id#8, d_date_sk#10]
 
-(73) HashAggregate [codegen id : 25]
+(81) HashAggregate [codegen id : 29]
 Input [5]: [ss_quantity#3, ss_list_price#4, i_brand_id#6, i_class_id#7, i_category_id#8]
 Keys [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
 Functions [2]: [partial_sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true)), partial_count(1)]
-Aggregate Attributes [3]: [sum#32, isEmpty#33, count#34]
-Results [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#35, isEmpty#36, count#37]
+Aggregate Attributes [3]: [sum#34, isEmpty#35, count#36]
+Results [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#37, isEmpty#38, count#39]
 
-(74) Exchange
-Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#35, isEmpty#36, count#37]
-Arguments: hashpartitioning(i_brand_id#6, i_class_id#7, i_category_id#8, 5), true, [id=#38]
+(82) Exchange
+Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#37, isEmpty#38, count#39]
+Arguments: hashpartitioning(i_brand_id#6, i_class_id#7, i_category_id#8, 5), ENSURE_REQUIREMENTS, [id=#40]
 
-(75) HashAggregate [codegen id : 52]
-Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#35, isEmpty#36, count#37]
+(83) HashAggregate [codegen id : 60]
+Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#37, isEmpty#38, count#39]
 Keys [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
 Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#39, count(1)#40]
-Results [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#39 AS sales#41, count(1)#40 AS number_sales#42, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#39 AS sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#43]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#41, count(1)#42]
+Results [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#41 AS sales#43, count(1)#42 AS number_sales#44, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#41 AS sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#45]
 
-(76) Filter [codegen id : 52]
-Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#41, number_sales#42, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#43]
-Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#43) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#43 as decimal(32,6)) > cast(Subquery scalar-subquery#44, [id=#45] as decimal(32,6))))
+(84) Filter [codegen id : 60]
+Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#43, number_sales#44, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#45]
+Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#45) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#45 as decimal(32,6)) > cast(Subquery scalar-subquery#46, [id=#47] as decimal(32,6))))
 
-(77) Project [codegen id : 52]
-Output [6]: [store AS channel#46, i_brand_id#6, i_class_id#7, i_category_id#8, sales#41, number_sales#42]
-Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#41, number_sales#42, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#43]
+(85) Project [codegen id : 60]
+Output [6]: [store AS channel#48, i_brand_id#6, i_class_id#7, i_category_id#8, sales#43, number_sales#44]
+Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#43, number_sales#44, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#45]
 
-(78) Scan parquet default.store_sales
+(86) Scan parquet default.store_sales
 Output [4]: [ss_sold_date_sk#1, ss_item_sk#2, ss_quantity#3, ss_list_price#4]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_sold_date_sk)]
 ReadSchema: struct<ss_sold_date_sk:int,ss_item_sk:int,ss_quantity:int,ss_list_price:decimal(7,2)>
 
-(79) ColumnarToRow [codegen id : 50]
+(87) ColumnarToRow [codegen id : 58]
 Input [4]: [ss_sold_date_sk#1, ss_item_sk#2, ss_quantity#3, ss_list_price#4]
 
-(80) Filter [codegen id : 50]
+(88) Filter [codegen id : 58]
 Input [4]: [ss_sold_date_sk#1, ss_item_sk#2, ss_quantity#3, ss_list_price#4]
 Condition : (isnotnull(ss_item_sk#2) AND isnotnull(ss_sold_date_sk#1))
 
-(81) ReusedExchange [Reuses operator id: 56]
-Output [1]: [ss_item_sk#25]
+(89) ReusedExchange [Reuses operator id: 64]
+Output [1]: [ss_item_sk#27]
 
-(82) BroadcastHashJoin [codegen id : 50]
+(90) BroadcastHashJoin [codegen id : 58]
 Left keys [1]: [ss_item_sk#2]
-Right keys [1]: [ss_item_sk#25]
+Right keys [1]: [ss_item_sk#27]
 Join condition: None
 
-(83) ReusedExchange [Reuses operator id: 63]
-Output [4]: [i_item_sk#47, i_brand_id#48, i_class_id#49, i_category_id#50]
+(91) ReusedExchange [Reuses operator id: 71]
+Output [4]: [i_item_sk#49, i_brand_id#50, i_class_id#51, i_category_id#52]
 
-(84) BroadcastHashJoin [codegen id : 50]
+(92) BroadcastHashJoin [codegen id : 58]
 Left keys [1]: [ss_item_sk#2]
-Right keys [1]: [i_item_sk#47]
+Right keys [1]: [i_item_sk#49]
 Join condition: None
 
-(85) Project [codegen id : 50]
-Output [6]: [ss_sold_date_sk#1, ss_quantity#3, ss_list_price#4, i_brand_id#48, i_class_id#49, i_category_id#50]
-Input [8]: [ss_sold_date_sk#1, ss_item_sk#2, ss_quantity#3, ss_list_price#4, i_item_sk#47, i_brand_id#48, i_class_id#49, i_category_id#50]
+(93) Project [codegen id : 58]
+Output [6]: [ss_sold_date_sk#1, ss_quantity#3, ss_list_price#4, i_brand_id#50, i_class_id#51, i_category_id#52]
+Input [8]: [ss_sold_date_sk#1, ss_item_sk#2, ss_quantity#3, ss_list_price#4, i_item_sk#49, i_brand_id#50, i_class_id#51, i_category_id#52]
 
-(86) Scan parquet default.date_dim
-Output [2]: [d_date_sk#10, d_week_seq#28]
+(94) Scan parquet default.date_dim
+Output [2]: [d_date_sk#10, d_week_seq#30]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_week_seq), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int>
 
-(87) ColumnarToRow [codegen id : 49]
-Input [2]: [d_date_sk#10, d_week_seq#28]
+(95) ColumnarToRow [codegen id : 57]
+Input [2]: [d_date_sk#10, d_week_seq#30]
 
-(88) Filter [codegen id : 49]
-Input [2]: [d_date_sk#10, d_week_seq#28]
-Condition : ((isnotnull(d_week_seq#28) AND (d_week_seq#28 = Subquery scalar-subquery#51, [id=#52])) AND isnotnull(d_date_sk#10))
+(96) Filter [codegen id : 57]
+Input [2]: [d_date_sk#10, d_week_seq#30]
+Condition : ((isnotnull(d_week_seq#30) AND (d_week_seq#30 = Subquery scalar-subquery#53, [id=#54])) AND isnotnull(d_date_sk#10))
 
-(89) Project [codegen id : 49]
+(97) Project [codegen id : 57]
 Output [1]: [d_date_sk#10]
-Input [2]: [d_date_sk#10, d_week_seq#28]
+Input [2]: [d_date_sk#10, d_week_seq#30]
 
-(90) BroadcastExchange
+(98) BroadcastExchange
 Input [1]: [d_date_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#53]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#55]
 
-(91) BroadcastHashJoin [codegen id : 50]
+(99) BroadcastHashJoin [codegen id : 58]
 Left keys [1]: [ss_sold_date_sk#1]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
-(92) Project [codegen id : 50]
-Output [5]: [ss_quantity#3, ss_list_price#4, i_brand_id#48, i_class_id#49, i_category_id#50]
-Input [7]: [ss_sold_date_sk#1, ss_quantity#3, ss_list_price#4, i_brand_id#48, i_class_id#49, i_category_id#50, d_date_sk#10]
+(100) Project [codegen id : 58]
+Output [5]: [ss_quantity#3, ss_list_price#4, i_brand_id#50, i_class_id#51, i_category_id#52]
+Input [7]: [ss_sold_date_sk#1, ss_quantity#3, ss_list_price#4, i_brand_id#50, i_class_id#51, i_category_id#52, d_date_sk#10]
 
-(93) HashAggregate [codegen id : 50]
-Input [5]: [ss_quantity#3, ss_list_price#4, i_brand_id#48, i_class_id#49, i_category_id#50]
-Keys [3]: [i_brand_id#48, i_class_id#49, i_category_id#50]
+(101) HashAggregate [codegen id : 58]
+Input [5]: [ss_quantity#3, ss_list_price#4, i_brand_id#50, i_class_id#51, i_category_id#52]
+Keys [3]: [i_brand_id#50, i_class_id#51, i_category_id#52]
 Functions [2]: [partial_sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true)), partial_count(1)]
-Aggregate Attributes [3]: [sum#54, isEmpty#55, count#56]
-Results [6]: [i_brand_id#48, i_class_id#49, i_category_id#50, sum#57, isEmpty#58, count#59]
+Aggregate Attributes [3]: [sum#56, isEmpty#57, count#58]
+Results [6]: [i_brand_id#50, i_class_id#51, i_category_id#52, sum#59, isEmpty#60, count#61]
 
-(94) Exchange
-Input [6]: [i_brand_id#48, i_class_id#49, i_category_id#50, sum#57, isEmpty#58, count#59]
-Arguments: hashpartitioning(i_brand_id#48, i_class_id#49, i_category_id#50, 5), true, [id=#60]
+(102) Exchange
+Input [6]: [i_brand_id#50, i_class_id#51, i_category_id#52, sum#59, isEmpty#60, count#61]
+Arguments: hashpartitioning(i_brand_id#50, i_class_id#51, i_category_id#52, 5), ENSURE_REQUIREMENTS, [id=#62]
 
-(95) HashAggregate [codegen id : 51]
-Input [6]: [i_brand_id#48, i_class_id#49, i_category_id#50, sum#57, isEmpty#58, count#59]
-Keys [3]: [i_brand_id#48, i_class_id#49, i_category_id#50]
+(103) HashAggregate [codegen id : 59]
+Input [6]: [i_brand_id#50, i_class_id#51, i_category_id#52, sum#59, isEmpty#60, count#61]
+Keys [3]: [i_brand_id#50, i_class_id#51, i_category_id#52]
 Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#61, count(1)#62]
-Results [6]: [i_brand_id#48, i_class_id#49, i_category_id#50, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#61 AS sales#63, count(1)#62 AS number_sales#64, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#61 AS sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#65]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#63, count(1)#64]
+Results [6]: [i_brand_id#50, i_class_id#51, i_category_id#52, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#63 AS sales#65, count(1)#64 AS number_sales#66, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#63 AS sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#67]
 
-(96) Filter [codegen id : 51]
-Input [6]: [i_brand_id#48, i_class_id#49, i_category_id#50, sales#63, number_sales#64, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#65]
-Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#65) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#65 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#44, [id=#45] as decimal(32,6))))
+(104) Filter [codegen id : 59]
+Input [6]: [i_brand_id#50, i_class_id#51, i_category_id#52, sales#65, number_sales#66, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#67]
+Condition : (isnotnull(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#67) AND (cast(sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#67 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#46, [id=#47] as decimal(32,6))))
 
-(97) Project [codegen id : 51]
-Output [6]: [store AS channel#66, i_brand_id#48, i_class_id#49, i_category_id#50, sales#63, number_sales#64]
-Input [6]: [i_brand_id#48, i_class_id#49, i_category_id#50, sales#63, number_sales#64, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#65]
+(105) Project [codegen id : 59]
+Output [6]: [store AS channel#68, i_brand_id#50, i_class_id#51, i_category_id#52, sales#65, number_sales#66]
+Input [6]: [i_brand_id#50, i_class_id#51, i_category_id#52, sales#65, number_sales#66, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#3 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#4 as decimal(12,2)))), DecimalType(18,2), true))#67]
 
-(98) BroadcastExchange
-Input [6]: [channel#66, i_brand_id#48, i_class_id#49, i_category_id#50, sales#63, number_sales#64]
-Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, true], input[3, int, true]),false), [id=#67]
+(106) BroadcastExchange
+Input [6]: [channel#68, i_brand_id#50, i_class_id#51, i_category_id#52, sales#65, number_sales#66]
+Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, true], input[3, int, true]),false), [id=#69]
 
-(99) BroadcastHashJoin [codegen id : 52]
+(107) BroadcastHashJoin [codegen id : 60]
 Left keys [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
-Right keys [3]: [i_brand_id#48, i_class_id#49, i_category_id#50]
+Right keys [3]: [i_brand_id#50, i_class_id#51, i_category_id#52]
 Join condition: None
 
-(100) TakeOrderedAndProject
-Input [12]: [channel#46, i_brand_id#6, i_class_id#7, i_category_id#8, sales#41, number_sales#42, channel#66, i_brand_id#48, i_class_id#49, i_category_id#50, sales#63, number_sales#64]
-Arguments: 100, [i_brand_id#6 ASC NULLS FIRST, i_class_id#7 ASC NULLS FIRST, i_category_id#8 ASC NULLS FIRST], [channel#46, i_brand_id#6, i_class_id#7, i_category_id#8, sales#41, number_sales#42, channel#66, i_brand_id#48, i_class_id#49, i_category_id#50, sales#63, number_sales#64]
+(108) TakeOrderedAndProject
+Input [12]: [channel#48, i_brand_id#6, i_class_id#7, i_category_id#8, sales#43, number_sales#44, channel#68, i_brand_id#50, i_class_id#51, i_category_id#52, sales#65, number_sales#66]
+Arguments: 100, [i_brand_id#6 ASC NULLS FIRST, i_class_id#7 ASC NULLS FIRST, i_category_id#8 ASC NULLS FIRST], [channel#48, i_brand_id#6, i_class_id#7, i_category_id#8, sales#43, number_sales#44, channel#68, i_brand_id#50, i_class_id#51, i_category_id#52, sales#65, number_sales#66]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 76 Hosting Expression = Subquery scalar-subquery#44, [id=#45]
-* HashAggregate (126)
-+- Exchange (125)
-   +- * HashAggregate (124)
-      +- Union (123)
-         :- * Project (110)
-         :  +- * BroadcastHashJoin Inner BuildRight (109)
-         :     :- * Filter (103)
-         :     :  +- * ColumnarToRow (102)
-         :     :     +- Scan parquet default.store_sales (101)
-         :     +- BroadcastExchange (108)
-         :        +- * Project (107)
-         :           +- * Filter (106)
-         :              +- * ColumnarToRow (105)
-         :                 +- Scan parquet default.date_dim (104)
-         :- * Project (116)
-         :  +- * BroadcastHashJoin Inner BuildRight (115)
-         :     :- * Filter (113)
-         :     :  +- * ColumnarToRow (112)
-         :     :     +- Scan parquet default.catalog_sales (111)
-         :     +- ReusedExchange (114)
-         +- * Project (122)
-            +- * BroadcastHashJoin Inner BuildRight (121)
-               :- * Filter (119)
-               :  +- * ColumnarToRow (118)
-               :     +- Scan parquet default.web_sales (117)
-               +- ReusedExchange (120)
+Subquery:1 Hosting operator id = 84 Hosting Expression = Subquery scalar-subquery#46, [id=#47]
+* HashAggregate (134)
++- Exchange (133)
+   +- * HashAggregate (132)
+      +- Union (131)
+         :- * Project (118)
+         :  +- * BroadcastHashJoin Inner BuildRight (117)
+         :     :- * Filter (111)
+         :     :  +- * ColumnarToRow (110)
+         :     :     +- Scan parquet default.store_sales (109)
+         :     +- BroadcastExchange (116)
+         :        +- * Project (115)
+         :           +- * Filter (114)
+         :              +- * ColumnarToRow (113)
+         :                 +- Scan parquet default.date_dim (112)
+         :- * Project (124)
+         :  +- * BroadcastHashJoin Inner BuildRight (123)
+         :     :- * Filter (121)
+         :     :  +- * ColumnarToRow (120)
+         :     :     +- Scan parquet default.catalog_sales (119)
+         :     +- ReusedExchange (122)
+         +- * Project (130)
+            +- * BroadcastHashJoin Inner BuildRight (129)
+               :- * Filter (127)
+               :  +- * ColumnarToRow (126)
+               :     +- Scan parquet default.web_sales (125)
+               +- ReusedExchange (128)
 
 
-(101) Scan parquet default.store_sales
+(109) Scan parquet default.store_sales
 Output [3]: [ss_sold_date_sk#1, ss_quantity#3, ss_list_price#4]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_sold_date_sk)]
 ReadSchema: struct<ss_sold_date_sk:int,ss_quantity:int,ss_list_price:decimal(7,2)>
 
-(102) ColumnarToRow [codegen id : 2]
+(110) ColumnarToRow [codegen id : 2]
 Input [3]: [ss_sold_date_sk#1, ss_quantity#3, ss_list_price#4]
 
-(103) Filter [codegen id : 2]
+(111) Filter [codegen id : 2]
 Input [3]: [ss_sold_date_sk#1, ss_quantity#3, ss_list_price#4]
 Condition : isnotnull(ss_sold_date_sk#1)
 
-(104) Scan parquet default.date_dim
+(112) Scan parquet default.date_dim
 Output [2]: [d_date_sk#10, d_year#11]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), GreaterThanOrEqual(d_year,1999), LessThanOrEqual(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(105) ColumnarToRow [codegen id : 1]
+(113) ColumnarToRow [codegen id : 1]
 Input [2]: [d_date_sk#10, d_year#11]
 
-(106) Filter [codegen id : 1]
+(114) Filter [codegen id : 1]
 Input [2]: [d_date_sk#10, d_year#11]
 Condition : (((isnotnull(d_year#11) AND (d_year#11 >= 1999)) AND (d_year#11 <= 2001)) AND isnotnull(d_date_sk#10))
 
-(107) Project [codegen id : 1]
+(115) Project [codegen id : 1]
 Output [1]: [d_date_sk#10]
 Input [2]: [d_date_sk#10, d_year#11]
 
-(108) BroadcastExchange
+(116) BroadcastExchange
 Input [1]: [d_date_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#68]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#70]
 
-(109) BroadcastHashJoin [codegen id : 2]
+(117) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#1]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
-(110) Project [codegen id : 2]
-Output [2]: [ss_quantity#3 AS quantity#69, ss_list_price#4 AS list_price#70]
+(118) Project [codegen id : 2]
+Output [2]: [ss_quantity#3 AS quantity#71, ss_list_price#4 AS list_price#72]
 Input [4]: [ss_sold_date_sk#1, ss_quantity#3, ss_list_price#4, d_date_sk#10]
 
-(111) Scan parquet default.catalog_sales
-Output [3]: [cs_sold_date_sk#16, cs_quantity#71, cs_list_price#72]
+(119) Scan parquet default.catalog_sales
+Output [3]: [cs_sold_date_sk#17, cs_quantity#73, cs_list_price#74]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_sales]
 PushedFilters: [IsNotNull(cs_sold_date_sk)]
 ReadSchema: struct<cs_sold_date_sk:int,cs_quantity:int,cs_list_price:decimal(7,2)>
 
-(112) ColumnarToRow [codegen id : 4]
-Input [3]: [cs_sold_date_sk#16, cs_quantity#71, cs_list_price#72]
+(120) ColumnarToRow [codegen id : 4]
+Input [3]: [cs_sold_date_sk#17, cs_quantity#73, cs_list_price#74]
 
-(113) Filter [codegen id : 4]
-Input [3]: [cs_sold_date_sk#16, cs_quantity#71, cs_list_price#72]
-Condition : isnotnull(cs_sold_date_sk#16)
+(121) Filter [codegen id : 4]
+Input [3]: [cs_sold_date_sk#17, cs_quantity#73, cs_list_price#74]
+Condition : isnotnull(cs_sold_date_sk#17)
 
-(114) ReusedExchange [Reuses operator id: 108]
+(122) ReusedExchange [Reuses operator id: 116]
 Output [1]: [d_date_sk#10]
 
-(115) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [cs_sold_date_sk#16]
+(123) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [cs_sold_date_sk#17]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
-(116) Project [codegen id : 4]
-Output [2]: [cs_quantity#71 AS quantity#73, cs_list_price#72 AS list_price#74]
-Input [4]: [cs_sold_date_sk#16, cs_quantity#71, cs_list_price#72, d_date_sk#10]
+(124) Project [codegen id : 4]
+Output [2]: [cs_quantity#73 AS quantity#75, cs_list_price#74 AS list_price#76]
+Input [4]: [cs_sold_date_sk#17, cs_quantity#73, cs_list_price#74, d_date_sk#10]
 
-(117) Scan parquet default.web_sales
-Output [3]: [ws_sold_date_sk#20, ws_quantity#75, ws_list_price#76]
+(125) Scan parquet default.web_sales
+Output [3]: [ws_sold_date_sk#22, ws_quantity#77, ws_list_price#78]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_sales]
 PushedFilters: [IsNotNull(ws_sold_date_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_quantity:int,ws_list_price:decimal(7,2)>
 
-(118) ColumnarToRow [codegen id : 6]
-Input [3]: [ws_sold_date_sk#20, ws_quantity#75, ws_list_price#76]
+(126) ColumnarToRow [codegen id : 6]
+Input [3]: [ws_sold_date_sk#22, ws_quantity#77, ws_list_price#78]
 
-(119) Filter [codegen id : 6]
-Input [3]: [ws_sold_date_sk#20, ws_quantity#75, ws_list_price#76]
-Condition : isnotnull(ws_sold_date_sk#20)
+(127) Filter [codegen id : 6]
+Input [3]: [ws_sold_date_sk#22, ws_quantity#77, ws_list_price#78]
+Condition : isnotnull(ws_sold_date_sk#22)
 
-(120) ReusedExchange [Reuses operator id: 108]
+(128) ReusedExchange [Reuses operator id: 116]
 Output [1]: [d_date_sk#10]
 
-(121) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ws_sold_date_sk#20]
+(129) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [ws_sold_date_sk#22]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
-(122) Project [codegen id : 6]
-Output [2]: [ws_quantity#75 AS quantity#77, ws_list_price#76 AS list_price#78]
-Input [4]: [ws_sold_date_sk#20, ws_quantity#75, ws_list_price#76, d_date_sk#10]
+(130) Project [codegen id : 6]
+Output [2]: [ws_quantity#77 AS quantity#79, ws_list_price#78 AS list_price#80]
+Input [4]: [ws_sold_date_sk#22, ws_quantity#77, ws_list_price#78, d_date_sk#10]
 
-(123) Union
+(131) Union
 
-(124) HashAggregate [codegen id : 7]
-Input [2]: [quantity#69, list_price#70]
+(132) HashAggregate [codegen id : 7]
+Input [2]: [quantity#71, list_price#72]
 Keys: []
-Functions [1]: [partial_avg(CheckOverflow((promote_precision(cast(cast(quantity#69 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#70 as decimal(12,2)))), DecimalType(18,2), true))]
-Aggregate Attributes [2]: [sum#79, count#80]
-Results [2]: [sum#81, count#82]
+Functions [1]: [partial_avg(CheckOverflow((promote_precision(cast(cast(quantity#71 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#72 as decimal(12,2)))), DecimalType(18,2), true))]
+Aggregate Attributes [2]: [sum#81, count#82]
+Results [2]: [sum#83, count#84]
 
-(125) Exchange
-Input [2]: [sum#81, count#82]
-Arguments: SinglePartition, true, [id=#83]
+(133) Exchange
+Input [2]: [sum#83, count#84]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#85]
 
-(126) HashAggregate [codegen id : 8]
-Input [2]: [sum#81, count#82]
+(134) HashAggregate [codegen id : 8]
+Input [2]: [sum#83, count#84]
 Keys: []
-Functions [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#69 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#70 as decimal(12,2)))), DecimalType(18,2), true))]
-Aggregate Attributes [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#69 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#70 as decimal(12,2)))), DecimalType(18,2), true))#84]
-Results [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#69 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#70 as decimal(12,2)))), DecimalType(18,2), true))#84 AS average_sales#85]
+Functions [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#71 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#72 as decimal(12,2)))), DecimalType(18,2), true))]
+Aggregate Attributes [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#71 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#72 as decimal(12,2)))), DecimalType(18,2), true))#86]
+Results [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#71 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#72 as decimal(12,2)))), DecimalType(18,2), true))#86 AS average_sales#87]
 
-Subquery:2 Hosting operator id = 68 Hosting Expression = Subquery scalar-subquery#29, [id=#30]
-* Project (130)
-+- * Filter (129)
-   +- * ColumnarToRow (128)
-      +- Scan parquet default.date_dim (127)
+Subquery:2 Hosting operator id = 76 Hosting Expression = Subquery scalar-subquery#31, [id=#32]
+* Project (138)
++- * Filter (137)
+   +- * ColumnarToRow (136)
+      +- Scan parquet default.date_dim (135)
 
 
-(127) Scan parquet default.date_dim
-Output [4]: [d_week_seq#28, d_year#11, d_moy#86, d_dom#87]
+(135) Scan parquet default.date_dim
+Output [4]: [d_week_seq#30, d_year#11, d_moy#88, d_dom#89]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), IsNotNull(d_dom), EqualTo(d_year,2000), EqualTo(d_moy,12), EqualTo(d_dom,11)]
 ReadSchema: struct<d_week_seq:int,d_year:int,d_moy:int,d_dom:int>
 
-(128) ColumnarToRow [codegen id : 1]
-Input [4]: [d_week_seq#28, d_year#11, d_moy#86, d_dom#87]
+(136) ColumnarToRow [codegen id : 1]
+Input [4]: [d_week_seq#30, d_year#11, d_moy#88, d_dom#89]
 
-(129) Filter [codegen id : 1]
-Input [4]: [d_week_seq#28, d_year#11, d_moy#86, d_dom#87]
-Condition : (((((isnotnull(d_year#11) AND isnotnull(d_moy#86)) AND isnotnull(d_dom#87)) AND (d_year#11 = 2000)) AND (d_moy#86 = 12)) AND (d_dom#87 = 11))
+(137) Filter [codegen id : 1]
+Input [4]: [d_week_seq#30, d_year#11, d_moy#88, d_dom#89]
+Condition : (((((isnotnull(d_year#11) AND isnotnull(d_moy#88)) AND isnotnull(d_dom#89)) AND (d_year#11 = 2000)) AND (d_moy#88 = 12)) AND (d_dom#89 = 11))
 
-(130) Project [codegen id : 1]
-Output [1]: [d_week_seq#28]
-Input [4]: [d_week_seq#28, d_year#11, d_moy#86, d_dom#87]
+(138) Project [codegen id : 1]
+Output [1]: [d_week_seq#30]
+Input [4]: [d_week_seq#30, d_year#11, d_moy#88, d_dom#89]
 
-Subquery:3 Hosting operator id = 96 Hosting Expression = ReusedSubquery Subquery scalar-subquery#44, [id=#45]
+Subquery:3 Hosting operator id = 104 Hosting Expression = ReusedSubquery Subquery scalar-subquery#46, [id=#47]
 
-Subquery:4 Hosting operator id = 88 Hosting Expression = Subquery scalar-subquery#51, [id=#52]
-* Project (134)
-+- * Filter (133)
-   +- * ColumnarToRow (132)
-      +- Scan parquet default.date_dim (131)
+Subquery:4 Hosting operator id = 96 Hosting Expression = Subquery scalar-subquery#53, [id=#54]
+* Project (142)
++- * Filter (141)
+   +- * ColumnarToRow (140)
+      +- Scan parquet default.date_dim (139)
 
 
-(131) Scan parquet default.date_dim
-Output [4]: [d_week_seq#28, d_year#11, d_moy#86, d_dom#87]
+(139) Scan parquet default.date_dim
+Output [4]: [d_week_seq#30, d_year#11, d_moy#88, d_dom#89]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), IsNotNull(d_dom), EqualTo(d_year,1999), EqualTo(d_moy,12), EqualTo(d_dom,11)]
 ReadSchema: struct<d_week_seq:int,d_year:int,d_moy:int,d_dom:int>
 
-(132) ColumnarToRow [codegen id : 1]
-Input [4]: [d_week_seq#28, d_year#11, d_moy#86, d_dom#87]
+(140) ColumnarToRow [codegen id : 1]
+Input [4]: [d_week_seq#30, d_year#11, d_moy#88, d_dom#89]
 
-(133) Filter [codegen id : 1]
-Input [4]: [d_week_seq#28, d_year#11, d_moy#86, d_dom#87]
-Condition : (((((isnotnull(d_year#11) AND isnotnull(d_moy#86)) AND isnotnull(d_dom#87)) AND (d_year#11 = 1999)) AND (d_moy#86 = 12)) AND (d_dom#87 = 11))
+(141) Filter [codegen id : 1]
+Input [4]: [d_week_seq#30, d_year#11, d_moy#88, d_dom#89]
+Condition : (((((isnotnull(d_year#11) AND isnotnull(d_moy#88)) AND isnotnull(d_dom#89)) AND (d_year#11 = 1999)) AND (d_moy#88 = 12)) AND (d_dom#89 = 11))
 
-(134) Project [codegen id : 1]
-Output [1]: [d_week_seq#28]
-Input [4]: [d_week_seq#28, d_year#11, d_moy#86, d_dom#87]
+(142) Project [codegen id : 1]
+Output [1]: [d_week_seq#30]
+Input [4]: [d_week_seq#30, d_year#11, d_moy#88, d_dom#89]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b/simplified.txt
@@ -1,5 +1,5 @@
 TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_sales,channel,i_brand_id,i_class_id,i_category_id,sales,number_sales]
-  WholeStageCodegen (52)
+  WholeStageCodegen (60)
     BroadcastHashJoin [i_brand_id,i_class_id,i_category_id,i_brand_id,i_class_id,i_category_id]
       Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
         Filter [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true))]
@@ -7,7 +7,7 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
             WholeStageCodegen (8)
               HashAggregate [sum,count] [avg(CheckOverflow((promote_precision(cast(cast(quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price as decimal(12,2)))), DecimalType(18,2), true)),average_sales,sum,count]
                 InputAdapter
-                  Exchange #12
+                  Exchange #14
                     WholeStageCodegen (7)
                       HashAggregate [quantity,list_price] [sum,count,sum,count]
                         InputAdapter
@@ -20,7 +20,7 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                                       InputAdapter
                                         Scan parquet default.store_sales [ss_sold_date_sk,ss_quantity,ss_list_price]
                                   InputAdapter
-                                    BroadcastExchange #13
+                                    BroadcastExchange #15
                                       WholeStageCodegen (1)
                                         Project [d_date_sk]
                                           Filter [d_year,d_date_sk]
@@ -35,7 +35,7 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                                       InputAdapter
                                         Scan parquet default.catalog_sales [cs_sold_date_sk,cs_quantity,cs_list_price]
                                   InputAdapter
-                                    ReusedExchange [d_date_sk] #13
+                                    ReusedExchange [d_date_sk] #15
                             WholeStageCodegen (6)
                               Project [ws_quantity,ws_list_price]
                                 BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
@@ -44,11 +44,11 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                                       InputAdapter
                                         Scan parquet default.web_sales [ws_sold_date_sk,ws_quantity,ws_list_price]
                                   InputAdapter
-                                    ReusedExchange [d_date_sk] #13
+                                    ReusedExchange [d_date_sk] #15
           HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
             InputAdapter
               Exchange [i_brand_id,i_class_id,i_category_id] #1
-                WholeStageCodegen (25)
+                WholeStageCodegen (29)
                   HashAggregate [i_brand_id,i_class_id,i_category_id,ss_quantity,ss_list_price] [sum,isEmpty,count,sum,isEmpty,count]
                     Project [ss_quantity,ss_list_price,i_brand_id,i_class_id,i_category_id]
                       BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
@@ -61,7 +61,7 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                                     Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk,ss_quantity,ss_list_price]
                               InputAdapter
                                 BroadcastExchange #2
-                                  WholeStageCodegen (11)
+                                  WholeStageCodegen (13)
                                     Project [i_item_sk]
                                       BroadcastHashJoin [i_brand_id,i_class_id,i_category_id,brand_id,class_id,category_id]
                                         Filter [i_brand_id,i_class_id,i_category_id]
@@ -70,62 +70,74 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                                               Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
                                         InputAdapter
                                           BroadcastExchange #3
-                                            WholeStageCodegen (10)
+                                            WholeStageCodegen (12)
                                               HashAggregate [brand_id,class_id,category_id]
                                                 HashAggregate [brand_id,class_id,category_id]
-                                                  HashAggregate [brand_id,class_id,category_id]
-                                                    InputAdapter
-                                                      Exchange [brand_id,class_id,category_id] #4
-                                                        WholeStageCodegen (9)
+                                                  BroadcastHashJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
+                                                    HashAggregate [brand_id,class_id,category_id]
+                                                      HashAggregate [brand_id,class_id,category_id]
+                                                        BroadcastHashJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
                                                           HashAggregate [brand_id,class_id,category_id]
-                                                            BroadcastHashJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
-                                                              BroadcastHashJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
-                                                                Project [i_brand_id,i_class_id,i_category_id]
-                                                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                    Project [ss_sold_date_sk,i_brand_id,i_class_id,i_category_id]
-                                                                      BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                                        Filter [ss_item_sk,ss_sold_date_sk]
-                                                                          ColumnarToRow
-                                                                            InputAdapter
-                                                                              Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk]
-                                                                        InputAdapter
-                                                                          BroadcastExchange #5
-                                                                            WholeStageCodegen (1)
-                                                                              Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                    InputAdapter
-                                                                      BroadcastExchange #6
-                                                                        WholeStageCodegen (2)
-                                                                          Project [d_date_sk]
-                                                                            Filter [d_year,d_date_sk]
+                                                            InputAdapter
+                                                              Exchange [brand_id,class_id,category_id] #4
+                                                                WholeStageCodegen (3)
+                                                                  HashAggregate [brand_id,class_id,category_id]
+                                                                    Project [i_brand_id,i_class_id,i_category_id]
+                                                                      BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                                        Project [ss_sold_date_sk,i_brand_id,i_class_id,i_category_id]
+                                                                          BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                                            Filter [ss_item_sk,ss_sold_date_sk]
                                                                               ColumnarToRow
                                                                                 InputAdapter
-                                                                                  Scan parquet default.date_dim [d_date_sk,d_year]
-                                                                InputAdapter
-                                                                  BroadcastExchange #7
-                                                                    WholeStageCodegen (5)
-                                                                      Project [i_brand_id,i_class_id,i_category_id]
-                                                                        BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                          Project [cs_sold_date_sk,i_brand_id,i_class_id,i_category_id]
-                                                                            BroadcastHashJoin [cs_item_sk,i_item_sk]
-                                                                              Filter [cs_item_sk,cs_sold_date_sk]
-                                                                                ColumnarToRow
+                                                                                  Scan parquet default.store_sales [ss_sold_date_sk,ss_item_sk]
+                                                                            InputAdapter
+                                                                              BroadcastExchange #5
+                                                                                WholeStageCodegen (1)
+                                                                                  Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                                    ColumnarToRow
+                                                                                      InputAdapter
+                                                                                        Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                        InputAdapter
+                                                                          BroadcastExchange #6
+                                                                            WholeStageCodegen (2)
+                                                                              Project [d_date_sk]
+                                                                                Filter [d_year,d_date_sk]
+                                                                                  ColumnarToRow
+                                                                                    InputAdapter
+                                                                                      Scan parquet default.date_dim [d_date_sk,d_year]
+                                                          InputAdapter
+                                                            BroadcastExchange #7
+                                                              WholeStageCodegen (7)
+                                                                HashAggregate [i_brand_id,i_class_id,i_category_id]
+                                                                  InputAdapter
+                                                                    Exchange [i_brand_id,i_class_id,i_category_id] #8
+                                                                      WholeStageCodegen (6)
+                                                                        HashAggregate [i_brand_id,i_class_id,i_category_id]
+                                                                          Project [i_brand_id,i_class_id,i_category_id]
+                                                                            BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                                              Project [cs_sold_date_sk,i_brand_id,i_class_id,i_category_id]
+                                                                                BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                                                  Filter [cs_item_sk,cs_sold_date_sk]
+                                                                                    ColumnarToRow
+                                                                                      InputAdapter
+                                                                                        Scan parquet default.catalog_sales [cs_sold_date_sk,cs_item_sk]
                                                                                   InputAdapter
-                                                                                    Scan parquet default.catalog_sales [cs_sold_date_sk,cs_item_sk]
+                                                                                    BroadcastExchange #9
+                                                                                      WholeStageCodegen (4)
+                                                                                        Filter [i_item_sk]
+                                                                                          ColumnarToRow
+                                                                                            InputAdapter
+                                                                                              Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
                                                                               InputAdapter
-                                                                                BroadcastExchange #8
-                                                                                  WholeStageCodegen (3)
-                                                                                    Filter [i_item_sk]
-                                                                                      ColumnarToRow
-                                                                                        InputAdapter
-                                                                                          Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                          InputAdapter
-                                                                            ReusedExchange [d_date_sk] #6
-                                                              InputAdapter
-                                                                BroadcastExchange #9
-                                                                  WholeStageCodegen (8)
+                                                                                ReusedExchange [d_date_sk] #6
+                                                    InputAdapter
+                                                      BroadcastExchange #10
+                                                        WholeStageCodegen (11)
+                                                          HashAggregate [i_brand_id,i_class_id,i_category_id]
+                                                            InputAdapter
+                                                              Exchange [i_brand_id,i_class_id,i_category_id] #11
+                                                                WholeStageCodegen (10)
+                                                                  HashAggregate [i_brand_id,i_class_id,i_category_id]
                                                                     Project [i_brand_id,i_class_id,i_category_id]
                                                                       BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                                         Project [ws_sold_date_sk,i_brand_id,i_class_id,i_category_id]
@@ -135,12 +147,12 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                                                                                 InputAdapter
                                                                                   Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk]
                                                                             InputAdapter
-                                                                              ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #8
+                                                                              ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #9
                                                                         InputAdapter
                                                                           ReusedExchange [d_date_sk] #6
                             InputAdapter
-                              BroadcastExchange #10
-                                WholeStageCodegen (23)
+                              BroadcastExchange #12
+                                WholeStageCodegen (27)
                                   BroadcastHashJoin [i_item_sk,ss_item_sk]
                                     Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
                                       ColumnarToRow
@@ -149,8 +161,8 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                                     InputAdapter
                                       ReusedExchange [ss_item_sk] #2
                         InputAdapter
-                          BroadcastExchange #11
-                            WholeStageCodegen (24)
+                          BroadcastExchange #13
+                            WholeStageCodegen (28)
                               Project [d_date_sk]
                                 Filter [d_week_seq,d_date_sk]
                                   Subquery #1
@@ -164,15 +176,15 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                                     InputAdapter
                                       Scan parquet default.date_dim [d_date_sk,d_week_seq]
       InputAdapter
-        BroadcastExchange #14
-          WholeStageCodegen (51)
+        BroadcastExchange #16
+          WholeStageCodegen (59)
             Project [i_brand_id,i_class_id,i_category_id,sales,number_sales]
               Filter [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true))]
                 ReusedSubquery [average_sales] #2
                 HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),sum,isEmpty,count]
                   InputAdapter
-                    Exchange [i_brand_id,i_class_id,i_category_id] #15
-                      WholeStageCodegen (50)
+                    Exchange [i_brand_id,i_class_id,i_category_id] #17
+                      WholeStageCodegen (58)
                         HashAggregate [i_brand_id,i_class_id,i_category_id,ss_quantity,ss_list_price] [sum,isEmpty,count,sum,isEmpty,count]
                           Project [ss_quantity,ss_list_price,i_brand_id,i_class_id,i_category_id]
                             BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
@@ -186,10 +198,10 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                                     InputAdapter
                                       ReusedExchange [ss_item_sk] #2
                                   InputAdapter
-                                    ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #10
+                                    ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #12
                               InputAdapter
-                                BroadcastExchange #16
-                                  WholeStageCodegen (49)
+                                BroadcastExchange #18
+                                  WholeStageCodegen (57)
                                     Project [d_date_sk]
                                       Filter [d_week_seq,d_date_sk]
                                         Subquery #3

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q38/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q38/explain.txt
@@ -4,55 +4,55 @@
    +- * HashAggregate (52)
       +- * HashAggregate (51)
          +- * HashAggregate (50)
-            +- * HashAggregate (49)
-               +- * HashAggregate (48)
+            +- * BroadcastHashJoin LeftSemi BuildRight (49)
+               :- * HashAggregate (35)
+               :  +- * HashAggregate (34)
+               :     +- * BroadcastHashJoin LeftSemi BuildRight (33)
+               :        :- * HashAggregate (19)
+               :        :  +- Exchange (18)
+               :        :     +- * HashAggregate (17)
+               :        :        +- * Project (16)
+               :        :           +- * BroadcastHashJoin Inner BuildRight (15)
+               :        :              :- * Project (10)
+               :        :              :  +- * BroadcastHashJoin Inner BuildRight (9)
+               :        :              :     :- * Filter (3)
+               :        :              :     :  +- * ColumnarToRow (2)
+               :        :              :     :     +- Scan parquet default.store_sales (1)
+               :        :              :     +- BroadcastExchange (8)
+               :        :              :        +- * Project (7)
+               :        :              :           +- * Filter (6)
+               :        :              :              +- * ColumnarToRow (5)
+               :        :              :                 +- Scan parquet default.date_dim (4)
+               :        :              +- BroadcastExchange (14)
+               :        :                 +- * Filter (13)
+               :        :                    +- * ColumnarToRow (12)
+               :        :                       +- Scan parquet default.customer (11)
+               :        +- BroadcastExchange (32)
+               :           +- * HashAggregate (31)
+               :              +- Exchange (30)
+               :                 +- * HashAggregate (29)
+               :                    +- * Project (28)
+               :                       +- * BroadcastHashJoin Inner BuildRight (27)
+               :                          :- * Project (25)
+               :                          :  +- * BroadcastHashJoin Inner BuildRight (24)
+               :                          :     :- * Filter (22)
+               :                          :     :  +- * ColumnarToRow (21)
+               :                          :     :     +- Scan parquet default.catalog_sales (20)
+               :                          :     +- ReusedExchange (23)
+               :                          +- ReusedExchange (26)
+               +- BroadcastExchange (48)
                   +- * HashAggregate (47)
                      +- Exchange (46)
                         +- * HashAggregate (45)
-                           +- * BroadcastHashJoin LeftSemi BuildRight (44)
-                              :- * BroadcastHashJoin LeftSemi BuildRight (30)
-                              :  :- * Project (16)
-                              :  :  +- * BroadcastHashJoin Inner BuildRight (15)
-                              :  :     :- * Project (10)
-                              :  :     :  +- * BroadcastHashJoin Inner BuildRight (9)
-                              :  :     :     :- * Filter (3)
-                              :  :     :     :  +- * ColumnarToRow (2)
-                              :  :     :     :     +- Scan parquet default.store_sales (1)
-                              :  :     :     +- BroadcastExchange (8)
-                              :  :     :        +- * Project (7)
-                              :  :     :           +- * Filter (6)
-                              :  :     :              +- * ColumnarToRow (5)
-                              :  :     :                 +- Scan parquet default.date_dim (4)
-                              :  :     +- BroadcastExchange (14)
-                              :  :        +- * Filter (13)
-                              :  :           +- * ColumnarToRow (12)
-                              :  :              +- Scan parquet default.customer (11)
-                              :  +- BroadcastExchange (29)
-                              :     +- * HashAggregate (28)
-                              :        +- Exchange (27)
-                              :           +- * HashAggregate (26)
-                              :              +- * Project (25)
-                              :                 +- * BroadcastHashJoin Inner BuildRight (24)
-                              :                    :- * Project (22)
-                              :                    :  +- * BroadcastHashJoin Inner BuildRight (21)
-                              :                    :     :- * Filter (19)
-                              :                    :     :  +- * ColumnarToRow (18)
-                              :                    :     :     +- Scan parquet default.catalog_sales (17)
-                              :                    :     +- ReusedExchange (20)
-                              :                    +- ReusedExchange (23)
-                              +- BroadcastExchange (43)
-                                 +- * HashAggregate (42)
-                                    +- Exchange (41)
-                                       +- * HashAggregate (40)
-                                          +- * Project (39)
-                                             +- * BroadcastHashJoin Inner BuildRight (38)
-                                                :- * Project (36)
-                                                :  +- * BroadcastHashJoin Inner BuildRight (35)
-                                                :     :- * Filter (33)
-                                                :     :  +- * ColumnarToRow (32)
-                                                :     :     +- Scan parquet default.web_sales (31)
-                                                :     +- ReusedExchange (34)
-                                                +- ReusedExchange (37)
+                           +- * Project (44)
+                              +- * BroadcastHashJoin Inner BuildRight (43)
+                                 :- * Project (41)
+                                 :  +- * BroadcastHashJoin Inner BuildRight (40)
+                                 :     :- * Filter (38)
+                                 :     :  +- * ColumnarToRow (37)
+                                 :     :     +- Scan parquet default.web_sales (36)
+                                 :     +- ReusedExchange (39)
+                                 +- ReusedExchange (42)
 
 
 (1) Scan parquet default.store_sales
@@ -62,10 +62,10 @@ Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_sold_date_sk), IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_sold_date_sk:int,ss_customer_sk:int>
 
-(2) ColumnarToRow [codegen id : 11]
+(2) ColumnarToRow [codegen id : 3]
 Input [2]: [ss_sold_date_sk#1, ss_customer_sk#2]
 
-(3) Filter [codegen id : 11]
+(3) Filter [codegen id : 3]
 Input [2]: [ss_sold_date_sk#1, ss_customer_sk#2]
 Condition : (isnotnull(ss_sold_date_sk#1) AND isnotnull(ss_customer_sk#2))
 
@@ -91,12 +91,12 @@ Input [3]: [d_date_sk#3, d_date#4, d_month_seq#5]
 Input [2]: [d_date_sk#3, d_date#4]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#6]
 
-(9) BroadcastHashJoin [codegen id : 11]
+(9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#1]
 Right keys [1]: [d_date_sk#3]
 Join condition: None
 
-(10) Project [codegen id : 11]
+(10) Project [codegen id : 3]
 Output [2]: [ss_customer_sk#2, d_date#4]
 Input [4]: [ss_sold_date_sk#1, ss_customer_sk#2, d_date_sk#3, d_date#4]
 
@@ -118,176 +118,176 @@ Condition : isnotnull(c_customer_sk#7)
 Input [3]: [c_customer_sk#7, c_first_name#8, c_last_name#9]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#10]
 
-(15) BroadcastHashJoin [codegen id : 11]
+(15) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_customer_sk#2]
 Right keys [1]: [c_customer_sk#7]
 Join condition: None
 
-(16) Project [codegen id : 11]
-Output [3]: [d_date#4, c_first_name#8, c_last_name#9]
+(16) Project [codegen id : 3]
+Output [3]: [c_last_name#9, c_first_name#8, d_date#4]
 Input [5]: [ss_customer_sk#2, d_date#4, c_customer_sk#7, c_first_name#8, c_last_name#9]
 
-(17) Scan parquet default.catalog_sales
-Output [2]: [cs_sold_date_sk#11, cs_bill_customer_sk#12]
+(17) HashAggregate [codegen id : 3]
+Input [3]: [c_last_name#9, c_first_name#8, d_date#4]
+Keys [3]: [c_last_name#9, c_first_name#8, d_date#4]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [c_last_name#9, c_first_name#8, d_date#4]
+
+(18) Exchange
+Input [3]: [c_last_name#9, c_first_name#8, d_date#4]
+Arguments: hashpartitioning(c_last_name#9, c_first_name#8, d_date#4, 5), ENSURE_REQUIREMENTS, [id=#11]
+
+(19) HashAggregate [codegen id : 12]
+Input [3]: [c_last_name#9, c_first_name#8, d_date#4]
+Keys [3]: [c_last_name#9, c_first_name#8, d_date#4]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [c_last_name#9, c_first_name#8, d_date#4]
+
+(20) Scan parquet default.catalog_sales
+Output [2]: [cs_sold_date_sk#12, cs_bill_customer_sk#13]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_sales]
 PushedFilters: [IsNotNull(cs_sold_date_sk), IsNotNull(cs_bill_customer_sk)]
 ReadSchema: struct<cs_sold_date_sk:int,cs_bill_customer_sk:int>
 
-(18) ColumnarToRow [codegen id : 5]
-Input [2]: [cs_sold_date_sk#11, cs_bill_customer_sk#12]
+(21) ColumnarToRow [codegen id : 6]
+Input [2]: [cs_sold_date_sk#12, cs_bill_customer_sk#13]
 
-(19) Filter [codegen id : 5]
-Input [2]: [cs_sold_date_sk#11, cs_bill_customer_sk#12]
-Condition : (isnotnull(cs_sold_date_sk#11) AND isnotnull(cs_bill_customer_sk#12))
+(22) Filter [codegen id : 6]
+Input [2]: [cs_sold_date_sk#12, cs_bill_customer_sk#13]
+Condition : (isnotnull(cs_sold_date_sk#12) AND isnotnull(cs_bill_customer_sk#13))
 
-(20) ReusedExchange [Reuses operator id: 8]
-Output [2]: [d_date_sk#13, d_date#14]
+(23) ReusedExchange [Reuses operator id: 8]
+Output [2]: [d_date_sk#14, d_date#15]
 
-(21) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [cs_sold_date_sk#11]
-Right keys [1]: [d_date_sk#13]
+(24) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [cs_sold_date_sk#12]
+Right keys [1]: [d_date_sk#14]
 Join condition: None
 
-(22) Project [codegen id : 5]
-Output [2]: [cs_bill_customer_sk#12, d_date#14]
-Input [4]: [cs_sold_date_sk#11, cs_bill_customer_sk#12, d_date_sk#13, d_date#14]
+(25) Project [codegen id : 6]
+Output [2]: [cs_bill_customer_sk#13, d_date#15]
+Input [4]: [cs_sold_date_sk#12, cs_bill_customer_sk#13, d_date_sk#14, d_date#15]
 
-(23) ReusedExchange [Reuses operator id: 14]
-Output [3]: [c_customer_sk#15, c_first_name#16, c_last_name#17]
+(26) ReusedExchange [Reuses operator id: 14]
+Output [3]: [c_customer_sk#16, c_first_name#17, c_last_name#18]
 
-(24) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [cs_bill_customer_sk#12]
-Right keys [1]: [c_customer_sk#15]
+(27) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [cs_bill_customer_sk#13]
+Right keys [1]: [c_customer_sk#16]
 Join condition: None
 
-(25) Project [codegen id : 5]
-Output [3]: [c_last_name#17, c_first_name#16, d_date#14]
-Input [5]: [cs_bill_customer_sk#12, d_date#14, c_customer_sk#15, c_first_name#16, c_last_name#17]
+(28) Project [codegen id : 6]
+Output [3]: [c_last_name#18, c_first_name#17, d_date#15]
+Input [5]: [cs_bill_customer_sk#13, d_date#15, c_customer_sk#16, c_first_name#17, c_last_name#18]
 
-(26) HashAggregate [codegen id : 5]
-Input [3]: [c_last_name#17, c_first_name#16, d_date#14]
-Keys [3]: [c_last_name#17, c_first_name#16, d_date#14]
+(29) HashAggregate [codegen id : 6]
+Input [3]: [c_last_name#18, c_first_name#17, d_date#15]
+Keys [3]: [c_last_name#18, c_first_name#17, d_date#15]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [c_last_name#17, c_first_name#16, d_date#14]
+Results [3]: [c_last_name#18, c_first_name#17, d_date#15]
 
-(27) Exchange
-Input [3]: [c_last_name#17, c_first_name#16, d_date#14]
-Arguments: hashpartitioning(c_last_name#17, c_first_name#16, d_date#14, 5), true, [id=#18]
+(30) Exchange
+Input [3]: [c_last_name#18, c_first_name#17, d_date#15]
+Arguments: hashpartitioning(c_last_name#18, c_first_name#17, d_date#15, 5), ENSURE_REQUIREMENTS, [id=#19]
 
-(28) HashAggregate [codegen id : 6]
-Input [3]: [c_last_name#17, c_first_name#16, d_date#14]
-Keys [3]: [c_last_name#17, c_first_name#16, d_date#14]
+(31) HashAggregate [codegen id : 7]
+Input [3]: [c_last_name#18, c_first_name#17, d_date#15]
+Keys [3]: [c_last_name#18, c_first_name#17, d_date#15]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [c_last_name#17, c_first_name#16, d_date#14]
+Results [3]: [c_last_name#18, c_first_name#17, d_date#15]
 
-(29) BroadcastExchange
-Input [3]: [c_last_name#17, c_first_name#16, d_date#14]
-Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, string, true], ), isnull(input[0, string, true]), coalesce(input[1, string, true], ), isnull(input[1, string, true]), coalesce(input[2, date, true], 0), isnull(input[2, date, true])),false), [id=#19]
+(32) BroadcastExchange
+Input [3]: [c_last_name#18, c_first_name#17, d_date#15]
+Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, string, true], ), isnull(input[0, string, true]), coalesce(input[1, string, true], ), isnull(input[1, string, true]), coalesce(input[2, date, true], 0), isnull(input[2, date, true])),false), [id=#20]
 
-(30) BroadcastHashJoin [codegen id : 11]
+(33) BroadcastHashJoin [codegen id : 12]
 Left keys [6]: [coalesce(c_last_name#9, ), isnull(c_last_name#9), coalesce(c_first_name#8, ), isnull(c_first_name#8), coalesce(d_date#4, 0), isnull(d_date#4)]
-Right keys [6]: [coalesce(c_last_name#17, ), isnull(c_last_name#17), coalesce(c_first_name#16, ), isnull(c_first_name#16), coalesce(d_date#14, 0), isnull(d_date#14)]
+Right keys [6]: [coalesce(c_last_name#18, ), isnull(c_last_name#18), coalesce(c_first_name#17, ), isnull(c_first_name#17), coalesce(d_date#15, 0), isnull(d_date#15)]
 Join condition: None
 
-(31) Scan parquet default.web_sales
-Output [2]: [ws_sold_date_sk#20, ws_bill_customer_sk#21]
+(34) HashAggregate [codegen id : 12]
+Input [3]: [c_last_name#9, c_first_name#8, d_date#4]
+Keys [3]: [c_last_name#9, c_first_name#8, d_date#4]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [c_last_name#9, c_first_name#8, d_date#4]
+
+(35) HashAggregate [codegen id : 12]
+Input [3]: [c_last_name#9, c_first_name#8, d_date#4]
+Keys [3]: [c_last_name#9, c_first_name#8, d_date#4]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [c_last_name#9, c_first_name#8, d_date#4]
+
+(36) Scan parquet default.web_sales
+Output [2]: [ws_sold_date_sk#21, ws_bill_customer_sk#22]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_sales]
 PushedFilters: [IsNotNull(ws_sold_date_sk), IsNotNull(ws_bill_customer_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_bill_customer_sk:int>
 
-(32) ColumnarToRow [codegen id : 9]
-Input [2]: [ws_sold_date_sk#20, ws_bill_customer_sk#21]
+(37) ColumnarToRow [codegen id : 10]
+Input [2]: [ws_sold_date_sk#21, ws_bill_customer_sk#22]
 
-(33) Filter [codegen id : 9]
-Input [2]: [ws_sold_date_sk#20, ws_bill_customer_sk#21]
-Condition : (isnotnull(ws_sold_date_sk#20) AND isnotnull(ws_bill_customer_sk#21))
+(38) Filter [codegen id : 10]
+Input [2]: [ws_sold_date_sk#21, ws_bill_customer_sk#22]
+Condition : (isnotnull(ws_sold_date_sk#21) AND isnotnull(ws_bill_customer_sk#22))
 
-(34) ReusedExchange [Reuses operator id: 8]
-Output [2]: [d_date_sk#22, d_date#23]
+(39) ReusedExchange [Reuses operator id: 8]
+Output [2]: [d_date_sk#23, d_date#24]
 
-(35) BroadcastHashJoin [codegen id : 9]
-Left keys [1]: [ws_sold_date_sk#20]
-Right keys [1]: [d_date_sk#22]
+(40) BroadcastHashJoin [codegen id : 10]
+Left keys [1]: [ws_sold_date_sk#21]
+Right keys [1]: [d_date_sk#23]
 Join condition: None
 
-(36) Project [codegen id : 9]
-Output [2]: [ws_bill_customer_sk#21, d_date#23]
-Input [4]: [ws_sold_date_sk#20, ws_bill_customer_sk#21, d_date_sk#22, d_date#23]
+(41) Project [codegen id : 10]
+Output [2]: [ws_bill_customer_sk#22, d_date#24]
+Input [4]: [ws_sold_date_sk#21, ws_bill_customer_sk#22, d_date_sk#23, d_date#24]
 
-(37) ReusedExchange [Reuses operator id: 14]
-Output [3]: [c_customer_sk#24, c_first_name#25, c_last_name#26]
+(42) ReusedExchange [Reuses operator id: 14]
+Output [3]: [c_customer_sk#25, c_first_name#26, c_last_name#27]
 
-(38) BroadcastHashJoin [codegen id : 9]
-Left keys [1]: [ws_bill_customer_sk#21]
-Right keys [1]: [c_customer_sk#24]
+(43) BroadcastHashJoin [codegen id : 10]
+Left keys [1]: [ws_bill_customer_sk#22]
+Right keys [1]: [c_customer_sk#25]
 Join condition: None
 
-(39) Project [codegen id : 9]
-Output [3]: [c_last_name#26, c_first_name#25, d_date#23]
-Input [5]: [ws_bill_customer_sk#21, d_date#23, c_customer_sk#24, c_first_name#25, c_last_name#26]
+(44) Project [codegen id : 10]
+Output [3]: [c_last_name#27, c_first_name#26, d_date#24]
+Input [5]: [ws_bill_customer_sk#22, d_date#24, c_customer_sk#25, c_first_name#26, c_last_name#27]
 
-(40) HashAggregate [codegen id : 9]
-Input [3]: [c_last_name#26, c_first_name#25, d_date#23]
-Keys [3]: [c_last_name#26, c_first_name#25, d_date#23]
+(45) HashAggregate [codegen id : 10]
+Input [3]: [c_last_name#27, c_first_name#26, d_date#24]
+Keys [3]: [c_last_name#27, c_first_name#26, d_date#24]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [c_last_name#26, c_first_name#25, d_date#23]
-
-(41) Exchange
-Input [3]: [c_last_name#26, c_first_name#25, d_date#23]
-Arguments: hashpartitioning(c_last_name#26, c_first_name#25, d_date#23, 5), true, [id=#27]
-
-(42) HashAggregate [codegen id : 10]
-Input [3]: [c_last_name#26, c_first_name#25, d_date#23]
-Keys [3]: [c_last_name#26, c_first_name#25, d_date#23]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [c_last_name#26, c_first_name#25, d_date#23]
-
-(43) BroadcastExchange
-Input [3]: [c_last_name#26, c_first_name#25, d_date#23]
-Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, string, true], ), isnull(input[0, string, true]), coalesce(input[1, string, true], ), isnull(input[1, string, true]), coalesce(input[2, date, true], 0), isnull(input[2, date, true])),false), [id=#28]
-
-(44) BroadcastHashJoin [codegen id : 11]
-Left keys [6]: [coalesce(c_last_name#9, ), isnull(c_last_name#9), coalesce(c_first_name#8, ), isnull(c_first_name#8), coalesce(d_date#4, 0), isnull(d_date#4)]
-Right keys [6]: [coalesce(c_last_name#26, ), isnull(c_last_name#26), coalesce(c_first_name#25, ), isnull(c_first_name#25), coalesce(d_date#23, 0), isnull(d_date#23)]
-Join condition: None
-
-(45) HashAggregate [codegen id : 11]
-Input [3]: [d_date#4, c_first_name#8, c_last_name#9]
-Keys [3]: [c_last_name#9, c_first_name#8, d_date#4]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [c_last_name#9, c_first_name#8, d_date#4]
+Results [3]: [c_last_name#27, c_first_name#26, d_date#24]
 
 (46) Exchange
-Input [3]: [c_last_name#9, c_first_name#8, d_date#4]
-Arguments: hashpartitioning(c_last_name#9, c_first_name#8, d_date#4, 5), true, [id=#29]
+Input [3]: [c_last_name#27, c_first_name#26, d_date#24]
+Arguments: hashpartitioning(c_last_name#27, c_first_name#26, d_date#24, 5), ENSURE_REQUIREMENTS, [id=#28]
 
-(47) HashAggregate [codegen id : 12]
-Input [3]: [c_last_name#9, c_first_name#8, d_date#4]
-Keys [3]: [c_last_name#9, c_first_name#8, d_date#4]
+(47) HashAggregate [codegen id : 11]
+Input [3]: [c_last_name#27, c_first_name#26, d_date#24]
+Keys [3]: [c_last_name#27, c_first_name#26, d_date#24]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [c_last_name#9, c_first_name#8, d_date#4]
+Results [3]: [c_last_name#27, c_first_name#26, d_date#24]
 
-(48) HashAggregate [codegen id : 12]
-Input [3]: [c_last_name#9, c_first_name#8, d_date#4]
-Keys [3]: [c_last_name#9, c_first_name#8, d_date#4]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [c_last_name#9, c_first_name#8, d_date#4]
+(48) BroadcastExchange
+Input [3]: [c_last_name#27, c_first_name#26, d_date#24]
+Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, string, true], ), isnull(input[0, string, true]), coalesce(input[1, string, true], ), isnull(input[1, string, true]), coalesce(input[2, date, true], 0), isnull(input[2, date, true])),false), [id=#29]
 
-(49) HashAggregate [codegen id : 12]
-Input [3]: [c_last_name#9, c_first_name#8, d_date#4]
-Keys [3]: [c_last_name#9, c_first_name#8, d_date#4]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [c_last_name#9, c_first_name#8, d_date#4]
+(49) BroadcastHashJoin [codegen id : 12]
+Left keys [6]: [coalesce(c_last_name#9, ), isnull(c_last_name#9), coalesce(c_first_name#8, ), isnull(c_first_name#8), coalesce(d_date#4, 0), isnull(d_date#4)]
+Right keys [6]: [coalesce(c_last_name#27, ), isnull(c_last_name#27), coalesce(c_first_name#26, ), isnull(c_first_name#26), coalesce(d_date#24, 0), isnull(d_date#24)]
+Join condition: None
 
 (50) HashAggregate [codegen id : 12]
 Input [3]: [c_last_name#9, c_first_name#8, d_date#4]
@@ -312,7 +312,7 @@ Results [1]: [count#31]
 
 (53) Exchange
 Input [1]: [count#31]
-Arguments: SinglePartition, true, [id=#32]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#32]
 
 (54) HashAggregate [codegen id : 13]
 Input [1]: [count#31]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q38/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q38/simplified.txt
@@ -6,16 +6,16 @@ WholeStageCodegen (13)
           HashAggregate [count,count]
             HashAggregate [c_last_name,c_first_name,d_date]
               HashAggregate [c_last_name,c_first_name,d_date]
-                HashAggregate [c_last_name,c_first_name,d_date]
+                BroadcastHashJoin [c_last_name,c_first_name,d_date,c_last_name,c_first_name,d_date]
                   HashAggregate [c_last_name,c_first_name,d_date]
                     HashAggregate [c_last_name,c_first_name,d_date]
-                      InputAdapter
-                        Exchange [c_last_name,c_first_name,d_date] #2
-                          WholeStageCodegen (11)
-                            HashAggregate [c_last_name,c_first_name,d_date]
-                              BroadcastHashJoin [c_last_name,c_first_name,d_date,c_last_name,c_first_name,d_date]
-                                BroadcastHashJoin [c_last_name,c_first_name,d_date,c_last_name,c_first_name,d_date]
-                                  Project [d_date,c_first_name,c_last_name]
+                      BroadcastHashJoin [c_last_name,c_first_name,d_date,c_last_name,c_first_name,d_date]
+                        HashAggregate [c_last_name,c_first_name,d_date]
+                          InputAdapter
+                            Exchange [c_last_name,c_first_name,d_date] #2
+                              WholeStageCodegen (3)
+                                HashAggregate [c_last_name,c_first_name,d_date]
+                                  Project [c_last_name,c_first_name,d_date]
                                     BroadcastHashJoin [ss_customer_sk,c_customer_sk]
                                       Project [ss_customer_sk,d_date]
                                         BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
@@ -38,43 +38,43 @@ WholeStageCodegen (13)
                                               ColumnarToRow
                                                 InputAdapter
                                                   Scan parquet default.customer [c_customer_sk,c_first_name,c_last_name]
-                                  InputAdapter
-                                    BroadcastExchange #5
-                                      WholeStageCodegen (6)
-                                        HashAggregate [c_last_name,c_first_name,d_date]
-                                          InputAdapter
-                                            Exchange [c_last_name,c_first_name,d_date] #6
-                                              WholeStageCodegen (5)
-                                                HashAggregate [c_last_name,c_first_name,d_date]
-                                                  Project [c_last_name,c_first_name,d_date]
-                                                    BroadcastHashJoin [cs_bill_customer_sk,c_customer_sk]
-                                                      Project [cs_bill_customer_sk,d_date]
-                                                        BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                          Filter [cs_sold_date_sk,cs_bill_customer_sk]
-                                                            ColumnarToRow
-                                                              InputAdapter
-                                                                Scan parquet default.catalog_sales [cs_sold_date_sk,cs_bill_customer_sk]
-                                                          InputAdapter
-                                                            ReusedExchange [d_date_sk,d_date] #3
-                                                      InputAdapter
-                                                        ReusedExchange [c_customer_sk,c_first_name,c_last_name] #4
+                        InputAdapter
+                          BroadcastExchange #5
+                            WholeStageCodegen (7)
+                              HashAggregate [c_last_name,c_first_name,d_date]
                                 InputAdapter
-                                  BroadcastExchange #7
-                                    WholeStageCodegen (10)
+                                  Exchange [c_last_name,c_first_name,d_date] #6
+                                    WholeStageCodegen (6)
                                       HashAggregate [c_last_name,c_first_name,d_date]
-                                        InputAdapter
-                                          Exchange [c_last_name,c_first_name,d_date] #8
-                                            WholeStageCodegen (9)
-                                              HashAggregate [c_last_name,c_first_name,d_date]
-                                                Project [c_last_name,c_first_name,d_date]
-                                                  BroadcastHashJoin [ws_bill_customer_sk,c_customer_sk]
-                                                    Project [ws_bill_customer_sk,d_date]
-                                                      BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                        Filter [ws_sold_date_sk,ws_bill_customer_sk]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet default.web_sales [ws_sold_date_sk,ws_bill_customer_sk]
-                                                        InputAdapter
-                                                          ReusedExchange [d_date_sk,d_date] #3
+                                        Project [c_last_name,c_first_name,d_date]
+                                          BroadcastHashJoin [cs_bill_customer_sk,c_customer_sk]
+                                            Project [cs_bill_customer_sk,d_date]
+                                              BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                Filter [cs_sold_date_sk,cs_bill_customer_sk]
+                                                  ColumnarToRow
                                                     InputAdapter
-                                                      ReusedExchange [c_customer_sk,c_first_name,c_last_name] #4
+                                                      Scan parquet default.catalog_sales [cs_sold_date_sk,cs_bill_customer_sk]
+                                                InputAdapter
+                                                  ReusedExchange [d_date_sk,d_date] #3
+                                            InputAdapter
+                                              ReusedExchange [c_customer_sk,c_first_name,c_last_name] #4
+                  InputAdapter
+                    BroadcastExchange #7
+                      WholeStageCodegen (11)
+                        HashAggregate [c_last_name,c_first_name,d_date]
+                          InputAdapter
+                            Exchange [c_last_name,c_first_name,d_date] #8
+                              WholeStageCodegen (10)
+                                HashAggregate [c_last_name,c_first_name,d_date]
+                                  Project [c_last_name,c_first_name,d_date]
+                                    BroadcastHashJoin [ws_bill_customer_sk,c_customer_sk]
+                                      Project [ws_bill_customer_sk,d_date]
+                                        BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                          Filter [ws_sold_date_sk,ws_bill_customer_sk]
+                                            ColumnarToRow
+                                              InputAdapter
+                                                Scan parquet default.web_sales [ws_sold_date_sk,ws_bill_customer_sk]
+                                          InputAdapter
+                                            ReusedExchange [d_date_sk,d_date] #3
+                                      InputAdapter
+                                        ReusedExchange [c_customer_sk,c_first_name,c_last_name] #4

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q87/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q87/explain.txt
@@ -4,55 +4,55 @@
    +- * HashAggregate (52)
       +- * HashAggregate (51)
          +- * HashAggregate (50)
-            +- * HashAggregate (49)
-               +- * HashAggregate (48)
+            +- * BroadcastHashJoin LeftAnti BuildRight (49)
+               :- * HashAggregate (35)
+               :  +- * HashAggregate (34)
+               :     +- * BroadcastHashJoin LeftAnti BuildRight (33)
+               :        :- * HashAggregate (19)
+               :        :  +- Exchange (18)
+               :        :     +- * HashAggregate (17)
+               :        :        +- * Project (16)
+               :        :           +- * BroadcastHashJoin Inner BuildRight (15)
+               :        :              :- * Project (10)
+               :        :              :  +- * BroadcastHashJoin Inner BuildRight (9)
+               :        :              :     :- * Filter (3)
+               :        :              :     :  +- * ColumnarToRow (2)
+               :        :              :     :     +- Scan parquet default.store_sales (1)
+               :        :              :     +- BroadcastExchange (8)
+               :        :              :        +- * Project (7)
+               :        :              :           +- * Filter (6)
+               :        :              :              +- * ColumnarToRow (5)
+               :        :              :                 +- Scan parquet default.date_dim (4)
+               :        :              +- BroadcastExchange (14)
+               :        :                 +- * Filter (13)
+               :        :                    +- * ColumnarToRow (12)
+               :        :                       +- Scan parquet default.customer (11)
+               :        +- BroadcastExchange (32)
+               :           +- * HashAggregate (31)
+               :              +- Exchange (30)
+               :                 +- * HashAggregate (29)
+               :                    +- * Project (28)
+               :                       +- * BroadcastHashJoin Inner BuildRight (27)
+               :                          :- * Project (25)
+               :                          :  +- * BroadcastHashJoin Inner BuildRight (24)
+               :                          :     :- * Filter (22)
+               :                          :     :  +- * ColumnarToRow (21)
+               :                          :     :     +- Scan parquet default.catalog_sales (20)
+               :                          :     +- ReusedExchange (23)
+               :                          +- ReusedExchange (26)
+               +- BroadcastExchange (48)
                   +- * HashAggregate (47)
                      +- Exchange (46)
                         +- * HashAggregate (45)
-                           +- * BroadcastHashJoin LeftAnti BuildRight (44)
-                              :- * BroadcastHashJoin LeftAnti BuildRight (30)
-                              :  :- * Project (16)
-                              :  :  +- * BroadcastHashJoin Inner BuildRight (15)
-                              :  :     :- * Project (10)
-                              :  :     :  +- * BroadcastHashJoin Inner BuildRight (9)
-                              :  :     :     :- * Filter (3)
-                              :  :     :     :  +- * ColumnarToRow (2)
-                              :  :     :     :     +- Scan parquet default.store_sales (1)
-                              :  :     :     +- BroadcastExchange (8)
-                              :  :     :        +- * Project (7)
-                              :  :     :           +- * Filter (6)
-                              :  :     :              +- * ColumnarToRow (5)
-                              :  :     :                 +- Scan parquet default.date_dim (4)
-                              :  :     +- BroadcastExchange (14)
-                              :  :        +- * Filter (13)
-                              :  :           +- * ColumnarToRow (12)
-                              :  :              +- Scan parquet default.customer (11)
-                              :  +- BroadcastExchange (29)
-                              :     +- * HashAggregate (28)
-                              :        +- Exchange (27)
-                              :           +- * HashAggregate (26)
-                              :              +- * Project (25)
-                              :                 +- * BroadcastHashJoin Inner BuildRight (24)
-                              :                    :- * Project (22)
-                              :                    :  +- * BroadcastHashJoin Inner BuildRight (21)
-                              :                    :     :- * Filter (19)
-                              :                    :     :  +- * ColumnarToRow (18)
-                              :                    :     :     +- Scan parquet default.catalog_sales (17)
-                              :                    :     +- ReusedExchange (20)
-                              :                    +- ReusedExchange (23)
-                              +- BroadcastExchange (43)
-                                 +- * HashAggregate (42)
-                                    +- Exchange (41)
-                                       +- * HashAggregate (40)
-                                          +- * Project (39)
-                                             +- * BroadcastHashJoin Inner BuildRight (38)
-                                                :- * Project (36)
-                                                :  +- * BroadcastHashJoin Inner BuildRight (35)
-                                                :     :- * Filter (33)
-                                                :     :  +- * ColumnarToRow (32)
-                                                :     :     +- Scan parquet default.web_sales (31)
-                                                :     +- ReusedExchange (34)
-                                                +- ReusedExchange (37)
+                           +- * Project (44)
+                              +- * BroadcastHashJoin Inner BuildRight (43)
+                                 :- * Project (41)
+                                 :  +- * BroadcastHashJoin Inner BuildRight (40)
+                                 :     :- * Filter (38)
+                                 :     :  +- * ColumnarToRow (37)
+                                 :     :     +- Scan parquet default.web_sales (36)
+                                 :     +- ReusedExchange (39)
+                                 +- ReusedExchange (42)
 
 
 (1) Scan parquet default.store_sales
@@ -62,10 +62,10 @@ Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_sold_date_sk), IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_sold_date_sk:int,ss_customer_sk:int>
 
-(2) ColumnarToRow [codegen id : 11]
+(2) ColumnarToRow [codegen id : 3]
 Input [2]: [ss_sold_date_sk#1, ss_customer_sk#2]
 
-(3) Filter [codegen id : 11]
+(3) Filter [codegen id : 3]
 Input [2]: [ss_sold_date_sk#1, ss_customer_sk#2]
 Condition : (isnotnull(ss_sold_date_sk#1) AND isnotnull(ss_customer_sk#2))
 
@@ -91,12 +91,12 @@ Input [3]: [d_date_sk#3, d_date#4, d_month_seq#5]
 Input [2]: [d_date_sk#3, d_date#4]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#6]
 
-(9) BroadcastHashJoin [codegen id : 11]
+(9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#1]
 Right keys [1]: [d_date_sk#3]
 Join condition: None
 
-(10) Project [codegen id : 11]
+(10) Project [codegen id : 3]
 Output [2]: [ss_customer_sk#2, d_date#4]
 Input [4]: [ss_sold_date_sk#1, ss_customer_sk#2, d_date_sk#3, d_date#4]
 
@@ -118,176 +118,176 @@ Condition : isnotnull(c_customer_sk#7)
 Input [3]: [c_customer_sk#7, c_first_name#8, c_last_name#9]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#10]
 
-(15) BroadcastHashJoin [codegen id : 11]
+(15) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_customer_sk#2]
 Right keys [1]: [c_customer_sk#7]
 Join condition: None
 
-(16) Project [codegen id : 11]
-Output [3]: [d_date#4, c_first_name#8, c_last_name#9]
+(16) Project [codegen id : 3]
+Output [3]: [c_last_name#9, c_first_name#8, d_date#4]
 Input [5]: [ss_customer_sk#2, d_date#4, c_customer_sk#7, c_first_name#8, c_last_name#9]
 
-(17) Scan parquet default.catalog_sales
-Output [2]: [cs_sold_date_sk#11, cs_bill_customer_sk#12]
+(17) HashAggregate [codegen id : 3]
+Input [3]: [c_last_name#9, c_first_name#8, d_date#4]
+Keys [3]: [c_last_name#9, c_first_name#8, d_date#4]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [c_last_name#9, c_first_name#8, d_date#4]
+
+(18) Exchange
+Input [3]: [c_last_name#9, c_first_name#8, d_date#4]
+Arguments: hashpartitioning(c_last_name#9, c_first_name#8, d_date#4, 5), ENSURE_REQUIREMENTS, [id=#11]
+
+(19) HashAggregate [codegen id : 12]
+Input [3]: [c_last_name#9, c_first_name#8, d_date#4]
+Keys [3]: [c_last_name#9, c_first_name#8, d_date#4]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [c_last_name#9, c_first_name#8, d_date#4]
+
+(20) Scan parquet default.catalog_sales
+Output [2]: [cs_sold_date_sk#12, cs_bill_customer_sk#13]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_sales]
 PushedFilters: [IsNotNull(cs_sold_date_sk), IsNotNull(cs_bill_customer_sk)]
 ReadSchema: struct<cs_sold_date_sk:int,cs_bill_customer_sk:int>
 
-(18) ColumnarToRow [codegen id : 5]
-Input [2]: [cs_sold_date_sk#11, cs_bill_customer_sk#12]
+(21) ColumnarToRow [codegen id : 6]
+Input [2]: [cs_sold_date_sk#12, cs_bill_customer_sk#13]
 
-(19) Filter [codegen id : 5]
-Input [2]: [cs_sold_date_sk#11, cs_bill_customer_sk#12]
-Condition : (isnotnull(cs_sold_date_sk#11) AND isnotnull(cs_bill_customer_sk#12))
+(22) Filter [codegen id : 6]
+Input [2]: [cs_sold_date_sk#12, cs_bill_customer_sk#13]
+Condition : (isnotnull(cs_sold_date_sk#12) AND isnotnull(cs_bill_customer_sk#13))
 
-(20) ReusedExchange [Reuses operator id: 8]
-Output [2]: [d_date_sk#13, d_date#14]
+(23) ReusedExchange [Reuses operator id: 8]
+Output [2]: [d_date_sk#14, d_date#15]
 
-(21) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [cs_sold_date_sk#11]
-Right keys [1]: [d_date_sk#13]
+(24) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [cs_sold_date_sk#12]
+Right keys [1]: [d_date_sk#14]
 Join condition: None
 
-(22) Project [codegen id : 5]
-Output [2]: [cs_bill_customer_sk#12, d_date#14]
-Input [4]: [cs_sold_date_sk#11, cs_bill_customer_sk#12, d_date_sk#13, d_date#14]
+(25) Project [codegen id : 6]
+Output [2]: [cs_bill_customer_sk#13, d_date#15]
+Input [4]: [cs_sold_date_sk#12, cs_bill_customer_sk#13, d_date_sk#14, d_date#15]
 
-(23) ReusedExchange [Reuses operator id: 14]
-Output [3]: [c_customer_sk#15, c_first_name#16, c_last_name#17]
+(26) ReusedExchange [Reuses operator id: 14]
+Output [3]: [c_customer_sk#16, c_first_name#17, c_last_name#18]
 
-(24) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [cs_bill_customer_sk#12]
-Right keys [1]: [c_customer_sk#15]
+(27) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [cs_bill_customer_sk#13]
+Right keys [1]: [c_customer_sk#16]
 Join condition: None
 
-(25) Project [codegen id : 5]
-Output [3]: [c_last_name#17, c_first_name#16, d_date#14]
-Input [5]: [cs_bill_customer_sk#12, d_date#14, c_customer_sk#15, c_first_name#16, c_last_name#17]
+(28) Project [codegen id : 6]
+Output [3]: [c_last_name#18, c_first_name#17, d_date#15]
+Input [5]: [cs_bill_customer_sk#13, d_date#15, c_customer_sk#16, c_first_name#17, c_last_name#18]
 
-(26) HashAggregate [codegen id : 5]
-Input [3]: [c_last_name#17, c_first_name#16, d_date#14]
-Keys [3]: [c_last_name#17, c_first_name#16, d_date#14]
+(29) HashAggregate [codegen id : 6]
+Input [3]: [c_last_name#18, c_first_name#17, d_date#15]
+Keys [3]: [c_last_name#18, c_first_name#17, d_date#15]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [c_last_name#17, c_first_name#16, d_date#14]
+Results [3]: [c_last_name#18, c_first_name#17, d_date#15]
 
-(27) Exchange
-Input [3]: [c_last_name#17, c_first_name#16, d_date#14]
-Arguments: hashpartitioning(c_last_name#17, c_first_name#16, d_date#14, 5), true, [id=#18]
+(30) Exchange
+Input [3]: [c_last_name#18, c_first_name#17, d_date#15]
+Arguments: hashpartitioning(c_last_name#18, c_first_name#17, d_date#15, 5), ENSURE_REQUIREMENTS, [id=#19]
 
-(28) HashAggregate [codegen id : 6]
-Input [3]: [c_last_name#17, c_first_name#16, d_date#14]
-Keys [3]: [c_last_name#17, c_first_name#16, d_date#14]
+(31) HashAggregate [codegen id : 7]
+Input [3]: [c_last_name#18, c_first_name#17, d_date#15]
+Keys [3]: [c_last_name#18, c_first_name#17, d_date#15]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [c_last_name#17, c_first_name#16, d_date#14]
+Results [3]: [c_last_name#18, c_first_name#17, d_date#15]
 
-(29) BroadcastExchange
-Input [3]: [c_last_name#17, c_first_name#16, d_date#14]
-Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, string, true], ), isnull(input[0, string, true]), coalesce(input[1, string, true], ), isnull(input[1, string, true]), coalesce(input[2, date, true], 0), isnull(input[2, date, true])),false), [id=#19]
+(32) BroadcastExchange
+Input [3]: [c_last_name#18, c_first_name#17, d_date#15]
+Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, string, true], ), isnull(input[0, string, true]), coalesce(input[1, string, true], ), isnull(input[1, string, true]), coalesce(input[2, date, true], 0), isnull(input[2, date, true])),false), [id=#20]
 
-(30) BroadcastHashJoin [codegen id : 11]
+(33) BroadcastHashJoin [codegen id : 12]
 Left keys [6]: [coalesce(c_last_name#9, ), isnull(c_last_name#9), coalesce(c_first_name#8, ), isnull(c_first_name#8), coalesce(d_date#4, 0), isnull(d_date#4)]
-Right keys [6]: [coalesce(c_last_name#17, ), isnull(c_last_name#17), coalesce(c_first_name#16, ), isnull(c_first_name#16), coalesce(d_date#14, 0), isnull(d_date#14)]
+Right keys [6]: [coalesce(c_last_name#18, ), isnull(c_last_name#18), coalesce(c_first_name#17, ), isnull(c_first_name#17), coalesce(d_date#15, 0), isnull(d_date#15)]
 Join condition: None
 
-(31) Scan parquet default.web_sales
-Output [2]: [ws_sold_date_sk#20, ws_bill_customer_sk#21]
+(34) HashAggregate [codegen id : 12]
+Input [3]: [c_last_name#9, c_first_name#8, d_date#4]
+Keys [3]: [c_last_name#9, c_first_name#8, d_date#4]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [c_last_name#9, c_first_name#8, d_date#4]
+
+(35) HashAggregate [codegen id : 12]
+Input [3]: [c_last_name#9, c_first_name#8, d_date#4]
+Keys [3]: [c_last_name#9, c_first_name#8, d_date#4]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [c_last_name#9, c_first_name#8, d_date#4]
+
+(36) Scan parquet default.web_sales
+Output [2]: [ws_sold_date_sk#21, ws_bill_customer_sk#22]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_sales]
 PushedFilters: [IsNotNull(ws_sold_date_sk), IsNotNull(ws_bill_customer_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_bill_customer_sk:int>
 
-(32) ColumnarToRow [codegen id : 9]
-Input [2]: [ws_sold_date_sk#20, ws_bill_customer_sk#21]
+(37) ColumnarToRow [codegen id : 10]
+Input [2]: [ws_sold_date_sk#21, ws_bill_customer_sk#22]
 
-(33) Filter [codegen id : 9]
-Input [2]: [ws_sold_date_sk#20, ws_bill_customer_sk#21]
-Condition : (isnotnull(ws_sold_date_sk#20) AND isnotnull(ws_bill_customer_sk#21))
+(38) Filter [codegen id : 10]
+Input [2]: [ws_sold_date_sk#21, ws_bill_customer_sk#22]
+Condition : (isnotnull(ws_sold_date_sk#21) AND isnotnull(ws_bill_customer_sk#22))
 
-(34) ReusedExchange [Reuses operator id: 8]
-Output [2]: [d_date_sk#22, d_date#23]
+(39) ReusedExchange [Reuses operator id: 8]
+Output [2]: [d_date_sk#23, d_date#24]
 
-(35) BroadcastHashJoin [codegen id : 9]
-Left keys [1]: [ws_sold_date_sk#20]
-Right keys [1]: [d_date_sk#22]
+(40) BroadcastHashJoin [codegen id : 10]
+Left keys [1]: [ws_sold_date_sk#21]
+Right keys [1]: [d_date_sk#23]
 Join condition: None
 
-(36) Project [codegen id : 9]
-Output [2]: [ws_bill_customer_sk#21, d_date#23]
-Input [4]: [ws_sold_date_sk#20, ws_bill_customer_sk#21, d_date_sk#22, d_date#23]
+(41) Project [codegen id : 10]
+Output [2]: [ws_bill_customer_sk#22, d_date#24]
+Input [4]: [ws_sold_date_sk#21, ws_bill_customer_sk#22, d_date_sk#23, d_date#24]
 
-(37) ReusedExchange [Reuses operator id: 14]
-Output [3]: [c_customer_sk#24, c_first_name#25, c_last_name#26]
+(42) ReusedExchange [Reuses operator id: 14]
+Output [3]: [c_customer_sk#25, c_first_name#26, c_last_name#27]
 
-(38) BroadcastHashJoin [codegen id : 9]
-Left keys [1]: [ws_bill_customer_sk#21]
-Right keys [1]: [c_customer_sk#24]
+(43) BroadcastHashJoin [codegen id : 10]
+Left keys [1]: [ws_bill_customer_sk#22]
+Right keys [1]: [c_customer_sk#25]
 Join condition: None
 
-(39) Project [codegen id : 9]
-Output [3]: [c_last_name#26, c_first_name#25, d_date#23]
-Input [5]: [ws_bill_customer_sk#21, d_date#23, c_customer_sk#24, c_first_name#25, c_last_name#26]
+(44) Project [codegen id : 10]
+Output [3]: [c_last_name#27, c_first_name#26, d_date#24]
+Input [5]: [ws_bill_customer_sk#22, d_date#24, c_customer_sk#25, c_first_name#26, c_last_name#27]
 
-(40) HashAggregate [codegen id : 9]
-Input [3]: [c_last_name#26, c_first_name#25, d_date#23]
-Keys [3]: [c_last_name#26, c_first_name#25, d_date#23]
+(45) HashAggregate [codegen id : 10]
+Input [3]: [c_last_name#27, c_first_name#26, d_date#24]
+Keys [3]: [c_last_name#27, c_first_name#26, d_date#24]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [c_last_name#26, c_first_name#25, d_date#23]
-
-(41) Exchange
-Input [3]: [c_last_name#26, c_first_name#25, d_date#23]
-Arguments: hashpartitioning(c_last_name#26, c_first_name#25, d_date#23, 5), true, [id=#27]
-
-(42) HashAggregate [codegen id : 10]
-Input [3]: [c_last_name#26, c_first_name#25, d_date#23]
-Keys [3]: [c_last_name#26, c_first_name#25, d_date#23]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [c_last_name#26, c_first_name#25, d_date#23]
-
-(43) BroadcastExchange
-Input [3]: [c_last_name#26, c_first_name#25, d_date#23]
-Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, string, true], ), isnull(input[0, string, true]), coalesce(input[1, string, true], ), isnull(input[1, string, true]), coalesce(input[2, date, true], 0), isnull(input[2, date, true])),false), [id=#28]
-
-(44) BroadcastHashJoin [codegen id : 11]
-Left keys [6]: [coalesce(c_last_name#9, ), isnull(c_last_name#9), coalesce(c_first_name#8, ), isnull(c_first_name#8), coalesce(d_date#4, 0), isnull(d_date#4)]
-Right keys [6]: [coalesce(c_last_name#26, ), isnull(c_last_name#26), coalesce(c_first_name#25, ), isnull(c_first_name#25), coalesce(d_date#23, 0), isnull(d_date#23)]
-Join condition: None
-
-(45) HashAggregate [codegen id : 11]
-Input [3]: [d_date#4, c_first_name#8, c_last_name#9]
-Keys [3]: [c_last_name#9, c_first_name#8, d_date#4]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [c_last_name#9, c_first_name#8, d_date#4]
+Results [3]: [c_last_name#27, c_first_name#26, d_date#24]
 
 (46) Exchange
-Input [3]: [c_last_name#9, c_first_name#8, d_date#4]
-Arguments: hashpartitioning(c_last_name#9, c_first_name#8, d_date#4, 5), true, [id=#29]
+Input [3]: [c_last_name#27, c_first_name#26, d_date#24]
+Arguments: hashpartitioning(c_last_name#27, c_first_name#26, d_date#24, 5), ENSURE_REQUIREMENTS, [id=#28]
 
-(47) HashAggregate [codegen id : 12]
-Input [3]: [c_last_name#9, c_first_name#8, d_date#4]
-Keys [3]: [c_last_name#9, c_first_name#8, d_date#4]
+(47) HashAggregate [codegen id : 11]
+Input [3]: [c_last_name#27, c_first_name#26, d_date#24]
+Keys [3]: [c_last_name#27, c_first_name#26, d_date#24]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [c_last_name#9, c_first_name#8, d_date#4]
+Results [3]: [c_last_name#27, c_first_name#26, d_date#24]
 
-(48) HashAggregate [codegen id : 12]
-Input [3]: [c_last_name#9, c_first_name#8, d_date#4]
-Keys [3]: [c_last_name#9, c_first_name#8, d_date#4]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [c_last_name#9, c_first_name#8, d_date#4]
+(48) BroadcastExchange
+Input [3]: [c_last_name#27, c_first_name#26, d_date#24]
+Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, string, true], ), isnull(input[0, string, true]), coalesce(input[1, string, true], ), isnull(input[1, string, true]), coalesce(input[2, date, true], 0), isnull(input[2, date, true])),false), [id=#29]
 
-(49) HashAggregate [codegen id : 12]
-Input [3]: [c_last_name#9, c_first_name#8, d_date#4]
-Keys [3]: [c_last_name#9, c_first_name#8, d_date#4]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [c_last_name#9, c_first_name#8, d_date#4]
+(49) BroadcastHashJoin [codegen id : 12]
+Left keys [6]: [coalesce(c_last_name#9, ), isnull(c_last_name#9), coalesce(c_first_name#8, ), isnull(c_first_name#8), coalesce(d_date#4, 0), isnull(d_date#4)]
+Right keys [6]: [coalesce(c_last_name#27, ), isnull(c_last_name#27), coalesce(c_first_name#26, ), isnull(c_first_name#26), coalesce(d_date#24, 0), isnull(d_date#24)]
+Join condition: None
 
 (50) HashAggregate [codegen id : 12]
 Input [3]: [c_last_name#9, c_first_name#8, d_date#4]
@@ -312,7 +312,7 @@ Results [1]: [count#31]
 
 (53) Exchange
 Input [1]: [count#31]
-Arguments: SinglePartition, true, [id=#32]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#32]
 
 (54) HashAggregate [codegen id : 13]
 Input [1]: [count#31]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q87/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q87/simplified.txt
@@ -6,16 +6,16 @@ WholeStageCodegen (13)
           HashAggregate [count,count]
             HashAggregate [c_last_name,c_first_name,d_date]
               HashAggregate [c_last_name,c_first_name,d_date]
-                HashAggregate [c_last_name,c_first_name,d_date]
+                BroadcastHashJoin [c_last_name,c_first_name,d_date,c_last_name,c_first_name,d_date]
                   HashAggregate [c_last_name,c_first_name,d_date]
                     HashAggregate [c_last_name,c_first_name,d_date]
-                      InputAdapter
-                        Exchange [c_last_name,c_first_name,d_date] #2
-                          WholeStageCodegen (11)
-                            HashAggregate [c_last_name,c_first_name,d_date]
-                              BroadcastHashJoin [c_last_name,c_first_name,d_date,c_last_name,c_first_name,d_date]
-                                BroadcastHashJoin [c_last_name,c_first_name,d_date,c_last_name,c_first_name,d_date]
-                                  Project [d_date,c_first_name,c_last_name]
+                      BroadcastHashJoin [c_last_name,c_first_name,d_date,c_last_name,c_first_name,d_date]
+                        HashAggregate [c_last_name,c_first_name,d_date]
+                          InputAdapter
+                            Exchange [c_last_name,c_first_name,d_date] #2
+                              WholeStageCodegen (3)
+                                HashAggregate [c_last_name,c_first_name,d_date]
+                                  Project [c_last_name,c_first_name,d_date]
                                     BroadcastHashJoin [ss_customer_sk,c_customer_sk]
                                       Project [ss_customer_sk,d_date]
                                         BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
@@ -38,43 +38,43 @@ WholeStageCodegen (13)
                                               ColumnarToRow
                                                 InputAdapter
                                                   Scan parquet default.customer [c_customer_sk,c_first_name,c_last_name]
-                                  InputAdapter
-                                    BroadcastExchange #5
-                                      WholeStageCodegen (6)
-                                        HashAggregate [c_last_name,c_first_name,d_date]
-                                          InputAdapter
-                                            Exchange [c_last_name,c_first_name,d_date] #6
-                                              WholeStageCodegen (5)
-                                                HashAggregate [c_last_name,c_first_name,d_date]
-                                                  Project [c_last_name,c_first_name,d_date]
-                                                    BroadcastHashJoin [cs_bill_customer_sk,c_customer_sk]
-                                                      Project [cs_bill_customer_sk,d_date]
-                                                        BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                          Filter [cs_sold_date_sk,cs_bill_customer_sk]
-                                                            ColumnarToRow
-                                                              InputAdapter
-                                                                Scan parquet default.catalog_sales [cs_sold_date_sk,cs_bill_customer_sk]
-                                                          InputAdapter
-                                                            ReusedExchange [d_date_sk,d_date] #3
-                                                      InputAdapter
-                                                        ReusedExchange [c_customer_sk,c_first_name,c_last_name] #4
+                        InputAdapter
+                          BroadcastExchange #5
+                            WholeStageCodegen (7)
+                              HashAggregate [c_last_name,c_first_name,d_date]
                                 InputAdapter
-                                  BroadcastExchange #7
-                                    WholeStageCodegen (10)
+                                  Exchange [c_last_name,c_first_name,d_date] #6
+                                    WholeStageCodegen (6)
                                       HashAggregate [c_last_name,c_first_name,d_date]
-                                        InputAdapter
-                                          Exchange [c_last_name,c_first_name,d_date] #8
-                                            WholeStageCodegen (9)
-                                              HashAggregate [c_last_name,c_first_name,d_date]
-                                                Project [c_last_name,c_first_name,d_date]
-                                                  BroadcastHashJoin [ws_bill_customer_sk,c_customer_sk]
-                                                    Project [ws_bill_customer_sk,d_date]
-                                                      BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                        Filter [ws_sold_date_sk,ws_bill_customer_sk]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet default.web_sales [ws_sold_date_sk,ws_bill_customer_sk]
-                                                        InputAdapter
-                                                          ReusedExchange [d_date_sk,d_date] #3
+                                        Project [c_last_name,c_first_name,d_date]
+                                          BroadcastHashJoin [cs_bill_customer_sk,c_customer_sk]
+                                            Project [cs_bill_customer_sk,d_date]
+                                              BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                Filter [cs_sold_date_sk,cs_bill_customer_sk]
+                                                  ColumnarToRow
                                                     InputAdapter
-                                                      ReusedExchange [c_customer_sk,c_first_name,c_last_name] #4
+                                                      Scan parquet default.catalog_sales [cs_sold_date_sk,cs_bill_customer_sk]
+                                                InputAdapter
+                                                  ReusedExchange [d_date_sk,d_date] #3
+                                            InputAdapter
+                                              ReusedExchange [c_customer_sk,c_first_name,c_last_name] #4
+                  InputAdapter
+                    BroadcastExchange #7
+                      WholeStageCodegen (11)
+                        HashAggregate [c_last_name,c_first_name,d_date]
+                          InputAdapter
+                            Exchange [c_last_name,c_first_name,d_date] #8
+                              WholeStageCodegen (10)
+                                HashAggregate [c_last_name,c_first_name,d_date]
+                                  Project [c_last_name,c_first_name,d_date]
+                                    BroadcastHashJoin [ws_bill_customer_sk,c_customer_sk]
+                                      Project [ws_bill_customer_sk,d_date]
+                                        BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                          Filter [ws_sold_date_sk,ws_bill_customer_sk]
+                                            ColumnarToRow
+                                              InputAdapter
+                                                Scan parquet default.web_sales [ws_sold_date_sk,ws_bill_customer_sk]
+                                          InputAdapter
+                                            ReusedExchange [d_date_sk,d_date] #3
+                                      InputAdapter
+                                        ReusedExchange [c_customer_sk,c_first_name,c_last_name] #4

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14/explain.txt
@@ -23,50 +23,50 @@ TakeOrderedAndProject (100)
    :                    :     :           +- BroadcastExchange (53)
    :                    :     :              +- * HashAggregate (52)
    :                    :     :                 +- * HashAggregate (51)
-   :                    :     :                    +- * HashAggregate (50)
-   :                    :     :                       +- Exchange (49)
-   :                    :     :                          +- * HashAggregate (48)
-   :                    :     :                             +- * BroadcastHashJoin LeftSemi BuildRight (47)
-   :                    :     :                                :- * BroadcastHashJoin LeftSemi BuildRight (36)
-   :                    :     :                                :  :- * Project (22)
-   :                    :     :                                :  :  +- * BroadcastHashJoin Inner BuildRight (21)
-   :                    :     :                                :  :     :- * Project (15)
-   :                    :     :                                :  :     :  +- * BroadcastHashJoin Inner BuildRight (14)
-   :                    :     :                                :  :     :     :- * Filter (9)
-   :                    :     :                                :  :     :     :  +- * ColumnarToRow (8)
-   :                    :     :                                :  :     :     :     +- Scan parquet default.store_sales (7)
-   :                    :     :                                :  :     :     +- BroadcastExchange (13)
-   :                    :     :                                :  :     :        +- * Filter (12)
-   :                    :     :                                :  :     :           +- * ColumnarToRow (11)
-   :                    :     :                                :  :     :              +- Scan parquet default.item (10)
-   :                    :     :                                :  :     +- BroadcastExchange (20)
-   :                    :     :                                :  :        +- * Project (19)
-   :                    :     :                                :  :           +- * Filter (18)
-   :                    :     :                                :  :              +- * ColumnarToRow (17)
-   :                    :     :                                :  :                 +- Scan parquet default.date_dim (16)
-   :                    :     :                                :  +- BroadcastExchange (35)
-   :                    :     :                                :     +- * Project (34)
-   :                    :     :                                :        +- * BroadcastHashJoin Inner BuildRight (33)
-   :                    :     :                                :           :- * Project (31)
-   :                    :     :                                :           :  +- * BroadcastHashJoin Inner BuildRight (30)
-   :                    :     :                                :           :     :- * Filter (25)
-   :                    :     :                                :           :     :  +- * ColumnarToRow (24)
-   :                    :     :                                :           :     :     +- Scan parquet default.catalog_sales (23)
-   :                    :     :                                :           :     +- BroadcastExchange (29)
-   :                    :     :                                :           :        +- * Filter (28)
-   :                    :     :                                :           :           +- * ColumnarToRow (27)
-   :                    :     :                                :           :              +- Scan parquet default.item (26)
-   :                    :     :                                :           +- ReusedExchange (32)
-   :                    :     :                                +- BroadcastExchange (46)
-   :                    :     :                                   +- * Project (45)
-   :                    :     :                                      +- * BroadcastHashJoin Inner BuildRight (44)
-   :                    :     :                                         :- * Project (42)
-   :                    :     :                                         :  +- * BroadcastHashJoin Inner BuildRight (41)
-   :                    :     :                                         :     :- * Filter (39)
-   :                    :     :                                         :     :  +- * ColumnarToRow (38)
-   :                    :     :                                         :     :     +- Scan parquet default.web_sales (37)
-   :                    :     :                                         :     +- ReusedExchange (40)
-   :                    :     :                                         +- ReusedExchange (43)
+   :                    :     :                    +- * BroadcastHashJoin LeftSemi BuildRight (50)
+   :                    :     :                       :- * HashAggregate (39)
+   :                    :     :                       :  +- Exchange (38)
+   :                    :     :                       :     +- * HashAggregate (37)
+   :                    :     :                       :        +- * BroadcastHashJoin LeftSemi BuildRight (36)
+   :                    :     :                       :           :- * Project (22)
+   :                    :     :                       :           :  +- * BroadcastHashJoin Inner BuildRight (21)
+   :                    :     :                       :           :     :- * Project (15)
+   :                    :     :                       :           :     :  +- * BroadcastHashJoin Inner BuildRight (14)
+   :                    :     :                       :           :     :     :- * Filter (9)
+   :                    :     :                       :           :     :     :  +- * ColumnarToRow (8)
+   :                    :     :                       :           :     :     :     +- Scan parquet default.store_sales (7)
+   :                    :     :                       :           :     :     +- BroadcastExchange (13)
+   :                    :     :                       :           :     :        +- * Filter (12)
+   :                    :     :                       :           :     :           +- * ColumnarToRow (11)
+   :                    :     :                       :           :     :              +- Scan parquet default.item (10)
+   :                    :     :                       :           :     +- BroadcastExchange (20)
+   :                    :     :                       :           :        +- * Project (19)
+   :                    :     :                       :           :           +- * Filter (18)
+   :                    :     :                       :           :              +- * ColumnarToRow (17)
+   :                    :     :                       :           :                 +- Scan parquet default.date_dim (16)
+   :                    :     :                       :           +- BroadcastExchange (35)
+   :                    :     :                       :              +- * Project (34)
+   :                    :     :                       :                 +- * BroadcastHashJoin Inner BuildRight (33)
+   :                    :     :                       :                    :- * Project (31)
+   :                    :     :                       :                    :  +- * BroadcastHashJoin Inner BuildRight (30)
+   :                    :     :                       :                    :     :- * Filter (25)
+   :                    :     :                       :                    :     :  +- * ColumnarToRow (24)
+   :                    :     :                       :                    :     :     +- Scan parquet default.catalog_sales (23)
+   :                    :     :                       :                    :     +- BroadcastExchange (29)
+   :                    :     :                       :                    :        +- * Filter (28)
+   :                    :     :                       :                    :           +- * ColumnarToRow (27)
+   :                    :     :                       :                    :              +- Scan parquet default.item (26)
+   :                    :     :                       :                    +- ReusedExchange (32)
+   :                    :     :                       +- BroadcastExchange (49)
+   :                    :     :                          +- * Project (48)
+   :                    :     :                             +- * BroadcastHashJoin Inner BuildRight (47)
+   :                    :     :                                :- * Project (45)
+   :                    :     :                                :  +- * BroadcastHashJoin Inner BuildRight (44)
+   :                    :     :                                :     :- * Filter (42)
+   :                    :     :                                :     :  +- * ColumnarToRow (41)
+   :                    :     :                                :     :     +- Scan parquet default.web_sales (40)
+   :                    :     :                                :     +- ReusedExchange (43)
+   :                    :     :                                +- ReusedExchange (46)
    :                    :     +- BroadcastExchange (63)
    :                    :        +- * BroadcastHashJoin LeftSemi BuildRight (62)
    :                    :           :- * Filter (60)
@@ -136,10 +136,10 @@ Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_sold_date_sk)]
 ReadSchema: struct<ss_sold_date_sk:int,ss_item_sk:int>
 
-(8) ColumnarToRow [codegen id : 9]
+(8) ColumnarToRow [codegen id : 6]
 Input [2]: [ss_sold_date_sk#1, ss_item_sk#2]
 
-(9) Filter [codegen id : 9]
+(9) Filter [codegen id : 6]
 Input [2]: [ss_sold_date_sk#1, ss_item_sk#2]
 Condition : (isnotnull(ss_item_sk#2) AND isnotnull(ss_sold_date_sk#1))
 
@@ -161,12 +161,12 @@ Condition : (((isnotnull(i_item_sk#5) AND isnotnull(i_brand_id#6)) AND isnotnull
 Input [4]: [i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#9]
 
-(14) BroadcastHashJoin [codegen id : 9]
+(14) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_item_sk#2]
 Right keys [1]: [i_item_sk#5]
 Join condition: None
 
-(15) Project [codegen id : 9]
+(15) Project [codegen id : 6]
 Output [4]: [ss_sold_date_sk#1, i_brand_id#6, i_class_id#7, i_category_id#8]
 Input [6]: [ss_sold_date_sk#1, ss_item_sk#2, i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
 
@@ -192,12 +192,12 @@ Input [2]: [d_date_sk#10, d_year#11]
 Input [1]: [d_date_sk#10]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#12]
 
-(21) BroadcastHashJoin [codegen id : 9]
+(21) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_sold_date_sk#1]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
-(22) Project [codegen id : 9]
+(22) Project [codegen id : 6]
 Output [3]: [i_brand_id#6 AS brand_id#13, i_class_id#7 AS class_id#14, i_category_id#8 AS category_id#15]
 Input [5]: [ss_sold_date_sk#1, i_brand_id#6, i_class_id#7, i_category_id#8, d_date_sk#10]
 
@@ -258,75 +258,75 @@ Input [5]: [cs_sold_date_sk#16, i_brand_id#6, i_class_id#7, i_category_id#8, d_d
 Input [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
 Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true]), coalesce(input[1, int, true], 0), isnull(input[1, int, true]), coalesce(input[2, int, true], 0), isnull(input[2, int, true])),false), [id=#19]
 
-(36) BroadcastHashJoin [codegen id : 9]
+(36) BroadcastHashJoin [codegen id : 6]
 Left keys [6]: [coalesce(brand_id#13, 0), isnull(brand_id#13), coalesce(class_id#14, 0), isnull(class_id#14), coalesce(category_id#15, 0), isnull(category_id#15)]
 Right keys [6]: [coalesce(i_brand_id#6, 0), isnull(i_brand_id#6), coalesce(i_class_id#7, 0), isnull(i_class_id#7), coalesce(i_category_id#8, 0), isnull(i_category_id#8)]
 Join condition: None
 
-(37) Scan parquet default.web_sales
-Output [2]: [ws_sold_date_sk#20, ws_item_sk#21]
+(37) HashAggregate [codegen id : 6]
+Input [3]: [brand_id#13, class_id#14, category_id#15]
+Keys [3]: [brand_id#13, class_id#14, category_id#15]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [brand_id#13, class_id#14, category_id#15]
+
+(38) Exchange
+Input [3]: [brand_id#13, class_id#14, category_id#15]
+Arguments: hashpartitioning(brand_id#13, class_id#14, category_id#15, 5), ENSURE_REQUIREMENTS, [id=#20]
+
+(39) HashAggregate [codegen id : 10]
+Input [3]: [brand_id#13, class_id#14, category_id#15]
+Keys [3]: [brand_id#13, class_id#14, category_id#15]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [brand_id#13, class_id#14, category_id#15]
+
+(40) Scan parquet default.web_sales
+Output [2]: [ws_sold_date_sk#21, ws_item_sk#22]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_sales]
 PushedFilters: [IsNotNull(ws_item_sk), IsNotNull(ws_sold_date_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_item_sk:int>
 
-(38) ColumnarToRow [codegen id : 8]
-Input [2]: [ws_sold_date_sk#20, ws_item_sk#21]
+(41) ColumnarToRow [codegen id : 9]
+Input [2]: [ws_sold_date_sk#21, ws_item_sk#22]
 
-(39) Filter [codegen id : 8]
-Input [2]: [ws_sold_date_sk#20, ws_item_sk#21]
-Condition : (isnotnull(ws_item_sk#21) AND isnotnull(ws_sold_date_sk#20))
+(42) Filter [codegen id : 9]
+Input [2]: [ws_sold_date_sk#21, ws_item_sk#22]
+Condition : (isnotnull(ws_item_sk#22) AND isnotnull(ws_sold_date_sk#21))
 
-(40) ReusedExchange [Reuses operator id: 29]
+(43) ReusedExchange [Reuses operator id: 29]
 Output [4]: [i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
 
-(41) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [ws_item_sk#21]
+(44) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [ws_item_sk#22]
 Right keys [1]: [i_item_sk#5]
 Join condition: None
 
-(42) Project [codegen id : 8]
-Output [4]: [ws_sold_date_sk#20, i_brand_id#6, i_class_id#7, i_category_id#8]
-Input [6]: [ws_sold_date_sk#20, ws_item_sk#21, i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
+(45) Project [codegen id : 9]
+Output [4]: [ws_sold_date_sk#21, i_brand_id#6, i_class_id#7, i_category_id#8]
+Input [6]: [ws_sold_date_sk#21, ws_item_sk#22, i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
 
-(43) ReusedExchange [Reuses operator id: 20]
+(46) ReusedExchange [Reuses operator id: 20]
 Output [1]: [d_date_sk#10]
 
-(44) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [ws_sold_date_sk#20]
+(47) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [ws_sold_date_sk#21]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
-(45) Project [codegen id : 8]
+(48) Project [codegen id : 9]
 Output [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
-Input [5]: [ws_sold_date_sk#20, i_brand_id#6, i_class_id#7, i_category_id#8, d_date_sk#10]
+Input [5]: [ws_sold_date_sk#21, i_brand_id#6, i_class_id#7, i_category_id#8, d_date_sk#10]
 
-(46) BroadcastExchange
+(49) BroadcastExchange
 Input [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
-Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true]), coalesce(input[1, int, true], 0), isnull(input[1, int, true]), coalesce(input[2, int, true], 0), isnull(input[2, int, true])),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true]), coalesce(input[1, int, true], 0), isnull(input[1, int, true]), coalesce(input[2, int, true], 0), isnull(input[2, int, true])),false), [id=#23]
 
-(47) BroadcastHashJoin [codegen id : 9]
+(50) BroadcastHashJoin [codegen id : 10]
 Left keys [6]: [coalesce(brand_id#13, 0), isnull(brand_id#13), coalesce(class_id#14, 0), isnull(class_id#14), coalesce(category_id#15, 0), isnull(category_id#15)]
 Right keys [6]: [coalesce(i_brand_id#6, 0), isnull(i_brand_id#6), coalesce(i_class_id#7, 0), isnull(i_class_id#7), coalesce(i_category_id#8, 0), isnull(i_category_id#8)]
 Join condition: None
-
-(48) HashAggregate [codegen id : 9]
-Input [3]: [brand_id#13, class_id#14, category_id#15]
-Keys [3]: [brand_id#13, class_id#14, category_id#15]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [brand_id#13, class_id#14, category_id#15]
-
-(49) Exchange
-Input [3]: [brand_id#13, class_id#14, category_id#15]
-Arguments: hashpartitioning(brand_id#13, class_id#14, category_id#15, 5), true, [id=#23]
-
-(50) HashAggregate [codegen id : 10]
-Input [3]: [brand_id#13, class_id#14, category_id#15]
-Keys [3]: [brand_id#13, class_id#14, category_id#15]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [brand_id#13, class_id#14, category_id#15]
 
 (51) HashAggregate [codegen id : 10]
 Input [3]: [brand_id#13, class_id#14, category_id#15]
@@ -439,7 +439,7 @@ Results [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#35, isEmpty#36, c
 
 (74) Exchange
 Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#35, isEmpty#36, count#37]
-Arguments: hashpartitioning(i_brand_id#6, i_class_id#7, i_category_id#8, 5), true, [id=#38]
+Arguments: hashpartitioning(i_brand_id#6, i_class_id#7, i_category_id#8, 5), ENSURE_REQUIREMENTS, [id=#38]
 
 (75) HashAggregate [codegen id : 52]
 Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sum#35, isEmpty#36, count#37]
@@ -530,7 +530,7 @@ Results [6]: [i_brand_id#48, i_class_id#49, i_category_id#50, sum#57, isEmpty#58
 
 (94) Exchange
 Input [6]: [i_brand_id#48, i_class_id#49, i_category_id#50, sum#57, isEmpty#58, count#59]
-Arguments: hashpartitioning(i_brand_id#48, i_class_id#49, i_category_id#50, 5), true, [id=#60]
+Arguments: hashpartitioning(i_brand_id#48, i_class_id#49, i_category_id#50, 5), ENSURE_REQUIREMENTS, [id=#60]
 
 (95) HashAggregate [codegen id : 51]
 Input [6]: [i_brand_id#48, i_class_id#49, i_category_id#50, sum#57, isEmpty#58, count#59]
@@ -663,30 +663,30 @@ Output [2]: [cs_quantity#71 AS quantity#73, cs_list_price#72 AS list_price#74]
 Input [4]: [cs_sold_date_sk#16, cs_quantity#71, cs_list_price#72, d_date_sk#10]
 
 (117) Scan parquet default.web_sales
-Output [3]: [ws_sold_date_sk#20, ws_quantity#75, ws_list_price#76]
+Output [3]: [ws_sold_date_sk#21, ws_quantity#75, ws_list_price#76]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_sales]
 PushedFilters: [IsNotNull(ws_sold_date_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_quantity:int,ws_list_price:decimal(7,2)>
 
 (118) ColumnarToRow [codegen id : 6]
-Input [3]: [ws_sold_date_sk#20, ws_quantity#75, ws_list_price#76]
+Input [3]: [ws_sold_date_sk#21, ws_quantity#75, ws_list_price#76]
 
 (119) Filter [codegen id : 6]
-Input [3]: [ws_sold_date_sk#20, ws_quantity#75, ws_list_price#76]
-Condition : isnotnull(ws_sold_date_sk#20)
+Input [3]: [ws_sold_date_sk#21, ws_quantity#75, ws_list_price#76]
+Condition : isnotnull(ws_sold_date_sk#21)
 
 (120) ReusedExchange [Reuses operator id: 108]
 Output [1]: [d_date_sk#10]
 
 (121) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ws_sold_date_sk#20]
+Left keys [1]: [ws_sold_date_sk#21]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
 (122) Project [codegen id : 6]
 Output [2]: [ws_quantity#75 AS quantity#77, ws_list_price#76 AS list_price#78]
-Input [4]: [ws_sold_date_sk#20, ws_quantity#75, ws_list_price#76, d_date_sk#10]
+Input [4]: [ws_sold_date_sk#21, ws_quantity#75, ws_list_price#76, d_date_sk#10]
 
 (123) Union
 
@@ -699,7 +699,7 @@ Results [2]: [sum#81, count#82]
 
 (125) Exchange
 Input [2]: [sum#81, count#82]
-Arguments: SinglePartition, true, [id=#83]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#83]
 
 (126) HashAggregate [codegen id : 8]
 Input [2]: [sum#81, count#82]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14/simplified.txt
@@ -73,12 +73,12 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                                             WholeStageCodegen (10)
                                               HashAggregate [brand_id,class_id,category_id]
                                                 HashAggregate [brand_id,class_id,category_id]
-                                                  HashAggregate [brand_id,class_id,category_id]
-                                                    InputAdapter
-                                                      Exchange [brand_id,class_id,category_id] #4
-                                                        WholeStageCodegen (9)
-                                                          HashAggregate [brand_id,class_id,category_id]
-                                                            BroadcastHashJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
+                                                  BroadcastHashJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
+                                                    HashAggregate [brand_id,class_id,category_id]
+                                                      InputAdapter
+                                                        Exchange [brand_id,class_id,category_id] #4
+                                                          WholeStageCodegen (6)
+                                                            HashAggregate [brand_id,class_id,category_id]
                                                               BroadcastHashJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
                                                                 Project [i_brand_id,i_class_id,i_category_id]
                                                                   BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
@@ -123,21 +123,21 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                                                                                           Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
                                                                           InputAdapter
                                                                             ReusedExchange [d_date_sk] #6
+                                                    InputAdapter
+                                                      BroadcastExchange #9
+                                                        WholeStageCodegen (9)
+                                                          Project [i_brand_id,i_class_id,i_category_id]
+                                                            BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                              Project [ws_sold_date_sk,i_brand_id,i_class_id,i_category_id]
+                                                                BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                                  Filter [ws_item_sk,ws_sold_date_sk]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk]
+                                                                  InputAdapter
+                                                                    ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #8
                                                               InputAdapter
-                                                                BroadcastExchange #9
-                                                                  WholeStageCodegen (8)
-                                                                    Project [i_brand_id,i_class_id,i_category_id]
-                                                                      BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                        Project [ws_sold_date_sk,i_brand_id,i_class_id,i_category_id]
-                                                                          BroadcastHashJoin [ws_item_sk,i_item_sk]
-                                                                            Filter [ws_item_sk,ws_sold_date_sk]
-                                                                              ColumnarToRow
-                                                                                InputAdapter
-                                                                                  Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk]
-                                                                            InputAdapter
-                                                                              ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #8
-                                                                        InputAdapter
-                                                                          ReusedExchange [d_date_sk] #6
+                                                                ReusedExchange [d_date_sk] #6
                             InputAdapter
                               BroadcastExchange #10
                                 WholeStageCodegen (23)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a/explain.txt
@@ -30,50 +30,50 @@ TakeOrderedAndProject (194)
             :           :                    :     :           +- BroadcastExchange (53)
             :           :                    :     :              +- * HashAggregate (52)
             :           :                    :     :                 +- * HashAggregate (51)
-            :           :                    :     :                    +- * HashAggregate (50)
-            :           :                    :     :                       +- Exchange (49)
-            :           :                    :     :                          +- * HashAggregate (48)
-            :           :                    :     :                             +- * BroadcastHashJoin LeftSemi BuildRight (47)
-            :           :                    :     :                                :- * BroadcastHashJoin LeftSemi BuildRight (36)
-            :           :                    :     :                                :  :- * Project (22)
-            :           :                    :     :                                :  :  +- * BroadcastHashJoin Inner BuildRight (21)
-            :           :                    :     :                                :  :     :- * Project (15)
-            :           :                    :     :                                :  :     :  +- * BroadcastHashJoin Inner BuildRight (14)
-            :           :                    :     :                                :  :     :     :- * Filter (9)
-            :           :                    :     :                                :  :     :     :  +- * ColumnarToRow (8)
-            :           :                    :     :                                :  :     :     :     +- Scan parquet default.store_sales (7)
-            :           :                    :     :                                :  :     :     +- BroadcastExchange (13)
-            :           :                    :     :                                :  :     :        +- * Filter (12)
-            :           :                    :     :                                :  :     :           +- * ColumnarToRow (11)
-            :           :                    :     :                                :  :     :              +- Scan parquet default.item (10)
-            :           :                    :     :                                :  :     +- BroadcastExchange (20)
-            :           :                    :     :                                :  :        +- * Project (19)
-            :           :                    :     :                                :  :           +- * Filter (18)
-            :           :                    :     :                                :  :              +- * ColumnarToRow (17)
-            :           :                    :     :                                :  :                 +- Scan parquet default.date_dim (16)
-            :           :                    :     :                                :  +- BroadcastExchange (35)
-            :           :                    :     :                                :     +- * Project (34)
-            :           :                    :     :                                :        +- * BroadcastHashJoin Inner BuildRight (33)
-            :           :                    :     :                                :           :- * Project (31)
-            :           :                    :     :                                :           :  +- * BroadcastHashJoin Inner BuildRight (30)
-            :           :                    :     :                                :           :     :- * Filter (25)
-            :           :                    :     :                                :           :     :  +- * ColumnarToRow (24)
-            :           :                    :     :                                :           :     :     +- Scan parquet default.catalog_sales (23)
-            :           :                    :     :                                :           :     +- BroadcastExchange (29)
-            :           :                    :     :                                :           :        +- * Filter (28)
-            :           :                    :     :                                :           :           +- * ColumnarToRow (27)
-            :           :                    :     :                                :           :              +- Scan parquet default.item (26)
-            :           :                    :     :                                :           +- ReusedExchange (32)
-            :           :                    :     :                                +- BroadcastExchange (46)
-            :           :                    :     :                                   +- * Project (45)
-            :           :                    :     :                                      +- * BroadcastHashJoin Inner BuildRight (44)
-            :           :                    :     :                                         :- * Project (42)
-            :           :                    :     :                                         :  +- * BroadcastHashJoin Inner BuildRight (41)
-            :           :                    :     :                                         :     :- * Filter (39)
-            :           :                    :     :                                         :     :  +- * ColumnarToRow (38)
-            :           :                    :     :                                         :     :     +- Scan parquet default.web_sales (37)
-            :           :                    :     :                                         :     +- ReusedExchange (40)
-            :           :                    :     :                                         +- ReusedExchange (43)
+            :           :                    :     :                    +- * BroadcastHashJoin LeftSemi BuildRight (50)
+            :           :                    :     :                       :- * HashAggregate (39)
+            :           :                    :     :                       :  +- Exchange (38)
+            :           :                    :     :                       :     +- * HashAggregate (37)
+            :           :                    :     :                       :        +- * BroadcastHashJoin LeftSemi BuildRight (36)
+            :           :                    :     :                       :           :- * Project (22)
+            :           :                    :     :                       :           :  +- * BroadcastHashJoin Inner BuildRight (21)
+            :           :                    :     :                       :           :     :- * Project (15)
+            :           :                    :     :                       :           :     :  +- * BroadcastHashJoin Inner BuildRight (14)
+            :           :                    :     :                       :           :     :     :- * Filter (9)
+            :           :                    :     :                       :           :     :     :  +- * ColumnarToRow (8)
+            :           :                    :     :                       :           :     :     :     +- Scan parquet default.store_sales (7)
+            :           :                    :     :                       :           :     :     +- BroadcastExchange (13)
+            :           :                    :     :                       :           :     :        +- * Filter (12)
+            :           :                    :     :                       :           :     :           +- * ColumnarToRow (11)
+            :           :                    :     :                       :           :     :              +- Scan parquet default.item (10)
+            :           :                    :     :                       :           :     +- BroadcastExchange (20)
+            :           :                    :     :                       :           :        +- * Project (19)
+            :           :                    :     :                       :           :           +- * Filter (18)
+            :           :                    :     :                       :           :              +- * ColumnarToRow (17)
+            :           :                    :     :                       :           :                 +- Scan parquet default.date_dim (16)
+            :           :                    :     :                       :           +- BroadcastExchange (35)
+            :           :                    :     :                       :              +- * Project (34)
+            :           :                    :     :                       :                 +- * BroadcastHashJoin Inner BuildRight (33)
+            :           :                    :     :                       :                    :- * Project (31)
+            :           :                    :     :                       :                    :  +- * BroadcastHashJoin Inner BuildRight (30)
+            :           :                    :     :                       :                    :     :- * Filter (25)
+            :           :                    :     :                       :                    :     :  +- * ColumnarToRow (24)
+            :           :                    :     :                       :                    :     :     +- Scan parquet default.catalog_sales (23)
+            :           :                    :     :                       :                    :     +- BroadcastExchange (29)
+            :           :                    :     :                       :                    :        +- * Filter (28)
+            :           :                    :     :                       :                    :           +- * ColumnarToRow (27)
+            :           :                    :     :                       :                    :              +- Scan parquet default.item (26)
+            :           :                    :     :                       :                    +- ReusedExchange (32)
+            :           :                    :     :                       +- BroadcastExchange (49)
+            :           :                    :     :                          +- * Project (48)
+            :           :                    :     :                             +- * BroadcastHashJoin Inner BuildRight (47)
+            :           :                    :     :                                :- * Project (45)
+            :           :                    :     :                                :  +- * BroadcastHashJoin Inner BuildRight (44)
+            :           :                    :     :                                :     :- * Filter (42)
+            :           :                    :     :                                :     :  +- * ColumnarToRow (41)
+            :           :                    :     :                                :     :     +- Scan parquet default.web_sales (40)
+            :           :                    :     :                                :     +- ReusedExchange (43)
+            :           :                    :     :                                +- ReusedExchange (46)
             :           :                    :     +- BroadcastExchange (63)
             :           :                    :        +- * BroadcastHashJoin LeftSemi BuildRight (62)
             :           :                    :           :- * Filter (60)
@@ -230,10 +230,10 @@ Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_sold_date_sk)]
 ReadSchema: struct<ss_sold_date_sk:int,ss_item_sk:int>
 
-(8) ColumnarToRow [codegen id : 9]
+(8) ColumnarToRow [codegen id : 6]
 Input [2]: [ss_sold_date_sk#1, ss_item_sk#2]
 
-(9) Filter [codegen id : 9]
+(9) Filter [codegen id : 6]
 Input [2]: [ss_sold_date_sk#1, ss_item_sk#2]
 Condition : (isnotnull(ss_item_sk#2) AND isnotnull(ss_sold_date_sk#1))
 
@@ -255,12 +255,12 @@ Condition : (((isnotnull(i_item_sk#5) AND isnotnull(i_brand_id#6)) AND isnotnull
 Input [4]: [i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#9]
 
-(14) BroadcastHashJoin [codegen id : 9]
+(14) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_item_sk#2]
 Right keys [1]: [i_item_sk#5]
 Join condition: None
 
-(15) Project [codegen id : 9]
+(15) Project [codegen id : 6]
 Output [4]: [ss_sold_date_sk#1, i_brand_id#6, i_class_id#7, i_category_id#8]
 Input [6]: [ss_sold_date_sk#1, ss_item_sk#2, i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
 
@@ -286,12 +286,12 @@ Input [2]: [d_date_sk#10, d_year#11]
 Input [1]: [d_date_sk#10]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#12]
 
-(21) BroadcastHashJoin [codegen id : 9]
+(21) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_sold_date_sk#1]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
-(22) Project [codegen id : 9]
+(22) Project [codegen id : 6]
 Output [3]: [i_brand_id#6 AS brand_id#13, i_class_id#7 AS class_id#14, i_category_id#8 AS category_id#15]
 Input [5]: [ss_sold_date_sk#1, i_brand_id#6, i_class_id#7, i_category_id#8, d_date_sk#10]
 
@@ -352,75 +352,75 @@ Input [5]: [cs_sold_date_sk#16, i_brand_id#6, i_class_id#7, i_category_id#8, d_d
 Input [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
 Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true]), coalesce(input[1, int, true], 0), isnull(input[1, int, true]), coalesce(input[2, int, true], 0), isnull(input[2, int, true])),false), [id=#19]
 
-(36) BroadcastHashJoin [codegen id : 9]
+(36) BroadcastHashJoin [codegen id : 6]
 Left keys [6]: [coalesce(brand_id#13, 0), isnull(brand_id#13), coalesce(class_id#14, 0), isnull(class_id#14), coalesce(category_id#15, 0), isnull(category_id#15)]
 Right keys [6]: [coalesce(i_brand_id#6, 0), isnull(i_brand_id#6), coalesce(i_class_id#7, 0), isnull(i_class_id#7), coalesce(i_category_id#8, 0), isnull(i_category_id#8)]
 Join condition: None
 
-(37) Scan parquet default.web_sales
-Output [2]: [ws_sold_date_sk#20, ws_item_sk#21]
+(37) HashAggregate [codegen id : 6]
+Input [3]: [brand_id#13, class_id#14, category_id#15]
+Keys [3]: [brand_id#13, class_id#14, category_id#15]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [brand_id#13, class_id#14, category_id#15]
+
+(38) Exchange
+Input [3]: [brand_id#13, class_id#14, category_id#15]
+Arguments: hashpartitioning(brand_id#13, class_id#14, category_id#15, 5), ENSURE_REQUIREMENTS, [id=#20]
+
+(39) HashAggregate [codegen id : 10]
+Input [3]: [brand_id#13, class_id#14, category_id#15]
+Keys [3]: [brand_id#13, class_id#14, category_id#15]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [brand_id#13, class_id#14, category_id#15]
+
+(40) Scan parquet default.web_sales
+Output [2]: [ws_sold_date_sk#21, ws_item_sk#22]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_sales]
 PushedFilters: [IsNotNull(ws_item_sk), IsNotNull(ws_sold_date_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_item_sk:int>
 
-(38) ColumnarToRow [codegen id : 8]
-Input [2]: [ws_sold_date_sk#20, ws_item_sk#21]
+(41) ColumnarToRow [codegen id : 9]
+Input [2]: [ws_sold_date_sk#21, ws_item_sk#22]
 
-(39) Filter [codegen id : 8]
-Input [2]: [ws_sold_date_sk#20, ws_item_sk#21]
-Condition : (isnotnull(ws_item_sk#21) AND isnotnull(ws_sold_date_sk#20))
+(42) Filter [codegen id : 9]
+Input [2]: [ws_sold_date_sk#21, ws_item_sk#22]
+Condition : (isnotnull(ws_item_sk#22) AND isnotnull(ws_sold_date_sk#21))
 
-(40) ReusedExchange [Reuses operator id: 29]
+(43) ReusedExchange [Reuses operator id: 29]
 Output [4]: [i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
 
-(41) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [ws_item_sk#21]
+(44) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [ws_item_sk#22]
 Right keys [1]: [i_item_sk#5]
 Join condition: None
 
-(42) Project [codegen id : 8]
-Output [4]: [ws_sold_date_sk#20, i_brand_id#6, i_class_id#7, i_category_id#8]
-Input [6]: [ws_sold_date_sk#20, ws_item_sk#21, i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
+(45) Project [codegen id : 9]
+Output [4]: [ws_sold_date_sk#21, i_brand_id#6, i_class_id#7, i_category_id#8]
+Input [6]: [ws_sold_date_sk#21, ws_item_sk#22, i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
 
-(43) ReusedExchange [Reuses operator id: 20]
+(46) ReusedExchange [Reuses operator id: 20]
 Output [1]: [d_date_sk#10]
 
-(44) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [ws_sold_date_sk#20]
+(47) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [ws_sold_date_sk#21]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
-(45) Project [codegen id : 8]
+(48) Project [codegen id : 9]
 Output [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
-Input [5]: [ws_sold_date_sk#20, i_brand_id#6, i_class_id#7, i_category_id#8, d_date_sk#10]
+Input [5]: [ws_sold_date_sk#21, i_brand_id#6, i_class_id#7, i_category_id#8, d_date_sk#10]
 
-(46) BroadcastExchange
+(49) BroadcastExchange
 Input [3]: [i_brand_id#6, i_class_id#7, i_category_id#8]
-Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true]), coalesce(input[1, int, true], 0), isnull(input[1, int, true]), coalesce(input[2, int, true], 0), isnull(input[2, int, true])),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true]), coalesce(input[1, int, true], 0), isnull(input[1, int, true]), coalesce(input[2, int, true], 0), isnull(input[2, int, true])),false), [id=#23]
 
-(47) BroadcastHashJoin [codegen id : 9]
+(50) BroadcastHashJoin [codegen id : 10]
 Left keys [6]: [coalesce(brand_id#13, 0), isnull(brand_id#13), coalesce(class_id#14, 0), isnull(class_id#14), coalesce(category_id#15, 0), isnull(category_id#15)]
 Right keys [6]: [coalesce(i_brand_id#6, 0), isnull(i_brand_id#6), coalesce(i_class_id#7, 0), isnull(i_class_id#7), coalesce(i_category_id#8, 0), isnull(i_category_id#8)]
 Join condition: None
-
-(48) HashAggregate [codegen id : 9]
-Input [3]: [brand_id#13, class_id#14, category_id#15]
-Keys [3]: [brand_id#13, class_id#14, category_id#15]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [brand_id#13, class_id#14, category_id#15]
-
-(49) Exchange
-Input [3]: [brand_id#13, class_id#14, category_id#15]
-Arguments: hashpartitioning(brand_id#13, class_id#14, category_id#15, 5), ENSURE_REQUIREMENTS, [id=#23]
-
-(50) HashAggregate [codegen id : 10]
-Input [3]: [brand_id#13, class_id#14, category_id#15]
-Keys [3]: [brand_id#13, class_id#14, category_id#15]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [brand_id#13, class_id#14, category_id#15]
 
 (51) HashAggregate [codegen id : 10]
 Input [3]: [brand_id#13, class_id#14, category_id#15]
@@ -623,24 +623,24 @@ Output [6]: [catalog AS channel#59, i_brand_id#6, i_class_id#7, i_category_id#8,
 Input [6]: [i_brand_id#6, i_class_id#7, i_category_id#8, sales#56, number_sales#57, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#45 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#46 as decimal(12,2)))), DecimalType(18,2), true))#58]
 
 (94) Scan parquet default.web_sales
-Output [4]: [ws_sold_date_sk#20, ws_item_sk#21, ws_quantity#60, ws_list_price#61]
+Output [4]: [ws_sold_date_sk#21, ws_item_sk#22, ws_quantity#60, ws_list_price#61]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_sales]
 PushedFilters: [IsNotNull(ws_item_sk), IsNotNull(ws_sold_date_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_item_sk:int,ws_quantity:int,ws_list_price:decimal(7,2)>
 
 (95) ColumnarToRow [codegen id : 77]
-Input [4]: [ws_sold_date_sk#20, ws_item_sk#21, ws_quantity#60, ws_list_price#61]
+Input [4]: [ws_sold_date_sk#21, ws_item_sk#22, ws_quantity#60, ws_list_price#61]
 
 (96) Filter [codegen id : 77]
-Input [4]: [ws_sold_date_sk#20, ws_item_sk#21, ws_quantity#60, ws_list_price#61]
-Condition : (isnotnull(ws_item_sk#21) AND isnotnull(ws_sold_date_sk#20))
+Input [4]: [ws_sold_date_sk#21, ws_item_sk#22, ws_quantity#60, ws_list_price#61]
+Condition : (isnotnull(ws_item_sk#22) AND isnotnull(ws_sold_date_sk#21))
 
 (97) ReusedExchange [Reuses operator id: 56]
 Output [1]: [ss_item_sk#25]
 
 (98) BroadcastHashJoin [codegen id : 77]
-Left keys [1]: [ws_item_sk#21]
+Left keys [1]: [ws_item_sk#22]
 Right keys [1]: [ss_item_sk#25]
 Join condition: None
 
@@ -648,25 +648,25 @@ Join condition: None
 Output [4]: [i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
 
 (100) BroadcastHashJoin [codegen id : 77]
-Left keys [1]: [ws_item_sk#21]
+Left keys [1]: [ws_item_sk#22]
 Right keys [1]: [i_item_sk#5]
 Join condition: None
 
 (101) Project [codegen id : 77]
-Output [6]: [ws_sold_date_sk#20, ws_quantity#60, ws_list_price#61, i_brand_id#6, i_class_id#7, i_category_id#8]
-Input [8]: [ws_sold_date_sk#20, ws_item_sk#21, ws_quantity#60, ws_list_price#61, i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
+Output [6]: [ws_sold_date_sk#21, ws_quantity#60, ws_list_price#61, i_brand_id#6, i_class_id#7, i_category_id#8]
+Input [8]: [ws_sold_date_sk#21, ws_item_sk#22, ws_quantity#60, ws_list_price#61, i_item_sk#5, i_brand_id#6, i_class_id#7, i_category_id#8]
 
 (102) ReusedExchange [Reuses operator id: 70]
 Output [1]: [d_date_sk#10]
 
 (103) BroadcastHashJoin [codegen id : 77]
-Left keys [1]: [ws_sold_date_sk#20]
+Left keys [1]: [ws_sold_date_sk#21]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
 (104) Project [codegen id : 77]
 Output [5]: [ws_quantity#60, ws_list_price#61, i_brand_id#6, i_class_id#7, i_category_id#8]
-Input [7]: [ws_sold_date_sk#20, ws_quantity#60, ws_list_price#61, i_brand_id#6, i_class_id#7, i_category_id#8, d_date_sk#10]
+Input [7]: [ws_sold_date_sk#21, ws_quantity#60, ws_list_price#61, i_brand_id#6, i_class_id#7, i_category_id#8, d_date_sk#10]
 
 (105) HashAggregate [codegen id : 77]
 Input [5]: [ws_quantity#60, ws_list_price#61, i_brand_id#6, i_class_id#7, i_category_id#8]
@@ -1232,30 +1232,30 @@ Output [2]: [cs_quantity#45 AS quantity#261, cs_list_price#46 AS list_price#262]
 Input [4]: [cs_sold_date_sk#16, cs_quantity#45, cs_list_price#46, d_date_sk#10]
 
 (215) Scan parquet default.web_sales
-Output [3]: [ws_sold_date_sk#20, ws_quantity#60, ws_list_price#61]
+Output [3]: [ws_sold_date_sk#21, ws_quantity#60, ws_list_price#61]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_sales]
 PushedFilters: [IsNotNull(ws_sold_date_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_quantity:int,ws_list_price:decimal(7,2)>
 
 (216) ColumnarToRow [codegen id : 6]
-Input [3]: [ws_sold_date_sk#20, ws_quantity#60, ws_list_price#61]
+Input [3]: [ws_sold_date_sk#21, ws_quantity#60, ws_list_price#61]
 
 (217) Filter [codegen id : 6]
-Input [3]: [ws_sold_date_sk#20, ws_quantity#60, ws_list_price#61]
-Condition : isnotnull(ws_sold_date_sk#20)
+Input [3]: [ws_sold_date_sk#21, ws_quantity#60, ws_list_price#61]
+Condition : isnotnull(ws_sold_date_sk#21)
 
 (218) ReusedExchange [Reuses operator id: 212]
 Output [1]: [d_date_sk#10]
 
 (219) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ws_sold_date_sk#20]
+Left keys [1]: [ws_sold_date_sk#21]
 Right keys [1]: [d_date_sk#10]
 Join condition: None
 
 (220) Project [codegen id : 6]
 Output [2]: [ws_quantity#60 AS quantity#263, ws_list_price#61 AS list_price#264]
-Input [4]: [ws_sold_date_sk#20, ws_quantity#60, ws_list_price#61, d_date_sk#10]
+Input [4]: [ws_sold_date_sk#21, ws_quantity#60, ws_list_price#61, d_date_sk#10]
 
 (221) Union
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a/simplified.txt
@@ -94,12 +94,12 @@ TakeOrderedAndProject [channel,i_brand_id,i_class_id,i_category_id,sum_sales,num
                                                                           WholeStageCodegen (10)
                                                                             HashAggregate [brand_id,class_id,category_id]
                                                                               HashAggregate [brand_id,class_id,category_id]
-                                                                                HashAggregate [brand_id,class_id,category_id]
-                                                                                  InputAdapter
-                                                                                    Exchange [brand_id,class_id,category_id] #6
-                                                                                      WholeStageCodegen (9)
-                                                                                        HashAggregate [brand_id,class_id,category_id]
-                                                                                          BroadcastHashJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
+                                                                                BroadcastHashJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
+                                                                                  HashAggregate [brand_id,class_id,category_id]
+                                                                                    InputAdapter
+                                                                                      Exchange [brand_id,class_id,category_id] #6
+                                                                                        WholeStageCodegen (6)
+                                                                                          HashAggregate [brand_id,class_id,category_id]
                                                                                             BroadcastHashJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
                                                                                               Project [i_brand_id,i_class_id,i_category_id]
                                                                                                 BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
@@ -144,21 +144,21 @@ TakeOrderedAndProject [channel,i_brand_id,i_class_id,i_category_id,sum_sales,num
                                                                                                                         Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
                                                                                                         InputAdapter
                                                                                                           ReusedExchange [d_date_sk] #8
+                                                                                  InputAdapter
+                                                                                    BroadcastExchange #11
+                                                                                      WholeStageCodegen (9)
+                                                                                        Project [i_brand_id,i_class_id,i_category_id]
+                                                                                          BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                                                            Project [ws_sold_date_sk,i_brand_id,i_class_id,i_category_id]
+                                                                                              BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                                                                Filter [ws_item_sk,ws_sold_date_sk]
+                                                                                                  ColumnarToRow
+                                                                                                    InputAdapter
+                                                                                                      Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk]
+                                                                                                InputAdapter
+                                                                                                  ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #10
                                                                                             InputAdapter
-                                                                                              BroadcastExchange #11
-                                                                                                WholeStageCodegen (8)
-                                                                                                  Project [i_brand_id,i_class_id,i_category_id]
-                                                                                                    BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                                                      Project [ws_sold_date_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                                        BroadcastHashJoin [ws_item_sk,i_item_sk]
-                                                                                                          Filter [ws_item_sk,ws_sold_date_sk]
-                                                                                                            ColumnarToRow
-                                                                                                              InputAdapter
-                                                                                                                Scan parquet default.web_sales [ws_sold_date_sk,ws_item_sk]
-                                                                                                          InputAdapter
-                                                                                                            ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #10
-                                                                                                      InputAdapter
-                                                                                                        ReusedExchange [d_date_sk] #8
+                                                                                              ReusedExchange [d_date_sk] #8
                                                           InputAdapter
                                                             BroadcastExchange #12
                                                               WholeStageCodegen (23)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pr disable LeftSemi/LeftAnti push down over Aggregate.


### Why are the changes needed?

LeftSemi/LeftAnti push down over Aggregate may affect performance. for example:
```sql
SELECT i_item_sk ss_item_sk
  FROM item,
    (SELECT
      distinct
      iss.i_brand_id brand_id,
      iss.i_class_id class_id,
      iss.i_category_id category_id
    FROM store_sales, item iss, date_dim d1
    WHERE ss_item_sk = iss.i_item_sk
      AND ss_sold_date_sk = d1.d_date_sk
      AND d1.d_year BETWEEN 1999 AND 1999 + 2
    INTERSECT
    SELECT
    distinct
      ics.i_brand_id,
      ics.i_class_id,
      ics.i_category_id
    FROM catalog_sales, item ics, date_dim d2
    WHERE cs_item_sk = ics.i_item_sk
      AND cs_sold_date_sk = d2.d_date_sk
      AND d2.d_year BETWEEN 1999 AND 1999 + 2
    INTERSECT
    SELECT
    distinct
      iws.i_brand_id,
      iws.i_class_id,
      iws.i_category_id
    FROM web_sales, item iws, date_dim d3
    WHERE ws_item_sk = iws.i_item_sk
      AND ws_sold_date_sk = d3.d_date_sk
      AND d3.d_year BETWEEN 1999 AND 1999 + 2) x
  WHERE i_brand_id = brand_id
    AND i_class_id = class_id
    AND i_category_id = category_id;
```

This query is rewritten from [q14b](https://github.com/apache/spark/blob/a78d6ce376edf2a8836e01f47b9dff5371058d4c/sql/core/src/test/resources/tpcds/q14b.sql#L2-L32).


CBO enabled | CBO disabled
-- | --
The statistics are more accurate, so it can plan as BroadcastHashJoin, and then push down aggregate. | It will not push down aggregate since [SPARK-34081](https://issues.apache.org/jira/browse/SPARK-34081).
![image](https://issues.apache.org/jira/secure/attachment/13018801/current.jpg) | ![image](https://issues.apache.org/jira/secure/attachment/13018802/disable_pushdown.jpg)



### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Unit test.
