### PR TITLE
[SPARK-33212][FOLLOW-UP][BUILD] Bring back duplicate dependency check and add more strict Hadoop version check

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/VersionUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/VersionUtils.scala
@@ -24,6 +24,7 @@ private[spark] object VersionUtils {
 
   private val majorMinorRegex = """^(\d+)\.(\d+)(\..*)?$""".r
   private val shortVersionRegex = """^(\d+\.\d+\.\d+)(.*)?$""".r
+  private val majorMinorPatchRegex = """^(\d+)(?:\.(\d+)(?:\.(\d+)(?:[.-].*)?)?)?$""".r
 
   /**
    * Given a Spark version string, return the major version number.
@@ -61,6 +62,39 @@ private[spark] object VersionUtils {
       case None =>
         throw new IllegalArgumentException(s"Spark tried to parse '$sparkVersion' as a Spark" +
           s" version string, but it could not find the major and minor version numbers.")
+    }
+  }
+
+  /**
+   * Retrieves the major, minor and patch parts from the input `version`. Returns `None` if the
+   * input is not of a valid format.
+   *
+   * Examples of valid version:
+   *  - 1
+   *  - 2.4
+   *  - 3.2.2
+   *  - 3.2.2.4
+   *  - 3.3.1-SNAPSHOT
+   *  - 3.2.2.4SNAPSHOT (we only retrieve the first 3 components)
+   *
+   * Examples of invalid version:
+   *  - ABC
+   *  - 1X
+   *  - 2.4XYZ
+   *  - 2.4-SNAPSHOT
+   *  - 3.4.5ABC
+   *
+   *  @return A non-empty option containing a 3-value tuple (major, minor, patch) iff the
+   *          input is a valid version. `None` otherwise.
+   */
+  def majorMinorPatchVersion(version: String): Option[(Int, Int, Int)] = {
+    majorMinorPatchRegex.findFirstMatchIn(version) match {
+      case Some(m) =>
+        val major = m.group(1).toInt
+        val minor = Option(m.group(2)).map(_.toInt).getOrElse(0)
+        val patch = Option(m.group(3)).map(_.toInt).getOrElse(0)
+        Some((major, minor, patch))
+      case None => None
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/util/VersionUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/VersionUtils.scala
@@ -66,16 +66,17 @@ private[spark] object VersionUtils {
   }
 
   /**
-   * Retrieves the major, minor and patch parts from the input `version`. Returns `None` if the
+   * Extracts the major, minor and patch parts from the input `version`. Note that if minor or patch
+   * version is missing from the input, this will return 0 for these parts. Returns `None` if the
    * input is not of a valid format.
    *
    * Examples of valid version:
-   *  - 1
-   *  - 2.4
-   *  - 3.2.2
-   *  - 3.2.2.4
-   *  - 3.3.1-SNAPSHOT
-   *  - 3.2.2.4SNAPSHOT (we only retrieve the first 3 components)
+   *  - 1   (extracts to (1, 0, 0))
+   *  - 2.4   (extracts to (2, 4, 0))
+   *  - 3.2.2   (extracts to (3, 2, 2))
+   *  - 3.2.2.4   (extracts to 3, 2, 2))
+   *  - 3.3.1-SNAPSHOT   (extracts to (3, 2, 2))
+   *  - 3.2.2.4SNAPSHOT   (extracts to (3, 2, 2), only the first 3 components)
    *
    * Examples of invalid version:
    *  - ABC
@@ -88,13 +89,11 @@ private[spark] object VersionUtils {
    *          input is a valid version. `None` otherwise.
    */
   def majorMinorPatchVersion(version: String): Option[(Int, Int, Int)] = {
-    majorMinorPatchRegex.findFirstMatchIn(version) match {
-      case Some(m) =>
-        val major = m.group(1).toInt
-        val minor = Option(m.group(2)).map(_.toInt).getOrElse(0)
-        val patch = Option(m.group(3)).map(_.toInt).getOrElse(0)
-        Some((major, minor, patch))
-      case None => None
+    majorMinorPatchRegex.findFirstMatchIn(version).map { m =>
+      val major = m.group(1).toInt
+      val minor = Option(m.group(2)).map(_.toInt).getOrElse(0)
+      val patch = Option(m.group(3)).map(_.toInt).getOrElse(0)
+      (major, minor, patch)
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/util/VersionUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/VersionUtils.scala
@@ -75,7 +75,7 @@ private[spark] object VersionUtils {
    *  - 2.4   (extracts to (2, 4, 0))
    *  - 3.2.2   (extracts to (3, 2, 2))
    *  - 3.2.2.4   (extracts to 3, 2, 2))
-   *  - 3.3.1-SNAPSHOT   (extracts to (3, 2, 2))
+   *  - 3.3.1-SNAPSHOT   (extracts to (3, 3, 1))
    *  - 3.2.2.4SNAPSHOT   (extracts to (3, 2, 2), only the first 3 components)
    *
    * Examples of invalid version:

--- a/core/src/test/scala/org/apache/spark/util/VersionUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/VersionUtilsSuite.scala
@@ -98,4 +98,21 @@ class VersionUtilsSuite extends SparkFunSuite {
       }
     }
   }
+
+  test("SPARK-33212: retrieve major/minor/patch version parts") {
+    assert(VersionUtils.majorMinorPatchVersion("3.2.2").contains((3, 2, 2)))
+    assert(VersionUtils.majorMinorPatchVersion("3.2.2.4").contains((3, 2, 2)))
+    assert(VersionUtils.majorMinorPatchVersion("3.2.2-SNAPSHOT").contains((3, 2, 2)))
+    assert(VersionUtils.majorMinorPatchVersion("3.2.2.4XXX").contains((3, 2, 2)))
+    assert(VersionUtils.majorMinorPatchVersion("3.2").contains((3, 2, 0)))
+    assert(VersionUtils.majorMinorPatchVersion("3").contains((3, 0, 0)))
+
+    // illegal cases
+    assert(VersionUtils.majorMinorPatchVersion("ABC").isEmpty)
+    assert(VersionUtils.majorMinorPatchVersion("3X").isEmpty)
+    assert(VersionUtils.majorMinorPatchVersion("3.2-SNAPSHOT").isEmpty)
+    assert(VersionUtils.majorMinorPatchVersion("3.2ABC").isEmpty)
+    assert(VersionUtils.majorMinorPatchVersion("3-ABC").isEmpty)
+    assert(VersionUtils.majorMinorPatchVersion("3.2.4XYZ").isEmpty)
+  }
 }

--- a/core/src/test/scala/org/apache/spark/util/VersionUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/VersionUtilsSuite.scala
@@ -108,11 +108,8 @@ class VersionUtilsSuite extends SparkFunSuite {
     assert(VersionUtils.majorMinorPatchVersion("3").contains((3, 0, 0)))
 
     // illegal cases
-    assert(VersionUtils.majorMinorPatchVersion("ABC").isEmpty)
-    assert(VersionUtils.majorMinorPatchVersion("3X").isEmpty)
-    assert(VersionUtils.majorMinorPatchVersion("3.2-SNAPSHOT").isEmpty)
-    assert(VersionUtils.majorMinorPatchVersion("3.2ABC").isEmpty)
-    assert(VersionUtils.majorMinorPatchVersion("3-ABC").isEmpty)
-    assert(VersionUtils.majorMinorPatchVersion("3.2.4XYZ").isEmpty)
+    Seq("ABC", "3X", "3.2-SNAPSHOT", "3.2ABC", "3-ABC", "3.2.4XYZ").foreach { version =>
+      assert(VersionUtils.majorMinorPatchVersion(version).isEmpty, s"version $version")
+    }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -2448,6 +2448,17 @@
                 </rules>
               </configuration>
             </execution>
+            <execution>
+              <id>enforce-no-duplicate-dependencies</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <banDuplicatePomDependencyVersions/>
+                </rules>
+              </configuration>
+            </execution>
           </executions>
         </plugin>
 	<plugin>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
@@ -107,12 +107,17 @@ private[hive] object IsolatedClientLoader extends Logging {
         s"Please set ${HiveUtils.HIVE_METASTORE_VERSION.key} with a valid version.")
   }
 
+  def supportHadoopShadedClient(hadoopVersion: String): Boolean = hadoopVersion match {
+    case "3.2.2" => true
+    case _ => false
+  }
+
   private def downloadVersion(
       version: HiveVersion,
       hadoopVersion: String,
       ivyPath: Option[String],
       remoteRepos: String): Seq[URL] = {
-    val hadoopJarNames = if (hadoopVersion.startsWith("3")) {
+    val hadoopJarNames = if (supportHadoopShadedClient(hadoopVersion)) {
       Seq(s"org.apache.hadoop:hadoop-client-api:$hadoopVersion",
         s"org.apache.hadoop:hadoop-client-runtime:$hadoopVersion")
     } else {
@@ -123,14 +128,6 @@ private[hive] object IsolatedClientLoader extends Logging {
         .map(a => s"org.apache.hive:$a:${version.fullVersion}") ++
       Seq("com.google.guava:guava:14.0.1") ++ hadoopJarNames
 
-    val extraExclusions = if (hadoopVersion.startsWith("3")) {
-      // this introduced from lower version of Hive could conflict with jars in Hadoop 3.2+, so
-      // exclude here in favor of the ones in Hadoop 3.2+
-      Seq("org.apache.hadoop:hadoop-auth")
-    } else {
-      Seq.empty
-    }
-
     val classpaths = quietly {
       SparkSubmitUtils.resolveMavenCoordinates(
         hiveArtifacts.mkString(","),
@@ -138,7 +135,7 @@ private[hive] object IsolatedClientLoader extends Logging {
           Some(remoteRepos),
           ivyPath),
         transitive = true,
-        exclusions = version.exclusions ++ extraExclusions)
+        exclusions = version.exclusions)
     }
     val allFiles = classpaths.map(new File(_)).toSet
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
@@ -21,6 +21,7 @@ import java.io.File
 import java.lang.reflect.InvocationTargetException
 import java.net.{URL, URLClassLoader}
 import java.util
+import java.util.regex.Pattern
 
 import scala.util.Try
 
@@ -88,28 +89,63 @@ private[hive] object IsolatedClientLoader extends Logging {
       barrierPrefixes = barrierPrefixes)
   }
 
-  def hiveVersion(version: String): HiveVersion = version match {
-    case "12" | "0.12" | "0.12.0" => hive.v12
-    case "13" | "0.13" | "0.13.0" | "0.13.1" => hive.v13
-    case "14" | "0.14" | "0.14.0" => hive.v14
-    case "1.0" | "1.0.0" | "1.0.1" => hive.v1_0
-    case "1.1" | "1.1.0" | "1.1.1" => hive.v1_1
-    case "1.2" | "1.2.0" | "1.2.1" | "1.2.2" => hive.v1_2
-    case "2.0" | "2.0.0" | "2.0.1" => hive.v2_0
-    case "2.1" | "2.1.0" | "2.1.1" => hive.v2_1
-    case "2.2" | "2.2.0" => hive.v2_2
-    case "2.3" | "2.3.0" | "2.3.1" | "2.3.2" | "2.3.3" | "2.3.4" | "2.3.5" | "2.3.6" | "2.3.7" |
-         "2.3.8" => hive.v2_3
-    case "3.0" | "3.0.0" => hive.v3_0
-    case "3.1" | "3.1.0" | "3.1.1" | "3.1.2" => hive.v3_1
-    case version =>
+  def hiveVersion(version: String): HiveVersion = {
+    getVersionParts(version).flatMap {
+      case (12, _, _) | (0, 12, _) => Some(hive.v12)
+      case (13, _, _) | (0, 13, _) => Some(hive.v13)
+      case (14, _, _) | (0, 14, _) => Some(hive.v14)
+      case (1, 0, _) => Some(hive.v1_0)
+      case (1, 1, _) => Some(hive.v1_1)
+      case (1, 2, _) => Some(hive.v1_2)
+      case (2, 0, _) => Some(hive.v2_0)
+      case (2, 1, _) => Some(hive.v2_1)
+      case (2, 2, _) => Some(hive.v2_2)
+      case (2, 3, _) => Some(hive.v2_3)
+      case (3, 0, _) => Some(hive.v3_0)
+      case (3, 1, _) => Some(hive.v3_1)
+      case _ => None
+    }.getOrElse {
       throw new UnsupportedOperationException(s"Unsupported Hive Metastore version ($version). " +
         s"Please set ${HiveUtils.HIVE_METASTORE_VERSION.key} with a valid version.")
+    }
   }
 
-  def supportHadoopShadedClient(hadoopVersion: String): Boolean = hadoopVersion match {
-    case "3.2.2" => true
-    case _ => false
+  def supportHadoopShadedClient(hadoopVersion: String): Boolean = {
+    getVersionParts(hadoopVersion).exists {
+      case (3, 2, v) if v >= 2 => true
+      case _ => false
+    }
+  }
+
+  /**
+   * Retrieves the major, minor and patch parts from the input `version`. Returns `None` if the
+   * input is not of a valid format.
+   *
+   * Examples of valid version:
+   *  - 1
+   *  - 2.4
+   *  - 3.2.2
+   *  - 3.2.2.4
+   *  - 3.3.1-SNAPSHOT
+   *  - 3.2.2.4SNAPSHOT (we only retrieve the first 3 components)
+   *
+   * Examples of invalid version:
+   *  - ABC
+   *  - 1X
+   *  - 2.4XYZ
+   *  - 2.4-SNAPSHOT
+   *  - 3.4.5ABC
+   */
+  def getVersionParts(version: String): Option[(Int, Int, Int)] = {
+    val matcher = VERSION_PATTERN.matcher(version)
+    if (matcher.matches() && matcher.groupCount() == 3) {
+      val major = matcher.group(1).toInt
+      val minor = if (matcher.group(2) == null) 0 else matcher.group(2).toInt
+      val patch = if (matcher.group(3) == null) 0 else matcher.group(3).toInt
+      Some((major, minor, patch))
+    } else {
+      None
+    }
   }
 
   private def downloadVersion(
@@ -145,6 +181,10 @@ private[hive] object IsolatedClientLoader extends Logging {
     logInfo(s"Downloaded metastore jars to ${tempDir.getCanonicalPath}")
     tempDir.listFiles().map(_.toURI.toURL)
   }
+
+  // A regex pattern to match Maven version numbers
+  private lazy val VERSION_PATTERN =
+    Pattern.compile("(\\d+)(?:\\.(\\d+)(?:\\.(\\d+)(?:[.-].*)?)?)?")
 
   // A map from a given pair of HiveVersion and Hadoop version to jar files.
   // It is only used by forVersion.

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
@@ -88,28 +88,26 @@ private[hive] object IsolatedClientLoader extends Logging {
       barrierPrefixes = barrierPrefixes)
   }
 
-  def hiveVersion(version: String): HiveVersion = {
-    VersionUtils.majorMinorPatchVersion(version).flatMap {
-      case (12, _, _) | (0, 12, _) => Some(hive.v12)
-      case (13, _, _) | (0, 13, _) => Some(hive.v13)
-      case (14, _, _) | (0, 14, _) => Some(hive.v14)
-      case (1, 0, _) => Some(hive.v1_0)
-      case (1, 1, _) => Some(hive.v1_1)
-      case (1, 2, _) => Some(hive.v1_2)
-      case (2, 0, _) => Some(hive.v2_0)
-      case (2, 1, _) => Some(hive.v2_1)
-      case (2, 2, _) => Some(hive.v2_2)
-      case (2, 3, _) => Some(hive.v2_3)
-      case (3, 0, _) => Some(hive.v3_0)
-      case (3, 1, _) => Some(hive.v3_1)
-      case _ => None
-    }.getOrElse {
+  def hiveVersion(version: String): HiveVersion = version match {
+    case "12" | "0.12" | "0.12.0" => hive.v12
+    case "13" | "0.13" | "0.13.0" | "0.13.1" => hive.v13
+    case "14" | "0.14" | "0.14.0" => hive.v14
+    case "1.0" | "1.0.0" | "1.0.1" => hive.v1_0
+    case "1.1" | "1.1.0" | "1.1.1" => hive.v1_1
+    case "1.2" | "1.2.0" | "1.2.1" | "1.2.2" => hive.v1_2
+    case "2.0" | "2.0.0" | "2.0.1" => hive.v2_0
+    case "2.1" | "2.1.0" | "2.1.1" => hive.v2_1
+    case "2.2" | "2.2.0" => hive.v2_2
+    case "2.3" | "2.3.0" | "2.3.1" | "2.3.2" | "2.3.3" | "2.3.4" | "2.3.5" | "2.3.6" | "2.3.7" |
+         "2.3.8" => hive.v2_3
+    case "3.0" | "3.0.0" => hive.v3_0
+    case "3.1" | "3.1.0" | "3.1.1" | "3.1.2" => hive.v3_1
+    case version =>
       throw new UnsupportedOperationException(s"Unsupported Hive Metastore version ($version). " +
         s"Please set ${HiveUtils.HIVE_METASTORE_VERSION.key} with a valid version.")
-    }
   }
 
-  def supportHadoopShadedClient(hadoopVersion: String): Boolean = {
+  def supportsHadoopShadedClient(hadoopVersion: String): Boolean = {
     VersionUtils.majorMinorPatchVersion(hadoopVersion).exists {
       case (3, 2, v) if v >= 2 => true
       case _ => false
@@ -121,7 +119,7 @@ private[hive] object IsolatedClientLoader extends Logging {
       hadoopVersion: String,
       ivyPath: Option[String],
       remoteRepos: String): Seq[URL] = {
-    val hadoopJarNames = if (supportHadoopShadedClient(hadoopVersion)) {
+    val hadoopJarNames = if (supportsHadoopShadedClient(hadoopVersion)) {
       Seq(s"org.apache.hadoop:hadoop-client-api:$hadoopVersion",
         s"org.apache.hadoop:hadoop-client-runtime:$hadoopVersion")
     } else {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HadoopVersionInfoSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HadoopVersionInfoSuite.scala
@@ -68,4 +68,35 @@ class HadoopVersionInfoSuite extends SparkFunSuite {
       Utils.deleteRecursively(ivyPath)
     }
   }
+
+  test("SPARK-33212: test getVersionParts()") {
+    assert(IsolatedClientLoader.getVersionParts("3.2.2").contains((3, 2, 2)))
+    assert(IsolatedClientLoader.getVersionParts("3.2.2.4").contains((3, 2, 2)))
+    assert(IsolatedClientLoader.getVersionParts("3.2.2-SNAPSHOT").contains((3, 2, 2)))
+    assert(IsolatedClientLoader.getVersionParts("3.2.2.4XXX").contains((3, 2, 2)))
+    assert(IsolatedClientLoader.getVersionParts("3.2").contains((3, 2, 0)))
+    assert(IsolatedClientLoader.getVersionParts("3").contains((3, 0, 0)))
+
+    // illegal cases
+    assert(IsolatedClientLoader.getVersionParts("ABC").isEmpty)
+    assert(IsolatedClientLoader.getVersionParts("3X").isEmpty)
+    assert(IsolatedClientLoader.getVersionParts("3.2-SNAPSHOT").isEmpty)
+    assert(IsolatedClientLoader.getVersionParts("3.2ABC").isEmpty)
+    assert(IsolatedClientLoader.getVersionParts("3-ABC").isEmpty)
+    assert(IsolatedClientLoader.getVersionParts("3.2.4XYZ").isEmpty)
+  }
+
+  test("SPARK-32212: test supportHadoopShadedClient()") {
+    assert(IsolatedClientLoader.supportHadoopShadedClient("3.2.2"))
+    assert(IsolatedClientLoader.supportHadoopShadedClient("3.2.3"))
+    assert(IsolatedClientLoader.supportHadoopShadedClient("3.2.2.1"))
+    assert(IsolatedClientLoader.supportHadoopShadedClient("3.2.2-XYZ"))
+    assert(IsolatedClientLoader.supportHadoopShadedClient("3.2.2.4-SNAPSHOT"))
+
+    // negative cases
+    assert(!IsolatedClientLoader.supportHadoopShadedClient("3.1.3"))
+    assert(!IsolatedClientLoader.supportHadoopShadedClient("3.2"))
+    assert(!IsolatedClientLoader.supportHadoopShadedClient("3.2.1"))
+    assert(!IsolatedClientLoader.supportHadoopShadedClient("4"))
+  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HadoopVersionInfoSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HadoopVersionInfoSuite.scala
@@ -21,6 +21,7 @@ import java.io.File
 import java.net.URLClassLoader
 
 import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.util.VersionInfo
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.sql.hive.{HiveExternalCatalog, HiveUtils}
@@ -69,23 +70,6 @@ class HadoopVersionInfoSuite extends SparkFunSuite {
     }
   }
 
-  test("SPARK-33212: test getVersionParts()") {
-    assert(IsolatedClientLoader.getVersionParts("3.2.2").contains((3, 2, 2)))
-    assert(IsolatedClientLoader.getVersionParts("3.2.2.4").contains((3, 2, 2)))
-    assert(IsolatedClientLoader.getVersionParts("3.2.2-SNAPSHOT").contains((3, 2, 2)))
-    assert(IsolatedClientLoader.getVersionParts("3.2.2.4XXX").contains((3, 2, 2)))
-    assert(IsolatedClientLoader.getVersionParts("3.2").contains((3, 2, 0)))
-    assert(IsolatedClientLoader.getVersionParts("3").contains((3, 0, 0)))
-
-    // illegal cases
-    assert(IsolatedClientLoader.getVersionParts("ABC").isEmpty)
-    assert(IsolatedClientLoader.getVersionParts("3X").isEmpty)
-    assert(IsolatedClientLoader.getVersionParts("3.2-SNAPSHOT").isEmpty)
-    assert(IsolatedClientLoader.getVersionParts("3.2ABC").isEmpty)
-    assert(IsolatedClientLoader.getVersionParts("3-ABC").isEmpty)
-    assert(IsolatedClientLoader.getVersionParts("3.2.4XYZ").isEmpty)
-  }
-
   test("SPARK-32212: test supportHadoopShadedClient()") {
     assert(IsolatedClientLoader.supportHadoopShadedClient("3.2.2"))
     assert(IsolatedClientLoader.supportHadoopShadedClient("3.2.3"))
@@ -98,5 +82,9 @@ class HadoopVersionInfoSuite extends SparkFunSuite {
     assert(!IsolatedClientLoader.supportHadoopShadedClient("3.2"))
     assert(!IsolatedClientLoader.supportHadoopShadedClient("3.2.1"))
     assert(!IsolatedClientLoader.supportHadoopShadedClient("4"))
+  }
+
+  test("SPARK-32212: built-in Hadoop version should support shaded client") {
+    assert(IsolatedClientLoader.supportHadoopShadedClient(VersionInfo.getVersion))
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HadoopVersionInfoSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HadoopVersionInfoSuite.scala
@@ -71,20 +71,17 @@ class HadoopVersionInfoSuite extends SparkFunSuite {
   }
 
   test("SPARK-32212: test supportHadoopShadedClient()") {
-    assert(IsolatedClientLoader.supportHadoopShadedClient("3.2.2"))
-    assert(IsolatedClientLoader.supportHadoopShadedClient("3.2.3"))
-    assert(IsolatedClientLoader.supportHadoopShadedClient("3.2.2.1"))
-    assert(IsolatedClientLoader.supportHadoopShadedClient("3.2.2-XYZ"))
-    assert(IsolatedClientLoader.supportHadoopShadedClient("3.2.2.4-SNAPSHOT"))
+    Seq("3.2.2", "3.2.3", "3.2.2.1", "3.2.2-XYZ", "3.2.2.4-SNAPSHOT").foreach { version =>
+      assert(IsolatedClientLoader.supportsHadoopShadedClient(version), s"version $version")
+    }
 
     // negative cases
-    assert(!IsolatedClientLoader.supportHadoopShadedClient("3.1.3"))
-    assert(!IsolatedClientLoader.supportHadoopShadedClient("3.2"))
-    assert(!IsolatedClientLoader.supportHadoopShadedClient("3.2.1"))
-    assert(!IsolatedClientLoader.supportHadoopShadedClient("4"))
+    Seq("3.1.3", "3.2", "3.2.1", "4").foreach { version =>
+      assert(!IsolatedClientLoader.supportsHadoopShadedClient(version), s"version $version")
+    }
   }
 
   test("SPARK-32212: built-in Hadoop version should support shaded client") {
-    assert(IsolatedClientLoader.supportHadoopShadedClient(VersionInfo.getVersion))
+    assert(IsolatedClientLoader.supportsHadoopShadedClient(VersionInfo.getVersion))
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

1. Add back Maven enforcer for duplicate dependencies check
2. More strict check on Hadoop versions which support shaded client in `IsolatedClientLoader`. To do proper version check, this adds a util function `majorMinorPatchVersion` to extract major/minor/patch version from a string.
3. Cleanup unnecessary code

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The Maven enforcer was removed as part of #30556. This proposes to add it back. 

Also, Hadoop shaded client doesn't work in certain cases (see [these comments](https://github.com/apache/spark/pull/30701#discussion_r558522227) for details). This strictly checks that the current Hadoop version (i.e., 3.2.2 at the moment) has good support of shaded client or otherwise fallback to old unshaded ones.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Existing tests.