### PR TITLE
[SPARK-34136][PYTHON][SQL] Add support for complex literals in PySpark

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -122,8 +122,8 @@ def lit(col):
         )
 
         return struct(*[
-            lit(x).alias(v)
-            for x, v in zip(col, fields)
+            lit(x).alias(a)
+            for x, a in zip(col, fields)
         ])
 
     elif isinstance(col, dict):

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -95,6 +95,16 @@ def lit(col):
     .. versionchanged:: 3.2.0
         Added support for complex type literals.
 
+    Parameters
+    ----------
+    col : bool, float, int, str, datetime.date, datetime.datetime, dict, list, tuple
+        Object to be converted into :class:`Column`.
+
+        If it is a collection, conversion will be applied recursively. In such case,
+        all stored values should be of compatible types.
+
+        I `col` is already a :class:`Column`, it will be returned unmodified.
+
     Examples
     --------
     >>> df.select(lit(5).alias('height')).withColumn('spark_user', lit(True)).take(1)

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -103,7 +103,7 @@ def lit(col):
         If it is a collection, conversion will be applied recursively. In such case,
         all stored values should be of compatible types.
 
-        I `col` is already a :class:`Column`, it will be returned unmodified.
+        The passed in object is returned directly if it is already a :class:`Column`.
 
     Examples
     --------

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -640,6 +640,48 @@ class FunctionsTests(ReusedSQLTestCase):
             str(cm.exception)
         )
 
+    def test_literals(self):
+        from collections import namedtuple
+
+        Person = namedtuple("Person", ["name", "age", "height"])
+
+        a_dict = {"a": 1, "b": 2}
+        a_list = [1.0, 2.0, 3.0]
+        a_tuple = ("foo", 3, True)
+        a_named_tuple = Person("Jane", 29, 171.5)
+        a_row = Row(x=1.0, y=2.0, valid=True)
+
+        df = self.spark.range(1).select(
+            lit(1).alias("one"),
+            lit("foo").alias("foo"),
+            lit(a_dict).alias("map"),
+            lit(a_list).alias("array"),
+            lit(a_tuple).alias("struct"),
+            lit(a_named_tuple).alias("named_struct"),
+            lit(a_row).alias("another_named_struct")
+        )
+        result = df.first()
+
+        self.assertEqual(
+            result,
+            (1, 'foo', a_dict, a_list, a_tuple, a_named_tuple, a_row)
+        )
+
+        self.assertEqual(
+            result["struct"].__fields__,
+            ["_1", "_2", "_3"]
+        )
+
+        self.assertEqual(
+            result["named_struct"].__fields__,
+            ["name", "age", "height"]
+        )
+
+        self.assertEqual(
+            result["another_named_struct"].__fields__,
+            ["x", "y", "valid"]
+        )
+
 
 if __name__ == "__main__":
     import unittest


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR extends `pyspark.sql.functions.lit` to support complex literals:

- `list` mapped to SQL `array`.
- `dict` mapped to SQL `map`.
- `tuple` mapped to `struct` (with support for capturing names from `namedtuple` and `Row`)

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Currently Python uses have to quite verbose constructs to create complex literals, i.e.

```python
from pyspark.sql.functions import array, lit

xs = [1, 2, 3]
array(*[lit(x) for x in xs])
```

```python
from pyspark.sql.functions import create_map, lit, map_from_arrays
from itertools import chain

kvs = {"a": 1, "b": 2}

create_map(*chain.from_iterable(
    (lit(k), lit(v)) for k, v in kvs.items()
))

# or

map_from_arrays(
    array(*[lit(k) for k in kvs.keys()]),
    array(*[lit(v) for v in kvs.values()])
)

```

In contrast, such literals can be created in Scala using `typedLit`.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes. It is merged users will be able to create complex literals directly with `lit`, i.e.

```python
lit({"a": 1, "b": 2})
lit(["foo", "bar"])
lit((1, ("a", True)))
```


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

New unit tests.
