### PR TITLE
[SPARK-34146][SQL][THRIFTSERVER] "*" should not throw Exception in SparkGetSchemasOperation

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkGetColumnsOperation.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkGetColumnsOperation.scala
@@ -102,8 +102,9 @@ private[hive] class SparkGetColumnsOperation(
 
       // Global temporary views
       val globalTempViewDb = catalog.globalTempViewManager.database
-      val databasePattern = Pattern.compile(CLIServiceUtils.patternToRegex(schemaName))
-      if (databasePattern.matcher(globalTempViewDb).matches()) {
+      if (schemaName == null || schemaName.isEmpty || schemaName == "*"
+        || Pattern.compile(CLIServiceUtils.patternToRegex(schemaName))
+        .matcher(globalTempViewDb).matches()) {
         catalog.globalTempViewManager.listViewNames(tablePattern).foreach { globalTempView =>
           catalog.getGlobalTempView(globalTempView).foreach { plan =>
             addToRowSet(columnPattern, globalTempViewDb, globalTempView, plan.schema)

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkGetSchemasOperation.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkGetSchemasOperation.scala
@@ -73,9 +73,9 @@ private[hive] class SparkGetSchemasOperation(
       }
 
       val globalTempViewDb = sqlContext.sessionState.catalog.globalTempViewManager.database
-      val databasePattern = Pattern.compile(CLIServiceUtils.patternToRegex(schemaName))
-      if (schemaName == null || schemaName.isEmpty ||
-          databasePattern.matcher(globalTempViewDb).matches()) {
+      if (schemaName == null || schemaName.isEmpty || schemaName == "*"
+        || Pattern.compile(CLIServiceUtils.patternToRegex(schemaName))
+        .matcher(globalTempViewDb).matches()) {
         rowSet.addRow(Array[AnyRef](globalTempViewDb, DEFAULT_HIVE_CATALOG))
       }
       setState(OperationState.FINISHED)

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkGetTablesOperation.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkGetTablesOperation.scala
@@ -96,8 +96,9 @@ private[hive] class SparkGetTablesOperation(
       // Temporary views and global temporary views
       if (tableTypes == null || tableTypes.isEmpty || tableTypes.contains(VIEW.name)) {
         val globalTempViewDb = catalog.globalTempViewManager.database
-        val databasePattern = Pattern.compile(CLIServiceUtils.patternToRegex(schemaName))
-        val tempViews = if (databasePattern.matcher(globalTempViewDb).matches()) {
+        val tempViews = if (schemaName == null || schemaName.isEmpty || schemaName == "*"
+          || Pattern.compile(CLIServiceUtils.patternToRegex(schemaName))
+          .matcher(globalTempViewDb).matches()) {
           catalog.listTables(globalTempViewDb, tablePattern, includeLocalTempViews = true)
         } else {
           catalog.listLocalTempViews(tablePattern)

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkMetadataOperationSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkMetadataOperationSuite.scala
@@ -49,7 +49,7 @@ class SparkMetadataOperationSuite extends HiveThriftServer2TestBase {
       dbs.foreach( db => statement.execute(s"CREATE DATABASE IF NOT EXISTS $db"))
       val metaData = statement.getConnection.getMetaData
 
-      Seq("", "%", null, ".*", "_*", "_%", ".%") foreach { pattern =>
+      Seq("", "%", null, "*", ".*", "_*", "_%", ".%") foreach { pattern =>
         checkResult(metaData.getSchemas(null, pattern), dbs ++ dbDflts)
       }
 
@@ -63,10 +63,6 @@ class SparkMetadataOperationSuite extends HiveThriftServer2TestBase {
 
       checkResult(metaData.getSchemas(null, "db1"), Seq("db1"))
       checkResult(metaData.getSchemas(null, "db_not_exist"), Seq.empty)
-
-      val e = intercept[HiveSQLException](metaData.getSchemas(null, "*"))
-      assert(e.getCause.getMessage ===
-        "Error operating GET_SCHEMAS Dangling meta character '*' near index 0\n*\n^")
     }
   }
 

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkMetadataOperationSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkMetadataOperationSuite.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.hive.thriftserver
 import java.sql.{DatabaseMetaData, ResultSet, SQLFeatureNotSupportedException}
 
 import org.apache.hive.common.util.HiveVersionInfo
-import org.apache.hive.service.cli.HiveSQLException
 
 import org.apache.spark.SPARK_VERSION
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
@@ -97,7 +96,13 @@ class SparkMetadataOperationSuite extends HiveThriftServer2TestBase {
       checkResult(metaData.getTables(null, "%", "%", Array("TABLE")),
         Seq("table1", "table2"))
 
+      checkResult(metaData.getTables(null, "*", "%", Array("TABLE")),
+        Seq("table1", "table2"))
+
       checkResult(metaData.getTables(null, "%", "%", Array("VIEW")),
+        Seq("view1", "view_global_temp_1", "view_temp_1"))
+
+      checkResult(metaData.getTables(null, "*", "%", Array("VIEW")),
         Seq("view1", "view_global_temp_1", "view_temp_1"))
 
       checkResult(metaData.getTables(null, "%", "view_global_temp_1", null),
@@ -175,6 +180,9 @@ class SparkMetadataOperationSuite extends HiveThriftServer2TestBase {
       checkResult(metaData.getColumns(null, "%", "view_temp_1", "col2"),
         Seq(("view_temp_1", "col2", "4", "INT", "")))
 
+      checkResult(metaData.getColumns(null, "*", "view_temp_1", "col2"),
+        Seq(("view_temp_1", "col2", "4", "INT", "")))
+
       checkResult(metaData.getColumns(null, "default", "%", null),
         Seq(
           ("table1", "key", "4", "INT", "Int column"),
@@ -224,6 +232,7 @@ class SparkMetadataOperationSuite extends HiveThriftServer2TestBase {
       val metaData = statement.getConnection.getMetaData
       // Hive does not have an overlay function, we use overlay to test.
       checkResult(metaData.getFunctions(null, null, "overlay"), Seq("overlay"))
+      checkResult(metaData.getFunctions(null, "*", "overlay"), Seq("overlay"))
       checkResult(metaData.getFunctions(null, null, "overla*"), Seq("overlay"))
       checkResult(metaData.getFunctions(null, "", "overla*"), Seq("overlay"))
       checkResult(metaData.getFunctions(null, null, "does-not-exist*"), Seq.empty)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Align schema pattern "*" behavior with HiveServer2

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
`HiveServer2` treat schema pattern "\*" as list all databases, but `SparkThriftServer` return an exception since "*" is an invalid regex.

https://github.com/apache/hive/blob/f1e87137034e4ecbe39a859d4ef44319800016d7/metastore/src/java/org/apache/hadoop/hive/metastore/ObjectStore.java#L827

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, now schema pattern "*" is valid and has same behavior with empty string in `MetadataOperation` such as `GetSchemasOperation`, `GetTablesOperation`, `GetFunctionsOperation`, `GetColumnsOperation` rather than throw `Exception`


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
UT
