### PR TITLE
[SPARK-34147][SQL][TEST] Keep table partitioning in TPCDSQueryBenchmak when CBO is enabled

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/TPCDSQueryBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/TPCDSQueryBenchmark.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.execution.benchmark
 
+import scala.util.Try
+
 import org.apache.spark.SparkConf
 import org.apache.spark.benchmark.Benchmark
 import org.apache.spark.internal.Logging
@@ -27,7 +29,6 @@ import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.catalyst.util.DateTimeConstants.NANOS_PER_SECOND
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.util.Utils
 
 /**
  * Benchmark to measure TPCDS query performance.
@@ -44,9 +45,6 @@ import org.apache.spark.util.Utils
  */
 object TPCDSQueryBenchmark extends SqlBasedBenchmark with Logging {
 
-  private lazy val warehousePath =
-    Utils.createTempDir(namePrefix = "spark-warehouse").getAbsolutePath
-
   override def getSparkSession: SparkSession = {
     val conf = new SparkConf()
       .setMaster("local[1]")
@@ -57,7 +55,6 @@ object TPCDSQueryBenchmark extends SqlBasedBenchmark with Logging {
       .set("spark.executor.memory", "3g")
       .set("spark.sql.autoBroadcastJoinThreshold", (20 * 1024 * 1024).toString)
       .set("spark.sql.crossJoin.enabled", "true")
-      .set("spark.sql.warehouse.dir", warehousePath)
 
     SparkSession.builder.config(conf).getOrCreate()
   }
@@ -70,11 +67,12 @@ object TPCDSQueryBenchmark extends SqlBasedBenchmark with Logging {
 
   def setupTables(dataLocation: String, createTempView: Boolean): Map[String, Long] = {
     tables.map { tableName =>
-      val df = spark.read.parquet(s"$dataLocation/$tableName")
       if (createTempView) {
-        df.createOrReplaceTempView(tableName)
+        spark.read.parquet(s"$dataLocation/$tableName").createOrReplaceTempView(tableName)
       } else {
-        df.write.saveAsTable(tableName)
+        spark.sql(s"DROP TABLE IF EXISTS $tableName")
+        spark.catalog.createTable(tableName, s"$dataLocation/$tableName", "parquet")
+        Try(spark.sql(s"ALTER TABLE $tableName RECOVER PARTITIONS"))
       }
       tableName -> spark.table(tableName).count()
     }.toMap

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/TPCDSQueryBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/TPCDSQueryBenchmark.scala
@@ -73,7 +73,11 @@ object TPCDSQueryBenchmark extends SqlBasedBenchmark with Logging {
         spark.sql(s"DROP TABLE IF EXISTS $tableName")
         spark.catalog.createTable(tableName, s"$dataLocation/$tableName", "parquet")
         // Recover partitions but don't fail if a table is not partitioned.
-        Try(spark.sql(s"ALTER TABLE $tableName RECOVER PARTITIONS"))
+        Try {
+          spark.sql(s"ALTER TABLE $tableName RECOVER PARTITIONS")
+        }.getOrElse {
+          logInfo(s"Recovering partitions of table $tableName failed")
+        }
       }
       tableName -> spark.table(tableName).count()
     }.toMap

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/TPCDSQueryBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/TPCDSQueryBenchmark.scala
@@ -72,6 +72,7 @@ object TPCDSQueryBenchmark extends SqlBasedBenchmark with Logging {
       } else {
         spark.sql(s"DROP TABLE IF EXISTS $tableName")
         spark.catalog.createTable(tableName, s"$dataLocation/$tableName", "parquet")
+        // Recover partitions but don't fail if a table is not partitioned.
         Try(spark.sql(s"ALTER TABLE $tableName RECOVER PARTITIONS"))
       }
       tableName -> spark.table(tableName).count()


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR keeps partitioning of input tables in TPCDSQueryBenchmark when `--cbo` option is enabled.

https://github.com/apache/spark/pull/31011 introduced the `--cbo` option but unfortunately in that mode the table partitioning of the input data is lost. This means that the results of CBO mode is very different to non CBO mode, one example is that Dynamic Partition Pruning doesn't kick in in CBO mode.

### Why are the changes needed?
To monitor performance changed with CBO enabled.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manually checked.
