### PR TITLE
[MINOR][DOCS] Fix broken python doc links

### DIFF
--- a/docs/ml-classification-regression.md
+++ b/docs/ml-classification-regression.md
@@ -756,7 +756,7 @@ Refer to the [Java API docs](api/java/org/apache/spark/ml/regression/Generalized
 
 <div data-lang="python" markdown="1">
 
-Refer to the [Python API docs](http://127.0.0.1:4000/api/python/reference/api/pyspark.ml.regression.GeneralizedLinearRegression.html#pyspark.ml.regression.GeneralizedLinearRegression) for more details.
+Refer to the [Python API docs](api/python/reference/api/pyspark.ml.regression.GeneralizedLinearRegression.html#pyspark.ml.regression.GeneralizedLinearRegression) for more details.
 
 {% include_example python/ml/generalized_linear_regression_example.py %}
 </div>
@@ -1096,7 +1096,7 @@ Refer to the [Java API docs](api/java/org/apache/spark/ml/regression/FMRegressor
 
 <div data-lang="python" markdown="1">
 
-Refer to the [Python API docs](http://127.0.0.1:4000/api/python/reference/api/pyspark.ml.regression.FMRegressor.html#pyspark.ml.regression.FMRegressor) for more details.
+Refer to the [Python API docs](api/python/reference/api/pyspark.ml.regression.FMRegressor.html#pyspark.ml.regression.FMRegressor) for more details.
 
 {% include_example python/ml/fm_regressor_example.py %}
 </div>

--- a/docs/ml-classification-regression.md
+++ b/docs/ml-classification-regression.md
@@ -85,7 +85,7 @@ More details on parameters can be found in the [Java API documentation](api/java
 
 <div data-lang="python" markdown="1">
 
-More details on parameters can be found in the [Python API documentation](api/python/pyspark.ml.html#pyspark.ml.classification.LogisticRegression).
+More details on parameters can be found in the [Python API documentation](api/python/reference/api/pyspark.ml.classification.LogisticRegression.html).
 
 {% include_example python/ml/logistic_regression_with_elastic_net.py %}
 </div>
@@ -135,11 +135,11 @@ Continuing the earlier example:
 </div>
 
 <div data-lang="python" markdown="1">
-[`LogisticRegressionTrainingSummary`](api/python/pyspark.ml.html#pyspark.ml.classification.LogisticRegressionSummary)
+[`LogisticRegressionTrainingSummary`](api/python/reference/api/pyspark.ml.classification.LogisticRegressionSummary.html)
 provides a summary for a
-[`LogisticRegressionModel`](api/python/pyspark.ml.html#pyspark.ml.classification.LogisticRegressionModel).
+[`LogisticRegressionModel`](api/python/reference/api/pyspark.ml.classification.LogisticRegressionModel.html).
 In the case of binary classification, certain additional metrics are
-available, e.g. ROC curve. See [`BinaryLogisticRegressionTrainingSummary`](api/python/pyspark.ml.html#pyspark.ml.classification.BinaryLogisticRegressionTrainingSummary).
+available, e.g. ROC curve. See [`BinaryLogisticRegressionTrainingSummary`](api/python/reference/api/pyspark.ml.classification.BinaryLogisticRegressionTrainingSummary.html).
 
 Continuing the earlier example:
 
@@ -232,7 +232,7 @@ More details on parameters can be found in the [Java API documentation](api/java
 
 <div data-lang="python" markdown="1">
 
-More details on parameters can be found in the [Python API documentation](api/python/pyspark.ml.html#pyspark.ml.classification.DecisionTreeClassifier).
+More details on parameters can be found in the [Python API documentation](api/python/reference/api/pyspark.ml.classification.DecisionTreeClassifier.html).
 
 {% include_example python/ml/decision_tree_classification_example.py %}
 
@@ -275,7 +275,7 @@ Refer to the [Java API docs](api/java/org/apache/spark/ml/classification/RandomF
 
 <div data-lang="python" markdown="1">
 
-Refer to the [Python API docs](api/python/pyspark.ml.html#pyspark.ml.classification.RandomForestClassifier) for more details.
+Refer to the [Python API docs](api/python/reference/api/pyspark.ml.classification.RandomForestClassifier.html) for more details.
 
 {% include_example python/ml/random_forest_classifier_example.py %}
 </div>
@@ -316,7 +316,7 @@ Refer to the [Java API docs](api/java/org/apache/spark/ml/classification/GBTClas
 
 <div data-lang="python" markdown="1">
 
-Refer to the [Python API docs](api/python/pyspark.ml.html#pyspark.ml.classification.GBTClassifier) for more details.
+Refer to the [Python API docs](api/python/reference/api/pyspark.ml.classification.GBTClassifier.html) for more details.
 
 {% include_example python/ml/gradient_boosted_tree_classifier_example.py %}
 </div>
@@ -372,7 +372,7 @@ Refer to the [Java API docs](api/java/org/apache/spark/ml/classification/Multila
 
 <div data-lang="python" markdown="1">
 
-Refer to the [Python API docs](api/python/pyspark.ml.html#pyspark.ml.classification.MultilayerPerceptronClassifier) for more details.
+Refer to the [Python API docs](api/python/reference/api/pyspark.ml.classification.MultilayerPerceptronClassifier.html) for more details.
 
 {% include_example python/ml/multilayer_perceptron_classification.py %}
 </div>
@@ -417,7 +417,7 @@ Refer to the [Java API docs](api/java/org/apache/spark/ml/classification/LinearS
 
 <div data-lang="python" markdown="1">
 
-Refer to the [Python API docs](api/python/pyspark.ml.html#pyspark.ml.classification.LinearSVC) for more details.
+Refer to the [Python API docs](api/python/reference/api/pyspark.ml.classification.LinearSVC.html) for more details.
 
 {% include_example python/ml/linearsvc.py %}
 </div>
@@ -461,7 +461,7 @@ Refer to the [Java API docs](api/java/org/apache/spark/ml/classification/OneVsRe
 
 <div data-lang="python" markdown="1">
 
-Refer to the [Python API docs](api/python/pyspark.ml.html#pyspark.ml.classification.OneVsRest) for more details.
+Refer to the [Python API docs](api/python/reference/api/pyspark.ml.classification.OneVsRest.html) for more details.
 
 {% include_example python/ml/one_vs_rest_example.py %}
 </div>
@@ -515,7 +515,7 @@ Refer to the [Java API docs](api/java/org/apache/spark/ml/classification/NaiveBa
 
 <div data-lang="python" markdown="1">
 
-Refer to the [Python API docs](api/python/pyspark.ml.html#pyspark.ml.classification.NaiveBayes) for more details.
+Refer to the [Python API docs](api/python/reference/api/pyspark.ml.classification.NaiveBayes.html) for more details.
 
 {% include_example python/ml/naive_bayes_example.py %}
 </div>
@@ -558,7 +558,7 @@ Refer to the [Java API docs](api/java/org/apache/spark/ml/classification/FMClass
 
 <div data-lang="python" markdown="1">
 
-Refer to the [Python API docs](api/python/pyspark.ml.html#pyspark.ml.classification.FMClassifier) for more details.
+Refer to the [Python API docs](api/python/reference/api/pyspark.ml.classification.FMClassifier.html) for more details.
 
 {% include_example python/ml/fm_classifier_example.py %}
 </div>
@@ -609,7 +609,7 @@ More details on parameters can be found in the [Java API documentation](api/java
 <div data-lang="python" markdown="1">
 <!--- TODO: Add python model summaries once implemented -->
 
-More details on parameters can be found in the [Python API documentation](api/python/pyspark.ml.html#pyspark.ml.regression.LinearRegression).
+More details on parameters can be found in the [Python API documentation](api/python/reference/api/pyspark.ml.regression.LinearRegression.html#pyspark.ml.regression.LinearRegression).
 
 {% include_example python/ml/linear_regression_with_elastic_net.py %}
 </div>
@@ -756,7 +756,7 @@ Refer to the [Java API docs](api/java/org/apache/spark/ml/regression/Generalized
 
 <div data-lang="python" markdown="1">
 
-Refer to the [Python API docs](api/python/pyspark.ml.html#pyspark.ml.regression.GeneralizedLinearRegression) for more details.
+Refer to the [Python API docs](http://127.0.0.1:4000/api/python/reference/api/pyspark.ml.regression.GeneralizedLinearRegression.html#pyspark.ml.regression.GeneralizedLinearRegression) for more details.
 
 {% include_example python/ml/generalized_linear_regression_example.py %}
 </div>
@@ -798,7 +798,7 @@ More details on parameters can be found in the [Java API documentation](api/java
 
 <div data-lang="python" markdown="1">
 
-More details on parameters can be found in the [Python API documentation](api/python/pyspark.ml.html#pyspark.ml.regression.DecisionTreeRegressor).
+More details on parameters can be found in the [Python API documentation](api/python/reference/api/pyspark.ml.regression.DecisionTreeRegressor.html#pyspark.ml.regression.DecisionTreeRegressor).
 
 {% include_example python/ml/decision_tree_regression_example.py %}
 </div>
@@ -840,7 +840,7 @@ Refer to the [Java API docs](api/java/org/apache/spark/ml/regression/RandomFores
 
 <div data-lang="python" markdown="1">
 
-Refer to the [Python API docs](api/python/pyspark.ml.html#pyspark.ml.regression.RandomForestRegressor) for more details.
+Refer to the [Python API docs](api/python/reference/api/pyspark.ml.regression.RandomForestRegressor.html#pyspark.ml.regression.RandomForestRegressor) for more details.
 
 {% include_example python/ml/random_forest_regressor_example.py %}
 </div>
@@ -881,7 +881,7 @@ Refer to the [Java API docs](api/java/org/apache/spark/ml/regression/GBTRegresso
 
 <div data-lang="python" markdown="1">
 
-Refer to the [Python API docs](api/python/pyspark.ml.html#pyspark.ml.regression.GBTRegressor) for more details.
+Refer to the [Python API docs](api/python/reference/api/pyspark.ml.regression.GBTRegressor.html#pyspark.ml.regression.GBTRegressor) for more details.
 
 {% include_example python/ml/gradient_boosted_tree_regressor_example.py %}
 </div>
@@ -975,7 +975,7 @@ Refer to the [Java API docs](api/java/org/apache/spark/ml/regression/AFTSurvival
 
 <div data-lang="python" markdown="1">
 
-Refer to the [Python API docs](api/python/pyspark.ml.html#pyspark.ml.regression.AFTSurvivalRegression) for more details.
+Refer to the [Python API docs](api/python/reference/api/pyspark.ml.regression.AFTSurvivalRegression.html#pyspark.ml.regression.AFTSurvivalRegression) for more details.
 
 {% include_example python/ml/aft_survival_regression.py %}
 </div>
@@ -1053,7 +1053,7 @@ Refer to the [`IsotonicRegression` Java docs](api/java/org/apache/spark/ml/regre
 </div>
 <div data-lang="python" markdown="1">
 
-Refer to the [`IsotonicRegression` Python docs](api/python/pyspark.ml.html#pyspark.ml.regression.IsotonicRegression) for more details on the API.
+Refer to the [`IsotonicRegression` Python docs](api/python/reference/api/pyspark.ml.regression.IsotonicRegression.html#pyspark.ml.regression.IsotonicRegression) for more details on the API.
 
 {% include_example python/ml/isotonic_regression_example.py %}
 </div>
@@ -1096,7 +1096,7 @@ Refer to the [Java API docs](api/java/org/apache/spark/ml/regression/FMRegressor
 
 <div data-lang="python" markdown="1">
 
-Refer to the [Python API docs](api/python/pyspark.ml.html#pyspark.ml.regression.FMRegressor) for more details.
+Refer to the [Python API docs](http://127.0.0.1:4000/api/python/reference/api/pyspark.ml.regression.FMRegressor.html#pyspark.ml.regression.FMRegressor) for more details.
 
 {% include_example python/ml/fm_regressor_example.py %}
 </div>

--- a/docs/ml-clustering.md
+++ b/docs/ml-clustering.md
@@ -97,7 +97,7 @@ Refer to the [Java API docs](api/java/org/apache/spark/ml/clustering/KMeans.html
 </div>
 
 <div data-lang="python" markdown="1">
-Refer to the [Python API docs](api/python/pyspark.ml.html#pyspark.ml.clustering.KMeans) for more details.
+Refer to the [Python API docs](api/python/reference/api/pyspark.ml.clustering.KMeans.html) for more details.
 
 {% include_example python/ml/kmeans_example.py %}
 </div>
@@ -137,7 +137,7 @@ Refer to the [Java API docs](api/java/org/apache/spark/ml/clustering/LDA.html) f
 
 <div data-lang="python" markdown="1">
 
-Refer to the [Python API docs](api/python/pyspark.ml.html#pyspark.ml.clustering.LDA) for more details.
+Refer to the [Python API docs](api/python/reference/api/pyspark.ml.clustering.LDA.html) for more details.
 
 {% include_example python/ml/lda_example.py %}
 </div>
@@ -178,7 +178,7 @@ Refer to the [Java API docs](api/java/org/apache/spark/ml/clustering/BisectingKM
 </div>
 
 <div data-lang="python" markdown="1">
-Refer to the [Python API docs](api/python/pyspark.ml.html#pyspark.ml.clustering.BisectingKMeans) for more details.
+Refer to the [Python API docs](api/python/reference/api/pyspark.ml.clustering.BisectingKMeans.html) for more details.
 
 {% include_example python/ml/bisecting_k_means_example.py %}
 </div>
@@ -267,7 +267,7 @@ Refer to the [Java API docs](api/java/org/apache/spark/ml/clustering/GaussianMix
 </div>
 
 <div data-lang="python" markdown="1">
-Refer to the [Python API docs](api/python/pyspark.ml.html#pyspark.ml.clustering.GaussianMixture) for more details.
+Refer to the [Python API docs](api/python/reference/api/pyspark.ml.clustering.GaussianMixture.html) for more details.
 
 {% include_example python/ml/gaussian_mixture_example.py %}
 </div>
@@ -314,7 +314,7 @@ Refer to the [Java API docs](api/java/org/apache/spark/ml/clustering/PowerIterat
 </div>
 
 <div data-lang="python" markdown="1">
-Refer to the [Python API docs](api/python/pyspark.ml.html#pyspark.ml.clustering.PowerIterationClustering) for more details.
+Refer to the [Python API docs](api/python/reference/api/pyspark.ml.clustering.PowerIterationClustering.html) for more details.
 
 {% include_example python/ml/power_iteration_clustering_example.py %}
 </div>

--- a/docs/ml-collaborative-filtering.md
+++ b/docs/ml-collaborative-filtering.md
@@ -177,7 +177,7 @@ explicit (`implicitPrefs` is `False`).
 We evaluate the recommendation model by measuring the root-mean-square error of
 rating prediction.
 
-Refer to the [`ALS` Python docs](api/python/pyspark.ml.html#pyspark.ml.recommendation.ALS)
+Refer to the [`ALS` Python docs](api/python/reference/api/pyspark.ml.recommendation.ALS.html)
 for more details on the API.
 
 {% include_example python/ml/als_example.py %}

--- a/docs/ml-features.md
+++ b/docs/ml-features.md
@@ -112,8 +112,8 @@ Refer to the [HashingTF Java docs](api/java/org/apache/spark/ml/feature/HashingT
 
 <div data-lang="python" markdown="1">
 
-Refer to the [HashingTF Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.HashingTF) and
-the [IDF Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.IDF) for more details on the API.
+Refer to the [HashingTF Python docs](api/python/reference/api/pyspark.ml.feature.HashingTF.html) and
+the [IDF Python docs](api/python/reference/api/pyspark.ml.feature.IDF.html) for more details on the API.
 
 {% include_example python/ml/tf_idf_example.py %}
 </div>
@@ -151,7 +151,7 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [Word2Vec Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.Word2Vec)
+Refer to the [Word2Vec Python docs](api/python/reference/api/pyspark.ml.feature.Word2Vec.html)
 for more details on the API.
 
 {% include_example python/ml/word2vec_example.py %}
@@ -218,8 +218,8 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [CountVectorizer Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.CountVectorizer)
-and the [CountVectorizerModel Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.CountVectorizerModel)
+Refer to the [CountVectorizer Python docs](api/python/reference/api/pyspark.ml.feature.CountVectorizer.html)
+and the [CountVectorizerModel Python docs](api/python/reference/api/pyspark.ml.feature.CountVectorizerModel.html)
 for more details on the API.
 
 {% include_example python/ml/count_vectorizer_example.py %}
@@ -302,7 +302,7 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [FeatureHasher Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.FeatureHasher)
+Refer to the [FeatureHasher Python docs](api/python/reference/api/pyspark.ml.feature.FeatureHasher.html)
 for more details on the API.
 
 {% include_example python/ml/feature_hasher_example.py %}
@@ -344,8 +344,8 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [Tokenizer Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.Tokenizer) and
-the [RegexTokenizer Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.RegexTokenizer)
+Refer to the [Tokenizer Python docs](api/python/reference/api/pyspark.ml.feature.Tokenizer.html) and
+the [RegexTokenizer Python docs](api/python/reference/api/pyspark.ml.feature.RegexTokenizer.html)
 for more details on the API.
 
 {% include_example python/ml/tokenizer_example.py %}
@@ -411,7 +411,7 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [StopWordsRemover Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.StopWordsRemover)
+Refer to the [StopWordsRemover Python docs](api/python/reference/api/pyspark.ml.feature.StopWordsRemover.html)
 for more details on the API.
 
 {% include_example python/ml/stopwords_remover_example.py %}
@@ -446,7 +446,7 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [NGram Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.NGram)
+Refer to the [NGram Python docs](api/python/reference/api/pyspark.ml.feature.NGram.html)
 for more details on the API.
 
 {% include_example python/ml/n_gram_example.py %}
@@ -484,7 +484,7 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [Binarizer Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.Binarizer)
+Refer to the [Binarizer Python docs](api/python/reference/api/pyspark.ml.feature.Binarizer.html)
 for more details on the API.
 
 {% include_example python/ml/binarizer_example.py %}
@@ -516,7 +516,7 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [PCA Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.PCA)
+Refer to the [PCA Python docs](api/python/reference/api/pyspark.ml.feature.PCA.html)
 for more details on the API.
 
 {% include_example python/ml/pca_example.py %}
@@ -548,7 +548,7 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [PolynomialExpansion Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.PolynomialExpansion)
+Refer to the [PolynomialExpansion Python docs](api/python/reference/api/pyspark.ml.feature.PolynomialExpansion.html)
 for more details on the API.
 
 {% include_example python/ml/polynomial_expansion_example.py %}
@@ -590,7 +590,7 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [DCT Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.DCT)
+Refer to the [DCT Python docs](api/python/reference/api/pyspark.ml.feature.DCT.html)
 for more details on the API.
 
 {% include_example python/ml/dct_example.py %}
@@ -720,7 +720,7 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [StringIndexer Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.StringIndexer)
+Refer to the [StringIndexer Python docs](api/python/reference/api/pyspark.ml.feature.StringIndexer.html)
 for more details on the API.
 
 {% include_example python/ml/string_indexer_example.py %}
@@ -788,7 +788,7 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [IndexToString Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.IndexToString)
+Refer to the [IndexToString Python docs](api/python/reference/api/pyspark.ml.feature.IndexToString.html)
 for more details on the API.
 
 {% include_example python/ml/index_to_string_example.py %}
@@ -824,7 +824,7 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [OneHotEncoder Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.OneHotEncoder) for more details on the API.
+Refer to the [OneHotEncoder Python docs](api/python/reference/api/pyspark.ml.feature.OneHotEncoder.html) for more details on the API.
 
 {% include_example python/ml/onehot_encoder_example.py %}
 </div>
@@ -865,7 +865,7 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [VectorIndexer Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.VectorIndexer)
+Refer to the [VectorIndexer Python docs](api/python/reference/api/pyspark.ml.feature.VectorIndexer.html)
 for more details on the API.
 
 {% include_example python/ml/vector_indexer_example.py %}
@@ -926,7 +926,7 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [Interaction Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.Interaction)
+Refer to the [Interaction Python docs](api/python/reference/api/pyspark.ml.feature.Interaction.html)
 for more details on the API.
 
 {% include_example python/ml/interaction_example.py %}
@@ -960,7 +960,7 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [Normalizer Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.Normalizer)
+Refer to the [Normalizer Python docs](api/python/reference/api/pyspark.ml.feature.Normalizer.html)
 for more details on the API.
 
 {% include_example python/ml/normalizer_example.py %}
@@ -1002,7 +1002,7 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [StandardScaler Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.StandardScaler)
+Refer to the [StandardScaler Python docs](api/python/reference/api/pyspark.ml.feature.StandardScaler.html)
 for more details on the API.
 
 {% include_example python/ml/standard_scaler_example.py %}
@@ -1046,7 +1046,7 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [RobustScaler Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.RobustScaler)
+Refer to the [RobustScaler Python docs](api/python/reference/api/pyspark.ml.feature.RobustScaler.html)
 for more details on the API.
 
 {% include_example python/ml/robust_scaler_example.py %}
@@ -1096,8 +1096,8 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [MinMaxScaler Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.MinMaxScaler)
-and the [MinMaxScalerModel Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.MinMaxScalerModel)
+Refer to the [MinMaxScaler Python docs](api/python/reference/api/pyspark.ml.feature.MinMaxScaler.html)
+and the [MinMaxScalerModel Python docs](api/python/reference/api/pyspark.ml.feature.MinMaxScalerModel.html)
 for more details on the API.
 
 {% include_example python/ml/min_max_scaler_example.py %}
@@ -1139,8 +1139,8 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [MaxAbsScaler Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.MaxAbsScaler)
-and the [MaxAbsScalerModel Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.MaxAbsScalerModel)
+Refer to the [MaxAbsScaler Python docs](api/python/reference/api/pyspark.ml.feature.MaxAbsScaler.html)
+and the [MaxAbsScalerModel Python docs](api/python/reference/api/pyspark.ml.feature.MaxAbsScalerModel.html)
 for more details on the API.
 
 {% include_example python/ml/max_abs_scaler_example.py %}
@@ -1182,7 +1182,7 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [Bucketizer Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.Bucketizer)
+Refer to the [Bucketizer Python docs](api/python/reference/api/pyspark.ml.feature.Bucketizer.html)
 for more details on the API.
 
 {% include_example python/ml/bucketizer_example.py %}
@@ -1232,7 +1232,7 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [ElementwiseProduct Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.ElementwiseProduct)
+Refer to the [ElementwiseProduct Python docs](api/python/reference/api/pyspark.ml.feature.ElementwiseProduct.html)
 for more details on the API.
 
 {% include_example python/ml/elementwise_product_example.py %}
@@ -1292,7 +1292,7 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [SQLTransformer Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.SQLTransformer) for more details on the API.
+Refer to the [SQLTransformer Python docs](api/python/reference/api/pyspark.ml.feature.SQLTransformer.html) for more details on the API.
 
 {% include_example python/ml/sql_transformer.py %}
 </div>
@@ -1352,7 +1352,7 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [VectorAssembler Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.VectorAssembler)
+Refer to the [VectorAssembler Python docs](api/python/reference/api/pyspark.ml.feature.VectorAssembler.html)
 for more details on the API.
 
 {% include_example python/ml/vector_assembler_example.py %}
@@ -1403,7 +1403,7 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [VectorSizeHint Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.VectorSizeHint)
+Refer to the [VectorSizeHint Python docs](api/python/reference/api/pyspark.ml.feature.VectorSizeHint.html)
 for more details on the API.
 
 {% include_example python/ml/vector_size_hint_example.py %}
@@ -1486,7 +1486,7 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [QuantileDiscretizer Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.QuantileDiscretizer)
+Refer to the [QuantileDiscretizer Python docs](api/python/reference/api/pyspark.ml.feature.QuantileDiscretizer.html)
 for more details on the API.
 
 {% include_example python/ml/quantile_discretizer_example.py %}
@@ -1555,7 +1555,7 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [Imputer Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.Imputer)
+Refer to the [Imputer Python docs](api/python/reference/api/pyspark.ml.feature.Imputer.html)
 for more details on the API.
 
 {% include_example python/ml/imputer_example.py %}
@@ -1636,7 +1636,7 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [VectorSlicer Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.VectorSlicer)
+Refer to the [VectorSlicer Python docs](api/python/reference/api/pyspark.ml.feature.VectorSlicer.html)
 for more details on the API.
 
 {% include_example python/ml/vector_slicer_example.py %}
@@ -1722,7 +1722,7 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [RFormula Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.RFormula)
+Refer to the [RFormula Python docs](api/python/reference/api/pyspark.ml.feature.RFormula.html)
 for more details on the API.
 
 {% include_example python/ml/rformula_example.py %}
@@ -1786,7 +1786,7 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [ChiSqSelector Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.ChiSqSelector)
+Refer to the [ChiSqSelector Python docs](api/python/reference/api/pyspark.ml.feature.ChiSqSelector.html)
 for more details on the API.
 
 {% include_example python/ml/chisq_selector_example.py %}
@@ -1929,7 +1929,7 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [VarianceThresholdSelector Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.VarianceThresholdSelector)
+Refer to the [VarianceThresholdSelector Python docs](api/python/reference/api/pyspark.ml.feature.VarianceThresholdSelector.html)
 for more details on the API.
 
 {% include_example python/ml/variance_threshold_selector_example.py %}
@@ -2015,7 +2015,7 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [BucketedRandomProjectionLSH Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.BucketedRandomProjectionLSH)
+Refer to the [BucketedRandomProjectionLSH Python docs](api/python/reference/api/pyspark.ml.feature.BucketedRandomProjectionLSH.html)
 for more details on the API.
 
 {% include_example python/ml/bucketed_random_projection_lsh_example.py %}
@@ -2056,7 +2056,7 @@ for more details on the API.
 
 <div data-lang="python" markdown="1">
 
-Refer to the [MinHashLSH Python docs](api/python/pyspark.ml.html#pyspark.ml.feature.MinHashLSH)
+Refer to the [MinHashLSH Python docs](api/python/reference/api/pyspark.ml.feature.MinHashLSH.html)
 for more details on the API.
 
 {% include_example python/ml/min_hash_lsh_example.py %}

--- a/docs/ml-features.md
+++ b/docs/ml-features.md
@@ -1913,7 +1913,7 @@ id | features                       | selectedFeatures
 <div class="codetabs">
 <div data-lang="scala" markdown="1">
 
-Refer to the [VarianceThresholdSelector Scala docs]((api/python/pyspark.ml.html#pyspark.ml.feature.VarianceThresholdSelector))
+Refer to the [VarianceThresholdSelector Scala docs](api/scala/org/apache/spark/ml/feature/VarianceThresholdSelector.html)
 for more details on the API.
 
 {% include_example scala/org/apache/spark/examples/ml/VarianceThresholdSelectorExample.scala %}

--- a/docs/ml-frequent-pattern-mining.md
+++ b/docs/ml-frequent-pattern-mining.md
@@ -87,7 +87,7 @@ Refer to the [Java API docs](api/java/org/apache/spark/ml/fpm/FPGrowth.html) for
 </div>
 
 <div data-lang="python" markdown="1">
-Refer to the [Python API docs](api/python/pyspark.ml.html#pyspark.ml.fpm.FPGrowth) for more details.
+Refer to the [Python API docs](api/python/reference/api/pyspark.ml.fpm.FPGrowth.html) for more details.
 
 {% include_example python/ml/fpgrowth_example.py %}
 </div>
@@ -140,7 +140,7 @@ Refer to the [Java API docs](api/java/org/apache/spark/ml/fpm/PrefixSpan.html) f
 </div>
 
 <div data-lang="python" markdown="1">
-Refer to the [Python API docs](api/python/pyspark.ml.html#pyspark.ml.fpm.PrefixSpan) for more details.
+Refer to the [Python API docs](api/python/reference/api/pyspark.ml.fpm.PrefixSpan) for more details.
 
 {% include_example python/ml/prefixspan_example.py %}
 </div>

--- a/docs/ml-pipeline.md
+++ b/docs/ml-pipeline.md
@@ -268,9 +268,9 @@ the [`Params` Java docs](api/java/org/apache/spark/ml/param/Params.html) for det
 
 <div data-lang="python" markdown="1">
 
-Refer to the [`Estimator` Python docs](api/python/pyspark.ml.html#pyspark.ml.Estimator),
-the [`Transformer` Python docs](api/python/pyspark.ml.html#pyspark.ml.Transformer) and
-the [`Params` Python docs](api/python/pyspark.ml.html#pyspark.ml.param.Params) for more details on the API.
+Refer to the [`Estimator` Python docs](api/python/reference/api/pyspark.ml.Estimator.html),
+the [`Transformer` Python docs](api/python/reference/api/pyspark.ml.Transformer.html) and
+the [`Params` Python docs](api/python/reference/api/pyspark.ml.param.Params.html) for more details on the API.
 
 {% include_example python/ml/estimator_transformer_param_example.py %}
 </div>
@@ -300,7 +300,7 @@ Refer to the [`Pipeline` Java docs](api/java/org/apache/spark/ml/Pipeline.html) 
 
 <div data-lang="python" markdown="1">
 
-Refer to the [`Pipeline` Python docs](api/python/pyspark.ml.html#pyspark.ml.Pipeline) for more details on the API.
+Refer to the [`Pipeline` Python docs](api/python/reference/api/pyspark.ml.Pipeline.html) for more details on the API.
 
 {% include_example python/ml/pipeline_example.py %}
 </div>

--- a/docs/ml-statistics.md
+++ b/docs/ml-statistics.md
@@ -66,7 +66,7 @@ The output will be a DataFrame that contains the correlation matrix of the colum
 </div>
 
 <div data-lang="python" markdown="1">
-[`Correlation`](api/python/pyspark.ml.html#pyspark.ml.stat.Correlation$)
+[`Correlation`](api/python/reference/api/pyspark.ml.stat.Correlation.html)
 computes the correlation matrix for the input Dataset of Vectors using the specified method.
 The output will be a DataFrame that contains the correlation matrix of the column of vectors.
 
@@ -101,7 +101,7 @@ Refer to the [`ChiSquareTest` Java docs](api/java/org/apache/spark/ml/stat/ChiSq
 </div>
 
 <div data-lang="python" markdown="1">
-Refer to the [`ChiSquareTest` Python docs](api/python/index.html#pyspark.ml.stat.ChiSquareTest$) for details on the API.
+Refer to the [`ChiSquareTest` Python docs](api/python/reference/api/pyspark.ml.stat.ChiSquareTest.html) for details on the API.
 
 {% include_example python/ml/chi_square_test_example.py %}
 </div>
@@ -130,7 +130,7 @@ to compute the mean and variance for a vector column of the input dataframe, wit
 </div>
 
 <div data-lang="python" markdown="1">
-Refer to the [`Summarizer` Python docs](api/python/index.html#pyspark.ml.stat.Summarizer$) for details on the API.
+Refer to the [`Summarizer` Python docs](api/python/reference/api/pyspark.ml.stat.Summarizer.html) for details on the API.
 
 {% include_example python/ml/summarizer_example.py %}
 </div>

--- a/docs/ml-tuning.md
+++ b/docs/ml-tuning.md
@@ -109,7 +109,7 @@ Refer to the [`CrossValidator` Java docs](api/java/org/apache/spark/ml/tuning/Cr
 
 <div data-lang="python" markdown="1">
 
-Refer to the [`CrossValidator` Python docs](api/python/pyspark.ml.html#pyspark.ml.tuning.CrossValidator) for more details on the API.
+Refer to the [`CrossValidator` Python docs](api/python/reference/api/pyspark.ml.tuning.CrossValidator.html) for more details on the API.
 
 {% include_example python/ml/cross_validator.py %}
 </div>
@@ -149,7 +149,7 @@ Refer to the [`TrainValidationSplit` Java docs](api/java/org/apache/spark/ml/tun
 
 <div data-lang="python" markdown="1">
 
-Refer to the [`TrainValidationSplit` Python docs](api/python/pyspark.ml.html#pyspark.ml.tuning.TrainValidationSplit) for more details on the API.
+Refer to the [`TrainValidationSplit` Python docs](api/python/reference/api/pyspark.ml.tuning.TrainValidationSplit.html) for more details on the API.
 
 {% include_example python/ml/train_validation_split.py %}
 </div>

--- a/docs/mllib-clustering.md
+++ b/docs/mllib-clustering.md
@@ -85,7 +85,7 @@ data into two clusters. The number of desired clusters is passed to the algorith
 Within Set Sum of Squared Error (WSSSE). You can reduce this error measure by increasing *k*. In
 fact the optimal *k* is usually one where there is an "elbow" in the WSSSE graph.
 
-Refer to the [`KMeans` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.clustering.KMeans) and [`KMeansModel` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.clustering.KMeansModel) for more details on the API.
+Refer to the [`KMeans` Python docs](api/python/reference/api/pyspark.mllib.clustering.KMeans.html) and [`KMeansModel` Python docs](api/python/reference/api/pyspark.mllib.clustering.KMeansModel.html) for more details on the API.
 
 {% include_example python/mllib/k_means_example.py %}
 </div>
@@ -134,11 +134,11 @@ Refer to the [`GaussianMixture` Java docs](api/java/org/apache/spark/mllib/clust
 
 <div data-lang="python" markdown="1">
 In the following example after loading and parsing data, we use a
-[GaussianMixture](api/python/pyspark.mllib.html#pyspark.mllib.clustering.GaussianMixture)
+[GaussianMixture](api/python/reference/api/pyspark.mllib.clustering.GaussianMixture.html)
 object to cluster the data into two clusters. The number of desired clusters is passed
 to the algorithm. We then output the parameters of the mixture model.
 
-Refer to the [`GaussianMixture` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.clustering.GaussianMixture) and [`GaussianMixtureModel` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.clustering.GaussianMixtureModel) for more details on the API.
+Refer to the [`GaussianMixture` Python docs](api/python/reference/api/pyspark.mllib.clustering.GaussianMixture.html) and [`GaussianMixtureModel` Python docs](api/python/reference/api/pyspark.mllib.clustering.GaussianMixtureModel.html) for more details on the API.
 
 {% include_example python/mllib/gaussian_mixture_example.py %}
 </div>
@@ -202,15 +202,15 @@ Refer to the [`PowerIterationClustering` Java docs](api/java/org/apache/spark/ml
 
 <div data-lang="python" markdown="1">
 
-[`PowerIterationClustering`](api/python/pyspark.mllib.html#pyspark.mllib.clustering.PowerIterationClustering)
+[`PowerIterationClustering`](api/python/reference/api/pyspark.mllib.clustering.PowerIterationClustering.html)
 implements the PIC algorithm.
 It takes an `RDD` of `(srcId: Long, dstId: Long, similarity: Double)` tuples representing the
 affinity matrix.
 Calling `PowerIterationClustering.run` returns a
-[`PowerIterationClusteringModel`](api/python/pyspark.mllib.html#pyspark.mllib.clustering.PowerIterationClustering),
+[`PowerIterationClusteringModel`](api/python/reference/api/pyspark.mllib.clustering.PowerIterationClustering.html),
 which contains the computed clustering assignments.
 
-Refer to the [`PowerIterationClustering` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.clustering.PowerIterationClustering) and [`PowerIterationClusteringModel` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.clustering.PowerIterationClusteringModel) for more details on the API.
+Refer to the [`PowerIterationClustering` Python docs](api/python/reference/api/pyspark.mllib.clustering.PowerIterationClustering.html) and [`PowerIterationClusteringModel` Python docs](api/python/reference/api/pyspark.mllib.clustering.PowerIterationClusteringModel.html) for more details on the API.
 
 {% include_example python/mllib/power_iteration_clustering_example.py %}
 </div>
@@ -368,7 +368,7 @@ Refer to the [`LDA` Java docs](api/java/org/apache/spark/mllib/clustering/LDA.ht
 </div>
 
 <div data-lang="python" markdown="1">
-Refer to the [`LDA` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.clustering.LDA) and [`LDAModel` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.clustering.LDAModel) for more details on the API.
+Refer to the [`LDA` Python docs](api/python/reference/api/pyspark.mllib.clustering.LDA.html) and [`LDAModel` Python docs](api/python/reference/api/pyspark.mllib.clustering.LDAModel.html) for more details on the API.
 
 {% include_example python/mllib/latent_dirichlet_allocation_example.py %}
 </div>
@@ -410,7 +410,7 @@ Refer to the [`BisectingKMeans` Java docs](api/java/org/apache/spark/mllib/clust
 </div>
 
 <div data-lang="python" markdown="1">
-Refer to the [`BisectingKMeans` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.clustering.BisectingKMeans) and [`BisectingKMeansModel` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.clustering.BisectingKMeansModel) for more details on the API.
+Refer to the [`BisectingKMeans` Python docs](api/python/reference/api/pyspark.mllib.clustering.BisectingKMeans.html) and [`BisectingKMeansModel` Python docs](api/python/reference/api/pyspark.mllib.clustering.BisectingKMeansModel.html) for more details on the API.
 
 {% include_example python/mllib/bisecting_k_means_example.py %}
 </div>
@@ -458,7 +458,7 @@ And Refer to [Spark Streaming Programming Guide](streaming-programming-guide.htm
 </div>
 
 <div data-lang="python" markdown="1">
-Refer to the [`StreamingKMeans` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.clustering.StreamingKMeans) for more details on the API.
+Refer to the [`StreamingKMeans` Python docs](api/python/reference/api/pyspark.mllib.clustering.StreamingKMeans.html) for more details on the API.
 And Refer to [Spark Streaming Programming Guide](streaming-programming-guide.html#initializing) for details on StreamingContext.
 
 {% include_example python/mllib/streaming_k_means_example.py %}

--- a/docs/mllib-collaborative-filtering.md
+++ b/docs/mllib-collaborative-filtering.md
@@ -111,7 +111,7 @@ In the following example we load rating data. Each row consists of a user, a pro
 We use the default ALS.train() method which assumes ratings are explicit. We evaluate the
 recommendation by measuring the Mean Squared Error of rating prediction.
 
-Refer to the [`ALS` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.recommendation.ALS) for more details on the API.
+Refer to the [`ALS` Python docs](api/python/reference/api/pyspark.mllib.recommendation.ALS.html) for more details on the API.
 
 {% include_example python/mllib/recommendation_example.py %}
 

--- a/docs/mllib-data-types.md
+++ b/docs/mllib-data-types.md
@@ -97,15 +97,15 @@ MLlib recognizes the following types as dense vectors:
 
 and the following as sparse vectors:
 
-* MLlib's [`SparseVector`](api/python/pyspark.mllib.html#pyspark.mllib.linalg.SparseVector).
+* MLlib's [`SparseVector`](api/python/reference/api/pyspark.mllib.linalg.SparseVector.html).
 * SciPy's
   [`csc_matrix`](http://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csc_matrix.html#scipy.sparse.csc_matrix)
   with a single column
 
 We recommend using NumPy arrays over lists for efficiency, and using the factory methods implemented
-in [`Vectors`](api/python/pyspark.mllib.html#pyspark.mllib.linalg.Vectors) to create sparse vectors.
+in [`Vectors`](api/python/reference/api/pyspark.mllib.linalg.Vectors.html) to create sparse vectors.
 
-Refer to the [`Vectors` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.linalg.Vectors) for more details on the API.
+Refer to the [`Vectors` Python docs](api/python/reference/api/pyspark.mllib.linalg.Vectors.html) for more details on the API.
 
 {% highlight python %}
 import numpy as np
@@ -176,9 +176,9 @@ LabeledPoint neg = new LabeledPoint(0.0, Vectors.sparse(3, new int[] {0, 2}, new
 <div data-lang="python" markdown="1">
 
 A labeled point is represented by
-[`LabeledPoint`](api/python/pyspark.mllib.html#pyspark.mllib.regression.LabeledPoint).
+[`LabeledPoint`](api/python/reference/api/pyspark.mllib.regression.LabeledPoint.html).
 
-Refer to the [`LabeledPoint` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.regression.LabeledPoint) for more details on the API.
+Refer to the [`LabeledPoint` Python docs](api/python/reference/api/pyspark.mllib.regression.LabeledPoint.html) for more details on the API.
 
 {% highlight python %}
 from pyspark.mllib.linalg import SparseVector
@@ -242,10 +242,10 @@ JavaRDD<LabeledPoint> examples =
 </div>
 
 <div data-lang="python" markdown="1">
-[`MLUtils.loadLibSVMFile`](api/python/pyspark.mllib.html#pyspark.mllib.util.MLUtils) reads training
+[`MLUtils.loadLibSVMFile`](api/python/reference/api/pyspark.mllib.util.MLUtils.html) reads training
 examples stored in LIBSVM format.
 
-Refer to the [`MLUtils` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.util.MLUtils) for more details on the API.
+Refer to the [`MLUtils` Python docs](api/python/reference/api/pyspark.mllib.util.MLUtils.html) for more details on the API.
 
 {% highlight python %}
 from pyspark.mllib.util import MLUtils
@@ -319,14 +319,14 @@ Matrix sm = Matrices.sparse(3, 2, new int[] {0, 1, 3}, new int[] {0, 2, 1}, new 
 <div data-lang="python" markdown="1">
 
 The base class of local matrices is
-[`Matrix`](api/python/pyspark.mllib.html#pyspark.mllib.linalg.Matrix), and we provide two
-implementations: [`DenseMatrix`](api/python/pyspark.mllib.html#pyspark.mllib.linalg.DenseMatrix),
-and [`SparseMatrix`](api/python/pyspark.mllib.html#pyspark.mllib.linalg.SparseMatrix).
+[`Matrix`](api/python/reference/api/pyspark.mllib.linalg.Matrix.html), and we provide two
+implementations: [`DenseMatrix`](api/python/reference/api/pyspark.mllib.linalg.DenseMatrix.html),
+and [`SparseMatrix`](api/python/reference/api/pyspark.mllib.linalg.SparseMatrix.html).
 We recommend using the factory methods implemented
-in [`Matrices`](api/python/pyspark.mllib.html#pyspark.mllib.linalg.Matrices) to create local
+in [`Matrices`](api/python/reference/api/pyspark.mllib.linalg.Matrices.html) to create local
 matrices. Remember, local matrices in MLlib are stored in column-major order.
 
-Refer to the [`Matrix` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.linalg.Matrix) and [`Matrices` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.linalg.Matrices) for more details on the API.
+Refer to the [`Matrix` Python docs](api/python/reference/api/pyspark.mllib.linalg.Matrix.html) and [`Matrices` Python docs](api/python/reference/api/pyspark.mllib.linalg.Matrices.html) for more details on the API.
 
 {% highlight python %}
 from pyspark.mllib.linalg import Matrix, Matrices
@@ -428,10 +428,10 @@ QRDecomposition<RowMatrix, Matrix> result = mat.tallSkinnyQR(true);
 
 <div data-lang="python" markdown="1">
 
-A [`RowMatrix`](api/python/pyspark.mllib.html#pyspark.mllib.linalg.distributed.RowMatrix) can be 
+A [`RowMatrix`](api/python/reference/api/pyspark.mllib.linalg.distributed.RowMatrix.html) can be 
 created from an `RDD` of vectors.
 
-Refer to the [`RowMatrix` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.linalg.distributed.RowMatrix) for more details on the API.
+Refer to the [`RowMatrix` Python docs](api/python/reference/api/pyspark.mllib.linalg.distributed.RowMatrix.html) for more details on the API.
 
 {% highlight python %}
 from pyspark.mllib.linalg.distributed import RowMatrix
@@ -519,13 +519,13 @@ RowMatrix rowMat = mat.toRowMatrix();
 
 <div data-lang="python" markdown="1">
 
-An [`IndexedRowMatrix`](api/python/pyspark.mllib.html#pyspark.mllib.linalg.distributed.IndexedRowMatrix)
+An [`IndexedRowMatrix`](api/python/reference/api/pyspark.mllib.linalg.distributed.IndexedRowMatrix.html)
 can be created from an `RDD` of `IndexedRow`s, where 
-[`IndexedRow`](api/python/pyspark.mllib.html#pyspark.mllib.linalg.distributed.IndexedRow) is a 
+[`IndexedRow`](api/python/reference/api/pyspark.mllib.linalg.distributed.IndexedRow.html) is a 
 wrapper over `(long, vector)`.  An `IndexedRowMatrix` can be converted to a `RowMatrix` by dropping
 its row indices.
 
-Refer to the [`IndexedRowMatrix` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.linalg.distributed.IndexedRowMatrix) for more details on the API.
+Refer to the [`IndexedRowMatrix` Python docs](api/python/reference/api/pyspark.mllib.linalg.distributed.IndexedRowMatrix.html) for more details on the API.
 
 {% highlight python %}
 from pyspark.mllib.linalg.distributed import IndexedRow, IndexedRowMatrix
@@ -626,13 +626,13 @@ IndexedRowMatrix indexedRowMatrix = mat.toIndexedRowMatrix();
 
 <div data-lang="python" markdown="1">
 
-A [`CoordinateMatrix`](api/python/pyspark.mllib.html#pyspark.mllib.linalg.distributed.CoordinateMatrix)
+A [`CoordinateMatrix`](api/python/reference/api/pyspark.mllib.linalg.distributed.CoordinateMatrix.html)
 can be created from an `RDD` of `MatrixEntry` entries, where 
-[`MatrixEntry`](api/python/pyspark.mllib.html#pyspark.mllib.linalg.distributed.MatrixEntry) is a 
+[`MatrixEntry`](api/python/reference/api/pyspark.mllib.linalg.distributed.MatrixEntry.html) is a 
 wrapper over `(long, long, float)`.  A `CoordinateMatrix` can be converted to a `RowMatrix` by 
 calling `toRowMatrix`, or to an `IndexedRowMatrix` with sparse rows by calling `toIndexedRowMatrix`.
 
-Refer to the [`CoordinateMatrix` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.linalg.distributed.CoordinateMatrix) for more details on the API.
+Refer to the [`CoordinateMatrix` Python docs](api/python/reference/api/pyspark.mllib.linalg.distributed.CoordinateMatrix.html) for more details on the API.
 
 {% highlight python %}
 from pyspark.mllib.linalg.distributed import CoordinateMatrix, MatrixEntry
@@ -735,11 +735,11 @@ BlockMatrix ata = matA.transpose().multiply(matA);
 
 <div data-lang="python" markdown="1">
 
-A [`BlockMatrix`](api/python/pyspark.mllib.html#pyspark.mllib.linalg.distributed.BlockMatrix) 
+A [`BlockMatrix`](api/python/reference/api/pyspark.mllib.linalg.distributed.BlockMatrix.html) 
 can be created from an `RDD` of sub-matrix blocks, where a sub-matrix block is a 
 `((blockRowIndex, blockColIndex), sub-matrix)` tuple.
 
-Refer to the [`BlockMatrix` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.linalg.distributed.BlockMatrix) for more details on the API.
+Refer to the [`BlockMatrix` Python docs](api/python/reference/api/pyspark.mllib.linalg.distributed.BlockMatrix.html) for more details on the API.
 
 {% highlight python %}
 from pyspark.mllib.linalg import Matrices

--- a/docs/mllib-decision-tree.md
+++ b/docs/mllib-decision-tree.md
@@ -219,7 +219,7 @@ Refer to the [`DecisionTree` Java docs](api/java/org/apache/spark/mllib/tree/Dec
 </div>
 
 <div data-lang="python" markdown="1">
-Refer to the [`DecisionTree` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.tree.DecisionTree) and [`DecisionTreeModel` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.tree.DecisionTreeModel) for more details on the API.
+Refer to the [`DecisionTree` Python docs](api/python/reference/api/pyspark.mllib.tree.DecisionTree.html) and [`DecisionTreeModel` Python docs](api/python/reference/api/pyspark.mllib.tree.DecisionTreeModel.html) for more details on the API.
 
 {% include_example python/mllib/decision_tree_classification_example.py %}
 </div>
@@ -250,7 +250,7 @@ Refer to the [`DecisionTree` Java docs](api/java/org/apache/spark/mllib/tree/Dec
 </div>
 
 <div data-lang="python" markdown="1">
-Refer to the [`DecisionTree` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.tree.DecisionTree) and [`DecisionTreeModel` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.tree.DecisionTreeModel) for more details on the API.
+Refer to the [`DecisionTree` Python docs](api/python/reference/api/pyspark.mllib.tree.DecisionTree.html) and [`DecisionTreeModel` Python docs](api/python/reference/api/pyspark.mllib.tree.DecisionTreeModel.html) for more details on the API.
 
 {% include_example python/mllib/decision_tree_regression_example.py %}
 </div>

--- a/docs/mllib-dimensionality-reduction.md
+++ b/docs/mllib-dimensionality-reduction.md
@@ -93,7 +93,7 @@ The same code applies to `IndexedRowMatrix` if `U` is defined as an
 `IndexedRowMatrix`.
 </div>
 <div data-lang="python" markdown="1">
-Refer to the [`SingularValueDecomposition` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.linalg.distributed.SingularValueDecomposition) for details on the API.
+Refer to the [`SingularValueDecomposition` Python docs](api/python/reference/api/pyspark.mllib.linalg.distributed.SingularValueDecomposition.html) for details on the API.
 
 {% include_example python/mllib/svd_example.py %}
 
@@ -146,7 +146,7 @@ Refer to the [`RowMatrix` Java docs](api/java/org/apache/spark/mllib/linalg/dist
 The following code demonstrates how to compute principal components on a `RowMatrix`
 and use them to project the vectors into a low-dimensional space.
 
-Refer to the [`RowMatrix` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.linalg.distributed.RowMatrix) for details on the API.
+Refer to the [`RowMatrix` Python docs](api/python/reference/api/pyspark.mllib.linalg.distributed.RowMatrix.html) for details on the API.
 
 {% include_example python/mllib/pca_rowmatrix_example.py %}
 

--- a/docs/mllib-ensembles.md
+++ b/docs/mllib-ensembles.md
@@ -123,7 +123,7 @@ Refer to the [`RandomForest` Java docs](api/java/org/apache/spark/mllib/tree/Ran
 </div>
 
 <div data-lang="python" markdown="1">
-Refer to the [`RandomForest` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.tree.RandomForest) and [`RandomForest` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.tree.RandomForestModel) for more details on the API.
+Refer to the [`RandomForest` Python docs](api/python/reference/api/pyspark.mllib.tree.RandomForest.html) and [`RandomForest` Python docs](api/python/reference/api/pyspark.mllib.tree.RandomForestModel.html) for more details on the API.
 
 {% include_example python/mllib/random_forest_classification_example.py %}
 </div>
@@ -154,7 +154,7 @@ Refer to the [`RandomForest` Java docs](api/java/org/apache/spark/mllib/tree/Ran
 </div>
 
 <div data-lang="python" markdown="1">
-Refer to the [`RandomForest` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.tree.RandomForest) and [`RandomForest` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.tree.RandomForestModel) for more details on the API.
+Refer to the [`RandomForest` Python docs](api/python/reference/api/pyspark.mllib.tree.RandomForest.html) and [`RandomForest` Python docs](api/python/reference/api/pyspark.mllib.tree.RandomForestModel.html) for more details on the API.
 
 {% include_example python/mllib/random_forest_regression_example.py %}
 </div>
@@ -264,7 +264,7 @@ Refer to the [`GradientBoostedTrees` Java docs](api/java/org/apache/spark/mllib/
 </div>
 
 <div data-lang="python" markdown="1">
-Refer to the [`GradientBoostedTrees` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.tree.GradientBoostedTrees) and [`GradientBoostedTreesModel` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.tree.GradientBoostedTreesModel) for more details on the API.
+Refer to the [`GradientBoostedTrees` Python docs](api/python/reference/api/pyspark.mllib.tree.GradientBoostedTrees.html) and [`GradientBoostedTreesModel` Python docs](api/python/reference/api/pyspark.mllib.tree.GradientBoostedTreesModel.html) for more details on the API.
 
 {% include_example python/mllib/gradient_boosting_classification_example.py %}
 </div>
@@ -295,7 +295,7 @@ Refer to the [`GradientBoostedTrees` Java docs](api/java/org/apache/spark/mllib/
 </div>
 
 <div data-lang="python" markdown="1">
-Refer to the [`GradientBoostedTrees` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.tree.GradientBoostedTrees) and [`GradientBoostedTreesModel` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.tree.GradientBoostedTreesModel) for more details on the API.
+Refer to the [`GradientBoostedTrees` Python docs](api/python/reference/api/pyspark.mllib.tree.GradientBoostedTrees.html) and [`GradientBoostedTreesModel` Python docs](api/python/reference/api/pyspark.mllib.tree.GradientBoostedTreesModel.html) for more details on the API.
 
 {% include_example python/mllib/gradient_boosting_regression_example.py %}
 </div>

--- a/docs/mllib-evaluation-metrics.md
+++ b/docs/mllib-evaluation-metrics.md
@@ -131,7 +131,7 @@ Refer to the [`LogisticRegressionModel` Java docs](api/java/org/apache/spark/mll
 </div>
 
 <div data-lang="python" markdown="1">
-Refer to the [`BinaryClassificationMetrics` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.evaluation.BinaryClassificationMetrics) and [`LogisticRegressionWithLBFGS` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.classification.LogisticRegressionWithLBFGS) for more details on the API.
+Refer to the [`BinaryClassificationMetrics` Python docs](api/python/reference/api/pyspark.mllib.evaluation.BinaryClassificationMetrics.html) and [`LogisticRegressionWithLBFGS` Python docs](api/python/reference/api/pyspark.mllib.classification.LogisticRegressionWithLBFGS.html) for more details on the API.
 
 {% include_example python/mllib/binary_classification_metrics_example.py %}
 </div>
@@ -257,7 +257,7 @@ Refer to the [`MulticlassMetrics` Java docs](api/java/org/apache/spark/mllib/eva
 </div>
 
 <div data-lang="python" markdown="1">
-Refer to the [`MulticlassMetrics` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.evaluation.MulticlassMetrics) for more details on the API.
+Refer to the [`MulticlassMetrics` Python docs](api/python/reference/api/pyspark.mllib.evaluation.MulticlassMetrics.html) for more details on the API.
 
 {% include_example python/mllib/multi_class_metrics_example.py %}
 
@@ -407,7 +407,7 @@ Refer to the [`MultilabelMetrics` Java docs](api/java/org/apache/spark/mllib/eva
 </div>
 
 <div data-lang="python" markdown="1">
-Refer to the [`MultilabelMetrics` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.evaluation.MultilabelMetrics) for more details on the API.
+Refer to the [`MultilabelMetrics` Python docs](api/python/reference/api/pyspark.mllib.evaluation.MultilabelMetrics.html) for more details on the API.
 
 {% include_example python/mllib/multi_label_metrics_example.py %}
 
@@ -535,7 +535,7 @@ Refer to the [`RegressionMetrics` Java docs](api/java/org/apache/spark/mllib/eva
 </div>
 
 <div data-lang="python" markdown="1">
-Refer to the [`RegressionMetrics` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.evaluation.RegressionMetrics) and [`RankingMetrics` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.evaluation.RankingMetrics) for more details on the API.
+Refer to the [`RegressionMetrics` Python docs](api/python/reference/api/pyspark.mllib.evaluation.RegressionMetrics.html) and [`RankingMetrics` Python docs](api/python/reference/api/pyspark.mllib.evaluation.RankingMetrics.html) for more details on the API.
 
 {% include_example python/mllib/ranking_metrics_example.py %}
 

--- a/docs/mllib-feature-extraction.md
+++ b/docs/mllib-feature-extraction.md
@@ -80,13 +80,13 @@ Refer to the [`HashingTF` Scala docs](api/scala/org/apache/spark/mllib/feature/H
 </div>
 <div data-lang="python" markdown="1">
 
-TF and IDF are implemented in [HashingTF](api/python/pyspark.mllib.html#pyspark.mllib.feature.HashingTF)
-and [IDF](api/python/pyspark.mllib.html#pyspark.mllib.feature.IDF).
+TF and IDF are implemented in [HashingTF](api/python/reference/api/pyspark.mllib.feature.HashingTF.html)
+and [IDF](api/python/reference/api/pyspark.mllib.feature.IDF.html).
 `HashingTF` takes an RDD of list as the input.
 Each record could be an iterable of strings or other types.
 
 
-Refer to the [`HashingTF` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.feature.HashingTF) for details on the API.
+Refer to the [`HashingTF` Python docs](api/python/reference/api/pyspark.mllib.feature.HashingTF.html) for details on the API.
 
 {% include_example python/mllib/tf_idf_example.py %}
 </div>
@@ -140,7 +140,7 @@ Refer to the [`Word2Vec` Scala docs](api/scala/org/apache/spark/mllib/feature/Wo
 {% include_example scala/org/apache/spark/examples/mllib/Word2VecExample.scala %}
 </div>
 <div data-lang="python" markdown="1">
-Refer to the [`Word2Vec` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.feature.Word2Vec) for more details on the API.
+Refer to the [`Word2Vec` Python docs](api/python/reference/api/pyspark.mllib.feature.Word2Vec.html) for more details on the API.
 
 {% include_example python/mllib/word2vec_example.py %}
 </div>
@@ -191,7 +191,7 @@ Refer to the [`StandardScaler` Scala docs](api/scala/org/apache/spark/mllib/feat
 </div>
 
 <div data-lang="python" markdown="1">
-Refer to the [`StandardScaler` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.feature.StandardScaler) for more details on the API.
+Refer to the [`StandardScaler` Python docs](api/python/reference/api/pyspark.mllib.feature.StandardScaler.html) for more details on the API.
 
 {% include_example python/mllib/standard_scaler_example.py %}
 </div>
@@ -227,7 +227,7 @@ Refer to the [`Normalizer` Scala docs](api/scala/org/apache/spark/mllib/feature/
 </div>
 
 <div data-lang="python" markdown="1">
-Refer to the [`Normalizer` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.feature.Normalizer) for more details on the API.
+Refer to the [`Normalizer` Python docs](api/python/reference/api/pyspark.mllib.feature.Normalizer.html) for more details on the API.
 
 {% include_example python/mllib/normalizer_example.py %}
 </div>
@@ -337,7 +337,7 @@ Refer to the [`ElementwiseProduct` Java docs](api/java/org/apache/spark/mllib/fe
 </div>
 
 <div data-lang="python" markdown="1">
-Refer to the [`ElementwiseProduct` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.feature.ElementwiseProduct) for more details on the API.
+Refer to the [`ElementwiseProduct` Python docs](api/python/reference/api/pyspark.mllib.feature.ElementwiseProduct.html) for more details on the API.
 
 {% include_example python/mllib/elementwise_product_example.py %}
 </div>

--- a/docs/mllib-frequent-pattern-mining.md
+++ b/docs/mllib-frequent-pattern-mining.md
@@ -92,14 +92,14 @@ Refer to the [`FPGrowth` Java docs](api/java/org/apache/spark/mllib/fpm/FPGrowth
 
 <div data-lang="python" markdown="1">
 
-[`FPGrowth`](api/python/pyspark.mllib.html#pyspark.mllib.fpm.FPGrowth) implements the
+[`FPGrowth`](api/python/reference/api/pyspark.mllib.fpm.FPGrowth.html) implements the
 FP-growth algorithm.
 It takes an `RDD` of transactions, where each transaction is an `List` of items of a generic type.
 Calling `FPGrowth.train` with transactions returns an
-[`FPGrowthModel`](api/python/pyspark.mllib.html#pyspark.mllib.fpm.FPGrowthModel)
+[`FPGrowthModel`](api/python/reference/api/pyspark.mllib.fpm.FPGrowthModel.html)
 that stores the frequent itemsets with their frequencies.
 
-Refer to the [`FPGrowth` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.fpm.FPGrowth) for more details on the API.
+Refer to the [`FPGrowth` Python docs](api/python/reference/api/pyspark.mllib.fpm.FPGrowth.html) for more details on the API.
 
 {% include_example python/mllib/fpgrowth_example.py %}
 

--- a/docs/mllib-isotonic-regression.md
+++ b/docs/mllib-isotonic-regression.md
@@ -94,7 +94,7 @@ i.e. 4710.28,500.00. The data are split to training and testing set.
 Model is created using the training set and a mean squared error is calculated from the predicted
 labels and real labels in the test set.
 
-Refer to the [`IsotonicRegression` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.regression.IsotonicRegression) and [`IsotonicRegressionModel` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.regression.IsotonicRegressionModel) for more details on the API.
+Refer to the [`IsotonicRegression` Python docs](api/python/reference/api/pyspark.mllib.regression.IsotonicRegression.html) and [`IsotonicRegressionModel` Python docs](api/python/reference/api/pyspark.mllib.regression.IsotonicRegressionModel.html) for more details on the API.
 
 {% include_example python/mllib/isotonic_regression_example.py %}
 </div>

--- a/docs/mllib-linear-methods.md
+++ b/docs/mllib-linear-methods.md
@@ -251,7 +251,7 @@ a dependency.
 The following example shows how to load a sample dataset, build SVM model,
 and make predictions with the resulting model to compute the training error.
 
-Refer to the [`SVMWithSGD` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.classification.SVMWithSGD) and [`SVMModel` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.classification.SVMModel) for more details on the API.
+Refer to the [`SVMWithSGD` Python docs](api/python/reference/api/pyspark.mllib.classification.SVMWithSGD.html) and [`SVMModel` Python docs](api/python/reference/api/pyspark.mllib.classification.SVMModel.html) for more details on the API.
 
 {% include_example python/mllib/svm_with_sgd_example.py %}
 </div>
@@ -334,7 +334,7 @@ and make predictions with the resulting model to compute the training error.
 Note that the Python API does not yet support multiclass classification and model save/load but
 will in the future.
 
-Refer to the [`LogisticRegressionWithLBFGS` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.classification.LogisticRegressionWithLBFGS) and [`LogisticRegressionModel` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.classification.LogisticRegressionModel) for more details on the API.
+Refer to the [`LogisticRegressionWithLBFGS` Python docs](api/python/reference/api/pyspark.mllib.classification.LogisticRegressionWithLBFGS.html) and [`LogisticRegressionModel` Python docs](api/python/reference/api/pyspark.mllib.classification.LogisticRegressionModel.html) for more details on the API.
 
 {% include_example python/mllib/logistic_regression_with_lbfgs_example.py %}
 </div>

--- a/docs/mllib-naive-bayes.md
+++ b/docs/mllib-naive-bayes.md
@@ -72,16 +72,16 @@ Refer to the [`NaiveBayes` Java docs](api/java/org/apache/spark/mllib/classifica
 </div>
 <div data-lang="python" markdown="1">
 
-[NaiveBayes](api/python/pyspark.mllib.html#pyspark.mllib.classification.NaiveBayes) implements multinomial
+[NaiveBayes](api/python/reference/api/pyspark.mllib.classification.NaiveBayes.html) implements multinomial
 naive Bayes. It takes an RDD of
-[LabeledPoint](api/python/pyspark.mllib.html#pyspark.mllib.regression.LabeledPoint) and an optionally
+[LabeledPoint](api/python/reference/api/pyspark.mllib.regression.LabeledPoint.html) and an optionally
 smoothing parameter `lambda` as input, and output a
-[NaiveBayesModel](api/python/pyspark.mllib.html#pyspark.mllib.classification.NaiveBayesModel), which can be
+[NaiveBayesModel](api/python/reference/api/pyspark.mllib.classification.NaiveBayesModel.html), which can be
 used for evaluation and prediction.
 
 Note that the Python API does not yet support model save/load but will in the future.
 
-Refer to the [`NaiveBayes` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.classification.NaiveBayes) and [`NaiveBayesModel` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.classification.NaiveBayesModel) for more details on the API.
+Refer to the [`NaiveBayes` Python docs](api/python/reference/api/pyspark.mllib.classification.NaiveBayes.html) and [`NaiveBayesModel` Python docs](api/python/reference/api/pyspark.mllib.classification.NaiveBayesModel.html) for more details on the API.
 
 {% include_example python/mllib/naive_bayes_example.py %}
 </div>

--- a/docs/mllib-statistics.md
+++ b/docs/mllib-statistics.md
@@ -71,12 +71,12 @@ Refer to the [`MultivariateStatisticalSummary` Java docs](api/java/org/apache/sp
 </div>
 
 <div data-lang="python" markdown="1">
-[`colStats()`](api/python/pyspark.mllib.html#pyspark.mllib.stat.Statistics.colStats) returns an instance of
-[`MultivariateStatisticalSummary`](api/python/pyspark.mllib.html#pyspark.mllib.stat.MultivariateStatisticalSummary),
+[`colStats()`](api/python/reference/api/pyspark.mllib.stat.Statistics.html#pyspark.mllib.stat.Statistics.colStats) returns an instance of
+[`MultivariateStatisticalSummary`](api/python/reference/api/pyspark.mllib.stat.MultivariateStatisticalSummary.html),
 which contains the column-wise max, min, mean, variance, and number of nonzeros, as well as the
 total count.
 
-Refer to the [`MultivariateStatisticalSummary` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.stat.MultivariateStatisticalSummary) for more details on the API.
+Refer to the [`MultivariateStatisticalSummary` Python docs](api/python/reference/api/pyspark.mllib.stat.MultivariateStatisticalSummary.html) for more details on the API.
 
 {% include_example python/mllib/summary_statistics_example.py %}
 </div>
@@ -111,11 +111,11 @@ Refer to the [`Statistics` Java docs](api/java/org/apache/spark/mllib/stat/Stati
 </div>
 
 <div data-lang="python" markdown="1">
-[`Statistics`](api/python/pyspark.mllib.html#pyspark.mllib.stat.Statistics) provides methods to
+[`Statistics`](api/python/reference/api/pyspark.mllib.stat.Statistics.html) provides methods to
 calculate correlations between series. Depending on the type of input, two `RDD[Double]`s or
 an `RDD[Vector]`, the output will be a `Double` or the correlation `Matrix` respectively.
 
-Refer to the [`Statistics` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.stat.Statistics) for more details on the API.
+Refer to the [`Statistics` Python docs](api/python/reference/api/pyspark.mllib.stat.Statistics.html) for more details on the API.
 
 {% include_example python/mllib/correlations_example.py %}
 </div>
@@ -156,7 +156,7 @@ size, whereas sampling with replacement requires two additional passes.
 {% include_example java/org/apache/spark/examples/mllib/JavaStratifiedSamplingExample.java %}
 </div>
 <div data-lang="python" markdown="1">
-[`sampleByKey()`](api/python/pyspark.html#pyspark.RDD.sampleByKey) allows users to
+[`sampleByKey()`](api/python/reference/api/pyspark.RDD.sampleByKey.html#pyspark.RDD.sampleByKey) allows users to
 sample approximately $\lceil f_k \cdot n_k \rceil \, \forall k \in K$ items, where $f_k$ is the
 desired fraction for key $k$, $n_k$ is the number of key-value pairs for key $k$, and $K$ is the
 set of keys.
@@ -199,11 +199,11 @@ Refer to the [`ChiSqTestResult` Java docs](api/java/org/apache/spark/mllib/stat/
 </div>
 
 <div data-lang="python" markdown="1">
-[`Statistics`](api/python/index.html#pyspark.mllib.stat.Statistics$) provides methods to
+[`Statistics`](api/python/reference/api/pyspark.mllib.stat.Statistics.html) provides methods to
 run Pearson's chi-squared tests. The following example demonstrates how to run and interpret
 hypothesis tests.
 
-Refer to the [`Statistics` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.stat.Statistics) for more details on the API.
+Refer to the [`Statistics` Python docs](api/python/reference/api/pyspark.mllib.stat.Statistics.html) for more details on the API.
 
 {% include_example python/mllib/hypothesis_testing_example.py %}
 </div>
@@ -241,11 +241,11 @@ Refer to the [`Statistics` Java docs](api/java/org/apache/spark/mllib/stat/Stati
 </div>
 
 <div data-lang="python" markdown="1">
-[`Statistics`](api/python/pyspark.mllib.html#pyspark.mllib.stat.Statistics) provides methods to
+[`Statistics`](api/python/reference/api/pyspark.mllib.stat.Statistics.html) provides methods to
 run a 1-sample, 2-sided Kolmogorov-Smirnov test. The following example demonstrates how to run
 and interpret the hypothesis tests.
 
-Refer to the [`Statistics` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.stat.Statistics) for more details on the API.
+Refer to the [`Statistics` Python docs](api/python/reference/api/pyspark.mllib.stat.Statistics.html) for more details on the API.
 
 {% include_example python/mllib/hypothesis_testing_kolmogorov_smirnov_test_example.py %}
 </div>
@@ -337,12 +337,12 @@ JavaDoubleRDD v = u.mapToDouble(x -> 1.0 + 2.0 * x);
 </div>
 
 <div data-lang="python" markdown="1">
-[`RandomRDDs`](api/python/pyspark.mllib.html#pyspark.mllib.random.RandomRDDs) provides factory
+[`RandomRDDs`](api/python/reference/api/pyspark.mllib.random.RandomRDDs.html) provides factory
 methods to generate random double RDDs or vector RDDs.
 The following example generates a random double RDD, whose values follows the standard normal
 distribution `N(0, 1)`, and then map it to `N(1, 4)`.
 
-Refer to the [`RandomRDDs` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.random.RandomRDDs) for more details on the API.
+Refer to the [`RandomRDDs` Python docs](api/python/reference/api/pyspark.mllib.random.RandomRDDs.html) for more details on the API.
 
 {% highlight python %}
 from pyspark.mllib.random import RandomRDDs
@@ -390,11 +390,11 @@ Refer to the [`KernelDensity` Java docs](api/java/org/apache/spark/mllib/stat/Ke
 </div>
 
 <div data-lang="python" markdown="1">
-[`KernelDensity`](api/python/pyspark.mllib.html#pyspark.mllib.stat.KernelDensity) provides methods
+[`KernelDensity`](api/python/reference/api/pyspark.mllib.stat.KernelDensity.html) provides methods
 to compute kernel density estimates from an RDD of samples. The following example demonstrates how
 to do so.
 
-Refer to the [`KernelDensity` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.stat.KernelDensity) for more details on the API.
+Refer to the [`KernelDensity` Python docs](api/python/reference/api/pyspark.mllib.stat.KernelDensity.html) for more details on the API.
 
 {% include_example python/mllib/kernel_density_estimation_example.py %}
 </div>


### PR DESCRIPTION


### What changes were proposed in this pull request?
Fix broken python links


### Why are the changes needed?
links broken. 
![image](https://user-images.githubusercontent.com/13592258/104859361-9f60c980-58d9-11eb-8810-cb0669040af4.png)

![image](https://user-images.githubusercontent.com/13592258/104859350-8b1ccc80-58d9-11eb-9a8a-6ba8792595aa.png)



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manually checked