### PR TITLE
[SPARK-34064][SQL] Cancel the running broadcast sub-jobs when SQL statement is cancelled

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -761,8 +761,9 @@ class SparkContext(config: SparkConf) extends Logging {
    */
   def setJobGroup(groupId: String,
       description: String, interruptOnCancel: Boolean = false): Unit = {
+    val actualGroupId = getJobGroupId(groupId)
     setLocalProperty(SparkContext.SPARK_JOB_DESCRIPTION, description)
-    setLocalProperty(SparkContext.SPARK_JOB_GROUP_ID, groupId)
+    setLocalProperty(SparkContext.SPARK_JOB_GROUP_ID, actualGroupId)
     // Note: Specifying interruptOnCancel in setJobGroup (rather than cancelJobGroup) avoids
     // changing several public APIs and allows Spark cancellations outside of the cancelJobGroup
     // APIs to also take advantage of this property (e.g., internal job failures or canceling from
@@ -775,6 +776,14 @@ class SparkContext(config: SparkConf) extends Logging {
     setLocalProperty(SparkContext.SPARK_JOB_DESCRIPTION, null)
     setLocalProperty(SparkContext.SPARK_JOB_GROUP_ID, null)
     setLocalProperty(SparkContext.SPARK_JOB_INTERRUPT_ON_CANCEL, null)
+    setLocalProperty(SparkContext.SPARK_JOB_GROUP_OVERRIDE_ID, null)
+  }
+
+  /**
+   * Return the overridden group id if it exists, or the groupId from parameter
+   */
+  private def getJobGroupId(groupId: String): String = {
+    Option(getLocalProperty(SparkContext.SPARK_JOB_GROUP_OVERRIDE_ID)).getOrElse(groupId)
   }
 
   /**
@@ -2386,11 +2395,12 @@ class SparkContext(config: SparkConf) extends Logging {
 
   /**
    * Cancel active jobs for the specified group. See `org.apache.spark.SparkContext.setJobGroup`
-   * for more information.
+   * for more information. If the spark.jobGroup.overrideId is set, use the overrideId instead.
    */
   def cancelJobGroup(groupId: String): Unit = {
     assertNotStopped()
-    dagScheduler.cancelJobGroup(groupId)
+    val actualGroupId = getJobGroupId(groupId)
+    dagScheduler.cancelJobGroup(actualGroupId)
   }
 
   /** Cancel all jobs that have been scheduled or are running.  */
@@ -2764,6 +2774,9 @@ object SparkContext extends Logging {
   private[spark] val SPARK_SCHEDULER_POOL = "spark.scheduler.pool"
   private[spark] val RDD_SCOPE_KEY = "spark.rdd.scope"
   private[spark] val RDD_SCOPE_NO_OVERRIDE_KEY = "spark.rdd.scope.noOverride"
+  // If it's set, all the jobs submitted by SQL queries should use it as job group id,
+  // regardless of what the current job group id is.
+  private[spark] val SPARK_JOB_GROUP_OVERRIDE_ID = "spark.jobGroup.overrideId"
 
   /**
    * Executor id for the driver.  In earlier versions of Spark, this was `<driver>`, but this was

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
@@ -24,7 +24,7 @@ import scala.concurrent.{ExecutionContext, Promise}
 import scala.concurrent.duration.NANOSECONDS
 import scala.util.control.NonFatal
 
-import org.apache.spark.{broadcast, SparkException}
+import org.apache.spark.{broadcast, SparkContext, SparkException}
 import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -74,7 +74,9 @@ case class BroadcastExchangeExec(
     child: SparkPlan) extends BroadcastExchangeLike {
   import BroadcastExchangeExec._
 
-  override val runId: UUID = UUID.randomUUID
+  // runId must be a UUID. We set it to statementId if defined.
+  override val runId: UUID = Option(sparkContext.getLocalProperty(SparkContext.SPARK_STATEMENT_ID))
+      .map(UUID.fromString).getOrElse(UUID.randomUUID)
 
   override lazy val metrics = Map(
     "dataSize" -> SQLMetrics.createSizeMetric(sparkContext, "data size"),

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
@@ -31,6 +31,7 @@ import org.apache.hive.service.cli._
 import org.apache.hive.service.cli.operation.ExecuteStatementOperation
 import org.apache.hive.service.cli.session.HiveSession
 
+import org.apache.spark.SparkContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{DataFrame, Row => SparkRow, SQLContext}
 import org.apache.spark.sql.execution.HiveResult.{getTimeFormatters, toHiveString, TimeFormatters}
@@ -285,7 +286,9 @@ private[hive] class SparkExecuteStatementOperation(
       if (!runInBackground) {
         parentSession.getSessionState.getConf.setClassLoader(executionHiveClassLoader)
       }
-
+      // In Spark thrift server, we override the job group id by statementId
+      sqlContext.sparkContext
+        .setLocalProperty(SparkContext.SPARK_JOB_GROUP_OVERRIDE_ID, statementId)
       sqlContext.sparkContext.setJobGroup(statementId, substitutorStatement, forceCancel)
       result = sqlContext.sql(statement)
       logDebug(result.queryExecution.toString())


### PR DESCRIPTION
### What changes were proposed in this pull request?
The refactor PR for #31119.
In this PR, we add a local property key `spark.statement.id` which set by STS. STS will set statementId to this local property,
in broadcast exchange, the `runId` reads the value from this property if defined, or uses a random UUID.


### Why are the changes needed?
When broadcasting a table takes too long and the SQL statement is cancelled. However, the background Spark job is still running and it wastes resources.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manually test.
Since broadcasting a table is too fast to cancel in UT, but it is very easy to verify manually: 
1. Start a Spark thrift-server with less resource (or set executor memory to a very big value) in YARN.
2. When the driver is running but no executors are launched, submit a SQL which will broadcast tables from beeline.
3. Cancel the SQL in beeline