### PR TITLE
[SPARK-34087][SQL] Make ExecutionListenerManager.listenerBus removable.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/util/QueryExecutionListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/util/QueryExecutionListener.scala
@@ -110,8 +110,22 @@ class ExecutionListenerManager private[sql](session: SparkSession, loadExtension
   }
 
   /**
-   * Removes [[ExecutionListenerBus]] from LiveListenerBus.queues. people should call this function
-   * when the manager belongs session was removed.
+   * Removes [[ExecutionListenerBus]] from LiveListenerBus.queues.
+   * Each SparkSession has its own listener manager, and this manager won't be cleared by Spark.
+   * Developers are expected to call this function (to clean up the listener manager) while
+   * destroying a session
+   *
+   * == Example ==
+   *
+   * {{{
+   *   val newSession = spark.cloneSession()
+   *   // run query
+   *   newSession.sql(...)
+   *   // destroy current spark session.
+   *   newSession.listenerManager.clearListenerBus()
+   *   SparkSession.clearActiveSession()
+   *   SparkSession.clearDefaultSession()
+   * }}}
    */
   @DeveloperApi
   def clearListenerBus(): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/util/QueryExecutionListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/util/QueryExecutionListener.scala
@@ -109,6 +109,16 @@ class ExecutionListenerManager private[sql](session: SparkSession, loadExtension
     listenerBus.removeAllListeners()
   }
 
+  /**
+   * Removes [[ExecutionListenerBus]] from LiveListenerBus.queues. people should call this function
+   * when the manager belongs session was removed.
+   */
+  @DeveloperApi
+  def clearListenerBus(): Unit = {
+    session.sparkContext.removeSparkListener(listenerBus)
+  }
+
+
   /** Only exposed for testing. */
   private[sql] def listListeners(): Array[QueryExecutionListener] = {
     listenerBus.listeners.asScala.toArray

--- a/sql/core/src/main/scala/org/apache/spark/sql/util/QueryExecutionListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/util/QueryExecutionListener.scala
@@ -76,7 +76,7 @@ trait QueryExecutionListener {
 class ExecutionListenerManager private[sql](session: SparkSession, loadExtensions: Boolean)
   extends Logging {
 
-  private val listenerBus = new ExecutionListenerBus(session)
+  private[sql] val listenerBus = new ExecutionListenerBus(session)
 
   if (loadExtensions) {
     val conf = session.sparkContext.conf

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
@@ -421,11 +421,11 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
       .master("local")
       .appName("SPARK-34087")
       .getOrCreate()
-    (1 to 1000).foreach(_ => {
+    (1 to 1000).foreach { _ =>
       val session = spark.cloneSession()
       session.listenerManager.clearListenerBus()
       SparkSession.clearActiveSession()
-    })
+    }
 
     val count = spark.sparkContext
         .listenerBus

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
@@ -20,8 +20,8 @@ package org.apache.spark.sql
 import scala.collection.JavaConverters._
 
 import org.scalatest.BeforeAndAfterEach
-import org.apache.spark.{SparkConf, SparkContext, SparkException, SparkFunSuite}
 
+import org.apache.spark.{SparkConf, SparkContext, SparkException, SparkFunSuite}
 import org.apache.spark.internal.config.EXECUTOR_ALLOW_SPARK_CONTEXT
 import org.apache.spark.internal.config.UI.UI_ENABLED
 import org.apache.spark.scheduler.SparkListener


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


make `ExecutionListenerManager.listenerBus` removable. then we can manually remove `ExecutionListenerBus` when its belongs session was removed.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

new test.