### PR TITLE
[SPARK-34115][CORE] Check SPARK_TESTING as lazy val to avoid slowdown

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1943,7 +1943,6 @@ private[spark] object Utils extends Logging {
     // we directly use the Java APIs instead.
     System.getenv("SPARK_TESTING") != null || System.getProperty(IS_TESTING.key) != null
   }
-  }
 
   /**
    * Terminates a process waiting for at most the specified duration.

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1939,7 +1939,15 @@ private[spark] object Utils extends Logging {
    * Indicates whether Spark is currently running unit tests.
    */
   def isTesting: Boolean = {
-    sys.env.contains("SPARK_TESTING") || sys.props.contains(IS_TESTING.key)
+    hasSparkTestingEnv || sys.props.contains(IS_TESTING.key)
+  }
+
+  /**
+   * Indicates if SPARK_TESTING environment variable is present.
+   */
+  private lazy val hasSparkTestingEnv: Boolean = {
+    // as lazy val because sys.env can be slow with many environment variables.
+    sys.env.contains("SPARK_TESTING")
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1939,15 +1939,10 @@ private[spark] object Utils extends Logging {
    * Indicates whether Spark is currently running unit tests.
    */
   def isTesting: Boolean = {
-    hasSparkTestingEnv || sys.props.contains(IS_TESTING.key)
+    // Scala's `sys.env` creates a ton of garbage by constructing Scala immutable maps, so
+    // we directly use the Java APIs instead.
+    System.getenv("SPARK_TESTING") != null || System.getProperty(IS_TESTING.key) != null
   }
-
-  /**
-   * Indicates if SPARK_TESTING environment variable is present.
-   */
-  private lazy val hasSparkTestingEnv: Boolean = {
-    // as lazy val because sys.env can be slow with many environment variables.
-    sys.env.contains("SPARK_TESTING")
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
Check SPARK_TESTING as lazy val to avoid slow down when there are many environment variables

### Why are the changes needed?
If there are many environment variables, sys.env slows is very slow. As Utils.isTesting is called very often during Dataframe-Optimization, this can slow down evaluation very much.

An example for triggering the problem can be found in the bug ticket https://issues.apache.org/jira/browse/SPARK-34115

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
With the example provided in the ticket.
