### PR TITLE
[SPARK-34161][SQL][TESTS] Check re-caching of v2 table dependents after table altering

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLCommandTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLCommandTestUtils.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.command
 import org.scalactic.source.Position
 import org.scalatest.Tag
 
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.execution.datasources.PartitioningUtils
 import org.apache.spark.sql.test.SQLTestUtils
@@ -107,5 +107,16 @@ trait DDLCommandTestUtils extends SQLTestUtils {
       case _ => throw new IllegalArgumentException("Not found table size in stats")
     }
     size
+  }
+
+  def cacheRelation(name: String): Unit = {
+    assert(!spark.catalog.isCached(name))
+    sql(s"CACHE TABLE $name")
+    assert(spark.catalog.isCached(name))
+  }
+
+  def checkCachedRelation(name: String, expected: Seq[Row]): Unit = {
+    assert(spark.catalog.isCached(name))
+    QueryTest.checkAnswer(sql(s"SELECT * FROM $name"), expected)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableAddPartitionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableAddPartitionSuite.scala
@@ -69,7 +69,7 @@ class AlterTableAddPartitionSuite
     }
   }
 
-  test("SPARK-34099, SPARK-34161: keep dependents cashed after table altering") {
+  test("SPARK-34099, SPARK-34161: keep dependents cached after table altering") {
     withNamespaceAndTable("ns", "tbl") { t =>
       sql(s"CREATE TABLE $t (id int, part int) $defaultUsing PARTITIONED BY (id, part)")
       sql(s"INSERT INTO $t PARTITION (part=0) SELECT 0")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableAddPartitionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableAddPartitionSuite.scala
@@ -68,4 +68,35 @@ class AlterTableAddPartitionSuite
       checkAnswer(sql(s"SELECT * FROM $t"), Seq(Row(0), Row(1)))
     }
   }
+
+  test("SPARK-34099, SPARK-34161: keep dependents cashed after table altering") {
+    withNamespaceAndTable("ns", "tbl") { t =>
+      sql(s"CREATE TABLE $t (id int, part int) $defaultUsing PARTITIONED BY (id, part)")
+      sql(s"INSERT INTO $t PARTITION (part=0) SELECT 0")
+      cacheRelation(t)
+      checkCachedRelation(t, Seq(Row(0, 0)))
+
+      withView("v0") {
+        sql(s"CREATE VIEW v0 AS SELECT * FROM $t")
+        cacheRelation("v0")
+        sql(s"ALTER TABLE $t ADD PARTITION (id=0, part=1)")
+        checkCachedRelation("v0", Seq(Row(0, 0), Row(0, 1)))
+      }
+
+      withTempView("v1") {
+        sql(s"CREATE TEMP VIEW v1 AS SELECT * FROM $t")
+        cacheRelation("v1")
+        sql(s"ALTER TABLE $t ADD PARTITION (id=1, part=2)")
+        checkCachedRelation("v1", Seq(Row(0, 0), Row(0, 1), Row(1, 2)))
+      }
+
+      val v2 = s"${spark.sharedState.globalTempViewManager.database}.v2"
+      withGlobalTempView(v2) {
+        sql(s"CREATE GLOBAL TEMP VIEW v2 AS SELECT * FROM $t")
+        cacheRelation(v2)
+        sql(s"ALTER TABLE $t ADD PARTITION (id=2, part=3)")
+        checkCachedRelation(v2, Seq(Row(0, 0), Row(0, 1), Row(1, 2), Row(2, 3)))
+      }
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableDropPartitionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableDropPartitionSuite.scala
@@ -64,7 +64,7 @@ class AlterTableDropPartitionSuite
     }
   }
 
-  test("SPARK-34099, SPARK-34161: keep dependents cashed after table altering") {
+  test("SPARK-34099, SPARK-34161: keep dependents cached after table altering") {
     withNamespaceAndTable("ns", "tbl") { t =>
       sql(s"CREATE TABLE $t (id int, part int) $defaultUsing PARTITIONED BY (part)")
       sql(s"INSERT INTO $t PARTITION (part=0) SELECT 0")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableDropPartitionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableDropPartitionSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.command.v2
 
-import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.execution.command
 
 /**
@@ -61,6 +61,40 @@ class AlterTableDropPartitionSuite
       sql(s"ALTER TABLE $t ADD PARTITION (p1 = '')")
       sql(s"ALTER TABLE $t DROP PARTITION (p1 = '')")
       checkPartitions(t)
+    }
+  }
+
+  test("SPARK-34099, SPARK-34161: keep dependents cashed after table altering") {
+    withNamespaceAndTable("ns", "tbl") { t =>
+      sql(s"CREATE TABLE $t (id int, part int) $defaultUsing PARTITIONED BY (part)")
+      sql(s"INSERT INTO $t PARTITION (part=0) SELECT 0")
+      sql(s"INSERT INTO $t PARTITION (part=1) SELECT 1")
+      sql(s"INSERT INTO $t PARTITION (part=2) SELECT 2")
+      sql(s"INSERT INTO $t PARTITION (part=3) SELECT 3")
+      cacheRelation(t)
+      checkCachedRelation(t, Seq(Row(0, 0), Row(1, 1), Row(2, 2), Row(3, 3)))
+
+      withView("v0") {
+        sql(s"CREATE VIEW v0 AS SELECT * FROM $t")
+        cacheRelation("v0")
+        sql(s"ALTER TABLE $t DROP PARTITION (part=1)")
+        checkCachedRelation("v0", Seq(Row(0, 0), Row(2, 2), Row(3, 3)))
+      }
+
+      withTempView("v1") {
+        sql(s"CREATE TEMP VIEW v1 AS SELECT * FROM $t")
+        cacheRelation("v1")
+        sql(s"ALTER TABLE $t DROP PARTITION (part=2)")
+        checkCachedRelation("v1", Seq(Row(0, 0), Row(3, 3)))
+      }
+
+      val v2 = s"${spark.sharedState.globalTempViewManager.database}.v2"
+      withGlobalTempView(v2) {
+        sql(s"CREATE GLOBAL TEMP VIEW v2 AS SELECT * FROM $t")
+        cacheRelation(v2)
+        sql(s"ALTER TABLE $t DROP PARTITION (part=3)")
+        checkCachedRelation(v2, Seq(Row(0, 0)))
+      }
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableRenamePartitionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableRenamePartitionSuite.scala
@@ -45,7 +45,7 @@ class AlterTableRenamePartitionSuite
     }
   }
 
-  test("SPARK-34099, SPARK-34161: keep dependents cashed after table altering") {
+  test("SPARK-34099, SPARK-34161: keep dependents cached after table altering") {
     withNamespaceAndTable("ns", "tbl") { t =>
       sql(s"CREATE TABLE $t (id int, part int) $defaultUsing PARTITIONED BY (part)")
       sql(s"INSERT INTO $t PARTITION (part=0) SELECT 0")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add tests to check that v2 table dependents are re-cached after table altering via the commands:
- `ALTER TABLE .. ADD PARTITION`
- `ALTER TABLE .. DROP PARTITION`
- `ALTER TABLE .. RENAME PARTITION` 

### Why are the changes needed?
To improve test coverage and prevent regressions.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
By running the modified test suites:
```
$ build/sbt -Phive-2.3 -Phive-thriftserver "test:testOnly *.AlterTableAddPartitionSuite"
$ build/sbt -Phive-2.3 -Phive-thriftserver "test:testOnly *.AlterTableDropPartitionSuite"
$ build/sbt -Phive-2.3 -Phive-thriftserver "test:testOnly *.AlterTableRenamePartitionSuite"
```