### PR TITLE
[SPARK-33888][SQL][FOLLOWUP] Restored scale metadata for ARRAY type (Postgres)

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -306,13 +306,14 @@ object JdbcUtils extends Logging {
       }
       val metadata = new MetadataBuilder()
       // SPARK-33888
-      // - include scale in metadata for only DECIMAL & NUMERIC
+      // - include scale in metadata for only DECIMAL & NUMERIC as well as ARRAY (for Postgres)
       // - include TIME type metadata
       // - always build the metadata
       dataType match {
         // scalastyle:off
         case java.sql.Types.NUMERIC => metadata.putLong("scale", fieldScale)
         case java.sql.Types.DECIMAL => metadata.putLong("scale", fieldScale)
+        case java.sql.Types.ARRAY   => metadata.putLong("scale", fieldScale) // PostgresDialect.scala wants this information
         case java.sql.Types.TIME    => metadata.putBoolean("logical_time_type", true)
         case _                      =>
         // scalastyle:on


### PR DESCRIPTION
This satisfies PostgresDialect's requirement for scale in Numeric arrays (as it was before SPARK-33888 removed the metadata)

### What changes were proposed in this pull request?

Ensuring that a numeric scale component is provided to Postgres for Array type metadata processing.

### Why are the changes needed?

The initial changes in SPARK-33888 restrict the "scale" column metadata to NUMERIC and DECIMAL types, but PostgresDialect was also using "scale" for Array types.

### Does this PR introduce _any_ user-facing change?

No. (This restores master to the same [Postgres] behavior as it had on 3 Jan 2021)

### How was this patch tested?

Manually tested by loading a Postgres table that specified a numeric array column.