### PR TITLE
[SPARK-32165][SQL] Ensure Spark only initiates SharedState once across SparkSessions

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -132,7 +132,7 @@ class SparkSession private(
   @Unstable
   @transient
   lazy val sharedState: SharedState = {
-    existingSharedState.getOrElse(new SharedState(sparkContext, initialSessionOptions))
+    existingSharedState.getOrElse(SharedState.getSharedState(sparkContext, initialSessionOptions))
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -132,7 +132,7 @@ class SparkSession private(
   @Unstable
   @transient
   lazy val sharedState: SharedState = {
-    existingSharedState.getOrElse(SharedState.getSharedState(sparkContext, initialSessionOptions))
+    existingSharedState.getOrElse(SharedState.get(sparkContext, initialSessionOptions))
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -171,15 +171,15 @@ private[sql] class SharedState(
 
 object SharedState extends Logging {
   @volatile private var fsUrlStreamHandlerFactoryInitialized = false
-  private var sharedState: SharedState = _
+  private var _sharedState: SharedState = _
 
   def get(sparkContext: SparkContext, initialConfigs: scala.collection.Map[String, String])
     : SharedState = synchronized {
-    if (sharedState == null) {
+    if (_sharedState == null) {
       // Ensure that we only initiate SharedState once
-      sharedState = new SharedState(sparkContext, initialConfigs)
+      _sharedState = new SharedState(sparkContext, initialConfigs)
     }
-    sharedState
+    _sharedState
   }
 
   private def setFsUrlStreamHandlerFactory(conf: SparkConf, hadoopConf: Configuration): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -178,7 +178,6 @@ object SharedState extends Logging {
     if (_sharedState == null) {
       synchronized {
         if (_sharedState == null) {
-          // Ensure that we only initiate SharedState once
           _sharedState = new SharedState(sparkContext, initialConfigs)
         }
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -171,6 +171,18 @@ private[sql] class SharedState(
 
 object SharedState extends Logging {
   @volatile private var fsUrlStreamHandlerFactoryInitialized = false
+  private var sharedState: SharedState = _
+
+  def getSharedState(
+      sparkContext: SparkContext,
+      initialConfigs: scala.collection.Map[String, String])
+    : SharedState = synchronized {
+    if (sharedState == null) {
+      // Ensure that we only initiate SharedState once
+      sharedState = new SharedState(sparkContext, initialConfigs)
+    }
+    sharedState
+  }
 
   private def setFsUrlStreamHandlerFactory(conf: SparkConf, hadoopConf: Configuration): Unit = {
     if (!fsUrlStreamHandlerFactoryInitialized &&

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -171,13 +171,17 @@ private[sql] class SharedState(
 
 object SharedState extends Logging {
   @volatile private var fsUrlStreamHandlerFactoryInitialized = false
-  private var _sharedState: SharedState = _
+  @volatile private var _sharedState: SharedState = _
 
   def get(sparkContext: SparkContext, initialConfigs: scala.collection.Map[String, String])
-    : SharedState = synchronized {
+    : SharedState = {
     if (_sharedState == null) {
-      // Ensure that we only initiate SharedState once
-      _sharedState = new SharedState(sparkContext, initialConfigs)
+      synchronized {
+        if (_sharedState == null) {
+          // Ensure that we only initiate SharedState once
+          _sharedState = new SharedState(sparkContext, initialConfigs)
+        }
+      }
     }
     _sharedState
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -173,9 +173,7 @@ object SharedState extends Logging {
   @volatile private var fsUrlStreamHandlerFactoryInitialized = false
   private var sharedState: SharedState = _
 
-  def getSharedState(
-      sparkContext: SparkContext,
-      initialConfigs: scala.collection.Map[String, String])
+  def get(sparkContext: SparkContext, initialConfigs: scala.collection.Map[String, String])
     : SharedState = synchronized {
     if (sharedState == null) {
       // Ensure that we only initiate SharedState once

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
@@ -233,7 +233,7 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
     context.stop()
   }
 
-  test("SPARK-32165: Ensure only initiates one SharedState") {
+  test("SPARK-32165: Ensure only initiates SharedState once") {
     val conf = new SparkConf()
       .setMaster("local")
       .setAppName("test-initiates-one-shared-state")

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql
 
+import scala.collection.JavaConverters._
+
 import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.{SparkConf, SparkContext, SparkException, SparkFunSuite}
@@ -257,7 +259,6 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
   }
 
   private def countListener(listener: String, context: SparkContext): Int = {
-    import scala.collection.JavaConverters._
     val listeners = context.listenerBus.listeners.asScala
     listeners.count(_.getClass.getSimpleName === listener)
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR makes sure that `SharedState` would be only initiated once across SparkSessions.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This helps us to fix the listener(e.g., SQLAppStatusListener) leak issue, and allow SparkSessions created by `getOrCreate` to share the `CacheManager`,  global temp view, etc.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Added UTs.

Close https://github.com/apache/spark/pull/31053