### PR TITLE
[SPARK-34180][SQL] Revert SPARK-33888

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.execution.datasources.jdbc
 
 import java.sql.{Connection, Driver, JDBCType, PreparedStatement, ResultSet, ResultSetMetaData, SQLException, SQLFeatureNotSupportedException}
 import java.util.Locale
-import java.util.concurrent.TimeUnit
 
 import scala.util.Try
 import scala.util.control.NonFatal
@@ -227,7 +226,7 @@ object JdbcUtils extends Logging {
       case java.sql.Types.SMALLINT      => IntegerType
       case java.sql.Types.SQLXML        => StringType
       case java.sql.Types.STRUCT        => StringType
-      case java.sql.Types.TIME          => IntegerType
+      case java.sql.Types.TIME          => TimestampType
       case java.sql.Types.TIME_WITH_TIMEZONE
                                         => null
       case java.sql.Types.TIMESTAMP     => TimestampType
@@ -304,23 +303,11 @@ object JdbcUtils extends Logging {
       } else {
         rsmd.isNullable(i + 1) != ResultSetMetaData.columnNoNulls
       }
-      val metadata = new MetadataBuilder()
-      // SPARK-33888
-      // - include scale in metadata for only DECIMAL & NUMERIC
-      // - include TIME type metadata
-      // - always build the metadata
-      dataType match {
-        // scalastyle:off
-        case java.sql.Types.NUMERIC => metadata.putLong("scale", fieldScale)
-        case java.sql.Types.DECIMAL => metadata.putLong("scale", fieldScale)
-        case java.sql.Types.TIME    => metadata.putBoolean("logical_time_type", true)
-        case _                      =>
-        // scalastyle:on
-      }
+      val metadata = new MetadataBuilder().putLong("scale", fieldScale)
       val columnType =
         dialect.getCatalystType(dataType, typeName, fieldSize, metadata).getOrElse(
           getCatalystType(dataType, fieldSize, fieldScale, isSigned))
-      fields(i) = StructField(columnName, columnType, nullable, metadata.build())
+      fields(i) = StructField(columnName, columnType, nullable)
       i = i + 1
     }
     new StructType(fields)
@@ -420,23 +407,6 @@ object JdbcUtils extends Logging {
     case FloatType =>
       (rs: ResultSet, row: InternalRow, pos: Int) =>
         row.setFloat(pos, rs.getFloat(pos + 1))
-
-
-    // SPARK-33888 - sql TIME type represents as physical int in millis
-    // Represents a time of day, with no reference to a particular calendar,
-    // time zone or date, with a precision of one millisecond.
-    // It stores the number of milliseconds after midnight, 00:00:00.000.
-    case IntegerType if metadata.contains("logical_time_type") =>
-      (rs: ResultSet, row: InternalRow, pos: Int) => {
-        val rawTime = rs.getTime(pos + 1)
-        if (rawTime != null) {
-          val rawTimeInNano = rawTime.toLocalTime().toNanoOfDay()
-          val timeInMillis = Math.toIntExact(TimeUnit.NANOSECONDS.toMillis(rawTimeInNano))
-          row.setInt(pos, timeInMillis)
-        } else {
-          row.update(pos, null)
-        }
-      }
 
     case IntegerType =>
       (rs: ResultSet, row: InternalRow, pos: Int) =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.jdbc
 import java.math.BigDecimal
 import java.sql.{Date, DriverManager, SQLException, Timestamp}
 import java.util.{Calendar, GregorianCalendar, Properties}
-import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters._
 
@@ -611,13 +610,7 @@ class JDBCSuite extends QueryTest
   test("H2 time types") {
     val rows = sql("SELECT * FROM timetypes").collect()
     val cal = new GregorianCalendar(java.util.Locale.ROOT)
-    val epochMillis = java.time.LocalTime.ofNanoOfDay(
-      TimeUnit.MILLISECONDS.toNanos(rows(0).getAs[Int](0)))
-      .atDate(java.time.LocalDate.ofEpochDay(0))
-      .atZone(java.time.ZoneId.systemDefault())
-      .toInstant()
-      .toEpochMilli()
-    cal.setTime(new Date(epochMillis))
+    cal.setTime(rows(0).getAs[java.sql.Timestamp](0))
     assert(cal.get(Calendar.HOUR_OF_DAY) === 12)
     assert(cal.get(Calendar.MINUTE) === 34)
     assert(cal.get(Calendar.SECOND) === 56)
@@ -632,24 +625,7 @@ class JDBCSuite extends QueryTest
     assert(cal.get(Calendar.HOUR) === 11)
     assert(cal.get(Calendar.MINUTE) === 22)
     assert(cal.get(Calendar.SECOND) === 33)
-    assert(cal.get(Calendar.MILLISECOND) === 543)
     assert(rows(0).getAs[java.sql.Timestamp](2).getNanos === 543543000)
-  }
-
-  test("SPARK-33888: test TIME types") {
-    val rows = spark.read.jdbc(
-      urlWithUserAndPass, "TEST.TIMETYPES", new Properties()).collect()
-    val cachedRows = spark.read.jdbc(urlWithUserAndPass, "TEST.TIMETYPES", new Properties())
-      .cache().collect()
-    val expectedTimeRaw = java.sql.Time.valueOf("12:34:56")
-    val expectedTimeMillis = Math.toIntExact(
-      java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(
-        expectedTimeRaw.toLocalTime().toNanoOfDay()
-      )
-    )
-    assert(rows(0).getAs[Int](0) === expectedTimeMillis)
-    assert(rows(1).getAs[Int](0) === expectedTimeMillis)
-    assert(cachedRows(0).getAs[Int](0) === expectedTimeMillis)
   }
 
   test("test DATE types") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR reverts SPARK-33888 (#30902) .
That PR has the two serious problems.

1. A regression which affects PostgresDialect causing `PostgreSQLIntegrationSuite` to fail.
2. That PR changes the JDBC-Catalyst type mapping. `sql.Types.TIME` is mapped to `sql.types.IntegerType` so we'll get millisecond value. But the start time point is different between `MsSqlServer` and other RDBMSs. For `MsSqlServer`, it starts from `1900-01-01 00:00:00` while `1970-01-01 00:00:00` for other RDBMS.

More about problem-2, the following assertion passes before SPARK-33888.
```
// This is from jdbc.MsSqlServerIntegrationSuite
assert(row.getAs[Timestamp](5).equals(Timestamp.valueOf("1900-01-01 13:31:24.0")))
```

But after SPARK-33888, the following modified assertion fails because the millisecond value is considered starting from `1970-01-01 00:00:00`.
```
assert(row.getAs[Integer](5).equals(Timestamp.valueOf("1900-01-01 13:31:24.0").getTime.toInt))
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To fix the serious issues.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
This is just reverting a previous change.