### PR TITLE
[SPARK-34185][DOCS] Review and fix issues in API docs

### DIFF
--- a/core/src/main/java/org/apache/spark/shuffle/api/WritableByteChannelWrapper.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/WritableByteChannelWrapper.java
@@ -24,7 +24,6 @@ import org.apache.spark.annotation.Private;
 
 /**
  * :: Private ::
- *
  * A thin wrapper around a {@link WritableByteChannel}.
  * <p>
  * This is primarily provided for the local disk shuffle implementation to provide a

--- a/core/src/main/java/org/apache/spark/shuffle/api/metadata/MapOutputCommitMessage.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/metadata/MapOutputCommitMessage.java
@@ -23,7 +23,6 @@ import org.apache.spark.annotation.Private;
 
 /**
  * :: Private ::
- *
  * Represents the result of writing map outputs for a shuffle map task.
  * <p>
  * Partition lengths represents the length of each block written in the map task. This can

--- a/core/src/main/java/org/apache/spark/shuffle/api/metadata/MapOutputMetadata.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/metadata/MapOutputMetadata.java
@@ -21,7 +21,6 @@ import java.io.Serializable;
 
 /**
  * :: Private ::
- *
  * An opaque metadata tag for registering the result of committing the output of a
  * shuffle map task.
  * <p>

--- a/core/src/main/scala/org/apache/spark/ContextAwareIterator.scala
+++ b/core/src/main/scala/org/apache/spark/ContextAwareIterator.scala
@@ -28,6 +28,8 @@ import org.apache.spark.annotation.DeveloperApi
  * If an off-heap access exists in the parent iterator, it could cause segmentation fault
  * which crashes the executor.
  * Thus, we should use [[ContextAwareIterator]] to stop consuming after the task ends.
+ *
+ * @since 3.1.0
  */
 @DeveloperApi
 class ContextAwareIterator[+T](val context: TaskContext, val delegate: Iterator[T])

--- a/core/src/main/scala/org/apache/spark/scheduler/ExecutorDecommissionInfo.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ExecutorDecommissionInfo.scala
@@ -31,10 +31,8 @@ case class ExecutorDecommissionInfo(message: String, workerHost: Option[String] 
  * State related to decommissioning that is kept by the TaskSchedulerImpl. This state is derived
  * from the info message above but it is kept distinct to allow the state to evolve independently
  * from the message.
- *
- * @since 3.1.0
  */
-case class ExecutorDecommissionState(
+private[scheduler] case class ExecutorDecommissionState(
     // Timestamp the decommissioning commenced as per the Driver's clock,
     // to estimate when the executor might eventually be lost if EXECUTOR_DECOMMISSION_KILL_INTERVAL
     // is configured.

--- a/core/src/main/scala/org/apache/spark/scheduler/ExecutorDecommissionInfo.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ExecutorDecommissionInfo.scala
@@ -31,6 +31,8 @@ case class ExecutorDecommissionInfo(message: String, workerHost: Option[String] 
  * State related to decommissioning that is kept by the TaskSchedulerImpl. This state is derived
  * from the info message above but it is kept distinct to allow the state to evolve independently
  * from the message.
+ *
+ * @since 3.1.0
  */
 case class ExecutorDecommissionState(
     // Timestamp the decommissioning commenced as per the Driver's clock,

--- a/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
@@ -25,7 +25,7 @@ import scala.collection.Map
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 
 import org.apache.spark.TaskEndReason
-import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.annotation.{DeveloperApi, Since}
 import org.apache.spark.executor.{ExecutorMetrics, TaskMetrics}
 import org.apache.spark.resource.ResourceProfile
 import org.apache.spark.scheduler.cluster.ExecutorInfo
@@ -126,6 +126,7 @@ case class SparkListenerExecutorBlacklisted(
   extends SparkListenerEvent
 
 @DeveloperApi
+@Since("3.1.0")
 case class SparkListenerExecutorExcluded(
     time: Long,
     executorId: String,
@@ -144,6 +145,7 @@ case class SparkListenerExecutorBlacklistedForStage(
 
 
 @DeveloperApi
+@Since("3.1.0")
 case class SparkListenerExecutorExcludedForStage(
     time: Long,
     executorId: String,
@@ -164,6 +166,7 @@ case class SparkListenerNodeBlacklistedForStage(
 
 
 @DeveloperApi
+@Since("3.1.0")
 case class SparkListenerNodeExcludedForStage(
     time: Long,
     hostId: String,
@@ -192,6 +195,7 @@ case class SparkListenerNodeBlacklisted(
 
 
 @DeveloperApi
+@Since("3.1.0")
 case class SparkListenerNodeExcluded(
     time: Long,
     hostId: String,
@@ -204,15 +208,18 @@ case class SparkListenerNodeUnblacklisted(time: Long, hostId: String)
   extends SparkListenerEvent
 
 @DeveloperApi
+@Since("3.1.0")
 case class SparkListenerNodeUnexcluded(time: Long, hostId: String)
   extends SparkListenerEvent
 
 @DeveloperApi
+@Since("3.1.0")
 case class SparkListenerUnschedulableTaskSetAdded(
   stageId: Int,
   stageAttemptId: Int) extends SparkListenerEvent
 
 @DeveloperApi
+@Since("3.1.0")
 case class SparkListenerUnschedulableTaskSetRemoved(
   stageId: Int,
   stageAttemptId: Int) extends SparkListenerEvent
@@ -225,6 +232,8 @@ case class SparkListenerBlockUpdated(blockUpdatedInfo: BlockUpdatedInfo) extends
  * @param execId executor id
  * @param accumUpdates sequence of (taskId, stageId, stageAttemptId, accumUpdates)
  * @param executorUpdates executor level per-stage metrics updates
+ *
+ * @since 3.1.0
  */
 @DeveloperApi
 case class SparkListenerExecutorMetricsUpdate(
@@ -269,6 +278,7 @@ case class SparkListenerApplicationEnd(time: Long) extends SparkListenerEvent
 case class SparkListenerLogStart(sparkVersion: String) extends SparkListenerEvent
 
 @DeveloperApi
+@Since("3.1.0")
 case class SparkListenerResourceProfileAdded(resourceProfile: ResourceProfile)
   extends SparkListenerEvent
 

--- a/core/src/main/scala/org/apache/spark/security/SecurityConfigurationLock.scala
+++ b/core/src/main/scala/org/apache/spark/security/SecurityConfigurationLock.scala
@@ -21,4 +21,4 @@ package org.apache.spark.security
  * There are cases when global JVM security configuration must be modified.
  * In order to avoid race the modification must be synchronized with this.
  */
-object SecurityConfigurationLock
+private[spark] object SecurityConfigurationLock

--- a/core/src/main/scala/org/apache/spark/storage/BlockSavedOnDecommissionedBlockManagerException.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockSavedOnDecommissionedBlockManagerException.scala
@@ -17,5 +17,5 @@
 
 package org.apache.spark.storage
 
-class BlockSavedOnDecommissionedBlockManagerException(blockId: BlockId)
+private[storage] class BlockSavedOnDecommissionedBlockManagerException(blockId: BlockId)
   extends Exception(s"Block $blockId cannot be saved on decommissioned executor")

--- a/core/src/main/scala/org/apache/spark/storage/FallbackStorage.scala
+++ b/core/src/main/scala/org/apache/spark/storage/FallbackStorage.scala
@@ -90,7 +90,7 @@ private[storage] class FallbackStorage(conf: SparkConf) extends Logging {
   }
 }
 
-class NoopRpcEndpointRef(conf: SparkConf) extends RpcEndpointRef(conf) {
+private[storage] class NoopRpcEndpointRef(conf: SparkConf) extends RpcEndpointRef(conf) {
   import scala.concurrent.ExecutionContext.Implicits.global
   override def address: RpcAddress = null
   override def name: String = "fallback"
@@ -100,7 +100,7 @@ class NoopRpcEndpointRef(conf: SparkConf) extends RpcEndpointRef(conf) {
   }
 }
 
-object FallbackStorage extends Logging {
+private[spark] object FallbackStorage extends Logging {
   /** We use one block manager id as a place holder. */
   val FALLBACK_BLOCK_MANAGER_ID: BlockManagerId = BlockManagerId("fallback", "remote", 7337)
 

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -910,7 +910,7 @@ object Unidoc {
       .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/catalyst")))
       .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/execution")))
       .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/internal")))
-      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/hive/test")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/hive")))
       .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/catalog/v2/utils")))
       .map(_.filterNot(_.getCanonicalPath.contains("org/apache/hive")))
       .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/v2/avro")))

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -910,7 +910,7 @@ object Unidoc {
       .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/catalyst")))
       .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/execution")))
       .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/internal")))
-      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/hive")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/hive/test")))
       .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/catalog/v2/utils")))
       .map(_.filterNot(_.getCanonicalPath.contains("org/apache/hive")))
       .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/v2/avro")))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.types.{AbstractDataType, DataType, StructType}
  * Object for grouping all error messages of the query compilation.
  * Currently it includes all AnalysisExceptions.
  */
-object QueryCompilationErrors {
+private[spark] object QueryCompilationErrors {
 
   def groupingIDMismatchError(groupingID: GroupingID, groupByExprs: Seq[Expression]): Throwable = {
     new AnalysisException(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/util/PartitioningUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/util/PartitioningUtils.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.analysis.Resolver
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 
-object PartitioningUtils {
+private[sql] object PartitioningUtils {
   /**
    * Normalize the column names in partition specification, w.r.t. the real partition column names
    * and case sensitivity. e.g., if the partition spec has a column named `monTh`, and there is a

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/ui/StreamingQueryPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/ui/StreamingQueryPage.scala
@@ -111,7 +111,7 @@ private[ui] class StreamingQueryPage(parent: StreamingQueryTab)
   }
 }
 
-class StreamingQueryPagedTable(
+private[ui] class StreamingQueryPagedTable(
     request: HttpServletRequest,
     parent: StreamingQueryTab,
     data: Seq[StreamingQueryUIData],
@@ -206,12 +206,13 @@ class StreamingQueryPagedTable(
   }
 }
 
-case class StructuredStreamingRow(
+private[ui] case class StructuredStreamingRow(
     duration: Long,
     avgInput: Double,
     avgProcess: Double,
     streamingUIData: StreamingQueryUIData)
 
+private[ui]
 class StreamingQueryDataSource(uiData: Seq[StreamingQueryUIData], sortColumn: String, desc: Boolean,
     pageSize: Int, isActive: Boolean) extends PagedDataSource[StructuredStreamingRow](pageSize) {
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/ui/StreamingQueryPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/ui/StreamingQueryPage.scala
@@ -212,9 +212,12 @@ private[ui] case class StructuredStreamingRow(
     avgProcess: Double,
     streamingUIData: StreamingQueryUIData)
 
-private[ui]
-class StreamingQueryDataSource(uiData: Seq[StreamingQueryUIData], sortColumn: String, desc: Boolean,
-    pageSize: Int, isActive: Boolean) extends PagedDataSource[StructuredStreamingRow](pageSize) {
+private[ui] class StreamingQueryDataSource(
+    uiData: Seq[StreamingQueryUIData],
+    sortColumn: String,
+    desc: Boolean,
+    pageSize: Int,
+    isActive: Boolean) extends PagedDataSource[StructuredStreamingRow](pageSize) {
 
   // convert StreamingQueryUIData to StreamingRow to provide required data for sorting and sort it
   private val data = uiData.map(streamingRow).sorted(ordering(sortColumn, desc))

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -1268,7 +1268,7 @@ private[hive] object HiveClientImpl extends Logging {
   }
 }
 
-case object HiveVoidType extends DataType {
+private[hive] case object HiveVoidType extends DataType {
   override def defaultSize: Int = 1
   override def asNullable: DataType = HiveVoidType
   override def simpleString: String = "void"

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveScriptTransformationExec.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveScriptTransformationExec.scala
@@ -48,7 +48,7 @@ import org.apache.spark.util.{CircularBuffer, Utils}
  * @param child logical plan whose output is transformed.
  * @param ioschema the class set that defines how to handle input/output data.
  */
-case class HiveScriptTransformationExec(
+private[hive] case class HiveScriptTransformationExec(
     input: Seq[Expression],
     script: String,
     output: Seq[Attribute],
@@ -186,7 +186,7 @@ case class HiveScriptTransformationExec(
   }
 }
 
-case class HiveScriptTransformationWriterThread(
+private[hive] case class HiveScriptTransformationWriterThread(
     iter: Iterator[InternalRow],
     inputSchema: Seq[DataType],
     inputSerde: AbstractSerDe,


### PR DESCRIPTION
### What changes were proposed in this pull request?
Compare the 3.1.1 API doc with the latest release version 3.0.1. Fix the following issues:
- Add missing `Since` annotation for new APIs
- Remove the leaking class/object in API doc


### Why are the changes needed?
Fix the issues in the Spark 3.1.1 release API docs.


### Does this PR introduce _any_ user-facing change?
Yes, API doc changes.


### How was this patch tested?
Manually test.
