### PR TITLE
[SPARK-34188][SQL] Estimate the statistics with the origin expr with charvarchar in CBO

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
@@ -23,7 +23,7 @@ import scala.math.BigDecimal.RoundingMode
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeMap, Expression}
 import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
 import org.apache.spark.sql.catalyst.plans.logical._
-import org.apache.spark.sql.catalyst.util.CharVarcharUtils
+import org.apache.spark.sql.catalyst.util.CharVarcharCodegenUtils
 import org.apache.spark.sql.types.{DecimalType, _}
 
 object EstimationUtils {
@@ -82,8 +82,8 @@ object EstimationUtils {
     expressions.flatMap {
       case alias @ Alias(attr: Attribute, _) if attributeStats.contains(attr) =>
         Some(alias.toAttribute -> attributeStats(attr))
-      case alias @ Alias(s: StaticInvoke, _) if alias.explicitMetadata.nonEmpty &&
-          CharVarcharUtils.getRawType(alias.explicitMetadata.get).nonEmpty => s.children.flatMap {
+      case alias @ Alias(StaticInvoke(cls, _, _, arguments, _, _), _)
+          if cls.isAssignableFrom(classOf[CharVarcharCodegenUtils]) => arguments.head match {
         case attr: Attribute if attributeStats.contains(attr) =>
           Some(alias.toAttribute -> attributeStats(attr))
         case _ => None

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
@@ -21,7 +21,9 @@ import scala.collection.mutable.ArrayBuffer
 import scala.math.BigDecimal.RoundingMode
 
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeMap, Expression}
+import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
 import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.types.{DecimalType, _}
 
 object EstimationUtils {
@@ -77,9 +79,16 @@ object EstimationUtils {
   def getAliasStats(
       expressions: Seq[Expression],
       attributeStats: AttributeMap[ColumnStat]): Seq[(Attribute, ColumnStat)] = {
-    expressions.collect {
+    expressions.flatMap {
       case alias @ Alias(attr: Attribute, _) if attributeStats.contains(attr) =>
-        alias.toAttribute -> attributeStats(attr)
+        Some(alias.toAttribute -> attributeStats(attr))
+      case alias @ Alias(s: StaticInvoke, _) if alias.explicitMetadata.nonEmpty &&
+          CharVarcharUtils.getRawType(alias.explicitMetadata.get).nonEmpty => s.children.flatMap {
+        case attr: Attribute if attributeStats.contains(attr) =>
+          Some(alias.toAttribute -> attributeStats(attr))
+        case _ => None
+      }
+      case _ => None
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

An unexpected change was found here https://github.com/apache/spark/pull/31012#discussion_r560050954, which shows that the char/varchar rule will block the plan stats from being propagated or estimating.



### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fix cbo performance regression.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

no
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
new tests