### PR TITLE
[SPARK-33489][PYSPARK] Add NullType support for Arrow executions.

### DIFF
--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -22,7 +22,7 @@ pandas instances during the type conversion.
 
 from pyspark.sql.types import BooleanType, ByteType, ShortType, IntegerType, LongType, \
     FloatType, DoubleType, DecimalType, StringType, BinaryType, DateType, TimestampType, \
-    ArrayType, MapType, StructType, StructField
+    ArrayType, MapType, StructType, StructField, NullType
 
 
 def to_arrow_type(dt):
@@ -72,6 +72,8 @@ def to_arrow_type(dt):
         fields = [pa.field(field.name, to_arrow_type(field.dataType), nullable=field.nullable)
                   for field in dt]
         arrow_type = pa.struct(fields)
+    elif type(dt) == NullType:
+        arrow_type = pa.null()
     else:
         raise TypeError("Unsupported type in conversion to Arrow: " + str(dt))
     return arrow_type
@@ -134,6 +136,8 @@ def from_arrow_type(at):
              for field in at])
     elif types.is_dictionary(at):
         spark_type = from_arrow_type(at.value_type)
+    elif types.is_null(at):
+        spark_type = NullType()
     else:
         raise TypeError("Unsupported type in conversion from Arrow: " + str(at))
     return spark_type

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -27,7 +27,8 @@ from pyspark import SparkContext, SparkConf
 from pyspark.sql import Row, SparkSession
 from pyspark.sql.functions import udf
 from pyspark.sql.types import StructType, StringType, IntegerType, LongType, \
-    FloatType, DoubleType, DecimalType, DateType, TimestampType, BinaryType, StructField, ArrayType
+    FloatType, DoubleType, DecimalType, DateType, TimestampType, BinaryType, StructField, \
+    ArrayType, NullType
 from pyspark.testing.sqlutils import ReusedSQLTestCase, have_pandas, have_pyarrow, \
     pandas_requirement_message, pyarrow_requirement_message
 from pyspark.testing.utils import QuietTest
@@ -76,7 +77,7 @@ class ArrowTests(ReusedSQLTestCase):
         # Disable fallback by default to easily detect the failures.
         cls.spark.conf.set("spark.sql.execution.arrow.pyspark.fallback.enabled", "false")
 
-        cls.schema = StructType([
+        cls.schema_wo_null = StructType([
             StructField("1_str_t", StringType(), True),
             StructField("2_int_t", IntegerType(), True),
             StructField("3_long_t", LongType(), True),
@@ -86,14 +87,18 @@ class ArrowTests(ReusedSQLTestCase):
             StructField("7_date_t", DateType(), True),
             StructField("8_timestamp_t", TimestampType(), True),
             StructField("9_binary_t", BinaryType(), True)])
-        cls.data = [(u"a", 1, 10, 0.2, 2.0, Decimal("2.0"),
-                     date(1969, 1, 1), datetime(1969, 1, 1, 1, 1, 1), bytearray(b"a")),
-                    (u"b", 2, 20, 0.4, 4.0, Decimal("4.0"),
-                     date(2012, 2, 2), datetime(2012, 2, 2, 2, 2, 2), bytearray(b"bb")),
-                    (u"c", 3, 30, 0.8, 6.0, Decimal("6.0"),
-                     date(2100, 3, 3), datetime(2100, 3, 3, 3, 3, 3), bytearray(b"ccc")),
-                    (u"d", 4, 40, 1.0, 8.0, Decimal("8.0"),
-                     date(2262, 4, 12), datetime(2262, 3, 3, 3, 3, 3), bytearray(b"dddd"))]
+        cls.schema = cls.schema_wo_null.add("10_null_t", NullType(), True)
+        cls.data_wo_null = [
+            (u"a", 1, 10, 0.2, 2.0, Decimal("2.0"),
+             date(1969, 1, 1), datetime(1969, 1, 1, 1, 1, 1), bytearray(b"a")),
+            (u"b", 2, 20, 0.4, 4.0, Decimal("4.0"),
+             date(2012, 2, 2), datetime(2012, 2, 2, 2, 2, 2), bytearray(b"bb")),
+            (u"c", 3, 30, 0.8, 6.0, Decimal("6.0"),
+             date(2100, 3, 3), datetime(2100, 3, 3, 3, 3, 3), bytearray(b"ccc")),
+            (u"d", 4, 40, 1.0, 8.0, Decimal("8.0"),
+             date(2262, 4, 12), datetime(2262, 3, 3, 3, 3, 3), bytearray(b"dddd")),
+        ]
+        cls.data = [tuple(list(d) + [None]) for d in cls.data_wo_null]
 
     @classmethod
     def tearDownClass(cls):
@@ -141,8 +146,8 @@ class ArrowTests(ReusedSQLTestCase):
                     df.toPandas()
 
     def test_null_conversion(self):
-        df_null = self.spark.createDataFrame([tuple([None for _ in range(len(self.data[0]))])] +
-                                             self.data)
+        df_null = self.spark.createDataFrame(
+            [tuple([None for _ in range(len(self.data_wo_null[0]))])] + self.data_wo_null)
         pdf = df_null.toPandas()
         null_counts = pdf.isnull().sum().tolist()
         self.assertTrue(all([c == 1 for c in null_counts]))

--- a/python/pyspark/sql/tests/test_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/test_pandas_grouped_map.py
@@ -57,14 +57,15 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
             4, 5, 1.1,
             2.2, Decimal(1.123),
             [1, 2, 2], True, 'hello',
-            bytearray([0x01, 0x02])
+            bytearray([0x01, 0x02]),
+            None
         ]
         output_fields = [
             ('id', IntegerType()), ('byte', ByteType()), ('short', ShortType()),
             ('int', IntegerType()), ('long', LongType()), ('float', FloatType()),
             ('double', DoubleType()), ('decim', DecimalType(10, 3)),
             ('array', ArrayType(IntegerType())), ('bool', BooleanType()), ('str', StringType()),
-            ('bin', BinaryType())
+            ('bin', BinaryType()), ('null', NullType())
         ]
 
         output_schema = StructType([StructField(*x) for x in output_fields])
@@ -83,7 +84,8 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
                 bool=False if pdf.bool else True,
                 str=pdf.str + 'there',
                 array=pdf.array,
-                bin=pdf.bin
+                bin=pdf.bin,
+                null=pdf.null
             ),
             output_schema,
             PandasUDFType.GROUPED_MAP
@@ -101,7 +103,8 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
                 bool=False if pdf.bool else True,
                 str=pdf.str + 'there',
                 array=pdf.array,
-                bin=pdf.bin
+                bin=pdf.bin,
+                null=pdf.null
             ),
             output_schema,
             PandasUDFType.GROUPED_MAP
@@ -120,7 +123,8 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
                 bool=False if pdf.bool else True,
                 str=pdf.str + 'there',
                 array=pdf.array,
-                bin=pdf.bin
+                bin=pdf.bin,
+                null=pdf.null
             ),
             output_schema,
             PandasUDFType.GROUPED_MAP
@@ -277,7 +281,6 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
         common_err_msg = 'Invalid return type.*grouped map Pandas UDF.*'
         unsupported_types = [
             StructField('arr_ts', ArrayType(TimestampType())),
-            StructField('null', NullType()),
             StructField('struct', StructType([StructField('l', LongType())])),
         ]
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ArrowColumnVector.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ArrowColumnVector.java
@@ -170,6 +170,8 @@ public final class ArrowColumnVector extends ColumnVector {
       for (int i = 0; i < childColumns.length; ++i) {
         childColumns[i] = new ArrowColumnVector(structVector.getVectorById(i));
       }
+    } else if (vector instanceof NullVector) {
+      accessor = new NullAccessor((NullVector) vector);
     } else {
       throw new UnsupportedOperationException();
     }
@@ -497,6 +499,13 @@ public final class ArrowColumnVector extends ColumnVector {
       int offset = accessor.getOffsetBuffer().getInt(index);
       int length = accessor.getInnerValueCountAt(rowId);
       return new ColumnarMap(keys, values, offset, length);
+    }
+  }
+
+  private static class NullAccessor extends ArrowVectorAccessor {
+
+    NullAccessor(NullVector vector) {
+      super(vector);
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
@@ -53,6 +53,7 @@ private[sql] object ArrowUtils {
       } else {
         new ArrowType.Timestamp(TimeUnit.MICROSECOND, timeZoneId)
       }
+    case NullType => ArrowType.Null.INSTANCE
     case _ =>
       throw new UnsupportedOperationException(s"Unsupported data type: ${dt.catalogString}")
   }
@@ -72,6 +73,7 @@ private[sql] object ArrowUtils {
     case d: ArrowType.Decimal => DecimalType(d.getPrecision, d.getScale)
     case date: ArrowType.Date if date.getUnit == DateUnit.DAY => DateType
     case ts: ArrowType.Timestamp if ts.getUnit == TimeUnit.MICROSECOND => TimestampType
+    case ArrowType.Null.INSTANCE => NullType
     case _ => throw new UnsupportedOperationException(s"Unsupported data type: $dt")
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowWriter.scala
@@ -72,6 +72,7 @@ object ArrowWriter {
           createFieldWriter(vector.getChildByOrdinal(ordinal))
         }
         new StructWriter(vector, children.toArray)
+      case (NullType, vector: NullVector) => new NullWriter(vector)
       case (dt, _) =>
         throw new UnsupportedOperationException(s"Unsupported data type: ${dt.catalogString}")
     }
@@ -80,9 +81,7 @@ object ArrowWriter {
 
 class ArrowWriter(val root: VectorSchemaRoot, fields: Array[ArrowFieldWriter]) {
 
-  def schema: StructType = StructType(fields.map { f =>
-    StructField(f.name, f.dataType, f.nullable)
-  })
+  def schema: StructType = ArrowUtils.fromArrowSchema(root.getSchema())
 
   private var count: Int = 0
 
@@ -383,5 +382,14 @@ private[arrow] class MapWriter(
     super.reset()
     keyWriter.reset()
     valueWriter.reset()
+  }
+}
+
+private[arrow] class NullWriter(val valueVector: NullVector) extends ArrowFieldWriter {
+
+  override def setNull(): Unit = {
+  }
+
+  override def setValue(input: SpecializedGetters, ordinal: Int): Unit = {
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowConvertersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowConvertersSuite.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.{BinaryType, Decimal, IntegerType, StructField, StructType}
+import org.apache.spark.sql.types.{ArrayType, BinaryType, Decimal, IntegerType, NullType, StructField, StructType}
 import org.apache.spark.sql.util.ArrowUtils
 import org.apache.spark.util.Utils
 
@@ -1069,6 +1069,61 @@ class ArrowConvertersSuite extends SharedSparkSession {
     val df = spark.createDataFrame(rdd, schema)
 
     collectAndValidate(df, json, "structData.json")
+  }
+
+  test("null type conversion") {
+    val json =
+      s"""
+         |{
+         |  "schema" : {
+         |    "fields": [ {
+         |      "name" : "a",
+         |      "type" : {
+         |        "name" : "null"
+         |      },
+         |      "nullable" : true,
+         |      "children" : [ ]
+         |    }, {
+         |      "name" : "b",
+         |      "type" : {
+         |        "name" : "list"
+         |      },
+         |      "nullable" : true,
+         |      "children" : [ {
+         |        "name" : "element",
+         |        "type" : {
+         |          "name" : "null"
+         |        },
+         |        "nullable" : true,
+         |        "children" : [ ]
+         |      } ]
+         |    } ]
+         |  },
+         |  "batches" : [ {
+         |    "count" : 3,
+         |    "columns" : [ {
+         |      "name" : "a",
+         |      "count" : 3
+         |    }, {
+         |      "name" : "b",
+         |      "count" : 3,
+         |      "VALIDITY" : [ 1, 1, 1 ],
+         |      "OFFSET" : [ 0, 2, 4, 6 ],
+         |      "children" : [ {
+         |        "name" : "element",
+         |        "count" : 6
+         |      } ]
+         |    } ]
+         |  } ]
+         |}
+       """.stripMargin
+
+    val data = Seq(null, null, null)
+    val rdd = sparkContext.parallelize(data.map(n => Row(n, Seq(n, n))))
+    val schema = new StructType().add("a", NullType).add("b", ArrayType(NullType))
+    val df = spark.createDataFrame(rdd, schema)
+
+    collectAndValidate(df, json, "nullData.json")
   }
 
   test("partitioned DataFrame") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds `NullType` support for Arrow executions.

### Why are the changes needed?

As Arrow supports null type, we can convert `NullType` between PySpark and pandas with Arrow enabled.

### Does this PR introduce _any_ user-facing change?

Yes, if a user has a DataFrame including `NullType`, it will be able to convert with Arrow enabled.

### How was this patch tested?

Added tests.
