### PR TITLE
[SPARK-34205][SQL][SS] Add pipe to Dataset to enable Streaming Dataset pipe

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/PipedRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PipedRDD.scala
@@ -230,7 +230,7 @@ private[spark] class PipedRDD[T: ClassTag](
   }
 }
 
-private object PipedRDD {
+object PipedRDD {
   // Split a string into words using a standard StringTokenizer
   def tokenize(command: String): Seq[String] = {
     val buf = new ArrayBuffer[String]

--- a/core/src/main/scala/org/apache/spark/rdd/PipedRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PipedRDD.scala
@@ -230,7 +230,7 @@ private[spark] class PipedRDD[T: ClassTag](
   }
 }
 
-object PipedRDD {
+private[spark] object PipedRDD {
   // Split a string into words using a standard StringTokenizer
   def tokenize(command: String): Seq[String] = {
     val buf = new ArrayBuffer[String]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/object.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/object.scala
@@ -589,6 +589,7 @@ case class CoGroup(
 object PipeElements {
   def apply[T : Encoder](
       command: String,
+      printElement: (Any, String => Unit) => Unit,
       child: LogicalPlan): LogicalPlan = {
     val deserialized = CatalystSerde.deserialize[T](child)
     implicit val encoder = Encoders.STRING
@@ -597,6 +598,7 @@ object PipeElements {
       implicitly[Encoder[T]].schema,
       CatalystSerde.generateObjAttr[String],
       command,
+      printElement,
       deserialized)
     CatalystSerde.serialize[String](piped)
   }
@@ -610,4 +612,5 @@ case class PipeElements[T](
     argumentSchema: StructType,
     outputObjAttr: Attribute,
     command: String,
+    printElement: (Any, String => Unit) => Unit,
     child: LogicalPlan) extends ObjectConsumer with ObjectProducer

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2890,6 +2890,24 @@ class Dataset[T] private[sql](
   }
 
   /**
+   * Return a new Dataset of string created by piping elements to a forked external process.
+   * The resulting Dataset is computed by executing the given process once per partition.
+   * All elements of each input partition are written to a process's stdin as lines of input
+   * separated by a newline. The resulting partition consists of the process's stdout output, with
+   * each line of stdout resulting in one element of the output partition. A process is invoked
+   * even for empty partitions.
+   *
+   * @param command command to run in forked process.
+   *
+   * @group typedrel
+   * @since 3.2.0
+   */
+  def pipe(command: String): Dataset[String] = {
+    implicit val stringEncoder = Encoders.STRING
+    withTypedPlan[String](PipeElements[T](command, logicalPlan))
+  }
+
+  /**
    * Applies a function `f` to all rows.
    *
    * @group action

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2898,7 +2898,10 @@ class Dataset[T] private[sql](
    * even for empty partitions.
    *
    * Note that for micro-batch streaming Dataset, the effect of pipe is only per micro-batch, not
-   * cross entire stream.
+   * cross entire stream. If your external process does aggregation-like on inputs, e.g. `wc -l`,
+   * the aggregation is applied per a partition in micro-batch. You may want to aggregate these
+   * outputs after calling pipe to get global aggregation across partitions and also across
+   * micro-batches.
    *
    * @param command command to run in forked process.
    * @param printElement Use this function to customize how to pipe elements. This function

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -666,6 +666,8 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         execution.python.MapInPandasExec(func, output, planLater(child)) :: Nil
       case logical.MapElements(f, _, _, objAttr, child) =>
         execution.MapElementsExec(f, objAttr, planLater(child)) :: Nil
+      case logical.PipeElements(_, _, objAttr, command, child) =>
+        execution.PipeElementsExec(objAttr, command, planLater(child)) :: Nil
       case logical.AppendColumns(f, _, _, in, out, child) =>
         execution.AppendColumnsExec(f, in, out, planLater(child)) :: Nil
       case logical.AppendColumnsWithObject(f, childSer, newSer, child) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -666,8 +666,8 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         execution.python.MapInPandasExec(func, output, planLater(child)) :: Nil
       case logical.MapElements(f, _, _, objAttr, child) =>
         execution.MapElementsExec(f, objAttr, planLater(child)) :: Nil
-      case logical.PipeElements(_, _, objAttr, command, child) =>
-        execution.PipeElementsExec(objAttr, command, planLater(child)) :: Nil
+      case logical.PipeElements(_, _, objAttr, command, printElement, child) =>
+        execution.PipeElementsExec(objAttr, command, printElement, planLater(child)) :: Nil
       case logical.AppendColumns(f, _, _, in, out, child) =>
         execution.AppendColumnsExec(f, in, out, planLater(child)) :: Nil
       case logical.AppendColumnsWithObject(f, childSer, newSer, child) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/objects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/objects.scala
@@ -645,7 +645,7 @@ case class PipeElementsExec(
       .pipe(command = PipedRDD.tokenize(command), printRDDElement = printRDDElement)
       .mapPartitionsInternal { iter =>
         val outputObject = ObjectOperator.wrapObjectToRow(outputObjectType)
-        iter.map(ele => outputObject(ele))
+        iter.map(e => outputObject(e))
       }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/objects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/objects.scala
@@ -632,13 +632,15 @@ case class CoGroupExec(
 case class PipeElementsExec(
     outputObjAttr: Attribute,
     command: String,
+    printElement: (Any, String => Unit) => Unit,
     child: SparkPlan)
   extends ObjectConsumerExec with ObjectProducerExec {
 
   override protected def doExecute(): RDD[InternalRow] = {
     val getObject = ObjectOperator.unwrapObjectFromRow(child.output.head.dataType)
     val printRDDElement: (InternalRow, String => Unit) => Unit = (row, printFunc) => {
-      printFunc(getObject(row).toString)
+      val obj = getObject(row)
+      printElement(obj, printFunc)
     }
 
     child.execute()

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -24,7 +24,7 @@ import org.scalatest.Assertions._
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.prop.TableDrivenPropertyChecks._
 
-import org.apache.spark.{SparkException, TaskContext}
+import org.apache.spark.{SparkException, TaskContext, TestUtils}
 import org.apache.spark.sql.catalyst.{FooClassWithEnum, FooEnum, ScroogeLikeExample}
 import org.apache.spark.sql.catalyst.encoders.{OuterScopes, RowEncoder}
 import org.apache.spark.sql.catalyst.plans.{LeftAnti, LeftSemi}
@@ -2006,6 +2006,20 @@ class DatasetSuite extends QueryTest
         StructField("c2", StructType(StructField("a", IntegerType, false) :: Nil)) :: Nil))
 
     checkAnswer(withUDF, Row(Row(1), null, null) :: Row(Row(1), null, null) :: Nil)
+  }
+
+  test("Pipe Dataset") {
+    assume(TestUtils.testCommandAvailable("cat"))
+
+    val nums = spark.range(4)
+    val piped = nums.pipe("cat").toDF
+
+    checkAnswer(piped, Row("0") :: Row("1") :: Row("2") :: Row("3") :: Nil)
+
+    val piped2 = nums.pipe("wc -l").toDF.collect()
+    assert(piped2.size == 2)
+    assert(piped2(0).getString(0).trim == "2")
+    assert(piped2(1).getString(0).trim == "2")
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -2008,7 +2008,7 @@ class DatasetSuite extends QueryTest
     checkAnswer(withUDF, Row(Row(1), null, null) :: Row(Row(1), null, null) :: Nil)
   }
 
-  test("Pipe Dataset") {
+  test("SPARK-34205: Pipe Dataset") {
     assume(TestUtils.testCommandAvailable("cat"))
 
     val nums = spark.range(4)
@@ -2020,6 +2020,14 @@ class DatasetSuite extends QueryTest
     assert(piped2.size == 2)
     assert(piped2(0).getString(0).trim == "2")
     assert(piped2(1).getString(0).trim == "2")
+  }
+
+  test("SPARK-34205: pipe Dataset with empty partition") {
+    val data = Seq(123, 4567).toDF("num").repartition(8, $"num")
+    val piped = data.pipe("wc -l")
+    assert(piped.count == 8)
+    val lineCounts = piped.map(_.trim.toInt).collect().toSet
+    assert(Set(0, 1, 1) == lineCounts)
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -1264,6 +1264,20 @@ class StreamSuite extends StreamTest {
       }
     }
   }
+
+  test("Pipe Streaming Dataset") {
+    assume(TestUtils.testCommandAvailable("cat"))
+
+    val inputData = MemoryStream[Int]
+    val piped = inputData.toDS()
+      .pipe("cat").toDF
+
+    testStream(piped)(
+      AddData(inputData, 1, 2, 3),
+      CheckAnswer(Row("1"), Row("2"), Row("3")),
+      AddData(inputData, 4),
+      CheckAnswer(Row("1"), Row("2"), Row("3"), Row("4")))
+  }
 }
 
 abstract class FakeSource extends StreamSourceProvider {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -1270,7 +1270,7 @@ class StreamSuite extends StreamTest {
 
     val inputData = MemoryStream[Int]
     val piped = inputData.toDS()
-      .pipe("cat").toDF
+      .pipe("cat", (n, printFunc) => printFunc(n.toString)).toDF
 
     testStream(piped)(
       AddData(inputData, 1, 2, 3),

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -1265,7 +1265,7 @@ class StreamSuite extends StreamTest {
     }
   }
 
-  test("Pipe Streaming Dataset") {
+  test("SPARK-34205: Pipe Streaming Dataset") {
     assume(TestUtils.testCommandAvailable("cat"))
 
     val inputData = MemoryStream[Int]

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -1276,7 +1276,7 @@ class StreamSuite extends StreamTest {
       AddData(inputData, 1, 2, 3),
       CheckAnswer(Row("1"), Row("2"), Row("3")),
       AddData(inputData, 4),
-      CheckAnswer(Row("1"), Row("2"), Row("3"), Row("4")))
+      CheckNewAnswer(Row("4")))
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This patch proposes to add `pipe` API to `Dataset` to enable pipe feature for streaming Dataset.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

`Dataset` doesn't have `pipe` API but `RDD` has it. Although for normal `Dataset`, user can convert a `Dataset` to `RDD` and call `RDD.pipe` and then convert it back to a `Dataset`, for streaming Dataset it is not possible since queries with streaming sources must be executed with `writeStream.start()`.

So that being said, this is actually a requirement from Structured Streaming, but we need to add `pipe` API to `Dataset` to enable it in Structured Streaming. From `Dataset` perspective, it is also easier to use `Dataset` API instead of converting between `Dataset` and `RDD`.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, a new API `pipe` is added to `Dataset`.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Unit test.