### PR TITLE
[SPARK-34210][SQL] After upgrading 3.0.1, Spark SQL access hive on HBase table access exception

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -299,10 +299,10 @@ class HadoopTableReader(
    */
   private def createHadoopRDD(localTableDesc: TableDesc, inputPathStr: String): RDD[Writable] = {
     val inputFormatClazz = localTableDesc.getInputFileFormatClass
-    if (classOf[newInputClass[_, _]].isAssignableFrom(inputFormatClazz)) {
-      createNewHadoopRDD(localTableDesc, inputPathStr)
-    } else {
+    if (classOf[oldInputClass[_, _]].isAssignableFrom(inputFormatClazz)) {
       createOldHadoopRDD(localTableDesc, inputPathStr)
+    } else {
+      createNewHadoopRDD(localTableDesc, inputPathStr)
     }
   }
 


### PR DESCRIPTION
Hivehbasetableinputformat relies on two versions of inputformat，one is org.apache.hadoop.mapred.InputFormat, the other is org.apache.hadoop.mapreduce.InputFormat,Causes both conditions to be true:
1.  classOf[oldInputClass[_, _]].isAssignableFrom(inputFormatClazz) is true
2. classOf[newInputClass[_, _]].isAssignableFrom(inputFormatClazz) is true
In view of this situation,It is expected to be compatible with the old version first
 