### PR TITLE
[SPARK-34211][SQL][TESTS] Benchmark TPC-DS with 1GB scale factor

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -449,7 +449,7 @@ jobs:
           java-version: 8
       - name: Run TPCDSQueryBenchmark
         run: |
-          SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/test:runMain org.apache.spark.sql.execution.benchmark.TPCDSQueryBenchmark --data-location `pwd`/tpcds1g --query-filter --cbo"
+          SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/test:runMain org.apache.spark.sql.execution.benchmark.TPCDSQueryBenchmark --data-location `pwd`/tpcds1g --cbo"
       - name: Upload benchmark result to report
         if: always()
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -438,15 +438,24 @@ jobs:
     steps:
       - name: Checkout Spark repository
         uses: actions/checkout@v2
-      - name: Checkout TPC-DS 1G repository
+      - name: Checkout tpcds-kit repository
         uses: actions/checkout@v2
         with:
-          repository: wangyum/tpcds1g
-          path: ./tpcds1g
+          repository: databricks/tpcds-kit
+          path: ./tpcds-kit
+      - name: Checkout spark-sql-perf repository
+        uses: actions/checkout@v2
+        with:
+          repository: wangyum/spark-sql-perf
+          path: ./spark-sql-perf
       - name: Install Java 8
         uses: actions/setup-java@v1
         with:
           java-version: 8
+      - name: Build tpcds-kit
+        run: cd tpcds-kit/tools && make OS=LINUX
+      - name: Gen TPCDS Data
+        run: cd spark-sql-perf && build/sbt "test:runMain com.databricks.spark.sql.GenTPCDSData `pwd`/../tpcds-kit/tools 1 `pwd`/../tpcds1g parquet"
       - name: Run TPCDSQueryBenchmark
         run: |
           SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/test:runMain org.apache.spark.sql.execution.benchmark.TPCDSQueryBenchmark --data-location `pwd`/tpcds1g --cbo"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -430,3 +430,29 @@ jobs:
     - name: Build with SBT
       run: |
         ./build/sbt -Pyarn -Pmesos -Pkubernetes -Phive -Phive-thriftserver -Phadoop-cloud -Pkinesis-asl -Phadoop-2.7 compile test:compile
+
+  tpcds1g:
+    name: Benchmark TPC-DS with 1GB scale factor
+    runs-on: ubuntu-20.04
+    continue-on-error: true
+    steps:
+      - name: Checkout Spark repository
+        uses: actions/checkout@v2
+      - name: Checkout TPC-DS 1G repository
+        uses: actions/checkout@v2
+        with:
+          repository: wangyum/tpcds1g
+          path: ./tpcds1g
+      - name: Install Java 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Run TPCDSQueryBenchmark
+        run: |
+          SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/test:runMain org.apache.spark.sql.execution.benchmark.TPCDSQueryBenchmark --data-location `pwd`/tpcds1g --query-filter --cbo"
+      - name: Upload benchmark result to report
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: TPC-DS 1GB benchmark result
+          path: "sql/core/benchmarks/TPCDSQueryBenchmark-results.txt"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pr add a new Github action to benchmark TPC-DS with 1GB scale factor.

### Why are the changes needed?

1. To track performance changes:
   http://apache-spark-developers-list.1001551.n3.nabble.com/VOTE-Release-Spark-3-1-1-RC1-tt30579.html#a30603
2. To track the compatibility of Parquet upgrades:
   https://issues.apache.org/jira/browse/SPARK-26346


### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

N/A.