### PR TITLE
[SPARK-34214][SQL][PYTHON] Expose regexp_extract_all in PySpark

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2791,7 +2791,7 @@ def regexp_extract_all(str, pattern, idx):
     r"""Extract all matches of the given group in a regex, from the specified string column.
     If the regex did not match, or the specified group did not match, an empty array is returned.
 
-    .. versionadded:: 3.1.0
+    .. versionadded:: 3.2.0
 
     Parameters
     ----------

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2754,7 +2754,7 @@ def split(str, pattern, limit=-1):
 
 
 def regexp_extract(str, pattern, idx):
-    r"""Extract a specific group matched by a Java regex, from the specified string column.
+    r"""Extract the first match of a specific group in a Java regex, from the specified string column.
     If the regex did not match, or the specified group did not match, an empty string is returned.
 
     .. versionadded:: 1.5.0
@@ -2773,6 +2773,29 @@ def regexp_extract(str, pattern, idx):
     """
     sc = SparkContext._active_spark_context
     jc = sc._jvm.functions.regexp_extract(_to_java_column(str), pattern, idx)
+    return Column(jc)
+
+
+def regexp_extract_all(str, pattern, idx):
+    r"""Extract all matches of a specific group in a Java regex, from the specified string column.
+    If the regex did not match, or the specified group did not match, an empty array is returned.
+
+    .. versionadded:: 3.1.0
+
+    Examples
+    --------
+    >>> df = spark.createDataFrame([('100-200, 300-400',)], ['str'])
+    >>> df.select(regexp_extract_all('str', r'(\d+)-(\d+)', 1).alias('d')).collect()
+    [Row(d=['100', '300'])]
+    >>> df = spark.createDataFrame([('foo',)], ['str'])
+    >>> df.select(regexp_extract_all('str', r'(\d+)', 1).alias('d')).collect()
+    [Row(d=[])]
+    >>> df = spark.createDataFrame([('aaaac',)], ['str'])
+    >>> df.select(regexp_extract_all('str', '(a+)(b)?(c)', 2).alias('d')).collect()
+    [Row(d=[''])]
+    """
+    sc = SparkContext._active_spark_context
+    jc = sc._jvm.functions.regexp_extract_all(_to_java_column(str), pattern, idx)
     return Column(jc)
 
 

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2754,8 +2754,9 @@ def split(str, pattern, limit=-1):
 
 
 def regexp_extract(str, pattern, idx):
-    r"""Extract the first match of a specific group in a Java regex, from the specified string column.
+    r"""Extract the first match of the given group in a regex, from the specified string column.
     If the regex did not match, or the specified group did not match, an empty string is returned.
+    Java-style regex syntax is expected.
 
     .. versionadded:: 1.5.0
 
@@ -2777,8 +2778,9 @@ def regexp_extract(str, pattern, idx):
 
 
 def regexp_extract_all(str, pattern, idx):
-    r"""Extract all matches of a specific group in a Java regex, from the specified string column.
+    r"""Extract all matches of the given group in a regex, from the specified string column.
     If the regex did not match, or the specified group did not match, an empty array is returned.
+    Java-style regex syntax is expected.
 
     .. versionadded:: 3.1.0
 

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2756,9 +2756,19 @@ def split(str, pattern, limit=-1):
 def regexp_extract(str, pattern, idx):
     r"""Extract the first match of the given group in a regex, from the specified string column.
     If the regex did not match, or the specified group did not match, an empty string is returned.
-    Java-style regex syntax is expected.
 
     .. versionadded:: 1.5.0
+
+    Parameters
+    ----------
+    str : :class:`Column` or str
+        a string expression to extract from
+    pattern : str
+        a string representing a regular expression. The regex string should be a Java regular
+        expression.
+    idx : int
+        the regex group from which to extract a potential match. 0 stands for the entire regex, and
+        only non-negative numbers are allowed.
 
     Examples
     --------
@@ -2780,9 +2790,19 @@ def regexp_extract(str, pattern, idx):
 def regexp_extract_all(str, pattern, idx):
     r"""Extract all matches of the given group in a regex, from the specified string column.
     If the regex did not match, or the specified group did not match, an empty array is returned.
-    Java-style regex syntax is expected.
 
     .. versionadded:: 3.1.0
+
+    Parameters
+    ----------
+    str : :class:`Column` or str
+        a string expression to extract from
+    pattern : str
+        a string representing a regular expression. The regex string should be a Java regular
+        expression.
+    idx : int
+        the regex group from which to extract all matches. 0 stands for the entire regex, and only
+        non-negative numbers are allowed.
 
     Examples
     --------


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR implements [SPARK-34214](https://issues.apache.org/jira/browse/SPARK-34214), by exposing the already existing `regexp_extract_all` SQL function in the PySpark API.

### Why are the changes needed?
Please refer to [SPARK-24884](https://issues.apache.org/jira/browse/SPARK-24884) for why this function is useful. This PR merely exposes it to the PySpark API, for added consistency and greater availability for users.

### Does this PR introduce _any_ user-facing change?
Yes, a new function is made available in the PySpark API. The associated docstring is included. Also I tweaked the description of the original `regexp_extract` function to highlight how its behaviour differs from that of `regexp_extract_all`.

### How was this patch tested?
I tested it locally in a pyspark console session. I didn't find any tests for `regexp_extract`, so I didn't add any for the new function, but happy to do so if desired.