### PR TITLE
[SPARK-34217][INFRA] Fix Scala 2.12 release profile

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -426,7 +426,7 @@ if [[ "$1" == "publish-release" ]]; then
   if [[ $PUBLISH_SCALA_2_12 = 1 ]]; then
     ./dev/change-scala-version.sh 2.12
     $MVN -DzincPort=$((ZINC_PORT + 2)) -Dmaven.repo.local=$tmp_repo -DskipTests \
-      $SCALA_2_11_PROFILES $PUBLISH_PROFILES clean install
+      $SCALA_2_12_PROFILES $PUBLISH_PROFILES clean install
   fi
 
   pushd $tmp_repo/org/apache/spark


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix the Scala 2.12 release profile in `release-build.sh`.

### Why are the changes needed?

Since 3.0.0 (SPARK-26132), the release script is using `SCALA_2_11_PROFILES` to publish Scala 2.12 artifacts.

After looking at the code, this is not a blocker because `-Pscala-2.11` is no-op in `branch-3.x`.
In addition `scala-2.12` profile is enabled by default and it's an empty profile without any configuration technically.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

This is used by release manager only.
Manually. This should land at `master/3.1/3.0`.