### PR TITLE
[SPARK-34220][ML] BucketedRandomProjectionLSH transform optimization

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/BucketedRandomProjectionLSH.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/BucketedRandomProjectionLSH.scala
@@ -19,7 +19,6 @@ package org.apache.spark.ml.feature
 
 import scala.util.Random
 
-import breeze.linalg.normalize
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.annotation.Since
@@ -60,13 +59,19 @@ private[ml] trait BucketedRandomProjectionLSHParams extends Params {
  * where `r_i` is the i-th random unit vector. The number of buckets will be `(max L2 norm of input
  * vectors) / bucketLength`.
  *
- * @param randUnitVectors An array of random unit vectors. Each vector represents a hash function.
+ * @param randMatrix A matrix with each row representing a hash function.
  */
 @Since("2.1.0")
 class BucketedRandomProjectionLSHModel private[ml](
     override val uid: String,
-    private[ml] val randUnitVectors: Array[Vector])
+    private[ml] val randMatrix: Matrix)
   extends LSHModel[BucketedRandomProjectionLSHModel] with BucketedRandomProjectionLSHParams {
+
+  private[ml] def this(uid: String, randUnitVectors: Array[Vector]) = {
+    this(uid, Matrices.fromVectors(randUnitVectors))
+  }
+
+  private[ml] def randUnitVectors: Array[Vector] = randMatrix.rowIter.toArray
 
   /** @group setParam */
   @Since("2.4.0")
@@ -78,11 +83,10 @@ class BucketedRandomProjectionLSHModel private[ml](
 
   @Since("2.1.0")
   override protected[ml] def hashFunction(elems: Vector): Array[Vector] = {
-    val hashValues = randUnitVectors.map(
-      randUnitVector => Math.floor(BLAS.dot(elems, randUnitVector) / $(bucketLength))
-    )
+    val hashVec = new DenseVector(Array.ofDim[Double](randMatrix.numRows))
+    BLAS.gemv(1.0 / $(bucketLength), randMatrix, elems, 0.0, hashVec)
     // TODO: Output vectors of dimension numHashFunctions in SPARK-18450
-    hashValues.map(Vectors.dense(_))
+    hashVec.values.map(h => Vectors.dense(h.floor))
   }
 
   @Since("2.1.0")
@@ -98,7 +102,7 @@ class BucketedRandomProjectionLSHModel private[ml](
 
   @Since("2.1.0")
   override def copy(extra: ParamMap): BucketedRandomProjectionLSHModel = {
-    val copied = new BucketedRandomProjectionLSHModel(uid, randUnitVectors).setParent(parent)
+    val copied = new BucketedRandomProjectionLSHModel(uid, randMatrix).setParent(parent)
     copyValues(copied, extra)
   }
 
@@ -144,9 +148,7 @@ class BucketedRandomProjectionLSH(override val uid: String)
   override def setNumHashTables(value: Int): this.type = super.setNumHashTables(value)
 
   @Since("2.1.0")
-  def this() = {
-    this(Identifiable.randomUID("brp-lsh"))
-  }
+  def this() = this(Identifiable.randomUID("brp-lsh"))
 
   /** @group setParam */
   @Since("2.1.0")
@@ -159,14 +161,18 @@ class BucketedRandomProjectionLSH(override val uid: String)
   @Since("2.1.0")
   override protected[this] def createRawLSHModel(
     inputDim: Int): BucketedRandomProjectionLSHModel = {
-    val rand = new Random($(seed))
-    val randUnitVectors: Array[Vector] = {
-      Array.fill($(numHashTables)) {
-        val randArray = Array.fill(inputDim)(rand.nextGaussian())
-        Vectors.fromBreeze(normalize(breeze.linalg.Vector(randArray)))
-      }
+    val rng = new Random($(seed))
+    val localNumHashTables = $(numHashTables)
+    val values = Array.fill(localNumHashTables * inputDim)(rng.nextGaussian)
+    var i = 0
+    while (i < localNumHashTables) {
+      val offset = i * inputDim
+      val norm = BLAS.f2jBLAS.dnrm2(inputDim, values, offset, 1)
+      if (norm != 0) BLAS.f2jBLAS.dscal(inputDim, 1.0 / norm, values, offset, 1)
+      i += 1
     }
-    new BucketedRandomProjectionLSHModel(uid, randUnitVectors)
+    val randMatrix = new DenseMatrix(localNumHashTables, inputDim, values, true)
+    new BucketedRandomProjectionLSHModel(uid, randMatrix)
   }
 
   @Since("2.1.0")
@@ -205,12 +211,7 @@ object BucketedRandomProjectionLSHModel extends MLReadable[BucketedRandomProject
 
     override protected def saveImpl(path: String): Unit = {
       DefaultParamsWriter.saveMetadata(instance, path, sc)
-      val numRows = instance.randUnitVectors.length
-      require(numRows > 0)
-      val numCols = instance.randUnitVectors.head.size
-      val values = instance.randUnitVectors.map(_.toArray).reduce(Array.concat(_, _))
-      val randMatrix = Matrices.dense(numRows, numCols, values)
-      val data = Data(randMatrix)
+      val data = Data(instance.randMatrix)
       val dataPath = new Path(path, "data").toString
       sparkSession.createDataFrame(Seq(data)).repartition(1).write.parquet(dataPath)
     }
@@ -227,11 +228,10 @@ object BucketedRandomProjectionLSHModel extends MLReadable[BucketedRandomProject
 
       val dataPath = new Path(path, "data").toString
       val data = sparkSession.read.parquet(dataPath)
-      val Row(randUnitVectors: Matrix) = MLUtils.convertMatrixColumnsToML(data, "randUnitVectors")
+      val Row(randMatrix: Matrix) = MLUtils.convertMatrixColumnsToML(data, "randUnitVectors")
         .select("randUnitVectors")
         .head()
-      val model = new BucketedRandomProjectionLSHModel(metadata.uid,
-        randUnitVectors.rowIter.toArray)
+      val model = new BucketedRandomProjectionLSHModel(metadata.uid, randMatrix)
 
       metadata.getAndSetParams(model)
       model


### PR DESCRIPTION
### What changes were proposed in this pull request?
use GEMV instead of DOT

### Why are the changes needed?
1, better performance, could be 20% faster than existing impl
2, simplify model saving

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
existing testsuites