### PR TITLE
[SPARK-34221][WEBUI] Ensure if a stage fails in the UI page, the corresponding error message can be displayed correctly.

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
@@ -882,8 +882,8 @@ $(document).ready(function () {
                                 if (typeof msg === 'undefined') {
                                     return "";
                                 } else {
-                                    var indexOfReason = msg.indexOf("Reason");
-                                    var formHead = indexOfReason > 0 ? msg.substring(0, indexOfReason) : 
+                                    var indexOfLineSperator = msg.indexOf("\n");
+                                    var formHead = indexOfLineSperator > 0 ? msg.substring(0, indexOfLineSperator) : 
                                     (msg.length > 100 ? msg.substring(0, 100) : msg)
                                     var form = "<span onclick=\"this.parentNode.querySelector('.stacktrace-details').classList.toggle('collapsed')\" class=\"expand-details\">+details</span>";
                                     var formMsg = "<div class=\"stacktrace-details collapsed\"><pre>" + row.errorMessage + "</pre></div>";

--- a/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
@@ -882,7 +882,9 @@ $(document).ready(function () {
                                 if (typeof msg === 'undefined') {
                                     return "";
                                 } else {
-                                    var formHead = msg.substring(0, msg.indexOf("at"));
+                                    var indexOfReason = msg.indexOf("Reason");
+                                    var formHead = indexOfReason > 0 ? msg.substring(0, indexOfReason) : 
+                                    (msg.length > 100 ? msg.substring(0, 100) : msg)
                                     var form = "<span onclick=\"this.parentNode.querySelector('.stacktrace-details').classList.toggle('collapsed')\" class=\"expand-details\">+details</span>";
                                     var formMsg = "<div class=\"stacktrace-details collapsed\"><pre>" + row.errorMessage + "</pre></div>";
                                     return formHead + form + formMsg;

--- a/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
@@ -882,9 +882,9 @@ $(document).ready(function () {
                                 if (typeof msg === 'undefined') {
                                     return "";
                                 } else {
-                                    var indexOfLineSperator = msg.indexOf("\n");
-                                    var formHead = indexOfLineSperator > 0 ? msg.substring(0, indexOfLineSperator) : 
-                                    (msg.length > 100 ? msg.substring(0, 100) : msg)
+                                    var indexOfLineSeperator = msg.indexOf("\n");
+                                    var formHead = indexOfLineSeperator > 0 ? msg.substring(0, indexOfLineSeperator).replace(/(\s*$)/g, ""); : 
+                                    (msg.length > 100 ? msg.substring(0, 100).replace(/(\s*$)/g, "") : msg)
                                     var form = "<span onclick=\"this.parentNode.querySelector('.stacktrace-details').classList.toggle('collapsed')\" class=\"expand-details\">+details</span>";
                                     var formMsg = "<div class=\"stacktrace-details collapsed\"><pre>" + row.errorMessage + "</pre></div>";
                                     return formHead + form + formMsg;

--- a/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
@@ -884,7 +884,7 @@ $(document).ready(function () {
                                 } else {
                                     var indexOfLineSeperator = msg.indexOf("\n");
                                     var formHead = indexOfLineSeperator > 0 ? msg.substring(0, indexOfLineSeperator).replace(/(\s*$)/g, "") : 
-                                    (msg.length > 100 ? msg.substring(0, 100).replace(/(\s*$)/g, "") : msg)
+                                    (msg.length > 100 ? msg.substring(0, 100).replace(/(\s*$)/g, "") : msg);
                                     var form = "<span onclick=\"this.parentNode.querySelector('.stacktrace-details').classList.toggle('collapsed')\" class=\"expand-details\">+details</span>";
                                     var formMsg = "<div class=\"stacktrace-details collapsed\"><pre>" + row.errorMessage + "</pre></div>";
                                     return formHead + form + formMsg;

--- a/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
@@ -882,9 +882,8 @@ $(document).ready(function () {
                                 if (typeof msg === 'undefined') {
                                     return "";
                                 } else {
-                                    var indexOfLineSeperator = msg.indexOf("\n");
-                                    var formHead = indexOfLineSeperator > 0 ? msg.substring(0, indexOfLineSeperator).replace(/(\s*$)/g, "") : 
-                                    (msg.length > 100 ? msg.substring(0, 100).replace(/(\s*$)/g, "") : msg);
+                                    var indexOfLineSeparator = msg.indexOf("\n");
+                                    var formHead = indexOfLineSeparator > 0 ? msg.substring(0, indexOfLineSeparator) : (msg.length > 100 ? msg.substring(0, 100) : msg);
                                     var form = "<span onclick=\"this.parentNode.querySelector('.stacktrace-details').classList.toggle('collapsed')\" class=\"expand-details\">+details</span>";
                                     var formMsg = "<div class=\"stacktrace-details collapsed\"><pre>" + row.errorMessage + "</pre></div>";
                                     return formHead + form + formMsg;

--- a/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
@@ -883,7 +883,7 @@ $(document).ready(function () {
                                     return "";
                                 } else {
                                     var indexOfLineSeperator = msg.indexOf("\n");
-                                    var formHead = indexOfLineSeperator > 0 ? msg.substring(0, indexOfLineSeperator).replace(/(\s*$)/g, ""); : 
+                                    var formHead = indexOfLineSeperator > 0 ? msg.substring(0, indexOfLineSeperator).replace(/(\s*$)/g, "") : 
                                     (msg.length > 100 ? msg.substring(0, 100).replace(/(\s*$)/g, "") : msg)
                                     var form = "<span onclick=\"this.parentNode.querySelector('.stacktrace-details').classList.toggle('collapsed')\" class=\"expand-details\">+details</span>";
                                     var formMsg = "<div class=\"stacktrace-details collapsed\"><pre>" + row.errorMessage + "</pre></div>";


### PR DESCRIPTION
### What changes were proposed in this pull request?
Ensure that if a stage fails in the UI page, the corresponding error message can be displayed correctly.


### Why are the changes needed?
errormessage is not handled properly in JavaScript. If the 'at' is not exist, the error message on the page will be blank.
I made wochanges,
1. `msg.indexOf("at")` => `msg.indexOf("\n")`
 
![image](https://user-images.githubusercontent.com/52202080/105663531-7362cb00-5f0d-11eb-87fd-008ed65c33ca.png)

  As shows ablove, truncated at the 'at' position will result in a strange abstract of the error message. If there is a `\n` worit is more reasonable to truncate at the '\n' position.
  
2. If the `\n` does not exist check whether the msg  is more than 100. If true, then truncate the display to avoid too long error message


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manual test shows as belows, just a js change:

before modified:
![problem](https://user-images.githubusercontent.com/52202080/105712153-661cff00-5f54-11eb-80bf-e33c323c4e55.png)

after modified
![after mdified](https://user-images.githubusercontent.com/52202080/105712180-6c12e000-5f54-11eb-8998-ff8bc8a0a503.png)


