### PR TITLE
[SPARK-32852][SQL][FOLLOW_UP] Add notice about keep hive version consistence when config hive jars location

### DIFF
--- a/docs/sql-data-sources-hive-tables.md
+++ b/docs/sql-data-sources-hive-tables.md
@@ -150,11 +150,13 @@ The following options can be used to configure the version of Hive that is used 
         is not generally recommended for production deployments.
         <li><code>path</code></li>
         Use Hive jars configured by <code>spark.sql.hive.metastore.jars.path</code>
-        in comma separated format. Support both local or remote paths.
+        in comma separated format. Support both local or remote paths. The provided jars should be
+        the same version as <code>spark.sql.hive.metastore.version</code>.
         <li>A classpath in the standard format for the JVM. This classpath must include all of Hive
-        and its dependencies, including the correct version of Hadoop. These jars only need to be
-        present on the driver, but if you are running in yarn cluster mode then you must ensure
-        they are packaged with your application.</li>
+        and its dependencies, including the correct version of Hadoop. The provided jars should be
+        the same version as <code>spark.sql.hive.metastore.version</code>. These jars only need to be present on the
+        driver, but if you are running in yarn cluster mode then you must ensure they are packaged
+        with your application.</li>
       </ol>
     </td>
     <td>1.4.0</td>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -89,6 +89,8 @@ private[spark] object HiveUtils extends Logging {
       |   Use Hive jars configured by `spark.sql.hive.metastore.jars.path`
       |   in comma separated format. Support both local or remote paths.
       | 4. A classpath in the standard format for both Hive and Hadoop.
+      | Note that when use mode 3 or 4, we should keep hive version consistence
+      |   between ${HIVE_METASTORE_VERSION} and involved jars.
       """.stripMargin)
     .version("1.4.0")
     .stringConf

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -77,7 +77,7 @@ private[spark] object HiveUtils extends Logging {
   val HIVE_METASTORE_JARS = buildStaticConf("spark.sql.hive.metastore.jars")
     .doc(s"""
       | Location of the jars that should be used to instantiate the HiveMetastoreClient.
-      | This property can be one of four options: "
+      | This property can be one of four options:
       | 1. "builtin"
       |   Use Hive ${builtinHiveVersion}, which is bundled with the Spark assembly when
       |   <code>-Phive</code> is enabled. When this option is chosen,
@@ -87,10 +87,10 @@ private[spark] object HiveUtils extends Logging {
       |   Use Hive jars of specified version downloaded from Maven repositories.
       | 3. "path"
       |   Use Hive jars configured by `spark.sql.hive.metastore.jars.path`
-      |   in comma separated format. Support both local or remote paths.
-      | 4. A classpath in the standard format for both Hive and Hadoop.
-      | Note that when use mode 3 or 4, we should keep hive version consistence
-      |   between ${HIVE_METASTORE_VERSION} and involved jars.
+      |   in comma separated format. Support both local or remote paths.The provided jars
+      |   should be the same version as ${HIVE_METASTORE_VERSION}.
+      | 4. A classpath in the standard format for both Hive and Hadoop. The provided jars
+      |   should be the same version as ${HIVE_METASTORE_VERSION}.
       """.stripMargin)
     .version("1.4.0")
     .stringConf


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add notice about keep hive version consistence when config hive jars location

With PR #29881, if we don't keep hive version consistence. we will got below error.
```
Builtin jars can only be used when hive execution version == hive metastore version. Execution: 2.3.8 != Metastore: 1.2.1. Specify a valid path to the correct hive jars using spark.sql.hive.metastore.jars or change spark.sql.hive.metastore.version to 2.3.8.
```

![image](https://user-images.githubusercontent.com/46485123/105795169-512d8380-5fc7-11eb-97c3-0259a0d2aa58.png)

### Why are the changes needed?
Make config doc detail


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Not need