### PR TITLE
[SPARK-34222][SQL] Enhance boolean simplification rule

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -168,14 +168,11 @@ trait PredicateHelper extends AliasHelper with Logging {
     exprs match {
       case Seq(expression) => expression
       case expressions =>
-        val grouped = expressions.grouped(2).toSeq
-        val pairwiseExprs = for (g <- grouped) yield {
-          g match {
-            case Seq(a, b) => op(a, b)
-            case Seq(x) => x
-          }
+        val pairwiseExprs = expressions.grouped(2).map {
+          case Seq(e1, e2) => op(e1, e2)
+          case Seq(e) => e
         }
-        buildBalancedPredicate(pairwiseExprs, op)
+        buildBalancedPredicate(pairwiseExprs.toSeq, op)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -376,7 +376,7 @@ object BooleanSimplification extends Rule[LogicalPlan] with PredicateHelper {
             and
           } else {
             // (a && b) && a && (a && c) => a && b && c
-            mergeConjunctivePredicates(distinct.toSeq)
+            buildBalancedPredicate(distinct.toSeq, And)
           }
         }
 
@@ -414,7 +414,7 @@ object BooleanSimplification extends Rule[LogicalPlan] with PredicateHelper {
             or
           } else {
             // (a || b) || a || (a || c) => a || b || c
-            mergeDisjunctivePredicates(distinct.toSeq)
+            buildBalancedPredicate(distinct.toSeq, Or)
           }
         }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -356,7 +356,7 @@ object BooleanSimplification extends Rule[LogicalPlan] with PredicateHelper {
         val lhs = splitDisjunctivePredicates(left)
         val rhs = splitDisjunctivePredicates(right)
         val common = lhs.filter(e => rhs.exists(e.semanticEquals))
-        if (!common.isEmpty) {
+        if (common.nonEmpty) {
           val ldiff = lhs.filterNot(e => common.exists(e.semanticEquals))
           val rdiff = rhs.filterNot(e => common.exists(e.semanticEquals))
           if (ldiff.isEmpty || rdiff.isEmpty) {
@@ -394,7 +394,7 @@ object BooleanSimplification extends Rule[LogicalPlan] with PredicateHelper {
         val lhs = splitConjunctivePredicates(left)
         val rhs = splitConjunctivePredicates(right)
         val common = lhs.filter(e => rhs.exists(e.semanticEquals))
-        if (!common.isEmpty) {
+        if (common.nonEmpty) {
           val ldiff = lhs.filterNot(e => common.exists(e.semanticEquals))
           val rdiff = rhs.filterNot(e => common.exists(e.semanticEquals))
           if (ldiff.isEmpty || rdiff.isEmpty) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -376,7 +376,7 @@ object BooleanSimplification extends Rule[LogicalPlan] with PredicateHelper {
             and
           } else {
             // (a && b) && a && (a && c) => a && b && c
-            distinct.reduce(And)
+            mergeConjunctivePredicates(distinct.toSeq)
           }
         }
 
@@ -414,7 +414,7 @@ object BooleanSimplification extends Rule[LogicalPlan] with PredicateHelper {
             or
           } else {
             // (a || b) || a || (a || c) => a || b || c
-            distinct.reduce(Or)
+            mergeDisjunctivePredicates(distinct.toSeq)
           }
         }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BooleanSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BooleanSimplificationSuite.scala
@@ -126,6 +126,56 @@ class BooleanSimplificationSuite extends PlanTest with ExpressionEvalHelper with
       'a === 'b || 'b > 3 && 'a > 3 && 'a < 5)
   }
 
+  test("(((a && b) && a && (a && c))) => a && b && c") {
+
+    checkCondition((('a > 1 && 'b > 2) && 'a > 1 &&('a > 1 && 'c > 3)),
+      ('a > 1 && ('b > 2 && 'c > 3)))
+
+    checkCondition((('a > 1 && 'b >2) && ('a > 4 && 'b > 5) && ('a > 1 && 'c > 3)),
+      ('a > 1 && 'b > 2 && 'c > 3 && 'a > 4 && 'b > 5))
+
+    checkCondition(
+      ('a > 1 && 'b > 3 && ('a > 1 && 'b > 3 && ('a > 1 && 'b > 3 && 'c >1))),
+      ('a > 1 && 'b > 3 && 'c >1))
+
+    checkCondition(
+      (('a > 1 || 'b > 3) && (('a > 1 || 'b > 3) && 'd > 0 && (('a > 1 || 'b > 3) && 'c >1))),
+      (('a > 1 || 'b > 3) && 'd > 0 && 'c >1))
+
+    checkCondition(
+      ('a > 1 && 'b > 2 && 'a > 1 && 'c > 3),
+      ('a > 1 && 'b > 2 && 'c > 3))
+
+    checkCondition(
+      ('a > 1 &&  'b > 3 && 'a > 1 ) || ('a > 1 &&  'b > 3 && 'a > 1 && 'c > 1 )
+      , ('a > 1 && 'b > 3))
+  }
+
+  test("(((a || b) || a || (a || c))) => a || b || c") {
+
+    checkCondition((('a > 1 || 'b > 2) || 'a > 1 ||('a > 1 || 'c > 3)),
+      ('a > 1 || 'b > 2 || 'c > 3))
+
+    checkCondition((('a > 1 || 'b >2) || 'a > 4 ||('a > 1 || 'c > 3)),
+      ('a > 1 || 'b > 2 || 'a > 4 || 'c > 3))
+
+    checkCondition(
+      ('a > 1 || 'b > 3 || ( 'a > 1 || 'b > 3 || ('a > 1 || 'b > 3 || 'c > 1)))
+      , ('a > 1 || 'b > 3 || 'c > 1))
+
+    checkCondition(
+      (('a > 1 && 'b > 3) || ( ('a > 1 && 'b > 3) || (('a > 1 && 'b > 3) || 'c > 1)))
+      , (('a > 1 && 'b > 3) || 'c > 1))
+
+    checkCondition(
+      ('a > 1 || 'b > 2 || 'a > 1 || 'c > 3),
+      ('a > 1 || 'b > 2 || 'c > 3))
+
+    checkCondition(
+      ('a > 1 ||  'b > 3 || 'a > 1 ) && ('a > 1 ||  'b > 3 || 'a > 1 || 'c > 1 )
+      , ('a > 1 || 'b > 3))
+  }
+
   test("e && (!e || f) - not nullable") {
     checkConditionInNotNullableRelation('e && (!'e || 'f ), 'e && 'f)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BooleanSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BooleanSimplificationSuite.scala
@@ -126,7 +126,7 @@ class BooleanSimplificationSuite extends PlanTest with ExpressionEvalHelper with
       'a === 'b || 'b > 3 && 'a > 3 && 'a < 5)
   }
 
-  test("(((a && b) && a && (a && c))) => a && b && c") {
+  test("SPARK-34222: (((a && b) && a && (a && c))) => a && b && c") {
 
     checkCondition((('a > 1 && 'b > 2) && 'a > 1 &&('a > 1 && 'c > 3)),
       ('a > 1 && ('b > 2 && 'c > 3)))
@@ -151,7 +151,7 @@ class BooleanSimplificationSuite extends PlanTest with ExpressionEvalHelper with
       , ('a > 1 && 'b > 3))
   }
 
-  test("(((a || b) || a || (a || c))) => a || b || c") {
+  test("SPARK-34222: (((a || b) || a || (a || c))) => a || b || c") {
 
     checkCondition((('a > 1 || 'b > 2) || 'a > 1 ||('a > 1 || 'c > 3)),
       ('a > 1 || 'b > 2 || 'c > 3))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BooleanSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BooleanSimplificationSuite.scala
@@ -126,52 +126,52 @@ class BooleanSimplificationSuite extends PlanTest with ExpressionEvalHelper with
       'a === 'b || 'b > 3 && 'a > 3 && 'a < 5)
   }
 
-  test("SPARK-34222: (((a && b) && a && (a && c))) => a && b && c") {
-    checkCondition((('a > 1 && 'b > 2) && 'a > 1 && ('a > 1 && 'c > 3)),
-      ('a > 1 && ('b > 2 && 'c > 3)))
+  test("SPARK-34222: (a && b) && a && (a && c) => a && b && c") {
+    checkCondition(('a > 1 && 'b > 2) && 'a > 1 && ('a > 1 && 'c > 3),
+      'a > 1 && ('b > 2 && 'c > 3))
 
-    checkCondition((('a > 1 && 'b >2) && ('a > 4 && 'b > 5) && ('a > 1 && 'c > 3)),
-      ('a > 1 && 'b > 2 && 'c > 3 && 'a > 4 && 'b > 5))
-
-    checkCondition(
-      ('a > 1 && 'b > 3 && ('a > 1 && 'b > 3 && ('a > 1 && 'b > 3 && 'c >1))),
-      ('a > 1 && 'b > 3 && 'c >1))
+    checkCondition(('a > 1 && 'b >2) && ('a > 4 && 'b > 5) && ('a > 1 && 'c > 3),
+      'a > 1 && 'b > 2 && 'c > 3 && 'a > 4 && 'b > 5)
 
     checkCondition(
-      (('a > 1 || 'b > 3) && (('a > 1 || 'b > 3) && 'd > 0 && (('a > 1 || 'b > 3) && 'c >1))),
-      (('a > 1 || 'b > 3) && 'd > 0 && 'c >1))
+      'a > 1 && 'b > 3 && ('a > 1 && 'b > 3 && ('a > 1 && 'b > 3 && 'c >1)),
+      'a > 1 && 'b > 3 && 'c >1)
 
     checkCondition(
-      ('a > 1 && 'b > 2 && 'a > 1 && 'c > 3),
-      ('a > 1 && 'b > 2 && 'c > 3))
+      ('a > 1 || 'b > 3) && (('a > 1 || 'b > 3) && 'd > 0 && (('a > 1 || 'b > 3) && 'c >1)),
+      ('a > 1 || 'b > 3) && 'd > 0 && 'c >1)
 
     checkCondition(
-      ('a > 1 &&  'b > 3 && 'a > 1 ) || ('a > 1 &&  'b > 3 && 'a > 1 && 'c > 1),
-      ('a > 1 && 'b > 3))
+      'a > 1 && 'b > 2 && 'a > 1 && 'c > 3,
+      'a > 1 && 'b > 2 && 'c > 3)
+
+    checkCondition(
+      ('a > 1 && 'b > 3 && 'a > 1 ) || ('a > 1 && 'b > 3 && 'a > 1 && 'c > 1),
+      'a > 1 && 'b > 3)
   }
 
-  test("SPARK-34222: (((a || b) || a || (a || c))) => a || b || c") {
-    checkCondition((('a > 1 || 'b > 2) || 'a > 1 ||('a > 1 || 'c > 3)),
-      ('a > 1 || 'b > 2 || 'c > 3))
+  test("SPARK-34222: (a || b) || a || (a || c) => a || b || c") {
+    checkCondition(('a > 1 || 'b > 2) || 'a > 1 || ('a > 1 || 'c > 3),
+      'a > 1 || 'b > 2 || 'c > 3)
 
-    checkCondition((('a > 1 || 'b >2) || 'a > 4 ||('a > 1 || 'c > 3)),
-      ('a > 1 || 'b > 2 || 'a > 4 || 'c > 3))
-
-    checkCondition(
-      ('a > 1 || 'b > 3 || ( 'a > 1 || 'b > 3 || ('a > 1 || 'b > 3 || 'c > 1))),
-      ('a > 1 || 'b > 3 || 'c > 1))
+    checkCondition(('a > 1 || 'b >2) || 'a > 4 ||('a > 1 || 'c > 3),
+      'a > 1 || 'b > 2 || 'a > 4 || 'c > 3)
 
     checkCondition(
-      (('a > 1 && 'b > 3) || ( ('a > 1 && 'b > 3) || (('a > 1 && 'b > 3) || 'c > 1))),
-      (('a > 1 && 'b > 3) || 'c > 1))
+      'a > 1 || 'b > 3 || ('a > 1 || 'b > 3 || ('a > 1 || 'b > 3 || 'c > 1)),
+      'a > 1 || 'b > 3 || 'c > 1)
 
     checkCondition(
-      ('a > 1 || 'b > 2 || 'a > 1 || 'c > 3),
-      ('a > 1 || 'b > 2 || 'c > 3))
+      ('a > 1 && 'b > 3) || (('a > 1 && 'b > 3) || (('a > 1 && 'b > 3) || 'c > 1)),
+      ('a > 1 && 'b > 3) || 'c > 1)
 
     checkCondition(
-      ('a > 1 ||  'b > 3 || 'a > 1 ) && ('a > 1 ||  'b > 3 || 'a > 1 || 'c > 1 ),
-      ('a > 1 || 'b > 3))
+      'a > 1 || 'b > 2 || 'a > 1 || 'c > 3,
+      'a > 1 || 'b > 2 || 'c > 3)
+
+    checkCondition(
+      ('a > 1 || 'b > 3 || 'a > 1 ) && ('a > 1 || 'b > 3 || 'a > 1 || 'c > 1 ),
+      'a > 1 || 'b > 3)
   }
 
   test("e && (!e || f) - not nullable") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BooleanSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BooleanSimplificationSuite.scala
@@ -131,7 +131,7 @@ class BooleanSimplificationSuite extends PlanTest with ExpressionEvalHelper with
       'a > 1 && ('b > 2 && 'c > 3))
 
     checkCondition(('a > 1 && 'b >2) && ('a > 4 && 'b > 5) && ('a > 1 && 'c > 3),
-      'a > 1 && 'b > 2 && 'c > 3 && 'a > 4 && 'b > 5)
+      ('a > 1 && 'b > 2) && ('c > 3 && 'a > 4) && 'b > 5)
 
     checkCondition(
       'a > 1 && 'b > 3 && ('a > 1 && 'b > 3 && ('a > 1 && 'b > 3 && 'c >1)),
@@ -154,8 +154,8 @@ class BooleanSimplificationSuite extends PlanTest with ExpressionEvalHelper with
     checkCondition(('a > 1 || 'b > 2) || 'a > 1 || ('a > 1 || 'c > 3),
       'a > 1 || 'b > 2 || 'c > 3)
 
-    checkCondition(('a > 1 || 'b >2) || 'a > 4 ||('a > 1 || 'c > 3),
-      'a > 1 || 'b > 2 || 'a > 4 || 'c > 3)
+    checkCondition(('a > 1 || 'b >2) || ('a > 4 || 'b > 5) ||('a > 1 || 'c > 3),
+      ('a > 1 || 'b > 2) || ('a > 4 || 'b > 5) || 'c > 3)
 
     checkCondition(
       'a > 1 || 'b > 3 || ('a > 1 || 'b > 3 || ('a > 1 || 'b > 3 || 'c > 1)),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BooleanSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BooleanSimplificationSuite.scala
@@ -126,7 +126,7 @@ class BooleanSimplificationSuite extends PlanTest with ExpressionEvalHelper with
       'a === 'b || 'b > 3 && 'a > 3 && 'a < 5)
   }
 
-  test("SPARK-34222: (a && b) && a && (a && c) => a && b && c") {
+  test("SPARK-34222: simplify conjunctive predicates (a && b) && a && (a && c) => a && b && c") {
     checkCondition(('a > 1 && 'b > 2) && 'a > 1 && ('a > 1 && 'c > 3),
       'a > 1 && ('b > 2 && 'c > 3))
 
@@ -150,7 +150,7 @@ class BooleanSimplificationSuite extends PlanTest with ExpressionEvalHelper with
       'a > 1 && 'b > 3)
   }
 
-  test("SPARK-34222: (a || b) || a || (a || c) => a || b || c") {
+  test("SPARK-34222: simplify disjunctive predicates (a || b) || a || (a || c) => a || b || c") {
     checkCondition(('a > 1 || 'b > 2) || 'a > 1 || ('a > 1 || 'c > 3),
       'a > 1 || 'b > 2 || 'c > 3)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BooleanSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BooleanSimplificationSuite.scala
@@ -127,8 +127,7 @@ class BooleanSimplificationSuite extends PlanTest with ExpressionEvalHelper with
   }
 
   test("SPARK-34222: (((a && b) && a && (a && c))) => a && b && c") {
-
-    checkCondition((('a > 1 && 'b > 2) && 'a > 1 &&('a > 1 && 'c > 3)),
+    checkCondition((('a > 1 && 'b > 2) && 'a > 1 && ('a > 1 && 'c > 3)),
       ('a > 1 && ('b > 2 && 'c > 3)))
 
     checkCondition((('a > 1 && 'b >2) && ('a > 4 && 'b > 5) && ('a > 1 && 'c > 3)),
@@ -147,12 +146,11 @@ class BooleanSimplificationSuite extends PlanTest with ExpressionEvalHelper with
       ('a > 1 && 'b > 2 && 'c > 3))
 
     checkCondition(
-      ('a > 1 &&  'b > 3 && 'a > 1 ) || ('a > 1 &&  'b > 3 && 'a > 1 && 'c > 1 )
-      , ('a > 1 && 'b > 3))
+      ('a > 1 &&  'b > 3 && 'a > 1 ) || ('a > 1 &&  'b > 3 && 'a > 1 && 'c > 1),
+      ('a > 1 && 'b > 3))
   }
 
   test("SPARK-34222: (((a || b) || a || (a || c))) => a || b || c") {
-
     checkCondition((('a > 1 || 'b > 2) || 'a > 1 ||('a > 1 || 'c > 3)),
       ('a > 1 || 'b > 2 || 'c > 3))
 
@@ -160,20 +158,20 @@ class BooleanSimplificationSuite extends PlanTest with ExpressionEvalHelper with
       ('a > 1 || 'b > 2 || 'a > 4 || 'c > 3))
 
     checkCondition(
-      ('a > 1 || 'b > 3 || ( 'a > 1 || 'b > 3 || ('a > 1 || 'b > 3 || 'c > 1)))
-      , ('a > 1 || 'b > 3 || 'c > 1))
+      ('a > 1 || 'b > 3 || ( 'a > 1 || 'b > 3 || ('a > 1 || 'b > 3 || 'c > 1))),
+      ('a > 1 || 'b > 3 || 'c > 1))
 
     checkCondition(
-      (('a > 1 && 'b > 3) || ( ('a > 1 && 'b > 3) || (('a > 1 && 'b > 3) || 'c > 1)))
-      , (('a > 1 && 'b > 3) || 'c > 1))
+      (('a > 1 && 'b > 3) || ( ('a > 1 && 'b > 3) || (('a > 1 && 'b > 3) || 'c > 1))),
+      (('a > 1 && 'b > 3) || 'c > 1))
 
     checkCondition(
       ('a > 1 || 'b > 2 || 'a > 1 || 'c > 3),
       ('a > 1 || 'b > 2 || 'c > 3))
 
     checkCondition(
-      ('a > 1 ||  'b > 3 || 'a > 1 ) && ('a > 1 ||  'b > 3 || 'a > 1 || 'c > 1 )
-      , ('a > 1 || 'b > 3))
+      ('a > 1 ||  'b > 3 || 'a > 1 ) && ('a > 1 ||  'b > 3 || 'a > 1 || 'c > 1 ),
+      ('a > 1 || 'b > 3))
   }
 
   test("e && (!e || f) - not nullable") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BooleanSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BooleanSimplificationSuite.scala
@@ -130,23 +130,23 @@ class BooleanSimplificationSuite extends PlanTest with ExpressionEvalHelper with
     checkCondition(('a > 1 && 'b > 2) && 'a > 1 && ('a > 1 && 'c > 3),
       'a > 1 && ('b > 2 && 'c > 3))
 
-    checkCondition(('a > 1 && 'b >2) && ('a > 4 && 'b > 5) && ('a > 1 && 'c > 3),
+    checkCondition(('a > 1 && 'b > 2) && ('a > 4 && 'b > 5) && ('a > 1 && 'c > 3),
       ('a > 1 && 'b > 2) && ('c > 3 && 'a > 4) && 'b > 5)
 
     checkCondition(
-      'a > 1 && 'b > 3 && ('a > 1 && 'b > 3 && ('a > 1 && 'b > 3 && 'c >1)),
-      'a > 1 && 'b > 3 && 'c >1)
+      'a > 1 && 'b > 3 && ('a > 1 && 'b > 3 && ('a > 1 && 'b > 3 && 'c > 1)),
+      'a > 1 && 'b > 3 && 'c > 1)
 
     checkCondition(
-      ('a > 1 || 'b > 3) && (('a > 1 || 'b > 3) && 'd > 0 && (('a > 1 || 'b > 3) && 'c >1)),
-      ('a > 1 || 'b > 3) && 'd > 0 && 'c >1)
+      ('a > 1 || 'b > 3) && (('a > 1 || 'b > 3) && 'd > 0 && (('a > 1 || 'b > 3) && 'c > 1)),
+      ('a > 1 || 'b > 3) && 'd > 0 && 'c > 1)
 
     checkCondition(
       'a > 1 && 'b > 2 && 'a > 1 && 'c > 3,
       'a > 1 && 'b > 2 && 'c > 3)
 
     checkCondition(
-      ('a > 1 && 'b > 3 && 'a > 1 ) || ('a > 1 && 'b > 3 && 'a > 1 && 'c > 1),
+      ('a > 1 && 'b > 3 && 'a > 1) || ('a > 1 && 'b > 3 && 'a > 1 && 'c > 1),
       'a > 1 && 'b > 3)
   }
 
@@ -154,7 +154,7 @@ class BooleanSimplificationSuite extends PlanTest with ExpressionEvalHelper with
     checkCondition(('a > 1 || 'b > 2) || 'a > 1 || ('a > 1 || 'c > 3),
       'a > 1 || 'b > 2 || 'c > 3)
 
-    checkCondition(('a > 1 || 'b >2) || ('a > 4 || 'b > 5) ||('a > 1 || 'c > 3),
+    checkCondition(('a > 1 || 'b > 2) || ('a > 4 || 'b > 5) ||('a > 1 || 'c > 3),
       ('a > 1 || 'b > 2) || ('a > 4 || 'b > 5) || 'c > 3)
 
     checkCondition(
@@ -170,7 +170,7 @@ class BooleanSimplificationSuite extends PlanTest with ExpressionEvalHelper with
       'a > 1 || 'b > 2 || 'c > 3)
 
     checkCondition(
-      ('a > 1 || 'b > 3 || 'a > 1 ) && ('a > 1 || 'b > 3 || 'a > 1 || 'c > 1 ),
+      ('a > 1 || 'b > 3 || 'a > 1) && ('a > 1 || 'b > 3 || 'a > 1 || 'c > 1 ),
       'a > 1 || 'b > 3)
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enhance boolean simplification rule by handling following scenarios:
(((a && b) && a && (a && c))) => a && b && c)
(((a || b) || a || (a || c))) => a || b || c


### Why are the changes needed?
Minor improvement


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added UTs
