### PR TITLE
[SPARK-34212][SQL] Fix incorrect decimal reading from Parquet files

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetReadSupport.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetReadSupport.scala
@@ -193,7 +193,9 @@ object ParquetReadSupport {
         if (t.precision == p.getPrecision && t.scale == p.getScale) {
           parquetType
         } else {
-          throw new UnsupportedOperationException("Schema evolution not supported.")
+          throw new UnsupportedOperationException(
+            "Parquet vectorized reader doesn't support schema evolution on decimal types." +
+            s"You may try to use ${SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key}=false")
         }
 
       case _ =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
@@ -268,18 +268,29 @@ private[parquet] class ParquetRowConverter(
         }
 
       // For INT32 backed decimals
-      case t: DecimalType if parquetType.asPrimitiveType().getPrimitiveTypeName == INT32 =>
-        new ParquetIntDictionaryAwareDecimalConverter(t.precision, t.scale, updater)
+      case _: DecimalType if parquetType.asPrimitiveType().getPrimitiveTypeName == INT32 =>
+        // SPARK-34212 Interpret the Parquet long value with the corresponding Parquet's file type.
+        val metadata = parquetType.asPrimitiveType().getDecimalMetadata
+        val precision = metadata.getPrecision()
+        val scale = metadata.getScale()
+        new ParquetIntDictionaryAwareDecimalConverter(precision, scale, updater)
 
       // For INT64 backed decimals
-      case t: DecimalType if parquetType.asPrimitiveType().getPrimitiveTypeName == INT64 =>
-        new ParquetLongDictionaryAwareDecimalConverter(t.precision, t.scale, updater)
+      case _: DecimalType if parquetType.asPrimitiveType().getPrimitiveTypeName == INT64 =>
+        // SPARK-34212 Interpret the Parquet long value with the corresponding Parquet's file type.
+        val metadata = parquetType.asPrimitiveType().getDecimalMetadata
+        val precision = metadata.getPrecision()
+        val scale = metadata.getScale()
+        new ParquetLongDictionaryAwareDecimalConverter(precision, scale, updater)
 
       // For BINARY and FIXED_LEN_BYTE_ARRAY backed decimals
-      case t: DecimalType
+      case _: DecimalType
         if parquetType.asPrimitiveType().getPrimitiveTypeName == FIXED_LEN_BYTE_ARRAY ||
            parquetType.asPrimitiveType().getPrimitiveTypeName == BINARY =>
-        new ParquetBinaryDictionaryAwareDecimalConverter(t.precision, t.scale, updater)
+        val metadata = parquetType.asPrimitiveType().getDecimalMetadata
+        val precision = metadata.getPrecision()
+        val scale = metadata.getScale()
+        new ParquetBinaryDictionaryAwareDecimalConverter(precision, scale, updater)
 
       case t: DecimalType =>
         throw new RuntimeException(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
@@ -269,7 +269,6 @@ private[parquet] class ParquetRowConverter(
 
       // For INT32 backed decimals
       case _: DecimalType if parquetType.asPrimitiveType().getPrimitiveTypeName == INT32 =>
-        // SPARK-34212 Interpret the Parquet long value with the corresponding Parquet's file type.
         val metadata = parquetType.asPrimitiveType().getDecimalMetadata
         val precision = metadata.getPrecision()
         val scale = metadata.getScale()
@@ -277,7 +276,6 @@ private[parquet] class ParquetRowConverter(
 
       // For INT64 backed decimals
       case _: DecimalType if parquetType.asPrimitiveType().getPrimitiveTypeName == INT64 =>
-        // SPARK-34212 Interpret the Parquet long value with the corresponding Parquet's file type.
         val metadata = parquetType.asPrimitiveType().getDecimalMetadata
         val precision = metadata.getPrecision()
         val scale = metadata.getScale()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
@@ -268,26 +268,26 @@ private[parquet] class ParquetRowConverter(
         }
 
       // For INT32 backed decimals
-      case _: DecimalType if parquetType.asPrimitiveType().getPrimitiveTypeName == INT32 =>
+      case t: DecimalType if parquetType.asPrimitiveType().getPrimitiveTypeName == INT32 =>
         val metadata = parquetType.asPrimitiveType().getDecimalMetadata
-        val precision = metadata.getPrecision()
-        val scale = metadata.getScale()
+        val precision = if (metadata == null) t.precision else metadata.getPrecision()
+        val scale = if (metadata == null) t.scale else metadata.getScale()
         new ParquetIntDictionaryAwareDecimalConverter(precision, scale, updater)
 
       // For INT64 backed decimals
-      case _: DecimalType if parquetType.asPrimitiveType().getPrimitiveTypeName == INT64 =>
+      case t: DecimalType if parquetType.asPrimitiveType().getPrimitiveTypeName == INT64 =>
         val metadata = parquetType.asPrimitiveType().getDecimalMetadata
-        val precision = metadata.getPrecision()
-        val scale = metadata.getScale()
+        val precision = if (metadata == null) t.precision else metadata.getPrecision()
+        val scale = if (metadata == null) t.scale else metadata.getScale()
         new ParquetLongDictionaryAwareDecimalConverter(precision, scale, updater)
 
       // For BINARY and FIXED_LEN_BYTE_ARRAY backed decimals
-      case _: DecimalType
+      case t: DecimalType
         if parquetType.asPrimitiveType().getPrimitiveTypeName == FIXED_LEN_BYTE_ARRAY ||
            parquetType.asPrimitiveType().getPrimitiveTypeName == BINARY =>
         val metadata = parquetType.asPrimitiveType().getDecimalMetadata
-        val precision = metadata.getPrecision()
-        val scale = metadata.getScale()
+        val precision = if (metadata == null) t.precision else metadata.getPrecision()
+        val scale = if (metadata == null) t.scale else metadata.getScale()
         new ParquetBinaryDictionaryAwareDecimalConverter(precision, scale, updater)
 
       case t: DecimalType =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
@@ -243,6 +243,19 @@ private[parquet] class ParquetRowConverter(
   }
 
   /**
+   * Get a precision and a scale to interpret parquet decimal values.
+   * 1. If there is a decimal metadata, we read decimal values with the given precision and scale.
+   * 2. If there is no metadata, we read decimal values with scale `0` because it's plain integers
+   *    when it is written into INT32/INT64/BINARY/FIXED_LEN_BYTE_ARRAY types.
+   */
+  private def getPrecisionAndScale(parquetType: Type, t: DecimalType): (Int, Int) = {
+    val metadata = parquetType.asPrimitiveType().getDecimalMetadata
+    val precision = if (metadata == null) t.precision else metadata.getPrecision()
+    val scale = if (metadata == null) 0 else metadata.getScale()
+    (precision, scale)
+  }
+
+  /**
    * Creates a converter for the given Parquet type `parquetType` and Spark SQL data type
    * `catalystType`. Converted values are handled by `updater`.
    */
@@ -269,25 +282,19 @@ private[parquet] class ParquetRowConverter(
 
       // For INT32 backed decimals
       case t: DecimalType if parquetType.asPrimitiveType().getPrimitiveTypeName == INT32 =>
-        val metadata = parquetType.asPrimitiveType().getDecimalMetadata
-        val precision = if (metadata == null) t.precision else metadata.getPrecision()
-        val scale = if (metadata == null) t.scale else metadata.getScale()
+        val (precision, scale) = getPrecisionAndScale(parquetType, t)
         new ParquetIntDictionaryAwareDecimalConverter(precision, scale, updater)
 
       // For INT64 backed decimals
       case t: DecimalType if parquetType.asPrimitiveType().getPrimitiveTypeName == INT64 =>
-        val metadata = parquetType.asPrimitiveType().getDecimalMetadata
-        val precision = if (metadata == null) t.precision else metadata.getPrecision()
-        val scale = if (metadata == null) t.scale else metadata.getScale()
+        val (precision, scale) = getPrecisionAndScale(parquetType, t)
         new ParquetLongDictionaryAwareDecimalConverter(precision, scale, updater)
 
       // For BINARY and FIXED_LEN_BYTE_ARRAY backed decimals
       case t: DecimalType
         if parquetType.asPrimitiveType().getPrimitiveTypeName == FIXED_LEN_BYTE_ARRAY ||
            parquetType.asPrimitiveType().getPrimitiveTypeName == BINARY =>
-        val metadata = parquetType.asPrimitiveType().getDecimalMetadata
-        val precision = if (metadata == null) t.precision else metadata.getPrecision()
-        val scale = if (metadata == null) t.scale else metadata.getScale()
+        val (precision, scale) = getPrecisionAndScale(parquetType, t)
         new ParquetBinaryDictionaryAwareDecimalConverter(precision, scale, updater)
 
       case t: DecimalType =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3868,6 +3868,43 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
 
     assert(unions.size == 1)
   }
+
+  test("SPARK-34212 Parquet should read decimals correctly") {
+    // Decimal(2, 1) for INT32-backed decimal, Decimal(17, 2) for INT64-backed decimal
+    val df = sql("SELECT 1.0 a, CAST(100 AS DECIMAL(17, 2)) b, map(1, 2) c")
+
+    withTempPath { path =>
+      df.write.parquet(path.toString)
+
+      // 1. Complex schema disables vectorization automatically.
+      val schema1 = "a DECIMAL(3, 2), b DECIMAL(18, 3), c map<int,int>"
+      checkAnswer(spark.read.schema(schema1).parquet(path.toString), df)
+
+      // 2. Simple schema with explicitly-disabled vectorized reader
+      val schema2 = "a DECIMAL(3, 2), b DECIMAL(18, 3)"
+      withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false") {
+        checkAnswer(spark.read.schema(schema2).parquet(path.toString), df.select("a", "b"))
+      }
+
+      withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "true") {
+        // 3. Changed but incorrect
+        val schema3 = "a DECIMAL(3, 2), b DECIMAL(18, 3)"
+        val m1 = intercept[SparkException] {
+          checkAnswer(spark.read.schema(schema3).parquet(path.toString), df.select("a", "b"))
+        }.getCause.getMessage
+        assert(m1.contains("Schema evolution not supported"))
+
+        // 4. Spark raised SparkException due to SchemaColumnConvertNotSupportedException
+        //    because 19 > Decimal.MAX_LONG_DIGITS (18). Now, it raises SparkException
+        //    caused by UnsupportedOperationException.
+        val schema4 = "b DECIMAL(19, 3)"
+        val m2 = intercept[SparkException] {
+          checkAnswer(spark.read.schema(schema4).parquet(path.toString), df.select("b"))
+        }.getCause.getMessage
+        assert(m2.contains("Schema evolution not supported"))
+      }
+    }
+  }
 }
 
 case class Foo(bar: Option[String])

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3892,7 +3892,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
         val m1 = intercept[SparkException] {
           checkAnswer(spark.read.schema(schema3).parquet(path.toString), df.select("a", "b"))
         }.getCause.getMessage
-        assert(m1.contains("Schema evolution not supported"))
+        assert(m1.contains("Parquet vectorized reader doesn't support schema evolution on decimal"))
 
         // 4. Spark raised SparkException due to SchemaColumnConvertNotSupportedException
         //    because 19 > Decimal.MAX_LONG_DIGITS (18). Now, it raises SparkException
@@ -3901,7 +3901,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
         val m2 = intercept[SparkException] {
           checkAnswer(spark.read.schema(schema4).parquet(path.toString), df.select("b"))
         }.getCause.getMessage
-        assert(m2.contains("Schema evolution not supported"))
+        assert(m2.contains("Parquet vectorized reader doesn't support schema evolution on decimal"))
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to the correctness issues during reading decimal values from Parquet files.
- For **MR** code path, `ParquetRowConverter` can read Parquet's decimal values with the original precision and scale written in the corresponding footer.
- For **Vectorized** code path, `VectorizedColumnReader` throws `SchemaColumnConvertNotSupportedException`.

### Why are the changes needed?

Currently, Spark returns incorrect results when the Parquet file's decimal precision and scale are different from the Spark's schema. This happens when there is multiple files with different decimal schema or HiveMetastore has a new schema.

**BEFORE (Simplified example for correctness)**

```scala
scala> sql("SELECT 1.0 a").write.parquet("/tmp/decimal")
scala> spark.read.schema("a DECIMAL(3,2)").parquet("/tmp/decimal").show
+----+
|   a|
+----+
|0.10|
+----+
```

This works correctly in the other data sources, `ORC/JSON/CSV`, like the following.
```scala
scala> sql("SELECT 1.0 a").write.orc("/tmp/decimal_orc")
scala> spark.read.schema("a DECIMAL(3,2)").orc("/tmp/decimal_orc").show
+----+
|   a|
+----+
|1.00|
+----+
```

**AFTER**
1. **Vectorized** path: Instead of incorrect result, we will raise an explicit exception.
```scala
scala> spark.read.schema("a DECIMAL(3,2)").parquet("/tmp/decimal").show
java.lang.UnsupportedOperationException: Schema evolution not supported.
```

2. **MR** path (complex schema or explicit configuration): Spark returns correct results.
```scala
scala> spark.read.schema("a DECIMAL(3,2), b DECIMAL(18, 3), c MAP<INT,INT>").parquet("/tmp/decimal").show
+----+-------+--------+
|   a|      b|       c|
+----+-------+--------+
|1.00|100.000|{1 -> 2}|
+----+-------+--------+

scala> spark.read.schema("a DECIMAL(3,2), b DECIMAL(18, 3), c MAP<INT,INT>").parquet("/tmp/decimal").printSchema
root
 |-- a: decimal(3,2) (nullable = true)
 |-- b: decimal(18,3) (nullable = true)
 |-- c: map (nullable = true)
 |    |-- key: integer
 |    |-- value: integer (valueContainsNull = true)
```

### Does this PR introduce _any_ user-facing change?

Yes. This fixes the correctness issue.

### How was this patch tested?

Pass with the newly added test case.