### PR TITLE
[SPARK-34187][SS][2.4] Use available offset range obtained during polling when checking offset validation

### DIFF
--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaDataConsumer.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaDataConsumer.scala
@@ -98,18 +98,22 @@ private[kafka010] case class InternalKafkaConsumer(
    *                                 should check if the pre-fetched data is still valid.
    * @param _offsetAfterPoll the Kafka offset after calling `poll`. We will use this offset to
    *                           poll when `records` is drained.
+   * @param _availableOffsetRange the available offset range in Kafka when polling the records.
    */
   private case class FetchedData(
       private var _records: ju.ListIterator[ConsumerRecord[Array[Byte], Array[Byte]]],
       private var _nextOffsetInFetchedData: Long,
-      private var _offsetAfterPoll: Long) {
+      private var _offsetAfterPoll: Long,
+      private var _availableOffsetRange: AvailableOffsetRange) {
 
     def withNewPoll(
         records: ju.ListIterator[ConsumerRecord[Array[Byte], Array[Byte]]],
-        offsetAfterPoll: Long): FetchedData = {
+        offsetAfterPoll: Long,
+        availableOffsetRange: AvailableOffsetRange): FetchedData = {
       this._records = records
       this._nextOffsetInFetchedData = UNKNOWN_OFFSET
       this._offsetAfterPoll = offsetAfterPoll
+      this._availableOffsetRange = availableOffsetRange
       this
     }
 
@@ -136,6 +140,7 @@ private[kafka010] case class InternalKafkaConsumer(
       _records = ju.Collections.emptyListIterator()
       _nextOffsetInFetchedData = UNKNOWN_OFFSET
       _offsetAfterPoll = UNKNOWN_OFFSET
+      _availableOffsetRange = AvailableOffsetRange(UNKNOWN_OFFSET, UNKNOWN_OFFSET)
     }
 
     /**
@@ -148,6 +153,13 @@ private[kafka010] case class InternalKafkaConsumer(
      * Returns the next offset to poll after draining the pre-fetched records.
      */
     def offsetAfterPoll: Long = _offsetAfterPoll
+
+    /**
+     * Returns the tuple of earliest and latest offsets that is the available offset range when
+     * polling the records.
+     */
+    def availableOffsetRange: (Long, Long) =
+      (_availableOffsetRange.earliest, _availableOffsetRange.latest)
   }
 
   /**
@@ -186,7 +198,8 @@ private[kafka010] case class InternalKafkaConsumer(
   private val fetchedData = FetchedData(
     ju.Collections.emptyListIterator[ConsumerRecord[Array[Byte], Array[Byte]]],
     UNKNOWN_OFFSET,
-    UNKNOWN_OFFSET)
+    UNKNOWN_OFFSET,
+    AvailableOffsetRange(UNKNOWN_OFFSET, UNKNOWN_OFFSET))
 
   /**
    * The fetched record returned from the `fetchRecord` method. This is a reusable private object to
@@ -384,8 +397,8 @@ private[kafka010] case class InternalKafkaConsumer(
       // In general, Kafka uses the specified offset as the start point, and tries to fetch the next
       // available offset. Hence we need to handle offset mismatch.
       if (record.offset > offset) {
-        val range = getAvailableOffsetRange()
-        if (range.earliest <= offset) {
+        val (earliestOffset, _) = fetchedData.availableOffsetRange
+        if (earliestOffset <= offset) {
           // `offset` is still valid but the corresponding message is invisible. We should skip it
           // and jump to `record.offset`. Here we move `fetchedData` back so that the next call of
           // `fetchRecord` can just return `record` directly.
@@ -472,7 +485,8 @@ private[kafka010] case class InternalKafkaConsumer(
     logDebug(s"Polled $groupId ${p.partitions()}  ${r.size}")
     val offsetAfterPoll = consumer.position(topicPartition)
     logDebug(s"Offset changed from $offset to $offsetAfterPoll after polling")
-    fetchedData.withNewPoll(r.listIterator, offsetAfterPoll)
+    val range = getAvailableOffsetRange()
+    fetchedData.withNewPoll(r.listIterator, offsetAfterPoll, range)
     if (!fetchedData.hasNext) {
       // We cannot fetch anything after `poll`. Two possible cases:
       // - `offset` is out of range so that Kafka returns nothing. `OffsetOutOfRangeException` will
@@ -480,7 +494,6 @@ private[kafka010] case class InternalKafkaConsumer(
       // - Cannot fetch any data before timeout. `TimeoutException` will be thrown.
       // - Fetched something but all of them are not invisible. This is a valid case and let the
       //   caller handles this.
-      val range = getAvailableOffsetRange()
       if (offset < range.earliest || offset >= range.latest) {
         throw new OffsetOutOfRangeException(
           Map(topicPartition -> java.lang.Long.valueOf(offset)).asJava)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This patch uses the available offset range obtained during polling Kafka records to do offset validation check.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

We support non-consecutive offsets for Kafka since 2.4.0. In `fetchRecord`, we do offset validation by checking if the offset is in available offset range. But currently we obtain latest available offset range to do the check. It looks not correct as the available offset range could be changed during the batch, so the available offset range is different than the one when we polling the records from Kafka.

It is possible that an offset is valid when polling, but at the time we do the above check, it is out of latest available offset range. We will wrongly consider it as data loss case and fail the query or drop the record.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

This should pass existing unit tests.

This is hard to have unit test as the Kafka producer and the consumer is asynchronous. Further, we also need to make the offset out of new available offset range.