### PR TITLE
[SPARK-34203][SQL][TESTS][3.1][FOLLOWUP] Fix null partition values UT failure

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3773,17 +3773,6 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
       }
     }
   }
-
-  test("SPARK-33591: null as a partition value") {
-    val t = "part_table"
-    withTable(t) {
-      sql(s"CREATE TABLE $t (col1 INT, p1 STRING) USING PARQUET PARTITIONED BY (p1)")
-      sql(s"INSERT INTO TABLE $t PARTITION (p1 = null) SELECT 0")
-      checkAnswer(sql(s"SELECT * FROM $t"), Row(0, null))
-      sql(s"ALTER TABLE $t DROP PARTITION (p1 = null)")
-      checkAnswer(sql(s"SELECT * FROM $t"), Nil)
-    }
-  }
 }
 
 case class Foo(bar: Option[String])

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -1733,9 +1733,8 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
 
     // null partition values
     createTablePartition(catalog, Map("a" -> null, "b" -> null), tableIdent)
-    val nullPartValue = if (isUsingHiveMetastore) "__HIVE_DEFAULT_PARTITION__" else null
     assert(catalog.listPartitions(tableIdent).map(_.spec).toSet ==
-      Set(Map("a" -> nullPartValue, "b" -> nullPartValue)))
+      Set(Map("a" -> "__HIVE_DEFAULT_PARTITION__", "b" -> "__HIVE_DEFAULT_PARTITION__")))
     sql("ALTER TABLE tab1 DROP PARTITION (a = null, b = null)")
     assert(catalog.listPartitions(tableIdent).isEmpty)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Forward port changes in tests from https://github.com/apache/spark/pull/31326.

### Why are the changes needed?
This fixes a test failure.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
By running the affected test suite:
```
$ build/sbt -Phive -Phive-thriftserver "test:testOnly *CatalogedDDLSuite"
```