### PR TITLE
[SPARK-34182][AVRO] Improve error messages when matching Catalyst-to-Avro schemas

### DIFF
--- a/core/src/main/scala/org/apache/spark/TestUtils.scala
+++ b/core/src/main/scala/org/apache/spark/TestUtils.scala
@@ -34,6 +34,7 @@ import javax.tools.{JavaFileObject, SimpleJavaFileObject, ToolProvider}
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
+import scala.reflect.{classTag, ClassTag}
 import scala.sys.process.{Process, ProcessLogger}
 import scala.util.Try
 
@@ -223,24 +224,37 @@ private[spark] object TestUtils {
 
   /**
    * Asserts that exception message contains the message. Please note this checks all
-   * exceptions in the tree.
+   * exceptions in the tree. If a type parameter `E` is supplied, this will additionally confirm
+   * that the exception is a subtype of the exception provided in the type parameter.
    */
-  def assertExceptionMsg(exception: Throwable, msg: String, ignoreCase: Boolean = false): Unit = {
-    def contain(msg1: String, msg2: String): Boolean = {
+  def assertExceptionMsg[E <: Throwable : ClassTag](
+    exception: Throwable,
+    msg: String,
+    ignoreCase: Boolean = false): Unit = {
+
+    val (typeMsg, typeCheck) = if (classTag[E] == classTag[Nothing]) {
+      ("", (_: Throwable) => true)
+    } else {
+      val clazz = classTag[E].runtimeClass
+      (s"of type ${clazz.getName} ", (e: Throwable) => clazz.isAssignableFrom(e.getClass))
+    }
+
+    def contain(e: Throwable, msg: String): Boolean = {
       if (ignoreCase) {
-        msg1.toLowerCase(Locale.ROOT).contains(msg2.toLowerCase(Locale.ROOT))
+        e.getMessage.toLowerCase(Locale.ROOT).contains(msg.toLowerCase(Locale.ROOT))
       } else {
-        msg1.contains(msg2)
-      }
+        e.getMessage.contains(msg)
+      } && typeCheck(e)
     }
 
     var e = exception
-    var contains = contain(e.getMessage, msg)
+    var contains = contain(e, msg)
     while (e.getCause != null && !contains) {
       e = e.getCause
-      contains = contain(e.getMessage, msg)
+      contains = contain(e, msg)
     }
-    assert(contains, s"Exception tree doesn't contain the expected message: $msg")
+    assert(contains,
+      s"Exception tree doesn't contain the expected exception ${typeMsg}with message: $msg")
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/TestUtils.scala
+++ b/core/src/main/scala/org/apache/spark/TestUtils.scala
@@ -228,9 +228,9 @@ private[spark] object TestUtils {
    * that the exception is a subtype of the exception provided in the type parameter.
    */
   def assertExceptionMsg[E <: Throwable : ClassTag](
-    exception: Throwable,
-    msg: String,
-    ignoreCase: Boolean = false): Unit = {
+      exception: Throwable,
+      msg: String,
+      ignoreCase: Boolean = false): Unit = {
 
     val (typeMsg, typeCheck) = if (classTag[E] == classTag[Nothing]) {
       ("", (_: Throwable) => true)

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
@@ -93,7 +93,7 @@ private[sql] class AvroDeserializer(
     }
   } catch {
     case ise: IncompatibleSchemaException => throw new IncompatibleSchemaException(
-      s"Cannot convert Avro type $rootAvroType to Catalyst type $rootCatalystType.", ise)
+      s"Cannot convert Avro type $rootAvroType to Catalyst type ${rootCatalystType.sql}.", ise)
   }
 
   def deserialize(data: Any): Option[Any] = converter(data)
@@ -110,7 +110,7 @@ private[sql] class AvroDeserializer(
     val errorPrefix = s"Cannot convert Avro ${toFieldStr(avroPath)} to " +
         s"Catalyst ${toFieldStr(sqlPath)} because "
     val incompatibleMsg = errorPrefix +
-        s"schema is incompatible (avroType = $avroType, sqlType = $catalystType)"
+        s"schema is incompatible (avroType = $avroType, sqlType = ${catalystType.sql})"
 
     (avroType.getType, catalystType) match {
       case (NULL, NullType) => (updater, ordinal, _) =>

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
@@ -30,6 +30,7 @@ import org.apache.avro.Schema.Type._
 import org.apache.avro.generic._
 import org.apache.avro.util.Utf8
 
+import org.apache.spark.sql.avro.AvroUtils.toFieldStr
 import org.apache.spark.sql.catalyst.{InternalRow, NoopFilters, StructFilters}
 import org.apache.spark.sql.catalyst.expressions.{SpecificInternalRow, UnsafeArrayData}
 import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, ArrayData, DateTimeUtils, GenericArrayData}
@@ -64,30 +65,35 @@ private[sql] class AvroDeserializer(
   private val timestampRebaseFunc = DataSourceUtils.creteTimestampRebaseFuncInRead(
     datetimeRebaseMode, "Avro")
 
-  private val converter: Any => Option[Any] = rootCatalystType match {
-    // A shortcut for empty schema.
-    case st: StructType if st.isEmpty =>
-      (data: Any) => Some(InternalRow.empty)
+  private val converter: Any => Option[Any] = try {
+    rootCatalystType match {
+      // A shortcut for empty schema.
+      case st: StructType if st.isEmpty =>
+        (_: Any) => Some(InternalRow.empty)
 
-    case st: StructType =>
-      val resultRow = new SpecificInternalRow(st.map(_.dataType))
-      val fieldUpdater = new RowUpdater(resultRow)
-      val applyFilters = filters.skipRow(resultRow, _)
-      val writer = getRecordWriter(rootAvroType, st, Nil, applyFilters)
-      (data: Any) => {
-        val record = data.asInstanceOf[GenericRecord]
-        val skipRow = writer(fieldUpdater, record)
-        if (skipRow) None else Some(resultRow)
-      }
+      case st: StructType =>
+        val resultRow = new SpecificInternalRow(st.map(_.dataType))
+        val fieldUpdater = new RowUpdater(resultRow)
+        val applyFilters = filters.skipRow(resultRow, _)
+        val writer = getRecordWriter(rootAvroType, st, Nil, Nil, applyFilters)
+        (data: Any) => {
+          val record = data.asInstanceOf[GenericRecord]
+          val skipRow = writer(fieldUpdater, record)
+          if (skipRow) None else Some(resultRow)
+        }
 
-    case _ =>
-      val tmpRow = new SpecificInternalRow(Seq(rootCatalystType))
-      val fieldUpdater = new RowUpdater(tmpRow)
-      val writer = newWriter(rootAvroType, rootCatalystType, Nil)
-      (data: Any) => {
-        writer(fieldUpdater, 0, data)
-        Some(tmpRow.get(0, rootCatalystType))
-      }
+      case _ =>
+        val tmpRow = new SpecificInternalRow(Seq(rootCatalystType))
+        val fieldUpdater = new RowUpdater(tmpRow)
+        val writer = newWriter(rootAvroType, rootCatalystType, Nil, Nil)
+        (data: Any) => {
+          writer(fieldUpdater, 0, data)
+          Some(tmpRow.get(0, rootCatalystType))
+        }
+    }
+  } catch {
+    case ise: IncompatibleSchemaException => throw new IncompatibleSchemaException(
+      s"Cannot convert Avro type $rootAvroType to Catalyst type $rootCatalystType.", ise)
   }
 
   def deserialize(data: Any): Option[Any] = converter(data)
@@ -99,7 +105,13 @@ private[sql] class AvroDeserializer(
   private def newWriter(
       avroType: Schema,
       catalystType: DataType,
-      path: List[String]): (CatalystDataUpdater, Int, Any) => Unit =
+      avroPath: Seq[String],
+      sqlPath: Seq[String]): (CatalystDataUpdater, Int, Any) => Unit = {
+    val errorPrefix = s"Cannot convert Avro ${toFieldStr(avroPath)} to " +
+        s"Catalyst ${toFieldStr(sqlPath)} because "
+    val incompatibleMsg = errorPrefix +
+        s"schema is incompatible (avroType = $avroType, sqlType = $catalystType)"
+
     (avroType.getType, catalystType) match {
       case (NULL, NullType) => (updater, ordinal, _) =>
         updater.setNullAt(ordinal)
@@ -127,8 +139,8 @@ private[sql] class AvroDeserializer(
         case _: TimestampMicros => (updater, ordinal, value) =>
           val micros = value.asInstanceOf[Long]
           updater.setLong(ordinal, timestampRebaseFunc(micros))
-        case other => throw new IncompatibleSchemaException(
-          s"Cannot convert Avro logical type ${other} to Catalyst Timestamp type.")
+        case other => throw new IncompatibleSchemaException(errorPrefix +
+          s"Avro logical type $other cannot be converted to Catalyst Timestamp type.")
       }
 
       // Before we upgrade Avro to 1.8 for logical type support, spark-avro converts Long to Date.
@@ -165,7 +177,8 @@ private[sql] class AvroDeserializer(
             b.get(bytes)
             bytes
           case b: Array[Byte] => b
-          case other => throw new RuntimeException(s"$other is not a valid avro binary.")
+          case other =>
+            throw new RuntimeException(errorPrefix + s"$other is not a valid avro binary.")
         }
         updater.set(ordinal, bytes)
 
@@ -184,14 +197,17 @@ private[sql] class AvroDeserializer(
       case (RECORD, st: StructType) =>
         // Avro datasource doesn't accept filters with nested attributes. See SPARK-32328.
         // We can always return `false` from `applyFilters` for nested records.
-        val writeRecord = getRecordWriter(avroType, st, path, applyFilters = _ => false)
+        val writeRecord =
+          getRecordWriter(avroType, st, avroPath, sqlPath, applyFilters = _ => false)
         (updater, ordinal, value) =>
           val row = new SpecificInternalRow(st)
           writeRecord(new RowUpdater(row), value.asInstanceOf[GenericRecord])
           updater.set(ordinal, row)
 
       case (ARRAY, ArrayType(elementType, containsNull)) =>
-        val elementWriter = newWriter(avroType.getElementType, elementType, path)
+        val avroElementPath = avroPath :+ "element"
+        val elementWriter = newWriter(avroType.getElementType, elementType,
+          avroElementPath, sqlPath :+ "element")
         (updater, ordinal, value) =>
           val collection = value.asInstanceOf[java.util.Collection[Any]]
           val result = createArrayData(elementType, collection.size())
@@ -203,8 +219,8 @@ private[sql] class AvroDeserializer(
             val element = iter.next()
             if (element == null) {
               if (!containsNull) {
-                throw new RuntimeException(s"Array value at path ${path.mkString(".")} is not " +
-                  "allowed to be null")
+                throw new RuntimeException(
+                  s"Array value at path ${toFieldStr(avroElementPath)} is not allowed to be null")
               } else {
                 elementUpdater.setNullAt(i)
               }
@@ -217,8 +233,10 @@ private[sql] class AvroDeserializer(
           updater.set(ordinal, result)
 
       case (MAP, MapType(keyType, valueType, valueContainsNull)) if keyType == StringType =>
-        val keyWriter = newWriter(SchemaBuilder.builder().stringType(), StringType, path)
-        val valueWriter = newWriter(avroType.getValueType, valueType, path)
+        val keyWriter = newWriter(SchemaBuilder.builder().stringType(), StringType,
+          avroPath :+ "key", sqlPath :+ "key")
+        val valueWriter = newWriter(avroType.getValueType, valueType,
+          avroPath :+ "value", sqlPath :+ "value")
         (updater, ordinal, value) =>
           val map = value.asInstanceOf[java.util.Map[AnyRef, AnyRef]]
           val keyArray = createArrayData(keyType, map.size())
@@ -233,8 +251,8 @@ private[sql] class AvroDeserializer(
             keyWriter(keyUpdater, i, entry.getKey)
             if (entry.getValue == null) {
               if (!valueContainsNull) {
-                throw new RuntimeException(s"Map value at path ${path.mkString(".")} is not " +
-                  "allowed to be null")
+                throw new RuntimeException(
+                  s"Map value at path ${toFieldStr(avroPath :+ "value")} is not allowed to be null")
               } else {
                 valueUpdater.setNullAt(i)
               }
@@ -254,7 +272,7 @@ private[sql] class AvroDeserializer(
         val nonNullAvroType = Schema.createUnion(nonNullTypes.asJava)
         if (nonNullTypes.nonEmpty) {
           if (nonNullTypes.length == 1) {
-            newWriter(nonNullTypes.head, catalystType, path)
+            newWriter(nonNullTypes.head, catalystType, avroPath, sqlPath)
           } else {
             nonNullTypes.map(_.getType).toSeq match {
               case Seq(a, b) if Set(a, b) == Set(INT, LONG) && catalystType == LongType =>
@@ -275,7 +293,8 @@ private[sql] class AvroDeserializer(
                 catalystType match {
                   case st: StructType if st.length == nonNullTypes.size =>
                     val fieldWriters = nonNullTypes.zip(st.fields).map {
-                      case (schema, field) => newWriter(schema, field.dataType, path :+ field.name)
+                      case (schema, field) =>
+                        newWriter(schema, field.dataType, avroPath, sqlPath :+ field.name)
                     }.toArray
                     (updater, ordinal, value) => {
                       val row = new SpecificInternalRow(st)
@@ -285,27 +304,17 @@ private[sql] class AvroDeserializer(
                       updater.set(ordinal, row)
                     }
 
-                  case _ =>
-                    throw new IncompatibleSchemaException(
-                      s"Cannot convert Avro to catalyst because schema at path " +
-                        s"${path.mkString(".")} is not compatible " +
-                        s"(avroType = $avroType, sqlType = $catalystType).\n" +
-                        s"Source Avro schema: $rootAvroType.\n" +
-                        s"Target Catalyst type: $rootCatalystType")
+                  case _ => throw new IncompatibleSchemaException(incompatibleMsg)
                 }
             }
           }
         } else {
-          (updater, ordinal, value) => updater.setNullAt(ordinal)
+          (updater, ordinal, _) => updater.setNullAt(ordinal)
         }
 
-      case _ =>
-        throw new IncompatibleSchemaException(
-          s"Cannot convert Avro to catalyst because schema at path ${path.mkString(".")} " +
-            s"is not compatible (avroType = $avroType, sqlType = $catalystType).\n" +
-            s"Source Avro schema: $rootAvroType.\n" +
-            s"Target Catalyst type: $rootCatalystType")
+      case _ => throw new IncompatibleSchemaException(incompatibleMsg)
     }
+  }
 
   // TODO: move the following method in Decimal object on creating Decimal from BigDecimal?
   private def createDecimal(decimal: BigDecimal, precision: Int, scale: Int): Decimal = {
@@ -321,7 +330,8 @@ private[sql] class AvroDeserializer(
   private def getRecordWriter(
       avroType: Schema,
       sqlType: StructType,
-      path: List[String],
+      avroPath: Seq[String],
+      sqlPath: Seq[String],
       applyFilters: Int => Boolean): (CatalystDataUpdater, GenericRecord) => Boolean = {
     val validFieldIndexes = ArrayBuffer.empty[Int]
     val fieldWriters = ArrayBuffer.empty[(CatalystDataUpdater, Any) => Unit]
@@ -330,11 +340,12 @@ private[sql] class AvroDeserializer(
     var i = 0
     while (i < length) {
       val sqlField = sqlType.fields(i)
-      AvroUtils.getAvroFieldByName(avroType, sqlField.name) match {
+      AvroUtils.getAvroFieldByName(avroType, sqlField.name, avroPath) match {
         case Some(avroField) =>
           validFieldIndexes += avroField.pos()
 
-          val baseWriter = newWriter(avroField.schema(), sqlField.dataType, path :+ sqlField.name)
+          val baseWriter = newWriter(avroField.schema(), sqlField.dataType,
+            avroPath :+ avroField.name, sqlPath :+ sqlField.name)
           val ordinal = i
           val fieldWriter = (fieldUpdater: CatalystDataUpdater, value: Any) => {
             if (value == null) {
@@ -345,13 +356,8 @@ private[sql] class AvroDeserializer(
           }
           fieldWriters += fieldWriter
         case None if !sqlField.nullable =>
-          val fieldStr = s"${path.mkString(".")}.${sqlField.name}"
-          throw new IncompatibleSchemaException(
-            s"""
-               |Cannot find non-nullable field $fieldStr in Avro schema.
-               |Source Avro schema: $rootAvroType.
-               |Target Catalyst type: $rootCatalystType.
-           """.stripMargin)
+          throw new IncompatibleSchemaException(s"Cannot find non-nullable " +
+              s"${toFieldStr(sqlPath :+ sqlField.name)} in Avro schema.")
         case _ => // nothing to do
       }
       i += 1

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroSerializer.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroSerializer.scala
@@ -32,6 +32,7 @@ import org.apache.avro.generic.GenericData.Record
 import org.apache.avro.util.Utf8
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.avro.AvroUtils.toFieldStr
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{SpecializedGetters, SpecificInternalRow}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
@@ -67,15 +68,20 @@ private[sql] class AvroSerializer(
 
   private val converter: Any => Any = {
     val actualAvroType = resolveNullableType(rootAvroType, nullable)
-    val baseConverter = rootCatalystType match {
-      case st: StructType =>
-        newStructConverter(st, actualAvroType).asInstanceOf[Any => Any]
-      case _ =>
-        val tmpRow = new SpecificInternalRow(Seq(rootCatalystType))
-        val converter = newConverter(rootCatalystType, actualAvroType)
-        (data: Any) =>
-          tmpRow.update(0, data)
-          converter.apply(tmpRow, 0)
+    val baseConverter = try {
+      rootCatalystType match {
+        case st: StructType =>
+          newStructConverter(st, actualAvroType, Nil, Nil).asInstanceOf[Any => Any]
+        case _ =>
+          val tmpRow = new SpecificInternalRow(Seq(rootCatalystType))
+          val converter = newConverter(rootCatalystType, actualAvroType, Nil, Nil)
+          (data: Any) =>
+            tmpRow.update(0, data)
+            converter.apply(tmpRow, 0)
+      }
+    } catch {
+      case ise: IncompatibleSchemaException => throw new IncompatibleSchemaException(
+        s"Cannot convert Catalyst type $rootCatalystType to Avro type $rootAvroType.", ise)
     }
     if (nullable) {
       (data: Any) =>
@@ -93,7 +99,10 @@ private[sql] class AvroSerializer(
 
   private lazy val decimalConversions = new DecimalConversion()
 
-  private def newConverter(catalystType: DataType, avroType: Schema): Converter = {
+  private def newConverter(catalystType: DataType, avroType: Schema,
+    catalystPath: Seq[String], avroPath: Seq[String]): Converter = {
+    val errorPrefix = s"Cannot convert Catalyst ${toFieldStr(catalystPath)} " +
+      s"to Avro ${toFieldStr(avroPath)} because "
     (catalystType, avroType.getType) match {
       case (NullType, NULL) =>
         (getter, ordinal) => null
@@ -130,9 +139,9 @@ private[sql] class AvroSerializer(
         (getter, ordinal) =>
           val data = getter.getUTF8String(ordinal).toString
           if (!enumSymbols.contains(data)) {
-            throw new IncompatibleSchemaException(
-              "Cannot write \"" + data + "\" since it's not defined in enum \"" +
-                enumSymbols.mkString("\", \"") + "\"")
+            throw new IncompatibleSchemaException(errorPrefix +
+              s""""$data" cannot be written since it's not defined in enum """ +
+                enumSymbols.mkString("\"", "\", \"", "\""))
           }
           new EnumSymbol(avroType, data)
 
@@ -140,14 +149,13 @@ private[sql] class AvroSerializer(
         (getter, ordinal) => new Utf8(getter.getUTF8String(ordinal).getBytes)
 
       case (BinaryType, FIXED) =>
-        val size = avroType.getFixedSize()
+        val size = avroType.getFixedSize
         (getter, ordinal) =>
           val data: Array[Byte] = getter.getBinary(ordinal)
           if (data.length != size) {
-            throw new IncompatibleSchemaException(
-              s"Cannot write ${data.length} ${if (data.length > 1) "bytes" else "byte"} of " +
-                "binary data into FIXED Type with size of " +
-                s"$size ${if (size > 1) "bytes" else "byte"}")
+            def len2str(len: Int): String = s"$len ${if (len > 1) "bytes" else "byte"}"
+            throw new IncompatibleSchemaException(errorPrefix + len2str(data.length) +
+                " of binary data cannot be written into FIXED type with size of " + len2str(size))
           }
           new Fixed(avroType, data)
 
@@ -164,13 +172,14 @@ private[sql] class AvroSerializer(
             DateTimeUtils.microsToMillis(timestampRebaseFunc(getter.getLong(ordinal)))
           case _: TimestampMicros => (getter, ordinal) =>
             timestampRebaseFunc(getter.getLong(ordinal))
-          case other => throw new IncompatibleSchemaException(
-            s"Cannot convert Catalyst Timestamp type to Avro logical type ${other}")
+          case other => throw new IncompatibleSchemaException(errorPrefix +
+            s"Catalyst Timestamp type cannot be converted to Avro logical type $other")
         }
 
       case (ArrayType(et, containsNull), ARRAY) =>
         val elementConverter = newConverter(
-          et, resolveNullableType(avroType.getElementType, containsNull))
+          et, resolveNullableType(avroType.getElementType, containsNull),
+          catalystPath :+ "element", avroPath :+ "element")
         (getter, ordinal) => {
           val arrayData = getter.getArray(ordinal)
           val len = arrayData.numElements()
@@ -190,13 +199,14 @@ private[sql] class AvroSerializer(
         }
 
       case (st: StructType, RECORD) =>
-        val structConverter = newStructConverter(st, avroType)
+        val structConverter = newStructConverter(st, avroType, catalystPath, avroPath)
         val numFields = st.length
         (getter, ordinal) => structConverter(getter.getStruct(ordinal, numFields))
 
       case (MapType(kt, vt, valueContainsNull), MAP) if kt == StringType =>
         val valueConverter = newConverter(
-          vt, resolveNullableType(avroType.getValueType, valueContainsNull))
+          vt, resolveNullableType(avroType.getValueType, valueContainsNull),
+          catalystPath :+ "value", avroPath :+ "value")
         (getter, ordinal) =>
           val mapData = getter.getMap(ordinal)
           val len = mapData.numElements()
@@ -215,28 +225,40 @@ private[sql] class AvroSerializer(
           }
           result
 
-      case other =>
-        throw new IncompatibleSchemaException(s"Cannot convert Catalyst type $catalystType to " +
-          s"Avro type $avroType.")
+      case _ =>
+        throw new IncompatibleSchemaException(errorPrefix +
+          s"schema is incompatible (sqlType = $catalystType, avroType = $avroType)")
     }
   }
 
   private def newStructConverter(
-      catalystStruct: StructType, avroStruct: Schema): InternalRow => Record = {
-    if (avroStruct.getType != RECORD || avroStruct.getFields.size() != catalystStruct.length) {
-      throw new IncompatibleSchemaException(s"Cannot convert Catalyst type $catalystStruct to " +
-        s"Avro type $avroStruct.")
+      catalystStruct: StructType,
+      avroStruct: Schema,
+      catalystPath: Seq[String],
+      avroPath: Seq[String]): InternalRow => Record = {
+
+    val avroPathStr = toFieldStr(avroPath)
+    if (avroStruct.getType != RECORD) {
+      throw new IncompatibleSchemaException(s"$avroPathStr was not a RECORD")
+    }
+    val avroFields = avroStruct.getFields.asScala
+    if (avroFields.size != catalystStruct.length) {
+      throw new IncompatibleSchemaException(
+        s"Avro $avroPathStr schema length (${avroFields.size}) doesn't match " +
+        s"Catalyst ${toFieldStr(catalystPath)} schema length (${catalystStruct.length})")
     }
 
     val (avroIndices: Array[Int], fieldConverters: Array[Converter]) =
       catalystStruct.map { catalystField =>
-        val avroField = AvroUtils.getAvroFieldByName(avroStruct, catalystField.name) match {
+        val avroField = AvroUtils
+            .getAvroFieldByName(avroStruct, catalystField.name, avroPath) match {
           case Some(f) => f
-          case None => throw new IncompatibleSchemaException(
-            s"Cannot find ${catalystField.name} in Avro schema")
+          case None => throw new IncompatibleSchemaException(s"Cannot find " +
+              s"${toFieldStr(catalystPath :+ catalystField.name)} in Avro schema at $avroPathStr")
         }
-        val converter = newConverter(catalystField.dataType, resolveNullableType(
-          avroField.schema(), catalystField.nullable))
+        val converter = newConverter(catalystField.dataType,
+          resolveNullableType(avroField.schema(), catalystField.nullable),
+          catalystPath :+ catalystField.name, avroPath :+ avroField.name)
         (avroField.pos(), converter)
       }.toArray.unzip
 

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroSerializer.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroSerializer.scala
@@ -81,7 +81,7 @@ private[sql] class AvroSerializer(
       }
     } catch {
       case ise: IncompatibleSchemaException => throw new IncompatibleSchemaException(
-        s"Cannot convert Catalyst type ${rootCatalystType.sql} to Avro type $rootAvroType.", ise)
+        s"Cannot convert SQL type ${rootCatalystType.sql} to Avro type $rootAvroType.", ise)
     }
     if (nullable) {
       (data: Any) =>
@@ -99,9 +99,12 @@ private[sql] class AvroSerializer(
 
   private lazy val decimalConversions = new DecimalConversion()
 
-  private def newConverter(catalystType: DataType, avroType: Schema,
-    catalystPath: Seq[String], avroPath: Seq[String]): Converter = {
-    val errorPrefix = s"Cannot convert Catalyst ${toFieldStr(catalystPath)} " +
+  private def newConverter(
+      catalystType: DataType,
+      avroType: Schema,
+      catalystPath: Seq[String],
+      avroPath: Seq[String]): Converter = {
+    val errorPrefix = s"Cannot convert SQL ${toFieldStr(catalystPath)} " +
       s"to Avro ${toFieldStr(avroPath)} because "
     (catalystType, avroType.getType) match {
       case (NullType, NULL) =>
@@ -173,7 +176,7 @@ private[sql] class AvroSerializer(
           case _: TimestampMicros => (getter, ordinal) =>
             timestampRebaseFunc(getter.getLong(ordinal))
           case other => throw new IncompatibleSchemaException(errorPrefix +
-            s"Catalyst Timestamp type cannot be converted to Avro logical type $other")
+            s"SQL type ${TimestampType.sql} cannot be converted to Avro logical type $other")
         }
 
       case (ArrayType(et, containsNull), ARRAY) =>
@@ -245,7 +248,7 @@ private[sql] class AvroSerializer(
     if (avroFields.size != catalystStruct.length) {
       throw new IncompatibleSchemaException(
         s"Avro $avroPathStr schema length (${avroFields.size}) doesn't match " +
-        s"Catalyst ${toFieldStr(catalystPath)} schema length (${catalystStruct.length})")
+        s"SQL ${toFieldStr(catalystPath)} schema length (${catalystStruct.length})")
     }
 
     val (avroIndices: Array[Int], fieldConverters: Array[Converter]) =

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroSerializer.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroSerializer.scala
@@ -81,7 +81,7 @@ private[sql] class AvroSerializer(
       }
     } catch {
       case ise: IncompatibleSchemaException => throw new IncompatibleSchemaException(
-        s"Cannot convert Catalyst type $rootCatalystType to Avro type $rootAvroType.", ise)
+        s"Cannot convert Catalyst type ${rootCatalystType.sql} to Avro type $rootAvroType.", ise)
     }
     if (nullable) {
       (data: Any) =>
@@ -227,7 +227,7 @@ private[sql] class AvroSerializer(
 
       case _ =>
         throw new IncompatibleSchemaException(errorPrefix +
-          s"schema is incompatible (sqlType = $catalystType, avroType = $avroType)")
+          s"schema is incompatible (sqlType = ${catalystType.sql}, avroType = $avroType)")
     }
   }
 

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
@@ -240,10 +240,8 @@ private[sql] object AvroUtils extends Logging {
    * string representing the field, like "field 'foo.bar'". If `names` is empty, the string
    * "top-level record" is returned.
    */
-  private[avro] def toFieldStr(names: Seq[String]): String = {
-    names match {
-      case Seq() => "top-level record"
-      case n => s"field '${n.mkString(".")}'"
-    }
+  private[avro] def toFieldStr(names: Seq[String]): String = names match {
+    case Seq() => "top-level record"
+    case n => s"field '${n.mkString(".")}'"
   }
 }

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
@@ -210,6 +210,7 @@ private[sql] object AvroUtils extends Logging {
    *
    * @param avroSchema The schema in which to search for the field. Must be of type RECORD.
    * @param name The name of the field to search for.
+   * @param avroPath The seq of parent field names leading to `avroSchema`.
    * @return `Some(match)` if a matching Avro field is found, otherwise `None`.
    * @throws IncompatibleSchemaException if `avroSchema` is not a RECORD or contains multiple
    *                                     fields matching `name` (i.e., case-insensitive matching
@@ -218,7 +219,8 @@ private[sql] object AvroUtils extends Logging {
    */
   private[avro] def getAvroFieldByName(
       avroSchema: Schema,
-      name: String): Option[Schema.Field] = {
+      name: String,
+      avroPath: Seq[String]): Option[Schema.Field] = {
     if (avroSchema.getType != Schema.Type.RECORD) {
       throw new IncompatibleSchemaException(
         s"Attempting to treat ${avroSchema.getName} as a RECORD, but it was: ${avroSchema.getType}")
@@ -226,10 +228,22 @@ private[sql] object AvroUtils extends Logging {
     avroSchema.getFields.asScala.filter(f => SQLConf.get.resolver(f.name(), name)).toSeq match {
       case Seq(avroField) => Some(avroField)
       case Seq() => None
-      case matches => throw new IncompatibleSchemaException(
-        s"Searching for '$name' in Avro schema gave ${matches.size} matches. Candidates: " +
-            matches.map(_.name()).mkString("[", ", ", "]")
+      case matches => throw new IncompatibleSchemaException(s"Searching for '$name' in Avro " +
+          s"schema at ${toFieldStr(avroPath)} gave ${matches.size} matches. Candidates: " +
+          matches.map(_.name()).mkString("[", ", ", "]")
       )
+    }
+  }
+
+  /**
+   * Convert a sequence of hierarchical field names (like `Seq(foo, bar)`) into a human-readable
+   * string representing the field, like "field 'foo.bar'". If `names` is empty, the string
+   * "top-level record" is returned.
+   */
+  private[avro] def toFieldStr(names: Seq[String]): String = {
+    names match {
+      case Seq() => "top-level record"
+      case n => s"field '${n.mkString(".")}'"
     }
   }
 }

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroCatalystDataConversionSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroCatalystDataConversionSuite.scala
@@ -272,7 +272,7 @@ class AvroCatalystDataConversionSuite extends SparkFunSuite
     val message = intercept[IncompatibleSchemaException] {
       CatalystDataToAvro(Literal("SPADES"), Some("\"long\"")).eval()
     }.getMessage
-    assert(message ==  "Cannot convert Catalyst type StringType to Avro type \"long\".")
+    assert(message === "Cannot convert SQL type STRING to Avro type \"long\".")
   }
 
   private def checkDeserialization(

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSerdeSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSerdeSuite.scala
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.avro
+
+import org.apache.avro.{Schema, SchemaBuilder}
+import org.apache.avro.generic.GenericRecordBuilder
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.types.{IntegerType, StructType}
+
+/**
+ * Tests for [[AvroSerializer]] and [[AvroDeserializer]], complementing those in [[AvroSuite]]
+ * with a more specific focus on those classes.
+ */
+class AvroSerdeSuite extends SparkFunSuite {
+  import AvroSerdeSuite._
+
+  test("Test basic conversion") {
+    val avro = createNestedAvroSchemaWithFields("foo", _.optionalInt("bar"))
+    val record = new GenericRecordBuilder(avro)
+        .set("foo", new GenericRecordBuilder(avro.getField("foo").schema()).set("bar", 42).build())
+        .build()
+    val serializer = new AvroSerializer(CATALYST_STRUCT, avro, false)
+    val deserializer = new AvroDeserializer(avro, CATALYST_STRUCT)
+    assert(serializer.serialize(deserializer.deserialize(record).get) === record)
+  }
+
+  test("Fail to convert with field type mismatch") {
+    val avro = createAvroSchemaWithTopLevelFields(_.requiredInt("foo"))
+
+    assertFailedConversionMessage(avro, deserialize = true,
+      "Cannot convert Avro field 'foo' to Catalyst field 'foo' because schema is incompatible " +
+          s"""(avroType = "int", sqlType = ${CATALYST_STRUCT.head.dataType})""")
+
+    assertFailedConversionMessage(avro, deserialize = false,
+      s"Cannot convert Catalyst field 'foo' to Avro field 'foo' because schema is incompatible " +
+          s"""(sqlType = ${CATALYST_STRUCT.head.dataType}, avroType = "int")""")
+  }
+
+  test("Fail to convert with nested field type mismatch") {
+    val avro = createNestedAvroSchemaWithFields("foo", _.optionalFloat("bar"))
+
+    assertFailedConversionMessage(avro, deserialize = true,
+      "Cannot convert Avro field 'foo.bar' to Catalyst field 'foo.bar' because schema is " +
+          """incompatible (avroType = "float", sqlType = IntegerType)""")
+
+    assertFailedConversionMessage(avro, deserialize = false,
+      "Cannot convert Catalyst field 'foo.bar' to Avro field 'foo.bar' because " +
+        """schema is incompatible (sqlType = IntegerType, avroType = "float")""")
+  }
+
+  test("Fail to convert with nested field name mismatch") {
+    val avro = createNestedAvroSchemaWithFields("foo", _.optionalInt("NOTbar"))
+    val nonnullCatalyst = new StructType()
+        .add("foo", new StructType().add("bar", IntegerType, nullable = false))
+
+    // deserialize should have no issues when 'bar' is nullable but fail when it is nonnull
+    new AvroDeserializer(avro, CATALYST_STRUCT)
+    assertFailedConversionMessage(avro, deserialize = true,
+      "Cannot find non-nullable field 'foo.bar' in Avro schema.",
+      nonnullCatalyst)
+
+    // serialize fails whether or not 'bar' is nullable
+    val expectMsg = "Cannot find field 'foo.bar' in Avro schema at field 'foo'"
+    assertFailedConversionMessage(avro, deserialize = false, expectMsg)
+    assertFailedConversionMessage(avro, deserialize = false, expectMsg, nonnullCatalyst)
+  }
+
+  test("Fail to convert with deeply nested field type mismatch") {
+    val avro = SchemaBuilder.builder().record("toptest").fields()
+        .name("top").`type`(createNestedAvroSchemaWithFields("foo", _.optionalFloat("bar")))
+        .noDefault().endRecord()
+    val catalyst = new StructType().add("top", CATALYST_STRUCT)
+
+    assertFailedConversionMessage(avro, deserialize = true,
+      "Cannot convert Avro field 'top.foo.bar' to Catalyst field 'top.foo.bar' because schema " +
+        """is incompatible (avroType = "float", sqlType = IntegerType)""",
+      catalyst)
+
+    assertFailedConversionMessage(avro, deserialize = false,
+      "Cannot convert Catalyst field 'top.foo.bar' to Avro field 'top.foo.bar' because schema is " +
+          """incompatible (sqlType = IntegerType, avroType = "float")""",
+      catalyst)
+  }
+
+  test("Fail to convert for serialization with field count mismatch") {
+    val tooManyFields = createAvroSchemaWithTopLevelFields(_.optionalInt("foo").optionalLong("bar"))
+    assertFailedConversionMessage(tooManyFields, deserialize = false,
+      "Avro top-level record schema length (2) " +
+        "doesn't match Catalyst top-level record schema length (1)")
+
+    val tooFewFields = createAvroSchemaWithTopLevelFields(f => f)
+    assertFailedConversionMessage(tooFewFields, deserialize = false,
+      "Avro top-level record schema length (0) " +
+        "doesn't match Catalyst top-level record schema length (1)")
+  }
+
+  /**
+   * Attempt to convert `catalystSchema` to `avroSchema` (or vice-versa if `deserialize` is true),
+   * assert that it fails, and assert that the _cause_ of the thrown exception has a message
+   * matching `expectedCauseMessage`.
+   */
+  private def assertFailedConversionMessage(avroSchema: Schema,
+    deserialize: Boolean,
+    expectedCauseMessage: String,
+    catalystSchema: StructType = CATALYST_STRUCT): Unit = {
+    val e = intercept[IncompatibleSchemaException] {
+      if (deserialize) {
+        new AvroDeserializer(avroSchema, catalystSchema)
+      } else {
+        new AvroSerializer(catalystSchema, avroSchema, false)
+      }
+    }
+    val expectMsg = if (deserialize) {
+      s"Cannot convert Avro type $avroSchema to Catalyst type $catalystSchema."
+    } else {
+      s"Cannot convert Catalyst type $catalystSchema to Avro type $avroSchema."
+    }
+    assert(e.getMessage === expectMsg)
+    assert(e.getCause.getMessage === expectedCauseMessage)
+  }
+}
+
+
+object AvroSerdeSuite {
+
+  private val CATALYST_STRUCT = new StructType()
+      .add("foo", new StructType().add("bar", IntegerType))
+
+  /**
+   * Convenience method to create a top-level Avro schema with a single nested record
+   * (at field name `nestedRecordFieldName`) which has fields as defined by those set
+   * on the field assembler using `f`.
+   */
+  private def createNestedAvroSchemaWithFields(
+    nestedRecordFieldName: String,
+    f: SchemaBuilder.FieldAssembler[Schema] => SchemaBuilder.FieldAssembler[Schema]): Schema = {
+    createAvroSchemaWithTopLevelFields(_.name(nestedRecordFieldName)
+        .`type`(f(SchemaBuilder.builder().record("test").fields()).endRecord())
+        .noDefault())
+  }
+
+  /**
+   * Convenience method to create a top-level Avro schema with fields as defined by those set
+   * on the field assembler using `f`.
+   */
+  private def createAvroSchemaWithTopLevelFields(
+    f: SchemaBuilder.FieldAssembler[Schema] => SchemaBuilder.FieldAssembler[Schema]): Schema = {
+    f(SchemaBuilder.builder().record("top").fields()).endRecord()
+  }
+}

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSerdeSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSerdeSuite.scala
@@ -44,11 +44,11 @@ class AvroSerdeSuite extends SparkFunSuite {
 
     assertFailedConversionMessage(avro, deserialize = true,
       "Cannot convert Avro field 'foo' to Catalyst field 'foo' because schema is incompatible " +
-          s"""(avroType = "int", sqlType = ${CATALYST_STRUCT.head.dataType})""")
+          s"""(avroType = "int", sqlType = ${CATALYST_STRUCT.head.dataType.sql})""")
 
     assertFailedConversionMessage(avro, deserialize = false,
       s"Cannot convert Catalyst field 'foo' to Avro field 'foo' because schema is incompatible " +
-          s"""(sqlType = ${CATALYST_STRUCT.head.dataType}, avroType = "int")""")
+          s"""(sqlType = ${CATALYST_STRUCT.head.dataType.sql}, avroType = "int")""")
   }
 
   test("Fail to convert with nested field type mismatch") {
@@ -56,11 +56,11 @@ class AvroSerdeSuite extends SparkFunSuite {
 
     assertFailedConversionMessage(avro, deserialize = true,
       "Cannot convert Avro field 'foo.bar' to Catalyst field 'foo.bar' because schema is " +
-          """incompatible (avroType = "float", sqlType = IntegerType)""")
+          """incompatible (avroType = "float", sqlType = INT)""")
 
     assertFailedConversionMessage(avro, deserialize = false,
       "Cannot convert Catalyst field 'foo.bar' to Avro field 'foo.bar' because " +
-        """schema is incompatible (sqlType = IntegerType, avroType = "float")""")
+        """schema is incompatible (sqlType = INT, avroType = "float")""")
   }
 
   test("Fail to convert with nested field name mismatch") {
@@ -88,12 +88,12 @@ class AvroSerdeSuite extends SparkFunSuite {
 
     assertFailedConversionMessage(avro, deserialize = true,
       "Cannot convert Avro field 'top.foo.bar' to Catalyst field 'top.foo.bar' because schema " +
-        """is incompatible (avroType = "float", sqlType = IntegerType)""",
+        """is incompatible (avroType = "float", sqlType = INT)""",
       catalyst)
 
     assertFailedConversionMessage(avro, deserialize = false,
       "Cannot convert Catalyst field 'top.foo.bar' to Avro field 'top.foo.bar' because schema is " +
-          """incompatible (sqlType = IntegerType, avroType = "float")""",
+          """incompatible (sqlType = INT, avroType = "float")""",
       catalyst)
   }
 
@@ -126,9 +126,9 @@ class AvroSerdeSuite extends SparkFunSuite {
       }
     }
     val expectMsg = if (deserialize) {
-      s"Cannot convert Avro type $avroSchema to Catalyst type $catalystSchema."
+      s"Cannot convert Avro type $avroSchema to Catalyst type ${catalystSchema.sql}."
     } else {
-      s"Cannot convert Catalyst type $catalystSchema to Avro type $avroSchema."
+      s"Cannot convert Catalyst type ${catalystSchema.sql} to Avro type $avroSchema."
     }
     assert(e.getMessage === expectMsg)
     assert(e.getCause.getMessage === expectedCauseMessage)

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -25,7 +25,7 @@ import java.util.{Locale, UUID}
 
 import scala.collection.JavaConverters._
 
-import org.apache.avro.Schema
+import org.apache.avro.{AvroTypeException, Schema}
 import org.apache.avro.Schema.{Field, Type}
 import org.apache.avro.Schema.Type._
 import org.apache.avro.file.{DataFileReader, DataFileWriter}
@@ -774,15 +774,15 @@ abstract class AvroSuite
       checkAvroSchemaEquals(avroSchema, getAvroSchemaStringFromFiles(tempSaveDir))
 
       // Writing df containing data not in the enum will throw an exception
-      val message = intercept[SparkException] {
+      val e = intercept[SparkException] {
         spark.createDataFrame(spark.sparkContext.parallelize(Seq(
           Row("SPADES"), Row("NOT-IN-ENUM"), Row("HEARTS"), Row("DIAMONDS"))),
           StructType(Seq(StructField("Suit", StringType, true))))
           .write.format("avro").option("avroSchema", avroSchema)
           .save(s"$tempDir/${UUID.randomUUID()}")
-      }.getCause.getMessage
-      assert(message.contains("org.apache.spark.sql.avro.IncompatibleSchemaException: " +
-        "Cannot write \"NOT-IN-ENUM\" since it's not defined in enum"))
+      }
+      assertExceptionMsg[IncompatibleSchemaException](e,
+        """"NOT-IN-ENUM" cannot be written since it's not defined in enum""")
     }
   }
 
@@ -820,22 +820,22 @@ abstract class AvroSuite
 
       // Writing df containing nulls without using avro union type will
       // throw an exception as avro uses union type to handle null.
-      val message1 = intercept[SparkException] {
+      val e1 = intercept[SparkException] {
         dfWithNull.write.format("avro")
           .option("avroSchema", avroSchema).save(s"$tempDir/${UUID.randomUUID()}")
-      }.getCause.getMessage
-      assert(message1.contains("org.apache.avro.AvroTypeException: Not an enum: null"))
+      }
+      assertExceptionMsg[AvroTypeException](e1, "Not an enum: null")
 
       // Writing df containing data not in the enum will throw an exception
-      val message2 = intercept[SparkException] {
+      val e2 = intercept[SparkException] {
         spark.createDataFrame(spark.sparkContext.parallelize(Seq(
           Row("SPADES"), Row("NOT-IN-ENUM"), Row("HEARTS"), Row("DIAMONDS"))),
           StructType(Seq(StructField("Suit", StringType, false))))
           .write.format("avro").option("avroSchema", avroSchema)
           .save(s"$tempDir/${UUID.randomUUID()}")
-      }.getCause.getMessage
-      assert(message2.contains("org.apache.spark.sql.avro.IncompatibleSchemaException: " +
-        "Cannot write \"NOT-IN-ENUM\" since it's not defined in enum"))
+      }
+      assertExceptionMsg[IncompatibleSchemaException](e2,
+        """"NOT-IN-ENUM" cannot be written since it's not defined in enum""")
     }
   }
 
@@ -868,26 +868,26 @@ abstract class AvroSuite
       checkAvroSchemaEquals(avroSchema, getAvroSchemaStringFromFiles(tempSaveDir))
 
       // Writing df containing binary data that doesn't fit FIXED size will throw an exception
-      val message1 = intercept[SparkException] {
+      val e1 = intercept[SparkException] {
         spark.createDataFrame(spark.sparkContext.parallelize(Seq(
           Row(Array(192, 168, 1).map(_.toByte)))),
           StructType(Seq(StructField("fixed2", BinaryType, true))))
           .write.format("avro").option("avroSchema", avroSchema)
           .save(s"$tempDir/${UUID.randomUUID()}")
-      }.getCause.getMessage
-      assert(message1.contains("org.apache.spark.sql.avro.IncompatibleSchemaException: " +
-        "Cannot write 3 bytes of binary data into FIXED Type with size of 2 bytes"))
+      }
+      assertExceptionMsg[IncompatibleSchemaException](e1,
+        "3 bytes of binary data cannot be written into FIXED type with size of 2 bytes")
 
       // Writing df containing binary data that doesn't fit FIXED size will throw an exception
-      val message2 = intercept[SparkException] {
+      val e2 = intercept[SparkException] {
         spark.createDataFrame(spark.sparkContext.parallelize(Seq(
           Row(Array(192).map(_.toByte)))),
           StructType(Seq(StructField("fixed2", BinaryType, true))))
           .write.format("avro").option("avroSchema", avroSchema)
           .save(s"$tempDir/${UUID.randomUUID()}")
-      }.getCause.getMessage
-      assert(message2.contains("org.apache.spark.sql.avro.IncompatibleSchemaException: " +
-        "Cannot write 1 byte of binary data into FIXED Type with size of 2 bytes"))
+      }
+      assertExceptionMsg[IncompatibleSchemaException](e2,
+        "1 byte of binary data cannot be written into FIXED type with size of 2 bytes")
     }
   }
 
@@ -920,26 +920,26 @@ abstract class AvroSuite
       checkAvroSchemaEquals(avroSchema, getAvroSchemaStringFromFiles(tempSaveDir))
 
       // Writing df containing binary data that doesn't fit FIXED size will throw an exception
-      val message1 = intercept[SparkException] {
+      val e1 = intercept[SparkException] {
         spark.createDataFrame(spark.sparkContext.parallelize(Seq(
           Row(Array(192, 168, 1).map(_.toByte)))),
           StructType(Seq(StructField("fixed2", BinaryType, false))))
           .write.format("avro").option("avroSchema", avroSchema)
           .save(s"$tempDir/${UUID.randomUUID()}")
-      }.getCause.getMessage
-      assert(message1.contains("org.apache.spark.sql.avro.IncompatibleSchemaException: " +
-        "Cannot write 3 bytes of binary data into FIXED Type with size of 2 bytes"))
+      }
+      assertExceptionMsg[IncompatibleSchemaException](e1,
+        "3 bytes of binary data cannot be written into FIXED type with size of 2 bytes")
 
       // Writing df containing binary data that doesn't fit FIXED size will throw an exception
-      val message2 = intercept[SparkException] {
+      val e2 = intercept[SparkException] {
         spark.createDataFrame(spark.sparkContext.parallelize(Seq(
           Row(Array(192).map(_.toByte)))),
           StructType(Seq(StructField("fixed2", BinaryType, false))))
           .write.format("avro").option("avroSchema", avroSchema)
           .save(s"$tempDir/${UUID.randomUUID()}")
-      }.getCause.getMessage
-      assert(message2.contains("org.apache.spark.sql.avro.IncompatibleSchemaException: " +
-        "Cannot write 1 byte of binary data into FIXED Type with size of 2 bytes"))
+      }
+      assertExceptionMsg[IncompatibleSchemaException](e2,
+        "1 byte of binary data cannot be written into FIXED type with size of 2 bytes")
     }
   }
 
@@ -1317,7 +1317,8 @@ abstract class AvroSuite
         val e = intercept[SparkException] {
           df.write.option("avroSchema", avroSchema).format("avro").save(s"$tempDir/save2")
         }
-        assertExceptionMsg(e, "Cannot find FOO in Avro schema")
+        assertExceptionMsg[IncompatibleSchemaException](e,
+          "Cannot find field 'FOO' in Avro schema at top-level record")
       }
     }
   }
@@ -1336,7 +1337,8 @@ abstract class AvroSuite
           |}
       """.stripMargin
 
-      val errorMsg = "Searching for 'foo' in Avro schema gave 2 matches. Candidates: [foo, FOO]"
+      val errorMsg = "Searching for 'foo' in Avro schema at top-level record gave 2 matches. " +
+          "Candidates: [foo, FOO]"
       assertExceptionMsg(intercept[SparkException] {
         val fooBarDf = Seq((1, "3"), (2, "4")).toDF("foo", "bar")
         fooBarDf.write.option("avroSchema", avroSchema).format("avro").save(s"$tempDir/save-fail")

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -1131,7 +1131,7 @@ abstract class AvroSuite
       val message = intercept[org.apache.spark.sql.avro.IncompatibleSchemaException] {
         f()
       }.getMessage
-      assert(message.contains("Cannot convert Catalyst type"))
+      assert(message.contains("Cannot convert SQL type"))
     }
 
     def resolveNullable(schema: Schema, nullable: Boolean): Schema = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Improve the error messages for incompatibilities between Avro and Catalyst schemas. First, make `AvroSerializer` more similar to `AvroDeserializer` in printing out contextual information such as hierarchical field names. Standardize exception messages in both serializer and deserializer to always include such contextual information, and include a top-level exception which shows the full schemas which were being parsed when the incompatibility was found. Both now print out the hierarchical name for both the Avro and Catalyst fields, since they may be different due to case sensitivity and Avro union handling.

### Why are the changes needed?
The error messages in this type of failure scenario are very lacking in information on the write path (`AvroSerializer`). Below are two examples of messages that provide insufficient information to determine what went wrong (lacking in field names, context about the overall schema structure, etc.).
```
org.apache.spark.sql.avro.IncompatibleSchemaException: Cannot convert Catalyst type IntegerType to Avro type "float".

org.apache.spark.sql.avro.IncompatibleSchemaException: Cannot convert Catalyst type StructType(StructField(bar,IntegerType,true)) to Avro type {"type":"record","name":"test","fields":[{"name":"NOTbar","type":["null","int"],"default":null}]}.
```
The error messages currently existing in `AvroDeserializer` are much better, but still not very internally consistent, and it would be better if they were consistent with the newly added exception messages in `AvroSerializer`.

### Does this PR introduce _any_ user-facing change?
Error messages when there are incompatibilities between Avro and Catalyst schemas will be greatly improved on when writing Avro data using the `avroSchema` option, a little bit improved when reading Avro data, and much more consistent between the two.

Below is an example of a new message. See `AvroSerdeSuite` for more examples.
```
org.apache.spark.sql.avro.IncompatibleSchemaException: Cannot convert Catalyst type STRUCT<`foo`: STRUCT<`bar`: INT>> to Avro type {"type":"record","name":"top","fields":[{"name":"foo","type":"int"}]}
	at org.apache.spark.sql.avro.AvroSerializer.liftedTree1$1(AvroSerializer.scala:83)
...
Caused by: org.apache.spark.sql.avro.IncompatibleSchemaException: Cannot convert Catalyst field 'foo' to Avro field 'foo' because schema is incompatible (sqlType = STRUCT<`bar`: INT>, avroType = "int")
	at org.apache.spark.sql.avro.AvroSerializer.newConverter(AvroSerializer.scala:230)
...
```

### How was this patch tested?
New unit test suite, `AvroSerdeSuite`, was added to test corner cases on `AvroSerializer` and `AvroDeserializer` and verify that the exception messages are as expected. Existing tests in `AvroSuite` also continue to pass, with modifications in places where assertions were made about the exceptions that would be thrown.