### PR TITLE
[SPARK-31768][ML][FOLLOWUP] add getMetrics in Evaluators: cleanup

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/evaluation/ClusteringMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/evaluation/ClusteringMetrics.scala
@@ -37,13 +37,18 @@ class ClusteringMetrics private[spark](dataset: Dataset[_]) {
 
   def getDistanceMeasure: String = distanceMeasure
 
-  def setDistanceMeasure(value: String) : Unit = distanceMeasure = value
+  def setDistanceMeasure(value: String) : this.type = {
+    require(value.equalsIgnoreCase("squaredEuclidean") ||
+      value.equalsIgnoreCase("cosine"))
+    distanceMeasure = value
+    this
+  }
 
   /**
    * Returns the silhouette score
    */
   @Since("3.1.0")
-  lazy val silhouette: Double = {
+  def silhouette(): Double = {
     val columns = dataset.columns.toSeq
     if (distanceMeasure.equalsIgnoreCase("squaredEuclidean")) {
       SquaredEuclideanSilhouette.computeSilhouetteScore(


### PR DESCRIPTION
### What changes were proposed in this pull request?
1, make `silhouette` a method;
2, change return type of `setDistanceMeasure` to `this.type`;


### Why are the changes needed?
see comments in https://github.com/apache/spark/pull/28590

### Does this PR introduce _any_ user-facing change?
No, 3.1 has not been released


### How was this patch tested?
existing testsuites
