### PR TITLE
[SPARK-34233][SQL] FIX NPE for char padding in binary comparison

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3957,13 +3957,16 @@ object ApplyCharTypePadding extends Rule[LogicalPlan] {
           if attr.dataType == StringType && list.forall(_.foldable) =>
           CharVarcharUtils.getRawType(attr.metadata).flatMap {
             case CharType(length) =>
-              val literalCharLengths = list.map(_.eval().asInstanceOf[UTF8String].numChars())
-              val targetLen = (length +: literalCharLengths).max
-              Some(i.copy(
-                value = addPadding(attr, length, targetLen),
-                list = list.zip(literalCharLengths).map {
-                  case (lit, charLength) => addPadding(lit, charLength, targetLen)
-                }))
+              val (nulls, literalChars) =
+                list.map(_.eval().asInstanceOf[UTF8String]).partition(_ == null)
+              val literalCharLengths = literalChars.map(_.numChars())
+              val targetLen = literalCharLengths.fold(length)(_ max _)
+
+              val newAttr = addPadding(attr, length, targetLen)
+              val newList = list.zip(literalCharLengths).map {
+                case (lit, charLength) => addPadding(lit, charLength, targetLen)
+              } ++ nulls.map(Literal.create(_, StringType))
+              Some(i.copy(value = newAttr, list = newList))
             case _ => None
           }.getOrElse(i)
 
@@ -3984,13 +3987,17 @@ object ApplyCharTypePadding extends Rule[LogicalPlan] {
       CharVarcharUtils.getRawType(attr.metadata).flatMap {
         case CharType(length) =>
           val str = lit.eval().asInstanceOf[UTF8String]
-          val stringLitLen = str.numChars()
-          if (length < stringLitLen) {
-            Some(Seq(StringRPad(attr, Literal(stringLitLen)), lit))
-          } else if (length > stringLitLen) {
-            Some(Seq(attr, StringRPad(lit, Literal(length))))
-          } else {
+          if (str == null) {
             None
+          } else {
+            val stringLitLen = str.numChars()
+            if (length < stringLitLen) {
+              Some(Seq(StringRPad(attr, Literal(stringLitLen)), lit))
+            } else if (length > stringLitLen) {
+              Some(Seq(attr, StringRPad(lit, Literal(length))))
+            } else {
+              None
+            }
           }
         case _ => None
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3960,13 +3960,12 @@ object ApplyCharTypePadding extends Rule[LogicalPlan] {
               val (nulls, literalChars) =
                 list.map(_.eval().asInstanceOf[UTF8String]).partition(_ == null)
               val literalCharLengths = literalChars.map(_.numChars())
-              val targetLen = literalCharLengths.fold(length)(_ max _)
-
-              val newAttr = addPadding(attr, length, targetLen)
-              val newList = list.zip(literalCharLengths).map {
-                case (lit, charLength) => addPadding(lit, charLength, targetLen)
-              } ++ nulls.map(Literal.create(_, StringType))
-              Some(i.copy(value = newAttr, list = newList))
+              val targetLen = (length +: literalCharLengths).max
+              Some(i.copy(
+                value = addPadding(attr, length, targetLen),
+                list = list.zip(literalCharLengths).map {
+                  case (lit, charLength) => addPadding(lit, charLength, targetLen)
+                } ++ nulls.map(Literal.create(_, StringType))))
             case _ => None
           }.getOrElse(i)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -472,22 +472,17 @@ trait CharVarcharTestSuite extends QueryTest with SQLTestUtils {
   }
 
   test("SPARK-34233: char type comparison with null values") {
+    val conditions = Seq("c1 = null", "c1 IN ('e', null)", "c1 IN (null)")
     withTable("t") {
       sql(s"CREATE TABLE t(c1 CHAR(2), c2 CHAR(5)) USING $format")
       sql("INSERT INTO t VALUES ('a', 'a')")
-      testNullConditions(spark.table("t"), Seq(
-        "c1 = null",
-        "c1 IN ('e', null)",
-        "c1 IN (null)"))
+      testNullConditions(spark.table("t"), conditions)
     }
 
     withTable("t") {
       sql(s"CREATE TABLE t(i INT, c1 CHAR(2), c2 CHAR(5)) USING $format PARTITIONED BY (c1, c2)")
       sql("INSERT INTO t VALUES (1, 'a', 'a')")
-      testNullConditions(spark.table("t"), Seq(
-        "c1 = null",
-        "c1 IN ('e', null)",
-        "c1 IN (null)"))
+      testNullConditions(spark.table("t"), conditions)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -472,16 +472,16 @@ trait CharVarcharTestSuite extends QueryTest with SQLTestUtils {
   }
 
   test("SPARK-34233: char type comparison with null values") {
-    val conditions = Seq("c1 = null", "c1 IN ('e', null)", "c1 IN (null)")
+    val conditions = Seq("c = null", "c IN ('e', null)", "c IN (null)")
     withTable("t") {
-      sql(s"CREATE TABLE t(c1 CHAR(2), c2 CHAR(5)) USING $format")
-      sql("INSERT INTO t VALUES ('a', 'a')")
+      sql(s"CREATE TABLE t(c CHAR(2)) USING $format")
+      sql("INSERT INTO t VALUES ('a')")
       testNullConditions(spark.table("t"), conditions)
     }
 
     withTable("t") {
-      sql(s"CREATE TABLE t(i INT, c1 CHAR(2), c2 CHAR(5)) USING $format PARTITIONED BY (c1, c2)")
-      sql("INSERT INTO t VALUES (1, 'a', 'a')")
+      sql(s"CREATE TABLE t(i INT, c CHAR(2)) USING $format PARTITIONED BY (c)")
+      sql("INSERT INTO t VALUES (1, 'a')")
       testNullConditions(spark.table("t"), conditions)
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -146,7 +146,7 @@ trait CharVarcharTestSuite extends QueryTest with SQLTestUtils {
     }
   }
 
-  test("char/varchar with null value for partitioned columns") {
+  test("SPARK-34233: char/varchar with null value for partitioned columns") {
     Seq("CHAR(5)", "VARCHAR(5)").foreach { typ =>
       withTable("t") {
         sql(s"CREATE TABLE t(i STRING, c $typ) USING $format PARTITIONED BY (c)")
@@ -156,7 +156,7 @@ trait CharVarcharTestSuite extends QueryTest with SQLTestUtils {
         checkPlainResult(spark.table("t"), typ, null)
         sql("INSERT OVERWRITE t PARTITION (c=null) VALUES ('1')")
         checkPlainResult(spark.table("t"), typ, null)
-        sql(s"ALTER TABLE t DROP PARTITION(c=null)")
+        sql("ALTER TABLE t DROP PARTITION(c=null)")
         checkAnswer(spark.table("t"), Nil)
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

we need to check whether the `lit` is null  before calling `numChars`

### Why are the changes needed?

fix an obvious NPE bug


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
new tests