### PR TITLE
[SPARK-34218][INFRA][FOLLOWUP] Fix Scala 2.13 profile typo in publish-snapshot

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -381,7 +381,7 @@ if [[ "$1" == "publish-snapshot" ]]; then
 
   if [[ $PUBLISH_SCALA_2_13 = 1 ]]; then
     ./dev/change-scala-version.sh 2.13
-    $MVN -DzincPort=$ZINC_PORT --settings $tmp_settings -DskipTests $SCALA_2_12_PROFILES $PUBLISH_PROFILES clean deploy
+    $MVN -DzincPort=$ZINC_PORT --settings $tmp_settings -DskipTests $SCALA_2_13_PROFILES $PUBLISH_PROFILES clean deploy
   fi
 
   rm $tmp_settings


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of #31311 and fixes a typo in Scala 2.13 profile section in `publish-snapshot` command.

### Why are the changes needed?

To fix snapshot publishing for Scala 2.13.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual.