### PR TITLE
[SPARK-34241][SQL] For DDL command plan, we should define producedAttributes as it's outputSet

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Command.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Command.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.plans.logical
 
-import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet}
 
 /**
  * A logical node that represents a non-query command to be executed by the system.  For example,
@@ -26,6 +26,7 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
  */
 trait Command extends LogicalPlan {
   override def output: Seq[Attribute] = Seq.empty
+  override def producedAttributes: AttributeSet = outputSet
   override def children: Seq[LogicalPlan] = Seq.empty
   // Commands are eagerly executed. They will be converted to LocalRelation after the DataFrame
   // is created. That said, the statistics of a command is useless. Here we just return a dummy


### PR DESCRIPTION
### What changes were proposed in this pull request?

When write test about command,  when `checkAnswer`, 
Always got error as below
```
[info]   AttributeSet(partition#607) was not empty The analyzed logical plan has missing inputs:
[info]   ShowPartitionsCommand `ns`.`tbl`, [partition#607] (QueryTest.scala:224)
[info]   org.scalatest.exceptions.TestFailedException:
[info]   at org.scalatest.Assertions.newAssertionFailedException(Assertions.scala:472)
[info]   at org.scalatest.Assertions.newAssertionFailedException$(Assertions.scala:471)
```

For Command DDL plan, we can define  `producedAttributes` as it's `outputSet` and it's reasonable


### Why are the changes needed?
Add default   `producedAttributes` for Command LogicalPlan

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Not need 