### PR TITLE
[SPARK-34245][CORE] Ensure Master removes executors that failed to send finished state

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
@@ -28,6 +28,7 @@ import scala.collection.mutable.{HashMap, HashSet, LinkedHashMap}
 import scala.concurrent.ExecutionContext
 import scala.util.Random
 import scala.util.control.NonFatal
+
 import org.apache.spark.{SecurityManager, SparkConf}
 import org.apache.spark.deploy.{Command, ExecutorDescription, ExecutorState}
 import org.apache.spark.deploy.DeployMessages._
@@ -35,7 +36,7 @@ import org.apache.spark.deploy.ExternalShuffleService
 import org.apache.spark.deploy.StandaloneResourceUtils._
 import org.apache.spark.deploy.master.{DriverState, Master}
 import org.apache.spark.deploy.worker.ui.WorkerWebUI
-import org.apache.spark.internal.{Logging, config}
+import org.apache.spark.internal.{config, Logging}
 import org.apache.spark.internal.config.Tests.IS_TESTING
 import org.apache.spark.internal.config.UI._
 import org.apache.spark.internal.config.Worker._
@@ -44,8 +45,6 @@ import org.apache.spark.resource.ResourceInformation
 import org.apache.spark.resource.ResourceUtils._
 import org.apache.spark.rpc._
 import org.apache.spark.util.{SignalUtils, SparkUncaughtExceptionHandler, ThreadUtils, Utils}
-
-import scala.collection.mutable
 
 private[deploy] class Worker(
     override val rpcEnv: RpcEnv,

--- a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
@@ -159,7 +159,7 @@ private[deploy] class Worker(
   val appDirectories = new HashMap[String, Seq[String]]
   val finishedApps = new HashSet[String]
 
-  // Record the consecutive failure attempts of executor stage change syncing with Master,
+  // Record the consecutive failure attempts of executor state change syncing with Master,
   // so we don't try it endless. We will exit the Worker process at the end if the failure
   // attempts reach the max attempts(10). In that case, it's highly possible the Worker
   // suffers a severe network issue, and the Worker would exit finally either reaches max

--- a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
@@ -779,7 +779,7 @@ private[deploy] class Worker(
           executorStateSyncFailureAttempts.remove(fullId)
         } catch {
           case t: Throwable =>
-            val failures = executorStateSyncFailureAttempts.getOrElseUpdate(fullId, 0) + 1
+            val failures = executorStateSyncFailureAttempts.getOrElse(fullId, 0) + 1
             if (failures < 10) {
               logError(s"Failed to send $newState to Master $masterRef, " +
                 s"will retry ($failures/10).", t)

--- a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
@@ -758,7 +758,7 @@ private[deploy] class Worker(
     master match {
       case Some(masterRef) =>
         try {
-          // SPARK-34245: We use async `send` to send the state previously. In that case, the
+          // SPARK-34245: We used async `send` to send the state previously. In that case, the
           // finished executor can be leaked if Worker fails to send `ExecutorStateChanged`
           // message to Master due to some unexpected errors, e.g., temporary network error.
           // In the worst case, the application can get hang if the leaked executor is the only

--- a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
@@ -28,7 +28,6 @@ import scala.collection.mutable.{HashMap, HashSet, LinkedHashMap}
 import scala.concurrent.ExecutionContext
 import scala.util.Random
 import scala.util.control.NonFatal
-
 import org.apache.spark.{SecurityManager, SparkConf}
 import org.apache.spark.deploy.{Command, ExecutorDescription, ExecutorState}
 import org.apache.spark.deploy.DeployMessages._
@@ -36,7 +35,7 @@ import org.apache.spark.deploy.ExternalShuffleService
 import org.apache.spark.deploy.StandaloneResourceUtils._
 import org.apache.spark.deploy.master.{DriverState, Master}
 import org.apache.spark.deploy.worker.ui.WorkerWebUI
-import org.apache.spark.internal.{config, Logging}
+import org.apache.spark.internal.{Logging, config}
 import org.apache.spark.internal.config.Tests.IS_TESTING
 import org.apache.spark.internal.config.UI._
 import org.apache.spark.internal.config.Worker._
@@ -45,6 +44,8 @@ import org.apache.spark.resource.ResourceInformation
 import org.apache.spark.resource.ResourceUtils._
 import org.apache.spark.rpc._
 import org.apache.spark.util.{SignalUtils, SparkUncaughtExceptionHandler, ThreadUtils, Utils}
+
+import scala.collection.mutable
 
 private[deploy] class Worker(
     override val rpcEnv: RpcEnv,
@@ -158,6 +159,16 @@ private[deploy] class Worker(
   val finishedDrivers = new LinkedHashMap[String, DriverRunner]
   val appDirectories = new HashMap[String, Seq[String]]
   val finishedApps = new HashSet[String]
+
+  // Record the consecutive failure attempts of executor stage change syncing with Master,
+  // so we don't try it endless. We will exit the Worker process at the end if the failure
+  // attempts reach the max attempts(10). In that case, it's highly possible the Worker
+  // suffers a severe network issue, and the Worker would exit finally either reaches max
+  // re-register attempts or max state syncing attempts.
+  // Map from executor fullId to its consecutive failure attempts number. It's supposed
+  // to be very small since it's only used for the temporary network drop, which doesn't
+  // happen frequently and recover soon.
+  private val executorStateSyncFailureAttempts = new HashMap[String, Int]()
 
   val retainedExecutors = conf.get(WORKER_UI_RETAINED_EXECUTORS)
   val retainedDrivers = conf.get(WORKER_UI_RETAINED_DRIVERS)
@@ -757,6 +768,7 @@ private[deploy] class Worker(
   private def syncExecutorStateWithMaster(newState: ExecutorStateChanged): Unit = {
     master match {
       case Some(masterRef) =>
+        val fullId = s"${newState.appId}/${newState.execId}"
         try {
           // SPARK-34245: We used async `send` to send the state previously. In that case, the
           // finished executor can be leaked if Worker fails to send `ExecutorStateChanged`
@@ -765,13 +777,22 @@ private[deploy] class Worker(
           // or last executor for the application. Therefore, we switch to `askSync` to ensure
           // the state is handled by Master.
           masterRef.askSync[Boolean](newState)
+          executorStateSyncFailureAttempts.remove(fullId)
         } catch {
           case t: Throwable =>
-            logError(s"Failed to send $newState to Master $masterRef, will retry.", t)
-            // In case of the error is caused by a non-transient network error, we should leave
-            // some time for Worker to handle ReregisterWithMaster messages.
-            Thread.sleep(100)
-            self.send(newState)
+            val failures = executorStateSyncFailureAttempts.getOrElseUpdate(fullId, 0) + 1
+            if (failures < 10) {
+              logError(s"Failed to send $newState to Master $masterRef, " +
+                s"will retry ($failures/10).", t)
+              executorStateSyncFailureAttempts(fullId) = failures
+              // In case of the error is caused by a non-transient network error, we should leave
+              // some time for Worker to handle ReregisterWithMaster messages.
+              Thread.sleep(100)
+              self.send(newState)
+            } else {
+              logError(s"Failed to send $newState to Master $masterRef for 10 times. Giving up.")
+              System.exit(1)
+            }
         }
 
       case None =>

--- a/core/src/test/scala/org/apache/spark/deploy/master/MasterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/master/MasterSuite.scala
@@ -134,7 +134,7 @@ class MockExecutorLaunchFailWorker(master: Master, conf: SparkConf = new SparkCo
       assert(master.idToApp.contains(appId))
       appIdsToLaunchExecutor += appId
       failedCnt += 1
-      master.self.send(ExecutorStateChanged(appId, execId, ExecutorState.FAILED, None, None))
+      master.self.askSync(ExecutorStateChanged(appId, execId, ExecutorState.FAILED, None, None))
 
     case otherMsg => super.receive(otherMsg)
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Use `ask` instead of `send` to sync the `ExecutorStateChanged` between Worker and Master and retry(up to 5 times) on the failure until the message is successfully handled by the Master. And the Worker would exit itself if the message can not be sent after 5 times retry.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

If the Worker fails to send ExecutorStateChanged to the Master due to some unexpected errors, e.g., temporary network error, then the Master can't remove the finished executor normally and think the executor is still alive. In the worst case, if the executor is the only executor for the application, the application can get hang. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Pass existing tests.
